### PR TITLE
fix(configs): merge pathological sweep groups in example-study-full.yaml

### DIFF
--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -125,6 +125,16 @@ output:
 # Type-based disambiguation: list[scalar] = axis, list[dict] = group.
 # YAML anchors (&name) + merge keys (<<: *name) reduce repetition in groups.
 # See .product/designs/sweep-constraints.md for full design rationale.
+#
+# KNOWN-BAD CROSSES (do not add as independent axes):
+#   - pytorch.torch_compile=true  x  bitsandbytes load_in_{4,8}bit
+#     (dequant ops trigger per-call recompilation; see pytorch.compile_quant group)
+#   - pytorch.torch_compile_mode=max-autotune  x  pytorch.cache_implementation=static/sliding_window
+#     (per-shape kernel autotune on every cache reshape; slow but correct — follow-up)
+#   - Any backend x dataset.n_prompts > ~200 without raising
+#     study_execution.experiment_timeout_seconds above its 600s default
+# When in doubt, merge axes into a single group with hand-picked variants:
+# within-group variants are unioned (not crossed) while inter-group axes are.
 
 sweep: # TODO: maybe shared_sweep or global_sweep?
   # --- Universal (applies to all three backends) ---
@@ -136,25 +146,30 @@ sweep: # TODO: maybe shared_sweep or global_sweep?
 
   # --- PyTorch: dependent groups ─────────────────────────────────
 
-  # torch_compile_mode requires torch_compile: true
-  pytorch.compilation:
-    - pytorch.torch_compile: false
-    - pytorch.torch_compile: true
-      pytorch.torch_compile_backend: inductor
-      pytorch.torch_compile_mode: [default, reduce-overhead, max-autotune]
-
-  # load_in_4bit and load_in_8bit are mutually exclusive;
-  # bnb_4bit_* sub-params require load_in_4bit: true
-  pytorch.quantization:
-    - {}                                          # baseline: no quantisation
+  # torch.compile and bitsandbytes quantisation are merged into one group
+  # because their cross-product is pathological: bitsandbytes inserts dynamic
+  # dequant ops that trigger torch.compile recompilation on every call, and
+  # max-autotune compounds this with per-shape kernel search. Within-group
+  # variants are unioned (not crossed), so the variants below are exactly
+  # what runs — no bnb-with-compile cells exist.
+  pytorch.compile_quant:
+    # Baseline: no compile, no quantisation
+    - {}
+    # bitsandbytes 8-bit (no compile)
     - pytorch.load_in_8bit: true
+    # bitsandbytes 4-bit, nf4 and fp4 (no compile)
     - pytorch.load_in_4bit: true
       pytorch.bnb_4bit_compute_dtype: float16
       pytorch.bnb_4bit_quant_type: [nf4, fp4]
+    # bitsandbytes 4-bit + double-quant (no compile)
     - pytorch.load_in_4bit: true
       pytorch.bnb_4bit_compute_dtype: float16
       pytorch.bnb_4bit_quant_type: nf4
       pytorch.bnb_4bit_use_double_quant: true
+    # torch.compile on unquantised weights — all three modes safe here
+    - pytorch.torch_compile: true
+      pytorch.torch_compile_backend: inductor
+      pytorch.torch_compile_mode: [default, reduce-overhead, max-autotune]
 
   # cache_implementation requires use_cache: true
   pytorch.caching:


### PR DESCRIPTION
## Summary

`configs/example-study-full.yaml` defined two intra-`pytorch` groups (`pytorch.compilation` and `pytorch.quantization`) that the sweep expander Cartesian-products at `src/llenergymeasure/config/grid.py:896`. The product produced 12 cells where bitsandbytes 4/8-bit weights met `torch.compile` (especially `max-autotune`), causing endless graph recompilation: dequant ops are dynamic, so the inductor backend retraces on every call, and `max-autotune` compounds this with per-shape kernel search.

This PR merges the two groups into a single `pytorch.compile_quant` group. Within-group variants are unioned (not crossed), so this is the only zero-code primitive for uncrossing two same-backend groups — backend isolation via dot-prefix only operates at the first segment (`pytorch.*` vs `vllm.*`), not within a backend.

Coverage preserved for every individually-meaningful variant. The 12 `bnb x compile-mode` cells are gone.

A KNOWN-BAD-CROSSES warning is added to the sweep header so future contributors do not reintroduce the pathology as an independent axis.

## Why YAML-only

Three options were considered:
1. **Merge groups (chosen)** — zero code change, uses existing within-group union semantics
2. Explicit experiments — verbose, loses orthogonal sweeps with the rest of the parameter space
3. Add mutex-scope semantics to `grid.py` — architectural change, contradicts the runtime-config-probe design (`/.product/designs/runtime-config-probe.md`) which says pathologies should be runtime-detected, not statically rejected

## Verification

- `uv run python -c "from llenergymeasure.config.loader import load_study_config; ..."` -> 80,469 total experiments expand cleanly
- Manual scan: **0 pathological `bnb x torch_compile` cells** in the expanded sweep
- Pre-push hook (lint + format) passes

## Audit of remaining sweep cells (out of scope, noted for follow-ups)

- `pytorch.caching x max-autotune`: still crosses, second-worst combo. Per-shape kernel autotune on every cache reshape — slow but correct (no recompilation storm). Follow-up.
- `vllm.enforce_eager x enable_chunked_prefill`: orthogonal, no known interaction.
- `tensorrt.quant_config[W4A16_AWQ]`: needs a calibration dataset the group doesn't define; fails cleanly at engine build time. Covered by the per-experiment timeout in #250.
- `pytorch.batch_size=32 x dtype=float32`: fits on Qwen2.5-0.5B. Non-issue.

## Test plan

- [x] YAML parses and expands without error
- [x] Zero `bnb x torch_compile` cells in expanded sweep
- [x] Lint + format checks pass
- [ ] Optional: smoke-run one experiment from each `compile_quant` variant on Qwen2.5-0.5B

## Related

- Companion PR #250 (`feat(study): per-experiment wall-clock timeout`) — runtime safety net for any remaining or future pathology