### PR TITLE
refactor(infra): centralise SSOT constants

### DIFF
--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -13,7 +13,7 @@ from typing import Any, overload
 
 from llenergymeasure.config.loader import load_experiment_config
 from llenergymeasure.config.models import DatasetConfig, ExperimentConfig, StudyConfig
-from llenergymeasure.config.ssot import RUNNER_DOCKER
+from llenergymeasure.config.ssot import RUNNER_DOCKER, TEMP_PREFIX_TIMESERIES
 from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 from llenergymeasure.domain.experiment import ExperimentResult, StudyResult, StudySummary
 from llenergymeasure.domain.progress import ProgressCallback
@@ -650,7 +650,7 @@ def _run_in_process(
             progress.on_step_done("container_preflight", time.perf_counter() - t0)
 
         # Create temp dir for timeseries parquet (if enabled)
-        ts_tmpdir = Path(tempfile.mkdtemp(prefix="llem-ts-")) if save_ts else None
+        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES)) if save_ts else None
 
         try:
             backend = get_backend(config.backend)

--- a/src/llenergymeasure/cli/__init__.py
+++ b/src/llenergymeasure/cli/__init__.py
@@ -9,6 +9,7 @@ from typing import Annotated
 import typer
 
 from llenergymeasure._version import __version__
+from llenergymeasure.config.ssot import ENV_LOG_LEVEL
 
 app = typer.Typer(
     name="llem",
@@ -40,7 +41,7 @@ def _setup_logging(verbose: int = 0) -> None:
     elif verbose == 1:
         level = logging.INFO
     else:
-        env_level = os.environ.get("LLEM_LOG_LEVEL", "").upper()
+        env_level = os.environ.get(ENV_LOG_LEVEL, "").upper()
         level = getattr(logging, env_level, logging.WARNING)
 
     root_logger = logging.getLogger("llenergymeasure")

--- a/src/llenergymeasure/cli/_step_display.py
+++ b/src/llenergymeasure/cli/_step_display.py
@@ -23,6 +23,7 @@ from rich.live import Live
 from rich.table import Table
 from rich.text import Text
 
+from llenergymeasure.config.ssot import ENV_TABLE_ROWS
 from llenergymeasure.domain.progress import PHASE_MEASUREMENT, STEP_LABELS, STEP_PHASES
 from llenergymeasure.utils.compat import StrEnum
 from llenergymeasure.utils.formatting import format_elapsed as _format_elapsed
@@ -994,7 +995,7 @@ class StudyStepDisplay:
         """
         import os
 
-        env_rows = os.environ.get("LLEM_TABLE_ROWS")
+        env_rows = os.environ.get(ENV_TABLE_ROWS)
         if env_rows:
             try:
                 return max(3, int(env_rows))

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -1,12 +1,15 @@
-"""Single source of truth for backend capability constants.
+"""Single source of truth for project-wide constants.
 
-These dicts define which dtype modes and decoding strategies each backend
-supports. They are consumed by:
+Centralises backend capabilities, runner modes, environment variable names,
+temp file prefixes, and infrastructure timeout values. Consumers include:
 - ExperimentConfig cross-validators (structural validation)
 - config/introspection.py (backend capability metadata)
 - CLI help generation
+- Infrastructure modules (Docker runner, runner resolution, image registry)
+- Study runner and container lifecycle management
 
-Do not inline these values in validators — always import from here.
+Do not inline these values in validators or infrastructure code — always
+import from here.
 """
 
 from __future__ import annotations
@@ -39,6 +42,74 @@ RunnerMode = Literal["local", "docker"]
 
 DOCKER_PULL_TIMEOUT: Final = 1800
 """Maximum seconds to wait for ``docker pull`` (30 min — generous for large images like TensorRT ~10 GB)."""
+
+# ---------------------------------------------------------------------------
+# Environment variable name constants
+# ---------------------------------------------------------------------------
+
+ENV_RUNNER_PREFIX: Final = "LLEM_RUNNER_"
+"""Prefix for per-backend runner override env vars (e.g. ``LLEM_RUNNER_PYTORCH=docker``)."""
+
+ENV_IMAGE_PREFIX: Final = "LLEM_IMAGE_"
+"""Prefix for per-backend image override env vars (e.g. ``LLEM_IMAGE_VLLM=custom:tag``)."""
+
+ENV_CARBON_INTENSITY: Final = "LLEM_CARBON_INTENSITY"
+ENV_DATACENTER_PUE: Final = "LLEM_DATACENTER_PUE"
+ENV_NO_PROMPT: Final = "LLEM_NO_PROMPT"
+ENV_HF_TOKEN: Final = "HF_TOKEN"
+ENV_OUTPUT_DIR: Final = "LLEM_OUTPUT_DIR"
+ENV_SAVE_TIMESERIES: Final = "LLEM_SAVE_TIMESERIES"
+ENV_CONFIG_PATH: Final = "LLEM_CONFIG_PATH"
+ENV_LOG_LEVEL: Final = "LLEM_LOG_LEVEL"
+ENV_TABLE_ROWS: Final = "LLEM_TABLE_ROWS"
+
+# ---------------------------------------------------------------------------
+# Temp file/directory prefixes
+# ---------------------------------------------------------------------------
+
+TEMP_PREFIX_EXCHANGE: Final = "llem-"
+"""Prefix for exchange directory created by DockerRunner."""
+
+TEMP_PREFIX_ENV_FILE: Final = "llem-env"
+"""Prefix for env-file temp files used to pass secrets to Docker."""
+
+TEMP_PREFIX_TIMESERIES: Final = "llem-ts-"
+"""Prefix for temp directories holding timeseries parquet files."""
+
+# ---------------------------------------------------------------------------
+# Subprocess / thread timeout constants (seconds)
+# ---------------------------------------------------------------------------
+
+# Docker CLI subprocess timeouts
+TIMEOUT_DOCKER_CLI: Final = 5
+"""Quick Docker CLI calls: ``docker ps``, ``docker image inspect`` (cache check)."""
+
+TIMEOUT_DOCKER_INSPECT: Final = 10
+"""``docker image inspect`` in ensure_image / study runner image preparation."""
+
+TIMEOUT_DOCKER_STOP: Final = 10
+"""``docker stop`` graceful shutdown."""
+
+# NVIDIA tool subprocess timeouts
+TIMEOUT_NVCC: Final = 5
+"""``nvcc --version`` subprocess."""
+
+TIMEOUT_NVIDIA_SMI: Final = 10
+"""``nvidia-smi`` query subprocess."""
+
+# Background task timeouts
+TIMEOUT_ENV_SNAPSHOT: Final = 10
+"""Environment snapshot collection future."""
+
+# Thread / process lifecycle timeouts
+TIMEOUT_THREAD_JOIN: Final = 5
+"""Thread joins, process teardown."""
+
+TIMEOUT_SIGTERM_GRACE: Final = 2
+"""Grace period after SIGTERM before SIGKILL."""
+
+TIMEOUT_INTERRUPT_POLL: Final = 1
+"""Interrupt event wait loop tick."""
 
 # ---------------------------------------------------------------------------
 # Backend capability dicts
@@ -97,12 +168,37 @@ __all__ = [
     "BACKEND_PYTORCH",
     "BACKEND_TENSORRT",
     "BACKEND_VLLM",
+    "CONTAINER_EXCHANGE_DIR",
     "DECODER_PARAM_SUPPORT",
     "DECODING_SUPPORT",
     "DOCKER_PULL_TIMEOUT",
     "DTYPE_SUPPORT",
+    "ENV_CARBON_INTENSITY",
+    "ENV_CONFIG_PATH",
+    "ENV_DATACENTER_PUE",
+    "ENV_HF_TOKEN",
+    "ENV_IMAGE_PREFIX",
+    "ENV_LOG_LEVEL",
+    "ENV_NO_PROMPT",
+    "ENV_OUTPUT_DIR",
+    "ENV_RUNNER_PREFIX",
+    "ENV_SAVE_TIMESERIES",
+    "ENV_TABLE_ROWS",
     "RUNNER_DOCKER",
     "RUNNER_LOCAL",
+    "SOURCE_MULTI_BACKEND_ELEVATION",
+    "TEMP_PREFIX_ENV_FILE",
+    "TEMP_PREFIX_EXCHANGE",
+    "TEMP_PREFIX_TIMESERIES",
+    "TIMEOUT_DOCKER_CLI",
+    "TIMEOUT_DOCKER_INSPECT",
+    "TIMEOUT_DOCKER_STOP",
+    "TIMEOUT_ENV_SNAPSHOT",
+    "TIMEOUT_INTERRUPT_POLL",
+    "TIMEOUT_NVCC",
+    "TIMEOUT_NVIDIA_SMI",
+    "TIMEOUT_SIGTERM_GRACE",
+    "TIMEOUT_THREAD_JOIN",
     "BackendName",
     "RunnerMode",
 ]

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -91,8 +91,10 @@ TIMEOUT_DOCKER_STOP: Final = 10
 """``docker stop`` graceful shutdown."""
 
 # NVIDIA tool subprocess timeouts
-TIMEOUT_NVCC: Final = 5
-"""``nvcc --version`` subprocess."""
+# TIMEOUT_NVCC is defined in utils/constants.py because domain/environment.py
+# needs it, and domain/ cannot import config/ (sibling layers). Re-exported
+# here so existing ssot.py consumers keep their import path.
+from llenergymeasure.utils.constants import TIMEOUT_NVCC as TIMEOUT_NVCC  # noqa: E402
 
 TIMEOUT_NVIDIA_SMI: Final = 10
 """``nvidia-smi`` query subprocess."""

--- a/src/llenergymeasure/config/user_config.py
+++ b/src/llenergymeasure/config/user_config.py
@@ -19,6 +19,12 @@ import yaml
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from llenergymeasure.config.models import EnergySamplerName
+from llenergymeasure.config.ssot import (
+    ENV_CARBON_INTENSITY,
+    ENV_DATACENTER_PUE,
+    ENV_NO_PROMPT,
+    ENV_RUNNER_PREFIX,
+)
 
 
 class UserOutputConfig(BaseModel):
@@ -156,20 +162,20 @@ def _apply_env_overrides(config: UserConfig) -> UserConfig:
     """
     runners_updates: dict[str, str] = {}
     for backend in ("pytorch", "vllm", "tensorrt"):
-        env_key = f"LLEM_RUNNER_{backend.upper()}"
+        env_key = f"{ENV_RUNNER_PREFIX}{backend.upper()}"
         if val := os.environ.get(env_key):
             runners_updates[backend] = val
 
     measurement_updates: dict[str, Any] = {}
-    if val := os.environ.get("LLEM_CARBON_INTENSITY"):
+    if val := os.environ.get(ENV_CARBON_INTENSITY):
         with contextlib.suppress(ValueError):
             measurement_updates["carbon_intensity_gco2_kwh"] = float(val)
-    if val := os.environ.get("LLEM_DATACENTER_PUE"):
+    if val := os.environ.get(ENV_DATACENTER_PUE):
         with contextlib.suppress(ValueError):
             measurement_updates["datacenter_pue"] = float(val)
 
     ui_updates: dict[str, Any] = {}
-    if os.environ.get("LLEM_NO_PROMPT"):
+    if os.environ.get(ENV_NO_PROMPT):
         ui_updates["prompt"] = False
 
     # Apply updates using model_copy(update=...) for immutable Pydantic models

--- a/src/llenergymeasure/device/gpu_info.py
+++ b/src/llenergymeasure/device/gpu_info.py
@@ -15,7 +15,12 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
-from llenergymeasure.config.ssot import BACKEND_PYTORCH, BACKEND_TENSORRT, BACKEND_VLLM
+from llenergymeasure.config.ssot import (
+    BACKEND_PYTORCH,
+    BACKEND_TENSORRT,
+    BACKEND_VLLM,
+    TIMEOUT_NVIDIA_SMI,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +197,7 @@ def _get_mig_instance_counts() -> dict[int, int]:
             ["nvidia-smi", "-L"],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=TIMEOUT_NVIDIA_SMI,
         )
         if result.returncode != 0:
             return {}

--- a/src/llenergymeasure/domain/environment.py
+++ b/src/llenergymeasure/domain/environment.py
@@ -11,6 +11,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from llenergymeasure.utils.constants import TIMEOUT_NVCC
+
 logger = logging.getLogger(__name__)
 
 
@@ -202,7 +204,7 @@ def detect_cuda_version_with_source() -> tuple[str | None, str | None]:
             ["nvcc", "--version"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=TIMEOUT_NVCC,
         )
         match = re.search(r"release (\d+\.\d+)", result.stdout)
         if match:

--- a/src/llenergymeasure/entrypoints/container.py
+++ b/src/llenergymeasure/entrypoints/container.py
@@ -33,6 +33,13 @@ import time
 import traceback
 from pathlib import Path
 
+from llenergymeasure.config.ssot import (
+    CONTAINER_EXCHANGE_DIR,
+    ENV_CONFIG_PATH,
+    ENV_OUTPUT_DIR,
+    ENV_SAVE_TIMESERIES,
+)
+
 __all__ = ["StreamProgressCallback", "main", "run_container_experiment"]
 
 
@@ -145,12 +152,12 @@ def run_container_experiment(config_path: Path, result_dir: Path) -> Path:
     progress = StreamProgressCallback()
 
     # --- Resolve output params from env vars (set by DockerRunner) ---
-    output_dir = os.environ.get("LLEM_OUTPUT_DIR")
-    save_timeseries = os.environ.get("LLEM_SAVE_TIMESERIES", "1") != "0"
+    output_dir = os.environ.get(ENV_OUTPUT_DIR)
+    save_timeseries = os.environ.get(ENV_SAVE_TIMESERIES, "1") != "0"
 
     # --- Load baseline from disk cache (mounted by host StudyRunner) ---
     baseline = None
-    baseline_cache_path = Path("/run/llem/baseline_cache.json")
+    baseline_cache_path = Path(f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json")
     if baseline_cache_path.exists() and config.baseline.enabled:
         from llenergymeasure.harness.baseline import load_baseline_cache
 
@@ -200,10 +207,10 @@ def main() -> None:
             "traceback": "full traceback string"
         }
     """
-    config_path_env = os.environ.get("LLEM_CONFIG_PATH")
+    config_path_env = os.environ.get(ENV_CONFIG_PATH)
     if not config_path_env:
         raise RuntimeError(
-            "LLEM_CONFIG_PATH environment variable is not set. "
+            f"{ENV_CONFIG_PATH} environment variable is not set. "
             "The DockerRunner must set this before starting the container."
         )
 

--- a/src/llenergymeasure/harness/__init__.py
+++ b/src/llenergymeasure/harness/__init__.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from llenergymeasure._version import __version__
 from llenergymeasure.backends.protocol import BackendPlugin, InferenceOutput
+from llenergymeasure.config.ssot import TIMEOUT_ENV_SNAPSHOT
 from llenergymeasure.datasets import load_prompts
 from llenergymeasure.domain.experiment import (
     AggregationMetadata,
@@ -302,7 +303,7 @@ class MeasurementHarness:
 
         # 3b. Join snapshot future — collection hidden behind model loading
         if snapshot_future is not None:
-            snapshot = snapshot_future.result(timeout=10)
+            snapshot = snapshot_future.result(timeout=TIMEOUT_ENV_SNAPSHOT)
 
         # 4. Capture model memory baseline immediately after model load.
         # Must happen BEFORE warmup, which allocates KV cache.

--- a/src/llenergymeasure/infra/docker_preflight.py
+++ b/src/llenergymeasure/infra/docker_preflight.py
@@ -24,6 +24,7 @@ import logging
 import shutil
 import subprocess
 
+from llenergymeasure.config.ssot import TIMEOUT_NVIDIA_SMI
 from llenergymeasure.utils.exceptions import DockerPreFlightError
 
 __all__ = ["run_docker_preflight"]
@@ -90,7 +91,7 @@ def _get_host_driver_version() -> str | None:
             ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=TIMEOUT_NVIDIA_SMI,
         )
         if result.returncode == 0:
             version = result.stdout.strip().splitlines()[0].strip()

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -32,7 +32,20 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from llenergymeasure.domain.progress import ProgressCallback
 
-from llenergymeasure.config.ssot import BACKEND_TENSORRT, DOCKER_PULL_TIMEOUT
+from llenergymeasure.config.ssot import (
+    BACKEND_TENSORRT,
+    CONTAINER_EXCHANGE_DIR,
+    DOCKER_PULL_TIMEOUT,
+    ENV_CONFIG_PATH,
+    ENV_HF_TOKEN,
+    ENV_OUTPUT_DIR,
+    ENV_SAVE_TIMESERIES,
+    TEMP_PREFIX_ENV_FILE,
+    TEMP_PREFIX_EXCHANGE,
+    TEMP_PREFIX_TIMESERIES,
+    TIMEOUT_DOCKER_INSPECT,
+    TIMEOUT_THREAD_JOIN,
+)
 from llenergymeasure.infra.docker_errors import (
     DockerContainerError,
     DockerTimeoutError,
@@ -64,7 +77,7 @@ def _env_file(secrets: dict[str, str]) -> Iterator[Path | None]:
         yield None
         return
 
-    fd, path_str = tempfile.mkstemp(prefix="llem-env", suffix=".env")
+    fd, path_str = tempfile.mkstemp(prefix=TEMP_PREFIX_ENV_FILE, suffix=".env")
     path = Path(path_str)
     try:
         with os.fdopen(fd, "w") as f:
@@ -167,13 +180,13 @@ class DockerRunner:
         # Lazy import to avoid heavy domain imports at module load time
         from llenergymeasure.domain.experiment import compute_measurement_config_hash
 
-        exchange_dir = Path(tempfile.mkdtemp(prefix="llem-"))
+        exchange_dir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_EXCHANGE))
 
         # Collect secrets for env-file (never pass as CLI args)
         secrets: dict[str, str] = {}
-        hf_token = os.environ.get("HF_TOKEN")
+        hf_token = os.environ.get(ENV_HF_TOKEN)
         if hf_token:
-            secrets["HF_TOKEN"] = hf_token
+            secrets[ENV_HF_TOKEN] = hf_token
 
         _p = progress  # short alias
 
@@ -194,8 +207,8 @@ class DockerRunner:
 
             # Pass output params via env vars so the container entrypoint can
             # forward them to the harness as runtime params.
-            secrets["LLEM_OUTPUT_DIR"] = "/run/llem"
-            secrets["LLEM_SAVE_TIMESERIES"] = "1" if save_timeseries else "0"
+            secrets[ENV_OUTPUT_DIR] = CONTAINER_EXCHANGE_DIR
+            secrets[ENV_SAVE_TIMESERIES] = "1" if save_timeseries else "0"
 
             # --- Build and execute docker command ---
             t0_container: float | None = None
@@ -293,7 +306,7 @@ class DockerRunner:
             ts_parquet = exchange_dir / "timeseries.parquet"
             ts_tmpdir: Path | None = None
             if ts_parquet.exists() and not isinstance(result, dict):
-                ts_tmpdir = Path(tempfile.mkdtemp(prefix="llem-ts-"))
+                ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
                 shutil.move(str(ts_parquet), str(ts_tmpdir / "timeseries.parquet"))
 
             # --- Success: clean up ---
@@ -332,7 +345,7 @@ class DockerRunner:
         check = subprocess.run(
             ["docker", "image", "inspect", self.image],
             capture_output=True,
-            timeout=10,
+            timeout=TIMEOUT_DOCKER_INSPECT,
         )
         if check.returncode == 0:
             if progress:
@@ -534,7 +547,7 @@ class DockerRunner:
                 fix_suggestion="Increase timeout or reduce experiment size.",
             ) from exc
 
-        stderr_thread.join(timeout=5)
+        stderr_thread.join(timeout=TIMEOUT_THREAD_JOIN)
         stderr_text = "".join(stderr_lines)
 
         return proc.returncode, stderr_text
@@ -573,9 +586,9 @@ class DockerRunner:
             "--gpus",
             "all",
             "-v",
-            f"{exchange_dir}:/run/llem",
+            f"{exchange_dir}:{CONTAINER_EXCHANGE_DIR}",
             "-e",
-            f"LLEM_CONFIG_PATH=/run/llem/{config_hash}_config.json",
+            f"{ENV_CONFIG_PATH}={CONTAINER_EXCHANGE_DIR}/{config_hash}_config.json",
             "--shm-size",
             "8g",
         ]

--- a/src/llenergymeasure/infra/image_registry.py
+++ b/src/llenergymeasure/infra/image_registry.py
@@ -38,8 +38,11 @@ from llenergymeasure.config.ssot import (
     BACKEND_PYTORCH,
     BACKEND_TENSORRT,
     BACKEND_VLLM,
+    ENV_IMAGE_PREFIX,
     RUNNER_DOCKER,
     RUNNER_LOCAL,
+    TIMEOUT_DOCKER_CLI,
+    TIMEOUT_NVCC,
     RunnerMode,
 )
 
@@ -88,7 +91,7 @@ def get_cuda_major_version() -> str | None:
             ["nvcc", "--version"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=TIMEOUT_NVCC,
         )
         if result.returncode == 0:
             major = _parse_cuda_major_from_nvcc(result.stdout)
@@ -186,7 +189,7 @@ def _image_exists_locally(image: str) -> bool:
         result = subprocess.run(
             ["docker", "image", "inspect", image],
             capture_output=True,
-            timeout=5,
+            timeout=TIMEOUT_DOCKER_CLI,
         )
         return result.returncode == 0
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
@@ -232,7 +235,7 @@ def resolve_image(
     _load_dotenv()
 
     # 1. Env var (includes .env via python-dotenv)
-    env_key = f"LLEM_IMAGE_{backend.upper()}"
+    env_key = f"{ENV_IMAGE_PREFIX}{backend.upper()}"
     if env_val := os.environ.get(env_key):
         logger.info("Image for %s resolved from env var %s: %s", backend, env_key, env_val)
         return (env_val, "env")

--- a/src/llenergymeasure/infra/runner_resolution.py
+++ b/src/llenergymeasure/infra/runner_resolution.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from llenergymeasure.config.user_config import UserRunnersConfig
 
-from llenergymeasure.config.ssot import RUNNER_DOCKER, RUNNER_LOCAL, RunnerMode
+from llenergymeasure.config.ssot import ENV_RUNNER_PREFIX, RUNNER_DOCKER, RUNNER_LOCAL, RunnerMode
 
 # Re-exported from image_registry for convenience — parse_runner_value is defined
 # there (canonical home) but used heavily in this module and its tests.
@@ -165,7 +165,7 @@ def resolve_runner(
     _load_dotenv()
 
     # 1. Env var: LLEM_RUNNER_{BACKEND} (highest precedence)
-    env_key = f"LLEM_RUNNER_{backend.upper()}"
+    env_key = f"{ENV_RUNNER_PREFIX}{backend.upper()}"
     if env_val := os.environ.get(env_key):
         mode, image = parse_runner_value(env_val)
         return RunnerSpec(mode=mode, image=image, source="env")

--- a/src/llenergymeasure/study/container_lifecycle.py
+++ b/src/llenergymeasure/study/container_lifecycle.py
@@ -23,6 +23,8 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from llenergymeasure.config.ssot import TIMEOUT_DOCKER_CLI, TIMEOUT_DOCKER_STOP
+
 __all__ = [
     "cleanup_study_containers",
     "generate_container_labels",
@@ -93,14 +95,14 @@ def cleanup_study_containers(study_id: str) -> None:
             ["docker", "ps", "-q", "--filter", f"label=llem.study_id={study_id}"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=TIMEOUT_DOCKER_CLI,
         )
         for cid in result.stdout.strip().splitlines():
             if cid.strip():
                 subprocess.run(
                     ["docker", "stop", "-t", "5", cid.strip()],
                     capture_output=True,
-                    timeout=10,
+                    timeout=TIMEOUT_DOCKER_STOP,
                 )
     except Exception:
         pass  # Best-effort; atexit handlers must never raise
@@ -172,7 +174,7 @@ def reap_orphaned_containers() -> int:
             ],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=TIMEOUT_DOCKER_CLI,
         )
         for line in result.stdout.strip().splitlines():
             parts = line.split()
@@ -186,7 +188,7 @@ def reap_orphaned_containers() -> int:
                 subprocess.run(
                     ["docker", "stop", "-t", "5", cid],
                     capture_output=True,
-                    timeout=10,
+                    timeout=TIMEOUT_DOCKER_STOP,
                 )
                 reaped += 1
             except PermissionError:

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -33,7 +33,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from llenergymeasure.config.ssot import DOCKER_PULL_TIMEOUT, RUNNER_DOCKER
+from llenergymeasure.config.ssot import (
+    CONTAINER_EXCHANGE_DIR,
+    DOCKER_PULL_TIMEOUT,
+    RUNNER_DOCKER,
+    TEMP_PREFIX_TIMESERIES,
+    TIMEOUT_DOCKER_INSPECT,
+    TIMEOUT_ENV_SNAPSHOT,
+    TIMEOUT_INTERRUPT_POLL,
+    TIMEOUT_SIGTERM_GRACE,
+    TIMEOUT_THREAD_JOIN,
+)
 from llenergymeasure.domain.progress import STEPS_DOCKER, STEPS_DOCKER_RUN, STEPS_LOCAL
 from llenergymeasure.study.gaps import run_gap
 
@@ -745,7 +755,7 @@ class StudyRunner:
             from llenergymeasure.harness.environment import collect_environment_snapshot_async
 
             self._env_snapshot_future = collect_environment_snapshot_async()
-        return self._env_snapshot_future.result(timeout=10)
+        return self._env_snapshot_future.result(timeout=TIMEOUT_ENV_SNAPSHOT)
 
     def _get_baseline(self, config: ExperimentConfig) -> Any:
         """Return baseline power according to the configured strategy.
@@ -928,7 +938,7 @@ class StudyRunner:
                 check = subprocess.run(
                     ["docker", "image", "inspect", image],
                     capture_output=True,
-                    timeout=10,
+                    timeout=TIMEOUT_DOCKER_INSPECT,
                 )
             except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
                 check = None
@@ -979,7 +989,7 @@ class StudyRunner:
                 inspect = subprocess.run(
                     ["docker", "image", "inspect", image],
                     capture_output=True,
-                    timeout=10,
+                    timeout=TIMEOUT_DOCKER_INSPECT,
                 )
                 metadata = self._parse_image_metadata(inspect.stdout)
             except Exception:
@@ -1050,7 +1060,7 @@ class StudyRunner:
                 if self._interrupt_event.is_set():
                     break
                 self._progress.show_gap(f"{label}: {format_gap_duration(remaining)}")
-                self._interrupt_event.wait(timeout=1)
+                self._interrupt_event.wait(timeout=TIMEOUT_INTERRUPT_POLL)
             self._progress.clear_gap()
         else:
             # Fall back to terminal countdown
@@ -1101,7 +1111,7 @@ class StudyRunner:
         # output_dir as a runtime param (not from config). The temp dir is
         # cleaned up after _handle_result copies the parquet into the study directory.
         save_ts = self.study.output.save_timeseries
-        ts_tmpdir = Path(tempfile.mkdtemp(prefix="llem-ts-")) if save_ts else None
+        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES)) if save_ts else None
 
         # Resolve cached snapshot in parent — serialised to subprocess via Pipe
         snapshot = self._get_env_snapshot()
@@ -1151,13 +1161,13 @@ class StudyRunner:
             except Exception:
                 pipe_payload = _UNSET
 
-        # Non-blocking join after pipe is drained (5s grace for teardown)
-        p.join(timeout=5)
+        # Non-blocking join after pipe is drained (grace for teardown)
+        p.join(timeout=TIMEOUT_THREAD_JOIN)
 
         # SIGINT was received during join: SIGTERM was already sent by handler.
-        # Give child 2s grace for clean CUDA teardown, then SIGKILL.
+        # Grace period for clean CUDA teardown, then SIGKILL.
         if self._interrupt_event.is_set() and p.is_alive():
-            p.join(timeout=2)  # 2s grace after SIGTERM
+            p.join(timeout=TIMEOUT_SIGTERM_GRACE)
             if p.is_alive():
                 _kill_process_group(p.pid, signal.SIGKILL)
                 p.join()
@@ -1237,8 +1247,6 @@ class StudyRunner:
                     )
                     is_docker = spec is not None and spec.mode == RUNNER_DOCKER
                     if is_docker:
-                        from llenergymeasure.config.ssot import CONTAINER_EXCHANGE_DIR
-
                         self._progress.on_substep("save", f"container: {CONTAINER_EXCHANGE_DIR}")
                     self._progress.on_substep("save", f"host: {host_path}")
 
@@ -1316,7 +1324,9 @@ class StudyRunner:
             and baseline_cache_path is not None
             and baseline_cache_path.exists()
         ):
-            extra_mounts.append((str(baseline_cache_path), "/run/llem/baseline_cache.json"))
+            extra_mounts.append(
+                (str(baseline_cache_path), f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json")
+            )
 
         docker_runner = DockerRunner(
             image=image,

--- a/src/llenergymeasure/utils/constants.py
+++ b/src/llenergymeasure/utils/constants.py
@@ -1,4 +1,14 @@
 """Constants for LLenergyMeasure framework."""
 
+from typing import Final
+
 # Completion marker prefix for aggregated result files
 COMPLETION_MARKER_PREFIX = ".completed_"
+
+# Subprocess timeouts needed by layer-0 modules (config, domain).
+# Kept here rather than in config/ssot.py because domain/ and config/ are
+# sibling layers — domain cannot import config, so shared constants live in
+# utils/ (the layer below both). config/ssot.py re-exports these for ergonomic
+# access alongside the rest of the infrastructure constants.
+TIMEOUT_NVCC: Final = 5
+"""``nvcc --version`` subprocess timeout (seconds)."""

--- a/tests/unit/config/test_config_user_config.py
+++ b/tests/unit/config/test_config_user_config.py
@@ -10,6 +10,12 @@ from pathlib import Path
 
 import pytest
 
+from llenergymeasure.config.ssot import (
+    ENV_CARBON_INTENSITY,
+    ENV_DATACENTER_PUE,
+    ENV_NO_PROMPT,
+    ENV_RUNNER_PREFIX,
+)
 from llenergymeasure.config.user_config import UserConfig, get_user_config_path, load_user_config
 
 # ---------------------------------------------------------------------------
@@ -98,28 +104,28 @@ def test_load_user_config_energy_sampler_override(tmp_path):
 
 def test_env_var_llem_carbon_intensity(tmp_path, monkeypatch):
     """LLEM_CARBON_INTENSITY env var sets carbon_intensity_gco2_kwh."""
-    monkeypatch.setenv("LLEM_CARBON_INTENSITY", "450.0")
+    monkeypatch.setenv(ENV_CARBON_INTENSITY, "450.0")
     config = load_user_config(config_path=tmp_path / "nonexistent.yaml")
     assert config.measurement.carbon_intensity_gco2_kwh == pytest.approx(450.0)
 
 
 def test_env_var_llem_datacenter_pue(tmp_path, monkeypatch):
     """LLEM_DATACENTER_PUE env var sets datacenter_pue."""
-    monkeypatch.setenv("LLEM_DATACENTER_PUE", "1.5")
+    monkeypatch.setenv(ENV_DATACENTER_PUE, "1.5")
     config = load_user_config(config_path=tmp_path / "nonexistent.yaml")
     assert config.measurement.datacenter_pue == pytest.approx(1.5)
 
 
 def test_env_var_llem_no_prompt(tmp_path, monkeypatch):
     """LLEM_NO_PROMPT env var disables interactive prompts."""
-    monkeypatch.setenv("LLEM_NO_PROMPT", "1")
+    monkeypatch.setenv(ENV_NO_PROMPT, "1")
     config = load_user_config(config_path=tmp_path / "nonexistent.yaml")
     assert config.ui.prompt is False
 
 
 def test_env_var_runner_pytorch(tmp_path, monkeypatch):
     """LLEM_RUNNER_PYTORCH env var overrides pytorch runner."""
-    monkeypatch.setenv("LLEM_RUNNER_PYTORCH", "docker:nvcr.io/nvidia/pytorch:latest")
+    monkeypatch.setenv(f"{ENV_RUNNER_PREFIX}PYTORCH", "docker:nvcr.io/nvidia/pytorch:latest")
     config = load_user_config(config_path=tmp_path / "nonexistent.yaml")
     assert config.runners.pytorch == "docker:nvcr.io/nvidia/pytorch:latest"
 
@@ -128,7 +134,7 @@ def test_env_var_overrides_take_precedence_over_file(tmp_path, monkeypatch):
     """Env var overrides take precedence over config file values."""
     config_file = tmp_path / "config.yaml"
     config_file.write_text("measurement:\n  datacenter_pue: 1.2\n")
-    monkeypatch.setenv("LLEM_DATACENTER_PUE", "1.8")
+    monkeypatch.setenv(ENV_DATACENTER_PUE, "1.8")
     config = load_user_config(config_path=config_file)
     assert config.measurement.datacenter_pue == pytest.approx(1.8)
 
@@ -140,7 +146,7 @@ def test_env_var_overrides_take_precedence_over_file(tmp_path, monkeypatch):
 
 def test_silent_ignore_invalid_float_carbon_intensity(tmp_path, monkeypatch):
     """LLEM_CARBON_INTENSITY='not_a_number' is silently ignored (treated as not set)."""
-    monkeypatch.setenv("LLEM_CARBON_INTENSITY", "not_a_number")
+    monkeypatch.setenv(ENV_CARBON_INTENSITY, "not_a_number")
     # Should not raise
     config = load_user_config(config_path=tmp_path / "nonexistent.yaml")
     # Value is not set (treated as None — same as not providing the env var)
@@ -149,7 +155,7 @@ def test_silent_ignore_invalid_float_carbon_intensity(tmp_path, monkeypatch):
 
 def test_silent_ignore_invalid_float_datacenter_pue(tmp_path, monkeypatch):
     """LLEM_DATACENTER_PUE='abc' is silently ignored (treated as not set)."""
-    monkeypatch.setenv("LLEM_DATACENTER_PUE", "abc")
+    monkeypatch.setenv(ENV_DATACENTER_PUE, "abc")
     # Should not raise — value is silently ignored
     config = load_user_config(config_path=tmp_path / "nonexistent.yaml")
     # Falls back to default when invalid

--- a/tests/unit/docker/test_container_entrypoint.py
+++ b/tests/unit/docker/test_container_entrypoint.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from llenergymeasure.config.ssot import CONTAINER_EXCHANGE_DIR, ENV_CONFIG_PATH
 from tests.conftest import make_config, make_result
 
 # Patch targets: patch the source modules, not container_entrypoint references,
@@ -151,7 +152,7 @@ class TestMainErrorHandling:
         config_path = tmp_path / "abc123_config.json"
         config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
 
-        monkeypatch.setenv("LLEM_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv(ENV_CONFIG_PATH, str(config_path))
 
         with (
             patch(_PATCH_PREFLIGHT),
@@ -180,7 +181,7 @@ class TestMainErrorHandling:
         config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
         fake_result = make_result()
 
-        monkeypatch.setenv("LLEM_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv(ENV_CONFIG_PATH, str(config_path))
 
         with (
             patch(_PATCH_PREFLIGHT),
@@ -197,11 +198,11 @@ class TestMainErrorHandling:
         assert len(result_files) == 1
 
     def test_main_raises_if_env_var_missing(self, monkeypatch):
-        monkeypatch.delenv("LLEM_CONFIG_PATH", raising=False)
+        monkeypatch.delenv(ENV_CONFIG_PATH, raising=False)
 
         from llenergymeasure.entrypoints.container import main
 
-        with pytest.raises(RuntimeError, match="LLEM_CONFIG_PATH"):
+        with pytest.raises(RuntimeError, match=ENV_CONFIG_PATH):
             main()
 
     def test_error_json_has_required_keys(self, tmp_path: Path, monkeypatch):
@@ -209,7 +210,7 @@ class TestMainErrorHandling:
         config_path = tmp_path / "abc123_config.json"
         config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
 
-        monkeypatch.setenv("LLEM_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv(ENV_CONFIG_PATH, str(config_path))
 
         with (
             patch(_PATCH_PREFLIGHT),
@@ -265,7 +266,7 @@ class TestContainerBaselineLoading:
             mock_cache_path.exists.return_value = True
 
             def path_factory(p):
-                if p == "/run/llem/baseline_cache.json":
+                if p == f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json":
                     return mock_cache_path
                 return Path(p)
 
@@ -322,7 +323,7 @@ class TestContainerBaselineLoading:
             mock_cache_path.exists.return_value = True
 
             def path_factory(p):
-                if p == "/run/llem/baseline_cache.json":
+                if p == f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json":
                     return mock_cache_path
                 return Path(p)
 
@@ -359,7 +360,7 @@ class TestContainerBaselineLoading:
             mock_cache_path.exists.return_value = True
 
             def path_factory(p):
-                if p == "/run/llem/baseline_cache.json":
+                if p == f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json":
                     return mock_cache_path
                 return Path(p)
 
@@ -392,7 +393,7 @@ class TestContainerBaselineLoading:
             mock_cache_path.exists.return_value = True
 
             def path_factory(p):
-                if p == "/run/llem/baseline_cache.json":
+                if p == f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json":
                     return mock_cache_path
                 return Path(p)
 

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -12,6 +12,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from llenergymeasure.config.ssot import (
+    CONTAINER_EXCHANGE_DIR,
+    ENV_CONFIG_PATH,
+    ENV_HF_TOKEN,
+)
 from llenergymeasure.infra.docker_errors import (
     DockerContainerError,
     DockerImagePullError,
@@ -438,12 +443,12 @@ class TestDockerCommandStructure:
         assert "--shm-size" in cmd
         assert "8g" in cmd
 
-        # Volume mount: exchange_dir:/run/llem
+        # Volume mount: exchange_dir:{CONTAINER_EXCHANGE_DIR}
         joined = " ".join(cmd)
-        assert ":/run/llem" in joined
+        assert f":{CONTAINER_EXCHANGE_DIR}" in joined
 
-        # LLEM_CONFIG_PATH env var
-        assert any("LLEM_CONFIG_PATH" in arg for arg in cmd)
+        # Config path env var
+        assert any(ENV_CONFIG_PATH in arg for arg in cmd)
 
         # Entrypoint module
         assert "llenergymeasure.entrypoints.container" in joined
@@ -460,7 +465,7 @@ class TestDockerCommandStructure:
 class TestHFTokenPropagation:
     def test_hf_token_uses_env_file_not_cli_arg(self, tmp_path, monkeypatch):
         """HF_TOKEN is forwarded via --env-file, not as a -e CLI argument."""
-        monkeypatch.setenv("HF_TOKEN", "hf_test_secret_token")
+        monkeypatch.setenv(ENV_HF_TOKEN, "hf_test_secret_token")
         config = make_config()
         exchange_dir = tmp_path / "llem-hftoken"
         exchange_dir.mkdir()
@@ -494,7 +499,7 @@ class TestHFTokenPropagation:
 
     def test_hf_token_absent_when_not_set(self, tmp_path, monkeypatch):
         """HF_TOKEN is not added to docker command when env var is absent."""
-        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.delenv(ENV_HF_TOKEN, raising=False)
         config = make_config()
         exchange_dir = tmp_path / "llem-nohf"
         exchange_dir.mkdir()
@@ -521,7 +526,7 @@ class TestHFTokenPropagation:
 
         cmd = captured_cmds[0]
         joined = " ".join(cmd)
-        assert "HF_TOKEN" not in joined
+        assert ENV_HF_TOKEN not in joined
 
 
 # ---------------------------------------------------------------------------
@@ -619,7 +624,7 @@ class TestCleanupWarning:
 class TestHFTokenSecure:
     def test_hf_token_not_in_cmd_args(self, tmp_path, monkeypatch):
         """HF_TOKEN value never appears in docker run command args (S1 security fix)."""
-        monkeypatch.setenv("HF_TOKEN", "hf_test_secret_token_12345")
+        monkeypatch.setenv(ENV_HF_TOKEN, "hf_test_secret_token_12345")
         config = make_config()
         exchange_dir = tmp_path / "llem-s1-cmd"
         exchange_dir.mkdir()
@@ -648,13 +653,13 @@ class TestHFTokenSecure:
         # Token value must not appear in any cmd element
         assert not any("hf_test_secret_token_12345" in arg for arg in cmd)
         # Token must not be passed as -e KEY=VALUE
-        assert not any("HF_TOKEN" in arg and "=" in arg for arg in cmd)
+        assert not any(ENV_HF_TOKEN in arg and "=" in arg for arg in cmd)
         # --env-file must be present
         assert "--env-file" in cmd
 
     def test_hf_token_env_file_content(self):
         """_env_file creates a file with KEY=VALUE format; file is deleted after context exits."""
-        secrets = {"HF_TOKEN": "hf_test_secret_value"}
+        secrets = {ENV_HF_TOKEN: "hf_test_secret_value"}
 
         captured_path: list[Path] = []
 
@@ -669,7 +674,7 @@ class TestHFTokenSecure:
 
     def test_env_file_without_hf_token_still_has_output_vars(self, tmp_path, monkeypatch):
         """When HF_TOKEN is absent, env-file still exists (LLEM_OUTPUT_DIR etc.) but has no HF_TOKEN."""
-        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.delenv(ENV_HF_TOKEN, raising=False)
         config = make_config()
         exchange_dir = tmp_path / "llem-s1-notoken"
         exchange_dir.mkdir()
@@ -695,15 +700,15 @@ class TestHFTokenSecure:
                 runner.run(config)
 
         cmd = captured_cmds[0]
-        # Env-file is still used for LLEM_OUTPUT_DIR and LLEM_SAVE_TIMESERIES
+        # Env-file is still used for ENV_OUTPUT_DIR and ENV_SAVE_TIMESERIES
         assert "--env-file" in cmd
         # But HF_TOKEN must not appear anywhere in the command
         joined = " ".join(cmd)
-        assert "HF_TOKEN" not in joined
+        assert ENV_HF_TOKEN not in joined
 
     def test_env_file_cleanup_on_failure(self):
         """Temp env-file is deleted even when an exception is raised inside the context."""
-        secrets = {"HF_TOKEN": "hf_cleanup_test_value"}
+        secrets = {ENV_HF_TOKEN: "hf_cleanup_test_value"}
         captured_path: list[Path] = []
 
         try:
@@ -723,10 +728,10 @@ class TestHFTokenSecure:
         """_mask_secrets replaces long secret values with *** in strings."""
         # Long values (>4 chars) are masked
         result = _mask_secrets(
-            "docker run -e HF_TOKEN=abc123xyz",
-            {"HF_TOKEN": "abc123xyz"},
+            f"docker run -e {ENV_HF_TOKEN}=abc123xyz",
+            {ENV_HF_TOKEN: "abc123xyz"},
         )
-        assert result == "docker run -e HF_TOKEN=***"
+        assert result == f"docker run -e {ENV_HF_TOKEN}=***"
 
         # Short values (<=4 chars) are NOT masked — avoids false positives
         result_short = _mask_secrets(
@@ -880,7 +885,7 @@ class TestExtraMounts:
         # Only one -v flag: the exchange dir
         v_count = cmd.count("-v")
         assert v_count == 1
-        assert "/tmp/llem-test:/run/llem" in cmd
+        assert f"/tmp/llem-test:{CONTAINER_EXCHANGE_DIR}" in cmd
 
     def test_tensorrt_auto_cache_mount(self, tmp_path):
         """TRT-LLM backend auto-mounts ~/.cache/trt-llm:/root/.cache/trt-llm."""

--- a/tests/unit/docker/test_image_registry.py
+++ b/tests/unit/docker/test_image_registry.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
+from llenergymeasure.config.ssot import ENV_IMAGE_PREFIX
+
 
 @pytest.fixture(autouse=True)
 def clear_cuda_version_cache():
@@ -158,7 +160,7 @@ class TestResolveImage:
     def test_env_var_takes_highest_precedence(self, monkeypatch):
         from llenergymeasure.infra.image_registry import resolve_image
 
-        monkeypatch.setenv("LLEM_IMAGE_VLLM", "custom/env-image:v1")
+        monkeypatch.setenv(f"{ENV_IMAGE_PREFIX}VLLM", "custom/env-image:v1")
 
         image, source = resolve_image(
             "vllm",
@@ -232,7 +234,7 @@ class TestResolveImage:
     def test_env_var_case_insensitive_backend(self, monkeypatch):
         from llenergymeasure.infra.image_registry import resolve_image
 
-        monkeypatch.setenv("LLEM_IMAGE_PYTORCH", "my/pytorch:v1")
+        monkeypatch.setenv(f"{ENV_IMAGE_PREFIX}PYTORCH", "my/pytorch:v1")
         image, source = resolve_image("pytorch")
         assert image == "my/pytorch:v1"
         assert source == "env"

--- a/tests/unit/test_runner_resolution.py
+++ b/tests/unit/test_runner_resolution.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
+from llenergymeasure.config.ssot import ENV_RUNNER_PREFIX
 from llenergymeasure.config.user_config import UserRunnersConfig
 from llenergymeasure.infra.runner_resolution import (
     RunnerSpec,
@@ -129,7 +130,7 @@ class TestResolveRunner:
 
     def test_env_var_wins_over_everything(self, monkeypatch):
         """LLEM_RUNNER_VLLM=docker:custom/img wins over yaml and user_config."""
-        monkeypatch.setenv("LLEM_RUNNER_VLLM", "docker:custom/img")
+        monkeypatch.setenv(f"{ENV_RUNNER_PREFIX}VLLM", "docker:custom/img")
         yaml_runners = {"vllm": "local"}
         user_config = UserRunnersConfig(vllm="local")
 
@@ -141,7 +142,7 @@ class TestResolveRunner:
 
     def test_env_var_bare_docker(self, monkeypatch):
         """LLEM_RUNNER_PYTORCH=docker (bare) sets mode=docker, image=None."""
-        monkeypatch.setenv("LLEM_RUNNER_PYTORCH", "docker")
+        monkeypatch.setenv(f"{ENV_RUNNER_PREFIX}PYTORCH", "docker")
 
         spec = resolve_runner("pytorch")
 
@@ -151,7 +152,7 @@ class TestResolveRunner:
 
     def test_env_var_local_overrides_yaml_docker(self, monkeypatch):
         """Env var 'local' takes precedence even when yaml says 'docker'."""
-        monkeypatch.setenv("LLEM_RUNNER_PYTORCH", "local")
+        monkeypatch.setenv(f"{ENV_RUNNER_PREFIX}PYTORCH", "local")
         spec = resolve_runner("pytorch", yaml_runners={"pytorch": "docker"})
         assert spec.source == "env"
         assert spec.mode == "local"
@@ -316,7 +317,7 @@ class TestResolveRunner:
 
     def test_parse_runner_value_integration_docker_custom_image(self, monkeypatch):
         """parse_runner_value integration: 'docker:ghcr.io/custom:v1' resolves image."""
-        monkeypatch.setenv("LLEM_RUNNER_PYTORCH", "docker:ghcr.io/custom:v1")
+        monkeypatch.setenv(f"{ENV_RUNNER_PREFIX}PYTORCH", "docker:ghcr.io/custom:v1")
         spec = resolve_runner("pytorch")
         assert spec.mode == "docker"
         assert spec.image == "ghcr.io/custom:v1"


### PR DESCRIPTION
## Summary

Recovers and lands the PR 47.3 scope from Phase 47 (`results-bundle-rationalisation`). This was done earlier today in a background agent worktree but the worktree was torn down before the branch was pushed, leaving two orphaned commits that would have been garbage-collected.

Replaces scattered hardcoded strings and magic numbers across infrastructure modules with named constants in `config/ssot.py`. Adds three new categories alongside the existing capability constants:

- **Environment variable names** — `LLEM_RUNNER_*`, `LLEM_IMAGE_*`, `LLEM_CARBON_INTENSITY`, `HF_TOKEN`, `LLEM_OUTPUT_DIR`, etc.
- **Temp file / directory prefixes** — `llem-`, `llem-env`, `llem-ts-`
- **Subprocess / thread timeouts** — Docker CLI, `nvidia-smi`, `nvcc`, thread joins, SIGTERM grace, env snapshot collection

Call sites updated across `cli/`, `api/`, `entrypoints/`, `infra/`, `study/`, `device/`, `domain/`, `harness/` and associated tests. No behaviour change — pure centralisation refactor.

## Commits

1. `refactor(infra): centralise SSOT constants` — main refactor (20 files, +271/-96). Also moves `TIMEOUT_NVCC` to `utils/constants.py` and re-exports from `ssot.py`, because `domain/environment.py` consumes it and `domain/` cannot import `config/` (sibling layers per the import-linter `main-layers` contract). The layer fix was originally a separate commit recovered alongside the rest, but has been folded into the parent to keep the branch clean.
2. `refactor(infra): use TIMEOUT_* constants in remaining subprocess call sites` — mop-up covering three call sites missed in the first pass: `domain/environment.py` (nvcc), `device/gpu_info.py` (nvidia-smi), `harness/__init__.py` (env snapshot future).

## Test plan

- [x] `ruff check src/llenergymeasure/` — clean
- [x] `lint-imports` — 3/3 contracts kept (including `main-layers` which the original commit was breaking)
- [x] `pytest tests/unit/` — 1715 passed
- [x] Targeted: `tests/unit/docker/`, `tests/unit/config/`, `tests/unit/test_runner_resolution.py`, `tests/unit/domain/`, `tests/unit/infra/`, `tests/unit/device/` — 513 passed

## Context

Closes the remaining scope of Phase 47 (`.planning/phases/47-results-bundle-rationalisation/PLAN.md`). PR 47.1 (#244) and PR 47.2 (#246) already landed. This is the last cleanup task for the phase.