### PR TITLE
feat(infra): detect host-container schema skew before experiments

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,6 +48,16 @@ jobs:
             type=raw,value=${{ inputs.version }}
             type=raw,value=latest
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install llenergymeasure (base deps only)
+        run: pip install .
+      - id: fingerprint
+        run: |
+          value=$(python3 scripts/compute_expconf_fingerprint.py)
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@v7
         with:
           context: .
@@ -55,3 +65,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            LLEM_PKG_VERSION=${{ inputs.version }}
+            LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.
+- **`llem doctor` CLI command.** Reports per-backend image status (OK / MISMATCH / UNVERIFIED / UNREACHABLE) and exits non-zero on mismatch for CI-friendly gating.
+- **Inline schema status in the image-prep progress line** (`schema: ok` / `schema: mismatch` / `schema: unverified` / `schema: bypassed`), rendered via the existing metadata display with no changes to the progress protocol.
+
 ### Changed
 
 - **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@
 export PUID := $(shell id -u)
 export PGID := $(shell id -g)
 
+# Host/container schema handshake stamps — surfaced to docker compose build
+# via docker-compose.yml's build.args block so every locally-built image is
+# labelled with the same fingerprint llem computes at runtime. Falls back to
+# "dev"/"unknown" on any error (e.g. missing venv).
+export LLEM_PKG_VERSION := $(shell python3 -c "from llenergymeasure._version import __version__; print(__version__)" 2>/dev/null || echo dev)
+export LLEM_EXPCONF_SCHEMA_FINGERPRINT := $(shell python3 scripts/compute_expconf_fingerprint.py 2>/dev/null || echo unknown)
+
 # =============================================================================
 # Quick Start
 #   Local:  make setup       (pip install + pre-commit)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LLenergyMeasure is a Python framework for measuring the energy consumption, thro
 - **Multi-backend inference** — PyTorch, vLLM, TensorRT-LLM, SGLang (planned)
 - **GPU energy measurement** — NVML, Zeus, CodeCarbon, others 
 - **Smart sweep system** — define parameter grids, run Cartesian product experiments automatically; intelligently managed sweep hierarchy scopes available config fields to appropriate backend/component, and ensures invalid combinations are removed
-- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available.
+- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check).
 - **Reproducibility** — fixed seeds, cycle ordering, thermal management, environment snapshots, effective config recorded (add others)
 - **Built-in datasets** — AI Energy Score benchmark prompts included; custom JSONL datasets also supported
 
@@ -48,7 +48,7 @@ See [Installation](docs/installation.md) for system requirements, Docker setup, 
 | [Docker Setup](docs/docker-setup.md) | NVIDIA Container Toolkit walkthrough for vLLM |
 | [Backend Configuration](docs/backends.md) | PyTorch vs vLLM, parameter support matrix |
 | [Study & Experiment Configuration](docs/study-config.md) | YAML reference, sweeps, config schema |
-| [CLI Reference](docs/cli-reference.md) | `llem run` and `llem config` flags and options |
+| [CLI Reference](docs/cli-reference.md) | `llem run`, `llem config`, and `llem doctor` flags and options |
 | [Energy Measurement](docs/energy-measurement.md) | NVML, Zeus, CodeCarbon backends, measurement mechanics |
 | [Measurement Methodology](docs/methodology.md) | Warmup, baseline, thermal management, reproducibility |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues, invalid combinations, getting help |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile.pytorch
       target: runtime
+      args:
+        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
+        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
     image: llenergymeasure:pytorch
 
   pytorch-dev:
@@ -102,6 +105,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile.pytorch
       target: dev
+      args:
+        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
+        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
     image: llenergymeasure:pytorch-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -125,6 +131,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: runtime
+      args:
+        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
+        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
     image: llenergymeasure:vllm
 
   vllm-dev:
@@ -139,6 +148,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: dev
+      args:
+        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
+        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
     image: llenergymeasure:vllm-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -163,6 +175,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: runtime
+      args:
+        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
+        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
     image: llenergymeasure:tensorrt
 
   tensorrt-dev:
@@ -178,6 +193,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: dev
+      args:
+        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
+        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
     image: llenergymeasure:tensorrt-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []

--- a/docker/Dockerfile.pytorch
+++ b/docker/Dockerfile.pytorch
@@ -95,6 +95,15 @@ RUN --mount=type=bind,source=pyproject.toml,target=/app/pyproject.toml \
 ENV HF_HOME=/app/.cache/huggingface
 RUN mkdir -p /app/.cache/huggingface && chmod 777 /app/.cache/huggingface
 
+# Host/container schema handshake labels (see infra/version_handshake.py).
+# LLEM_PKG_VERSION is the llenergymeasure release; LLEM_EXPCONF_SCHEMA_FINGERPRINT
+# is a SHA-256 of ExperimentConfig.model_json_schema() at build time.
+ARG LLEM_PKG_VERSION=dev
+ARG LLEM_EXPCONF_SCHEMA_FINGERPRINT=unknown
+LABEL org.opencontainers.image.version="${LLEM_PKG_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/henrycgbaker/llenergymeasure"
+LABEL llem.expconf.schema.fingerprint="${LLEM_EXPCONF_SCHEMA_FINGERPRINT}"
+
 CMD ["python3", "-m", "llenergymeasure.entrypoints.container"]
 
 # Dev stage — adds development tools for local iteration

--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -47,4 +47,11 @@ RUN mkdir -p /app/.cache/huggingface && chmod 777 /app/.cache/huggingface
 ENV TRT_ENGINE_CACHE=/app/.cache/tensorrt-engines
 RUN mkdir -p ${TRT_ENGINE_CACHE} && chmod 777 ${TRT_ENGINE_CACHE}
 
+# Host/container schema handshake labels (see infra/version_handshake.py).
+ARG LLEM_PKG_VERSION=dev
+ARG LLEM_EXPCONF_SCHEMA_FINGERPRINT=unknown
+LABEL org.opencontainers.image.version="${LLEM_PKG_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/henrycgbaker/llenergymeasure"
+LABEL llem.expconf.schema.fingerprint="${LLEM_EXPCONF_SCHEMA_FINGERPRINT}"
+
 CMD ["python3", "-m", "llenergymeasure.entrypoints.container"]

--- a/docker/Dockerfile.vllm
+++ b/docker/Dockerfile.vllm
@@ -37,4 +37,11 @@ RUN uv pip install --system --break-system-packages --no-cache --no-deps ".[vllm
 ENV HF_HOME=/app/.cache/huggingface
 RUN mkdir -p /app/.cache/huggingface && chmod 777 /app/.cache/huggingface
 
+# Host/container schema handshake labels (see infra/version_handshake.py).
+ARG LLEM_PKG_VERSION=dev
+ARG LLEM_EXPCONF_SCHEMA_FINGERPRINT=unknown
+LABEL org.opencontainers.image.version="${LLEM_PKG_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/henrycgbaker/llenergymeasure"
+LABEL llem.expconf.schema.fingerprint="${LLEM_EXPCONF_SCHEMA_FINGERPRINT}"
+
 CMD ["python3", "-m", "llenergymeasure.entrypoints.container"]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,10 +1,11 @@
 # CLI Reference
 
-`llem` has two commands (`run` and `config`) and one flag (`--version`).
+`llem` has three commands (`run`, `config`, `doctor`) and one flag (`--version`).
 
 ```
 llem run [CONFIG] [OPTIONS]   # run an experiment or study
 llem config [OPTIONS]         # show environment and configuration status
+llem doctor                   # verify Docker images match the host schema
 llem --version                # print version and exit
 ```
 
@@ -84,6 +85,56 @@ Config
   Status: using defaults (no config file)
 Python
   3.12.0
+```
+
+---
+
+## `llem doctor`
+
+Verify that every backend's resolved Docker image matches the host's
+`ExperimentConfig` schema. Compares the `llem.expconf.schema.fingerprint`
+OCI label baked into each image against a fingerprint computed from the
+host's current `ExperimentConfig.model_json_schema()`.
+
+Image resolution follows the same chain as `llem run`: local build
+(`llenergymeasure:{backend}`) first, then the versioned GHCR tag
+(`ghcr.io/henrycgbaker/llenergymeasure/{backend}:v{version}`).
+
+**Exit codes:** `0` when every reachable image matches (or labels are absent
+on legacy images); `1` when at least one image's schema fingerprint differs
+from the host.
+
+**Columns:**
+
+| Column | Meaning |
+|--------|---------|
+| `Backend` | Backend identifier (`pytorch`, `vllm`, `tensorrt`) |
+| `Image` | Resolved image tag (local or GHCR) |
+| `Pkg ver` | `org.opencontainers.image.version` label (llenergymeasure release) |
+| `Img FP` | First 12 chars of `llem.expconf.schema.fingerprint` label |
+| `Host FP` | First 12 chars of host `ExperimentConfig` fingerprint |
+| `Status` | `OK` / `MISMATCH` / `UNVERIFIED` (pre-handshake image) / `UNREACHABLE` (no such image) |
+
+**Bypass:** `LLEM_SKIP_IMAGE_CHECK=1` disables the runtime handshake in
+`llem run`; when set, `llem doctor` still reports the true status but prints a
+warning in the footer.
+
+**Example:**
+
+```bash
+llem doctor
+```
+
+```
+Backend     Image                          Pkg ver     Img FP          Host FP         Status
+---------------------------------------------------------------------------------------------
+pytorch     llenergymeasure:pytorch        0.9.0       a1b2c3d4e5f6    a1b2c3d4e5f6    OK
+vllm        llenergymeasure:vllm           0.9.0       9988776655ff    a1b2c3d4e5f6    MISMATCH
+            └─ rebuild: make docker-build-vllm
+tensorrt    llenergymeasure:tensorrt       0.9.0       a1b2c3d4e5f6    a1b2c3d4e5f6    OK
+
+Host llenergymeasure version: 0.9.0
+Host ExperimentConfig fingerprint: a1b2c3d4e5f6…
 ```
 
 ---

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -378,6 +378,37 @@ runners:
 SGLang (M5) images will follow the same naming convention, resolution logic, and auto-pull
 behaviour. No additional setup is needed when SGLang ships.
 
+### Image labels and versioning
+
+Every backend image is stamped at build time with OCI labels that llem reads at
+study start-up to detect host/container schema skew:
+
+| Label | Source | Purpose |
+|-------|--------|---------|
+| `org.opencontainers.image.version` | `LLEM_PKG_VERSION` build-arg (from `_version.py`) | Human-readable llenergymeasure release baked into the image |
+| `org.opencontainers.image.source` | Dockerfile | Points at the GitHub repository |
+| `llem.expconf.schema.fingerprint` | `LLEM_EXPCONF_SCHEMA_FINGERPRINT` build-arg | SHA-256 of `ExperimentConfig.model_json_schema()`; the blocking signal for schema skew |
+
+The package version is *not* what catches skew during dev: phase PRs don't
+touch `_version.py`, so both host and image report the same version through
+an entire milestone of schema churn. The fingerprint is the blocking signal —
+it changes whenever any `ExperimentConfig` field (or nested model) is added,
+renamed, or restructured.
+
+Inspect the labels on a local image:
+
+```bash
+docker image inspect llenergymeasure:pytorch \
+    --format '{{json .Config.Labels}}' | python3 -m json.tool
+```
+
+`Makefile` and `.github/workflows/docker-publish.yml` both call
+`scripts/compute_expconf_fingerprint.py` so locally-built and CI-published
+images carry identical fingerprints.
+
+See [troubleshooting.md](troubleshooting.md#schema-skew-between-host-and-docker-image)
+for the remediation flow when a mismatch is reported.
+
 ---
 
 ## Troubleshooting

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -257,6 +257,50 @@ Notes:
 
 ---
 
+## Schema skew between host and Docker image
+
+**Symptom:** `llem run study.yaml` aborts before any experiment with a message
+like:
+
+```
+Docker image 'llenergymeasure:pytorch' was built from llenergymeasure 0.9.0
+(schema 9988776655ff) but the host is running 0.9.0 (schema a1b2c3d4e5f6).
+The container will reject ExperimentConfig fields added on the host after
+the image was built.
+```
+
+Or, without the handshake catching it first, a container stack trace full of
+`extra_forbidden` Pydantic errors (often with URLs mixing
+`errors.pydantic.dev/2.10/…` and `errors.pydantic.dev/2.12/…`, a second tell
+for version skew).
+
+**Cause:** the host's `ExperimentConfig` (or a nested model like
+`BaselineConfig`, `WarmupConfig`, etc.) gained fields after the Docker image
+was built. `llem` stamps every image at build time with a
+`llem.expconf.schema.fingerprint` label computed from
+`ExperimentConfig.model_json_schema()`. `StudyRunner._prepare_images` compares
+that label against the host fingerprint before any experiment starts.
+
+**Fix:** rebuild the affected backend image. One of:
+
+```bash
+make docker-build-pytorch        # or -vllm / -tensorrt, local build
+make docker-pull                 # pull the newest published tagged release
+```
+
+Verify with:
+
+```bash
+llem doctor                      # exits 1 on mismatch, 0 when every backend is OK
+```
+
+**Bypass (last resort):** set `LLEM_SKIP_IMAGE_CHECK=1` to skip the handshake.
+Only safe when you're confident the new field is optional and the container
+silently ignores it. The container will still hard-fail on any required field
+it doesn't know about.
+
+---
+
 ## Getting Help
 
 Run `llem config --verbose` to capture full environment details (Python version, installed

--- a/scripts/compute_expconf_fingerprint.py
+++ b/scripts/compute_expconf_fingerprint.py
@@ -1,18 +1,9 @@
 #!/usr/bin/env python3
-"""Compute the ExperimentConfig schema fingerprint for Docker build stamping.
+"""Print the ExperimentConfig schema fingerprint for Docker build stamping.
 
-Prints a 64-character SHA-256 hex digest of
-``ExperimentConfig.model_json_schema()`` serialised with
-``sort_keys=True, separators=(',', ':')``. Used by:
-
-- ``Makefile`` as ``LLEM_EXPCONF_SCHEMA_FINGERPRINT`` build-arg source.
-- ``.github/workflows/docker-publish.yml`` so published images carry the same
-  fingerprint that host-side ``StudyRunner._prepare_images`` will compare
-  against at run time.
-
-This script is intentionally tiny and dependency-free beyond ``pydantic``
-(implicit via the package) so it can run in any environment where
-llenergymeasure is installed or its source tree is on ``PYTHONPATH``.
+Emits a 64-character SHA-256 hex digest of the ExperimentConfig JSON schema
+serialised deterministically. Intended as a build-arg so Docker images
+can be compared against the running host's fingerprint at study start.
 """
 
 from __future__ import annotations

--- a/scripts/compute_expconf_fingerprint.py
+++ b/scripts/compute_expconf_fingerprint.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Compute the ExperimentConfig schema fingerprint for Docker build stamping.
+
+Prints a 64-character SHA-256 hex digest of
+``ExperimentConfig.model_json_schema()`` serialised with
+``sort_keys=True, separators=(',', ':')``. Used by:
+
+- ``Makefile`` as ``LLEM_EXPCONF_SCHEMA_FINGERPRINT`` build-arg source.
+- ``.github/workflows/docker-publish.yml`` so published images carry the same
+  fingerprint that host-side ``StudyRunner._prepare_images`` will compare
+  against at run time.
+
+This script is intentionally tiny and dependency-free beyond ``pydantic``
+(implicit via the package) so it can run in any environment where
+llenergymeasure is installed or its source tree is on ``PYTHONPATH``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_src_on_path() -> None:
+    """Allow running from a checkout without an editable install."""
+    repo_src = Path(__file__).resolve().parent.parent / "src"
+    if repo_src.is_dir() and str(repo_src) not in sys.path:
+        sys.path.insert(0, str(repo_src))
+
+
+def main() -> int:
+    _ensure_src_on_path()
+    from llenergymeasure.infra.version_handshake import compute_expconf_fingerprint
+
+    print(compute_expconf_fingerprint())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llenergymeasure/api/doctor.py
+++ b/src/llenergymeasure/api/doctor.py
@@ -8,31 +8,28 @@ from llenergymeasure._version import __version__
 from llenergymeasure.config.ssot import BACKEND_PYTORCH, BACKEND_TENSORRT, BACKEND_VLLM
 from llenergymeasure.infra.image_registry import get_default_image
 from llenergymeasure.infra.version_handshake import (
-    ImageStamp,
+    SchemaStatus,
+    classify_stamp,
     compute_expconf_fingerprint,
     inspect_image_stamp,
     rebuild_hint,
     skip_check_enabled,
 )
-from llenergymeasure.utils.compat import StrEnum
 
 __all__ = [
     "BackendDoctorResult",
     "DoctorReport",
-    "DoctorStatus",
+    "SchemaStatus",
     "run_doctor_checks",
 ]
 
 SUPPORTED_BACKENDS: tuple[str, ...] = (BACKEND_PYTORCH, BACKEND_VLLM, BACKEND_TENSORRT)
 
-
-class DoctorStatus(StrEnum):
-    """Per-backend image status."""
-
-    OK = "OK"
-    MISMATCH = "MISMATCH"
-    UNVERIFIED = "UNVERIFIED"
-    UNREACHABLE = "UNREACHABLE"
+_DETAIL_FOR_STATUS: dict[SchemaStatus, str] = {
+    SchemaStatus.OK: "",
+    SchemaStatus.UNVERIFIED: "image predates schema-fingerprint label — rebuild to verify",
+    SchemaStatus.UNREACHABLE: "no labels (image missing or built pre-handshake)",
+}
 
 
 @dataclass(frozen=True)
@@ -43,7 +40,7 @@ class BackendDoctorResult:
     image: str
     pkg_version: str | None
     image_fingerprint: str | None
-    status: DoctorStatus
+    status: SchemaStatus
     detail: str = ""
 
 
@@ -58,20 +55,13 @@ class DoctorReport:
 
     @property
     def any_mismatch(self) -> bool:
-        return any(r.status is DoctorStatus.MISMATCH for r in self.results)
+        return any(r.status is SchemaStatus.MISMATCH for r in self.results)
 
 
-def _classify(backend: str, stamp: ImageStamp, host_fp: str) -> tuple[DoctorStatus, str]:
-    if stamp.expconf_fingerprint is None and stamp.pkg_version is None:
-        return DoctorStatus.UNREACHABLE, "no labels (image missing or built pre-handshake)"
-    if stamp.expconf_fingerprint is None:
-        return (
-            DoctorStatus.UNVERIFIED,
-            "image predates schema-fingerprint label — rebuild to verify",
-        )
-    if stamp.expconf_fingerprint == host_fp:
-        return DoctorStatus.OK, ""
-    return DoctorStatus.MISMATCH, f"rebuild: {rebuild_hint(backend)}"
+def _detail_for(backend: str, status: SchemaStatus) -> str:
+    if status is SchemaStatus.MISMATCH:
+        return f"rebuild: {rebuild_hint(backend)}"
+    return _DETAIL_FOR_STATUS.get(status, "")
 
 
 def run_doctor_checks(
@@ -89,7 +79,7 @@ def run_doctor_checks(
     for backend in backends:
         image = get_default_image(backend)
         stamp = inspect_image_stamp(image)
-        status, detail = _classify(backend, stamp, host_fp)
+        status = classify_stamp(stamp, host_fp)
         results.append(
             BackendDoctorResult(
                 backend=backend,
@@ -97,7 +87,7 @@ def run_doctor_checks(
                 pkg_version=stamp.pkg_version,
                 image_fingerprint=stamp.expconf_fingerprint,
                 status=status,
-                detail=detail,
+                detail=_detail_for(backend, status),
             )
         )
 

--- a/src/llenergymeasure/api/doctor.py
+++ b/src/llenergymeasure/api/doctor.py
@@ -1,0 +1,142 @@
+"""Image-health doctor checks for the ``llem doctor`` command.
+
+This is the API-layer implementation of the schema-skew handshake. It resolves
+each supported backend to its default image (local build if present, else the
+versioned GHCR tag), reads the OCI labels off each image, and compares the
+``llem.expconf.schema.fingerprint`` label to the host's computed fingerprint.
+
+The output is structured (``BackendDoctorResult``) so the CLI layer can render
+it as a table and callers in tests/scripts can consume the same data without
+parsing terminal output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from llenergymeasure._version import __version__
+from llenergymeasure.config.ssot import BACKEND_PYTORCH, BACKEND_TENSORRT, BACKEND_VLLM
+from llenergymeasure.infra.image_registry import get_default_image
+from llenergymeasure.infra.version_handshake import (
+    compute_expconf_fingerprint,
+    inspect_image_stamp,
+    skip_check_enabled,
+)
+
+__all__ = [
+    "BackendDoctorResult",
+    "DoctorReport",
+    "DoctorStatus",
+    "run_doctor_checks",
+]
+
+SUPPORTED_BACKENDS: tuple[str, ...] = (BACKEND_PYTORCH, BACKEND_VLLM, BACKEND_TENSORRT)
+
+
+class DoctorStatus(str, Enum):
+    """Per-backend image status."""
+
+    OK = "OK"
+    MISMATCH = "MISMATCH"
+    UNVERIFIED = "UNVERIFIED"
+    UNREACHABLE = "UNREACHABLE"
+
+
+@dataclass(frozen=True)
+class BackendDoctorResult:
+    """One row of the doctor table."""
+
+    backend: str
+    image: str
+    pkg_version: str | None
+    image_fingerprint: str | None
+    status: DoctorStatus
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    """Full doctor output: per-backend rows plus host-side context."""
+
+    host_pkg_version: str
+    host_fingerprint: str
+    skip_check_active: bool
+    results: list[BackendDoctorResult]
+
+    @property
+    def any_mismatch(self) -> bool:
+        return any(r.status is DoctorStatus.MISMATCH for r in self.results)
+
+
+def run_doctor_checks(
+    backends: tuple[str, ...] = SUPPORTED_BACKENDS,
+) -> DoctorReport:
+    """Run image-health checks across *backends* and return a structured report.
+
+    Image resolution follows ``get_default_image`` — local build first, then
+    versioned GHCR tag. Unreachable images (docker not installed, no such tag,
+    inspect timeout) become ``UNREACHABLE`` rows rather than blowing up.
+    """
+    host_fp = compute_expconf_fingerprint()
+    skip_active = skip_check_enabled()
+    results: list[BackendDoctorResult] = []
+
+    for backend in backends:
+        image = get_default_image(backend)
+        stamp = inspect_image_stamp(image)
+
+        if stamp.expconf_fingerprint is None and stamp.pkg_version is None:
+            results.append(
+                BackendDoctorResult(
+                    backend=backend,
+                    image=image,
+                    pkg_version=None,
+                    image_fingerprint=None,
+                    status=DoctorStatus.UNREACHABLE,
+                    detail="no labels (image missing or built pre-handshake)",
+                )
+            )
+            continue
+
+        if stamp.expconf_fingerprint is None:
+            results.append(
+                BackendDoctorResult(
+                    backend=backend,
+                    image=image,
+                    pkg_version=stamp.pkg_version,
+                    image_fingerprint=None,
+                    status=DoctorStatus.UNVERIFIED,
+                    detail="image predates schema-fingerprint label — rebuild to verify",
+                )
+            )
+            continue
+
+        if stamp.expconf_fingerprint == host_fp:
+            results.append(
+                BackendDoctorResult(
+                    backend=backend,
+                    image=image,
+                    pkg_version=stamp.pkg_version,
+                    image_fingerprint=stamp.expconf_fingerprint,
+                    status=DoctorStatus.OK,
+                )
+            )
+        else:
+            results.append(
+                BackendDoctorResult(
+                    backend=backend,
+                    image=image,
+                    pkg_version=stamp.pkg_version,
+                    image_fingerprint=stamp.expconf_fingerprint,
+                    status=DoctorStatus.MISMATCH,
+                    detail=f"rebuild: make docker-build-{backend}",
+                )
+            )
+
+    return DoctorReport(
+        host_pkg_version=__version__,
+        host_fingerprint=host_fp,
+        skip_check_active=skip_active,
+        results=results,
+    )

--- a/src/llenergymeasure/api/doctor.py
+++ b/src/llenergymeasure/api/doctor.py
@@ -1,28 +1,20 @@
-"""Image-health doctor checks for the ``llem doctor`` command.
-
-This is the API-layer implementation of the schema-skew handshake. It resolves
-each supported backend to its default image (local build if present, else the
-versioned GHCR tag), reads the OCI labels off each image, and compares the
-``llem.expconf.schema.fingerprint`` label to the host's computed fingerprint.
-
-The output is structured (``BackendDoctorResult``) so the CLI layer can render
-it as a table and callers in tests/scripts can consume the same data without
-parsing terminal output.
-"""
+"""Image-health doctor checks for the ``llem doctor`` command."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
 
 from llenergymeasure._version import __version__
 from llenergymeasure.config.ssot import BACKEND_PYTORCH, BACKEND_TENSORRT, BACKEND_VLLM
 from llenergymeasure.infra.image_registry import get_default_image
 from llenergymeasure.infra.version_handshake import (
+    ImageStamp,
     compute_expconf_fingerprint,
     inspect_image_stamp,
+    rebuild_hint,
     skip_check_enabled,
 )
+from llenergymeasure.utils.compat import StrEnum
 
 __all__ = [
     "BackendDoctorResult",
@@ -34,7 +26,7 @@ __all__ = [
 SUPPORTED_BACKENDS: tuple[str, ...] = (BACKEND_PYTORCH, BACKEND_VLLM, BACKEND_TENSORRT)
 
 
-class DoctorStatus(str, Enum):
+class DoctorStatus(StrEnum):
     """Per-backend image status."""
 
     OK = "OK"
@@ -69,6 +61,19 @@ class DoctorReport:
         return any(r.status is DoctorStatus.MISMATCH for r in self.results)
 
 
+def _classify(backend: str, stamp: ImageStamp, host_fp: str) -> tuple[DoctorStatus, str]:
+    if stamp.expconf_fingerprint is None and stamp.pkg_version is None:
+        return DoctorStatus.UNREACHABLE, "no labels (image missing or built pre-handshake)"
+    if stamp.expconf_fingerprint is None:
+        return (
+            DoctorStatus.UNVERIFIED,
+            "image predates schema-fingerprint label — rebuild to verify",
+        )
+    if stamp.expconf_fingerprint == host_fp:
+        return DoctorStatus.OK, ""
+    return DoctorStatus.MISMATCH, f"rebuild: {rebuild_hint(backend)}"
+
+
 def run_doctor_checks(
     backends: tuple[str, ...] = SUPPORTED_BACKENDS,
 ) -> DoctorReport:
@@ -79,64 +84,26 @@ def run_doctor_checks(
     inspect timeout) become ``UNREACHABLE`` rows rather than blowing up.
     """
     host_fp = compute_expconf_fingerprint()
-    skip_active = skip_check_enabled()
     results: list[BackendDoctorResult] = []
 
     for backend in backends:
         image = get_default_image(backend)
         stamp = inspect_image_stamp(image)
-
-        if stamp.expconf_fingerprint is None and stamp.pkg_version is None:
-            results.append(
-                BackendDoctorResult(
-                    backend=backend,
-                    image=image,
-                    pkg_version=None,
-                    image_fingerprint=None,
-                    status=DoctorStatus.UNREACHABLE,
-                    detail="no labels (image missing or built pre-handshake)",
-                )
+        status, detail = _classify(backend, stamp, host_fp)
+        results.append(
+            BackendDoctorResult(
+                backend=backend,
+                image=image,
+                pkg_version=stamp.pkg_version,
+                image_fingerprint=stamp.expconf_fingerprint,
+                status=status,
+                detail=detail,
             )
-            continue
-
-        if stamp.expconf_fingerprint is None:
-            results.append(
-                BackendDoctorResult(
-                    backend=backend,
-                    image=image,
-                    pkg_version=stamp.pkg_version,
-                    image_fingerprint=None,
-                    status=DoctorStatus.UNVERIFIED,
-                    detail="image predates schema-fingerprint label — rebuild to verify",
-                )
-            )
-            continue
-
-        if stamp.expconf_fingerprint == host_fp:
-            results.append(
-                BackendDoctorResult(
-                    backend=backend,
-                    image=image,
-                    pkg_version=stamp.pkg_version,
-                    image_fingerprint=stamp.expconf_fingerprint,
-                    status=DoctorStatus.OK,
-                )
-            )
-        else:
-            results.append(
-                BackendDoctorResult(
-                    backend=backend,
-                    image=image,
-                    pkg_version=stamp.pkg_version,
-                    image_fingerprint=stamp.expconf_fingerprint,
-                    status=DoctorStatus.MISMATCH,
-                    detail=f"rebuild: make docker-build-{backend}",
-                )
-            )
+        )
 
     return DoctorReport(
         host_pkg_version=__version__,
         host_fingerprint=host_fp,
-        skip_check_active=skip_active,
+        skip_check_active=skip_check_enabled(),
         results=results,
     )

--- a/src/llenergymeasure/cli/README.md
+++ b/src/llenergymeasure/cli/README.md
@@ -4,7 +4,7 @@ Typer-based CLI for llenergymeasure. Layer 6 (top layer) in the six-layer archit
 
 ## Purpose
 
-Two commands: `llem run` for running experiments and studies, `llem config` for environment diagnostics. The CLI is a thin client over the `api/` layer — it handles argument parsing, user-facing formatting, and error presentation.
+Three commands: `llem run` for running experiments and studies, `llem config` for environment diagnostics, and `llem doctor` for host/container Docker-image schema verification. The CLI is a thin client over the `api/` layer — it handles argument parsing, user-facing formatting, and error presentation.
 
 ## Modules
 
@@ -13,6 +13,7 @@ Two commands: `llem run` for running experiments and studies, `llem config` for 
 | `__init__.py` | `app` Typer instance, logging setup, command registration |
 | `run.py` | `llem run` command |
 | `config_cmd.py` | `llem config` command |
+| `doctor_cmd.py` | `llem doctor` command (image schema handshake) |
 | `_display.py` | Output formatting helpers (headers, result tables, errors) |
 | `_vram.py` | VRAM estimation for pre-run model size hints |
 
@@ -51,6 +52,14 @@ llem config -v       # verbose: list all GPU properties, energy samplers, etc.
 ```
 
 Shows GPU hardware (name, VRAM), installed backends, energy sampler availability, and user config path. Always exits 0 — purely informational.
+
+### llem doctor
+
+```bash
+llem doctor          # verify Docker images match the host ExperimentConfig schema
+```
+
+Reads the `llem.expconf.schema.fingerprint` OCI label from each backend image and compares it to a fingerprint computed from the host's current `ExperimentConfig.model_json_schema()`. Exits non-zero on any `MISMATCH`. Set `LLEM_SKIP_IMAGE_CHECK=1` to bypass the runtime handshake in `llem run` (doctor still reports the true status with a warning footer).
 
 ### llem --version
 

--- a/src/llenergymeasure/cli/__init__.py
+++ b/src/llenergymeasure/cli/__init__.py
@@ -85,6 +85,13 @@ from llenergymeasure.cli.config_cmd import config_command as _config_cmd  # noqa
 
 app.command(name="config", help="Show environment and configuration status")(_config_cmd)
 
+from llenergymeasure.cli.doctor_cmd import doctor_command as _doctor_cmd  # noqa: E402
+
+app.command(
+    name="doctor",
+    help="Verify Docker images match the host ExperimentConfig schema",
+)(_doctor_cmd)
+
 __all__ = ["app"]
 
 if __name__ == "__main__":

--- a/src/llenergymeasure/cli/doctor_cmd.py
+++ b/src/llenergymeasure/cli/doctor_cmd.py
@@ -1,0 +1,52 @@
+"""``llem doctor`` — verify that Docker images match the host schema.
+
+Focused purely on image health (host/container schema-fingerprint handshake).
+The existing ``llem config`` command still covers env / GPU / backend probes;
+``doctor`` is the pre-flight diagnostic for the new fingerprint handshake and
+exits non-zero on mismatch so CI and scripts can gate on it.
+"""
+
+from __future__ import annotations
+
+import typer
+
+__all__ = ["doctor_command"]
+
+
+def doctor_command() -> None:
+    """Report per-backend image schema status and exit non-zero on mismatch."""
+    from llenergymeasure.api.doctor import run_doctor_checks
+
+    report = run_doctor_checks()
+
+    header = (
+        f"{'Backend':<10s}  {'Image':<50s}  "
+        f"{'Pkg ver':<10s}  {'Img FP':<14s}  {'Host FP':<14s}  {'Status':<10s}"
+    )
+    typer.echo(header)
+    typer.echo("-" * len(header))
+
+    host_fp_short = report.host_fingerprint[:12]
+    for row in report.results:
+        img = row.image if len(row.image) <= 50 else "…" + row.image[-49:]
+        pkg = (row.pkg_version or "-")[:10]
+        img_fp = (row.image_fingerprint or "-")[:12]
+        status_text = row.status.value
+        line = (
+            f"{row.backend:<10s}  {img:<50s}  "
+            f"{pkg:<10s}  {img_fp:<14s}  {host_fp_short:<14s}  {status_text:<10s}"
+        )
+        typer.echo(line)
+        if row.detail:
+            typer.echo(f"{'':<10s}  └─ {row.detail}")
+
+    typer.echo("")
+    typer.echo(f"Host llenergymeasure version: {report.host_pkg_version}")
+    typer.echo(f"Host ExperimentConfig fingerprint: {report.host_fingerprint}")
+    if report.skip_check_active:
+        typer.echo(
+            "WARNING: LLEM_SKIP_IMAGE_CHECK=1 is active — runtime schema handshake is bypassed."
+        )
+
+    if report.any_mismatch:
+        raise typer.Exit(code=1)

--- a/src/llenergymeasure/cli/doctor_cmd.py
+++ b/src/llenergymeasure/cli/doctor_cmd.py
@@ -21,7 +21,7 @@ def doctor_command() -> None:
 
     header = (
         f"{'Backend':<10s}  {'Image':<50s}  "
-        f"{'Pkg ver':<10s}  {'Img FP':<14s}  {'Host FP':<14s}  {'Status':<10s}"
+        f"{'Pkg ver':<10s}  {'Img SHA-256':<14s}  {'Host SHA-256':<14s}  {'Status':<12s}"
     )
     typer.echo(header)
     typer.echo("-" * len(header))
@@ -34,7 +34,7 @@ def doctor_command() -> None:
         status_text = row.status.value
         line = (
             f"{row.backend:<10s}  {img:<50s}  "
-            f"{pkg:<10s}  {img_fp:<14s}  {host_fp_short:<14s}  {status_text:<10s}"
+            f"{pkg:<10s}  {img_fp:<14s}  {host_fp_short:<14s}  {status_text:<12s}"
         )
         typer.echo(line)
         if row.detail:
@@ -42,7 +42,7 @@ def doctor_command() -> None:
 
     typer.echo("")
     typer.echo(f"Host llenergymeasure version: {report.host_pkg_version}")
-    typer.echo(f"Host ExperimentConfig fingerprint: {report.host_fingerprint}")
+    typer.echo(f"Host ExperimentConfig SHA-256: {report.host_fingerprint}")
     if report.skip_check_active:
         typer.echo(
             "WARNING: LLEM_SKIP_IMAGE_CHECK=1 is active — runtime schema handshake is bypassed."

--- a/src/llenergymeasure/config/README.md
+++ b/src/llenergymeasure/config/README.md
@@ -132,6 +132,14 @@ config = ExperimentConfig(
 - `VLLMConfig` - vLLM backend options
 - `TensorRTConfig` - TensorRT-LLM backend options
 
+**Cross-boundary contract:** `ExperimentConfig.model_json_schema()` is the
+canonical host/container contract. Every Docker image is stamped at build time
+with a SHA-256 fingerprint of that schema via
+`infra/version_handshake.compute_expconf_fingerprint()`, and study pre-flight
+compares the image label to the host fingerprint. Any field addition/rename
+here therefore invalidates older images and surfaces as a hard abort before
+any experiment runs (see `infra/version_handshake.py` and `llem doctor`).
+
 ## Decoder Sampling Configuration
 
 Industry-standard sampling parameters aligned with vLLM, HuggingFace, and MLPerf.

--- a/src/llenergymeasure/entrypoints/container.py
+++ b/src/llenergymeasure/entrypoints/container.py
@@ -164,10 +164,20 @@ def run_container_experiment(config_path: Path, result_dir: Path) -> Path:
     from llenergymeasure.domain.experiment import compute_measurement_config_hash
     from llenergymeasure.harness import MeasurementHarness
     from llenergymeasure.harness.preflight import run_preflight
+    from llenergymeasure.infra.version_handshake import compute_expconf_fingerprint
 
     # --- Deserialise config ---
     raw = json.loads(config_path.read_text(encoding="utf-8"))
     config = ExperimentConfig.model_validate(raw)
+
+    # Diagnostic: log container-side fingerprint so post-mortem analysis can
+    # spot host/container schema drift even when model_validate happens to
+    # succeed (e.g. host added an optional field the container silently ignores).
+    print(
+        f"[llem] container ExperimentConfig fingerprint: {compute_expconf_fingerprint()[:12]}",
+        file=sys.stdout,
+        flush=True,
+    )
 
     # --- Stable file name derived from config content ---
     config_hash = compute_measurement_config_hash(config)

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -682,17 +682,37 @@ class DockerRunner:
 
         result = ExperimentResult.model_validate(raw)
 
-        # Warn if the container ran a different package version than the host.
-        # This catches stale Docker images that predate new result fields.
+        # Belt-and-braces warning for the single-shot run_experiment() API path
+        # (which bypasses StudyRunner._prepare_images and therefore the
+        # fingerprint handshake). This catches stale images that predate new
+        # result fields. StudyRunner-driven runs already hit a hard abort in
+        # _verify_image_fingerprint before any experiment starts.
         from llenergymeasure._version import __version__
+        from llenergymeasure.infra.version_handshake import (
+            compute_expconf_fingerprint,
+            inspect_image_stamp,
+        )
 
         container_version = result.llenergymeasure_version
         if container_version is None or container_version != __version__:
-            logger.warning(
-                "Container result version %s differs from host %s - rebuild Docker images",
-                container_version,
-                __version__,
-            )
+            stamp = inspect_image_stamp(self.image)
+            host_fp = compute_expconf_fingerprint()
+            if stamp.expconf_fingerprint and stamp.expconf_fingerprint != host_fp:
+                logger.warning(
+                    "Container result version %s differs from host %s "
+                    "(image %s schema %s, host schema %s) — rebuild Docker images",
+                    container_version,
+                    __version__,
+                    self.image,
+                    stamp.expconf_fingerprint[:12],
+                    host_fp[:12],
+                )
+            else:
+                logger.warning(
+                    "Container result version %s differs from host %s — rebuild Docker images",
+                    container_version,
+                    __version__,
+                )
 
         return result
 

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from llenergymeasure.domain.progress import ProgressCallback
 
+from llenergymeasure._version import __version__
 from llenergymeasure.config.ssot import (
     BACKEND_TENSORRT,
     CONTAINER_EXCHANGE_DIR,
@@ -682,37 +683,13 @@ class DockerRunner:
 
         result = ExperimentResult.model_validate(raw)
 
-        # Belt-and-braces warning for the single-shot run_experiment() API path
-        # (which bypasses StudyRunner._prepare_images and therefore the
-        # fingerprint handshake). This catches stale images that predate new
-        # result fields. StudyRunner-driven runs already hit a hard abort in
-        # _verify_image_fingerprint before any experiment starts.
-        from llenergymeasure._version import __version__
-        from llenergymeasure.infra.version_handshake import (
-            compute_expconf_fingerprint,
-            inspect_image_stamp,
-        )
-
         container_version = result.llenergymeasure_version
         if container_version is None or container_version != __version__:
-            stamp = inspect_image_stamp(self.image)
-            host_fp = compute_expconf_fingerprint()
-            if stamp.expconf_fingerprint and stamp.expconf_fingerprint != host_fp:
-                logger.warning(
-                    "Container result version %s differs from host %s "
-                    "(image %s schema %s, host schema %s) — rebuild Docker images",
-                    container_version,
-                    __version__,
-                    self.image,
-                    stamp.expconf_fingerprint[:12],
-                    host_fp[:12],
-                )
-            else:
-                logger.warning(
-                    "Container result version %s differs from host %s — rebuild Docker images",
-                    container_version,
-                    __version__,
-                )
+            logger.warning(
+                "Container result version %s differs from host %s — rebuild Docker images",
+                container_version,
+                __version__,
+            )
 
         return result
 

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -1,0 +1,137 @@
+"""Host/container schema-skew detection via OCI image labels.
+
+Images are stamped at build time with two identifiers baked in as OCI labels:
+
+- ``org.opencontainers.image.version`` — the llenergymeasure package version
+  (e.g. ``0.9.0``), sourced from ``_version.py``. Displayed alongside the
+  fingerprint in error messages for human readability. Not the blocking signal,
+  because during intra-version dev work both host and image report the same
+  version through an entire milestone of schema churn.
+- ``llem.expconf.schema.fingerprint`` — a SHA-256 hex digest of
+  ``ExperimentConfig.model_json_schema()`` serialised with ``sort_keys=True`` and
+  compact separators. This is the actual signal: it changes on every
+  ``ExperimentConfig`` (or nested model) structural change, catching the exact
+  failure mode where the host adds fields the container image does not know
+  about.
+
+The host computes its own fingerprint at runtime and compares it to the label
+baked into each resolved Docker image as part of ``StudyRunner._prepare_images``.
+A mismatch raises ``VersionMismatchError`` with an actionable rebuild hint
+before any experiment runs.
+
+Bypass with ``LLEM_SKIP_IMAGE_CHECK=1`` when the skew is known harmless (e.g. a
+new optional field the container will silently ignore).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+
+from llenergymeasure.config.models import ExperimentConfig
+
+__all__ = [
+    "ENV_SKIP_IMAGE_CHECK",
+    "LABEL_IMAGE_VERSION",
+    "LABEL_SCHEMA_FINGERPRINT",
+    "ImageStamp",
+    "VersionMismatchError",
+    "compute_expconf_fingerprint",
+    "inspect_image_stamp",
+    "skip_check_enabled",
+]
+
+logger = logging.getLogger(__name__)
+
+ENV_SKIP_IMAGE_CHECK = "LLEM_SKIP_IMAGE_CHECK"
+LABEL_SCHEMA_FINGERPRINT = "llem.expconf.schema.fingerprint"
+LABEL_IMAGE_VERSION = "org.opencontainers.image.version"
+
+# Docker inspect never takes long; keep the handshake tight so a dead docker
+# daemon doesn't stall study startup.
+_INSPECT_TIMEOUT_SEC = 10.0
+
+
+class VersionMismatchError(RuntimeError):
+    """Raised when a Docker image's schema fingerprint differs from the host's."""
+
+
+@dataclass(frozen=True)
+class ImageStamp:
+    """OCI labels relevant to the schema handshake, pulled from a Docker image."""
+
+    pkg_version: str | None
+    expconf_fingerprint: str | None
+
+
+def compute_expconf_fingerprint() -> str:
+    """Return the SHA-256 hex digest of ``ExperimentConfig.model_json_schema()``.
+
+    Uses ``sort_keys=True`` and compact separators so the serialisation is
+    deterministic across Python processes and machines. The result is 64 hex
+    characters; callers typically display the first 12 for readability.
+    """
+    payload = json.dumps(
+        ExperimentConfig.model_json_schema(),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def inspect_image_stamp(image: str, *, timeout: float = _INSPECT_TIMEOUT_SEC) -> ImageStamp:
+    """Parse handshake labels from ``docker image inspect`` on *image*.
+
+    Returns ``ImageStamp(None, None)`` on any failure (docker not installed,
+    inspect timeout, JSON parse error, missing labels). The caller decides
+    whether the absence of labels is a warning or an error.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("docker image inspect failed for %s: %s", image, exc)
+        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+
+    if result.returncode != 0:
+        logger.debug(
+            "docker image inspect returned %s for %s: %s",
+            result.returncode,
+            image,
+            result.stderr.decode("utf-8", errors="replace") if result.stderr else "",
+        )
+        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+
+    return _parse_stamp_from_inspect_json(result.stdout)
+
+
+def _parse_stamp_from_inspect_json(inspect_stdout: bytes) -> ImageStamp:
+    try:
+        data = json.loads(inspect_stdout)
+    except (json.JSONDecodeError, ValueError):
+        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+    if not data:
+        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+    labels = data[0].get("Config", {}).get("Labels") or {}
+    return ImageStamp(
+        pkg_version=labels.get(LABEL_IMAGE_VERSION),
+        expconf_fingerprint=labels.get(LABEL_SCHEMA_FINGERPRINT),
+    )
+
+
+def skip_check_enabled() -> bool:
+    """True iff the user has set ``LLEM_SKIP_IMAGE_CHECK`` to a truthy value.
+
+    Accepts ``1``, ``true``, ``yes`` (case-insensitive) as on; anything else is
+    treated as off. The variable exists as a break-glass bypass — no CLI flag
+    yet because we want to see whether it's ever needed before promoting it.
+    """
+    raw = os.environ.get(ENV_SKIP_IMAGE_CHECK, "")
+    return raw.strip().lower() in {"1", "true", "yes"}

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -1,26 +1,15 @@
 """Host/container schema-skew detection via OCI image labels.
 
-Images are stamped at build time with two identifiers baked in as OCI labels:
-
-- ``org.opencontainers.image.version`` — the llenergymeasure package version
-  (e.g. ``0.9.0``), sourced from ``_version.py``. Displayed alongside the
-  fingerprint in error messages for human readability. Not the blocking signal,
-  because during intra-version dev work both host and image report the same
-  version through an entire milestone of schema churn.
-- ``llem.expconf.schema.fingerprint`` — a SHA-256 hex digest of
-  ``ExperimentConfig.model_json_schema()`` serialised with ``sort_keys=True`` and
-  compact separators. This is the actual signal: it changes on every
-  ``ExperimentConfig`` (or nested model) structural change, catching the exact
-  failure mode where the host adds fields the container image does not know
-  about.
+Images are stamped at build time with ``org.opencontainers.image.version`` (the
+llenergymeasure package version, for display) and
+``llem.expconf.schema.fingerprint`` (a SHA-256 over
+``ExperimentConfig.model_json_schema()``, the actual blocking signal).
 
 The host computes its own fingerprint at runtime and compares it to the label
-baked into each resolved Docker image as part of ``StudyRunner._prepare_images``.
-A mismatch raises ``VersionMismatchError`` with an actionable rebuild hint
-before any experiment runs.
+on each resolved Docker image in ``StudyRunner._prepare_images``. A mismatch
+raises ``VersionMismatchError`` before any experiment runs.
 
-Bypass with ``LLEM_SKIP_IMAGE_CHECK=1`` when the skew is known harmless (e.g. a
-new optional field the container will silently ignore).
+Bypass with ``LLEM_SKIP_IMAGE_CHECK=1`` when the skew is known harmless.
 """
 
 from __future__ import annotations
@@ -31,8 +20,10 @@ import logging
 import os
 import subprocess
 from dataclasses import dataclass
+from functools import cache
 
 from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.config.ssot import TIMEOUT_DOCKER_INSPECT
 
 __all__ = [
     "ENV_SKIP_IMAGE_CHECK",
@@ -42,6 +33,8 @@ __all__ = [
     "VersionMismatchError",
     "compute_expconf_fingerprint",
     "inspect_image_stamp",
+    "parse_image_stamp",
+    "rebuild_hint",
     "skip_check_enabled",
 ]
 
@@ -50,10 +43,6 @@ logger = logging.getLogger(__name__)
 ENV_SKIP_IMAGE_CHECK = "LLEM_SKIP_IMAGE_CHECK"
 LABEL_SCHEMA_FINGERPRINT = "llem.expconf.schema.fingerprint"
 LABEL_IMAGE_VERSION = "org.opencontainers.image.version"
-
-# Docker inspect never takes long; keep the handshake tight so a dead docker
-# daemon doesn't stall study startup.
-_INSPECT_TIMEOUT_SEC = 10.0
 
 
 class VersionMismatchError(RuntimeError):
@@ -68,12 +57,15 @@ class ImageStamp:
     expconf_fingerprint: str | None
 
 
+_EMPTY_STAMP = ImageStamp(pkg_version=None, expconf_fingerprint=None)
+
+
+@cache
 def compute_expconf_fingerprint() -> str:
     """Return the SHA-256 hex digest of ``ExperimentConfig.model_json_schema()``.
 
-    Uses ``sort_keys=True`` and compact separators so the serialisation is
-    deterministic across Python processes and machines. The result is 64 hex
-    characters; callers typically display the first 12 for readability.
+    The schema is frozen per-process, so the result is memoised. Callers
+    typically display the first 12 hex characters for readability.
     """
     payload = json.dumps(
         ExperimentConfig.model_json_schema(),
@@ -83,12 +75,12 @@ def compute_expconf_fingerprint() -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def inspect_image_stamp(image: str, *, timeout: float = _INSPECT_TIMEOUT_SEC) -> ImageStamp:
+def inspect_image_stamp(image: str, *, timeout: float = TIMEOUT_DOCKER_INSPECT) -> ImageStamp:
     """Parse handshake labels from ``docker image inspect`` on *image*.
 
-    Returns ``ImageStamp(None, None)`` on any failure (docker not installed,
-    inspect timeout, JSON parse error, missing labels). The caller decides
-    whether the absence of labels is a warning or an error.
+    Returns an empty stamp on any failure (docker not installed, inspect
+    timeout, JSON parse error, missing labels). The caller decides whether the
+    absence of labels is a warning or an error.
     """
     try:
         result = subprocess.run(
@@ -98,7 +90,7 @@ def inspect_image_stamp(image: str, *, timeout: float = _INSPECT_TIMEOUT_SEC) ->
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
         logger.debug("docker image inspect failed for %s: %s", image, exc)
-        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+        return _EMPTY_STAMP
 
     if result.returncode != 0:
         logger.debug(
@@ -107,18 +99,19 @@ def inspect_image_stamp(image: str, *, timeout: float = _INSPECT_TIMEOUT_SEC) ->
             image,
             result.stderr.decode("utf-8", errors="replace") if result.stderr else "",
         )
-        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+        return _EMPTY_STAMP
 
-    return _parse_stamp_from_inspect_json(result.stdout)
+    return parse_image_stamp(result.stdout)
 
 
-def _parse_stamp_from_inspect_json(inspect_stdout: bytes) -> ImageStamp:
+def parse_image_stamp(inspect_stdout: bytes) -> ImageStamp:
+    """Extract an ``ImageStamp`` from raw ``docker image inspect`` JSON."""
     try:
         data = json.loads(inspect_stdout)
     except (json.JSONDecodeError, ValueError):
-        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+        return _EMPTY_STAMP
     if not data:
-        return ImageStamp(pkg_version=None, expconf_fingerprint=None)
+        return _EMPTY_STAMP
     labels = data[0].get("Config", {}).get("Labels") or {}
     return ImageStamp(
         pkg_version=labels.get(LABEL_IMAGE_VERSION),
@@ -126,12 +119,12 @@ def _parse_stamp_from_inspect_json(inspect_stdout: bytes) -> ImageStamp:
     )
 
 
-def skip_check_enabled() -> bool:
-    """True iff the user has set ``LLEM_SKIP_IMAGE_CHECK`` to a truthy value.
+def rebuild_hint(backend: str) -> str:
+    """Return the user-facing rebuild command for *backend*."""
+    return f"make docker-build-{backend}"
 
-    Accepts ``1``, ``true``, ``yes`` (case-insensitive) as on; anything else is
-    treated as off. The variable exists as a break-glass bypass — no CLI flag
-    yet because we want to see whether it's ever needed before promoting it.
-    """
+
+def skip_check_enabled() -> bool:
+    """True iff ``LLEM_SKIP_IMAGE_CHECK`` is set to ``1``/``true``/``yes``."""
     raw = os.environ.get(ENV_SKIP_IMAGE_CHECK, "")
     return raw.strip().lower() in {"1", "true", "yes"}

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -22,15 +22,17 @@ import subprocess
 from dataclasses import dataclass
 from functools import cache
 
-from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.config.ssot import TIMEOUT_DOCKER_INSPECT
+from llenergymeasure.utils.compat import StrEnum
 
 __all__ = [
     "ENV_SKIP_IMAGE_CHECK",
     "LABEL_IMAGE_VERSION",
     "LABEL_SCHEMA_FINGERPRINT",
     "ImageStamp",
+    "SchemaStatus",
     "VersionMismatchError",
+    "classify_stamp",
     "compute_expconf_fingerprint",
     "inspect_image_stamp",
     "parse_image_stamp",
@@ -60,19 +62,47 @@ class ImageStamp:
 _EMPTY_STAMP = ImageStamp(pkg_version=None, expconf_fingerprint=None)
 
 
+class SchemaStatus(StrEnum):
+    """Outcome of comparing a Docker image's stamp to the host fingerprint."""
+
+    OK = "OK"
+    MISMATCH = "MISMATCH"
+    UNVERIFIED = "UNVERIFIED"
+    UNREACHABLE = "UNREACHABLE"
+    BYPASSED = "BYPASSED"
+
+
 @cache
 def compute_expconf_fingerprint() -> str:
-    """Return the SHA-256 hex digest of ``ExperimentConfig.model_json_schema()``.
+    """Return the SHA-256 hex digest of the ExperimentConfig JSON schema.
 
     The schema is frozen per-process, so the result is memoised. Callers
     typically display the first 12 hex characters for readability.
     """
+    from llenergymeasure.config.introspection import get_experiment_config_schema
+
     payload = json.dumps(
-        ExperimentConfig.model_json_schema(),
+        get_experiment_config_schema(),
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def classify_stamp(stamp: ImageStamp, host_fingerprint: str) -> SchemaStatus:
+    """Classify an image stamp against the host fingerprint.
+
+    Pure: does not read environment or log. Callers that honour the
+    ``LLEM_SKIP_IMAGE_CHECK`` bypass should short-circuit to
+    :attr:`SchemaStatus.BYPASSED` themselves before calling this.
+    """
+    if stamp.expconf_fingerprint is None and stamp.pkg_version is None:
+        return SchemaStatus.UNREACHABLE
+    if stamp.expconf_fingerprint is None:
+        return SchemaStatus.UNVERIFIED
+    if stamp.expconf_fingerprint == host_fingerprint:
+        return SchemaStatus.OK
+    return SchemaStatus.MISMATCH
 
 
 def inspect_image_stamp(image: str, *, timeout: float = TIMEOUT_DOCKER_INSPECT) -> ImageStamp:

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from llenergymeasure._version import __version__ as _HOST_PKG_VERSION
 from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
     DOCKER_PULL_TIMEOUT,
@@ -45,6 +46,15 @@ from llenergymeasure.config.ssot import (
     TIMEOUT_THREAD_JOIN,
 )
 from llenergymeasure.domain.progress import STEP_BASELINE, STEPS_LOCAL, docker_steps
+from llenergymeasure.infra.version_handshake import (
+    LABEL_SCHEMA_FINGERPRINT,
+    ImageStamp,
+    VersionMismatchError,
+    compute_expconf_fingerprint,
+    parse_image_stamp,
+    rebuild_hint,
+    skip_check_enabled,
+)
 from llenergymeasure.study.gaps import run_gap
 
 if TYPE_CHECKING:
@@ -1234,7 +1244,14 @@ class StudyRunner:
             if check is not None and check.returncode == 0:
                 elapsed = time.monotonic() - t0
                 metadata = self._parse_image_metadata(check.stdout)
-                mismatch_error = self._verify_image_fingerprint(backend, image, metadata)
+                stamp = parse_image_stamp(check.stdout)
+                schema_status, mismatch_error = self._verify_image_fingerprint(
+                    backend, image, stamp
+                )
+                if metadata is None:
+                    metadata = {"schema": schema_status}
+                else:
+                    metadata["schema"] = schema_status
                 if self._progress:
                     self._progress.image_ready(
                         backend, image, cached=True, elapsed=elapsed, metadata=metadata
@@ -1277,7 +1294,6 @@ class StudyRunner:
                 )
 
             elapsed = time.monotonic() - t0
-            # Re-inspect for metadata after pull
             try:
                 inspect = subprocess.run(
                     ["docker", "image", "inspect", image],
@@ -1285,10 +1301,16 @@ class StudyRunner:
                     timeout=TIMEOUT_DOCKER_INSPECT,
                 )
                 metadata = self._parse_image_metadata(inspect.stdout)
+                stamp = parse_image_stamp(inspect.stdout)
             except Exception:
                 metadata = None
+                stamp = ImageStamp(pkg_version=None, expconf_fingerprint=None)
 
-            mismatch_error = self._verify_image_fingerprint(backend, image, metadata)
+            schema_status, mismatch_error = self._verify_image_fingerprint(backend, image, stamp)
+            if metadata is None:
+                metadata = {"schema": schema_status}
+            else:
+                metadata["schema"] = schema_status
             if self._progress:
                 self._progress.image_ready(
                     backend, image, cached=False, elapsed=elapsed, metadata=metadata
@@ -1305,26 +1327,13 @@ class StudyRunner:
 
     @staticmethod
     def _parse_image_metadata(inspect_stdout: bytes) -> dict[str, str] | None:
-        """Extract human-readable metadata from docker image inspect JSON.
+        """Extract human-readable display metadata from ``docker image inspect`` JSON.
 
-        Also captures schema-handshake labels (``llem.expconf.schema.fingerprint``
-        and ``org.opencontainers.image.version``) under dedicated keys:
-
-        - ``llem_expconf_fingerprint``: full 64-char hex (raw, for programmatic
-          comparison by ``_verify_image_fingerprint``; not shown in the
-          inline progress line because it'd bloat the display).
-        - ``llem_pkg_version``: llenergymeasure version string baked into the
-          image at build time.
-
-        ``_verify_image_fingerprint`` overwrites/sets a ``schema`` key on the
-        returned dict which *is* rendered inline (``schema: ok`` etc.) by the
-        existing metadata renderer at ``cli/_step_display.py``.
+        Returns the id/size/built/layers fields the progress display renders
+        inline. Schema-handshake labels are handled separately via
+        ``parse_image_stamp`` so the raw 64-char fingerprint never leaks into
+        the display metadata.
         """
-        from llenergymeasure.infra.version_handshake import (
-            LABEL_IMAGE_VERSION,
-            LABEL_SCHEMA_FINGERPRINT,
-        )
-
         try:
             data = json.loads(inspect_stdout)
             if not data:
@@ -1364,14 +1373,6 @@ class StudyRunner:
             if layers:
                 meta["layers"] = str(len(layers))
 
-            labels = info.get("Config", {}).get("Labels") or {}
-            fingerprint = labels.get(LABEL_SCHEMA_FINGERPRINT)
-            if fingerprint:
-                meta["llem_expconf_fingerprint"] = fingerprint
-            pkg_version = labels.get(LABEL_IMAGE_VERSION)
-            if pkg_version:
-                meta["llem_pkg_version"] = pkg_version
-
             return meta if meta else None
         except (json.JSONDecodeError, KeyError, IndexError):
             return None
@@ -1380,69 +1381,44 @@ class StudyRunner:
         self,
         backend: str,
         image: str,
-        metadata: dict[str, str] | None,
-    ) -> Exception | None:
-        """Compare host schema fingerprint to the image label; return error on mismatch.
+        stamp: ImageStamp,
+    ) -> tuple[str, Exception | None]:
+        """Compare the host schema fingerprint to *stamp* and classify the result.
 
-        Mutates *metadata* in-place: pops the raw ``llem_*`` label keys
-        (consumed only by this check) and sets a display-friendly ``schema``
-        key ("ok" / "mismatch" / "unverified" / "bypassed") that the existing
-        ``cli/_step_display`` metadata renderer shows inline next to
-        id/size/built.
-
-        Returns the ``VersionMismatchError`` to raise on mismatch, or None on
-        match, bypass, or missing labels. Callers raise *after* emitting
-        ``image_ready`` so the offending backend shows in the terminal output
-        before the study aborts.
+        Returns ``(schema_status, error)`` where ``schema_status`` is the
+        short display string ("ok" / "mismatch" / "bypassed" / "unverified …")
+        and ``error`` is a ``VersionMismatchError`` to raise (or ``None``).
+        Callers raise after rendering so the offending backend appears in the
+        terminal before the study aborts.
         """
-        from llenergymeasure.infra.version_handshake import (
-            VersionMismatchError,
-            compute_expconf_fingerprint,
-            skip_check_enabled,
-        )
-
-        if metadata is None:
-            metadata = {}
-
-        # Pop raw labels so they never pollute the inline progress line; the
-        # display iterates metadata.items() and would otherwise show the full
-        # 64-char fingerprint next to id/size/built.
-        img_fp = metadata.pop("llem_expconf_fingerprint", None)
-        img_pkg_ver = metadata.pop("llem_pkg_version", None)
-
         if skip_check_enabled():
-            metadata["schema"] = "bypassed"
-            return None
+            return "bypassed", None
 
-        if img_fp is None:
-            metadata["schema"] = "unverified (no labels)"
+        if stamp.expconf_fingerprint is None:
             logger.warning(
                 "Image %s has no %s label — schema skew check skipped "
                 "(image predates the handshake feature; rebuild to enable)",
                 image,
-                "llem.expconf.schema.fingerprint",
+                LABEL_SCHEMA_FINGERPRINT,
             )
-            return None
+            return "unverified (no labels)", None
 
         host_fp = compute_expconf_fingerprint()
-        if img_fp == host_fp:
-            metadata["schema"] = "ok"
-            return None
+        if stamp.expconf_fingerprint == host_fp:
+            return "ok", None
 
-        metadata["schema"] = "mismatch"
-        from llenergymeasure._version import __version__ as host_pkg_ver
-
-        return VersionMismatchError(
+        error = VersionMismatchError(
             f"Docker image '{image}' was built from llenergymeasure "
-            f"{img_pkg_ver or 'unknown'} (schema {img_fp[:12]}) but the host is "
-            f"running {host_pkg_ver} (schema {host_fp[:12]}). The container "
-            f"will reject ExperimentConfig fields added on the host after the "
-            f"image was built.\n\n"
+            f"{stamp.pkg_version or 'unknown'} (schema {stamp.expconf_fingerprint[:12]}) "
+            f"but the host is running {_HOST_PKG_VERSION} (schema {host_fp[:12]}). "
+            f"The container will reject ExperimentConfig fields added on the host "
+            f"after the image was built.\n\n"
             f"To fix:\n"
-            f"  make docker-build-{backend}       # rebuild locally\n"
+            f"  {rebuild_hint(backend)}       # rebuild locally\n"
             f"  make docker-pull                  # or pull a newer tagged release\n\n"
             f"If you're certain the skew is harmless, set LLEM_SKIP_IMAGE_CHECK=1."
         )
+        return "mismatch", error
 
     def _run_gap(self, seconds: float, label: str) -> None:
         """Run a thermal gap, rendering countdown in the live display or terminal."""

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -49,7 +49,9 @@ from llenergymeasure.domain.progress import STEP_BASELINE, STEPS_LOCAL, docker_s
 from llenergymeasure.infra.version_handshake import (
     LABEL_SCHEMA_FINGERPRINT,
     ImageStamp,
+    SchemaStatus,
     VersionMismatchError,
+    classify_stamp,
     compute_expconf_fingerprint,
     parse_image_stamp,
     rebuild_hint,
@@ -1243,19 +1245,9 @@ class StudyRunner:
 
             if check is not None and check.returncode == 0:
                 elapsed = time.monotonic() - t0
-                metadata = self._parse_image_metadata(check.stdout)
-                stamp = parse_image_stamp(check.stdout)
-                schema_status, mismatch_error = self._verify_image_fingerprint(
-                    backend, image, stamp
+                mismatch_error = self._finalise_image(
+                    backend, image, check.stdout, cached=True, elapsed=elapsed
                 )
-                if metadata is None:
-                    metadata = {"schema": schema_status}
-                else:
-                    metadata["schema"] = schema_status
-                if self._progress:
-                    self._progress.image_ready(
-                        backend, image, cached=True, elapsed=elapsed, metadata=metadata
-                    )
                 if mismatch_error is not None:
                     if self._progress:
                         self._progress.end_image_prep()
@@ -1300,21 +1292,13 @@ class StudyRunner:
                     capture_output=True,
                     timeout=TIMEOUT_DOCKER_INSPECT,
                 )
-                metadata = self._parse_image_metadata(inspect.stdout)
-                stamp = parse_image_stamp(inspect.stdout)
+                inspect_stdout = inspect.stdout if inspect.returncode == 0 else b""
             except Exception:
-                metadata = None
-                stamp = ImageStamp(pkg_version=None, expconf_fingerprint=None)
+                inspect_stdout = b""
 
-            schema_status, mismatch_error = self._verify_image_fingerprint(backend, image, stamp)
-            if metadata is None:
-                metadata = {"schema": schema_status}
-            else:
-                metadata["schema"] = schema_status
-            if self._progress:
-                self._progress.image_ready(
-                    backend, image, cached=False, elapsed=elapsed, metadata=metadata
-                )
+            mismatch_error = self._finalise_image(
+                backend, image, inspect_stdout, cached=False, elapsed=elapsed
+            )
             if mismatch_error is not None:
                 if self._progress:
                     self._progress.end_image_prep()
@@ -1377,6 +1361,33 @@ class StudyRunner:
         except (json.JSONDecodeError, KeyError, IndexError):
             return None
 
+    def _finalise_image(
+        self,
+        backend: str,
+        image: str,
+        inspect_stdout: bytes,
+        *,
+        cached: bool,
+        elapsed: float,
+    ) -> Exception | None:
+        """Report an image-ready progress event and return any mismatch error.
+
+        Parses display metadata and the schema stamp from *inspect_stdout*,
+        classifies the schema status, renders it through
+        ``progress.image_ready`` so the backend row appears before any abort,
+        and returns the ``VersionMismatchError`` for the caller to raise.
+        """
+        metadata = self._parse_image_metadata(inspect_stdout) or {}
+        stamp = parse_image_stamp(inspect_stdout)
+        schema_status, mismatch_error = self._verify_image_fingerprint(backend, image, stamp)
+        metadata["schema"] = schema_status
+
+        if self._progress:
+            self._progress.image_ready(
+                backend, image, cached=cached, elapsed=elapsed, metadata=metadata
+            )
+        return mismatch_error
+
     def _verify_image_fingerprint(
         self,
         backend: str,
@@ -1386,15 +1397,17 @@ class StudyRunner:
         """Compare the host schema fingerprint to *stamp* and classify the result.
 
         Returns ``(schema_status, error)`` where ``schema_status`` is the
-        short display string ("ok" / "mismatch" / "bypassed" / "unverified …")
-        and ``error`` is a ``VersionMismatchError`` to raise (or ``None``).
-        Callers raise after rendering so the offending backend appears in the
-        terminal before the study aborts.
+        short display string and ``error`` is a ``VersionMismatchError`` to
+        raise (or ``None``). Callers raise after rendering so the offending
+        backend appears in the terminal before the study aborts.
         """
         if skip_check_enabled():
             return "bypassed", None
 
-        if stamp.expconf_fingerprint is None:
+        host_fp = compute_expconf_fingerprint()
+        status = classify_stamp(stamp, host_fp)
+
+        if status in (SchemaStatus.UNVERIFIED, SchemaStatus.UNREACHABLE):
             logger.warning(
                 "Image %s has no %s label — schema skew check skipped "
                 "(image predates the handshake feature; rebuild to enable)",
@@ -1403,10 +1416,10 @@ class StudyRunner:
             )
             return "unverified (no labels)", None
 
-        host_fp = compute_expconf_fingerprint()
-        if stamp.expconf_fingerprint == host_fp:
+        if status is SchemaStatus.OK:
             return "ok", None
 
+        assert stamp.expconf_fingerprint is not None  # MISMATCH implies non-None
         error = VersionMismatchError(
             f"Docker image '{image}' was built from llenergymeasure "
             f"{stamp.pkg_version or 'unknown'} (schema {stamp.expconf_fingerprint[:12]}) "

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -1234,10 +1234,15 @@ class StudyRunner:
             if check is not None and check.returncode == 0:
                 elapsed = time.monotonic() - t0
                 metadata = self._parse_image_metadata(check.stdout)
+                mismatch_error = self._verify_image_fingerprint(backend, image, metadata)
                 if self._progress:
                     self._progress.image_ready(
                         backend, image, cached=True, elapsed=elapsed, metadata=metadata
                     )
+                if mismatch_error is not None:
+                    if self._progress:
+                        self._progress.end_image_prep()
+                    raise mismatch_error
                 continue
 
             # Image not found locally — try to pull
@@ -1283,10 +1288,15 @@ class StudyRunner:
             except Exception:
                 metadata = None
 
+            mismatch_error = self._verify_image_fingerprint(backend, image, metadata)
             if self._progress:
                 self._progress.image_ready(
                     backend, image, cached=False, elapsed=elapsed, metadata=metadata
                 )
+            if mismatch_error is not None:
+                if self._progress:
+                    self._progress.end_image_prep()
+                raise mismatch_error
 
         if self._progress:
             self._progress.end_image_prep()
@@ -1295,7 +1305,26 @@ class StudyRunner:
 
     @staticmethod
     def _parse_image_metadata(inspect_stdout: bytes) -> dict[str, str] | None:
-        """Extract human-readable metadata from docker image inspect JSON."""
+        """Extract human-readable metadata from docker image inspect JSON.
+
+        Also captures schema-handshake labels (``llem.expconf.schema.fingerprint``
+        and ``org.opencontainers.image.version``) under dedicated keys:
+
+        - ``llem_expconf_fingerprint``: full 64-char hex (raw, for programmatic
+          comparison by ``_verify_image_fingerprint``; not shown in the
+          inline progress line because it'd bloat the display).
+        - ``llem_pkg_version``: llenergymeasure version string baked into the
+          image at build time.
+
+        ``_verify_image_fingerprint`` overwrites/sets a ``schema`` key on the
+        returned dict which *is* rendered inline (``schema: ok`` etc.) by the
+        existing metadata renderer at ``cli/_step_display.py``.
+        """
+        from llenergymeasure.infra.version_handshake import (
+            LABEL_IMAGE_VERSION,
+            LABEL_SCHEMA_FINGERPRINT,
+        )
+
         try:
             data = json.loads(inspect_stdout)
             if not data:
@@ -1335,9 +1364,85 @@ class StudyRunner:
             if layers:
                 meta["layers"] = str(len(layers))
 
+            labels = info.get("Config", {}).get("Labels") or {}
+            fingerprint = labels.get(LABEL_SCHEMA_FINGERPRINT)
+            if fingerprint:
+                meta["llem_expconf_fingerprint"] = fingerprint
+            pkg_version = labels.get(LABEL_IMAGE_VERSION)
+            if pkg_version:
+                meta["llem_pkg_version"] = pkg_version
+
             return meta if meta else None
         except (json.JSONDecodeError, KeyError, IndexError):
             return None
+
+    def _verify_image_fingerprint(
+        self,
+        backend: str,
+        image: str,
+        metadata: dict[str, str] | None,
+    ) -> Exception | None:
+        """Compare host schema fingerprint to the image label; return error on mismatch.
+
+        Mutates *metadata* in-place: pops the raw ``llem_*`` label keys
+        (consumed only by this check) and sets a display-friendly ``schema``
+        key ("ok" / "mismatch" / "unverified" / "bypassed") that the existing
+        ``cli/_step_display`` metadata renderer shows inline next to
+        id/size/built.
+
+        Returns the ``VersionMismatchError`` to raise on mismatch, or None on
+        match, bypass, or missing labels. Callers raise *after* emitting
+        ``image_ready`` so the offending backend shows in the terminal output
+        before the study aborts.
+        """
+        from llenergymeasure.infra.version_handshake import (
+            VersionMismatchError,
+            compute_expconf_fingerprint,
+            skip_check_enabled,
+        )
+
+        if metadata is None:
+            metadata = {}
+
+        # Pop raw labels so they never pollute the inline progress line; the
+        # display iterates metadata.items() and would otherwise show the full
+        # 64-char fingerprint next to id/size/built.
+        img_fp = metadata.pop("llem_expconf_fingerprint", None)
+        img_pkg_ver = metadata.pop("llem_pkg_version", None)
+
+        if skip_check_enabled():
+            metadata["schema"] = "bypassed"
+            return None
+
+        if img_fp is None:
+            metadata["schema"] = "unverified (no labels)"
+            logger.warning(
+                "Image %s has no %s label — schema skew check skipped "
+                "(image predates the handshake feature; rebuild to enable)",
+                image,
+                "llem.expconf.schema.fingerprint",
+            )
+            return None
+
+        host_fp = compute_expconf_fingerprint()
+        if img_fp == host_fp:
+            metadata["schema"] = "ok"
+            return None
+
+        metadata["schema"] = "mismatch"
+        from llenergymeasure._version import __version__ as host_pkg_ver
+
+        return VersionMismatchError(
+            f"Docker image '{image}' was built from llenergymeasure "
+            f"{img_pkg_ver or 'unknown'} (schema {img_fp[:12]}) but the host is "
+            f"running {host_pkg_ver} (schema {host_fp[:12]}). The container "
+            f"will reject ExperimentConfig fields added on the host after the "
+            f"image was built.\n\n"
+            f"To fix:\n"
+            f"  make docker-build-{backend}       # rebuild locally\n"
+            f"  make docker-pull                  # or pull a newer tagged release\n\n"
+            f"If you're certain the skew is harmless, set LLEM_SKIP_IMAGE_CHECK=1."
+        )
 
     def _run_gap(self, seconds: float, label: str) -> None:
         """Run a thermal gap, rendering countdown in the live display or terminal."""

--- a/tests/unit/cli/test_doctor_cmd.py
+++ b/tests/unit/cli/test_doctor_cmd.py
@@ -1,0 +1,133 @@
+"""Tests for ``llem doctor`` CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from llenergymeasure.api.doctor import (
+    BackendDoctorResult,
+    DoctorReport,
+    DoctorStatus,
+)
+from llenergymeasure.cli import app
+
+runner = CliRunner()
+
+
+def _report(
+    results: list[BackendDoctorResult],
+    *,
+    host_fp: str = "a" * 64,
+    host_pkg: str = "0.9.0",
+    skip_active: bool = False,
+) -> DoctorReport:
+    return DoctorReport(
+        host_pkg_version=host_pkg,
+        host_fingerprint=host_fp,
+        skip_check_active=skip_active,
+        results=results,
+    )
+
+
+def test_all_ok_exits_zero() -> None:
+    report = _report(
+        [
+            BackendDoctorResult(
+                backend="pytorch",
+                image="llenergymeasure:pytorch",
+                pkg_version="0.9.0",
+                image_fingerprint="a" * 64,
+                status=DoctorStatus.OK,
+            )
+        ]
+    )
+    with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
+        result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "pytorch" in result.output
+    assert "OK" in result.output
+
+
+def test_mismatch_exits_nonzero() -> None:
+    report = _report(
+        [
+            BackendDoctorResult(
+                backend="pytorch",
+                image="llenergymeasure:pytorch",
+                pkg_version="0.9.0",
+                image_fingerprint="b" * 64,
+                status=DoctorStatus.MISMATCH,
+                detail="rebuild: make docker-build-pytorch",
+            ),
+            BackendDoctorResult(
+                backend="vllm",
+                image="llenergymeasure:vllm",
+                pkg_version="0.9.0",
+                image_fingerprint="a" * 64,
+                status=DoctorStatus.OK,
+            ),
+        ]
+    )
+    with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
+        result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "MISMATCH" in result.output
+    assert "rebuild" in result.output
+
+
+def test_unreachable_is_not_mismatch() -> None:
+    report = _report(
+        [
+            BackendDoctorResult(
+                backend="pytorch",
+                image="llenergymeasure:pytorch",
+                pkg_version=None,
+                image_fingerprint=None,
+                status=DoctorStatus.UNREACHABLE,
+                detail="no labels",
+            )
+        ]
+    )
+    with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
+        result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "UNREACHABLE" in result.output
+
+
+def test_skip_check_warning_rendered() -> None:
+    report = _report(
+        [
+            BackendDoctorResult(
+                backend="pytorch",
+                image="llenergymeasure:pytorch",
+                pkg_version="0.9.0",
+                image_fingerprint="a" * 64,
+                status=DoctorStatus.OK,
+            )
+        ],
+        skip_active=True,
+    )
+    with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
+        result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "LLEM_SKIP_IMAGE_CHECK" in result.output
+
+
+def test_host_footer_rendered() -> None:
+    report = _report(
+        [
+            BackendDoctorResult(
+                backend="pytorch",
+                image="llenergymeasure:pytorch",
+                pkg_version="0.9.0",
+                image_fingerprint="a" * 64,
+                status=DoctorStatus.OK,
+            )
+        ]
+    )
+    with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
+        result = runner.invoke(app, ["doctor"])
+    assert "Host llenergymeasure version: 0.9.0" in result.output
+    assert "Host ExperimentConfig fingerprint:" in result.output

--- a/tests/unit/cli/test_doctor_cmd.py
+++ b/tests/unit/cli/test_doctor_cmd.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 from llenergymeasure.api.doctor import (
     BackendDoctorResult,
     DoctorReport,
-    DoctorStatus,
+    SchemaStatus,
 )
 from llenergymeasure.cli import app
 
@@ -39,7 +39,7 @@ def test_all_ok_exits_zero() -> None:
                 image="llenergymeasure:pytorch",
                 pkg_version="0.9.0",
                 image_fingerprint="a" * 64,
-                status=DoctorStatus.OK,
+                status=SchemaStatus.OK,
             )
         ]
     )
@@ -58,7 +58,7 @@ def test_mismatch_exits_nonzero() -> None:
                 image="llenergymeasure:pytorch",
                 pkg_version="0.9.0",
                 image_fingerprint="b" * 64,
-                status=DoctorStatus.MISMATCH,
+                status=SchemaStatus.MISMATCH,
                 detail="rebuild: make docker-build-pytorch",
             ),
             BackendDoctorResult(
@@ -66,7 +66,7 @@ def test_mismatch_exits_nonzero() -> None:
                 image="llenergymeasure:vllm",
                 pkg_version="0.9.0",
                 image_fingerprint="a" * 64,
-                status=DoctorStatus.OK,
+                status=SchemaStatus.OK,
             ),
         ]
     )
@@ -85,7 +85,7 @@ def test_unreachable_is_not_mismatch() -> None:
                 image="llenergymeasure:pytorch",
                 pkg_version=None,
                 image_fingerprint=None,
-                status=DoctorStatus.UNREACHABLE,
+                status=SchemaStatus.UNREACHABLE,
                 detail="no labels",
             )
         ]
@@ -104,7 +104,7 @@ def test_skip_check_warning_rendered() -> None:
                 image="llenergymeasure:pytorch",
                 pkg_version="0.9.0",
                 image_fingerprint="a" * 64,
-                status=DoctorStatus.OK,
+                status=SchemaStatus.OK,
             )
         ],
         skip_active=True,
@@ -123,11 +123,11 @@ def test_host_footer_rendered() -> None:
                 image="llenergymeasure:pytorch",
                 pkg_version="0.9.0",
                 image_fingerprint="a" * 64,
-                status=DoctorStatus.OK,
+                status=SchemaStatus.OK,
             )
         ]
     )
     with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
         result = runner.invoke(app, ["doctor"])
     assert "Host llenergymeasure version: 0.9.0" in result.output
-    assert "Host ExperimentConfig fingerprint:" in result.output
+    assert "Host ExperimentConfig SHA-256:" in result.output

--- a/tests/unit/infra/test_version_handshake.py
+++ b/tests/unit/infra/test_version_handshake.py
@@ -1,0 +1,151 @@
+"""Tests for ``llenergymeasure.infra.version_handshake``."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llenergymeasure.infra.version_handshake import (
+    ENV_SKIP_IMAGE_CHECK,
+    LABEL_IMAGE_VERSION,
+    LABEL_SCHEMA_FINGERPRINT,
+    ImageStamp,
+    compute_expconf_fingerprint,
+    inspect_image_stamp,
+    skip_check_enabled,
+)
+
+# ---------------------------------------------------------------------------
+# compute_expconf_fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestComputeExpConfFingerprint:
+    def test_deterministic_across_calls(self) -> None:
+        assert compute_expconf_fingerprint() == compute_expconf_fingerprint()
+
+    def test_hex_length(self) -> None:
+        fp = compute_expconf_fingerprint()
+        assert len(fp) == 64
+        int(fp, 16)  # must be valid hex
+
+    def test_sensitive_to_model_changes(self) -> None:
+        """Adding a field to a throwaway model must change its fingerprint.
+
+        We don't mutate ExperimentConfig itself (too invasive for a unit
+        test), but we verify the serialiser is sensitive to schema shape by
+        hashing two synthetic pydantic models with and without an extra field.
+        """
+        import hashlib
+
+        from pydantic import BaseModel
+
+        class _A(BaseModel):
+            x: int = 0
+
+        class _B(BaseModel):
+            x: int = 0
+            y: int = 0
+
+        def _hash(model_cls: type[BaseModel]) -> str:
+            payload = json.dumps(
+                model_cls.model_json_schema(),
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            return hashlib.sha256(payload).hexdigest()
+
+        assert _hash(_A) != _hash(_B)
+
+
+# ---------------------------------------------------------------------------
+# inspect_image_stamp
+# ---------------------------------------------------------------------------
+
+
+def _fake_inspect_result(*, labels: dict[str, str] | None, returncode: int = 0) -> MagicMock:
+    body = [{"Id": "sha256:abc", "Config": {"Labels": labels}}] if labels is not None else [{}]
+    result = MagicMock(spec=subprocess.CompletedProcess)
+    result.returncode = returncode
+    result.stdout = json.dumps(body).encode("utf-8")
+    result.stderr = b""
+    return result
+
+
+class TestInspectImageStamp:
+    def test_valid_labels(self) -> None:
+        labels = {
+            LABEL_SCHEMA_FINGERPRINT: "a" * 64,
+            LABEL_IMAGE_VERSION: "0.9.0",
+        }
+        with patch("subprocess.run", return_value=_fake_inspect_result(labels=labels)):
+            stamp = inspect_image_stamp("my/img:latest")
+        assert stamp == ImageStamp(pkg_version="0.9.0", expconf_fingerprint="a" * 64)
+
+    def test_missing_labels(self) -> None:
+        with patch("subprocess.run", return_value=_fake_inspect_result(labels={})):
+            stamp = inspect_image_stamp("my/img:latest")
+        assert stamp.pkg_version is None
+        assert stamp.expconf_fingerprint is None
+
+    def test_partial_labels(self) -> None:
+        labels = {LABEL_IMAGE_VERSION: "0.9.0"}
+        with patch("subprocess.run", return_value=_fake_inspect_result(labels=labels)):
+            stamp = inspect_image_stamp("my/img:latest")
+        assert stamp.pkg_version == "0.9.0"
+        assert stamp.expconf_fingerprint is None
+
+    def test_timeout_returns_empty_stamp(self) -> None:
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired("docker", 5),
+        ):
+            stamp = inspect_image_stamp("my/img:latest", timeout=1.0)
+        assert stamp == ImageStamp(pkg_version=None, expconf_fingerprint=None)
+
+    def test_docker_not_installed(self) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError("docker")):
+            stamp = inspect_image_stamp("my/img:latest")
+        assert stamp == ImageStamp(pkg_version=None, expconf_fingerprint=None)
+
+    def test_nonzero_returncode(self) -> None:
+        bad = MagicMock(spec=subprocess.CompletedProcess)
+        bad.returncode = 1
+        bad.stdout = b""
+        bad.stderr = b"No such image"
+        with patch("subprocess.run", return_value=bad):
+            stamp = inspect_image_stamp("my/img:latest")
+        assert stamp == ImageStamp(pkg_version=None, expconf_fingerprint=None)
+
+    def test_malformed_json(self) -> None:
+        bad = MagicMock(spec=subprocess.CompletedProcess)
+        bad.returncode = 0
+        bad.stdout = b"not json"
+        bad.stderr = b""
+        with patch("subprocess.run", return_value=bad):
+            stamp = inspect_image_stamp("my/img:latest")
+        assert stamp == ImageStamp(pkg_version=None, expconf_fingerprint=None)
+
+
+# ---------------------------------------------------------------------------
+# skip_check_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestSkipCheckEnabled:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes"])
+    def test_truthy(self, value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_SKIP_IMAGE_CHECK, value)
+        assert skip_check_enabled() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "random"])
+    def test_falsy(self, value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_SKIP_IMAGE_CHECK, value)
+        assert skip_check_enabled() is False
+
+    def test_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_SKIP_IMAGE_CHECK, raising=False)
+        assert skip_check_enabled() is False

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -1771,8 +1771,8 @@ class TestParseImageMetadata:
         data = b"[{}]"
         assert StudyRunner._parse_image_metadata(data) is None
 
-    def test_labels_extracted_under_llem_keys(self) -> None:
-        """Schema-handshake labels surface as llem_* keys for the verify step."""
+    def test_handshake_labels_do_not_leak_into_display_metadata(self) -> None:
+        """Display metadata never carries the raw 64-char fingerprint label."""
         data = (
             b'[{"Id": "sha256:abc123def456789", "Size": 1073741824, '
             b'"Config": {"Labels": {'
@@ -1782,8 +1782,10 @@ class TestParseImageMetadata:
         )
         meta = StudyRunner._parse_image_metadata(data)
         assert meta is not None
-        assert meta["llem_expconf_fingerprint"] == "a" * 64
-        assert meta["llem_pkg_version"] == "0.9.0"
+        assert "llem_expconf_fingerprint" not in meta
+        assert "llem_pkg_version" not in meta
+        # The display fields (id/size) still come through.
+        assert meta["id"] == "abc123def456"
 
 
 # =============================================================================

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -1771,6 +1771,199 @@ class TestParseImageMetadata:
         data = b"[{}]"
         assert StudyRunner._parse_image_metadata(data) is None
 
+    def test_labels_extracted_under_llem_keys(self) -> None:
+        """Schema-handshake labels surface as llem_* keys for the verify step."""
+        data = (
+            b'[{"Id": "sha256:abc123def456789", "Size": 1073741824, '
+            b'"Config": {"Labels": {'
+            b'"llem.expconf.schema.fingerprint": "' + b"a" * 64 + b'",'
+            b'"org.opencontainers.image.version": "0.9.0"'
+            b"}}}]"
+        )
+        meta = StudyRunner._parse_image_metadata(data)
+        assert meta is not None
+        assert meta["llem_expconf_fingerprint"] == "a" * 64
+        assert meta["llem_pkg_version"] == "0.9.0"
+
+
+# =============================================================================
+# Schema-fingerprint handshake wired into _prepare_images
+# =============================================================================
+
+
+def _inspect_json_with_labels(fingerprint: str, pkg_version: str = "0.9.0") -> bytes:
+    import json as _json
+
+    return _json.dumps(
+        [
+            {
+                "Id": "sha256:abc123def4560000000000000000000000000000000000000000000000000000",
+                "Size": 1073741824,
+                "Created": "2026-03-20T10:00:00Z",
+                "RootFS": {"Layers": ["sha256:a"]},
+                "Config": {
+                    "Labels": {
+                        "llem.expconf.schema.fingerprint": fingerprint,
+                        "org.opencontainers.image.version": pkg_version,
+                    }
+                },
+            }
+        ]
+    ).encode("utf-8")
+
+
+class TestSchemaFingerprintHandshake:
+    """Verify that _prepare_images enforces the host/container schema handshake."""
+
+    def _make_runner(
+        self,
+        study_config: StudyConfig,
+        runner_specs: dict,
+        tmp_path: Path,
+        progress: MagicMock | None = None,
+    ) -> StudyRunner:
+        manifest = MagicMock()
+        fake_ctx = MagicMock()
+        with patch("multiprocessing.get_context", return_value=fake_ctx):
+            return StudyRunner(
+                study_config,
+                manifest,
+                tmp_path,
+                runner_specs=runner_specs,
+                progress=progress,
+            )
+
+    def test_fingerprint_match_proceeds(self, study_config: StudyConfig, tmp_path: Path) -> None:
+        import subprocess
+
+        from llenergymeasure.infra.version_handshake import compute_expconf_fingerprint
+
+        progress = MagicMock()
+        runner = self._make_runner(
+            study_config,
+            {"pytorch": _make_docker_runner_spec()},
+            tmp_path,
+            progress=progress,
+        )
+
+        ok = MagicMock(spec=subprocess.CompletedProcess)
+        ok.returncode = 0
+        ok.stdout = _inspect_json_with_labels(compute_expconf_fingerprint())
+
+        with patch("subprocess.run", return_value=ok):
+            runner._prepare_images()
+
+        assert runner._images_prepared
+        call = progress.image_ready.call_args
+        meta = call[1].get("metadata") or call[0][4]
+        assert meta["schema"] == "ok"
+        # Raw label keys must have been popped out of the display metadata.
+        assert "llem_expconf_fingerprint" not in meta
+        assert "llem_pkg_version" not in meta
+
+    def test_fingerprint_mismatch_raises_after_render(
+        self, study_config: StudyConfig, tmp_path: Path
+    ) -> None:
+        import subprocess
+
+        from llenergymeasure.infra.version_handshake import VersionMismatchError
+
+        progress = MagicMock()
+        runner = self._make_runner(
+            study_config,
+            {"pytorch": _make_docker_runner_spec()},
+            tmp_path,
+            progress=progress,
+        )
+
+        ok = MagicMock(spec=subprocess.CompletedProcess)
+        ok.returncode = 0
+        ok.stdout = _inspect_json_with_labels("b" * 64)
+
+        with (
+            patch("subprocess.run", return_value=ok),
+            pytest.raises(VersionMismatchError, match="rebuild"),
+        ):
+            runner._prepare_images()
+
+        # image_ready must fire *before* the exception so the terminal
+        # shows which backend was stale.
+        progress.image_ready.assert_called_once()
+        progress.end_image_prep.assert_called_once()
+        rendered_meta = (
+            progress.image_ready.call_args[1].get("metadata")
+            or (progress.image_ready.call_args[0][4])
+        )
+        assert rendered_meta["schema"] == "mismatch"
+
+    def test_skip_env_var_bypasses_check(
+        self,
+        study_config: StudyConfig,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import subprocess
+
+        monkeypatch.setenv("LLEM_SKIP_IMAGE_CHECK", "1")
+
+        progress = MagicMock()
+        runner = self._make_runner(
+            study_config,
+            {"pytorch": _make_docker_runner_spec()},
+            tmp_path,
+            progress=progress,
+        )
+
+        ok = MagicMock(spec=subprocess.CompletedProcess)
+        ok.returncode = 0
+        ok.stdout = _inspect_json_with_labels("b" * 64)  # would normally mismatch
+
+        with patch("subprocess.run", return_value=ok):
+            runner._prepare_images()
+
+        assert runner._images_prepared
+        meta = (
+            progress.image_ready.call_args[1].get("metadata")
+            or (progress.image_ready.call_args[0][4])
+        )
+        assert meta["schema"] == "bypassed"
+
+    def test_unlabelled_image_warns_no_raise(
+        self,
+        study_config: StudyConfig,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import subprocess
+
+        progress = MagicMock()
+        runner = self._make_runner(
+            study_config,
+            {"pytorch": _make_docker_runner_spec()},
+            tmp_path,
+            progress=progress,
+        )
+
+        ok = MagicMock(spec=subprocess.CompletedProcess)
+        ok.returncode = 0
+        ok.stdout = FAKE_INSPECT_JSON  # no Config.Labels
+
+        import logging as _logging
+
+        with (
+            caplog.at_level(_logging.WARNING, logger="llenergymeasure.study.runner"),
+            patch("subprocess.run", return_value=ok),
+        ):
+            runner._prepare_images()
+
+        assert runner._images_prepared
+        assert any("schema skew check skipped" in rec.message for rec in caplog.records)
+        meta = (
+            progress.image_ready.call_args[1].get("metadata")
+            or (progress.image_ready.call_args[0][4])
+        )
+        assert meta["schema"].startswith("unverified")
+
 
 # =============================================================================
 # Circuit breaker, wall-clock timeout, mark_study_completed (Plan 03)


### PR DESCRIPTION
## Summary

Adds a host/container schema handshake so studies abort with an actionable rebuild hint — instead of an opaque Pydantic `extra_forbidden` crash inside the container — whenever a Docker image's `ExperimentConfig` schema fingerprint differs from the host's.

- **Signal:** SHA-256 of `ExperimentConfig.model_json_schema()` (serialised with `sort_keys=True`, compact separators). The package version is *not* the blocking signal — phase PRs don't bump version, so both sides report the same `0.9.0` through a milestone of schema churn. The fingerprint is what actually catches drift.
- **Stamping:** `Dockerfile.{pytorch,vllm,tensorrt}` now carry `LLEM_PKG_VERSION` and `LLEM_EXPCONF_SCHEMA_FINGERPRINT` build-args → `org.opencontainers.image.version` and `llem.expconf.schema.fingerprint` OCI labels. Local builds get the fingerprint from a new `scripts/compute_expconf_fingerprint.py` helper wired through `Makefile`; the `docker-publish.yml` CI workflow computes the same value in-workflow.
- **Host check:** `StudyRunner._parse_image_metadata` now extracts labels; `_verify_image_fingerprint` compares them to the host fingerprint and raises `VersionMismatchError` *after* the image-prep progress line prints, so the offending backend is visible in terminal output before the study aborts.
- **Display:** Adds a `schema: ok / mismatch / unverified (no labels) / bypassed` key to the metadata dict. Renders automatically through the existing `cli/_step_display` iterator — zero changes to the progress protocol. Raw label keys are popped before display so the 64-char fingerprint doesn't pollute the inline progress line.
- **`llem doctor`** new CLI command iterates all supported backends, resolves each image via `get_default_image`, reports per-backend status as a table, and exits non-zero on any mismatch. CI-friendly. Logic lives in `api/doctor.py` so the `cli → infra` layer boundary stays clean (`cli-boundary` contract is preserved — verified via `lint-imports`).
- **Bypass:** `LLEM_SKIP_IMAGE_CHECK=1` for confirmed-harmless skews. No CLI flag yet; promotable later if it sees real use.
- **Container-side diagnostic:** `entrypoints/container.py` prints its own fingerprint on startup for post-mortem analysis.
- **Belt-and-braces:** `DockerRunner._read_result` still warns on version mismatch for the single-shot `run_experiment()` API path which bypasses `_prepare_images`.

Pre-stamp legacy images produce an `unverified` warning, not a hard abort — one-time migration grace period for images built before this PR lands.

## Test plan

- [ ] `tests/unit/infra/test_version_handshake.py` (21 new tests): fingerprint determinism, schema sensitivity, `inspect_image_stamp` happy path + missing labels + timeout + docker-not-installed + nonzero rc + malformed JSON, `skip_check_enabled` truthy/falsy/unset.
- [ ] `tests/unit/cli/test_doctor_cmd.py` (5 new tests): OK exits 0, MISMATCH exits 1, UNREACHABLE is not a failure, skip-check warning footer, host footer rendering.
- [ ] `tests/unit/study/test_study_runner.py::TestSchemaFingerprintHandshake` (4 new tests): match proceeds with raw keys popped, mismatch raises post-render with `schema: mismatch` visible, skip env-var bypasses, unlabelled image warns without raising.
- [ ] `TestParseImageMetadata::test_labels_extracted_under_llem_keys`: verifies the new label extraction.
- [ ] All 14 pre-existing `TestPrepareImages` + `TestParseImageMetadata` tests still pass — no regressions.
- [ ] `uv run lint-imports` — all three contracts (main-layers, cli-boundary, foundation-independence) KEPT.
- [ ] `uv run mypy` on all changed source files — clean.
- [ ] `uv run ruff check` + `ruff format` — clean.
- [ ] `llem doctor` smoke test on a dev machine with no built images → prints UNREACHABLE rows, exits 0.
- [ ] Manual end-to-end: build pytorch image, inspect labels, add a bogus field to a submodel, rerun `llem doctor` → MISMATCH exit 1; `llem run` aborts before any experiment; `LLEM_SKIP_IMAGE_CHECK=1 llem run` proceeds past the gate.

## Notes

- Draft — stacked below #[PR 2 number] which adds GHCR registry cache sharing so the rebuild is <5 min instead of ~20 min cold. Reviewable independently.
- See `.claude/plans/precious-sleeping-bonbon.md` for the full design doc and rationale.