### PR TITLE
fix(harness): enforce baseline TTL, default to validated strategy

### DIFF
--- a/docs/energy-measurement.md
+++ b/docs/energy-measurement.md
@@ -215,8 +215,8 @@ conflate background power draw with inference energy.
 
 | Strategy | Behaviour | When to use |
 |:---------|:----------|:------------|
-| `cached` (default) | Measure once, persist to disk with configurable TTL (default 1 hour). After `cache_ttl_seconds` the baseline is re-measured automatically. Docker containers load the host's cached measurement via bind-mount. | Most studies - saves ~30s per experiment after the first. |
-| `validated` | Same as `cached`, but periodically spot-checks (5s quick measurement) every N experiments. If power drift exceeds the threshold, re-measures the full baseline. | Long-running studies where thermal conditions may shift. |
+| `cached` | Measure once, persist to disk with configurable TTL. After `cache_ttl_seconds` the baseline is re-measured automatically. Docker containers load the host's cached measurement via bind-mount. | Short studies where thermal conditions are stable. |
+| `validated` (default) | Same as `cached`, but periodically spot-checks (5s quick measurement) every N experiments. If power drift exceeds the threshold, re-measures the full baseline. | Most studies - catches thermal drift with negligible overhead (~5s per spot-check). |
 | `fresh` | Every experiment measures its own baseline independently. No study-level caching. | Maximum accuracy when measurement isolation matters more than speed. |
 
 Configure via the `baseline:` section:
@@ -225,8 +225,8 @@ Configure via the `baseline:` section:
 baseline:
   enabled: true
   duration_seconds: 30        # 5-120s accepted
-  strategy: cached            # or "validated" or "fresh"
-  cache_ttl_seconds: 3600     # 1 hour TTL (strategy: cached/validated)
+  strategy: validated          # or "cached" or "fresh"
+  cache_ttl_seconds: 7200     # 2 hour TTL (strategy: cached/validated)
   validation_interval: 5      # spot-check every 5 experiments (strategy: validated)
   drift_threshold: 0.10       # 10% drift triggers re-measurement (strategy: validated)
 ```
@@ -248,7 +248,7 @@ implementation details, or have single correct values:
 | CodeCarbon tracking mode | `process` | Better attribution than `machine` for single-workload benchmarks. |
 | CodeCarbon file output | Disabled | We extract metrics programmatically; prevents stray `emissions.csv`. |
 | GPU indices | Auto-resolved | Derived from backend config (tensor_parallel_size, device_map, etc.). |
-| Baseline cache TTL | 1 hour | Configurable via `baseline.cache_ttl_seconds`. Disk-persisted and shared with Docker containers. |
+| Baseline cache TTL | 2 hours | Configurable via `baseline.cache_ttl_seconds`. Disk-persisted and shared with Docker containers. |
 | Integration method | Trapezoidal rule | Standard for non-uniform timesteps; Simpson's offers no practical gain given +/-5% sensor noise. |
 | Power reading mode | Instantaneous | Uses least-smoothed NVML reading for best temporal resolution. |
 

--- a/docs/energy-measurement.md
+++ b/docs/energy-measurement.md
@@ -215,7 +215,7 @@ conflate background power draw with inference energy.
 
 | Strategy | Behaviour | When to use |
 |:---------|:----------|:------------|
-| `cached` (default) | Measure once, persist to disk with configurable TTL (default 30 min). Docker containers load the host's cached measurement via bind-mount. | Most studies - saves ~30s per experiment after the first. |
+| `cached` (default) | Measure once, persist to disk with configurable TTL (default 1 hour). After `cache_ttl_seconds` the baseline is re-measured automatically. Docker containers load the host's cached measurement via bind-mount. | Most studies - saves ~30s per experiment after the first. |
 | `validated` | Same as `cached`, but periodically spot-checks (5s quick measurement) every N experiments. If power drift exceeds the threshold, re-measures the full baseline. | Long-running studies where thermal conditions may shift. |
 | `fresh` | Every experiment measures its own baseline independently. No study-level caching. | Maximum accuracy when measurement isolation matters more than speed. |
 
@@ -226,7 +226,7 @@ baseline:
   enabled: true
   duration_seconds: 30        # 5-120s accepted
   strategy: cached            # or "validated" or "fresh"
-  cache_ttl_seconds: 1800     # 30 min TTL (strategy: cached/validated)
+  cache_ttl_seconds: 3600     # 1 hour TTL (strategy: cached/validated)
   validation_interval: 5      # spot-check every 5 experiments (strategy: validated)
   drift_threshold: 0.10       # 10% drift triggers re-measurement (strategy: validated)
 ```
@@ -248,7 +248,7 @@ implementation details, or have single correct values:
 | CodeCarbon tracking mode | `process` | Better attribution than `machine` for single-workload benchmarks. |
 | CodeCarbon file output | Disabled | We extract metrics programmatically; prevents stray `emissions.csv`. |
 | GPU indices | Auto-resolved | Derived from backend config (tensor_parallel_size, device_map, etc.). |
-| Baseline cache TTL | 30 min | Configurable via `baseline.cache_ttl_seconds`. Disk-persisted and shared with Docker containers. |
+| Baseline cache TTL | 1 hour | Configurable via `baseline.cache_ttl_seconds`. Disk-persisted and shared with Docker containers. |
 | Integration method | Trapezoidal rule | Standard for non-uniform timesteps; Simpson's offers no practical gain given +/-5% sensor noise. |
 | Power reading mode | Instantaneous | Uses least-smoothed NVML reading for best temporal resolution. |
 

--- a/docs/energy-measurement.md
+++ b/docs/energy-measurement.md
@@ -208,15 +208,27 @@ conflate background power draw with inference energy.
 - The sampler polls GPU power for `baseline.duration_seconds` (default: 30s) before
   the first experiment
 - The mean is stored as `baseline_power_watts`
-- Baseline results are cached per-session (1-hour TTL) so subsequent experiments in a
-  study reuse the same baseline measurement
+- Baseline results are persisted to disk (`_study-artefacts/baseline_cache.json`) and
+  shared across experiments in a study, including Docker containers via bind-mount
+
+**Caching strategies** (`baseline.strategy`):
+
+| Strategy | Behaviour | When to use |
+|:---------|:----------|:------------|
+| `cached` (default) | Measure once, persist to disk with configurable TTL (default 30 min). Docker containers load the host's cached measurement via bind-mount. | Most studies - saves ~30s per experiment after the first. |
+| `validated` | Same as `cached`, but periodically spot-checks (5s quick measurement) every N experiments. If power drift exceeds the threshold, re-measures the full baseline. | Long-running studies where thermal conditions may shift. |
+| `fresh` | Every experiment measures its own baseline independently. No study-level caching. | Maximum accuracy when measurement isolation matters more than speed. |
 
 Configure via the `baseline:` section:
 
 ```yaml
 baseline:
   enabled: true
-  duration_seconds: 30   # 5-120s accepted
+  duration_seconds: 30        # 5-120s accepted
+  strategy: cached            # or "validated" or "fresh"
+  cache_ttl_seconds: 1800     # 30 min TTL (strategy: cached/validated)
+  validation_interval: 5      # spot-check every 5 experiments (strategy: validated)
+  drift_threshold: 0.10       # 10% drift triggers re-measurement (strategy: validated)
 ```
 
 ---
@@ -236,7 +248,7 @@ implementation details, or have single correct values:
 | CodeCarbon tracking mode | `process` | Better attribution than `machine` for single-workload benchmarks. |
 | CodeCarbon file output | Disabled | We extract metrics programmatically; prevents stray `emissions.csv`. |
 | GPU indices | Auto-resolved | Derived from backend config (tensor_parallel_size, device_map, etc.). |
-| Baseline cache TTL | 1 hour | Session-scoped; fresh baseline for each study. |
+| Baseline cache TTL | 30 min | Configurable via `baseline.cache_ttl_seconds`. Disk-persisted and shared with Docker containers. |
 | Integration method | Trapezoidal rule | Standard for non-uniform timesteps; Simpson's offers no practical gain given +/-5% sensor noise. |
 | Power reading mode | Instantaneous | Uses least-smoothed NVML reading for best temporal resolution. |
 

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -656,7 +656,11 @@ Two modes: **fixed** (default) runs exactly `n_warmup` prompts; **CV convergence
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | boolean | `true` | Enable baseline power measurement |
-| `duration_seconds` | number | `30.0` | Baseline measurement duration in seconds |
+| `duration_seconds` | number | `30.0` | Baseline measurement duration in seconds (5-120s) |
+| `strategy` | string | `"cached"` | Caching strategy: `cached` (disk-persisted TTL), `validated` (cached with periodic spot-check), `fresh` (measure every experiment) |
+| `cache_ttl_seconds` | number | `1800.0` | TTL for cached baseline in seconds. Min 60s. Used with `cached`/`validated` strategies. |
+| `validation_interval` | integer | `5` | Re-validate baseline every N experiments. Used with `validated` strategy only. |
+| `drift_threshold` | number | `0.10` | Power drift fraction (0.01-0.50) to trigger re-measurement. Used with `validated` strategy only. |
 
 ### Energy Sampler (`energy_sampler:`)
 

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -657,8 +657,8 @@ Two modes: **fixed** (default) runs exactly `n_warmup` prompts; **CV convergence
 |-------|------|---------|-------------|
 | `enabled` | boolean | `true` | Enable baseline power measurement |
 | `duration_seconds` | number | `30.0` | Baseline measurement duration in seconds (5-120s) |
-| `strategy` | string | `"cached"` | Caching strategy: `cached` (disk-persisted TTL), `validated` (cached with periodic spot-check), `fresh` (measure every experiment) |
-| `cache_ttl_seconds` | number | `3600.0` | How long a cached baseline remains valid before re-measurement, in seconds. Min 60s. Used with `cached`/`validated` strategies. |
+| `strategy` | string | `"validated"` | Caching strategy: `validated` (cached with periodic spot-check, default), `cached` (disk-persisted TTL), `fresh` (measure every experiment) |
+| `cache_ttl_seconds` | number | `7200.0` | How long a cached baseline remains valid before re-measurement, in seconds. Min 60s. Used with `cached`/`validated` strategies. |
 | `validation_interval` | integer | `5` | Re-validate baseline every N experiments. Used with `validated` strategy only. |
 | `drift_threshold` | number | `0.10` | Power drift fraction (0.01-0.50) to trigger re-measurement. Used with `validated` strategy only. |
 

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -658,7 +658,7 @@ Two modes: **fixed** (default) runs exactly `n_warmup` prompts; **CV convergence
 | `enabled` | boolean | `true` | Enable baseline power measurement |
 | `duration_seconds` | number | `30.0` | Baseline measurement duration in seconds (5-120s) |
 | `strategy` | string | `"cached"` | Caching strategy: `cached` (disk-persisted TTL), `validated` (cached with periodic spot-check), `fresh` (measure every experiment) |
-| `cache_ttl_seconds` | number | `1800.0` | TTL for cached baseline in seconds. Min 60s. Used with `cached`/`validated` strategies. |
+| `cache_ttl_seconds` | number | `3600.0` | How long a cached baseline remains valid before re-measurement, in seconds. Min 60s. Used with `cached`/`validated` strategies. |
 | `validation_interval` | integer | `5` | Re-validate baseline every N experiments. Used with `validated` strategy only. |
 | `drift_threshold` | number | `0.10` | Power drift fraction (0.01-0.50) to trigger re-measurement. Used with `validated` strategy only. |
 

--- a/scripts/test_ttl_and_validation.py
+++ b/scripts/test_ttl_and_validation.py
@@ -60,90 +60,91 @@ def test_host_inmemory_ttl() -> None:
     from llenergymeasure.harness.baseline import BaselineCache
     from llenergymeasure.study.runner import StudyRunner
 
-    runner = StudyRunner.__new__(StudyRunner)
-    runner._study_config = MagicMock()
-    runner._baseline_cache_path = None
-    runner._experiments_since_validation = 0
-    runner.study_dir = Path(tempfile.mkdtemp())
+    with tempfile.TemporaryDirectory() as tmpdir1, tempfile.TemporaryDirectory() as tmpdir2:
+        runner = StudyRunner.__new__(StudyRunner)
+        runner._study_config = MagicMock()
+        runner._baseline_cache_path = None
+        runner._experiments_since_validation = 0
+        runner.study_dir = Path(tmpdir1)
 
-    mock_config = MagicMock()
-    mock_config.baseline.strategy = "cached"
-    mock_config.baseline.cache_ttl_seconds = 300.0  # 5-minute TTL
-    mock_config.baseline.duration_seconds = 30.0
-    mock_config.gpu_indices = [0]
+        mock_config = MagicMock()
+        mock_config.baseline.strategy = "cached"
+        mock_config.baseline.cache_ttl_seconds = 300.0  # 5-minute TTL
+        mock_config.baseline.duration_seconds = 30.0
+        mock_config.gpu_indices = [0]
 
-    # Case A: expired baseline (10 min old, 5-min TTL) -> should re-measure
-    old_baseline = BaselineCache(
-        power_w=50.0,
-        timestamp=time.time() - 600,  # 10 min ago
-        gpu_indices=[0],
-        sample_count=200,
-        duration_sec=30.0,
-    )
-    runner._baseline = old_baseline
+        # Case A: expired baseline (10 min old, 5-min TTL) -> should re-measure
+        old_baseline = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 600,  # 10 min ago
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        runner._baseline = old_baseline
 
-    fresh_baseline = BaselineCache(
-        power_w=52.0,
-        timestamp=time.time(),
-        gpu_indices=[0],
-        sample_count=200,
-        duration_sec=30.0,
-    )
+        fresh_baseline = BaselineCache(
+            power_w=52.0,
+            timestamp=time.time(),
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
 
-    with (
-        patch(
+        with (
+            patch(
+                "llenergymeasure.harness.baseline.measure_baseline_power",
+                return_value=fresh_baseline,
+            ) as mock_measure,
+            patch(
+                "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+                return_value=[0],
+            ),
+            patch("llenergymeasure.harness.baseline.save_baseline_cache"),
+            patch("llenergymeasure.harness.baseline.load_baseline_cache", return_value=None),
+        ):
+            result = runner._get_baseline(mock_config)
+
+        check(
+            "expired baseline triggers re-measurement",
+            mock_measure.call_count == 1,
+            f"measure called {mock_measure.call_count} time(s)",
+        )
+        check(
+            "returns fresh baseline (52W, not stale 50W)",
+            result is not None and result.power_w == 52.0,
+            f"power={result.power_w if result else None}",
+        )
+
+        # Case B: fresh baseline (1 min old, 5-min TTL) -> should reuse
+        runner2 = StudyRunner.__new__(StudyRunner)
+        runner2._study_config = MagicMock()
+        runner2._baseline_cache_path = None
+        runner2._experiments_since_validation = 0
+        runner2.study_dir = Path(tmpdir2)
+
+        fresh_inmem = BaselineCache(
+            power_w=55.0,
+            timestamp=time.time() - 60,  # 1 min ago
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        runner2._baseline = fresh_inmem
+
+        with patch(
             "llenergymeasure.harness.baseline.measure_baseline_power",
-            return_value=fresh_baseline,
-        ) as mock_measure,
-        patch(
-            "llenergymeasure.device.gpu_info._resolve_gpu_indices",
-            return_value=[0],
-        ),
-        patch("llenergymeasure.harness.baseline.save_baseline_cache"),
-        patch("llenergymeasure.harness.baseline.load_baseline_cache", return_value=None),
-    ):
-        result = runner._get_baseline(mock_config)
+        ) as mock_measure2:
+            result2 = runner2._get_baseline(mock_config)
 
-    check(
-        "expired baseline triggers re-measurement",
-        mock_measure.call_count == 1,
-        f"measure called {mock_measure.call_count} time(s)",
-    )
-    check(
-        "returns fresh baseline (52W, not stale 50W)",
-        result is not None and result.power_w == 52.0,
-        f"power={result.power_w if result else None}",
-    )
-
-    # Case B: fresh baseline (1 min old, 5-min TTL) -> should reuse
-    runner2 = StudyRunner.__new__(StudyRunner)
-    runner2._study_config = MagicMock()
-    runner2._baseline_cache_path = None
-    runner2._experiments_since_validation = 0
-    runner2.study_dir = Path(tempfile.mkdtemp())
-
-    fresh_inmem = BaselineCache(
-        power_w=55.0,
-        timestamp=time.time() - 60,  # 1 min ago
-        gpu_indices=[0],
-        sample_count=200,
-        duration_sec=30.0,
-    )
-    runner2._baseline = fresh_inmem
-
-    with patch(
-        "llenergymeasure.harness.baseline.measure_baseline_power",
-    ) as mock_measure2:
-        result2 = runner2._get_baseline(mock_config)
-
-    check(
-        "within-TTL baseline reused (no re-measurement)",
-        mock_measure2.call_count == 0,
-    )
-    check(
-        "same object returned",
-        result2 is fresh_inmem,
-    )
+        check(
+            "within-TTL baseline reused (no re-measurement)",
+            mock_measure2.call_count == 0,
+        )
+        check(
+            "same object returned",
+            result2 is fresh_inmem,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -397,91 +398,92 @@ def test_validated_with_ttl() -> None:
     from llenergymeasure.harness.baseline import BaselineCache
     from llenergymeasure.study.runner import StudyRunner
 
-    runner = StudyRunner.__new__(StudyRunner)
-    runner._study_config = MagicMock()
-    runner._baseline_cache_path = None
-    runner.study_dir = Path(tempfile.mkdtemp())
+    with tempfile.TemporaryDirectory() as tmpdir:
+        runner = StudyRunner.__new__(StudyRunner)
+        runner._study_config = MagicMock()
+        runner._baseline_cache_path = None
+        runner.study_dir = Path(tmpdir)
 
-    mock_config = MagicMock()
-    mock_config.baseline.strategy = "validated"
-    mock_config.baseline.validation_interval = 3
-    mock_config.baseline.drift_threshold = 0.10
-    mock_config.baseline.cache_ttl_seconds = 3600.0
-    mock_config.baseline.duration_seconds = 30.0
-    mock_config.gpu_indices = [0]
+        mock_config = MagicMock()
+        mock_config.baseline.strategy = "validated"
+        mock_config.baseline.validation_interval = 3
+        mock_config.baseline.drift_threshold = 0.10
+        mock_config.baseline.cache_ttl_seconds = 3600.0
+        mock_config.baseline.duration_seconds = 30.0
+        mock_config.gpu_indices = [0]
 
-    # Baseline within TTL
-    recent = BaselineCache(
-        power_w=50.0,
-        timestamp=time.time() - 1800,  # 30 min, within 1h TTL
-        gpu_indices=[0],
-        sample_count=200,
-        duration_sec=30.0,
-    )
-    runner._baseline = recent
-    runner._experiments_since_validation = 2  # next call triggers spot-check
+        # Baseline within TTL
+        recent = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 1800,  # 30 min, within 1h TTL
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        runner._baseline = recent
+        runner._experiments_since_validation = 2  # next call triggers spot-check
 
-    # Spot-check with no drift
-    with (
-        patch(
-            "llenergymeasure.harness.baseline.measure_spot_check",
-            return_value=51.0,  # 2% drift
-        ) as mock_spot,
-        patch(
-            "llenergymeasure.device.gpu_info._resolve_gpu_indices",
-            return_value=[0],
-        ),
-    ):
-        result = runner._get_baseline(mock_config)
+        # Spot-check with no drift
+        with (
+            patch(
+                "llenergymeasure.harness.baseline.measure_spot_check",
+                return_value=51.0,  # 2% drift
+            ) as mock_spot,
+            patch(
+                "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+                return_value=[0],
+            ),
+        ):
+            result = runner._get_baseline(mock_config)
 
-    check("spot-check triggered", mock_spot.call_count == 1)
-    check(
-        "baseline kept (within TTL + no drift)",
-        result.power_w == 50.0,
-    )
-    check("method set to validated", result.method == "validated")
+        check("spot-check triggered", mock_spot.call_count == 1)
+        check(
+            "baseline kept (within TTL + no drift)",
+            result.power_w == 50.0,
+        )
+        check("method set to validated", result.method == "validated")
 
-    # Now set baseline to expired + validated strategy
-    expired = BaselineCache(
-        power_w=50.0,
-        timestamp=time.time() - 7200,  # 2h, past 1h TTL
-        gpu_indices=[0],
-        sample_count=200,
-        duration_sec=30.0,
-    )
-    runner._baseline = expired
-    runner._experiments_since_validation = 0
+        # Now set baseline to expired + validated strategy
+        expired = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 7200,  # 2h, past 1h TTL
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        runner._baseline = expired
+        runner._experiments_since_validation = 0
 
-    fresh = BaselineCache(
-        power_w=55.0,
-        timestamp=time.time(),
-        gpu_indices=[0],
-        sample_count=200,
-        duration_sec=30.0,
-    )
+        fresh = BaselineCache(
+            power_w=55.0,
+            timestamp=time.time(),
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
 
-    with (
-        patch(
-            "llenergymeasure.harness.baseline.measure_baseline_power",
-            return_value=fresh,
-        ) as mock_measure,
-        patch(
-            "llenergymeasure.device.gpu_info._resolve_gpu_indices",
-            return_value=[0],
-        ),
-        patch("llenergymeasure.harness.baseline.save_baseline_cache"),
-        patch("llenergymeasure.harness.baseline.load_baseline_cache", return_value=None),
-    ):
-        result = runner._get_baseline(mock_config)
+        with (
+            patch(
+                "llenergymeasure.harness.baseline.measure_baseline_power",
+                return_value=fresh,
+            ) as mock_measure,
+            patch(
+                "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+                return_value=[0],
+            ),
+            patch("llenergymeasure.harness.baseline.save_baseline_cache"),
+            patch("llenergymeasure.harness.baseline.load_baseline_cache", return_value=None),
+        ):
+            result = runner._get_baseline(mock_config)
 
-    check(
-        "TTL-expired validated baseline triggers re-measurement",
-        mock_measure.call_count == 1,
-    )
-    check(
-        "fresh baseline returned (55W)",
-        result is not None and result.power_w == 55.0,
-    )
+        check(
+            "TTL-expired validated baseline triggers re-measurement",
+            mock_measure.call_count == 1,
+        )
+        check(
+            "fresh baseline returned (55W)",
+            result is not None and result.power_w == 55.0,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_ttl_and_validation.py
+++ b/scripts/test_ttl_and_validation.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Verification script for PR #242 + #243: host-managed TTL in Docker flow.
+
+Tests the end-to-end behaviour of the baseline cache across the host-container
+boundary, verifying that:
+
+  1. Host enforces TTL on in-memory baseline (the fix in #243)
+  2. Host reuses in-memory baseline when within TTL
+  3. Re-measurement after TTL expiry produces a fresh disk cache
+  4. Container accepts a freshly-saved cache from the host
+  5. Container rejects an expired cache (no host refresh)
+  6. Validated strategy: spot-check + no drift keeps baseline within TTL
+  7. Long study simulation: baseline stays valid across many experiments
+
+Run: python scripts/test_ttl_and_validation.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_passed = 0
+_failed = 0
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if condition:
+        _passed += 1
+    else:
+        _failed += 1
+    status = "PASS" if condition else "FAIL"
+    suffix = f"  ({detail})" if detail else ""
+    print(f"  [{status}] {name}{suffix}")
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+# ---------------------------------------------------------------------------
+# 1. Host in-memory TTL enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_host_inmemory_ttl() -> None:
+    """Host's _get_baseline rejects expired in-memory baseline, reuses fresh."""
+    section("1. Host enforces TTL on in-memory baseline")
+
+    from llenergymeasure.harness.baseline import BaselineCache
+    from llenergymeasure.study.runner import StudyRunner
+
+    runner = StudyRunner.__new__(StudyRunner)
+    runner._study_config = MagicMock()
+    runner._baseline_cache_path = None
+    runner._experiments_since_validation = 0
+    runner.study_dir = Path(tempfile.mkdtemp())
+
+    mock_config = MagicMock()
+    mock_config.baseline.strategy = "cached"
+    mock_config.baseline.cache_ttl_seconds = 300.0  # 5-minute TTL
+    mock_config.baseline.duration_seconds = 30.0
+    mock_config.gpu_indices = [0]
+
+    # Case A: expired baseline (10 min old, 5-min TTL) -> should re-measure
+    old_baseline = BaselineCache(
+        power_w=50.0,
+        timestamp=time.time() - 600,  # 10 min ago
+        gpu_indices=[0],
+        sample_count=200,
+        duration_sec=30.0,
+    )
+    runner._baseline = old_baseline
+
+    fresh_baseline = BaselineCache(
+        power_w=52.0,
+        timestamp=time.time(),
+        gpu_indices=[0],
+        sample_count=200,
+        duration_sec=30.0,
+    )
+
+    with (
+        patch(
+            "llenergymeasure.harness.baseline.measure_baseline_power",
+            return_value=fresh_baseline,
+        ) as mock_measure,
+        patch(
+            "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+            return_value=[0],
+        ),
+        patch("llenergymeasure.harness.baseline.save_baseline_cache"),
+        patch("llenergymeasure.harness.baseline.load_baseline_cache", return_value=None),
+    ):
+        result = runner._get_baseline(mock_config)
+
+    check(
+        "expired baseline triggers re-measurement",
+        mock_measure.call_count == 1,
+        f"measure called {mock_measure.call_count} time(s)",
+    )
+    check(
+        "returns fresh baseline (52W, not stale 50W)",
+        result is not None and result.power_w == 52.0,
+        f"power={result.power_w if result else None}",
+    )
+
+    # Case B: fresh baseline (1 min old, 5-min TTL) -> should reuse
+    runner2 = StudyRunner.__new__(StudyRunner)
+    runner2._study_config = MagicMock()
+    runner2._baseline_cache_path = None
+    runner2._experiments_since_validation = 0
+    runner2.study_dir = Path(tempfile.mkdtemp())
+
+    fresh_inmem = BaselineCache(
+        power_w=55.0,
+        timestamp=time.time() - 60,  # 1 min ago
+        gpu_indices=[0],
+        sample_count=200,
+        duration_sec=30.0,
+    )
+    runner2._baseline = fresh_inmem
+
+    with patch(
+        "llenergymeasure.harness.baseline.measure_baseline_power",
+    ) as mock_measure2:
+        result2 = runner2._get_baseline(mock_config)
+
+    check(
+        "within-TTL baseline reused (no re-measurement)",
+        mock_measure2.call_count == 0,
+    )
+    check(
+        "same object returned",
+        result2 is fresh_inmem,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Re-measurement produces fresh disk cache
+# ---------------------------------------------------------------------------
+
+
+def test_remeasurement_refreshes_disk() -> None:
+    """When host re-measures after TTL expiry, new baseline is saved to disk."""
+    section("2. Re-measurement refreshes disk cache")
+
+    from llenergymeasure.harness.baseline import BaselineCache
+    from llenergymeasure.study.runner import StudyRunner
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        runner = StudyRunner.__new__(StudyRunner)
+        runner._study_config = MagicMock()
+        runner._baseline_cache_path = None
+        runner._experiments_since_validation = 0
+        runner.study_dir = Path(tmpdir)
+
+        mock_config = MagicMock()
+        mock_config.baseline.strategy = "cached"
+        mock_config.baseline.cache_ttl_seconds = 300.0
+        mock_config.baseline.duration_seconds = 30.0
+        mock_config.gpu_indices = [0]
+
+        # Set up expired in-memory baseline
+        runner._baseline = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 600,
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+
+        fresh = BaselineCache(
+            power_w=52.0,
+            timestamp=time.time(),
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+
+        with (
+            patch(
+                "llenergymeasure.harness.baseline.measure_baseline_power",
+                return_value=fresh,
+            ),
+            patch(
+                "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+                return_value=[0],
+            ),
+            patch(
+                "llenergymeasure.harness.baseline.save_baseline_cache",
+            ) as mock_save,
+            patch(
+                "llenergymeasure.harness.baseline.load_baseline_cache",
+                return_value=None,
+            ),
+        ):
+            runner._get_baseline(mock_config)
+
+        check(
+            "fresh baseline saved to disk after re-measurement",
+            mock_save.call_count == 1,
+        )
+        # The saved baseline should have a recent timestamp
+        saved_baseline = mock_save.call_args[0][1]
+        age = time.time() - saved_baseline.timestamp
+        check(
+            "saved baseline has fresh timestamp",
+            age < 5,
+            f"age={age:.1f}s",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Container loads host-managed cache
+# ---------------------------------------------------------------------------
+
+
+def test_container_ttl_scenarios() -> None:
+    """Container correctly accepts/rejects cache based on TTL."""
+    section("3. Container-side TTL behaviour")
+
+    from llenergymeasure.harness.baseline import (
+        BaselineCache,
+        load_baseline_cache,
+        save_baseline_cache,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "baseline_cache.json"
+        ttl = 3600.0  # 1 hour (new default)
+
+        # Case A: 20-min-old cache -> valid
+        recent = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 1200,
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        save_baseline_cache(cache_path, recent)
+        loaded = load_baseline_cache(cache_path, ttl=ttl)
+        check("20-min-old cache accepted (1h TTL)", loaded is not None)
+
+        # Case B: 50-min-old cache -> valid (within 1h)
+        older = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 3000,
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        save_baseline_cache(cache_path, older)
+        loaded = load_baseline_cache(cache_path, ttl=ttl)
+        check("50-min-old cache accepted (1h TTL)", loaded is not None)
+
+        # Case C: 70-min-old cache -> expired
+        expired = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 4200,
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        save_baseline_cache(cache_path, expired)
+        loaded = load_baseline_cache(cache_path, ttl=ttl)
+        check("70-min-old cache rejected (1h TTL)", loaded is None)
+
+
+# ---------------------------------------------------------------------------
+# 4. Host-to-container flow: TTL stays consistent
+# ---------------------------------------------------------------------------
+
+
+def test_host_to_container_consistency() -> None:
+    """When host accepts baseline (within TTL), disk cache is also within TTL
+    for the container - because both share the same timestamp."""
+    section("4. Host-to-container TTL consistency")
+
+    from llenergymeasure.harness.baseline import (
+        BaselineCache,
+        load_baseline_cache,
+        save_baseline_cache,
+    )
+    from llenergymeasure.study.runner import StudyRunner
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        study_dir = Path(tmpdir)
+        ttl = 3600.0
+
+        runner = StudyRunner.__new__(StudyRunner)
+        runner._study_config = MagicMock()
+        runner._baseline_cache_path = None
+        runner._experiments_since_validation = 0
+        runner.study_dir = study_dir
+
+        mock_config = MagicMock()
+        mock_config.baseline.strategy = "cached"
+        mock_config.baseline.cache_ttl_seconds = ttl
+        mock_config.baseline.duration_seconds = 30.0
+        mock_config.gpu_indices = [0]
+
+        # Baseline measured 40 min ago (within 1h TTL)
+        baseline_40min = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 2400,
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+            method="cached",
+        )
+        runner._baseline = baseline_40min
+
+        # Host accepts it (within TTL)
+        result = runner._get_baseline(mock_config)
+        check(
+            "host accepts 40-min-old baseline (1h TTL)",
+            result is not None and result.power_w == 50.0,
+        )
+
+        # Save to disk (simulating what happens at initial measurement)
+        cache_path = runner._get_baseline_cache_path()
+        save_baseline_cache(cache_path, baseline_40min)
+
+        # Container loads the same file
+        container_loaded = load_baseline_cache(cache_path, ttl=ttl)
+        check(
+            "container also accepts (same timestamp, same TTL)",
+            container_loaded is not None,
+        )
+
+        # Now test that TTL-expired baseline is caught by host
+        baseline_70min = BaselineCache(
+            power_w=50.0,
+            timestamp=time.time() - 4200,  # 70 min, past 1h TTL
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+        runner._baseline = baseline_70min
+
+        fresh = BaselineCache(
+            power_w=53.0,
+            timestamp=time.time(),
+            gpu_indices=[0],
+            sample_count=200,
+            duration_sec=30.0,
+        )
+
+        with (
+            patch(
+                "llenergymeasure.harness.baseline.measure_baseline_power",
+                return_value=fresh,
+            ) as mock_measure,
+            patch(
+                "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+                return_value=[0],
+            ),
+            patch("llenergymeasure.harness.baseline.save_baseline_cache") as mock_save,
+            patch("llenergymeasure.harness.baseline.load_baseline_cache", return_value=None),
+        ):
+            result = runner._get_baseline(mock_config)
+
+        check(
+            "host rejects 70-min-old baseline, re-measures",
+            mock_measure.call_count == 1,
+        )
+        check(
+            "fresh baseline (53W) returned",
+            result is not None and result.power_w == 53.0,
+        )
+        check(
+            "fresh baseline saved to disk for containers",
+            mock_save.call_count == 1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Validated strategy with TTL
+# ---------------------------------------------------------------------------
+
+
+def test_validated_with_ttl() -> None:
+    """Validated strategy also enforces TTL on in-memory baseline."""
+    section("5. Validated strategy respects TTL")
+
+    from llenergymeasure.harness.baseline import BaselineCache
+    from llenergymeasure.study.runner import StudyRunner
+
+    runner = StudyRunner.__new__(StudyRunner)
+    runner._study_config = MagicMock()
+    runner._baseline_cache_path = None
+    runner.study_dir = Path(tempfile.mkdtemp())
+
+    mock_config = MagicMock()
+    mock_config.baseline.strategy = "validated"
+    mock_config.baseline.validation_interval = 3
+    mock_config.baseline.drift_threshold = 0.10
+    mock_config.baseline.cache_ttl_seconds = 3600.0
+    mock_config.baseline.duration_seconds = 30.0
+    mock_config.gpu_indices = [0]
+
+    # Baseline within TTL
+    recent = BaselineCache(
+        power_w=50.0,
+        timestamp=time.time() - 1800,  # 30 min, within 1h TTL
+        gpu_indices=[0],
+        sample_count=200,
+        duration_sec=30.0,
+    )
+    runner._baseline = recent
+    runner._experiments_since_validation = 2  # next call triggers spot-check
+
+    # Spot-check with no drift
+    with (
+        patch(
+            "llenergymeasure.harness.baseline.measure_spot_check",
+            return_value=51.0,  # 2% drift
+        ) as mock_spot,
+        patch(
+            "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+            return_value=[0],
+        ),
+    ):
+        result = runner._get_baseline(mock_config)
+
+    check("spot-check triggered", mock_spot.call_count == 1)
+    check(
+        "baseline kept (within TTL + no drift)",
+        result.power_w == 50.0,
+    )
+    check("method set to validated", result.method == "validated")
+
+    # Now set baseline to expired + validated strategy
+    expired = BaselineCache(
+        power_w=50.0,
+        timestamp=time.time() - 7200,  # 2h, past 1h TTL
+        gpu_indices=[0],
+        sample_count=200,
+        duration_sec=30.0,
+    )
+    runner._baseline = expired
+    runner._experiments_since_validation = 0
+
+    fresh = BaselineCache(
+        power_w=55.0,
+        timestamp=time.time(),
+        gpu_indices=[0],
+        sample_count=200,
+        duration_sec=30.0,
+    )
+
+    with (
+        patch(
+            "llenergymeasure.harness.baseline.measure_baseline_power",
+            return_value=fresh,
+        ) as mock_measure,
+        patch(
+            "llenergymeasure.device.gpu_info._resolve_gpu_indices",
+            return_value=[0],
+        ),
+        patch("llenergymeasure.harness.baseline.save_baseline_cache"),
+        patch("llenergymeasure.harness.baseline.load_baseline_cache", return_value=None),
+    ):
+        result = runner._get_baseline(mock_config)
+
+    check(
+        "TTL-expired validated baseline triggers re-measurement",
+        mock_measure.call_count == 1,
+    )
+    check(
+        "fresh baseline returned (55W)",
+        result is not None and result.power_w == 55.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Long study simulation with 1h TTL
+# ---------------------------------------------------------------------------
+
+
+def test_long_study_with_new_ttl() -> None:
+    """10-experiment study: all experiments within 1h TTL get cached baseline."""
+    section("6. Long study: 10 experiments over ~50 min (1h TTL)")
+
+    from llenergymeasure.harness.baseline import (
+        BaselineCache,
+        load_baseline_cache,
+        save_baseline_cache,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "baseline_cache.json"
+        ttl = 3600.0  # 1 hour
+
+        results = []
+        for i in range(10):
+            elapsed_min = (i + 1) * 5  # 5, 10, 15, ... 50 min
+            simulated_age = elapsed_min * 60
+
+            # Simulate disk cache with original measurement timestamp
+            entry = BaselineCache(
+                power_w=50.0,
+                timestamp=time.time() - simulated_age,
+                gpu_indices=[0],
+                sample_count=200,
+                duration_sec=30.0,
+            )
+            save_baseline_cache(cache_path, entry)
+
+            loaded = load_baseline_cache(cache_path, ttl=ttl)
+            results.append((elapsed_min, loaded is not None))
+
+        for elapsed_min, valid in results:
+            check(
+                f"t={elapsed_min}min",
+                valid,
+                "cache valid" if valid else "EXPIRED",
+            )
+
+        all_valid = all(valid for _, valid in results)
+        check(
+            "all 10 experiments use cached baseline",
+            all_valid,
+            "no wasted re-measurements",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. TTL boundary precision
+# ---------------------------------------------------------------------------
+
+
+def test_ttl_boundaries() -> None:
+    """Boundary cases for TTL comparison (strict > in load_baseline_cache)."""
+    section("7. TTL boundary precision")
+
+    from llenergymeasure.harness.baseline import (
+        BaselineCache,
+        load_baseline_cache,
+        save_baseline_cache,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "baseline_cache.json"
+        ttl = 60.0
+
+        # 1s inside TTL
+        entry = BaselineCache(
+            power_w=100.0,
+            timestamp=time.time() - 59.0,
+            gpu_indices=[0],
+            sample_count=100,
+            duration_sec=10.0,
+        )
+        save_baseline_cache(cache_path, entry)
+        check("59s old, 60s TTL -> valid", load_baseline_cache(cache_path, ttl=ttl) is not None)
+
+        # 1s past TTL
+        entry2 = BaselineCache(
+            power_w=100.0,
+            timestamp=time.time() - 61.0,
+            gpu_indices=[0],
+            sample_count=100,
+            duration_sec=10.0,
+        )
+        save_baseline_cache(cache_path, entry2)
+        check("61s old, 60s TTL -> expired", load_baseline_cache(cache_path, ttl=ttl) is None)
+
+        # Sub-second precision
+        entry3 = BaselineCache(
+            power_w=100.0,
+            timestamp=time.time() - 0.5,
+            gpu_indices=[0],
+            sample_count=100,
+            duration_sec=5.0,
+        )
+        save_baseline_cache(cache_path, entry3)
+        check("0.5s old, 1s TTL -> valid", load_baseline_cache(cache_path, ttl=1.0) is not None)
+
+
+# ---------------------------------------------------------------------------
+# 8. Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_ttl_validation() -> None:
+    """BaselineConfig enforces minimum TTL and valid strategies."""
+    section("8. Config model validation")
+
+    from pydantic import ValidationError
+
+    from llenergymeasure.config.models import BaselineConfig
+
+    # New default is 3600s
+    cfg = BaselineConfig()
+    check("default TTL is 7200s (2 hours)", cfg.cache_ttl_seconds == 7200.0)
+
+    # Minimum TTL enforced
+    try:
+        BaselineConfig(cache_ttl_seconds=59.0)
+        check("TTL < 60s rejected", False)
+    except ValidationError:
+        check("TTL < 60s rejected", True)
+
+    # All strategies accepted
+    for strat in ("cached", "validated", "fresh"):
+        c = BaselineConfig(strategy=strat)
+        check(f"strategy '{strat}' accepted", c.strategy == strat)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    print("\n" + "=" * 60)
+    print("  Host-Managed TTL Verification (PR #242 + #243)")
+    print("=" * 60)
+
+    test_host_inmemory_ttl()
+    test_remeasurement_refreshes_disk()
+    test_container_ttl_scenarios()
+    test_host_to_container_consistency()
+    test_validated_with_ttl()
+    test_long_study_with_new_ttl()
+    test_ttl_boundaries()
+    test_config_ttl_validation()
+
+    print(f"\n{'=' * 60}")
+    print(f"  RESULTS: {_passed} passed, {_failed} failed")
+    print(f"{'=' * 60}\n")
+
+    return 1 if _failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -213,10 +213,10 @@ class BaselineConfig(BaseModel):
         ),
     )
     cache_ttl_seconds: float = Field(
-        default=1800.0,
+        default=3600.0,
         ge=60.0,
         description=(
-            "TTL for cached baseline measurements in seconds. "
+            "How long a cached baseline remains valid before re-measurement, in seconds. "
             "Only used with strategy='cached' or 'validated'."
         ),
     )

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -205,7 +205,7 @@ class BaselineConfig(BaseModel):
         description="Baseline measurement duration in seconds",
     )
     strategy: Literal["cached", "validated", "fresh"] = Field(
-        default="cached",
+        default="validated",
         description=(
             "Baseline caching strategy: 'cached' (disk-persisted TTL), "
             "'validated' (cached with periodic spot-check), "
@@ -213,7 +213,7 @@ class BaselineConfig(BaseModel):
         ),
     )
     cache_ttl_seconds: float = Field(
-        default=3600.0,
+        default=7200.0,
         ge=60.0,
         description=(
             "How long a cached baseline remains valid before re-measurement, in seconds. "

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -769,9 +769,17 @@ class StudyRunner:
             if self._experiments_since_validation >= config.baseline.validation_interval:
                 self._validate_baseline(config)
 
-        # Return cached baseline if we have one
+        # Return cached baseline if still within TTL
         if self._baseline is not None:
-            return self._baseline
+            age = time.time() - self._baseline.timestamp
+            if age < config.baseline.cache_ttl_seconds:
+                return self._baseline
+            logger.info(
+                "Baseline expired (age=%.0fs > ttl=%.0fs). Re-measuring.",
+                age,
+                config.baseline.cache_ttl_seconds,
+            )
+            self._baseline = None
 
         # Try loading from disk first (handles mid-study restarts)
         cache_path = self._get_baseline_cache_path()

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -763,23 +763,26 @@ class StudyRunner:
         if strategy == "fresh":
             return None
 
-        # validated: check if we need to spot-check
+        # Check TTL before anything else — no point validating an expired baseline
+        if self._baseline is not None:
+            age = time.time() - self._baseline.timestamp
+            if age >= config.baseline.cache_ttl_seconds:
+                logger.info(
+                    "Baseline expired (age=%.0fs > ttl=%.0fs). Re-measuring.",
+                    age,
+                    config.baseline.cache_ttl_seconds,
+                )
+                self._baseline = None
+
+        # validated: periodic spot-check for drift (only if baseline still valid)
         if strategy == "validated" and self._baseline is not None:
             self._experiments_since_validation += 1
             if self._experiments_since_validation >= config.baseline.validation_interval:
                 self._validate_baseline(config)
 
-        # Return cached baseline if still within TTL
+        # Return cached baseline if we have one
         if self._baseline is not None:
-            age = time.time() - self._baseline.timestamp
-            if age < config.baseline.cache_ttl_seconds:
-                return self._baseline
-            logger.info(
-                "Baseline expired (age=%.0fs > ttl=%.0fs). Re-measuring.",
-                age,
-                config.baseline.cache_ttl_seconds,
-            )
-            self._baseline = None
+            return self._baseline
 
         # Try loading from disk first (handles mid-study restarts)
         cache_path = self._get_baseline_cache_path()

--- a/tests/unit/docker/test_container_entrypoint.py
+++ b/tests/unit/docker/test_container_entrypoint.py
@@ -230,6 +230,183 @@ class TestMainErrorHandling:
 
 
 # ---------------------------------------------------------------------------
+# Container-side baseline loading (PR #242)
+# ---------------------------------------------------------------------------
+
+
+_PATCH_LOAD_BASELINE = "llenergymeasure.harness.baseline.load_baseline_cache"
+
+
+class TestContainerBaselineLoading:
+    """Tests for baseline cache loading inside Docker containers.
+
+    The container entrypoint loads a host-persisted baseline from
+    /run/llem/baseline_cache.json when it exists and baseline is enabled.
+    """
+
+    def test_loads_baseline_when_cache_file_exists(self, config, result_dir: Path, tmp_path: Path):
+        """Baseline loaded from disk when cache file exists and baseline enabled."""
+        _cfg, config_path = config
+        fake_result = make_result()
+        fake_baseline = MagicMock()
+        fake_baseline.power_w = 55.0
+
+        with (
+            patch(_PATCH_PREFLIGHT),
+            patch(_PATCH_GET_BACKEND) as mock_get_backend,
+            patch(_PATCH_HARNESS_RUN, return_value=fake_result) as mock_run,
+            patch(_PATCH_LOAD_BASELINE, return_value=fake_baseline) as mock_load,
+            patch("llenergymeasure.entrypoints.container.Path") as mock_path_cls,
+        ):
+            mock_get_backend.return_value = MagicMock()
+
+            # Make the baseline cache path report as existing
+            mock_cache_path = MagicMock()
+            mock_cache_path.exists.return_value = True
+
+            def path_factory(p):
+                if p == "/run/llem/baseline_cache.json":
+                    return mock_cache_path
+                return Path(p)
+
+            mock_path_cls.side_effect = path_factory
+
+            from llenergymeasure.entrypoints.container import run_container_experiment
+
+            run_container_experiment(config_path, result_dir)
+
+        # Baseline was loaded from disk
+        mock_load.assert_called_once()
+        # Baseline was passed to harness.run
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("baseline") is fake_baseline
+
+    def test_no_baseline_when_cache_file_missing(self, config, result_dir: Path, tmp_path: Path):
+        """No baseline loaded when cache file does not exist."""
+        _cfg, config_path = config
+        fake_result = make_result()
+
+        with (
+            patch(_PATCH_PREFLIGHT),
+            patch(_PATCH_GET_BACKEND) as mock_get_backend,
+            patch(_PATCH_HARNESS_RUN, return_value=fake_result) as mock_run,
+            patch(_PATCH_LOAD_BASELINE) as mock_load,
+        ):
+            mock_get_backend.return_value = MagicMock()
+
+            from llenergymeasure.entrypoints.container import run_container_experiment
+
+            # /run/llem/baseline_cache.json doesn't exist (default in test env)
+            run_container_experiment(config_path, result_dir)
+
+        mock_load.assert_not_called()
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("baseline") is None
+
+    def test_no_baseline_when_disabled(self, tmp_path: Path, result_dir: Path):
+        """Baseline not loaded even if cache exists when baseline.enabled=False."""
+        cfg = make_config(model="gpt2", backend="pytorch", baseline={"enabled": False})
+        config_path = tmp_path / "abc123_config.json"
+        config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+        fake_result = make_result()
+
+        with (
+            patch(_PATCH_PREFLIGHT),
+            patch(_PATCH_GET_BACKEND) as mock_get_backend,
+            patch(_PATCH_HARNESS_RUN, return_value=fake_result) as mock_run,
+            patch(_PATCH_LOAD_BASELINE) as mock_load,
+            patch("llenergymeasure.entrypoints.container.Path") as mock_path_cls,
+        ):
+            mock_get_backend.return_value = MagicMock()
+            mock_cache_path = MagicMock()
+            mock_cache_path.exists.return_value = True
+
+            def path_factory(p):
+                if p == "/run/llem/baseline_cache.json":
+                    return mock_cache_path
+                return Path(p)
+
+            mock_path_cls.side_effect = path_factory
+
+            from llenergymeasure.entrypoints.container import run_container_experiment
+
+            run_container_experiment(config_path, result_dir)
+
+        mock_load.assert_not_called()
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("baseline") is None
+
+    def test_uses_config_ttl_for_loading(self, tmp_path: Path, result_dir: Path):
+        """load_baseline_cache is called with the config's cache_ttl_seconds."""
+        cfg = make_config(
+            model="gpt2",
+            backend="pytorch",
+            baseline={"enabled": True, "cache_ttl_seconds": 900.0},
+        )
+        config_path = tmp_path / "abc123_config.json"
+        config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+        fake_result = make_result()
+
+        with (
+            patch(_PATCH_PREFLIGHT),
+            patch(_PATCH_GET_BACKEND) as mock_get_backend,
+            patch(_PATCH_HARNESS_RUN, return_value=fake_result),
+            patch(_PATCH_LOAD_BASELINE, return_value=MagicMock()) as mock_load,
+            patch("llenergymeasure.entrypoints.container.Path") as mock_path_cls,
+        ):
+            mock_get_backend.return_value = MagicMock()
+            mock_cache_path = MagicMock()
+            mock_cache_path.exists.return_value = True
+
+            def path_factory(p):
+                if p == "/run/llem/baseline_cache.json":
+                    return mock_cache_path
+                return Path(p)
+
+            mock_path_cls.side_effect = path_factory
+
+            from llenergymeasure.entrypoints.container import run_container_experiment
+
+            run_container_experiment(config_path, result_dir)
+
+        mock_load.assert_called_once()
+        _, kwargs = mock_load.call_args
+        assert kwargs.get("ttl") == 900.0
+
+    def test_expired_cache_passes_none_baseline(self, tmp_path: Path, result_dir: Path):
+        """When disk cache is expired (load returns None), baseline=None."""
+        cfg = make_config(model="gpt2", backend="pytorch")
+        config_path = tmp_path / "abc123_config.json"
+        config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+        fake_result = make_result()
+
+        with (
+            patch(_PATCH_PREFLIGHT),
+            patch(_PATCH_GET_BACKEND) as mock_get_backend,
+            patch(_PATCH_HARNESS_RUN, return_value=fake_result) as mock_run,
+            patch(_PATCH_LOAD_BASELINE, return_value=None),
+            patch("llenergymeasure.entrypoints.container.Path") as mock_path_cls,
+        ):
+            mock_get_backend.return_value = MagicMock()
+            mock_cache_path = MagicMock()
+            mock_cache_path.exists.return_value = True
+
+            def path_factory(p):
+                if p == "/run/llem/baseline_cache.json":
+                    return mock_cache_path
+                return Path(p)
+
+            mock_path_cls.side_effect = path_factory
+
+            from llenergymeasure.entrypoints.container import run_container_experiment
+
+            run_container_experiment(config_path, result_dir)
+
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("baseline") is None
+
+
+# ---------------------------------------------------------------------------
 # __main__ guard — MPI safety contract
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -236,6 +236,57 @@ class TestStrategyCached:
 
         assert result is None
 
+    def test_ttl_expiry_triggers_remeasurement(self, tmp_path: Path):
+        """In-memory baseline is re-measured when TTL expires."""
+        config = ExperimentConfig(
+            model="test/model",
+            backend="pytorch",
+            baseline=BaselineConfig(strategy="cached", cache_ttl_seconds=3600.0),
+        )
+        runner = _make_runner(tmp_path, config)
+
+        # Initial baseline with old timestamp (2 hours ago)
+        old = _make_baseline(50.0, timestamp=time.time() - 7200)
+        fresh = _make_baseline(55.0)
+
+        with (
+            patch(_MEASURE, return_value=old),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            runner._get_baseline(config)
+
+        assert runner._baseline.power_w == 50.0
+
+        # Second call: old baseline has expired (age 7200 > ttl 3600)
+        with (
+            patch(_MEASURE, return_value=fresh) as mock_measure,
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_LOAD, return_value=None),
+        ):
+            result = runner._get_baseline(config)
+
+        assert result.power_w == 55.0  # re-measured
+        mock_measure.assert_called_once()
+
+    def test_ttl_not_expired_reuses_cache(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """In-memory baseline within TTL is reused without re-measurement."""
+        runner = _make_runner(tmp_path, config_cached)
+        # Recent baseline (timestamp = now)
+        recent = _make_baseline(60.0)
+
+        with (
+            patch(_MEASURE, return_value=recent) as mock_measure,
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            first = runner._get_baseline(config_cached)
+            second = runner._get_baseline(config_cached)
+
+        assert second is first
+        assert mock_measure.call_count == 1
+
 
 # =============================================================================
 # Strategy: validated

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -1,0 +1,484 @@
+"""Tests for StudyRunner baseline strategy dispatch and drift validation.
+
+Covers the _get_baseline() and _validate_baseline() methods introduced in PR #242.
+All tests run without GPU hardware - baseline measurement and GPU resolution are mocked.
+
+Test strategy mirrors test_study_runner.py: StudyRunner is instantiated with a
+MagicMock manifest and tmp_path study_dir. Lazy imports inside _get_baseline and
+_validate_baseline are patched at source module level.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llenergymeasure.config.models import (
+    BaselineConfig,
+    ExecutionConfig,
+    ExperimentConfig,
+    StudyConfig,
+)
+from llenergymeasure.harness.baseline import BaselineCache
+from llenergymeasure.study.runner import StudyRunner
+
+# Patch targets: source modules, not runner imports (lazy local imports)
+_MEASURE = "llenergymeasure.harness.baseline.measure_baseline_power"
+_SAVE = "llenergymeasure.harness.baseline.save_baseline_cache"
+_LOAD = "llenergymeasure.harness.baseline.load_baseline_cache"
+_SPOT = "llenergymeasure.harness.baseline.measure_spot_check"
+_RESOLVE_GPU = "llenergymeasure.device.gpu_info._resolve_gpu_indices"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_baseline(power_w: float = 50.0, **kwargs) -> BaselineCache:
+    defaults = {
+        "power_w": power_w,
+        "timestamp": time.time(),
+        "gpu_indices": [0],
+        "sample_count": 200,
+        "duration_sec": 30.0,
+    }
+    defaults.update(kwargs)
+    return BaselineCache(**defaults)
+
+
+def _make_runner(tmp_path: Path, config: ExperimentConfig) -> StudyRunner:
+    """Construct a StudyRunner with minimal plumbing for baseline testing."""
+    study = StudyConfig(
+        experiments=[config],
+        study_name="test-baseline",
+        study_execution=ExecutionConfig(n_cycles=1, experiment_order="sequential"),
+        study_design_hash="deadbeef12345678",
+    )
+    manifest = MagicMock()
+    runner = StudyRunner(study, manifest, tmp_path)
+    return runner
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def config_cached() -> ExperimentConfig:
+    """ExperimentConfig with strategy='cached' (default)."""
+    return ExperimentConfig(
+        model="test/model",
+        backend="pytorch",
+        baseline=BaselineConfig(strategy="cached", duration_seconds=30.0),
+    )
+
+
+@pytest.fixture
+def config_fresh() -> ExperimentConfig:
+    return ExperimentConfig(
+        model="test/model",
+        backend="pytorch",
+        baseline=BaselineConfig(strategy="fresh"),
+    )
+
+
+@pytest.fixture
+def config_validated() -> ExperimentConfig:
+    return ExperimentConfig(
+        model="test/model",
+        backend="pytorch",
+        baseline=BaselineConfig(
+            strategy="validated",
+            validation_interval=3,
+            drift_threshold=0.10,
+        ),
+    )
+
+
+# =============================================================================
+# Strategy: fresh
+# =============================================================================
+
+
+class TestStrategyFresh:
+    def test_returns_none(self, tmp_path: Path, config_fresh: ExperimentConfig):
+        """strategy='fresh' returns None — each experiment measures its own."""
+        runner = _make_runner(tmp_path, config_fresh)
+        result = runner._get_baseline(config_fresh)
+        assert result is None
+
+    def test_does_not_measure(self, tmp_path: Path, config_fresh: ExperimentConfig):
+        """strategy='fresh' never calls measure_baseline_power."""
+        runner = _make_runner(tmp_path, config_fresh)
+        with patch(_MEASURE) as mock_measure:
+            runner._get_baseline(config_fresh)
+            mock_measure.assert_not_called()
+
+
+# =============================================================================
+# Strategy: cached
+# =============================================================================
+
+
+class TestStrategyCached:
+    def test_measures_and_returns_baseline(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """First call measures a fresh baseline and returns it."""
+        runner = _make_runner(tmp_path, config_cached)
+        fake = _make_baseline(60.0)
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            result = runner._get_baseline(config_cached)
+
+        assert result is not None
+        assert result.power_w == 60.0
+
+    def test_persists_to_disk(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """First call saves the baseline to the artefacts directory."""
+        runner = _make_runner(tmp_path, config_cached)
+        fake = _make_baseline()
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE) as mock_save,
+        ):
+            runner._get_baseline(config_cached)
+
+        mock_save.assert_called_once()
+        saved_path = mock_save.call_args[0][0]
+        assert saved_path.name == "baseline_cache.json"
+        assert "_study-artefacts" in str(saved_path)
+
+    def test_sets_method_to_cached(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """Baseline method is set to 'cached' for result reporting."""
+        runner = _make_runner(tmp_path, config_cached)
+        fake = _make_baseline()
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            result = runner._get_baseline(config_cached)
+
+        assert result.method == "cached"
+
+    def test_reuses_on_second_call(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """Second call returns the cached baseline without re-measuring."""
+        runner = _make_runner(tmp_path, config_cached)
+        fake = _make_baseline()
+
+        with (
+            patch(_MEASURE, return_value=fake) as mock_measure,
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            first = runner._get_baseline(config_cached)
+            second = runner._get_baseline(config_cached)
+
+        assert second is first
+        assert mock_measure.call_count == 1  # measured only once
+
+    def test_loads_from_disk_on_restart(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """When in-memory cache is empty, loads from disk cache (mid-study restart)."""
+        runner = _make_runner(tmp_path, config_cached)
+        disk_baseline = _make_baseline(72.0, from_cache=True)
+
+        with (
+            patch(_LOAD, return_value=disk_baseline),
+            patch(_MEASURE) as mock_measure,
+        ):
+            result = runner._get_baseline(config_cached)
+
+        assert result is not None
+        assert result.power_w == 72.0
+        mock_measure.assert_not_called()  # loaded from disk, no fresh measurement
+
+    def test_measures_fresh_when_disk_cache_expired(
+        self, tmp_path: Path, config_cached: ExperimentConfig
+    ):
+        """When disk cache returns None (expired/missing), measures fresh."""
+        runner = _make_runner(tmp_path, config_cached)
+        fresh = _make_baseline(55.0)
+
+        with (
+            patch(_LOAD, return_value=None),
+            patch(_MEASURE, return_value=fresh),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            result = runner._get_baseline(config_cached)
+
+        assert result.power_w == 55.0
+
+    def test_measurement_failure_returns_none(
+        self, tmp_path: Path, config_cached: ExperimentConfig
+    ):
+        """When measurement fails (returns None), _get_baseline returns None."""
+        runner = _make_runner(tmp_path, config_cached)
+
+        with (
+            patch(_LOAD, return_value=None),
+            patch(_MEASURE, return_value=None),
+            patch(_RESOLVE_GPU, return_value=[0]),
+        ):
+            result = runner._get_baseline(config_cached)
+
+        assert result is None
+
+
+# =============================================================================
+# Strategy: validated
+# =============================================================================
+
+
+class TestStrategyValidated:
+    def test_first_call_measures_baseline(self, tmp_path: Path, config_validated: ExperimentConfig):
+        """First call behaves like 'cached' — measures and persists."""
+        runner = _make_runner(tmp_path, config_validated)
+        fake = _make_baseline()
+
+        with (
+            patch(_MEASURE, return_value=fake) as mock_measure,
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            result = runner._get_baseline(config_validated)
+
+        assert result is not None
+        mock_measure.assert_called_once()
+
+    def test_no_spot_check_before_interval(
+        self, tmp_path: Path, config_validated: ExperimentConfig
+    ):
+        """Spot-check not triggered until validation_interval (3) is reached."""
+        runner = _make_runner(tmp_path, config_validated)
+        fake = _make_baseline()
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_SPOT) as mock_spot,
+        ):
+            # First call: initial measurement (resets counter to 0)
+            runner._get_baseline(config_validated)
+            # Calls 2 and 3: counter goes to 1, 2 (below interval=3)
+            runner._get_baseline(config_validated)
+            runner._get_baseline(config_validated)
+
+        mock_spot.assert_not_called()
+
+    def test_spot_check_at_interval(self, tmp_path: Path, config_validated: ExperimentConfig):
+        """Spot-check triggered when validation_interval (3) is reached."""
+        runner = _make_runner(tmp_path, config_validated)
+        fake = _make_baseline(50.0)
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_SPOT, return_value=51.0) as mock_spot,
+        ):
+            runner._get_baseline(config_validated)  # initial measure, counter=0
+            runner._get_baseline(config_validated)  # counter=1
+            runner._get_baseline(config_validated)  # counter=2
+            runner._get_baseline(config_validated)  # counter=3 -> triggers
+
+        assert mock_spot.call_count == 1
+
+    def test_no_drift_keeps_baseline(self, tmp_path: Path, config_validated: ExperimentConfig):
+        """Drift below threshold keeps the existing baseline."""
+        runner = _make_runner(tmp_path, config_validated)
+        fake = _make_baseline(50.0)
+
+        with (
+            patch(_MEASURE, return_value=fake) as mock_measure,
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_SPOT, return_value=51.0),  # 2% drift, below 10% threshold
+        ):
+            runner._get_baseline(config_validated)
+            for _ in range(3):  # reach interval
+                runner._get_baseline(config_validated)
+
+        assert runner._baseline.power_w == 50.0  # unchanged
+        assert mock_measure.call_count == 1  # no re-measurement
+
+    def test_drift_triggers_remeasurement(self, tmp_path: Path, config_validated: ExperimentConfig):
+        """Drift above threshold triggers a full re-measurement."""
+        runner = _make_runner(tmp_path, config_validated)
+        original = _make_baseline(50.0)
+        remeasured = _make_baseline(58.0)
+
+        call_count = [0]
+
+        def measure_side_effect(**kwargs):
+            call_count[0] += 1
+            return original if call_count[0] == 1 else remeasured
+
+        with (
+            patch(_MEASURE, side_effect=measure_side_effect),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_SPOT, return_value=60.0),  # 20% drift, above 10% threshold
+        ):
+            runner._get_baseline(config_validated)
+            for _ in range(3):
+                runner._get_baseline(config_validated)
+
+        assert runner._baseline.power_w == 58.0  # updated
+        assert call_count[0] == 2  # initial + re-measurement
+
+    def test_drift_remeasurement_saved_to_disk(
+        self, tmp_path: Path, config_validated: ExperimentConfig
+    ):
+        """Re-measured baseline after drift is persisted to disk."""
+        runner = _make_runner(tmp_path, config_validated)
+        original = _make_baseline(50.0)
+        remeasured = _make_baseline(58.0)
+
+        call_count = [0]
+
+        def measure_side_effect(**kwargs):
+            call_count[0] += 1
+            return original if call_count[0] == 1 else remeasured
+
+        with (
+            patch(_MEASURE, side_effect=measure_side_effect),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE) as mock_save,
+            patch(_SPOT, return_value=60.0),
+        ):
+            runner._get_baseline(config_validated)
+            for _ in range(3):
+                runner._get_baseline(config_validated)
+
+        # save called twice: initial + after drift re-measurement
+        assert mock_save.call_count == 2
+
+    def test_method_set_to_validated(self, tmp_path: Path, config_validated: ExperimentConfig):
+        """After validation (no drift), method is set to 'validated'."""
+        runner = _make_runner(tmp_path, config_validated)
+        fake = _make_baseline(50.0)
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_SPOT, return_value=51.0),  # low drift
+        ):
+            runner._get_baseline(config_validated)
+            for _ in range(3):
+                runner._get_baseline(config_validated)
+
+        assert runner._baseline.method == "validated"
+
+    def test_spot_check_failure_is_nonfatal(
+        self, tmp_path: Path, config_validated: ExperimentConfig
+    ):
+        """If spot-check returns None, baseline is kept unchanged."""
+        runner = _make_runner(tmp_path, config_validated)
+        fake = _make_baseline(50.0)
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_SPOT, return_value=None),  # measurement failed
+        ):
+            runner._get_baseline(config_validated)
+            for _ in range(3):
+                runner._get_baseline(config_validated)
+
+        assert runner._baseline.power_w == 50.0  # kept original
+
+    def test_counter_resets_after_validation(
+        self, tmp_path: Path, config_validated: ExperimentConfig
+    ):
+        """Counter resets after each validation, so next check is interval calls away."""
+        runner = _make_runner(tmp_path, config_validated)
+        fake = _make_baseline(50.0)
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_SPOT, return_value=51.0) as mock_spot,
+        ):
+            runner._get_baseline(config_validated)  # initial measure
+            # First interval: 3 more calls
+            for _ in range(3):
+                runner._get_baseline(config_validated)
+            assert mock_spot.call_count == 1
+
+            # Second interval: 3 more calls
+            for _ in range(3):
+                runner._get_baseline(config_validated)
+            assert mock_spot.call_count == 2
+
+
+# =============================================================================
+# Baseline cache path
+# =============================================================================
+
+
+class TestBaselineCachePath:
+    def test_path_in_study_artefacts(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """Cache path is {study_dir}/_study-artefacts/baseline_cache.json."""
+        runner = _make_runner(tmp_path, config_cached)
+        path = runner._get_baseline_cache_path()
+        assert path == tmp_path / "_study-artefacts" / "baseline_cache.json"
+
+    def test_artefacts_dir_created(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """_get_baseline_cache_path creates the _study-artefacts directory."""
+        runner = _make_runner(tmp_path, config_cached)
+        runner._get_baseline_cache_path()
+        assert (tmp_path / "_study-artefacts").is_dir()
+
+    def test_path_cached_on_runner(self, tmp_path: Path, config_cached: ExperimentConfig):
+        """Second call returns the same Path object (no redundant mkdir)."""
+        runner = _make_runner(tmp_path, config_cached)
+        first = runner._get_baseline_cache_path()
+        second = runner._get_baseline_cache_path()
+        assert first is second
+
+
+# =============================================================================
+# Docker baseline mount
+# =============================================================================
+
+
+class TestDockerBaselineMount:
+    def test_baseline_cache_mounted_into_container(
+        self, tmp_path: Path, config_cached: ExperimentConfig
+    ):
+        """When baseline exists and cache file is on disk, it is mounted."""
+        runner = _make_runner(tmp_path, config_cached)
+        fake = _make_baseline()
+
+        # Pre-populate the cache file on disk
+        cache_path = tmp_path / "_study-artefacts" / "baseline_cache.json"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps({"power_w": 50.0}))
+
+        with (
+            patch(_MEASURE, return_value=fake),
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+        ):
+            runner._get_baseline(config_cached)
+
+        # Verify the cache file path is correct
+        assert runner._get_baseline_cache_path() == cache_path
+        assert cache_path.exists()

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -366,39 +366,15 @@ class TestStrategyValidated:
         assert runner._baseline.power_w == 50.0  # unchanged
         assert mock_measure.call_count == 1  # no re-measurement
 
-    def test_drift_triggers_remeasurement(self, tmp_path: Path, config_validated: ExperimentConfig):
-        """Drift above threshold triggers a full re-measurement."""
-        runner = _make_runner(tmp_path, config_validated)
+    @staticmethod
+    def _run_drift_scenario(tmp_path: Path, config: ExperimentConfig):
+        """Run a drift scenario: initial measure -> 3 calls -> drift triggers re-measure.
+
+        Returns (runner, mock_save) for assertions.
+        """
+        runner = _make_runner(tmp_path, config)
         original = _make_baseline(50.0)
         remeasured = _make_baseline(58.0)
-
-        call_count = [0]
-
-        def measure_side_effect(**kwargs):
-            call_count[0] += 1
-            return original if call_count[0] == 1 else remeasured
-
-        with (
-            patch(_MEASURE, side_effect=measure_side_effect),
-            patch(_RESOLVE_GPU, return_value=[0]),
-            patch(_SAVE),
-            patch(_SPOT, return_value=60.0),  # 20% drift, above 10% threshold
-        ):
-            runner._get_baseline(config_validated)
-            for _ in range(3):
-                runner._get_baseline(config_validated)
-
-        assert runner._baseline.power_w == 58.0  # updated
-        assert call_count[0] == 2  # initial + re-measurement
-
-    def test_drift_remeasurement_saved_to_disk(
-        self, tmp_path: Path, config_validated: ExperimentConfig
-    ):
-        """Re-measured baseline after drift is persisted to disk."""
-        runner = _make_runner(tmp_path, config_validated)
-        original = _make_baseline(50.0)
-        remeasured = _make_baseline(58.0)
-
         call_count = [0]
 
         def measure_side_effect(**kwargs):
@@ -409,11 +385,26 @@ class TestStrategyValidated:
             patch(_MEASURE, side_effect=measure_side_effect),
             patch(_RESOLVE_GPU, return_value=[0]),
             patch(_SAVE) as mock_save,
-            patch(_SPOT, return_value=60.0),
+            patch(_SPOT, return_value=60.0),  # 20% drift, above 10% threshold
         ):
-            runner._get_baseline(config_validated)
+            runner._get_baseline(config)
             for _ in range(3):
-                runner._get_baseline(config_validated)
+                runner._get_baseline(config)
+
+        return runner, mock_save, call_count[0]
+
+    def test_drift_triggers_remeasurement(self, tmp_path: Path, config_validated: ExperimentConfig):
+        """Drift above threshold triggers a full re-measurement."""
+        runner, _, measure_calls = self._run_drift_scenario(tmp_path, config_validated)
+
+        assert runner._baseline.power_w == 58.0  # updated
+        assert measure_calls == 2  # initial + re-measurement
+
+    def test_drift_remeasurement_saved_to_disk(
+        self, tmp_path: Path, config_validated: ExperimentConfig
+    ):
+        """Re-measured baseline after drift is persisted to disk."""
+        _, mock_save, _ = self._run_drift_scenario(tmp_path, config_validated)
 
         # save called twice: initial + after drift re-measurement
         assert mock_save.call_count == 2


### PR DESCRIPTION
## Summary

- Enforce `cache_ttl_seconds` on in-memory baseline in `_get_baseline()` — previously only checked on disk cache loads, so the in-memory baseline lived forever during long studies
- Check TTL before validation so expired baselines are caught immediately rather than wasting a 5s spot-check
- Default strategy changed from `cached` to `validated` (periodic drift spot-checks with negligible overhead)
- Default TTL bumped from 1800s to 7200s (2 hours) — better suited for long Docker-isolated studies
- Add unit tests for strategy dispatch, container loading, drift validation, TTL enforcement
- Add verification script for host-to-container TTL flow
- Update docs to reflect new defaults

## Test plan

- [x] 56 unit tests pass (test_baseline_strategy.py + test_baseline.py)
- [x] 38 verification script checks pass (scripts/test_ttl_and_validation.py)
- [x] Ruff clean
- [ ] Manual verification with Docker study (requires GPU)