### PR TITLE
feat(cli,baseline): live heartbeat sub-bullets for baseline calibration

### DIFF
--- a/src/llenergymeasure/cli/_step_display.py
+++ b/src/llenergymeasure/cli/_step_display.py
@@ -32,6 +32,7 @@ from llenergymeasure.utils.formatting import truncate_detail as _truncate_detail
 
 # Braille spinner frames (same as Docker BuildKit / ora)
 _SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_SPINNER_FPS = 8
 
 # Heartbeat interval for non-TTY mode (seconds)
 _HEARTBEAT_INTERVAL = 5.0
@@ -134,7 +135,7 @@ def _render_substep_lines(
     if active is not None:
         sub_text, start_ts = active
         elapsed = time.monotonic() - start_ts
-        frame_idx = int(elapsed * 8) % len(_SPINNER_FRAMES)
+        frame_idx = int(elapsed * _SPINNER_FPS) % len(_SPINNER_FRAMES)
         spinner = _SPINNER_FRAMES[frame_idx]
         lines.append(f"{indent}· {sub_text}", style="dim")
         lines.append(f"  {spinner}", style="dim")
@@ -578,7 +579,7 @@ class StepDisplay:
                         lines.append("\n")
                     elif step == self._active_step:
                         elapsed = time.monotonic() - self._active_start
-                        frame_idx = int(elapsed * 8) % len(_SPINNER_FRAMES)
+                        frame_idx = int(elapsed * _SPINNER_FPS) % len(_SPINNER_FRAMES)
                         spinner = _SPINNER_FRAMES[frame_idx]
                         prefix = _step_line_prefix(
                             idx, phase_total, self._active_label, self._active_detail
@@ -1262,7 +1263,7 @@ class StudyStepDisplay:
                 idx += 1
                 _step, label, detail, start = self._inner_active
                 elapsed = time.monotonic() - start
-                frame_idx = int(elapsed * 8) % len(_SPINNER_FRAMES)
+                frame_idx = int(elapsed * _SPINNER_FPS) % len(_SPINNER_FRAMES)
                 spinner = _SPINNER_FRAMES[frame_idx]
                 counter = f"[{idx}/{inner_total}]"
                 trunc_detail = _truncate_detail(detail)

--- a/src/llenergymeasure/cli/_step_display.py
+++ b/src/llenergymeasure/cli/_step_display.py
@@ -116,15 +116,29 @@ def _render_substep_lines(
     lines: Text,
     substeps: list[tuple[str, float]],
     indent: str = "              ",
+    active: tuple[str, float] | None = None,
 ) -> None:
     """Append substep lines (dim · prefix) to a Rich Text renderable.
 
     Shared between StepDisplay and StudyStepDisplay to avoid duplication.
+    Frozen substeps render as dim ``· text ✓ elapsed``; the optional
+    ``active`` substep (``(text, start_monotonic)``) renders with a dim
+    spinner and rising elapsed counter so Rich Live animates it each frame.
     """
     for sub_text, sub_elapsed in substeps:
         lines.append(f"{indent}· {sub_text}", style="dim")
         if sub_elapsed > 0:
+            lines.append("  \u2713", style="dim")
             lines.append(f"  {_format_elapsed(sub_elapsed)}", style="dim")
+        lines.append("\n")
+    if active is not None:
+        sub_text, start_ts = active
+        elapsed = time.monotonic() - start_ts
+        frame_idx = int(elapsed * 8) % len(_SPINNER_FRAMES)
+        spinner = _SPINNER_FRAMES[frame_idx]
+        lines.append(f"{indent}· {sub_text}", style="dim")
+        lines.append(f"  {spinner}", style="dim")
+        lines.append(f"  {_format_elapsed(elapsed)}", style="dim")
         lines.append("\n")
 
 
@@ -234,6 +248,10 @@ class StepDisplay:
 
         # Substeps per step: list of (text, elapsed_sec) tuples
         self._substeps: dict[str, list[tuple[str, float]]] = {}
+        # Active substep per step: (text, start_monotonic) — drives the
+        # heartbeat spinner for long-running sub-operations (e.g. CUDA init
+        # inside the baseline container) so Rich Live animates them.
+        self._active_substep: dict[str, tuple[str, float]] = {}
 
         # Active step
         self._active_step: str | None = None
@@ -344,6 +362,7 @@ class StepDisplay:
             self._skipped_steps.discard(step)
             self._step_data.pop(step, None)
             self._substeps.pop(step, None)
+            self._active_substep.pop(step, None)
             self._active_step = step
             self._active_label = description or STEP_LABELS.get(step, step)
             self._active_detail = detail
@@ -374,6 +393,14 @@ class StepDisplay:
             self._completed_steps.add(step)
             if self._active_step == step:
                 self._active_step = None
+            # Freeze any dangling active substep so it doesn't keep animating
+            # under a completed step. Uses its accumulated elapsed.
+            dangling = self._active_substep.pop(step, None)
+            if dangling is not None:
+                d_text, d_start = dangling
+                self._substeps.setdefault(step, []).append(
+                    (d_text, max(0.0, time.monotonic() - d_start))
+                )
         if not self._is_tty:
             self._print_completed_step(step, label, detail, elapsed_sec)
         self._refresh()
@@ -403,6 +430,50 @@ class StepDisplay:
             self._substeps[step].append((text, elapsed_sec))
         if not self._is_tty:
             self._print_substep_line(step, text, elapsed_sec)
+        self._refresh()
+
+    def on_substep_start(self, step: str, text: str) -> None:
+        """Begin a live sub-operation rendered with a dim spinner + counter."""
+        with self._lock:
+            # If a prior active substep for this step never got a matching
+            # done, freeze it so the new active substep doesn't overwrite
+            # silently. Uses its accumulated elapsed.
+            prior = self._active_substep.pop(step, None)
+            if prior is not None:
+                prior_text, prior_start = prior
+                self._substeps.setdefault(step, []).append(
+                    (prior_text, max(0.0, time.monotonic() - prior_start))
+                )
+            self._active_substep[step] = (text, time.monotonic())
+        if not self._is_tty:
+            self._print_substep_line(step, text, 0.0)
+        self._refresh()
+
+    def on_substep_done(
+        self,
+        step: str,
+        text: str | None = None,
+        elapsed_sec: float | None = None,
+    ) -> None:
+        """Freeze the currently-active substep with final text + elapsed."""
+        with self._lock:
+            active = self._active_substep.pop(step, None)
+            if active is None:
+                # No matching start — fall through as a regular completed substep.
+                final_text = text or ""
+                final_elapsed = elapsed_sec if elapsed_sec is not None else 0.0
+            else:
+                start_text, start_ts = active
+                final_text = text if text is not None else start_text
+                final_elapsed = (
+                    elapsed_sec
+                    if elapsed_sec is not None
+                    else max(0.0, time.monotonic() - start_ts)
+                )
+            if final_text:
+                self._substeps.setdefault(step, []).append((final_text, final_elapsed))
+        if not self._is_tty and final_text:
+            self._print_substep_line(step, final_text, final_elapsed)
         self._refresh()
 
     # -- Heartbeat (non-TTY only) --
@@ -494,7 +565,11 @@ class StepDisplay:
                         lines.append(prefix)
                         lines.append("  ✓", style="bold green")
                         lines.append(f"  {_format_elapsed(elapsed)}\n")
-                        _render_substep_lines(lines, self._substeps.get(step, []))
+                        _render_substep_lines(
+                            lines,
+                            self._substeps.get(step, []),
+                            active=self._active_substep.get(step),
+                        )
                     elif step in self._skipped_steps:
                         label, reason, _ = self._step_data[step]
                         prefix = _step_line_prefix(idx, phase_total, label, reason)
@@ -511,7 +586,11 @@ class StepDisplay:
                         lines.append(prefix)
                         lines.append(f"  {spinner}", style="yellow")
                         lines.append(f"  {_format_elapsed(elapsed)}\n")
-                        _render_substep_lines(lines, self._substeps.get(step, []))
+                        _render_substep_lines(
+                            lines,
+                            self._substeps.get(step, []),
+                            active=self._active_substep.get(step),
+                        )
                     # Pending steps: NOT shown (Docker BuildKit-style progressive output)
 
         return lines
@@ -621,6 +700,9 @@ class StudyStepDisplay:
         self._inner_steps: list[str] = []
         self._inner_skipped: dict[str, str] = {}  # step -> reason
         self._inner_substeps: dict[str, list[tuple[str, float]]] = {}
+        # Active substep per step: (text, start_monotonic) — same spinner
+        # heartbeat treatment as StepDisplay, used for live baseline stages.
+        self._inner_active_substep: dict[str, tuple[str, float]] = {}
         self._runner_info: dict[str, str | None] | None = None
 
         # Per-experiment save paths: (index, host_path, container_path | None)
@@ -716,6 +798,7 @@ class StudyStepDisplay:
             self._inner_steps = steps
             self._inner_skipped = {}
             self._inner_substeps = {}
+            self._inner_active_substep = {}
             self._runner_info = runner_info
         self._refresh()
 
@@ -845,6 +928,7 @@ class StudyStepDisplay:
             self._inner_completed = [c for c in self._inner_completed if c[0] != step]
             self._inner_skipped.pop(step, None)
             self._inner_substeps.pop(step, None)
+            self._inner_active_substep.pop(step, None)
             label = description or STEP_LABELS.get(step, step)
             self._inner_active = (step, label, detail, time.monotonic())
         self._refresh()
@@ -862,6 +946,14 @@ class StudyStepDisplay:
                 detail = self._inner_active[2]
                 self._inner_completed.append((step, label, detail, elapsed_sec))
                 self._inner_active = None
+            # Freeze any dangling active substep so it doesn't keep animating
+            # under a completed step.
+            dangling = self._inner_active_substep.pop(step, None)
+            if dangling is not None:
+                d_text, d_start = dangling
+                self._inner_substeps.setdefault(step, []).append(
+                    (d_text, max(0.0, time.monotonic() - d_start))
+                )
         self._refresh()
 
     def on_step_skip(self, step: str, reason: str = "") -> None:
@@ -876,6 +968,42 @@ class StudyStepDisplay:
             if step not in self._inner_substeps:
                 self._inner_substeps[step] = []
             self._inner_substeps[step].append((text, elapsed_sec))
+        self._refresh()
+
+    def on_substep_start(self, step: str, text: str) -> None:
+        """Begin a live sub-operation rendered with a dim spinner + counter."""
+        with self._lock:
+            prior = self._inner_active_substep.pop(step, None)
+            if prior is not None:
+                prior_text, prior_start = prior
+                self._inner_substeps.setdefault(step, []).append(
+                    (prior_text, max(0.0, time.monotonic() - prior_start))
+                )
+            self._inner_active_substep[step] = (text, time.monotonic())
+        self._refresh()
+
+    def on_substep_done(
+        self,
+        step: str,
+        text: str | None = None,
+        elapsed_sec: float | None = None,
+    ) -> None:
+        """Freeze the currently-active substep with final text + elapsed."""
+        with self._lock:
+            active = self._inner_active_substep.pop(step, None)
+            if active is None:
+                final_text = text or ""
+                final_elapsed = elapsed_sec if elapsed_sec is not None else 0.0
+            else:
+                start_text, start_ts = active
+                final_text = text if text is not None else start_text
+                final_elapsed = (
+                    elapsed_sec
+                    if elapsed_sec is not None
+                    else max(0.0, time.monotonic() - start_ts)
+                )
+            if final_text:
+                self._inner_substeps.setdefault(step, []).append((final_text, final_elapsed))
         self._refresh()
 
     def on_experiment_saved(
@@ -1115,7 +1243,10 @@ class StudyStepDisplay:
                 lines.append("  \u2713", style="bold green")
                 lines.append(f"  {_format_elapsed(elapsed)}\n")
                 _render_substep_lines(
-                    lines, self._inner_substeps.get(step, []), indent="                    "
+                    lines,
+                    self._inner_substeps.get(step, []),
+                    indent="                    ",
+                    active=self._inner_active_substep.get(step),
                 )
             elif step in self._inner_skipped:
                 idx += 1
@@ -1139,7 +1270,10 @@ class StudyStepDisplay:
                 lines.append(f"  {spinner}", style="yellow")
                 lines.append(f"  {_format_elapsed(elapsed)}\n")
                 _render_substep_lines(
-                    lines, self._inner_substeps.get(step, []), indent="                    "
+                    lines,
+                    self._inner_substeps.get(step, []),
+                    indent="                    ",
+                    active=self._inner_active_substep.get(step),
                 )
             # Pending steps: not shown (Docker BuildKit-style progressive output)
 

--- a/src/llenergymeasure/domain/progress.py
+++ b/src/llenergymeasure/domain/progress.py
@@ -88,6 +88,40 @@ class ProgressCallback(Protocol):
         """
         ...
 
+    def on_substep_start(self, step: str, text: str) -> None:
+        """Start a live sub-operation within the active step.
+
+        The substep renders as a dim indented bullet with a spinner and
+        rising elapsed counter until ``on_substep_done`` arrives. Only one
+        active substep per parent step is supported — calling
+        ``on_substep_start`` again without a matching ``on_substep_done``
+        freezes the prior substep with the previous start's text and its
+        accumulated elapsed.
+
+        Args:
+            step: Parent step identifier (must match the active step).
+            text: Present-tense description (e.g. "launching baseline container").
+        """
+        ...
+
+    def on_substep_done(
+        self,
+        step: str,
+        text: str | None = None,
+        elapsed_sec: float | None = None,
+    ) -> None:
+        """Freeze the currently-active sub-operation of ``step``.
+
+        Args:
+            step: Parent step identifier.
+            text: Optional final text (e.g. "42.6W · 288 samples"). If
+                ``None``, the original ``on_substep_start`` text is kept.
+            elapsed_sec: Optional override for the recorded duration. If
+                ``None``, the monotonic delta since ``on_substep_start`` is
+                used.
+        """
+        ...
+
 
 @runtime_checkable
 class StudyProgressCallback(ProgressCallback, Protocol):

--- a/src/llenergymeasure/entrypoints/container.py
+++ b/src/llenergymeasure/entrypoints/container.py
@@ -104,6 +104,30 @@ class StreamProgressCallback:
             }
         )
 
+    def on_substep_start(self, step: str, text: str) -> None:
+        _write_progress_line(
+            {
+                "event": "substep_start",
+                "step": step,
+                "text": text,
+            }
+        )
+
+    def on_substep_done(
+        self,
+        step: str,
+        text: str | None = None,
+        elapsed_sec: float | None = None,
+    ) -> None:
+        _write_progress_line(
+            {
+                "event": "substep_done",
+                "step": step,
+                "text": text,
+                "elapsed_sec": elapsed_sec,
+            }
+        )
+
 
 def _write_progress_line(event: dict[str, object]) -> None:
     """Write a JSON progress line to stdout and flush immediately."""

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -522,6 +522,14 @@ class DockerRunner:
                             event.get("text", ""),
                             event.get("elapsed_sec", 0.0),
                         )
+                    elif event_type == "substep_start":
+                        progress.on_substep_start(step, event.get("text", ""))
+                    elif event_type == "substep_done":
+                        progress.on_substep_done(
+                            step,
+                            event.get("text"),
+                            event.get("elapsed_sec"),
+                        )
                 except (json.JSONDecodeError, KeyError):
                     logger.debug("Unparseable progress line: %s", stripped)
             else:

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -214,6 +214,24 @@ class _QueueProgressCallback:
     def on_substep(self, step: str, text: str, elapsed_sec: float = 0.0) -> None:
         self._put({"event": "substep", "step": step, "text": text, "elapsed_sec": elapsed_sec})
 
+    def on_substep_start(self, step: str, text: str) -> None:
+        self._put({"event": "substep_start", "step": step, "text": text})
+
+    def on_substep_done(
+        self,
+        step: str,
+        text: str | None = None,
+        elapsed_sec: float | None = None,
+    ) -> None:
+        self._put(
+            {
+                "event": "substep_done",
+                "step": step,
+                "text": text,
+                "elapsed_sec": elapsed_sec,
+            }
+        )
+
 
 # =============================================================================
 # Worker function (runs inside child process)
@@ -355,6 +373,12 @@ def _consume_progress_events(
         elif event_type == "substep":
             study_progress.on_substep(
                 event["step"], event.get("text", ""), event.get("elapsed_sec", 0)
+            )
+        elif event_type == "substep_start":
+            study_progress.on_substep_start(event["step"], event.get("text", ""))
+        elif event_type == "substep_done":
+            study_progress.on_substep_done(
+                event["step"], event.get("text"), event.get("elapsed_sec")
             )
 
 
@@ -859,13 +883,30 @@ class StudyRunner:
 
         # Measure fresh baseline (in-container for Docker targets)
         dur = config.baseline.duration_seconds
+        # Resolve a short human-readable label for the baseline target. For
+        # Docker runs we prefer the image tag (e.g. "llenergymeasure:vllm")
+        # because it disambiguates local-build vs registry pulls and tells
+        # the user exactly which container is being waited on. Falls back to
+        # the backend name when no spec/image is available.
+        spec = self._runner_specs.get(config.backend) if self._runner_specs else None
+        target_label = (spec.image if spec and spec.image else config.backend) or "baseline"
         if self._progress is not None:
-            self._progress.on_step_start(
-                STEP_BASELINE, "Measuring", f"{location} · idle power ({dur:.0f}s)"
-            )
+            self._progress.on_step_start(STEP_BASELINE, "Calibrating", "sampling idle GPU draw")
             t0_meas = time.perf_counter()
+            # Seed the first live substep before dispatch so the CLI shows
+            # "launching container" *while* docker run is warming up, not
+            # only once the container reaches its first stage marker.
+            if cache_key != "local":
+                self._progress.on_substep_start(
+                    STEP_BASELINE,
+                    f"launching separate {target_label} baseline container",
+                )
 
-        on_stage = self._make_baseline_stage_callback() if self._progress is not None else None
+        on_stage = (
+            self._make_baseline_stage_callback(duration_sec=dur, target_label=target_label)
+            if self._progress is not None
+            else None
+        )
         measured = self._measure_baseline(config, cache_key, on_stage=on_stage)
 
         if measured is not None:
@@ -880,14 +921,15 @@ class StudyRunner:
         if self._progress is not None:
             elapsed = time.perf_counter() - t0_meas
             if measured is None:
-                # Surface the failure so users don't see a silent tick hiding a
-                # dispatch crash. The experiment container falls back to measuring
-                # its own baseline; the substep tells the user *why*.
-                self._progress.on_substep(
+                # Freeze any live substep with the failure text + accurate
+                # elapsed so users don't see a silent tick hiding a crash.
+                self._progress.on_substep_done(
                     STEP_BASELINE,
-                    f"measurement failed after {elapsed:.1f}s — see log warnings "
-                    f"(experiment container will re-measure fresh)",
-                    elapsed,
+                    text=(
+                        f"measurement failed after {elapsed:.1f}s — see log warnings "
+                        f"(experiment container will re-measure fresh)"
+                    ),
+                    elapsed_sec=elapsed,
                 )
             elif cache_key == "local":
                 # No container subprocess → emit a retroactive sampling substep
@@ -903,49 +945,55 @@ class StudyRunner:
 
         return measured
 
-    def _make_baseline_stage_callback(self) -> Any:
-        """Build a stage-marker callback that emits live baseline sub-bullets.
+    def _make_baseline_stage_callback(
+        self, *, duration_sec: float, target_label: str = "baseline"
+    ) -> Any:
+        """Build a stage-marker callback that drives live baseline sub-bullets.
 
-        Each sub-bullet reports the duration of *that stage* (delta since the
-        previous marker), so users see "launch took Xs, CUDA init took Ys,
-        sampling took Zs" rather than ever-increasing cumulative totals.
-        ``container_ready`` is the exception — its elapsed IS the container
-        launch cost (no prior marker to diff against).
+        Each stage transition ``on_substep_done``s the previous live substep
+        (freezing it with its final text + a tick) and ``on_substep_start``s
+        the next one (which begins animating with a dim spinner + counter).
+        The result is a heartbeating breakdown of "launching container → CUDA
+        init → sampling" that answers "why did a 30s measurement take 37s?"
+        without the user having to dig through logs.
+
+        The very first substep ("launching <target_label> container") is
+        started in ``_get_baseline`` just before ``subprocess.Popen`` fires —
+        so even the docker-run cold-start is visible.
         """
-        last_t = 0.0
+        dur_label = f"{duration_sec:.0f}s"
 
         def on_stage(name: str, elapsed: float, kv: dict[str, str]) -> None:
-            nonlocal last_t
             if self._progress is None:
                 return
-            delta = max(0.0, elapsed - last_t)
-            last_t = elapsed
             if name == "container_ready":
-                self._progress.on_substep(
-                    STEP_BASELINE,
-                    "dispatched baseline container · Python runtime ready",
-                    elapsed,
+                self._progress.on_substep_done(
+                    STEP_BASELINE, f"{target_label} baseline container ready"
+                )
+                self._progress.on_substep_start(
+                    STEP_BASELINE, "initialising CUDA runtime inside baseline container"
                 )
             elif name == "cuda_primed":
-                self._progress.on_substep(
-                    STEP_BASELINE,
-                    "initialised CUDA runtime · seeded torch allocator",
-                    delta,
+                self._progress.on_substep_done(STEP_BASELINE, "CUDA runtime primed")
+                self._progress.on_substep_start(
+                    STEP_BASELINE, f"sampling idle GPU draw ({dur_label})"
                 )
             elif name == "sampling_done":
                 power_w = kv.get("power_w", "?")
                 samples = kv.get("samples", "?")
                 sampled = kv.get("duration", "?")
-                self._progress.on_substep(
+                self._progress.on_substep_done(
                     STEP_BASELINE,
-                    f"sampled idle GPU power · {sampled}s ({power_w}W · {samples} samples)",
-                    delta,
+                    f"sampled idle GPU draw · {sampled}s ({power_w}W · {samples} samples)",
                 )
-            elif name == "result_written" and delta > 0.1:
-                self._progress.on_substep(
+                self._progress.on_substep_start(
                     STEP_BASELINE,
-                    "wrote result & container teardown",
-                    delta,
+                    f"writing baseline result · tearing down {target_label} baseline container",
+                )
+            elif name == "result_written":
+                self._progress.on_substep_done(
+                    STEP_BASELINE,
+                    f"baseline result cached · {target_label} baseline container torn down",
                 )
 
         return on_stage

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -883,19 +883,14 @@ class StudyRunner:
 
         # Measure fresh baseline (in-container for Docker targets)
         dur = config.baseline.duration_seconds
-        # Resolve a short human-readable label for the baseline target. For
-        # Docker runs we prefer the image tag (e.g. "llenergymeasure:vllm")
-        # because it disambiguates local-build vs registry pulls and tells
-        # the user exactly which container is being waited on. Falls back to
-        # the backend name when no spec/image is available.
+        # Prefer the image tag over backend name so users see which container
+        # is running in multi-backend studies.
         spec = self._runner_specs.get(config.backend) if self._runner_specs else None
         target_label = (spec.image if spec and spec.image else config.backend) or "baseline"
         if self._progress is not None:
             self._progress.on_step_start(STEP_BASELINE, "Calibrating", "sampling idle GPU draw")
             t0_meas = time.perf_counter()
-            # Seed the first live substep before dispatch so the CLI shows
-            # "launching container" *while* docker run is warming up, not
-            # only once the container reaches its first stage marker.
+            # Seed first substep before Popen so the docker cold-start is visible.
             if cache_key != "local":
                 self._progress.on_substep_start(
                     STEP_BASELINE,
@@ -950,16 +945,10 @@ class StudyRunner:
     ) -> Any:
         """Build a stage-marker callback that drives live baseline sub-bullets.
 
-        Each stage transition ``on_substep_done``s the previous live substep
-        (freezing it with its final text + a tick) and ``on_substep_start``s
-        the next one (which begins animating with a dim spinner + counter).
-        The result is a heartbeating breakdown of "launching container → CUDA
-        init → sampling" that answers "why did a 30s measurement take 37s?"
-        without the user having to dig through logs.
-
-        The very first substep ("launching <target_label> container") is
-        started in ``_get_baseline`` just before ``subprocess.Popen`` fires —
-        so even the docker-run cold-start is visible.
+        Each transition ``on_substep_done``s the prior substep (freezing with
+        a tick) and ``on_substep_start``s the next one. The very first substep
+        ("launching <target_label> container") is seeded in ``_get_baseline``
+        before ``subprocess.Popen`` so the docker cold-start is visible.
         """
         dur_label = f"{duration_sec:.0f}s"
 

--- a/tests/unit/cli/test_step_display.py
+++ b/tests/unit/cli/test_step_display.py
@@ -530,6 +530,174 @@ def test_substep_non_tty_prints_immediately():
 
 
 # ---------------------------------------------------------------------------
+# Heartbeat substeps (on_substep_start / on_substep_done)
+# ---------------------------------------------------------------------------
+
+
+def test_step_display_substep_start_done_lifecycle_freezes_with_elapsed():
+    """on_substep_start registers an active substep; on_substep_done freezes
+    it into the completed list with a positive elapsed value."""
+    import time as _time
+
+    console, _ = _make_console()
+    display = StepDisplay(console=console)
+    display.register_steps(["baseline"])
+    display.on_step_start("baseline", "Calibrating", "sampling idle GPU draw")
+
+    display.on_substep_start("baseline", "launching separate vllm baseline container")
+    # Active substep is tracked by step name
+    assert "baseline" in display._active_substep
+    _time.sleep(0.01)
+    display.on_substep_done("baseline", "vllm baseline container ready")
+
+    # Active slot cleared, frozen list has one entry with positive elapsed.
+    assert "baseline" not in display._active_substep
+    frozen = display._substeps["baseline"]
+    assert len(frozen) == 1
+    assert frozen[0][0] == "vllm baseline container ready"
+    assert frozen[0][1] > 0.0  # computed from monotonic delta
+
+
+def test_step_display_substep_done_preserves_start_text_when_final_omitted():
+    """on_substep_done() with text=None keeps the original start text."""
+    import time as _time
+
+    console, _ = _make_console()
+    display = StepDisplay(console=console)
+    display.register_steps(["baseline"])
+    display.on_step_start("baseline", "Calibrating", "")
+
+    display.on_substep_start("baseline", "initialising CUDA runtime")
+    _time.sleep(0.005)
+    display.on_substep_done("baseline")  # no override text
+
+    frozen = display._substeps["baseline"]
+    assert frozen[-1][0] == "initialising CUDA runtime"
+    assert frozen[-1][1] > 0.0
+
+
+def test_step_display_substep_start_without_prior_done_freezes_previous():
+    """Calling on_substep_start twice without a done in between freezes the
+    prior substep (with its accumulated elapsed) so the UI never has two
+    live substeps at once."""
+    import time as _time
+
+    console, _ = _make_console()
+    display = StepDisplay(console=console)
+    display.register_steps(["baseline"])
+    display.on_step_start("baseline", "Calibrating", "")
+
+    display.on_substep_start("baseline", "launching container")
+    _time.sleep(0.005)
+    display.on_substep_start("baseline", "initialising CUDA runtime")
+
+    # The first is now frozen with its accumulated elapsed
+    frozen = display._substeps["baseline"]
+    assert len(frozen) == 1
+    assert frozen[0][0] == "launching container"
+    assert frozen[0][1] > 0.0
+    # The second is the new active slot
+    assert display._active_substep["baseline"][0] == "initialising CUDA runtime"
+
+
+def test_step_display_substep_done_without_start_appends_frozen():
+    """on_substep_done with no prior start still appends a frozen substep
+    (failure path where the runner has to surface a final text without a
+    matching live substep)."""
+    console, _ = _make_console()
+    display = StepDisplay(console=console)
+    display.register_steps(["baseline"])
+    display.on_step_start("baseline", "Calibrating", "")
+
+    display.on_substep_done("baseline", text="measurement failed", elapsed_sec=5.7)
+
+    frozen = display._substeps["baseline"]
+    assert frozen == [("measurement failed", 5.7)]
+
+
+def test_step_display_on_step_done_freezes_dangling_active_substep():
+    """If a step completes while a substep is still active, that substep is
+    frozen rather than left animating under a completed parent."""
+    import time as _time
+
+    console, _ = _make_console()
+    display = StepDisplay(console=console)
+    display.register_steps(["baseline"])
+    display.on_step_start("baseline", "Calibrating", "")
+
+    display.on_substep_start("baseline", "wedged stage")
+    _time.sleep(0.005)
+    display.on_step_done("baseline", 0.1)
+
+    assert "baseline" not in display._active_substep
+    frozen = display._substeps["baseline"]
+    assert len(frozen) == 1
+    assert frozen[0][0] == "wedged stage"
+    assert frozen[0][1] > 0.0
+
+
+def test_study_display_substep_start_done_lifecycle_freezes_with_elapsed():
+    """StudyStepDisplay exhibits the same start/done freeze semantics as
+    StepDisplay for the heartbeat substep pattern."""
+    import time as _time
+
+    console, _ = _make_console()
+    display = StudyStepDisplay(total_experiments=1, console=console, force_plain=True)
+    display.begin_experiment(1, "gpt2 / pytorch / bf16", ["baseline"])
+    display.on_step_start("baseline", "Calibrating", "sampling idle GPU draw")
+
+    display.on_substep_start("baseline", "launching separate vllm baseline container")
+    assert "baseline" in display._inner_active_substep
+    _time.sleep(0.01)
+    display.on_substep_done("baseline", "vllm baseline container ready")
+
+    assert "baseline" not in display._inner_active_substep
+    frozen = display._inner_substeps["baseline"]
+    assert frozen[-1][0] == "vllm baseline container ready"
+    assert frozen[-1][1] > 0.0
+
+
+def test_study_display_on_step_start_refire_clears_active_substep():
+    """Re-firing on_step_start for the same step drops any prior active
+    substep so a retry doesn't carry stale heartbeat state from a failed
+    first attempt (e.g. baseline dispatch → container fallback)."""
+    console, _ = _make_console()
+    display = StudyStepDisplay(total_experiments=1, console=console, force_plain=True)
+    display.begin_experiment(1, "gpt2 / pytorch / bf16", ["baseline"])
+
+    display.on_step_start("baseline", "Calibrating", "sampling idle GPU draw")
+    display.on_substep_start("baseline", "launching baseline container")
+    assert "baseline" in display._inner_active_substep
+
+    # Host dispatch failed; experiment container re-fires the step.
+    display.on_step_start("baseline", "Measuring", "in-container fallback")
+    assert "baseline" not in display._inner_active_substep
+    assert "baseline" not in display._inner_substeps
+
+
+def test_study_display_active_substep_renders_in_active_step_view():
+    """The render pipeline forwards the active substep to _render_substep_lines
+    for the active step, so a spinner line appears under the parent."""
+    import time as _time
+
+    console = Console(file=StringIO(), force_terminal=True, no_color=True, width=200)
+    display = StudyStepDisplay(total_experiments=1, console=console)
+    display.begin_experiment(1, "gpt2 / pytorch / bf16", ["baseline"])
+    display.on_step_start("baseline", "Calibrating", "sampling idle GPU draw")
+
+    display.on_substep_start("baseline", "launching separate vllm baseline container")
+    _time.sleep(0.02)
+
+    rendered = display._render_active_steps()
+    plain = rendered.plain
+    assert "launching separate vllm baseline container" in plain
+    # The active substep shows an elapsed counter (> 0.0s)
+    assert " · launching separate vllm baseline container" in plain
+
+    display.stop()
+
+
+# ---------------------------------------------------------------------------
 # Viewport behaviour
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/docker/test_stream_progress.py
+++ b/tests/unit/docker/test_stream_progress.py
@@ -53,3 +53,48 @@ def test_stream_callback_step_done_writes_json():
     assert event["event"] == "step_done"
     assert event["step"] == "model"
     assert event["elapsed_sec"] == 42.3
+
+
+def test_stream_callback_substep_start_writes_json():
+    """on_substep_start writes a ``substep_start`` JSON line so the host
+    DockerRunner can forward it to the CLI's live heartbeat renderer."""
+    cb = StreamProgressCallback()
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        cb.on_substep_start("baseline", "launching separate vllm baseline container")
+
+    line = mock_stdout.getvalue().strip()
+    event = json.loads(line)
+    assert event["event"] == "substep_start"
+    assert event["step"] == "baseline"
+    assert event["text"] == "launching separate vllm baseline container"
+
+
+def test_stream_callback_substep_done_writes_json_with_optional_fields():
+    """on_substep_done emits ``substep_done`` with ``text`` / ``elapsed_sec``
+    both optional — the host side reuses the start's text + computed elapsed
+    when either is missing (None-safe over the wire)."""
+    cb = StreamProgressCallback()
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        cb.on_substep_done("baseline", "vllm baseline container ready", 2.5)
+
+    line = mock_stdout.getvalue().strip()
+    event = json.loads(line)
+    assert event["event"] == "substep_done"
+    assert event["step"] == "baseline"
+    assert event["text"] == "vllm baseline container ready"
+    assert event["elapsed_sec"] == 2.5
+
+
+def test_stream_callback_substep_done_null_fields_serialise():
+    """on_substep_done with no overrides must round-trip through JSON (None
+    values stay as nulls — consumer decodes them as missing)."""
+    cb = StreamProgressCallback()
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        cb.on_substep_done("baseline")
+
+    line = mock_stdout.getvalue().strip()
+    event = json.loads(line)
+    assert event["event"] == "substep_done"
+    assert event["step"] == "baseline"
+    assert event["text"] is None
+    assert event["elapsed_sec"] is None

--- a/tests/unit/domain/test_progress.py
+++ b/tests/unit/domain/test_progress.py
@@ -39,6 +39,14 @@ def test_protocol_is_runtime_checkable():
         def on_substep(self, step: str, text: str, elapsed_sec: float = 0.0) -> None:
             pass
 
+        def on_substep_start(self, step: str, text: str) -> None:
+            pass
+
+        def on_substep_done(
+            self, step: str, text: str | None = None, elapsed_sec: float | None = None
+        ) -> None:
+            pass
+
     assert isinstance(Impl(), ProgressCallback)
 
 

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -637,7 +637,7 @@ def _baseline_step_events(progress: MagicMock) -> list[tuple[str, tuple, dict]]:
 class TestBaselineHostProgressEvents:
     """Verify host-side baseline events fire for cached/validated strategies."""
 
-    def test_local_fresh_measure_emits_measuring_start_and_done(
+    def test_local_fresh_measure_emits_calibrating_start_and_done(
         self, tmp_path: Path, config_cached: ExperimentConfig
     ):
         runner, progress = _make_runner_with_progress(tmp_path, config_cached)
@@ -654,9 +654,13 @@ class TestBaselineHostProgressEvents:
         names = [e[0] for e in events]
         assert "on_step_start" in names
         assert "on_step_done" in names
-        # First emission is start with "Measuring" verb.
+        # Fresh measurement uses "Calibrating" verb + "sampling idle GPU draw"
+        # detail. The label was refactored away from "Measuring ... idle power
+        # (30s)" to keep the parent line concise while the sub-bullets carry
+        # the breakdown.
         start_event = next(e for e in events if e[0] == "on_step_start")
-        assert start_event[1][1] == "Measuring"
+        assert start_event[1][1] == "Calibrating"
+        assert start_event[1][2] == "sampling idle GPU draw"
 
     def test_disk_load_emits_loading_event_when_file_exists(
         self, tmp_path: Path, config_cached: ExperimentConfig
@@ -696,7 +700,7 @@ class TestBaselineHostProgressEvents:
         events = _baseline_step_events(progress)
         verbs = [e[1][1] for e in events if e[0] == "on_step_start"]
         assert "Loading" not in verbs
-        assert "Measuring" in verbs
+        assert "Calibrating" in verbs
 
     def test_disk_load_sets_method_for_backward_compat(
         self, tmp_path: Path, config_cached: ExperimentConfig
@@ -746,9 +750,10 @@ class TestBaselineHostProgressEvents:
         self, tmp_path: Path, config_cached: ExperimentConfig
     ):
         """When _measure_baseline returns None (e.g. baseline container
-        dispatch crashed because the image is stale), the host must emit a
-        failure substep before on_step_done — otherwise the UI silently
-        shows ✓ and users mistake it for a successful measurement.
+        dispatch crashed because the image is stale), the host must freeze
+        the dangling live substep with a failure text before on_step_done —
+        otherwise the UI silently shows ✓ and users mistake it for a
+        successful measurement.
         """
         runner, progress = _make_runner_with_progress(tmp_path, config_cached)
 
@@ -762,13 +767,21 @@ class TestBaselineHostProgressEvents:
         assert result is None
         mock_save.assert_not_called()  # nothing to persist when measurement failed
 
-        substep_calls = [
+        # Failure surfaces via on_substep_done (freezes any live substep with
+        # the failure text) — never as on_substep which would leave the
+        # dangling "launching ..." heartbeat alive beside it.
+        done_calls = [
             call
             for call in progress.mock_calls
-            if call[0] == "on_substep" and call[1] and call[1][0] == "baseline"
+            if call[0] == "on_substep_done" and call[1] and call[1][0] == "baseline"
         ]
-        assert substep_calls, "baseline failure must surface as a substep"
-        assert "failed" in substep_calls[0][1][1].lower()
+        assert done_calls, "baseline failure must surface as on_substep_done"
+        # Final text is passed via kwarg (text=...) in runner.py
+        fail_texts = [
+            call.kwargs.get("text") or (call.args[1] if len(call.args) > 1 else "")
+            for call in done_calls
+        ]
+        assert any("failed" in (t or "").lower() for t in fail_texts)
 
         events = _baseline_step_events(progress)
         names = [e[0] for e in events]
@@ -779,15 +792,16 @@ class TestBaselineHostProgressEvents:
     def test_docker_fresh_emits_live_stage_substeps(
         self, tmp_path: Path, config_cached: ExperimentConfig
     ):
-        """Streamed stage markers from run_baseline_container become sub-bullets
-        under the active baseline step, with per-stage deltas rather than
-        ever-increasing cumulative totals.
+        """Streamed stage markers from run_baseline_container drive
+        ``on_substep_start`` / ``on_substep_done`` pairs under the active
+        baseline step, producing heartbeating sub-bullets that animate while
+        each stage is in flight and freeze with a dim tick on completion.
 
         This is the regression for "why did a 30s measurement take 37s?" —
-        the user now sees dispatched + CUDA init + sampling as separate dim
-        sub-bullets whose durations add up to the parent elapsed.
+        the user now sees a live breakdown of launching container → CUDA init
+        → sampling → teardown instead of one opaque parent step.
         """
-        spec = RunnerSpec(mode="docker", image="test/pytorch:v0", source="yaml")
+        spec = RunnerSpec(mode="docker", image="test/vllm:v0", source="yaml")
         runner, progress = _make_runner_with_progress(
             tmp_path, config_cached, runner_specs={"pytorch": spec}
         )
@@ -803,8 +817,6 @@ class TestBaselineHostProgressEvents:
 
         def _fake_run_container(*_args, on_stage=None, **_kwargs):
             captured_on_stage.append(on_stage)
-            # Simulate the container emitting its five stage markers, each
-            # roughly 1s apart except for the sampling window.
             if on_stage is not None:
                 on_stage("container_ready", 2.5, {})
                 on_stage("cuda_primed", 4.1, {})
@@ -825,24 +837,64 @@ class TestBaselineHostProgressEvents:
             result = runner._get_baseline(config_cached)
 
         assert result is fake_cache
-        # Callback was threaded through _measure_baseline → run_baseline_container.
         assert captured_on_stage and captured_on_stage[0] is not None
 
-        substeps = [
-            call
-            for call in progress.mock_calls
-            if call[0] == "on_substep" and call[1] and call[1][0] == "baseline"
+        # Helper to pull the text out of a callback record regardless of
+        # whether it was passed positionally or as a kwarg.
+        def _text(call) -> str:
+            if len(call.args) > 1 and call.args[1] is not None:
+                return call.args[1]
+            return call.kwargs.get("text") or ""
+
+        baseline_calls = [
+            c
+            for c in progress.mock_calls
+            if c[0] in ("on_substep_start", "on_substep_done")
+            and c.args
+            and c.args[0] == "baseline"
         ]
-        # Expect three visible substeps: dispatched (from container_ready),
-        # CUDA primed, sampled. result_written fires but its delta is <0.1s
-        # so the substep is suppressed. sampling_started never emits.
-        texts = [call[1][1] for call in substeps]
-        assert any("dispatched" in t for t in texts)
-        assert any("CUDA" in t for t in texts)
-        assert any("sampled" in t and "42.68" in t and "289" in t for t in texts)
-        # No retroactive "container launch + teardown" substep — those were
-        # the old retroactive pre-streaming labels.
-        assert not any("container launch + teardown" in t for t in texts)
+        starts = [c for c in baseline_calls if c[0] == "on_substep_start"]
+        dones = [c for c in baseline_calls if c[0] == "on_substep_done"]
+
+        start_texts = [_text(c) for c in starts]
+        done_texts = [_text(c) for c in dones]
+
+        # 1. The pre-dispatch substep name uses the image tag (user asked
+        #    for "the actual image/container name w/ slug") and explicitly
+        #    says "baseline container" so users know this is a short-lived
+        #    dedicated container, not the experiment one.
+        assert any(
+            "launching" in t and "test/vllm:v0" in t and "baseline container" in t
+            for t in start_texts
+        ), start_texts
+
+        # 2. Stage lifecycle: launching → ready → CUDA init → primed →
+        #    sampling → sampled → writing/teardown → cached/torn down.
+        assert any("baseline container ready" in t and "test/vllm:v0" in t for t in done_texts), (
+            done_texts
+        )
+        assert any("initialising CUDA runtime" in t for t in start_texts)
+        assert any("CUDA runtime primed" in t for t in done_texts)
+        assert any("sampling idle GPU draw" in t and "30s" in t for t in start_texts)
+        assert any("sampled idle GPU draw" in t and "42.68" in t and "289" in t for t in done_texts)
+        assert any(
+            "writing baseline result" in t and "tearing down" in t and "test/vllm:v0" in t
+            for t in start_texts
+        )
+        assert any(
+            "baseline result cached" in t and "torn down" in t and "test/vllm:v0" in t
+            for t in done_texts
+        )
+
+        # 3. No retroactive "container launch + teardown" substeps — those
+        #    were the pre-streaming labels from before stage markers existed.
+        all_texts = start_texts + done_texts
+        assert not any("container launch + teardown" in t for t in all_texts)
+
+        # 4. Start/done pairs are balanced (4 starts, 4 dones: launching,
+        #    CUDA init, sampling, teardown). This guarantees the UI never
+        #    has two live substeps animating at once.
+        assert len(starts) == len(dones) == 4, (start_texts, done_texts)
 
     def test_validated_spot_check_no_drift_emits_validating(
         self, tmp_path: Path, config_validated: ExperimentConfig


### PR DESCRIPTION
## Summary

Extend \`ProgressCallback\` with \`on_substep_start\` / \`on_substep_done\` so baseline sub-operations render with the same live spinner + tick + elapsed pattern as top-level steps — but dim and indented. Users get a heartbeating breakdown of \"launching container → CUDA init → sampling idle GPU draw → result cached\" instead of a single 30s spinner.

Split from #252 — depends on #253 (core fix) and #254 (stage streaming).

## What this PR does

- **\`domain/progress.py\`**: add \`on_substep_start(step, text)\` and \`on_substep_done(step, text=None, elapsed_sec=None)\` to the \`ProgressCallback\` protocol. \`on_substep_done\` optionally overrides the final text or elapsed so failure paths can freeze a live substep with accurate diagnostics.
- **\`cli/_step_display.py\`**: render live substeps as dim indented bullets with a spinner + rising elapsed counter until \`on_substep_done\` arrives. Only one active substep per parent step; re-firing \`on_substep_start\` freezes the prior one. Handles step re-fire cleanup and dangling-active cleanup on \`step_done\`.
- **\`entrypoints/container.py\`** / **\`infra/docker_runner.py\`**: forward substep start/done events over the existing JSON wire protocol.
- **\`study/runner.py\`**: change the baseline verb from \"Measuring\" to \"Calibrating · sampling idle GPU draw\" and drive the new live heartbeat via \`_make_baseline_stage_callback\`. Each stage transition dones the previous live substep (freezing it with a tick) and starts the next. First substep is seeded *before* \`subprocess.Popen\` so the docker cold-start is visible. Failure path uses \`on_substep_done\` so dangling substeps are frozen with the failure text.

## Test plan

- [x] \`pytest tests/unit/cli/test_step_display.py\` — substep heartbeat freeze-on-restart, dangling-active cleanup on step_done, re-fire clears active substep
- [x] \`pytest tests/unit/docker/test_stream_progress.py\` — JSON wire format for new \`substep_start\` / \`substep_done\` events
- [x] \`pytest tests/unit/domain/test_progress.py\` — new Protocol methods runtime-checkable
- [x] \`pytest tests/unit/study/test_baseline_strategy.py\` — live substep lifecycle with image label, failure substep freezing