### PR TITLE
fix(ci): free disk space before docker-smoke builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,12 @@ jobs:
     continue-on-error: ${{ !matrix.blocking }}
     steps:
       - uses: actions/checkout@v6
+      - name: Free disk space
+        run: |
+          # Remove large pre-installed packages that aren't needed
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
       - name: Build ${{ matrix.dockerfile }} image
         run: docker build -f docker/Dockerfile.${{ matrix.dockerfile }} --build-arg INSTALL_FA3=false . -t smoke-${{ matrix.dockerfile }}
       - name: Smoke test ${{ matrix.dockerfile }}


### PR DESCRIPTION
## Summary

- Add disk space cleanup step before Docker builds in the `docker-smoke` CI job
- Removes pre-installed .NET SDK, Android SDK, GHC, and CodeQL bundles (~12GB+)
- Fixes `no space left on device` error when building PyTorch Docker image on `ubuntu-latest` runners

## Context

The PyTorch base image is ~3.3GB and the runner only has ~14GB free. The multi-stage build exceeds this during layer registration. This is the standard cleanup approach for GitHub-hosted runners.