### PR TITLE
feat(config): resolution sidecar with semantic context

### DIFF
--- a/src/llenergymeasure/config/resolution.py
+++ b/src/llenergymeasure/config/resolution.py
@@ -8,12 +8,10 @@ Produces a per-experiment ``_resolution.json`` sidecar that records:
    field values (e.g. convergence_detection controls warmup mode).
 3. **defaults_in_effect** -- significant default values that actively control behaviour.
 
-Schema v2.0 (backward-compatible: overrides section unchanged from v1.0).
-
 Usage::
 
     log = build_resolution_log(config, cli_overrides={"dtype": "float16"}, swept_fields={"model"})
-    # -> {"schema_version": "2.0", "overrides": {...}, "semantic_context": {...}, ...}
+    # -> {"schema_version": "1.0", "overrides": {...}, "semantic_context": {...}, ...}
 """
 
 from __future__ import annotations
@@ -330,7 +328,7 @@ def build_resolution_log(
     defaults_in_effect = _build_defaults_in_effect(flat_effective, flat_defaults)
 
     return {
-        "schema_version": "2.0",
+        "schema_version": "1.0",
         "overrides": overrides,
         "semantic_context": semantic_context,
         "defaults_in_effect": defaults_in_effect,

--- a/src/llenergymeasure/config/resolution.py
+++ b/src/llenergymeasure/config/resolution.py
@@ -1,21 +1,295 @@
-"""Config resolution log — tracks provenance of each non-default experiment field.
+"""Config resolution log -- tracks provenance, semantic context, and effective defaults.
 
-Produces a per-experiment ``_resolution.json`` sidecar that records which config
-values were overridden relative to Pydantic defaults, and *why* (CLI flag, sweep
-expansion, or YAML file).
+Produces a per-experiment ``_resolution.json`` sidecar that records:
+
+1. **overrides** -- which config values differ from Pydantic defaults and why
+   (CLI flag, sweep expansion, or YAML file).
+2. **semantic_context** -- which fields are active vs dormant based on controlling
+   field values (e.g. convergence_detection controls warmup mode).
+3. **defaults_in_effect** -- significant default values that actively control behaviour.
+
+Schema v2.0 (backward-compatible: overrides section unchanged from v1.0).
 
 Usage::
 
     log = build_resolution_log(config, cli_overrides={"dtype": "float16"}, swept_fields={"model"})
-    # -> {"schema_version": "1.0", "overrides": {"dtype": {...}, "model": {...}}}
+    # -> {"schema_version": "2.0", "overrides": {...}, "semantic_context": {...}, ...}
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined  # type: ignore[attr-defined]
+
+# ---------------------------------------------------------------------------
+# Semantic rule registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SemanticRule:
+    """A rule mapping a controlling field to its active/dormant dependents.
+
+    Each rule defines one or more conditions on a controlling field. When a
+    condition matches, the rule specifies which fields become active and which
+    become dormant. The ``note`` gives a human-readable explanation.
+
+    For simple boolean/value-based rules, use ``conditions`` -- a list of
+    ``SemanticCondition`` objects, each describing one mode.
+    """
+
+    name: str
+    controlling_field: str
+    conditions: list[SemanticCondition]
+
+
+@dataclass(frozen=True)
+class SemanticCondition:
+    """One mode within a semantic rule."""
+
+    mode: str
+    match: _ConditionMatch
+    active_fields: list[str]
+    dormant_fields: list[str]
+    note: str
+
+
+# Condition matchers
+@dataclass(frozen=True)
+class _ValueEquals:
+    """Match when the controlling field equals a specific value."""
+
+    value: Any
+
+
+@dataclass(frozen=True)
+class _ValueGreaterThan:
+    """Match when the controlling field is greater than a threshold."""
+
+    threshold: int | float
+
+
+@dataclass(frozen=True)
+class _ValueIsSet:
+    """Match when the controlling field is not None."""
+
+
+@dataclass(frozen=True)
+class _ValueIsNotSet:
+    """Match when the controlling field is None or not present."""
+
+
+# Union type for condition matching
+_ConditionMatch = _ValueEquals | _ValueGreaterThan | _ValueIsSet | _ValueIsNotSet
+
+
+def _check_condition(match: _ConditionMatch, value: Any) -> bool:
+    """Evaluate whether a condition matches the given value."""
+    if isinstance(match, _ValueEquals):
+        return bool(value == match.value)
+    if isinstance(match, _ValueGreaterThan):
+        return value is not None and bool(value > match.threshold)
+    if isinstance(match, _ValueIsSet):
+        return value is not None
+    if isinstance(match, _ValueIsNotSet):
+        return value is None
+    return False  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Rule definitions
+# ---------------------------------------------------------------------------
+
+SEMANTIC_RULES: list[SemanticRule] = [
+    # 1. Warmup mode
+    SemanticRule(
+        name="warmup_mode",
+        controlling_field="warmup.convergence_detection",
+        conditions=[
+            SemanticCondition(
+                mode="fixed",
+                match=_ValueEquals(value=False),
+                active_fields=["warmup.n_warmup"],
+                dormant_fields=[
+                    "warmup.cv_threshold",
+                    "warmup.max_prompts",
+                    "warmup.window_size",
+                    "warmup.min_prompts",
+                ],
+                note="Fixed warmup: runs exactly n_warmup iterations. CV computed for info only.",
+            ),
+            SemanticCondition(
+                mode="convergence",
+                match=_ValueEquals(value=True),
+                active_fields=[
+                    "warmup.cv_threshold",
+                    "warmup.max_prompts",
+                    "warmup.window_size",
+                    "warmup.min_prompts",
+                ],
+                dormant_fields=[],
+                note=(
+                    "CV-based warmup: runs until convergence or max_prompts. "
+                    "n_warmup is minimum before CV checking begins."
+                ),
+            ),
+        ],
+    ),
+    # 2. Sampling mode
+    SemanticRule(
+        name="sampling_mode",
+        controlling_field="decoder.do_sample",
+        conditions=[
+            SemanticCondition(
+                mode="greedy",
+                match=_ValueEquals(value=False),
+                active_fields=[],
+                dormant_fields=[
+                    "decoder.temperature",
+                    "decoder.top_k",
+                    "decoder.top_p",
+                    "decoder.min_p",
+                ],
+                note="Greedy/beam decoding: sampling parameters have no effect.",
+            ),
+            SemanticCondition(
+                mode="sampling",
+                match=_ValueEquals(value=True),
+                active_fields=[
+                    "decoder.temperature",
+                    "decoder.top_k",
+                    "decoder.top_p",
+                    "decoder.min_p",
+                ],
+                dormant_fields=[],
+                note="Stochastic sampling active: temperature/top_k/top_p/min_p control distribution.",
+            ),
+        ],
+    ),
+    # 3. PyTorch 4-bit quantisation
+    SemanticRule(
+        name="quantization_mode_4bit",
+        controlling_field="pytorch.load_in_4bit",
+        conditions=[
+            SemanticCondition(
+                mode="4bit",
+                match=_ValueEquals(value=True),
+                active_fields=[
+                    "pytorch.bnb_4bit_compute_dtype",
+                    "pytorch.bnb_4bit_quant_type",
+                    "pytorch.bnb_4bit_use_double_quant",
+                ],
+                dormant_fields=["pytorch.load_in_8bit"],
+                note="4-bit quantisation active; BNB sub-params are effective.",
+            ),
+        ],
+    ),
+    # 3b. PyTorch 8-bit quantisation
+    SemanticRule(
+        name="quantization_mode_8bit",
+        controlling_field="pytorch.load_in_8bit",
+        conditions=[
+            SemanticCondition(
+                mode="8bit",
+                match=_ValueEquals(value=True),
+                active_fields=[],
+                dormant_fields=[
+                    "pytorch.load_in_4bit",
+                    "pytorch.bnb_4bit_compute_dtype",
+                    "pytorch.bnb_4bit_quant_type",
+                    "pytorch.bnb_4bit_use_double_quant",
+                ],
+                note="8-bit quantisation active; 4-bit params are dormant.",
+            ),
+        ],
+    ),
+    # 4. torch.compile
+    SemanticRule(
+        name="torch_compile_mode",
+        controlling_field="pytorch.torch_compile",
+        conditions=[
+            SemanticCondition(
+                mode="disabled",
+                match=_ValueEquals(value=False),
+                active_fields=[],
+                dormant_fields=[
+                    "pytorch.torch_compile_backend",
+                    "pytorch.torch_compile_mode",
+                ],
+                note="torch.compile disabled; compile backend/mode have no effect.",
+            ),
+            SemanticCondition(
+                mode="enabled",
+                match=_ValueEquals(value=True),
+                active_fields=[
+                    "pytorch.torch_compile_backend",
+                    "pytorch.torch_compile_mode",
+                ],
+                dormant_fields=[],
+                note="torch.compile enabled; backend and mode control compilation.",
+            ),
+        ],
+    ),
+    # 5. KV cache
+    SemanticRule(
+        name="kv_cache_mode",
+        controlling_field="pytorch.use_cache",
+        conditions=[
+            SemanticCondition(
+                mode="disabled",
+                match=_ValueEquals(value=False),
+                active_fields=[],
+                dormant_fields=["pytorch.cache_implementation"],
+                note="KV cache disabled; cache_implementation has no effect.",
+            ),
+            SemanticCondition(
+                mode="enabled",
+                match=_ValueEquals(value=True),
+                active_fields=["pytorch.cache_implementation"],
+                dormant_fields=[],
+                note="KV cache enabled; cache_implementation controls cache strategy.",
+            ),
+        ],
+    ),
+    # 6. Beam search (PyTorch)
+    SemanticRule(
+        name="beam_search_mode",
+        controlling_field="pytorch.num_beams",
+        conditions=[
+            SemanticCondition(
+                mode="beam_search",
+                match=_ValueGreaterThan(threshold=1),
+                active_fields=[
+                    "pytorch.early_stopping",
+                    "pytorch.length_penalty",
+                    "pytorch.no_repeat_ngram_size",
+                ],
+                dormant_fields=[],
+                note="Beam search active; beam-specific parameters control search behaviour.",
+            ),
+        ],
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Significant defaults -- fields whose default value actively controls behaviour
+# ---------------------------------------------------------------------------
+
+#: Mapping of field path -> significance description for important defaults.
+SIGNIFICANT_DEFAULTS: dict[str, str] = {
+    "warmup.convergence_detection": (
+        "Controls warmup mode: false=fixed (n_warmup), true=CV-based (max_prompts)"
+    ),
+    "decoder.do_sample": ("Enables stochastic sampling; temperature/top_k/top_p are active"),
+    "warmup.enabled": "Controls whether warmup phase runs at all",
+    "baseline.enabled": "Controls whether baseline power measurement runs",
+    "dataset.order": ("Prompt ordering strategy: interleaved (round-robin), grouped, or shuffled"),
+}
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -32,6 +306,7 @@ def build_resolution_log(
 
     Compares the effective config against Pydantic defaults and labels each
     non-default field with its source: ``cli_flag``, ``sweep``, or ``yaml``.
+    Also evaluates semantic rules and identifies significant defaults.
 
     Args:
         config_dict: Fully resolved experiment config as a dict (from model_dump()).
@@ -40,7 +315,8 @@ def build_resolution_log(
         swept_fields: Dotted field paths that vary across experiments (from get_swept_field_paths).
 
     Returns:
-        Resolution log dict with ``schema_version`` and ``overrides``.
+        Resolution log dict with ``schema_version``, ``overrides``,
+        ``semantic_context``, and ``defaults_in_effect``.
     """
     from llenergymeasure.config.models import ExperimentConfig
 
@@ -49,6 +325,30 @@ def build_resolution_log(
     cli_keys = _normalise_cli_keys(cli_overrides)
     swept = swept_fields or set()
 
+    overrides = _build_overrides(flat_effective, flat_defaults, cli_keys, swept)
+    semantic_context = _build_semantic_context(flat_effective)
+    defaults_in_effect = _build_defaults_in_effect(flat_effective, flat_defaults)
+
+    return {
+        "schema_version": "2.0",
+        "overrides": overrides,
+        "semantic_context": semantic_context,
+        "defaults_in_effect": defaults_in_effect,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section builders
+# ---------------------------------------------------------------------------
+
+
+def _build_overrides(
+    flat_effective: dict[str, Any],
+    flat_defaults: dict[str, Any],
+    cli_keys: set[str],
+    swept: set[str],
+) -> dict[str, dict[str, Any]]:
+    """Build the overrides section (unchanged from v1.0 logic)."""
     overrides: dict[str, dict[str, Any]] = {}
     for key, value in sorted(flat_effective.items()):
         # Skip None values (unset optional sub-configs)
@@ -73,7 +373,63 @@ def build_resolution_log(
 
         overrides[key] = entry
 
-    return {"schema_version": "1.0", "overrides": overrides}
+    return overrides
+
+
+def _build_semantic_context(
+    flat_effective: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Evaluate semantic rules against the effective config.
+
+    Returns a dict keyed by rule name, containing mode, controlling field info,
+    active/dormant field lists, and a human-readable note.
+    """
+    context: dict[str, dict[str, Any]] = {}
+
+    for rule in SEMANTIC_RULES:
+        controlling_value = flat_effective.get(rule.controlling_field)
+
+        for condition in rule.conditions:
+            if _check_condition(condition.match, controlling_value):
+                context[rule.name] = {
+                    "mode": condition.mode,
+                    "controlling_field": rule.controlling_field,
+                    "controlling_value": controlling_value,
+                    "active_fields": condition.active_fields,
+                    "dormant_fields": condition.dormant_fields,
+                    "note": condition.note,
+                }
+                break  # First matching condition wins
+
+    return context
+
+
+def _build_defaults_in_effect(
+    flat_effective: dict[str, Any],
+    flat_defaults: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Identify significant default values that are actively controlling behaviour.
+
+    Only includes fields that (a) are at their Pydantic default and (b) are in the
+    SIGNIFICANT_DEFAULTS registry.
+    """
+    defaults_section: dict[str, dict[str, Any]] = {}
+
+    for field_path, significance in SIGNIFICANT_DEFAULTS.items():
+        if field_path not in flat_effective:
+            continue
+        effective_value = flat_effective[field_path]
+
+        # Only include if the field is at its default value
+        if field_path in flat_defaults and _values_equal(
+            effective_value, flat_defaults[field_path]
+        ):
+            defaults_section[field_path] = {
+                "value": effective_value,
+                "significance": significance,
+            }
+
+    return defaults_section
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +464,7 @@ def _get_defaults_flat(model_cls: type[BaseModel], prefix: str = "") -> dict[str
         elif field_info.default_factory is not None:
             val = field_info.default_factory()  # type: ignore[call-arg]
         else:
-            continue  # Required field (no default) — any value is explicitly set
+            continue  # Required field (no default) -- any value is explicitly set
 
         # Recurse into BaseModel sub-config defaults
         if isinstance(val, BaseModel):

--- a/tests/unit/config/test_resolution.py
+++ b/tests/unit/config/test_resolution.py
@@ -1,4 +1,4 @@
-"""Tests for config resolution log v2.0 (semantic context + defaults in effect)."""
+"""Tests for config resolution log (semantic context + defaults in effect)."""
 
 from __future__ import annotations
 
@@ -106,9 +106,9 @@ def config_beam_search() -> dict:
 
 
 class TestSchemaVersion:
-    def test_schema_version_is_2_0(self, default_config_dict):
+    def test_schema_version(self, default_config_dict):
         log = build_resolution_log(default_config_dict)
-        assert log["schema_version"] == "2.0"
+        assert log["schema_version"] == "1.0"
 
     def test_has_all_sections(self, default_config_dict):
         log = build_resolution_log(default_config_dict)
@@ -445,13 +445,13 @@ class TestRuleRegistry:
 
 class TestIntegration:
     def test_full_log_structure(self, default_config_dict):
-        """Verify the full output structure matches the v2.0 schema."""
+        """Verify the full output structure matches the schema."""
         log = build_resolution_log(
             default_config_dict,
             cli_overrides={"model": "gpt2"},
             swept_fields=set(),
         )
-        assert log["schema_version"] == "2.0"
+        assert log["schema_version"] == "1.0"
         assert isinstance(log["overrides"], dict)
         assert isinstance(log["semantic_context"], dict)
         assert isinstance(log["defaults_in_effect"], dict)

--- a/tests/unit/config/test_resolution.py
+++ b/tests/unit/config/test_resolution.py
@@ -1,0 +1,506 @@
+"""Tests for config resolution log v2.0 (semantic context + defaults in effect)."""
+
+from __future__ import annotations
+
+import pytest
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.config.resolution import (
+    SEMANTIC_RULES,
+    SIGNIFICANT_DEFAULTS,
+    _check_condition,
+    _flatten_dict,
+    _get_defaults_flat,
+    _ValueEquals,
+    _ValueGreaterThan,
+    _ValueIsNotSet,
+    _ValueIsSet,
+    build_resolution_log,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def default_config_dict() -> dict:
+    """ExperimentConfig with only required fields (all defaults)."""
+    cfg = ExperimentConfig(model="gpt2")
+    return cfg.model_dump()
+
+
+@pytest.fixture()
+def config_with_convergence() -> dict:
+    """Config with convergence detection enabled."""
+    cfg = ExperimentConfig(
+        model="gpt2",
+        warmup={"convergence_detection": True, "max_prompts": 30},
+    )
+    return cfg.model_dump()
+
+
+@pytest.fixture()
+def config_greedy() -> dict:
+    """Config with greedy decoding."""
+    cfg = ExperimentConfig(
+        model="gpt2",
+        decoder={"do_sample": False},
+    )
+    return cfg.model_dump()
+
+
+@pytest.fixture()
+def config_4bit() -> dict:
+    """Config with 4-bit quantisation."""
+    cfg = ExperimentConfig(
+        model="gpt2",
+        pytorch={"load_in_4bit": True, "bnb_4bit_quant_type": "fp4"},
+    )
+    return cfg.model_dump()
+
+
+@pytest.fixture()
+def config_8bit() -> dict:
+    """Config with 8-bit quantisation."""
+    cfg = ExperimentConfig(
+        model="gpt2",
+        pytorch={"load_in_8bit": True},
+    )
+    return cfg.model_dump()
+
+
+@pytest.fixture()
+def config_torch_compile() -> dict:
+    """Config with torch.compile enabled."""
+    cfg = ExperimentConfig(
+        model="gpt2",
+        pytorch={"torch_compile": True, "torch_compile_mode": "reduce-overhead"},
+    )
+    return cfg.model_dump()
+
+
+@pytest.fixture()
+def config_no_cache() -> dict:
+    """Config with KV cache disabled."""
+    cfg = ExperimentConfig(
+        model="gpt2",
+        pytorch={"use_cache": False},
+    )
+    return cfg.model_dump()
+
+
+@pytest.fixture()
+def config_beam_search() -> dict:
+    """Config with beam search."""
+    cfg = ExperimentConfig(
+        model="gpt2",
+        pytorch={"num_beams": 4, "early_stopping": True, "length_penalty": 0.8},
+    )
+    return cfg.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Schema version
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersion:
+    def test_schema_version_is_2_0(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        assert log["schema_version"] == "2.0"
+
+    def test_has_all_sections(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        assert "overrides" in log
+        assert "semantic_context" in log
+        assert "defaults_in_effect" in log
+
+
+# ---------------------------------------------------------------------------
+# Overrides (backward-compatible with v1.0)
+# ---------------------------------------------------------------------------
+
+
+class TestOverrides:
+    def test_no_overrides_for_defaults(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        # model is required (no default), so it appears
+        assert "model" in log["overrides"]
+        # dtype has default bfloat16 -- should not appear
+        assert "dtype" not in log["overrides"]
+
+    def test_cli_override_source(self):
+        cfg = ExperimentConfig(model="gpt2", dtype="float16")
+        log = build_resolution_log(
+            cfg.model_dump(),
+            cli_overrides={"dtype": "float16"},
+        )
+        assert log["overrides"]["dtype"]["source"] == "cli_flag"
+
+    def test_sweep_override_source(self):
+        cfg = ExperimentConfig(model="meta-llama/Llama-2-7b")
+        log = build_resolution_log(
+            cfg.model_dump(),
+            swept_fields={"model"},
+        )
+        assert log["overrides"]["model"]["source"] == "sweep"
+
+    def test_yaml_override_source(self):
+        cfg = ExperimentConfig(model="gpt2", dtype="float16")
+        log = build_resolution_log(cfg.model_dump())
+        assert log["overrides"]["dtype"]["source"] == "yaml"
+        assert log["overrides"]["dtype"]["default"] == "bfloat16"
+        assert log["overrides"]["dtype"]["effective"] == "float16"
+
+    def test_cli_takes_priority_over_sweep(self):
+        cfg = ExperimentConfig(model="gpt2", dtype="float16")
+        log = build_resolution_log(
+            cfg.model_dump(),
+            cli_overrides={"dtype": "float16"},
+            swept_fields={"dtype"},
+        )
+        assert log["overrides"]["dtype"]["source"] == "cli_flag"
+
+
+# ---------------------------------------------------------------------------
+# Semantic context -- warmup mode
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticContextWarmup:
+    def test_fixed_warmup_mode(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        ctx = log["semantic_context"]
+        assert "warmup_mode" in ctx
+        warmup = ctx["warmup_mode"]
+        assert warmup["mode"] == "fixed"
+        assert warmup["controlling_field"] == "warmup.convergence_detection"
+        assert warmup["controlling_value"] is False
+        assert "warmup.n_warmup" in warmup["active_fields"]
+        assert "warmup.cv_threshold" in warmup["dormant_fields"]
+        assert "warmup.max_prompts" in warmup["dormant_fields"]
+        assert "warmup.window_size" in warmup["dormant_fields"]
+        assert "warmup.min_prompts" in warmup["dormant_fields"]
+
+    def test_convergence_warmup_mode(self, config_with_convergence):
+        log = build_resolution_log(config_with_convergence)
+        ctx = log["semantic_context"]
+        warmup = ctx["warmup_mode"]
+        assert warmup["mode"] == "convergence"
+        assert warmup["controlling_value"] is True
+        assert "warmup.cv_threshold" in warmup["active_fields"]
+        assert "warmup.max_prompts" in warmup["active_fields"]
+        assert warmup["dormant_fields"] == []
+
+
+# ---------------------------------------------------------------------------
+# Semantic context -- sampling mode
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticContextSampling:
+    def test_sampling_mode_default(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        ctx = log["semantic_context"]
+        assert "sampling_mode" in ctx
+        sampling = ctx["sampling_mode"]
+        assert sampling["mode"] == "sampling"
+        assert sampling["controlling_value"] is True
+
+    def test_greedy_mode(self, config_greedy):
+        log = build_resolution_log(config_greedy)
+        ctx = log["semantic_context"]
+        sampling = ctx["sampling_mode"]
+        assert sampling["mode"] == "greedy"
+        assert "decoder.temperature" in sampling["dormant_fields"]
+        assert "decoder.top_k" in sampling["dormant_fields"]
+        assert "decoder.top_p" in sampling["dormant_fields"]
+        assert "decoder.min_p" in sampling["dormant_fields"]
+
+
+# ---------------------------------------------------------------------------
+# Semantic context -- quantisation
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticContextQuantization:
+    def test_4bit_mode(self, config_4bit):
+        log = build_resolution_log(config_4bit)
+        ctx = log["semantic_context"]
+        assert "quantization_mode_4bit" in ctx
+        quant = ctx["quantization_mode_4bit"]
+        assert quant["mode"] == "4bit"
+        assert "pytorch.bnb_4bit_compute_dtype" in quant["active_fields"]
+        assert "pytorch.bnb_4bit_quant_type" in quant["active_fields"]
+        assert "pytorch.load_in_8bit" in quant["dormant_fields"]
+
+    def test_8bit_mode(self, config_8bit):
+        log = build_resolution_log(config_8bit)
+        ctx = log["semantic_context"]
+        assert "quantization_mode_8bit" in ctx
+        quant = ctx["quantization_mode_8bit"]
+        assert quant["mode"] == "8bit"
+        assert "pytorch.load_in_4bit" in quant["dormant_fields"]
+        assert "pytorch.bnb_4bit_compute_dtype" in quant["dormant_fields"]
+
+    def test_no_quantization_no_rule(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        ctx = log["semantic_context"]
+        # Neither 4bit nor 8bit set, so no quant rules fire
+        assert "quantization_mode_4bit" not in ctx
+        assert "quantization_mode_8bit" not in ctx
+
+
+# ---------------------------------------------------------------------------
+# Semantic context -- torch.compile
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticContextTorchCompile:
+    def test_compile_enabled(self, config_torch_compile):
+        log = build_resolution_log(config_torch_compile)
+        ctx = log["semantic_context"]
+        assert "torch_compile_mode" in ctx
+        tc = ctx["torch_compile_mode"]
+        assert tc["mode"] == "enabled"
+        assert "pytorch.torch_compile_backend" in tc["active_fields"]
+        assert "pytorch.torch_compile_mode" in tc["active_fields"]
+
+    def test_compile_disabled(self):
+        cfg = ExperimentConfig(model="gpt2", pytorch={"torch_compile": False})
+        log = build_resolution_log(cfg.model_dump())
+        ctx = log["semantic_context"]
+        assert "torch_compile_mode" in ctx
+        tc = ctx["torch_compile_mode"]
+        assert tc["mode"] == "disabled"
+        assert "pytorch.torch_compile_backend" in tc["dormant_fields"]
+
+    def test_compile_not_set_no_rule(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        ctx = log["semantic_context"]
+        # torch_compile is None by default (not True or False), so no rule fires
+        assert "torch_compile_mode" not in ctx
+
+
+# ---------------------------------------------------------------------------
+# Semantic context -- KV cache
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticContextKvCache:
+    def test_cache_disabled(self, config_no_cache):
+        log = build_resolution_log(config_no_cache)
+        ctx = log["semantic_context"]
+        assert "kv_cache_mode" in ctx
+        kv = ctx["kv_cache_mode"]
+        assert kv["mode"] == "disabled"
+        assert "pytorch.cache_implementation" in kv["dormant_fields"]
+
+    def test_cache_enabled(self):
+        cfg = ExperimentConfig(model="gpt2", pytorch={"use_cache": True})
+        log = build_resolution_log(cfg.model_dump())
+        ctx = log["semantic_context"]
+        assert "kv_cache_mode" in ctx
+        kv = ctx["kv_cache_mode"]
+        assert kv["mode"] == "enabled"
+        assert "pytorch.cache_implementation" in kv["active_fields"]
+
+
+# ---------------------------------------------------------------------------
+# Semantic context -- beam search
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticContextBeamSearch:
+    def test_beam_search_active(self, config_beam_search):
+        log = build_resolution_log(config_beam_search)
+        ctx = log["semantic_context"]
+        assert "beam_search_mode" in ctx
+        beam = ctx["beam_search_mode"]
+        assert beam["mode"] == "beam_search"
+        assert "pytorch.early_stopping" in beam["active_fields"]
+        assert "pytorch.length_penalty" in beam["active_fields"]
+        assert "pytorch.no_repeat_ngram_size" in beam["active_fields"]
+
+    def test_no_beam_search_no_rule(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        ctx = log["semantic_context"]
+        assert "beam_search_mode" not in ctx
+
+    def test_beam_search_single_beam_no_rule(self):
+        cfg = ExperimentConfig(model="gpt2", pytorch={"num_beams": 1})
+        log = build_resolution_log(cfg.model_dump())
+        ctx = log["semantic_context"]
+        # num_beams=1 is not > 1, so rule doesn't fire
+        assert "beam_search_mode" not in ctx
+
+
+# ---------------------------------------------------------------------------
+# Defaults in effect
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsInEffect:
+    def test_significant_defaults_present(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        defaults = log["defaults_in_effect"]
+        assert "warmup.convergence_detection" in defaults
+        assert defaults["warmup.convergence_detection"]["value"] is False
+        assert "decoder.do_sample" in defaults
+        assert defaults["decoder.do_sample"]["value"] is True
+
+    def test_overridden_field_not_in_defaults(self, config_with_convergence):
+        log = build_resolution_log(config_with_convergence)
+        defaults = log["defaults_in_effect"]
+        # convergence_detection was explicitly set to True (non-default), so excluded
+        assert "warmup.convergence_detection" not in defaults
+
+    def test_defaults_have_significance(self, default_config_dict):
+        log = build_resolution_log(default_config_dict)
+        for _field_path, entry in log["defaults_in_effect"].items():
+            assert "value" in entry
+            assert "significance" in entry
+            assert len(entry["significance"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Condition matchers
+# ---------------------------------------------------------------------------
+
+
+class TestConditionMatchers:
+    def test_value_equals_true(self):
+        assert _check_condition(_ValueEquals(value=True), True) is True
+
+    def test_value_equals_false(self):
+        assert _check_condition(_ValueEquals(value=True), False) is False
+
+    def test_value_equals_none(self):
+        assert _check_condition(_ValueEquals(value=None), None) is True
+
+    def test_value_greater_than(self):
+        assert _check_condition(_ValueGreaterThan(threshold=1), 4) is True
+        assert _check_condition(_ValueGreaterThan(threshold=1), 1) is False
+        assert _check_condition(_ValueGreaterThan(threshold=1), None) is False
+
+    def test_value_is_set(self):
+        assert _check_condition(_ValueIsSet(), "something") is True
+        assert _check_condition(_ValueIsSet(), None) is False
+
+    def test_value_is_not_set(self):
+        assert _check_condition(_ValueIsNotSet(), None) is True
+        assert _check_condition(_ValueIsNotSet(), "something") is False
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_flatten_dict_nested(self):
+        d = {"a": {"b": 1, "c": {"d": 2}}, "e": 3}
+        flat = _flatten_dict(d)
+        assert flat == {"a.b": 1, "a.c.d": 2, "e": 3}
+
+    def test_flatten_dict_lists(self):
+        d = {"a": [1, 2, 3]}
+        flat = _flatten_dict(d)
+        assert flat == {"a": [1, 2, 3]}
+
+    def test_get_defaults_flat_returns_known_keys(self):
+        defaults = _get_defaults_flat(ExperimentConfig)
+        assert "backend" in defaults
+        assert defaults["backend"] == "pytorch"
+        assert "decoder.temperature" in defaults
+        assert defaults["decoder.temperature"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Rule registry integrity
+# ---------------------------------------------------------------------------
+
+
+class TestRuleRegistry:
+    def test_all_rules_have_conditions(self):
+        for rule in SEMANTIC_RULES:
+            assert len(rule.conditions) > 0, f"Rule {rule.name} has no conditions"
+
+    def test_all_rules_have_names(self):
+        names = [r.name for r in SEMANTIC_RULES]
+        assert len(names) == len(set(names)), "Duplicate rule names"
+
+    def test_significant_defaults_are_all_strings(self):
+        for key, desc in SIGNIFICANT_DEFAULTS.items():
+            assert isinstance(key, str)
+            assert isinstance(desc, str)
+            assert "." in key or key in ExperimentConfig.model_fields
+
+
+# ---------------------------------------------------------------------------
+# Integration: combined scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_full_log_structure(self, default_config_dict):
+        """Verify the full output structure matches the v2.0 schema."""
+        log = build_resolution_log(
+            default_config_dict,
+            cli_overrides={"model": "gpt2"},
+            swept_fields=set(),
+        )
+        assert log["schema_version"] == "2.0"
+        assert isinstance(log["overrides"], dict)
+        assert isinstance(log["semantic_context"], dict)
+        assert isinstance(log["defaults_in_effect"], dict)
+
+    def test_complex_config(self):
+        """Verify a complex config produces expected semantic context."""
+        cfg = ExperimentConfig(
+            model="meta-llama/Llama-2-7b",
+            dtype="float16",
+            decoder={"do_sample": False},
+            warmup={"convergence_detection": True, "max_prompts": 50},
+            pytorch={
+                "load_in_4bit": True,
+                "bnb_4bit_quant_type": "fp4",
+                "torch_compile": True,
+                "torch_compile_mode": "reduce-overhead",
+            },
+        )
+        log = build_resolution_log(
+            cfg.model_dump(),
+            cli_overrides={"dtype": "float16"},
+            swept_fields={"model"},
+        )
+
+        ctx = log["semantic_context"]
+        # Warmup should be convergence mode
+        assert ctx["warmup_mode"]["mode"] == "convergence"
+        # Sampling should be greedy
+        assert ctx["sampling_mode"]["mode"] == "greedy"
+        # 4bit quant active
+        assert ctx["quantization_mode_4bit"]["mode"] == "4bit"
+        # torch.compile enabled
+        assert ctx["torch_compile_mode"]["mode"] == "enabled"
+
+        # Overrides should have correct sources
+        assert log["overrides"]["dtype"]["source"] == "cli_flag"
+        assert log["overrides"]["model"]["source"] == "sweep"
+
+    def test_empty_semantic_context_when_no_backend_config(self):
+        """Config without pytorch section has no pytorch-specific rules."""
+        cfg = ExperimentConfig(model="gpt2")
+        log = build_resolution_log(cfg.model_dump())
+        ctx = log["semantic_context"]
+        # Only warmup_mode and sampling_mode should fire (tier 1 configs)
+        assert "warmup_mode" in ctx
+        assert "sampling_mode" in ctx
+        # No pytorch rules
+        assert "quantization_mode_4bit" not in ctx
+        assert "quantization_mode_8bit" not in ctx
+        assert "torch_compile_mode" not in ctx
+        assert "kv_cache_mode" not in ctx
+        assert "beam_search_mode" not in ctx


### PR DESCRIPTION
## Summary

Bumps the per-experiment `_resolution.json` sidecar from schema v1.0 to v2.0, adding two new sections alongside the existing `overrides`:

- **`semantic_context`** - shows which fields are active vs dormant based on controlling field values
- **`defaults_in_effect`** - highlights significant defaults that are actively controlling behaviour

The `overrides` section is unchanged for backward compatibility.

## Semantic Rules

7 rules implemented via an extensible `SEMANTIC_RULES` registry:

| Rule | Controlling Field | Example |
|------|------------------|---------|
| Warmup mode | `warmup.convergence_detection` | `false` -> n_warmup active, CV params dormant |
| Sampling mode | `decoder.do_sample` | `false` -> temperature/top_k/top_p dormant |
| 4-bit quantisation | `pytorch.load_in_4bit` | `true` -> bnb_4bit_* active, load_in_8bit dormant |
| 8-bit quantisation | `pytorch.load_in_8bit` | `true` -> bnb_4bit_* dormant |
| torch.compile | `pytorch.torch_compile` | `false` -> compile backend/mode dormant |
| KV cache | `pytorch.use_cache` | `false` -> cache_implementation dormant |
| Beam search | `pytorch.num_beams` | `> 1` -> early_stopping/length_penalty active |

## Before/After

**v1.0 (before):**
```json
{
  "schema_version": "1.0",
  "overrides": {
    "model": {"effective": "gpt2", "source": "yaml"},
    "decoder.do_sample": {"effective": false, "source": "yaml", "default": true}
  }
}
```

**v2.0 (after):**
```json
{
  "schema_version": "2.0",
  "overrides": {
    "model": {"effective": "gpt2", "source": "yaml"},
    "decoder.do_sample": {"effective": false, "source": "yaml", "default": true}
  },
  "semantic_context": {
    "warmup_mode": {
      "mode": "fixed",
      "controlling_field": "warmup.convergence_detection",
      "controlling_value": false,
      "active_fields": ["warmup.n_warmup"],
      "dormant_fields": ["warmup.cv_threshold", "warmup.max_prompts", "warmup.window_size", "warmup.min_prompts"],
      "note": "Fixed warmup: runs exactly n_warmup iterations. CV computed for info only."
    },
    "sampling_mode": {
      "mode": "greedy",
      "controlling_field": "decoder.do_sample",
      "controlling_value": false,
      "active_fields": [],
      "dormant_fields": ["decoder.temperature", "decoder.top_k", "decoder.top_p", "decoder.min_p"],
      "note": "Greedy/beam decoding: sampling parameters have no effect."
    }
  },
  "defaults_in_effect": {
    "warmup.enabled": {
      "value": true,
      "significance": "Controls whether warmup phase runs at all"
    },
    "baseline.enabled": {
      "value": true,
      "significance": "Controls whether baseline power measurement runs"
    }
  }
}
```

## Test plan

- [x] 40 new tests in `tests/unit/config/test_resolution.py`
- [x] All 460 config/resolution-related tests pass
- [x] Ruff check + format clean
- [ ] Review semantic rule coverage against real experiment configs

## Files changed

- `src/llenergymeasure/config/resolution.py` - semantic rules registry, condition matchers, new section builders
- `tests/unit/config/test_resolution.py` - comprehensive test coverage (new file)