### PR TITLE
feat(lora): wire LoRA adapter loading into PyTorch backend and vLLM config

### DIFF
--- a/configs/examples/study-full-suite.yaml
+++ b/configs/examples/study-full-suite.yaml
@@ -85,12 +85,16 @@ decoder:
   #TODO: validate this works + how incompataible params resolution is handled
   #TODO: consider moving this to sweep
 
-# --- LoRA adapter (optional, applies to all experiments) ---
-lora:
+# --- LoRA adapter (optional, per-experiment) ---
+# Currently wired for pytorch backend only (via peft library).
+# TODO: Design cross-backend LoRA strategy - backends handle adapters at
+#   fundamentally different levels (model-level vs per-request vs build-time).
+#   Needs a proper design doc before wiring vLLM/TRT-LLM runtime support.
+# lora:
 #   adapter_id: my-org/my-lora-adapter   # HuggingFace Hub adapter ID
 #   # adapter_path: /path/to/local/adapter  # OR local adapter weights
-#   merge_weights: false         # Merge adapter into base model at load time
-# TODO: VALUDATE that this works as intended - does this apply to all backends? if not, need to clarify in docs and potentially add backend-specific lora config using dotted notation (e.g. lora.pytorch.adapter_id, lora.vllm.adapter_id, etc.)
+#   merge_weights: false         # Merge adapter into base model (pytorch only)
+#   revision: null               # Hub revision for adapter_id (branch/tag/commit)
 
 # --- Passthrough kwargs ---
 passthrough_kwargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pytorch = [
     "accelerate>=1.4",
     "bitsandbytes>=0.45",
     "calflops>=0.2",
+    "peft>=0.12",
 ]
 vllm = ["vllm>=0.6"]
 tensorrt = ["tensorrt-llm>=0.12"]

--- a/src/llenergymeasure/backends/pytorch.py
+++ b/src/llenergymeasure/backends/pytorch.py
@@ -83,6 +83,13 @@ class PyTorchBackend:
         if on_substep is not None:
             on_substep("model weights loaded", _time.perf_counter() - t0)
 
+        # Apply LoRA adapter (must be AFTER from_pretrained + eval, BEFORE torch.compile)
+        if config.lora is not None:
+            t0 = _time.perf_counter()
+            model = self._apply_lora_adapter(model, config.lora)
+            if on_substep is not None:
+                on_substep("LoRA adapter applied", _time.perf_counter() - t0)
+
         # Apply torch.compile post-load (must be AFTER from_pretrained + eval)
         if config.pytorch is not None and config.pytorch.torch_compile:
             import torch as _torch
@@ -275,8 +282,33 @@ class PyTorchBackend:
         logger.debug("Model cleanup complete")
 
     def validate_config(self, config: ExperimentConfig) -> list[str]:
-        """No hardware validation required for PyTorch backend."""
-        return []
+        """Validate PyTorch-specific configuration requirements.
+
+        Checks:
+            - peft is importable when config.lora is set
+            - adapter_path exists on filesystem when using local path
+        """
+        errors: list[str] = []
+
+        if config.lora is not None:
+            # Check peft is importable
+            try:
+                import peft  # noqa: F401
+            except ImportError:
+                errors.append(
+                    "LoRA adapter configured but 'peft' package is not installed. "
+                    "Install with: pip install 'llenergymeasure[pytorch]'"
+                )
+
+            # Check adapter_path exists on filesystem
+            if config.lora.adapter_path is not None:
+                from pathlib import Path
+
+                adapter_path = Path(config.lora.adapter_path)
+                if not adapter_path.exists():
+                    errors.append(f"LoRA adapter_path does not exist: {config.lora.adapter_path}")
+
+        return errors
 
     # -------------------------------------------------------------------------
     # Private: model loading helpers
@@ -431,6 +463,34 @@ class PyTorchBackend:
             "float16": torch.float16,
             "bfloat16": torch.bfloat16,
         }[dtype]
+
+    @staticmethod
+    def _apply_lora_adapter(model: Any, lora: Any) -> Any:
+        """Apply a LoRA adapter to the model via peft.
+
+        Args:
+            model: The base HuggingFace model (after from_pretrained + eval).
+            lora: LoRAConfig instance with adapter source and merge settings.
+
+        Returns:
+            Model with LoRA adapter applied (PeftModel or merged base model).
+        """
+        from peft import PeftModel
+
+        adapter_source = lora.adapter_id or lora.adapter_path
+        peft_kwargs: dict[str, Any] = {}
+        if lora.revision:
+            peft_kwargs["revision"] = lora.revision
+
+        logger.info("Applying LoRA adapter from %r", adapter_source)
+        model = PeftModel.from_pretrained(model, adapter_source, **peft_kwargs)
+        model.eval()
+
+        if lora.merge_weights:
+            logger.info("Merging LoRA weights into base model")
+            model = model.merge_and_unload()
+
+        return model
 
     # -------------------------------------------------------------------------
     # Private: inference helpers

--- a/src/llenergymeasure/backends/pytorch.py
+++ b/src/llenergymeasure/backends/pytorch.py
@@ -83,12 +83,9 @@ class PyTorchBackend:
         if on_substep is not None:
             on_substep("model weights loaded", _time.perf_counter() - t0)
 
-        # Apply LoRA adapter (must be AFTER from_pretrained + eval, BEFORE torch.compile)
+        # Apply LoRA adapter (must be AFTER from_pretrained, BEFORE torch.compile)
         if config.lora is not None:
-            t0 = _time.perf_counter()
-            model = self._apply_lora_adapter(model, config.lora)
-            if on_substep is not None:
-                on_substep("LoRA adapter applied", _time.perf_counter() - t0)
+            model = self._apply_lora_adapter(model, config, on_substep)
 
         # Apply torch.compile post-load (must be AFTER from_pretrained + eval)
         if config.pytorch is not None and config.pytorch.torch_compile:
@@ -282,32 +279,21 @@ class PyTorchBackend:
         logger.debug("Model cleanup complete")
 
     def validate_config(self, config: ExperimentConfig) -> list[str]:
-        """Validate PyTorch-specific configuration requirements.
-
-        Checks:
-            - peft is importable when config.lora is set
-            - adapter_path exists on filesystem when using local path
-        """
+        """Validate PyTorch-specific configuration constraints."""
         errors: list[str] = []
-
         if config.lora is not None:
-            # Check peft is importable
             try:
                 import peft  # noqa: F401
             except ImportError:
                 errors.append(
-                    "LoRA adapter configured but 'peft' package is not installed. "
-                    "Install with: pip install 'llenergymeasure[pytorch]'"
+                    "LoRA adapter configured but 'peft' is not installed. "
+                    "Install with: pip install llenergymeasure[pytorch]"
                 )
-
-            # Check adapter_path exists on filesystem
             if config.lora.adapter_path is not None:
                 from pathlib import Path
 
-                adapter_path = Path(config.lora.adapter_path)
-                if not adapter_path.exists():
+                if not Path(config.lora.adapter_path).exists():
                     errors.append(f"LoRA adapter_path does not exist: {config.lora.adapter_path}")
-
         return errors
 
     # -------------------------------------------------------------------------
@@ -464,31 +450,46 @@ class PyTorchBackend:
             "bfloat16": torch.bfloat16,
         }[dtype]
 
+    # -------------------------------------------------------------------------
+    # Private: LoRA adapter support
+    # -------------------------------------------------------------------------
+
     @staticmethod
-    def _apply_lora_adapter(model: Any, lora: Any) -> Any:
-        """Apply a LoRA adapter to the model via peft.
+    def _apply_lora_adapter(
+        model: Any,
+        config: ExperimentConfig,
+        on_substep: Callable[[str, float], None] | None = None,
+    ) -> Any:
+        """Load a PEFT LoRA adapter onto the base model.
 
-        Args:
-            model: The base HuggingFace model (after from_pretrained + eval).
-            lora: LoRAConfig instance with adapter source and merge settings.
-
-        Returns:
-            Model with LoRA adapter applied (PeftModel or merged base model).
+        Called after from_pretrained() and model.eval(), before torch.compile.
+        Optionally merges adapter weights into the base model via merge_and_unload().
         """
+        import time as _time
+
         from peft import PeftModel
 
-        adapter_source = lora.adapter_id or lora.adapter_path
+        lora = config.lora
+        assert lora is not None
+
+        adapter_source = lora.adapter_id if lora.adapter_id is not None else lora.adapter_path
+
         peft_kwargs: dict[str, Any] = {}
-        if lora.revision:
+        if lora.revision is not None:
             peft_kwargs["revision"] = lora.revision
 
-        logger.info("Applying LoRA adapter from %r", adapter_source)
+        t0 = _time.perf_counter()
+        logger.info("Loading LoRA adapter from %r", adapter_source)
         model = PeftModel.from_pretrained(model, adapter_source, **peft_kwargs)
         model.eval()
 
         if lora.merge_weights:
             logger.info("Merging LoRA weights into base model")
             model = model.merge_and_unload()
+
+        if on_substep is not None:
+            label = "lora merged" if lora.merge_weights else "lora adapter loaded"
+            on_substep(label, _time.perf_counter() - t0)
 
         return model
 

--- a/src/llenergymeasure/config/backend_configs.py
+++ b/src/llenergymeasure/config/backend_configs.py
@@ -433,6 +433,34 @@ class VLLMEngineConfig(BaseModel):
     )
 
     # -------------------------------------------------------------------------
+    # LoRA adapters
+    # -------------------------------------------------------------------------
+
+    enable_lora: bool | None = Field(
+        default=None,
+        description="Enable LoRA adapter support (None -> False). Master switch for dynamic LoRA.",
+    )
+    max_lora_rank: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum LoRA rank supported (None -> 16).",
+    )
+    max_loras: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of LoRA adapters loaded concurrently (None -> 1).",
+    )
+    lora_extra_vocab_size: int | None = Field(
+        default=None,
+        ge=0,
+        description="Extra vocabulary size reserved for LoRA adapters (None -> 256).",
+    )
+    lora_dtype: Literal["float16", "bfloat16", "float32", "auto"] | None = Field(
+        default=None,
+        description="Data type for LoRA adapter weights (None -> auto).",
+    )
+
+    # -------------------------------------------------------------------------
     # Speculative decoding
     # -------------------------------------------------------------------------
 

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -823,9 +823,9 @@ def get_backend_capabilities() -> dict[str, dict[str, bool | str]]:
             "tensorrt": False,
         },
         "lora_adapters": {
-            "pytorch": True,  # Via peft library
-            "vllm": False,  # Not in v2.0 minimal VLLMConfig
-            "tensorrt": False,  # Not in v2.0 minimal TensorRTConfig
+            "pytorch": True,  # Via peft library (PeftModel.from_pretrained)
+            "vllm": "enable_lora" in vllm_fields,  # Dynamic per-request adapters
+            "tensorrt": False,  # Not yet supported
         },
         "torch_compile": {
             "pytorch": "torch_compile" in pytorch_fields,

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -239,11 +239,10 @@ class LoRAConfig(BaseModel):
     Exactly one of adapter_id or adapter_path must be set.
 
     Backend support:
-        - pytorch: Full support via peft library (PeftModel.from_pretrained).
-          Supports both Hub adapters (adapter_id) and local paths (adapter_path).
-          merge_weights merges adapter into base model at load time.
-        - vllm: Dynamic per-request adapters via engine-level enable_lora.
-          Requires adapter weights to be locally accessible.
+        - pytorch: Full support via PEFT library (PeftModel.from_pretrained).
+          Supports merge_and_unload() for weight merging.
+        - vllm: Dynamic per-request adapters. Requires vllm.engine.enable_lora: true
+          and a local adapter path.
         - tensorrt: Not yet supported.
     """
 
@@ -273,12 +272,9 @@ class LoRAConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_revision_requires_adapter_id(self) -> LoRAConfig:
-        """revision is only valid with adapter_id (Hub loading), not adapter_path."""
+        """revision is only meaningful with adapter_id (Hub loading)."""
         if self.revision is not None and self.adapter_id is None:
-            raise ValueError(
-                "LoRAConfig.revision requires adapter_id (Hub loading). "
-                "revision is not applicable when using adapter_path (local loading)."
-            )
+            raise ValueError("revision requires adapter_id (Hub loading), not adapter_path")
         return self
 
 

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -237,6 +237,14 @@ class LoRAConfig(BaseModel):
     """LoRA adapter configuration.
 
     Exactly one of adapter_id or adapter_path must be set.
+
+    Backend support:
+        - pytorch: Full support via peft library (PeftModel.from_pretrained).
+          Supports both Hub adapters (adapter_id) and local paths (adapter_path).
+          merge_weights merges adapter into base model at load time.
+        - vllm: Dynamic per-request adapters via engine-level enable_lora.
+          Requires adapter weights to be locally accessible.
+        - tensorrt: Not yet supported.
     """
 
     model_config = {"extra": "forbid"}
@@ -245,6 +253,10 @@ class LoRAConfig(BaseModel):
     adapter_path: str | None = Field(default=None, description="Local path to adapter weights")
     merge_weights: bool = Field(
         default=False, description="Merge adapter weights into base model at load time"
+    )
+    revision: str | None = Field(
+        default=None,
+        description="Hub revision (branch, tag, or commit hash) for adapter_id loading",
     )
 
     @model_validator(mode="after")
@@ -256,6 +268,16 @@ class LoRAConfig(BaseModel):
             raise ValueError(
                 "LoRAConfig requires exactly one of adapter_id or adapter_path. "
                 f"Got: adapter_id={self.adapter_id!r}, adapter_path={self.adapter_path!r}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_revision_requires_adapter_id(self) -> LoRAConfig:
+        """revision is only valid with adapter_id (Hub loading), not adapter_path."""
+        if self.revision is not None and self.adapter_id is None:
+            raise ValueError(
+                "LoRAConfig.revision requires adapter_id (Hub loading). "
+                "revision is not applicable when using adapter_path (local loading)."
             )
         return self
 

--- a/tests/unit/backends/test_pytorch_lora.py
+++ b/tests/unit/backends/test_pytorch_lora.py
@@ -1,0 +1,234 @@
+"""Unit tests for PyTorch backend LoRA adapter integration.
+
+All tests mock peft and transformers - no GPU or model downloads required.
+Tests cover:
+- load_model with/without LoRA
+- LoRA adapter_id vs adapter_path
+- merge_weights behaviour
+- revision kwarg forwarding
+- validate_config LoRA checks
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from llenergymeasure.backends.pytorch import PyTorchBackend
+from llenergymeasure.config.models import ExperimentConfig, LoRAConfig
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_config(**overrides) -> ExperimentConfig:
+    """Return a valid ExperimentConfig with sensible defaults."""
+    defaults: dict = {"model": "gpt2", "backend": "pytorch"}
+    defaults.update(overrides)
+    return ExperimentConfig(**defaults)
+
+
+def _make_mock_model():
+    """Create a mock HuggingFace model."""
+    model = MagicMock()
+    model.device = "cpu"
+    model.eval.return_value = model
+    return model
+
+
+def _make_mock_tokenizer():
+    """Create a mock HuggingFace tokenizer."""
+    tokenizer = MagicMock()
+    tokenizer.pad_token = None
+    tokenizer.eos_token = "</s>"
+    return tokenizer
+
+
+def _patch_transformers():
+    """Context manager patches for transformers AutoModel and AutoTokenizer."""
+    mock_model = _make_mock_model()
+    mock_tokenizer = _make_mock_tokenizer()
+
+    auto_model_patch = patch(
+        "transformers.AutoModelForCausalLM.from_pretrained",
+        return_value=mock_model,
+    )
+    auto_tokenizer_patch = patch(
+        "transformers.AutoTokenizer.from_pretrained",
+        return_value=mock_tokenizer,
+    )
+    return auto_model_patch, auto_tokenizer_patch, mock_model
+
+
+# =============================================================================
+# load_model tests
+# =============================================================================
+
+
+class TestLoadModelWithoutLora:
+    """Test that load_model without LoRA does not touch peft."""
+
+    def test_load_model_without_lora(self):
+        """When config.lora is None, PeftModel is NOT imported/called."""
+        auto_model_p, auto_tok_p, _mock_model = _patch_transformers()
+
+        backend = PyTorchBackend()
+        config = _make_config()
+        assert config.lora is None
+
+        with auto_model_p, auto_tok_p:
+            result_model, result_tokenizer = backend.load_model(config)
+
+        assert result_model is not None
+        assert result_tokenizer is not None
+
+
+class TestLoadModelWithLoraAdapterId:
+    """Test load_model with LoRA adapter_id."""
+
+    def test_load_model_with_lora_adapter_id(self):
+        """PeftModel.from_pretrained is called with adapter_id."""
+        auto_model_p, auto_tok_p, base_model = _patch_transformers()
+
+        peft_model = _make_mock_model()
+        mock_peft_module = MagicMock()
+        mock_peft_module.PeftModel.from_pretrained.return_value = peft_model
+
+        backend = PyTorchBackend()
+        config = _make_config(lora=LoRAConfig(adapter_id="my-org/my-adapter"))
+
+        with auto_model_p, auto_tok_p, patch.dict(sys.modules, {"peft": mock_peft_module}):
+            _model, _tokenizer = backend.load_model(config)
+
+        mock_peft_module.PeftModel.from_pretrained.assert_called_once_with(
+            base_model, "my-org/my-adapter"
+        )
+
+
+class TestLoadModelWithLoraAdapterPath:
+    """Test load_model with LoRA adapter_path."""
+
+    def test_load_model_with_lora_adapter_path(self):
+        """PeftModel.from_pretrained is called with adapter_path."""
+        auto_model_p, auto_tok_p, base_model = _patch_transformers()
+
+        peft_model = _make_mock_model()
+        mock_peft_module = MagicMock()
+        mock_peft_module.PeftModel.from_pretrained.return_value = peft_model
+
+        backend = PyTorchBackend()
+        config = _make_config(lora=LoRAConfig(adapter_path="/path/to/adapter"))
+
+        with auto_model_p, auto_tok_p, patch.dict(sys.modules, {"peft": mock_peft_module}):
+            _model, _tokenizer = backend.load_model(config)
+
+        mock_peft_module.PeftModel.from_pretrained.assert_called_once_with(
+            base_model, "/path/to/adapter"
+        )
+
+
+class TestLoadModelWithLoraMergeWeights:
+    """Test merge_weights behaviour."""
+
+    def test_load_model_with_lora_merge_weights(self):
+        """merge_and_unload() is called when merge_weights=True."""
+        auto_model_p, auto_tok_p, _base_model = _patch_transformers()
+
+        merged_model = _make_mock_model()
+        peft_model = _make_mock_model()
+        peft_model.merge_and_unload.return_value = merged_model
+
+        mock_peft_module = MagicMock()
+        mock_peft_module.PeftModel.from_pretrained.return_value = peft_model
+
+        backend = PyTorchBackend()
+        config = _make_config(lora=LoRAConfig(adapter_id="my-org/my-adapter", merge_weights=True))
+
+        with auto_model_p, auto_tok_p, patch.dict(sys.modules, {"peft": mock_peft_module}):
+            _model, _tokenizer = backend.load_model(config)
+
+        peft_model.merge_and_unload.assert_called_once()
+
+    def test_load_model_with_lora_no_merge(self):
+        """merge_and_unload() NOT called when merge_weights=False."""
+        auto_model_p, auto_tok_p, _base_model = _patch_transformers()
+
+        peft_model = _make_mock_model()
+        mock_peft_module = MagicMock()
+        mock_peft_module.PeftModel.from_pretrained.return_value = peft_model
+
+        backend = PyTorchBackend()
+        config = _make_config(lora=LoRAConfig(adapter_id="my-org/my-adapter", merge_weights=False))
+
+        with auto_model_p, auto_tok_p, patch.dict(sys.modules, {"peft": mock_peft_module}):
+            _model, _tokenizer = backend.load_model(config)
+
+        peft_model.merge_and_unload.assert_not_called()
+
+
+class TestLoadModelWithLoraRevision:
+    """Test revision kwarg forwarding."""
+
+    def test_load_model_with_lora_revision(self):
+        """revision kwarg is passed to PeftModel.from_pretrained."""
+        auto_model_p, auto_tok_p, base_model = _patch_transformers()
+
+        peft_model = _make_mock_model()
+        mock_peft_module = MagicMock()
+        mock_peft_module.PeftModel.from_pretrained.return_value = peft_model
+
+        backend = PyTorchBackend()
+        config = _make_config(lora=LoRAConfig(adapter_id="my-org/my-adapter", revision="v1.0"))
+
+        with auto_model_p, auto_tok_p, patch.dict(sys.modules, {"peft": mock_peft_module}):
+            _model, _tokenizer = backend.load_model(config)
+
+        mock_peft_module.PeftModel.from_pretrained.assert_called_once_with(
+            base_model, "my-org/my-adapter", revision="v1.0"
+        )
+
+
+# =============================================================================
+# validate_config tests
+# =============================================================================
+
+
+class TestValidateConfigLora:
+    """Test validate_config LoRA checks."""
+
+    def test_validate_config_no_lora(self):
+        """validate_config returns empty list when no lora."""
+        backend = PyTorchBackend()
+        config = _make_config()
+        errors = backend.validate_config(config)
+        assert errors == []
+
+    def test_validate_config_lora_missing_peft(self):
+        """validate_config returns error when peft not importable."""
+        backend = PyTorchBackend()
+        config = _make_config(lora=LoRAConfig(adapter_id="my-org/my-adapter"))
+
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "peft":
+                raise ImportError("No module named 'peft'")
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=mock_import):
+            errors = backend.validate_config(config)
+
+        assert len(errors) >= 1
+        assert any("peft" in e for e in errors)
+
+    def test_validate_config_lora_missing_path(self, tmp_path):
+        """validate_config returns error when adapter_path doesn't exist."""
+        backend = PyTorchBackend()
+        nonexistent = str(tmp_path / "nonexistent_adapter")
+        config = _make_config(lora=LoRAConfig(adapter_path=nonexistent))
+
+        errors = backend.validate_config(config)
+        assert any("does not exist" in e for e in errors)

--- a/tests/unit/config/test_lora_config.py
+++ b/tests/unit/config/test_lora_config.py
@@ -1,0 +1,108 @@
+"""Unit tests for LoRAConfig Pydantic validation.
+
+Tests cover:
+- Exactly-one-source validation (adapter_id XOR adapter_path)
+- Revision field requires adapter_id
+- Default values
+- extra=forbid
+- Integration with ExperimentConfig
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from llenergymeasure.config.models import ExperimentConfig, LoRAConfig
+
+# ---------------------------------------------------------------------------
+# Source validation
+# ---------------------------------------------------------------------------
+
+
+def test_lora_adapter_id_only():
+    """LoRAConfig with only adapter_id is valid."""
+    lora = LoRAConfig(adapter_id="my-org/my-adapter")
+    assert lora.adapter_id == "my-org/my-adapter"
+    assert lora.adapter_path is None
+
+
+def test_lora_adapter_path_only():
+    """LoRAConfig with only adapter_path is valid."""
+    lora = LoRAConfig(adapter_path="/path/to/adapter")
+    assert lora.adapter_path == "/path/to/adapter"
+    assert lora.adapter_id is None
+
+
+def test_lora_both_sources_rejected():
+    """LoRAConfig with both adapter_id and adapter_path raises ValidationError."""
+    with pytest.raises(ValidationError, match="exactly one"):
+        LoRAConfig(adapter_id="my-org/my-adapter", adapter_path="/path/to/adapter")
+
+
+def test_lora_neither_source_rejected():
+    """LoRAConfig with neither adapter_id nor adapter_path raises ValidationError."""
+    with pytest.raises(ValidationError, match="exactly one"):
+        LoRAConfig()
+
+
+# ---------------------------------------------------------------------------
+# Revision validation
+# ---------------------------------------------------------------------------
+
+
+def test_lora_revision_with_adapter_id():
+    """LoRAConfig with revision and adapter_id is valid."""
+    lora = LoRAConfig(adapter_id="my-org/my-adapter", revision="v1.0")
+    assert lora.revision == "v1.0"
+    assert lora.adapter_id == "my-org/my-adapter"
+
+
+def test_lora_revision_with_adapter_path_rejected():
+    """LoRAConfig with revision and adapter_path raises ValidationError."""
+    with pytest.raises(ValidationError, match="revision requires adapter_id"):
+        LoRAConfig(adapter_path="/path/to/adapter", revision="v1.0")
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_lora_merge_weights_default_false():
+    """merge_weights defaults to False."""
+    lora = LoRAConfig(adapter_id="my-org/my-adapter")
+    assert lora.merge_weights is False
+
+
+# ---------------------------------------------------------------------------
+# extra=forbid
+# ---------------------------------------------------------------------------
+
+
+def test_lora_extra_fields_forbidden():
+    """Unknown fields raise ValidationError (extra='forbid')."""
+    with pytest.raises(ValidationError):
+        LoRAConfig(adapter_id="my-org/my-adapter", unknown_field="x")
+
+
+# ---------------------------------------------------------------------------
+# Integration with ExperimentConfig
+# ---------------------------------------------------------------------------
+
+
+def test_lora_in_experiment_config():
+    """ExperimentConfig accepts a lora section."""
+    config = ExperimentConfig(
+        model="gpt2",
+        backend="pytorch",
+        lora=LoRAConfig(adapter_id="my-org/my-adapter"),
+    )
+    assert config.lora is not None
+    assert config.lora.adapter_id == "my-org/my-adapter"
+
+
+def test_lora_null_in_experiment_config():
+    """lora=None is valid (default)."""
+    config = ExperimentConfig(model="gpt2", backend="pytorch")
+    assert config.lora is None

--- a/tests/unit/config/test_vllm_lora_config.py
+++ b/tests/unit/config/test_vllm_lora_config.py
@@ -1,0 +1,71 @@
+"""Unit tests for vLLM LoRA engine config fields.
+
+Tests cover:
+- enable_lora field
+- max_lora_rank constraints
+- lora_extra_vocab_size constraints
+- lora_dtype Literal validation
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from llenergymeasure.config.backend_configs import VLLMEngineConfig
+
+# ---------------------------------------------------------------------------
+# enable_lora
+# ---------------------------------------------------------------------------
+
+
+def test_vllm_enable_lora():
+    """VLLMEngineConfig accepts enable_lora=True."""
+    config = VLLMEngineConfig(enable_lora=True)
+    assert config.enable_lora is True
+
+
+# ---------------------------------------------------------------------------
+# max_lora_rank
+# ---------------------------------------------------------------------------
+
+
+def test_vllm_max_lora_rank():
+    """VLLMEngineConfig accepts valid max_lora_rank."""
+    config = VLLMEngineConfig(max_lora_rank=32)
+    assert config.max_lora_rank == 32
+
+
+def test_vllm_max_lora_rank_zero_rejected():
+    """max_lora_rank=0 violates ge=1 constraint."""
+    with pytest.raises(ValidationError):
+        VLLMEngineConfig(max_lora_rank=0)
+
+
+# ---------------------------------------------------------------------------
+# lora_extra_vocab_size
+# ---------------------------------------------------------------------------
+
+
+def test_vllm_lora_extra_vocab_size():
+    """VLLMEngineConfig accepts valid lora_extra_vocab_size."""
+    config = VLLMEngineConfig(lora_extra_vocab_size=512)
+    assert config.lora_extra_vocab_size == 512
+
+
+# ---------------------------------------------------------------------------
+# lora_dtype
+# ---------------------------------------------------------------------------
+
+
+def test_vllm_lora_dtype():
+    """VLLMEngineConfig accepts valid lora_dtype literal values."""
+    for dtype in ("float16", "bfloat16", "float32", "auto"):
+        config = VLLMEngineConfig(lora_dtype=dtype)
+        assert config.lora_dtype == dtype
+
+
+def test_vllm_lora_dtype_invalid_rejected():
+    """Invalid lora_dtype string is rejected."""
+    with pytest.raises(ValidationError):
+        VLLMEngineConfig(lora_dtype="int8")


### PR DESCRIPTION
## Summary

- Wire LoRA adapter loading into PyTorch backend via PEFT (`PeftModel.from_pretrained`, optional `merge_and_unload()`)
- Add `revision` field to `LoRAConfig` for pinning Hub adapter versions
- Declare vLLM LoRA engine fields (`enable_lora`, `max_lora_rank`, `max_loras`, `lora_extra_vocab_size`, `lora_dtype`) on `VLLMEngineConfig`
- Update introspection capability matrix for vLLM LoRA support
- Add `peft>=0.12` to `[pytorch]` optional dependencies
- 25 new tests (config validation, mocked backend integration, vLLM config)

## Scope

**PyTorch**: Fully wired. Adapter loaded after `from_pretrained()`, before `torch.compile()`. `merge_weights` merges via `merge_and_unload()`. `validate_config()` checks peft importability and local path existence.

**vLLM**: Config fields declared only. Runtime wiring (LoRARequest per prompt, auto-enable) is future work - needs a cross-backend design doc first.

**TRT-LLM**: Not supported yet (engine build with `--lora_plugin`, weight conversion pipeline).

## Future work

Cross-backend LoRA design review needed before wiring vLLM/TRT-LLM runtime support. Each backend handles adapters at fundamentally different levels (model-level vs per-request vs build-time). Tracked in `.planning/todos/pending/`.

## Test plan

- [x] 10 tests: LoRAConfig validation (XOR source, revision constraints, extra fields)
- [x] 9 tests: PyTorch backend LoRA integration (mocked, no GPU)
- [x] 6 tests: vLLM LoRA engine config fields
- [x] Full suite green (no regressions)