### PR TITLE
refactor(test): clean up test infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,9 @@ markers = [
     "docker: marks tests as requiring Docker with NVIDIA runtime",
     "slow: marks tests as slow (>30s); excluded from Tier 1 fast runs",
 ]
+filterwarnings = [
+    "ignore:.*rm_rf.*:pytest.PytestWarning",
+]
 
 [tool.coverage.run]
 source = ["llenergymeasure"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,18 @@ from llenergymeasure.domain.metrics import (
 
 _REPLAY_DIR = Path(__file__).parent / "fixtures" / "replay"
 
+# ---------------------------------------------------------------------------
+# Shared test constants - single source of truth for magic values
+# ---------------------------------------------------------------------------
+
+TEST_MODEL = "gpt2"
+TEST_BACKEND = "pytorch"
+TEST_EXPERIMENT_ID = "test-001"
+TEST_CONFIG_HASH = "deadbeef12345678"
+TEST_MEASUREMENT_HASH = "abc123def4567890"
+TEST_POWER_MW = 200_000  # 200 W in milliwatts (pynvml convention)
+TEST_POWER_W = 200.0
+
 _EPOCH = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 _EPOCH_END = datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)
 
@@ -33,8 +45,8 @@ def make_config(**overrides) -> ExperimentConfig:
     Tests override only what they care about.
     """
     defaults: dict = {
-        "model": "gpt2",
-        "backend": "pytorch",
+        "model": TEST_MODEL,
+        "backend": TEST_BACKEND,
     }
     defaults.update(overrides)
     return ExperimentConfig(**defaults)
@@ -47,8 +59,8 @@ def make_result(**overrides) -> ExperimentResult:
     measurement_methodology, start_time, end_time) to prevent ValidationError.
     """
     defaults: dict = {
-        "experiment_id": "test-001",
-        "measurement_config_hash": "abc123def4567890",
+        "experiment_id": TEST_EXPERIMENT_ID,
+        "measurement_config_hash": TEST_MEASUREMENT_HASH,
         "measurement_methodology": "total",
         "aggregation": AggregationMetadata(num_processes=1),
         "total_tokens": 1000,
@@ -129,10 +141,10 @@ def make_raw_process_result(**overrides) -> RawProcessResult:
     make_compute_metrics factories for nested fields.
     """
     defaults: dict = {
-        "experiment_id": "test-001",
+        "experiment_id": TEST_EXPERIMENT_ID,
         "process_index": 0,
         "gpu_id": 0,
-        "model_name": "gpt2",
+        "model_name": TEST_MODEL,
         "timestamps": Timestamps.from_times(
             datetime(2026, 2, 26, 14, 0, 0, tzinfo=timezone.utc),
             datetime(2026, 2, 26, 14, 0, 10, tzinfo=timezone.utc),

--- a/tests/unit/backends/conftest.py
+++ b/tests/unit/backends/conftest.py
@@ -1,0 +1,1 @@
+"""Shared fixtures for backends/ tests."""

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,1 @@
+"""Shared fixtures for cli/ tests."""

--- a/tests/unit/config/conftest.py
+++ b/tests/unit/config/conftest.py
@@ -1,0 +1,1 @@
+"""Shared fixtures for config/ tests."""

--- a/tests/unit/config/test_backend_detection.py
+++ b/tests/unit/config/test_backend_detection.py
@@ -11,6 +11,8 @@ backend packages are imported or required.
 
 from __future__ import annotations
 
+import sys
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +23,26 @@ from llenergymeasure.config.backend_detection import (
     get_backend_install_hint,
     is_backend_available,
 )
+
+
+@contextmanager
+def _hide_module(name: str):
+    """Temporarily poison *name* in sys.modules so imports see it as missing.
+
+    Snapshots and restores **all** submodules (``name.*``) to prevent
+    order-dependent failures when pytest-randomly reorders tests.
+    """
+    saved = {k: sys.modules[k] for k in list(sys.modules) if k == name or k.startswith(f"{name}.")}
+    sys.modules[name] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        # Remove any entries added during the poisoned import attempt
+        for k in list(sys.modules):
+            if k == name or k.startswith(f"{name}."):
+                sys.modules.pop(k, None)
+        sys.modules.update(saved)
+
 
 # ---------------------------------------------------------------------------
 # is_backend_available
@@ -34,47 +56,18 @@ class TestIsBackendAvailable:
         assert result is True
 
     def test_returns_false_when_torch_not_importable(self):
-        import sys
-
-        # Temporarily hide torch from sys.modules so the deferred import inside
-        # is_backend_available() sees it as missing — no global builtins patch needed.
-        torch_mod = sys.modules.pop("torch", None)
-        sys.modules["torch"] = None  # type: ignore[assignment]
-        try:
+        with _hide_module("torch"):
             result = is_backend_available("pytorch")
-        finally:
-            sys.modules.pop("torch", None)
-            if torch_mod is not None:
-                sys.modules["torch"] = torch_mod
-
         assert result is False
 
     def test_returns_false_when_vllm_not_importable(self):
-        import sys
-
-        vllm_mod = sys.modules.pop("vllm", None)
-        sys.modules["vllm"] = None  # type: ignore[assignment]
-        try:
+        with _hide_module("vllm"):
             result = is_backend_available("vllm")
-        finally:
-            sys.modules.pop("vllm", None)
-            if vllm_mod is not None:
-                sys.modules["vllm"] = vllm_mod
-
         assert result is False
 
     def test_returns_false_when_tensorrt_not_importable(self):
-        import sys
-
-        trt_mod = sys.modules.pop("tensorrt_llm", None)
-        sys.modules["tensorrt_llm"] = None  # type: ignore[assignment]
-        try:
+        with _hide_module("tensorrt_llm"):
             result = is_backend_available("tensorrt")
-        finally:
-            sys.modules.pop("tensorrt_llm", None)
-            if trt_mod is not None:
-                sys.modules["tensorrt_llm"] = trt_mod
-
         assert result is False
 
     def test_returns_false_for_unknown_backend(self):
@@ -83,14 +76,7 @@ class TestIsBackendAvailable:
 
     def test_returns_false_when_oserror_on_import(self):
         """OSError (e.g. missing .so) should be caught and return False."""
-        import sys
-
         import llenergymeasure.config.backend_detection as _bd_mod
-
-        # Temporarily remove tensorrt_llm from sys.modules so the bare `import tensorrt_llm`
-        # inside is_backend_available() is re-evaluated. Then patch __import__ narrowly on
-        # the backend_detection module's builtins to raise OSError for that one module.
-        trt_mod = sys.modules.pop("tensorrt_llm", None)
 
         real_import = __import__
 
@@ -99,28 +85,22 @@ class TestIsBackendAvailable:
                 raise OSError("libcudart.so not found")
             return real_import(name, *args, **kwargs)
 
-        # Patch __import__ on the backend_detection module's builtins dict (narrow scope)
         original_builtins_import = _bd_mod.__builtins__.get("__import__")  # type: ignore[union-attr]
-        _bd_mod.__builtins__["__import__"] = _raise_oserror  # type: ignore[index]
-        try:
-            result = is_backend_available("tensorrt")
-        finally:
-            if original_builtins_import is not None:
-                _bd_mod.__builtins__["__import__"] = original_builtins_import  # type: ignore[index]
-            else:
-                del _bd_mod.__builtins__["__import__"]  # type: ignore[attr-defined]
-            if trt_mod is not None:
-                sys.modules["tensorrt_llm"] = trt_mod
+        with _hide_module("tensorrt_llm"):
+            _bd_mod.__builtins__["__import__"] = _raise_oserror  # type: ignore[index]
+            try:
+                result = is_backend_available("tensorrt")
+            finally:
+                if original_builtins_import is not None:
+                    _bd_mod.__builtins__["__import__"] = original_builtins_import  # type: ignore[index]
+                else:
+                    del _bd_mod.__builtins__["__import__"]  # type: ignore[attr-defined]
 
         assert result is False
 
     def test_handles_generic_exception_during_import(self):
         """Unexpected exception during import should be caught and return False."""
-        import sys
-
         import llenergymeasure.config.backend_detection as _bd_mod
-
-        vllm_mod = sys.modules.pop("vllm", None)
 
         real_import = __import__
 
@@ -130,16 +110,15 @@ class TestIsBackendAvailable:
             return real_import(name, *args, **kwargs)
 
         original_builtins_import = _bd_mod.__builtins__.get("__import__")  # type: ignore[union-attr]
-        _bd_mod.__builtins__["__import__"] = _raise_runtime  # type: ignore[index]
-        try:
-            result = is_backend_available("vllm")
-        finally:
-            if original_builtins_import is not None:
-                _bd_mod.__builtins__["__import__"] = original_builtins_import  # type: ignore[index]
-            else:
-                del _bd_mod.__builtins__["__import__"]  # type: ignore[attr-defined]
-            if vllm_mod is not None:
-                sys.modules["vllm"] = vllm_mod
+        with _hide_module("vllm"):
+            _bd_mod.__builtins__["__import__"] = _raise_runtime  # type: ignore[index]
+            try:
+                result = is_backend_available("vllm")
+            finally:
+                if original_builtins_import is not None:
+                    _bd_mod.__builtins__["__import__"] = original_builtins_import  # type: ignore[index]
+                else:
+                    del _bd_mod.__builtins__["__import__"]  # type: ignore[attr-defined]
 
         assert result is False
 

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures and factories for docker/ tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def make_subprocess_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    """Return a mock subprocess.CompletedProcess.
+
+    Replaces the identical _make_proc (test_docker_runner) and
+    _make_subprocess_result (test_docker_preflight) factories.
+    """
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc

--- a/tests/unit/docker/test_docker_preflight.py
+++ b/tests/unit/docker/test_docker_preflight.py
@@ -22,29 +22,21 @@ from llenergymeasure.utils.exceptions import (
     LLEMError,
     PreFlightError,
 )
+from tests.unit.docker.conftest import make_subprocess_result
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_subprocess_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
-    """Create a mock subprocess.CompletedProcess-like object."""
-    mock = MagicMock()
-    mock.returncode = returncode
-    mock.stdout = stdout
-    mock.stderr = stderr
-    return mock
-
-
 def _make_successful_probe(gpu_name: str = "Tesla A100", driver: str = "525.89.02") -> MagicMock:
     """Probe result with GPU name and driver version (tier 2 success)."""
-    return _make_subprocess_result(returncode=0, stdout=f"{gpu_name}, {driver}\n")
+    return make_subprocess_result(returncode=0, stdout=f"{gpu_name}, {driver}\n")
 
 
 def _make_nvidia_smi_result(driver: str = "525.89.02") -> MagicMock:
     """Host nvidia-smi result returning a driver version string."""
-    return _make_subprocess_result(returncode=0, stdout=f"{driver}\n")
+    return make_subprocess_result(returncode=0, stdout=f"{driver}\n")
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +319,7 @@ class TestTier2GPUVisibility:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),  # host nvidia-smi
-                _make_subprocess_result(
+                make_subprocess_result(
                     returncode=125,
                     stderr='could not select device driver "" with capabilities: [[gpu]]',
                 ),  # container probe fails
@@ -349,7 +341,7 @@ class TestTier2GPUVisibility:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(returncode=125, stderr="could not select device driver"),
+                make_subprocess_result(returncode=125, stderr="could not select device driver"),
             ]
             with pytest.raises(DockerPreFlightError) as exc_info:
                 run_docker_preflight()
@@ -450,7 +442,7 @@ class TestTier2CUDADriverCompat:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result("470.57.02"),  # old host driver
-                _make_subprocess_result(
+                make_subprocess_result(
                     returncode=1,
                     stderr="Failed to initialize NVML: Driver/library version mismatch\ncuda error",
                 ),
@@ -472,7 +464,7 @@ class TestTier2CUDADriverCompat:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result("470.57.02"),
-                _make_subprocess_result(
+                make_subprocess_result(
                     returncode=1,
                     stderr="CUDA version incompatible with driver",
                 ),
@@ -493,7 +485,7 @@ class TestTier2CUDADriverCompat:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result("470.57.02"),
-                _make_subprocess_result(
+                make_subprocess_result(
                     returncode=1,
                     stderr="Failed to initialize NVML: Driver/library version mismatch",
                 ),
@@ -654,7 +646,7 @@ class TestTier2QuotaAndFallbackStderr:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(
+                make_subprocess_result(
                     returncode=1,
                     stderr=(
                         "DS01 GPU Allocation Failed - You have reached your GPU quota limit. "
@@ -683,7 +675,7 @@ class TestTier2QuotaAndFallbackStderr:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(returncode=1, stderr=raw_stderr),
+                make_subprocess_result(returncode=1, stderr=raw_stderr),
             ]
             with pytest.raises(DockerPreFlightError) as exc_info:
                 run_docker_preflight()
@@ -701,7 +693,7 @@ class TestTier2QuotaAndFallbackStderr:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(returncode=1, stderr="GPU Allocation Failed"),
+                make_subprocess_result(returncode=1, stderr="GPU Allocation Failed"),
             ]
             with pytest.raises(DockerPreFlightError) as exc_info:
                 run_docker_preflight()
@@ -722,7 +714,7 @@ class TestTier2QuotaAndFallbackStderr:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(returncode=1, stderr="gpu quota limit reached"),
+                make_subprocess_result(returncode=1, stderr="gpu quota limit reached"),
             ]
             with pytest.raises(DockerPreFlightError) as exc_info:
                 run_docker_preflight()
@@ -743,7 +735,7 @@ class TestTier2QuotaAndFallbackStderr:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(returncode=1, stderr=raw_stderr),
+                make_subprocess_result(returncode=1, stderr=raw_stderr),
             ]
             with pytest.raises(DockerPreFlightError) as exc_info:
                 run_docker_preflight()
@@ -761,7 +753,7 @@ class TestTier2QuotaAndFallbackStderr:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(returncode=1, stderr=""),
+                make_subprocess_result(returncode=1, stderr=""),
             ]
             with pytest.raises(DockerPreFlightError) as exc_info:
                 run_docker_preflight()
@@ -779,7 +771,7 @@ class TestTier2QuotaAndFallbackStderr:
         ):
             mock_run.side_effect = [
                 _make_nvidia_smi_result(),
-                _make_subprocess_result(
+                make_subprocess_result(
                     returncode=125,
                     stderr='could not select device driver "" with capabilities: [[gpu]]',
                 ),

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -21,6 +21,7 @@ from llenergymeasure.infra.docker_errors import (
 )
 from llenergymeasure.infra.docker_runner import DockerRunner, _env_file, _mask_secrets
 from tests.conftest import make_config, make_result
+from tests.unit.docker.conftest import make_subprocess_result
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -41,15 +42,6 @@ def _docker_config_hash(config) -> str:
     return compute_measurement_config_hash(config)
 
 
-def _make_proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
-    """Return a mock CompletedProcess."""
-    proc = MagicMock()
-    proc.returncode = returncode
-    proc.stdout = stdout
-    proc.stderr = stderr
-    return proc
-
-
 def _subprocess_run_with_image_cached(*run_results: MagicMock):
     """Create a subprocess.run side_effect that handles _ensure_image's inspect call.
 
@@ -57,7 +49,9 @@ def _subprocess_run_with_image_cached(*run_results: MagicMock):
     ``_ensure_image`` — returns exit 0 (image cached). Subsequent calls
     return the provided results in order.
     """
-    results = iter([_make_proc(0), *run_results])  # image inspect → 0, then user results
+    results = iter(
+        [make_subprocess_result(0), *run_results]
+    )  # image inspect → 0, then user results
     return lambda *a, **k: next(results)
 
 
@@ -82,7 +76,7 @@ class TestSuccessPath:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree") as mock_rmtree,
         ):
@@ -125,7 +119,7 @@ class TestSuccessPath:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
         ):
@@ -153,7 +147,7 @@ class TestSuccessPath:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
         ):
@@ -189,7 +183,9 @@ class TestContainerFailure:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                return_value=_make_proc(1, stderr="Error: No such image: ghcr.io/example:latest"),
+                return_value=make_subprocess_result(
+                    1, stderr="Error: No such image: ghcr.io/example:latest"
+                ),
             ),
         ):
             runner = DockerRunner(image=IMAGE)
@@ -209,7 +205,7 @@ class TestContainerFailure:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                return_value=_make_proc(1, stderr="Error: No such image"),
+                return_value=make_subprocess_result(1, stderr="Error: No such image"),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree") as mock_rmtree,
         ):
@@ -237,8 +233,8 @@ class TestOOMError:
         # Second call is the actual docker run → return 137 (OOM).
         calls = iter(
             [
-                _make_proc(0),  # docker image inspect — image cached
-                _make_proc(137, stderr="OOM killer invoked: killed by container OOM"),
+                make_subprocess_result(0),  # docker image inspect — image cached
+                make_subprocess_result(137, stderr="OOM killer invoked: killed by container OOM"),
             ]
         )
 
@@ -272,7 +268,7 @@ class TestTimeout:
         # First call is image inspect (return 0), second is docker run (timeout)
         results = iter(
             [
-                _make_proc(0),  # docker image inspect
+                make_subprocess_result(0),  # docker image inspect
                 None,  # sentinel: raise TimeoutExpired
             ]
         )
@@ -318,7 +314,7 @@ class TestPermissionError:
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
-                    _make_proc(
+                    make_subprocess_result(
                         1,
                         stderr="Got permission denied while trying to connect to the Docker daemon socket",
                     )
@@ -349,7 +345,7 @@ class TestMissingResultFile:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                return_value=_make_proc(0),
+                return_value=make_subprocess_result(0),
             ),
         ):
             runner = DockerRunner(image=IMAGE)
@@ -382,7 +378,7 @@ class TestErrorPayloadFromContainer:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                return_value=_make_proc(0),
+                return_value=make_subprocess_result(0),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
         ):
@@ -416,9 +412,9 @@ class TestDockerCommandStructure:
         def fake_run(cmd, **kwargs):
             # Skip the _ensure_image "docker image inspect" call
             if cmd[:3] == ["docker", "image", "inspect"]:
-                return _make_proc(0)
+                return make_subprocess_result(0)
             captured_cmds.append(cmd)
-            return _make_proc(1, stderr="No such image")  # fail fast
+            return make_subprocess_result(1, stderr="No such image")  # fail fast
 
         with (
             patch(
@@ -474,9 +470,9 @@ class TestHFTokenPropagation:
         def fake_run(cmd, **kwargs):
             # Skip the _ensure_image "docker image inspect" call
             if cmd[:3] == ["docker", "image", "inspect"]:
-                return _make_proc(0)
+                return make_subprocess_result(0)
             captured_cmds.append(cmd)
-            return _make_proc(1, stderr="No such image")
+            return make_subprocess_result(1, stderr="No such image")
 
         with (
             patch(
@@ -508,9 +504,9 @@ class TestHFTokenPropagation:
         def fake_run(cmd, **kwargs):
             # Skip the _ensure_image "docker image inspect" call
             if cmd[:3] == ["docker", "image", "inspect"]:
-                return _make_proc(0)
+                return make_subprocess_result(0)
             captured_cmds.append(cmd)
-            return _make_proc(1, stderr="No such image")
+            return make_subprocess_result(1, stderr="No such image")
 
         with (
             patch(
@@ -556,7 +552,7 @@ class TestRunnerMetadata:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
         ):
@@ -593,7 +589,7 @@ class TestCleanupWarning:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.shutil.rmtree",
@@ -633,9 +629,9 @@ class TestHFTokenSecure:
         def fake_run(cmd, **kwargs):
             # Skip the _ensure_image "docker image inspect" call
             if cmd[:3] == ["docker", "image", "inspect"]:
-                return _make_proc(0)
+                return make_subprocess_result(0)
             captured_cmds.append(cmd)
-            return _make_proc(1, stderr="No such image")
+            return make_subprocess_result(1, stderr="No such image")
 
         with (
             patch(
@@ -683,9 +679,9 @@ class TestHFTokenSecure:
         def fake_run(cmd, **kwargs):
             # Skip the _ensure_image "docker image inspect" call
             if cmd[:3] == ["docker", "image", "inspect"]:
-                return _make_proc(0)
+                return make_subprocess_result(0)
             captured_cmds.append(cmd)
-            return _make_proc(1, stderr="No such image")
+            return make_subprocess_result(1, stderr="No such image")
 
         with (
             patch(
@@ -758,9 +754,9 @@ class TestMpirunInjection:
         def fake_run(cmd, **kwargs):
             # Skip the _ensure_image "docker image inspect" call
             if cmd[:3] == ["docker", "image", "inspect"]:
-                return _make_proc(0)
+                return make_subprocess_result(0)
             captured_cmds.append(cmd)
-            return _make_proc(1, stderr="No such image")
+            return make_subprocess_result(1, stderr="No such image")
 
         with (
             patch(
@@ -955,7 +951,7 @@ class TestContainerLogPersistence:
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
-                    _make_proc(137, stderr=stderr_content)
+                    make_subprocess_result(137, stderr=stderr_content)
                 ),
             ),
         ):
@@ -981,7 +977,7 @@ class TestContainerLogPersistence:
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
-                    _make_proc(1, stderr="some error text")
+                    make_subprocess_result(1, stderr="some error text")
                 ),
             ),
         ):
@@ -1029,7 +1025,7 @@ class TestTimeseriesParquetRescue:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.shutil.rmtree",
@@ -1069,7 +1065,7 @@ class TestTimeseriesParquetRescue:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
         ):
@@ -1098,7 +1094,7 @@ class TestTimeseriesParquetRescue:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
         ):
@@ -1146,7 +1142,7 @@ class TestErrorJsonOnNonZeroExit:
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
-                    _make_proc(1, stderr="some docker stderr noise")
+                    make_subprocess_result(1, stderr="some docker stderr noise")
                 ),
             ),
         ):
@@ -1185,7 +1181,7 @@ class TestErrorJsonOnNonZeroExit:
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
-                    _make_proc(1, stderr="Error: container failed with unknown reason")
+                    make_subprocess_result(1, stderr="Error: container failed with unknown reason")
                 ),
             ),
         ):
@@ -1217,7 +1213,7 @@ class TestVersionMismatchWarning:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
             caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker_runner"),
@@ -1248,7 +1244,7 @@ class TestVersionMismatchWarning:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
             caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker_runner"),
@@ -1281,7 +1277,7 @@ class TestVersionMismatchWarning:
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(_make_proc(0)),
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
             caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker_runner"),

--- a/tests/unit/harness/conftest.py
+++ b/tests/unit/harness/conftest.py
@@ -1,0 +1,32 @@
+"""Shared fixtures and factories for harness/ tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.conftest import TEST_POWER_MW
+
+
+def make_pynvml_mock(
+    *,
+    power_mw: int = TEST_POWER_MW,
+    power_mw_values: list[int] | None = None,
+) -> MagicMock:
+    """Build a minimal pynvml mock for baseline/power tests.
+
+    The thermal-throttle variant in test_power_thermal.py and the
+    memory variant in test_gpu_memory.py remain local (different shape).
+
+    Args:
+        power_mw: Constant return value for nvmlDeviceGetPowerUsage.
+        power_mw_values: Side-effect list (overrides power_mw).
+    """
+    mock = MagicMock()
+    mock.NVMLError = Exception
+
+    if power_mw_values is not None:
+        mock.nvmlDeviceGetPowerUsage.side_effect = power_mw_values
+    else:
+        mock.nvmlDeviceGetPowerUsage.return_value = power_mw
+
+    return mock

--- a/tests/unit/harness/test_baseline.py
+++ b/tests/unit/harness/test_baseline.py
@@ -37,28 +37,11 @@ from llenergymeasure.harness.baseline import (
     measure_baseline_power,
     save_baseline_cache,
 )
+from tests.unit.harness.conftest import make_pynvml_mock
 
 # =============================================================================
 # Helpers
 # =============================================================================
-
-
-def _make_pynvml_mock(power_mw_values: list[int] | None = None) -> MagicMock:
-    """Build a minimal pynvml mock.
-
-    power_mw_values: side_effect list for nvmlDeviceGetPowerUsage.
-                     If None, returns a constant 200_000 (200 W).
-    """
-    mock = MagicMock()
-    # Must define NVMLError as an exception class so `except pynvml.NVMLError` works
-    mock.NVMLError = Exception
-
-    if power_mw_values is not None:
-        mock.nvmlDeviceGetPowerUsage.side_effect = power_mw_values
-    else:
-        mock.nvmlDeviceGetPowerUsage.return_value = 200_000  # 200 W
-
-    return mock
 
 
 @contextmanager
@@ -107,7 +90,7 @@ def test_cache_hit_returns_cached_without_pynvml_call():
     entry = _make_fresh_cache_entry(gpu_indices=[0], power_w=42.0)
     _baseline_cache[(0,)] = entry
 
-    mock_pynvml = _make_pynvml_mock()
+    mock_pynvml = make_pynvml_mock()
 
     with (
         patch(f"{_MODULE}.nvml_context", _noop_nvml_context),
@@ -163,7 +146,7 @@ def test_cache_expired_triggers_fresh_measurement():
     expired = _make_expired_cache_entry(gpu_indices=[0], power_w=10.0)
     _baseline_cache[(0,)] = expired
 
-    mock_pynvml = _make_pynvml_mock(power_mw_values=[200_000])
+    mock_pynvml = make_pynvml_mock(power_mw_values=[200_000])
 
     # monotonic: start=0.0, loop-check=0.1 (< 1.0 duration, one iteration), then 999.0 exits
     mono_values = [0.0, 0.1, 999.0, 999.0]
@@ -187,7 +170,7 @@ def test_cache_expired_triggers_fresh_measurement():
 def test_fresh_measurement_samples_and_caches():
     """Empty cache: samples power, computes mean, stores in _baseline_cache."""
     power_values = [150_000, 155_000, 148_000]  # milliwatts
-    mock_pynvml = _make_pynvml_mock(power_mw_values=power_values)
+    mock_pynvml = make_pynvml_mock(power_mw_values=power_values)
 
     # monotonic: start=0.0, then 0.1, 0.2, 0.3 (< 0.4 duration) then 1.0 (exits)
     mono_values = [0.0, 0.1, 0.2, 0.3, 1.0, 1.0]
@@ -226,7 +209,7 @@ def test_pynvml_unavailable_returns_none():
 
 def test_device_handle_failure_returns_none():
     """nvmlDeviceGetHandleByIndex raises: measure_baseline_power returns None."""
-    mock_pynvml = _make_pynvml_mock()
+    mock_pynvml = make_pynvml_mock()
     mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = Exception("handle error")
 
     with (
@@ -245,7 +228,7 @@ def test_nvml_error_during_sampling_skips_bad_samples():
     # Alternating: good, bad, good
     power_side_effects = [200_000, nvml_error, 180_000]
 
-    mock_pynvml = _make_pynvml_mock(power_mw_values=power_side_effects)
+    mock_pynvml = make_pynvml_mock(power_mw_values=power_side_effects)
     mock_pynvml.NVMLError = type(nvml_error)
 
     mono_values = [0.0, 0.1, 0.2, 0.3, 1.0, 1.0]
@@ -269,7 +252,7 @@ def test_nvml_error_during_sampling_skips_bad_samples():
 def test_no_samples_collected_returns_none():
     """All nvmlDeviceGetPowerUsage calls raise NVMLError: returns None."""
     nvml_error = Exception("nvml error")
-    mock_pynvml = _make_pynvml_mock()
+    mock_pynvml = make_pynvml_mock()
     mock_pynvml.NVMLError = type(nvml_error)
     mock_pynvml.nvmlDeviceGetPowerUsage.side_effect = nvml_error
 

--- a/tests/unit/harness/test_flops_v2.py
+++ b/tests/unit/harness/test_flops_v2.py
@@ -245,30 +245,22 @@ def test_flops_result_invalid_method_rejected() -> None:
 
 
 def _make_experiment_result(**overrides):
-    """Build a minimal valid ExperimentResult for FLOPs derived field tests."""
-    from datetime import datetime, timezone
+    """Build a minimal valid ExperimentResult for FLOPs derived field tests.
 
-    from llenergymeasure.domain.experiment import AggregationMetadata, ExperimentResult
-
-    epoch = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    epoch_end = datetime(2026, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    Delegates to conftest make_result with FLOPs-specific defaults.
+    """
+    from tests.conftest import make_result
 
     defaults = {
         "experiment_id": "flops-test-001",
-        "measurement_config_hash": "abc123def4567890",
-        "measurement_methodology": "total",
-        "aggregation": AggregationMetadata(num_processes=1),
         "total_tokens": 100,
-        "total_energy_j": 10.0,
         "total_inference_time_sec": 10.0,
         "avg_tokens_per_second": 10.0,
         "avg_energy_per_token_j": 0.1,
         "total_flops": 0.0,
-        "start_time": epoch,
-        "end_time": epoch_end,
     }
     defaults.update(overrides)
-    return ExperimentResult(**defaults)
+    return make_result(**defaults)
 
 
 def test_flops_derived_fields_computed() -> None:

--- a/tests/unit/study/conftest.py
+++ b/tests/unit/study/conftest.py
@@ -1,0 +1,1 @@
+"""Shared fixtures for study/ tests."""

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -25,6 +25,7 @@ from llenergymeasure.config.models import (
 )
 from llenergymeasure.harness.baseline import BaselineCache
 from llenergymeasure.study.runner import StudyRunner
+from tests.conftest import TEST_CONFIG_HASH
 
 # Patch targets: source modules, not runner imports (lazy local imports)
 _MEASURE = "llenergymeasure.harness.baseline.measure_baseline_power"
@@ -57,7 +58,7 @@ def _make_runner(tmp_path: Path, config: ExperimentConfig) -> StudyRunner:
         experiments=[config],
         study_name="test-baseline",
         study_execution=ExecutionConfig(n_cycles=1, experiment_order="sequential"),
-        study_design_hash="deadbeef12345678",
+        study_design_hash=TEST_CONFIG_HASH,
     )
     manifest = MagicMock()
     runner = StudyRunner(study, manifest, tmp_path)

--- a/tests/unit/study/test_study_manifest.py
+++ b/tests/unit/study/test_study_manifest.py
@@ -28,6 +28,7 @@ from llenergymeasure.study.manifest import (
     create_study_dir,
     experiment_result_filename,
 )
+from tests.conftest import TEST_CONFIG_HASH
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -46,7 +47,7 @@ def _make_study(n_experiments: int = 2, n_cycles: int = 2) -> StudyConfig:
         study_name="test-study",
         experiments=experiments,
         study_execution=ExecutionConfig(n_cycles=n_cycles),
-        study_design_hash="deadbeef12345678",
+        study_design_hash=TEST_CONFIG_HASH,
     )
 
 

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -28,6 +28,7 @@ from llenergymeasure.study.runner import (
     _kill_process_group,
     _run_experiment_worker,
 )
+from tests.conftest import TEST_CONFIG_HASH
 
 # =============================================================================
 # Fixtures
@@ -57,7 +58,7 @@ def study_config(basic_config: ExperimentConfig) -> StudyConfig:
         experiments=[basic_config],
         study_name="test-study",
         study_execution=ExecutionConfig(n_cycles=1, experiment_order="sequential"),
-        study_design_hash="deadbeef12345678",
+        study_design_hash=TEST_CONFIG_HASH,
     )
 
 
@@ -443,7 +444,7 @@ def _make_sigint_study() -> StudyConfig:
         ],
         study_name="sigint-test",
         study_execution=ExecutionConfig(n_cycles=1, experiment_order="sequential"),
-        study_design_hash="deadbeef12345678",
+        study_design_hash=TEST_CONFIG_HASH,
     )
 
 
@@ -501,7 +502,7 @@ def test_sigint_during_gap_exits_immediately() -> None:
         study_execution=ExecutionConfig(
             n_cycles=1, experiment_order="sequential", experiment_gap_seconds=60.0
         ),
-        study_design_hash="deadbeef12345678",
+        study_design_hash=TEST_CONFIG_HASH,
     )
     manifest = MagicMock()
     fake_result = {"status": "ok"}

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -17,8 +17,6 @@ Tests cover Phase 3 and Phase 4 (Plan 03) success criteria:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import pytest
 
 import llenergymeasure
@@ -32,43 +30,9 @@ from llenergymeasure import (
     run_experiment,
     run_study,
 )
-from llenergymeasure.domain.experiment import AggregationMetadata, StudySummary
+from llenergymeasure.domain.experiment import StudySummary
 from llenergymeasure.utils.exceptions import BackendError, PreFlightError
-from tests.conftest import make_config, make_user_config
-
-_EPOCH = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-_EPOCH_END = datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)
-
-
-# =============================================================================
-# Test helper
-# =============================================================================
-
-
-def _make_experiment_result(**overrides) -> ExperimentResult:
-    """Build a minimal valid ExperimentResult for testing."""
-    defaults = {
-        "experiment_id": "test-001",
-        "measurement_config_hash": "abc123def4567890",
-        "measurement_methodology": "total",
-        "aggregation": AggregationMetadata(num_processes=1),
-        "total_tokens": 1000,
-        "total_energy_j": 10.0,
-        "total_inference_time_sec": 5.0,
-        "avg_tokens_per_second": 200.0,
-        "avg_energy_per_token_j": 0.01,
-        "total_flops": 1e9,
-        "start_time": _EPOCH,
-        "end_time": _EPOCH_END,
-    }
-    defaults.update(overrides)
-    return ExperimentResult(**defaults)
-
-
-def _make_study_result(**overrides) -> StudyResult:
-    """Build a StudyResult containing one ExperimentResult."""
-    return StudyResult(experiments=[_make_experiment_result()])
-
+from tests.conftest import make_config, make_result, make_study_result, make_user_config
 
 # =============================================================================
 # Test 1: Public imports resolve
@@ -114,7 +78,7 @@ def test_run_experiment_returns_experiment_result(monkeypatch):
     """run_experiment returns exactly ExperimentResult, not a union or None."""
     import llenergymeasure.api._impl as api_module
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: _make_study_result())
+    monkeypatch.setattr(api_module, "_run", lambda study, **kw: make_study_result())
 
     config = ExperimentConfig(model="gpt2")
     result = run_experiment(config)
@@ -138,7 +102,7 @@ def test_run_experiment_yaml_path_form(tmp_path, monkeypatch):
 
     def mock_run(study, **kw):
         captured_study["value"] = study
-        return _make_study_result()
+        return make_study_result()
 
     monkeypatch.setattr(api_module, "_run", mock_run)
 
@@ -165,7 +129,7 @@ def test_run_experiment_kwargs_form(monkeypatch):
 
     def mock_run(study, **kw):
         captured_study["value"] = study
-        return _make_study_result()
+        return make_study_result()
 
     monkeypatch.setattr(api_module, "_run", mock_run)
 
@@ -198,7 +162,7 @@ def test_run_experiment_no_disk_writes(tmp_path, monkeypatch):
     """run_experiment produces no disk writes when output_dir is not specified."""
     import llenergymeasure.api._impl as api_module
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: _make_study_result())
+    monkeypatch.setattr(api_module, "_run", lambda study, **kw: make_study_result())
 
     # Change working directory to tmp_path to catch any accidental writes
     config = ExperimentConfig(model="gpt2")
@@ -253,7 +217,7 @@ def test_run_experiment_path_object_form(tmp_path, monkeypatch):
     """run_experiment accepts a Path object as well as a str path."""
     import llenergymeasure.api._impl as api_module
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: _make_study_result())
+    monkeypatch.setattr(api_module, "_run", lambda study, **kw: make_study_result())
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text("model: gpt2\n")
@@ -275,7 +239,7 @@ def test_run_experiment_kwargs_backend(monkeypatch):
 
     def mock_run(study, **kw):
         captured_study["value"] = study
-        return _make_study_result()
+        return make_study_result()
 
     monkeypatch.setattr(api_module, "_run", mock_run)
 
@@ -365,7 +329,7 @@ def test_run_calls_preflight_once_per_config(monkeypatch, tmp_path):
     def mock_preflight(config):
         preflight_calls.append(config)
 
-    mock_result = _make_experiment_result()
+    mock_result = make_result()
     mock_backend = _MockBackend(mock_result)
 
     monkeypatch.setattr(pf_module, "run_preflight", mock_preflight)
@@ -400,7 +364,7 @@ def test_run_calls_get_backend_with_correct_name(monkeypatch, tmp_path):
     import llenergymeasure.harness.preflight as pf_module
     import llenergymeasure.study.preflight as study_pf_module
 
-    mock_result = _make_experiment_result()
+    mock_result = make_result()
     mock_backend = _MockBackend(mock_result)
 
     backend_calls: list[str] = []
@@ -441,7 +405,7 @@ def test_run_returns_study_result(monkeypatch, tmp_path):
     import llenergymeasure.harness.preflight as pf_module
     import llenergymeasure.study.preflight as study_pf_module
 
-    mock_result = _make_experiment_result(experiment_id="wired-001")
+    mock_result = make_result(experiment_id="wired-001")
     mock_backend = _MockBackend(mock_result)
 
     monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
@@ -486,7 +450,7 @@ def test_run_propagates_preflight_error(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "llenergymeasure.infra.runner_resolution.is_docker_available", lambda: False
     )
-    mock_result = _make_experiment_result()
+    mock_result = make_result()
     monkeypatch.setattr(backends_module, "get_backend", lambda name: _MockBackend(mock_result))
     _patch_harness(monkeypatch, mock_result)
     monkeypatch.setattr(
@@ -517,9 +481,7 @@ def test_run_propagates_backend_error(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "llenergymeasure.infra.runner_resolution.is_docker_available", lambda: False
     )
-    monkeypatch.setattr(
-        backends_module, "get_backend", lambda name: _MockBackend(_make_experiment_result())
-    )
+    monkeypatch.setattr(backends_module, "get_backend", lambda name: _MockBackend(make_result()))
     monkeypatch.setattr(harness_module.MeasurementHarness, "run", _failing_harness_run)
     monkeypatch.setattr(
         "llenergymeasure.study.manifest.create_study_dir",
@@ -539,7 +501,7 @@ def test_run_experiment_end_to_end_mocked(monkeypatch, tmp_path):
     import llenergymeasure.harness.preflight as pf_module
     import llenergymeasure.study.preflight as study_pf_module
 
-    expected_result = _make_experiment_result(experiment_id="e2e-test")
+    expected_result = make_result(experiment_id="e2e-test")
     mock_backend = _MockBackend(expected_result)
 
     monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
@@ -576,7 +538,7 @@ def test_run_study_accepts_study_config(monkeypatch, tmp_path):
     import llenergymeasure.harness.preflight as pf_module
     import llenergymeasure.study.preflight as study_pf_module
 
-    mock_result = _make_experiment_result(experiment_id="study-test")
+    mock_result = make_result(experiment_id="study-test")
     mock_backend = _MockBackend(mock_result)
 
     monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
@@ -614,7 +576,7 @@ def test_run_study_accepts_path(tmp_path, monkeypatch):
     yaml_path = tmp_path / "study.yaml"
     yaml_path.write_text(yaml_content)
 
-    mock_result = _make_experiment_result(experiment_id="path-test")
+    mock_result = make_result(experiment_id="path-test")
     mock_backend = _MockBackend(mock_result)
 
     monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
@@ -646,7 +608,7 @@ def test_run_dispatches_single_in_process(monkeypatch, tmp_path):
     import llenergymeasure.study.preflight as study_pf_module
     from llenergymeasure.study.runner import StudyRunner
 
-    mock_result = _make_experiment_result(experiment_id="inproc-test")
+    mock_result = make_result(experiment_id="inproc-test")
     mock_backend = _MockBackend(mock_result)
 
     runner_created = []
@@ -707,7 +669,7 @@ def test_run_resolves_runners_and_passes_to_study_runner(monkeypatch, tmp_path):
     import llenergymeasure.study.preflight as study_pf_module
     from llenergymeasure.infra.runner_resolution import RunnerSpec
 
-    mock_result = _make_experiment_result(experiment_id="runner-wired")
+    mock_result = make_result(experiment_id="runner-wired")
 
     resolved_specs = {
         "pytorch": RunnerSpec(mode="local", image=None, source="default"),
@@ -788,7 +750,7 @@ def test_run_in_process_calls_gpu_memory_check(monkeypatch, tmp_path):
     def mock_gpu_check(device_index=0, threshold_mb=1024.0):
         gpu_check_calls.append(device_index)
 
-    mock_result = _make_experiment_result(experiment_id="gpu-check-test")
+    mock_result = make_result(experiment_id="gpu-check-test")
     mock_backend = _MockBackend(mock_result)
 
     monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
@@ -834,7 +796,7 @@ def test_run_mixed_runner_warning_logged(monkeypatch, tmp_path, caplog):
         "vllm": RunnerSpec(mode="docker", image=None, source="yaml"),
     }
 
-    mock_result = _make_experiment_result()
+    mock_result = make_result()
     mock_backend = _MockBackend(mock_result)
 
     monkeypatch.setattr(
@@ -884,7 +846,7 @@ def test_study_summary_total_experiments_no_double_multiply(monkeypatch, tmp_pat
     import llenergymeasure.study.preflight as study_pf_module
 
     # Build 6 mock results (2 configs x 3 cycles, already cycle-expanded)
-    mock_results = [_make_experiment_result(experiment_id=f"b3-{i}") for i in range(6)]
+    mock_results = [make_result(experiment_id=f"b3-{i}") for i in range(6)]
 
     # Mock _run_via_runner to return pre-built results (bypasses real subprocess)
     def mock_run_via_runner(
@@ -1194,7 +1156,7 @@ def test_run_study_partial_failure_returns_partial_results(monkeypatch):
     """
     import llenergymeasure.api._impl as api_module
 
-    successful_result = _make_experiment_result(experiment_id="partial-ok")
+    successful_result = make_result(experiment_id="partial-ok")
 
     partial_study_result = StudyResult(
         experiments=[successful_result],  # 1 succeeded, 1 was filtered (None)


### PR DESCRIPTION
## Summary

- **Fix order-dependent test failures**: Extract `_hide_module()` context manager that snapshots/restores all submodules (`torch.*`, `vllm.*`, `tensorrt_llm.*`) in `sys.modules`, preventing pytest-randomly failures in `test_backend_protocol` and `test_peak_memory`
- **Add subdirectory conftest.py files**: Promote duplicated factories into scoped conftest files for `docker/` (`make_subprocess_result`) and `harness/` (`make_pynvml_mock`); add placeholder conftest files for `study/`, `cli/`, `backends/`, `config/`
- **Centralise shared test constants**: Add `TEST_MODEL`, `TEST_BACKEND`, `TEST_EXPERIMENT_ID`, `TEST_CONFIG_HASH`, `TEST_MEASUREMENT_HASH`, `TEST_POWER_MW`, `TEST_POWER_W` to root conftest; update factories and consumer files
- **Deduplicate factories**: Remove duplicate `_make_experiment_result`/`_make_study_result` from `test_api.py` (use root conftest); refactor `test_flops_v2.py` to delegate to `make_result`; merge identical `_make_proc`/`_make_subprocess_result` into shared docker conftest
- **Add `filterwarnings`** config in pyproject.toml for pytest `rm_rf` cleanup warnings

Net: -24 lines, 17 files touched. 1737 passed, 0 failed across 5 random seeds.

## Test plan

- [x] `pytest tests/ -q` - 1737 passed, 0 failed
- [x] 5 random seeds on previously-failing files - all green
- [x] `ruff check tests/` - all passed
- [x] `ruff format --check tests/` - all formatted
- [x] `grep -rn "def _make_proc\b" tests/` - gone
- [x] `grep -rn "_EPOCH = " tests/` - only in root conftest