### PR TITLE
feat(study): per-experiment wall-clock timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.
+
+### Removed
+
+- Internal helper `llenergymeasure.study.runner._calculate_timeout` (replaced by direct config reads; also removes a layer-boundary import from `api/_impl.py`).
+
 ## [v2.0.0](https://github.com/henrycgbaker/LLenergyMeasure/releases/tag/v2.0.0) (2026-01-14)
 
 Refactored CLI-based tool with clean architecture, comprehensive documentation, and improved configuration UX.

--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -33,6 +33,7 @@ study_execution:
   max_consecutive_failures: 10    # Circuit breaker: 0=disabled, 1=fail-fast, N=threshold
   circuit_breaker_cooldown_seconds: 60.0  # Pause before half-open probe
   wall_clock_timeout_hours: null  # Hard time limit in hours (null = no limit)
+  experiment_timeout_seconds: 600.0  # Per-experiment kill timeout (10 min). Raise for large n_prompts or slow engine builds.
 
 # =====================================================================
 # Shared fields (experiment-level)

--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -535,6 +535,7 @@ def _run(
         "experiment_gap_seconds": study.study_execution.experiment_gap_seconds,
         "cycle_gap_seconds": study.study_execution.cycle_gap_seconds,
         "shuffle_seed": study.study_execution.shuffle_seed,
+        "experiment_timeout_seconds": study.study_execution.experiment_timeout_seconds,
     }
 
     summary = StudySummary(
@@ -603,16 +604,16 @@ def _run_in_process(
 
     if spec is not None and spec.mode == RUNNER_DOCKER:
         # Docker path: dispatch to container directly (no subprocess)
+        from llenergymeasure.infra.docker_errors import DockerTimeoutError
         from llenergymeasure.infra.docker_runner import DockerRunner
         from llenergymeasure.infra.image_registry import get_default_image
         from llenergymeasure.utils.exceptions import DockerError
 
         image = spec.image if spec.image is not None else get_default_image(config.backend)
-        from llenergymeasure.study.runner import _calculate_timeout
 
         docker_runner = DockerRunner(
             image=image,
-            timeout=_calculate_timeout(config),
+            timeout=study.study_execution.experiment_timeout_seconds,
             source=spec.source,
             extra_mounts=spec.extra_mounts,
         )
@@ -621,9 +622,21 @@ def _run_in_process(
             result, docker_ts_dir = docker_runner.run(
                 config, progress=progress, save_timeseries=save_ts
             )
+        except DockerTimeoutError as exc:
+            # Normalise to "TimeoutError" so the circuit breaker sees the same
+            # failure class as the subprocess path.
+            error_payload: dict[str, Any] = {
+                "type": "TimeoutError",
+                "message": str(exc),
+                "config_hash": config_hash,
+            }
+            manifest.mark_failed(
+                config_hash, cycle, error_payload["type"], error_payload["message"]
+            )
+            return [], [None], [error_payload["message"]]
         except DockerError as exc:
             # Convert to failure dict — manifest marks failed, study continues
-            error_payload: dict[str, Any] = {
+            error_payload = {
                 "type": type(exc).__name__,
                 "message": str(exc),
                 "config_hash": config_hash,

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -659,6 +659,16 @@ class ExecutionConfig(BaseModel):
         gt=0.0,
         description="Study wall-clock timeout in hours. null = no limit.",
     )
+    experiment_timeout_seconds: float = Field(
+        default=600.0,
+        gt=0.0,
+        description=(
+            "Per-experiment wall-clock timeout in seconds. Applies to both the "
+            "local subprocess path and the Docker container path. Experiments "
+            "that exceed this budget are killed and recorded as TimeoutError; "
+            "the circuit breaker counts them toward max_consecutive_failures."
+        ),
+    )
 
 
 class StudyConfig(BaseModel):

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -120,7 +120,7 @@ class DockerRunner:
     def __init__(
         self,
         image: str,
-        timeout: int | None = None,
+        timeout: float | None = None,
         source: str = "unknown",
         extra_mounts: list[tuple[str, str]] | None = None,
         container_name: str | None = None,

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -356,7 +356,7 @@ def _collect_result(
     p: Any,  # multiprocessing.Process
     parent_conn: Any,  # multiprocessing.Connection (parent end)
     config: ExperimentConfig,
-    timeout: int,
+    timeout: float,
     pipe_payload: Any = _UNSET,
 ) -> Any:
     """Inspect process outcome and return either a result or a failure dict.

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -57,7 +57,6 @@ if TYPE_CHECKING:
 
 __all__ = [
     "StudyRunner",
-    "_calculate_timeout",
     "_kill_process_group",
     "_run_experiment_worker",
     "_save_and_record",
@@ -69,14 +68,6 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 # Module-level helpers
 # =============================================================================
-
-
-def _calculate_timeout(config: ExperimentConfig) -> int:
-    """Generous timeout heuristic: 2 seconds per prompt, minimum 10 minutes.
-
-    No model-size scaling — keep it simple.
-    """
-    return max(config.dataset.n_prompts * 2, 600)
 
 
 def _save_and_record(
@@ -1091,7 +1082,7 @@ class StudyRunner:
                 config, spec, config_hash=config_hash, cycle=cycle, index=index
             )
 
-        timeout = _calculate_timeout(config)
+        timeout = self.study.study_execution.experiment_timeout_seconds
 
         # Signal study display: new experiment starting (subprocess = local steps)
         if self._progress:
@@ -1296,6 +1287,7 @@ class StudyRunner:
         Returns:
             ExperimentResult on success, or a failure dict on error.
         """
+        from llenergymeasure.infra.docker_errors import DockerTimeoutError
         from llenergymeasure.infra.docker_runner import DockerRunner
         from llenergymeasure.infra.image_registry import get_default_image
         from llenergymeasure.study.container_lifecycle import (
@@ -1334,7 +1326,7 @@ class StudyRunner:
 
         docker_runner = DockerRunner(
             image=image,
-            timeout=_calculate_timeout(config),
+            timeout=self.study.study_execution.experiment_timeout_seconds,
             source=spec.source,
             extra_mounts=extra_mounts,
             container_name=container_name,
@@ -1375,6 +1367,15 @@ class StudyRunner:
                 save_timeseries=self.study.output.save_timeseries,
                 skip_image_check=self._images_prepared,
             )
+        except DockerTimeoutError as exc:
+            # Normalise to "TimeoutError" so the circuit breaker sees the same
+            # failure class as the subprocess path (see _collect_result).
+            result = {
+                "type": "TimeoutError",
+                "message": str(exc),
+                "config_hash": config_hash,
+            }
+            self._persist_failure_artefacts(exc, config_hash, cycle, result)
         except DockerError as exc:
             # Use structured error payload from container entrypoint when available,
             # falling back to the exception type/message for stderr-based errors.

--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -81,6 +81,22 @@ class TestExecutionConfig:
         ec = ExecutionConfig(shuffle_seed=12345)
         assert ec.shuffle_seed == 12345
 
+    def test_experiment_timeout_default(self):
+        assert ExecutionConfig().experiment_timeout_seconds == 600.0
+
+    def test_experiment_timeout_zero_raises(self):
+        with pytest.raises(ValidationError):
+            ExecutionConfig(experiment_timeout_seconds=0.0)
+
+    def test_experiment_timeout_negative_raises(self):
+        with pytest.raises(ValidationError):
+            ExecutionConfig(experiment_timeout_seconds=-1.0)
+
+    def test_experiment_timeout_roundtrip_from_yaml(self):
+        yaml_text = "n_cycles: 2\nexperiment_timeout_seconds: 1800.0\n"
+        ec = ExecutionConfig(**yaml.safe_load(yaml_text))
+        assert ec.experiment_timeout_seconds == 1800.0
+
 
 # =============================================================================
 # StudyConfig model tests

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -24,7 +24,6 @@ import pytest
 from llenergymeasure.config.models import ExecutionConfig, ExperimentConfig, StudyConfig
 from llenergymeasure.study.runner import (
     StudyRunner,
-    _calculate_timeout,
     _kill_process_group,
     _run_experiment_worker,
 )
@@ -39,16 +38,6 @@ from tests.conftest import TEST_CONFIG_HASH
 def basic_config() -> ExperimentConfig:
     """A minimal ExperimentConfig with n_prompts=100."""
     return ExperimentConfig(model="test/model", backend="pytorch")
-
-
-@pytest.fixture
-def large_config() -> ExperimentConfig:
-    """A minimal ExperimentConfig with n_prompts=1000."""
-    from llenergymeasure.config.models import DatasetConfig
-
-    return ExperimentConfig(
-        model="test/model", backend="pytorch", dataset=DatasetConfig(n_prompts=1000)
-    )
 
 
 @pytest.fixture
@@ -108,23 +97,6 @@ def _make_mock_context(
     ctx.Queue.return_value = queue.SimpleQueue()
 
     return ctx
-
-
-# =============================================================================
-# Task 1a: _calculate_timeout
-# =============================================================================
-
-
-def test_calculate_timeout_minimum(basic_config: ExperimentConfig) -> None:
-    """_calculate_timeout returns >= 600 for n_prompts=100."""
-    result = _calculate_timeout(basic_config)
-    assert result >= 600, f"Expected >= 600, got {result}"
-
-
-def test_calculate_timeout_scales_with_n(large_config: ExperimentConfig) -> None:
-    """_calculate_timeout returns >= 2000 for n_prompts=1000 (2s/prompt heuristic)."""
-    result = _calculate_timeout(large_config)
-    assert result >= 2000, f"Expected >= 2000 for n_prompts=1000, got {result}"
 
 
 # =============================================================================
@@ -995,6 +967,45 @@ def test_docker_error_caught_and_converted_to_failure_dict(
     # Manifest should record failure
     manifest.mark_failed.assert_called_once()
     manifest.mark_completed.assert_not_called()
+
+
+def test_docker_timeout_normalised_to_timeout_error(
+    study_config: StudyConfig,
+) -> None:
+    """DockerTimeoutError must be tagged as 'TimeoutError' so the circuit breaker
+    coalesces it with subprocess-path timeouts under one error class."""
+    manifest = MagicMock()
+    spec = _make_docker_runner_spec()
+    runner_specs = {"pytorch": spec}
+
+    from llenergymeasure.infra.docker_errors import DockerTimeoutError
+
+    def raise_docker_timeout(config, **kwargs):
+        raise DockerTimeoutError("Container exceeded 600s timeout")
+
+    fake_ctx = MagicMock()
+    fake_ctx.Process.side_effect = lambda **kwargs: MagicMock()
+
+    with (
+        patch("multiprocessing.get_context", return_value=fake_ctx),
+        patch(
+            "llenergymeasure.infra.docker_runner.DockerRunner.run",
+            side_effect=raise_docker_timeout,
+        ),
+        patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"),
+        patch("llenergymeasure.study._progress.print_study_progress"),
+    ):
+        runner = StudyRunner(
+            study_config, manifest, Path("/tmp/test-docker-timeout"), runner_specs=runner_specs
+        )
+        with patch.object(runner, "_prepare_images"):
+            results = runner.run()
+
+    assert len(results) == 1
+    assert isinstance(results[0], dict)
+    assert results[0]["type"] == "TimeoutError", (
+        f"Docker timeout must normalise to 'TimeoutError', got {results[0]['type']!r}"
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Configurable per-experiment timeout, replacing the hard-coded `max(n_prompts*2, 600)` heuristic, plus a long-standing tagging bug fix that was hiding cross-path timeout streaks from the circuit breaker.

### What changes

- **New field** `study_execution.experiment_timeout_seconds: float = 600.0` (`gt=0.0`) on `ExecutionConfig`. Both the local subprocess path and the Docker container path read it.
- **Docker timeout normalisation**: previously `DockerTimeoutError` flowed into the failure dict via `type(exc).__name__`, producing `"DockerTimeoutError"`. The subprocess path used `"TimeoutError"`. So a streak of timeouts that started in subprocess and continued in Docker (or vice versa) didn't trip `max_consecutive_failures`. Both catch sites (`study/runner.py:_run_one_docker` and `api/_impl.py:_run_in_process`) now have a specific `except DockerTimeoutError` branch normalising to `"TimeoutError"`.
- **Helper deletion + layer fix**: `_calculate_timeout()` is removed. Three call sites are inlined with direct `study.study_execution.experiment_timeout_seconds` reads. This also fixes a latent layer-boundary import (`api/` -> `study/`) that existed only because `api/_impl.py` was reaching into `study/runner.py` for the helper.
- **Surfaced in `measurement_protocol`** dict so the value lands in result JSON for reproducibility. The docstring at `domain/experiment.py:326` already listed the field as expected — this PR makes the docstring true.

### Tests

- Four new `TestExecutionConfig` tests: default, zero raises, negative raises, YAML round-trip.
- New `test_docker_timeout_normalised_to_timeout_error` asserts `DockerTimeoutError` is tagged `"TimeoutError"` in the failure dict (the regression guard for the tagging bug).
- Removed two now-stale `test_calculate_timeout_*` tests and the unused `large_config` fixture.
- Existing `test_study_runner_timeout` and `test_docker_error_caught_and_converted_to_failure_dict` unchanged (they assert behaviour that still holds).

## Test plan

- [x] `make test-unit` for the touched files (69 passing)
- [x] `ruff check` + `ruff format --check` clean
- [x] Pre-commit hooks pass on push
- [ ] Manual: set `experiment_timeout_seconds: 1.0` and confirm both subprocess and Docker backends fail within ~1-2s with `error_type == "TimeoutError"` in the manifest
- [ ] CI green

## Out of scope

- New failure-reason enum (the existing string convention is fine).
- Renaming `TimeoutError` -> `timed_out`.
- Changes to `circuit_breaker.py` (already generic; the tagging fix was the missing piece).
- Changes to `DockerRunner` itself (enforcement was already correct; only the tag mapping at the catch site was wrong).