### PR TITLE
feat(baseline): stream per-stage progress from baseline container to CLI

### DIFF
--- a/src/llenergymeasure/entrypoints/baseline_measure.py
+++ b/src/llenergymeasure/entrypoints/baseline_measure.py
@@ -48,7 +48,29 @@ from llenergymeasure.config.ssot import ENV_BASELINE_SPEC_PATH
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["_prime_cuda", "main", "run_baseline_measurement"]
+__all__ = ["_emit_stage", "_prime_cuda", "main", "run_baseline_measurement"]
+
+
+# Line prefix for stage markers emitted to stdout. The host dispatcher
+# (``study/baseline_container.py``) matches this prefix when streaming the
+# subprocess output line-by-line, so it can surface live sub-step progress
+# in the CLI instead of the user staring at a single spinner for ~30s.
+STAGE_LINE_PREFIX = "[llem.baseline]"
+
+
+def _emit_stage(name: str, **kv: object) -> None:
+    """Print a stage marker to stdout for the host to parse.
+
+    Wire format: ``[llem.baseline] stage=<name> [k=v ...]``. Keys and values
+    must be whitespace-free — this is a purpose-built internal protocol, not
+    a general key-value serialiser. ``flush=True`` is non-negotiable: without
+    it, container stdio buffering delays each marker until the pipe's 4-8KB
+    block fills, which hides the whole point of streaming.
+    """
+    parts = [f"stage={name}"]
+    for k, v in kv.items():
+        parts.append(f"{k}={v}")
+    print(f"{STAGE_LINE_PREFIX} " + " ".join(parts), flush=True)
 
 
 def _prime_cuda(gpu_indices: list[int]) -> None:
@@ -97,6 +119,11 @@ def run_baseline_measurement(spec_path: Path) -> Path:
         Any exception propagates up so ``main`` can serialise it into
         ``baseline_error.json``.
     """
+    # First line of output after Python has finished importing the package —
+    # the host interprets this as "container launched, runtime ready" and
+    # prints a dim sub-bullet with the elapsed time from subprocess start.
+    _emit_stage("container_ready")
+
     from llenergymeasure.harness.baseline import (
         measure_baseline_power,
         measure_spot_check,
@@ -113,11 +140,13 @@ def run_baseline_measurement(spec_path: Path) -> Path:
         )
 
     _prime_cuda(gpu_indices)
+    _emit_stage("cuda_primed")
 
     result_dir = spec_path.parent
     result_path = result_dir / "baseline_result.json"
 
     if mode == "measure":
+        _emit_stage("sampling_started", mode="measure", duration=f"{duration_sec:.1f}")
         measured = measure_baseline_power(
             gpu_indices=gpu_indices or None,
             duration_sec=duration_sec,
@@ -128,6 +157,12 @@ def run_baseline_measurement(spec_path: Path) -> Path:
                 "baseline_measure: measure_baseline_power returned None "
                 "(NVML unavailable or no samples collected)"
             )
+        _emit_stage(
+            "sampling_done",
+            power_w=f"{measured.power_w:.2f}",
+            samples=measured.sample_count,
+            duration=f"{measured.duration_sec:.2f}",
+        )
         payload = {
             "power_w": measured.power_w,
             "timestamp": measured.timestamp,
@@ -137,6 +172,7 @@ def run_baseline_measurement(spec_path: Path) -> Path:
             "mode": "measure",
         }
     else:
+        _emit_stage("sampling_started", mode="spot_check", duration=f"{duration_sec:.1f}")
         power_w = measure_spot_check(
             gpu_indices=gpu_indices or None,
             duration_sec=duration_sec,
@@ -148,6 +184,12 @@ def run_baseline_measurement(spec_path: Path) -> Path:
             )
         import time
 
+        _emit_stage(
+            "sampling_done",
+            power_w=f"{power_w:.2f}",
+            samples=0,
+            duration=f"{duration_sec:.2f}",
+        )
         payload = {
             "power_w": power_w,
             "timestamp": time.time(),
@@ -159,6 +201,7 @@ def run_baseline_measurement(spec_path: Path) -> Path:
 
     result_dir.mkdir(parents=True, exist_ok=True)
     result_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _emit_stage("result_written")
     return result_path
 
 

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from collections import deque
 from collections.abc import Callable
 from pathlib import Path
 
@@ -174,11 +175,8 @@ def run_baseline_container(
         gpu_indices,
     )
 
-    # Popen + line-buffered iteration gives the CLI a chance to emit live
-    # sub-step progress as the container transitions stages. stderr is merged
-    # into stdout so a single iterator covers both streams — avoids the risk
-    # of stderr's pipe buffer filling up and deadlocking the child while we
-    # drain stdout, and keeps the stage-marker parser simple.
+    # stderr merged into stdout so one iterator covers both streams and stderr's
+    # pipe buffer can't fill up and deadlock the child.
     try:
         process = subprocess.Popen(
             cmd,
@@ -193,12 +191,15 @@ def run_baseline_container(
         return None
 
     start = time.monotonic()
-    output_lines: list[str] = []
+    # Bounded tail — only the last 10 lines are logged on failure; torch/CUDA
+    # init can emit thousands of lines we never read.
+    output_tail: deque[str] = deque(maxlen=64)
 
     try:
-        assert process.stdout is not None
+        if process.stdout is None:
+            raise RuntimeError("Popen returned no stdout pipe")
         for line in process.stdout:
-            output_lines.append(line)
+            output_tail.append(line)
             stripped = line.rstrip("\n")
             parsed = parse_stage_line(stripped)
             if parsed is not None and on_stage is not None:
@@ -212,9 +213,7 @@ def run_baseline_container(
                         "baseline on_stage callback raised; continuing",
                         exc_info=True,
                     )
-            # Deadline check inside the read loop so a wedged container
-            # (e.g. stuck in CUDA init) is still killed when the budget
-            # expires, not only when the kernel delivers the next line.
+            # Kill a wedged container mid-stream rather than only when wait() fires.
             if (time.monotonic() - start) > timeout_sec:
                 process.kill()
                 with contextlib.suppress(Exception):
@@ -228,7 +227,8 @@ def run_baseline_container(
                     exchange_dir,
                 )
                 return None
-        returncode = process.wait(timeout=max(5.0, timeout_sec))
+        # Stdout closed → child is essentially done; a small grace is enough.
+        returncode = process.wait(timeout=5.0)
     except subprocess.TimeoutExpired:
         process.kill()
         with contextlib.suppress(Exception):
@@ -244,7 +244,7 @@ def run_baseline_container(
         return None
 
     if returncode != 0:
-        tail = [line.rstrip("\n") for line in output_lines[-10:]]
+        tail = [line.rstrip("\n") for line in list(output_tail)[-10:]]
         logger.warning(
             "Baseline container exited non-zero (code=%d, image=%s, mode=%s). "
             "Output tail: %s. Exchange dir preserved at %s.",

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -16,12 +16,14 @@ invocation.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import shutil
 import subprocess
 import tempfile
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from llenergymeasure.config.ssot import (
@@ -33,7 +35,18 @@ from llenergymeasure.harness.baseline import BaselineCache
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["build_baseline_docker_cmd", "run_baseline_container"]
+__all__ = [
+    "StageCallback",
+    "build_baseline_docker_cmd",
+    "parse_stage_line",
+    "run_baseline_container",
+]
+
+# Host callback signature for stage markers parsed from the container's stdout.
+# Positional args: (stage_name, elapsed_since_subprocess_start, kv_tags).
+StageCallback = Callable[[str, float, "dict[str, str]"], None]
+
+_STAGE_LINE_PREFIX = "[llem.baseline] stage="
 
 
 BASELINE_SPEC_FILENAME = "baseline_spec.json"
@@ -70,12 +83,36 @@ def build_baseline_docker_cmd(
     ]
 
 
+def parse_stage_line(line: str) -> tuple[str, dict[str, str]] | None:
+    """Parse a ``[llem.baseline] stage=NAME k=v ...`` line.
+
+    Returns ``(stage_name, kv)`` or ``None`` if the line is not a stage
+    marker. Malformed key-value tokens (no ``=``) are skipped silently;
+    we treat this wire format as a best-effort progress channel, not a
+    critical data path.
+    """
+    if not line.startswith(_STAGE_LINE_PREFIX):
+        return None
+    payload = line[len(_STAGE_LINE_PREFIX) :].strip()
+    if not payload:
+        return None
+    parts = payload.split()
+    stage_name = parts[0]
+    kv: dict[str, str] = {}
+    for token in parts[1:]:
+        if "=" in token:
+            k, v = token.split("=", 1)
+            kv[k] = v
+    return stage_name, kv
+
+
 def run_baseline_container(
     image: str,
     mode: str,
     duration_sec: float,
     gpu_indices: list[int],
     timeout_sec: float | None = None,
+    on_stage: StageCallback | None = None,
 ) -> BaselineCache | None:
     """Spawn a short-lived baseline container and return the measurement.
 
@@ -97,6 +134,12 @@ def run_baseline_container(
         timeout_sec: Subprocess timeout. Defaults to
             ``max(duration_sec * 2 + 60, 120)`` — enough for cold-start,
             sampling, and teardown with headroom.
+        on_stage: Optional callback invoked for each stage marker streamed on
+            the container's stdout (``container_ready``, ``cuda_primed``,
+            ``sampling_started``, ``sampling_done``, ``result_written``). The
+            callback is passed ``(stage_name, elapsed_since_popen, kv_tags)``
+            and is what the CLI hooks to emit live sub-bullets while the
+            container is still running.
 
     Returns:
         A ``BaselineCache`` with ``method=None`` on success (the caller sets
@@ -131,16 +174,65 @@ def run_baseline_container(
         gpu_indices,
     )
 
+    # Popen + line-buffered iteration gives the CLI a chance to emit live
+    # sub-step progress as the container transitions stages. stderr is merged
+    # into stdout so a single iterator covers both streams — avoids the risk
+    # of stderr's pipe buffer filling up and deadlocking the child while we
+    # drain stdout, and keeps the stage-marker parser simple.
     try:
-        completed = subprocess.run(
+        process = subprocess.Popen(
             cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
-            timeout=timeout_sec,
-            check=False,
+            bufsize=1,
         )
+    except FileNotFoundError:
+        logger.warning("Baseline container dispatch failed: `docker` binary not found on PATH")
+        _cleanup_exchange_dir(exchange_dir)
+        return None
+
+    start = time.monotonic()
+    output_lines: list[str] = []
+
+    try:
+        assert process.stdout is not None
+        for line in process.stdout:
+            output_lines.append(line)
+            stripped = line.rstrip("\n")
+            parsed = parse_stage_line(stripped)
+            if parsed is not None and on_stage is not None:
+                stage_name, kv = parsed
+                elapsed = time.monotonic() - start
+                try:
+                    on_stage(stage_name, elapsed, kv)
+                except Exception:
+                    # A broken CLI callback must never take down the measurement.
+                    logger.debug(
+                        "baseline on_stage callback raised; continuing",
+                        exc_info=True,
+                    )
+            # Deadline check inside the read loop so a wedged container
+            # (e.g. stuck in CUDA init) is still killed when the budget
+            # expires, not only when the kernel delivers the next line.
+            if (time.monotonic() - start) > timeout_sec:
+                process.kill()
+                with contextlib.suppress(Exception):
+                    process.wait(timeout=5)
+                logger.warning(
+                    "Baseline container timed out after %.0fs (image=%s, mode=%s). "
+                    "Exchange dir preserved at %s for post-mortem.",
+                    timeout_sec,
+                    image,
+                    mode,
+                    exchange_dir,
+                )
+                return None
+        returncode = process.wait(timeout=max(5.0, timeout_sec))
     except subprocess.TimeoutExpired:
+        process.kill()
+        with contextlib.suppress(Exception):
+            process.wait(timeout=5)
         logger.warning(
             "Baseline container timed out after %.0fs (image=%s, mode=%s). "
             "Exchange dir preserved at %s for post-mortem.",
@@ -150,20 +242,16 @@ def run_baseline_container(
             exchange_dir,
         )
         return None
-    except FileNotFoundError:
-        logger.warning("Baseline container dispatch failed: `docker` binary not found on PATH")
-        _cleanup_exchange_dir(exchange_dir)
-        return None
 
-    if completed.returncode != 0:
-        stderr_tail = (completed.stderr or "").strip().splitlines()[-10:]
+    if returncode != 0:
+        tail = [line.rstrip("\n") for line in output_lines[-10:]]
         logger.warning(
             "Baseline container exited non-zero (code=%d, image=%s, mode=%s). "
-            "Stderr tail: %s. Exchange dir preserved at %s.",
-            completed.returncode,
+            "Output tail: %s. Exchange dir preserved at %s.",
+            returncode,
             image,
             mode,
-            stderr_tail,
+            tail,
             exchange_dir,
         )
         if error_path.exists():

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -890,17 +890,15 @@ class StudyRunner:
                     elapsed,
                 )
             elif cache_key == "local":
-                # No container subprocess → no streamed stage markers; emit a
-                # retroactive sampling substep so the local path is not left
-                # without any breakdown.
+                # No container subprocess → emit a retroactive sampling substep
+                # so the local path still gets a breakdown. The Docker path
+                # already emitted substeps live via the on_stage callback.
                 self._emit_baseline_result_substeps(
                     measured,
                     elapsed=elapsed,
                     mode="fresh",
                     is_containerised=False,
                 )
-            # Docker path: substeps were already emitted live by the on_stage
-            # callback as each stage completed inside the container.
             self._progress.on_step_done(STEP_BASELINE, elapsed)
 
         return measured
@@ -908,25 +906,20 @@ class StudyRunner:
     def _make_baseline_stage_callback(self) -> Any:
         """Build a stage-marker callback that emits live baseline sub-bullets.
 
-        The returned closure receives ``(stage_name, elapsed_since_popen,
-        kv_tags)`` from ``run_baseline_container`` and translates each stage
-        transition into a dim sub-bullet under the active ``baseline`` step.
         Each sub-bullet reports the duration of *that stage* (delta since the
-        previous marker), not the cumulative elapsed — so users read the
-        breakdown as "launch took Xs, CUDA init took Ys, sampling took Zs"
-        instead of ever-increasing totals.
-
-        ``container_ready`` is the exception: its elapsed is reported as
-        time-since-subprocess-start because there is no prior marker to diff
-        against, and that number IS the container launch cost.
+        previous marker), so users see "launch took Xs, CUDA init took Ys,
+        sampling took Zs" rather than ever-increasing cumulative totals.
+        ``container_ready`` is the exception — its elapsed IS the container
+        launch cost (no prior marker to diff against).
         """
-        last_t = [0.0]
+        last_t = 0.0
 
         def on_stage(name: str, elapsed: float, kv: dict[str, str]) -> None:
-            if self._progress is None:  # defensive — caller already checks
+            nonlocal last_t
+            if self._progress is None:
                 return
-            delta = max(0.0, elapsed - last_t[0])
-            last_t[0] = elapsed
+            delta = max(0.0, elapsed - last_t)
+            last_t = elapsed
             if name == "container_ready":
                 self._progress.on_substep(
                     STEP_BASELINE,
@@ -939,10 +932,6 @@ class StudyRunner:
                     "initialised CUDA runtime · seeded torch allocator",
                     delta,
                 )
-            elif name == "sampling_started":
-                # Wait for sampling_done so the sub-bullet carries sampled
-                # duration + power + sample count.
-                pass
             elif name == "sampling_done":
                 power_w = kv.get("power_w", "?")
                 samples = kv.get("samples", "?")

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -826,6 +826,7 @@ class StudyRunner:
                     "Reusing",
                     f"cached {cached.power_w:.1f}W · {location}",
                 )
+                self._emit_baseline_result_substeps(cached, elapsed=0.0, mode="cached")
                 self._progress.on_step_done(STEP_BASELINE, 0.0)
             return cached
 
@@ -843,7 +844,10 @@ class StudyRunner:
             loaded = load_baseline_cache(disk_path, ttl=config.baseline.cache_ttl_seconds)
 
             if self._progress is not None:
-                self._progress.on_step_done(STEP_BASELINE, time.perf_counter() - t0_load)
+                load_elapsed = time.perf_counter() - t0_load
+                if loaded is not None:
+                    self._emit_baseline_result_substeps(loaded, elapsed=load_elapsed, mode="disk")
+                self._progress.on_step_done(STEP_BASELINE, load_elapsed)
 
             if loaded is not None:
                 if loaded.method is None:
@@ -861,7 +865,8 @@ class StudyRunner:
             )
             t0_meas = time.perf_counter()
 
-        measured = self._measure_baseline(config, cache_key)
+        on_stage = self._make_baseline_stage_callback() if self._progress is not None else None
+        measured = self._measure_baseline(config, cache_key, on_stage=on_stage)
 
         if measured is not None:
             measured.method = strategy
@@ -884,11 +889,134 @@ class StudyRunner:
                     f"(experiment container will re-measure fresh)",
                     elapsed,
                 )
+            elif cache_key == "local":
+                # No container subprocess → no streamed stage markers; emit a
+                # retroactive sampling substep so the local path is not left
+                # without any breakdown.
+                self._emit_baseline_result_substeps(
+                    measured,
+                    elapsed=elapsed,
+                    mode="fresh",
+                    is_containerised=False,
+                )
+            # Docker path: substeps were already emitted live by the on_stage
+            # callback as each stage completed inside the container.
             self._progress.on_step_done(STEP_BASELINE, elapsed)
 
         return measured
 
-    def _measure_baseline(self, config: ExperimentConfig, cache_key: str) -> Any:
+    def _make_baseline_stage_callback(self) -> Any:
+        """Build a stage-marker callback that emits live baseline sub-bullets.
+
+        The returned closure receives ``(stage_name, elapsed_since_popen,
+        kv_tags)`` from ``run_baseline_container`` and translates each stage
+        transition into a dim sub-bullet under the active ``baseline`` step.
+        Each sub-bullet reports the duration of *that stage* (delta since the
+        previous marker), not the cumulative elapsed — so users read the
+        breakdown as "launch took Xs, CUDA init took Ys, sampling took Zs"
+        instead of ever-increasing totals.
+
+        ``container_ready`` is the exception: its elapsed is reported as
+        time-since-subprocess-start because there is no prior marker to diff
+        against, and that number IS the container launch cost.
+        """
+        last_t = [0.0]
+
+        def on_stage(name: str, elapsed: float, kv: dict[str, str]) -> None:
+            if self._progress is None:  # defensive — caller already checks
+                return
+            delta = max(0.0, elapsed - last_t[0])
+            last_t[0] = elapsed
+            if name == "container_ready":
+                self._progress.on_substep(
+                    STEP_BASELINE,
+                    "dispatched baseline container · Python runtime ready",
+                    elapsed,
+                )
+            elif name == "cuda_primed":
+                self._progress.on_substep(
+                    STEP_BASELINE,
+                    "initialised CUDA runtime · seeded torch allocator",
+                    delta,
+                )
+            elif name == "sampling_started":
+                # Wait for sampling_done so the sub-bullet carries sampled
+                # duration + power + sample count.
+                pass
+            elif name == "sampling_done":
+                power_w = kv.get("power_w", "?")
+                samples = kv.get("samples", "?")
+                sampled = kv.get("duration", "?")
+                self._progress.on_substep(
+                    STEP_BASELINE,
+                    f"sampled idle GPU power · {sampled}s ({power_w}W · {samples} samples)",
+                    delta,
+                )
+            elif name == "result_written" and delta > 0.1:
+                self._progress.on_substep(
+                    STEP_BASELINE,
+                    "wrote result & container teardown",
+                    delta,
+                )
+
+        return on_stage
+
+    def _emit_baseline_result_substeps(
+        self,
+        baseline: Any,  # BaselineCache
+        *,
+        elapsed: float,
+        mode: str,  # "fresh" | "cached" | "disk"
+        is_containerised: bool = False,
+    ) -> None:
+        """Emit dim-bullet substeps explaining where the baseline time went.
+
+        For a fresh Docker measurement we split the wall-clock into container
+        launch/teardown (the residual) vs the NVML sampling window (recorded
+        inside ``measure_baseline_power``). This answers "why did a 30s
+        measurement take 37.7s?" without the user having to dig through logs.
+
+        For in-memory and disk-loaded reuse we only emit the result summary —
+        there is no sampling window to describe.
+        """
+        if self._progress is None:
+            return
+        if mode == "fresh" and is_containerised:
+            # Residual captures docker run startup + CUDA prime + result write
+            # + container teardown.
+            overhead = max(0.0, elapsed - baseline.duration_sec)
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"container launch + teardown: {overhead:.1f}s",
+                overhead,
+            )
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"sampling: {baseline.duration_sec:.1f}s "
+                f"({baseline.power_w:.1f}W · {baseline.sample_count} samples)",
+                baseline.duration_sec,
+            )
+        elif mode == "fresh":
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"sampling: {baseline.duration_sec:.1f}s "
+                f"({baseline.power_w:.1f}W · {baseline.sample_count} samples)",
+                baseline.duration_sec,
+            )
+        else:
+            source = "in-memory" if mode == "cached" else "disk"
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"reused from {source} cache: "
+                f"{baseline.power_w:.1f}W ({baseline.sample_count} samples)",
+            )
+
+    def _measure_baseline(
+        self,
+        config: ExperimentConfig,
+        cache_key: str,
+        on_stage: Any = None,  # StageCallback | None
+    ) -> Any:
         """Measure a fresh baseline on host or inside a baseline container.
 
         Local runner targets measure on host (no process boundary, no bias).
@@ -896,6 +1024,13 @@ class StudyRunner:
         image so the CUDA init state matches the experiment container. See
         ``.product/research/baseline-measurement-location.md`` for the
         empirical rationale (~8.7 W/GPU bias on A100).
+
+        Args:
+            config: Experiment config with baseline settings.
+            cache_key: "local" or "image_<slug>" — chooses dispatch path.
+            on_stage: Optional callback forwarded to ``run_baseline_container``
+                for streaming stage markers. Ignored on the local path (there
+                is no subprocess to stream from).
         """
         from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
@@ -921,6 +1056,7 @@ class StudyRunner:
             mode="measure",
             duration_sec=config.baseline.duration_seconds,
             gpu_indices=gpu_indices,
+            on_stage=on_stage,
         )
 
     def _spot_check_baseline(

--- a/tests/unit/study/test_baseline_container.py
+++ b/tests/unit/study/test_baseline_container.py
@@ -1,6 +1,6 @@
 """Tests for the host-side baseline container dispatch helper.
 
-All tests patch ``subprocess.run`` at the module boundary — nothing actually
+All tests patch ``subprocess.Popen`` at the module boundary — nothing actually
 talks to Docker.
 """
 
@@ -10,7 +10,7 @@ import json
 import subprocess
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -36,8 +36,36 @@ def _write_result(exchange_dir: Path, power_w: float = 42.59) -> None:
     )
 
 
-def _make_subprocess_result(returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=["docker"], returncode=returncode, stderr=stderr)
+def _make_fake_popen(
+    lines: list[str],
+    returncode: int = 0,
+    on_open: callable | None = None,
+) -> MagicMock:
+    """Build a MagicMock that quacks like a Popen object for our iterator.
+
+    - ``process.stdout`` iterates ``lines`` (must include trailing newlines).
+    - ``process.wait`` returns ``returncode``.
+    - ``on_open`` lets a test simulate the container writing files on start
+      (e.g. baseline_result.json or baseline_error.json).
+    """
+
+    def _factory(cmd, **kwargs):
+        if on_open is not None:
+            on_open()
+        mock = MagicMock()
+        mock.stdout = iter(lines)
+        mock.stderr = None
+        mock.returncode = returncode
+
+        def _wait(timeout=None):
+            mock.returncode = returncode
+            return returncode
+
+        mock.wait = _wait
+        mock.kill = MagicMock()
+        return mock
+
+    return _factory
 
 
 class TestBuildBaselineDockerCmd:
@@ -70,6 +98,33 @@ class TestBuildBaselineDockerCmd:
         assert any("CUDA_VISIBLE_DEVICES=" in part for part in cmd)
 
 
+class TestParseStageLine:
+    def test_non_marker_returns_none(self):
+        assert baseline_container.parse_stage_line("hello world") is None
+        assert baseline_container.parse_stage_line("") is None
+
+    def test_bare_stage(self):
+        parsed = baseline_container.parse_stage_line("[llem.baseline] stage=container_ready")
+        assert parsed == ("container_ready", {})
+
+    def test_stage_with_kv(self):
+        parsed = baseline_container.parse_stage_line(
+            "[llem.baseline] stage=sampling_done power_w=42.68 samples=289 duration=30.00"
+        )
+        assert parsed is not None
+        name, kv = parsed
+        assert name == "sampling_done"
+        assert kv == {"power_w": "42.68", "samples": "289", "duration": "30.00"}
+
+    def test_malformed_tokens_dropped(self):
+        parsed = baseline_container.parse_stage_line(
+            "[llem.baseline] stage=cuda_primed junk_no_equals power=5.0"
+        )
+        assert parsed is not None
+        _, kv = parsed
+        assert kv == {"power": "5.0"}
+
+
 class TestRunBaselineContainerSuccess:
     def test_run_success_returns_baseline_cache(self, tmp_path: Path, monkeypatch):
         # Force mkdtemp to land inside tmp_path so the test can write the result file.
@@ -77,11 +132,13 @@ class TestRunBaselineContainerSuccess:
         exchange_dir.mkdir()
         monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
 
-        def _fake_run(cmd, **kwargs):
-            _write_result(exchange_dir, power_w=42.6)
-            return _make_subprocess_result(returncode=0)
+        popen_factory = _make_fake_popen(
+            lines=[],
+            returncode=0,
+            on_open=lambda: _write_result(exchange_dir, power_w=42.6),
+        )
 
-        with patch(f"{_MODULE}.subprocess.run", side_effect=_fake_run):
+        with patch(f"{_MODULE}.subprocess.Popen", side_effect=popen_factory):
             result = baseline_container.run_baseline_container(
                 image="img:latest",
                 mode="measure",
@@ -98,11 +155,13 @@ class TestRunBaselineContainerSuccess:
         exchange_dir.mkdir()
         monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
 
-        def _fake_run(cmd, **kwargs):
-            _write_result(exchange_dir)
-            return _make_subprocess_result(returncode=0)
+        popen_factory = _make_fake_popen(
+            lines=[],
+            returncode=0,
+            on_open=lambda: _write_result(exchange_dir),
+        )
 
-        with patch(f"{_MODULE}.subprocess.run", side_effect=_fake_run):
+        with patch(f"{_MODULE}.subprocess.Popen", side_effect=popen_factory):
             baseline_container.run_baseline_container(
                 image="img:latest",
                 mode="measure",
@@ -112,6 +171,88 @@ class TestRunBaselineContainerSuccess:
 
         assert not exchange_dir.exists()
 
+    def test_stage_markers_forwarded_to_callback(self, tmp_path: Path, monkeypatch):
+        """Streamed stage markers reach the on_stage callback in order with
+        monotonic elapsed times and parsed key-value tags."""
+        exchange_dir = tmp_path / "exchange"
+        exchange_dir.mkdir()
+        monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
+
+        stage_lines = [
+            "[llem.baseline] stage=container_ready\n",
+            "Some unrelated stdout line\n",
+            "[llem.baseline] stage=cuda_primed\n",
+            "[llem.baseline] stage=sampling_started duration=30.0\n",
+            "[llem.baseline] stage=sampling_done power_w=42.68 samples=289 duration=30.00\n",
+            "[llem.baseline] stage=result_written\n",
+        ]
+        popen_factory = _make_fake_popen(
+            lines=stage_lines,
+            returncode=0,
+            on_open=lambda: _write_result(exchange_dir),
+        )
+
+        events: list[tuple[str, dict[str, str]]] = []
+        elapsed_seen: list[float] = []
+
+        def on_stage(name: str, elapsed: float, kv: dict[str, str]) -> None:
+            events.append((name, kv))
+            elapsed_seen.append(elapsed)
+
+        with patch(f"{_MODULE}.subprocess.Popen", side_effect=popen_factory):
+            baseline_container.run_baseline_container(
+                image="img:latest",
+                mode="measure",
+                duration_sec=30.0,
+                gpu_indices=[0],
+                on_stage=on_stage,
+            )
+
+        names = [e[0] for e in events]
+        assert names == [
+            "container_ready",
+            "cuda_primed",
+            "sampling_started",
+            "sampling_done",
+            "result_written",
+        ]
+        # sampling_done carries the measurement summary.
+        sampling_done = next(kv for name, kv in events if name == "sampling_done")
+        assert sampling_done == {
+            "power_w": "42.68",
+            "samples": "289",
+            "duration": "30.00",
+        }
+        # Elapsed values are monotonically non-decreasing — a mock may fire
+        # them in the same tick, so we allow equality.
+        assert elapsed_seen == sorted(elapsed_seen)
+
+    def test_callback_exception_does_not_abort_run(self, tmp_path: Path, monkeypatch):
+        """A broken on_stage callback must not crash the baseline container."""
+        exchange_dir = tmp_path / "exchange"
+        exchange_dir.mkdir()
+        monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
+
+        popen_factory = _make_fake_popen(
+            lines=["[llem.baseline] stage=container_ready\n"],
+            returncode=0,
+            on_open=lambda: _write_result(exchange_dir),
+        )
+
+        def broken(*_args, **_kwargs):
+            raise RuntimeError("callback exploded")
+
+        with patch(f"{_MODULE}.subprocess.Popen", side_effect=popen_factory):
+            result = baseline_container.run_baseline_container(
+                image="img:latest",
+                mode="measure",
+                duration_sec=30.0,
+                gpu_indices=[0],
+                on_stage=broken,
+            )
+
+        assert result is not None  # measurement still succeeded
+
 
 class TestRunBaselineContainerFailure:
     def test_nonzero_exit_reads_error_json(self, tmp_path: Path, monkeypatch, caplog):
@@ -119,7 +260,7 @@ class TestRunBaselineContainerFailure:
         exchange_dir.mkdir()
         monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
 
-        def _fake_run(cmd, **kwargs):
+        def _write_error():
             (exchange_dir / "baseline_error.json").write_text(
                 json.dumps(
                     {
@@ -130,11 +271,16 @@ class TestRunBaselineContainerFailure:
                 ),
                 encoding="utf-8",
             )
-            return _make_subprocess_result(returncode=1, stderr="nvml error\n")
+
+        popen_factory = _make_fake_popen(
+            lines=["nvml error\n"],
+            returncode=1,
+            on_open=_write_error,
+        )
 
         with (
             caplog.at_level("WARNING"),
-            patch(f"{_MODULE}.subprocess.run", side_effect=_fake_run),
+            patch(f"{_MODULE}.subprocess.Popen", side_effect=popen_factory),
         ):
             result = baseline_container.run_baseline_container(
                 image="img:latest",
@@ -153,10 +299,9 @@ class TestRunBaselineContainerFailure:
         exchange_dir.mkdir()
         monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
 
-        with patch(
-            f"{_MODULE}.subprocess.run",
-            return_value=_make_subprocess_result(returncode=0),
-        ):
+        popen_factory = _make_fake_popen(lines=[], returncode=0)
+
+        with patch(f"{_MODULE}.subprocess.Popen", side_effect=popen_factory):
             result = baseline_container.run_baseline_container(
                 image="img:latest",
                 mode="measure",
@@ -171,12 +316,32 @@ class TestRunBaselineContainerFailure:
         exchange_dir.mkdir()
         monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
 
-        def _raise_timeout(*a, **kw):
-            raise subprocess.TimeoutExpired(cmd=["docker"], timeout=1.0)
+        def _factory(cmd, **kwargs):
+            mock = MagicMock()
+
+            def _never_ending():
+                # Simulate a wedged container: block indefinitely in stdout.
+                # We yield one line then sleep — but our loop checks the
+                # timeout every iteration, so we just yield nothing and
+                # let the outer timeout check trigger. Instead, raise
+                # TimeoutExpired on wait().
+                return
+                yield  # pragma: no cover
+
+            mock.stdout = iter([])
+            mock.stderr = None
+
+            def _wait(timeout=None):
+                raise subprocess.TimeoutExpired(cmd=["docker"], timeout=1.0)
+
+            mock.wait = _wait
+            mock.kill = MagicMock()
+            mock.returncode = None
+            return mock
 
         with (
             caplog.at_level("WARNING"),
-            patch(f"{_MODULE}.subprocess.run", side_effect=_raise_timeout),
+            patch(f"{_MODULE}.subprocess.Popen", side_effect=_factory),
         ):
             result = baseline_container.run_baseline_container(
                 image="img:latest",
@@ -193,13 +358,18 @@ class TestRunBaselineContainerFailure:
         exchange_dir.mkdir()
         monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
 
-        def _fake_run(cmd, **kwargs):
+        def _write_bad():
             (exchange_dir / "baseline_result.json").write_text(
                 "not valid json{{{", encoding="utf-8"
             )
-            return _make_subprocess_result(returncode=0)
 
-        with patch(f"{_MODULE}.subprocess.run", side_effect=_fake_run):
+        popen_factory = _make_fake_popen(
+            lines=[],
+            returncode=0,
+            on_open=_write_bad,
+        )
+
+        with patch(f"{_MODULE}.subprocess.Popen", side_effect=popen_factory):
             result = baseline_container.run_baseline_container(
                 image="img:latest",
                 mode="measure",
@@ -214,7 +384,7 @@ class TestRunBaselineContainerFailure:
         exchange_dir.mkdir()
         monkeypatch.setattr(f"{_MODULE}.tempfile.mkdtemp", lambda prefix="": str(exchange_dir))
 
-        with patch(f"{_MODULE}.subprocess.run", side_effect=FileNotFoundError("docker")):
+        with patch(f"{_MODULE}.subprocess.Popen", side_effect=FileNotFoundError("docker")):
             result = baseline_container.run_baseline_container(
                 image="img:latest",
                 mode="measure",

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -776,6 +776,74 @@ class TestBaselineHostProgressEvents:
         # the measurement itself failed — the substep carries the "why".
         assert "on_step_done" in names
 
+    def test_docker_fresh_emits_live_stage_substeps(
+        self, tmp_path: Path, config_cached: ExperimentConfig
+    ):
+        """Streamed stage markers from run_baseline_container become sub-bullets
+        under the active baseline step, with per-stage deltas rather than
+        ever-increasing cumulative totals.
+
+        This is the regression for "why did a 30s measurement take 37s?" —
+        the user now sees dispatched + CUDA init + sampling as separate dim
+        sub-bullets whose durations add up to the parent elapsed.
+        """
+        spec = RunnerSpec(mode="docker", image="test/pytorch:v0", source="yaml")
+        runner, progress = _make_runner_with_progress(
+            tmp_path, config_cached, runner_specs={"pytorch": spec}
+        )
+
+        fake_cache = _make_baseline(
+            power_w=42.68,
+            sample_count=289,
+            duration_sec=30.00,
+            gpu_indices=[0],
+        )
+
+        captured_on_stage: list = []
+
+        def _fake_run_container(*_args, on_stage=None, **_kwargs):
+            captured_on_stage.append(on_stage)
+            # Simulate the container emitting its five stage markers, each
+            # roughly 1s apart except for the sampling window.
+            if on_stage is not None:
+                on_stage("container_ready", 2.5, {})
+                on_stage("cuda_primed", 4.1, {})
+                on_stage("sampling_started", 4.2, {"duration": "30.0"})
+                on_stage(
+                    "sampling_done",
+                    34.3,
+                    {"power_w": "42.68", "samples": "289", "duration": "30.00"},
+                )
+                on_stage("result_written", 34.4, {})
+            return fake_cache
+
+        with (
+            patch(_RESOLVE_GPU, return_value=[0]),
+            patch(_SAVE),
+            patch(_RUN_BASELINE_CONTAINER, side_effect=_fake_run_container),
+        ):
+            result = runner._get_baseline(config_cached)
+
+        assert result is fake_cache
+        # Callback was threaded through _measure_baseline → run_baseline_container.
+        assert captured_on_stage and captured_on_stage[0] is not None
+
+        substeps = [
+            call
+            for call in progress.mock_calls
+            if call[0] == "on_substep" and call[1] and call[1][0] == "baseline"
+        ]
+        # Expect three visible substeps: dispatched (from container_ready),
+        # CUDA primed, sampled. result_written fires but its delta is <0.1s
+        # so the substep is suppressed. sampling_started never emits.
+        texts = [call[1][1] for call in substeps]
+        assert any("dispatched" in t for t in texts)
+        assert any("CUDA" in t for t in texts)
+        assert any("sampled" in t and "42.68" in t and "289" in t for t in texts)
+        # No retroactive "container launch + teardown" substep — those were
+        # the old retroactive pre-streaming labels.
+        assert not any("container launch + teardown" in t for t in texts)
+
     def test_validated_spot_check_no_drift_emits_validating(
         self, tmp_path: Path, config_validated: ExperimentConfig
     ):


### PR DESCRIPTION
## Summary

Make the baseline container emit per-stage progress markers that the host parses and forwards into the CLI progress pipeline, so users see what is happening during the ~30s baseline window instead of staring at a single spinner.

Split from #252 — depends on #253 (core baseline fix).

## What this PR does

- **Container side** (\`entrypoints/baseline_measure.py\`): emit stage markers on stdout as sampling proceeds — \`container_ready\`, \`cuda_primed\`, \`sampling_started\`, \`sampling_done\`, \`result_written\`. Wire format is a purpose-built \`[llem.baseline] stage=<name> k=v ...\` line with \`flush=True\` so stdio buffering does not swallow markers.
- **Host side** (\`study/baseline_container.py\`): switch subprocess dispatch from \`subprocess.run\` to a \`Popen\` + line-buffered iterator so stage markers arrive live. stderr is merged into stdout to avoid pipe-buffer deadlocks. A new \`on_stage\` callback is exposed so callers can hook into the marker stream.
- **Runner side** (\`study/runner.py\`): build a stage callback that translates each marker into a dim sub-bullet under the active \`baseline\` step. Each sub-bullet reports the duration of *that stage* (delta since the previous marker), not the cumulative elapsed, so users read the breakdown as \"launch took Xs, CUDA init took Ys, sampling took Zs\". Reuse paths (in-memory / disk-loaded) get retroactive summary substeps too.

## Test plan

- [x] \`pytest tests/unit/entrypoints/test_baseline_measure.py\` — stage emitter wire format
- [x] \`pytest tests/unit/study/test_baseline_container.py\` — Popen parsing, stderr merge, on_stage plumbing
- [x] \`pytest tests/unit/study/test_baseline_strategy.py\` — substep emission for fresh / cached / disk / local paths