### PR TITLE
ci(docker): share build cache via GHCR registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,3 +68,13 @@ jobs:
           build-args: |
             LLEM_PKG_VERSION=${{ inputs.version }}
             LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
+          # Share BuildKit layer cache across machines via GHCR. Pulling the
+          # :latest layers turns a cold flash-attn FA2+FA3 rebuild (~15 min)
+          # into a warm rebuild (<5 min) on any dev box or fresh runner.
+          # mode=max exports intermediate layers too (including the heavy
+          # flash-attn compile) so downstream builders actually hit them.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:latest
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:${{ inputs.version }}
+          cache-to: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:latest,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,11 +68,9 @@ jobs:
           build-args: |
             LLEM_PKG_VERSION=${{ inputs.version }}
             LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
-          # Share BuildKit layer cache across machines via GHCR. Pulling the
-          # :latest layers turns a cold flash-attn FA2+FA3 rebuild (~15 min)
-          # into a warm rebuild (<5 min) on any dev box or fresh runner.
-          # mode=max exports intermediate layers too (including the heavy
-          # flash-attn compile) so downstream builders actually hit them.
+          # mode=max exports intermediate layers (including the flash-attn
+          # compile) so downstream builders can reuse them, not just the final
+          # image layers.
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:latest
             type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 
-- **Docker rebuilds now warm layer cache from published GHCR images** via BuildKit `cache_from` (compose) and `cache-to=type=registry,mode=max` (publish workflow). Typical warm rebuild is under 5 min vs ~15-20 min cold, with the flash-attn FA2+FA3 compile pulled pre-built. Cache is keyed on `LLEM_PKG_VERSION` so it survives intra-milestone schema churn and only re-baselines at releases.
+- **Docker rebuilds pull BuildKit layer cache from GHCR.** Publish workflow uses `cache-to=type=registry,mode=max` and `docker-compose.yml` consumes it via `cache_from`, cutting warm rebuilds from ~15-20 min to under 5 min (flash-attn compile included). Cache is keyed on `LLEM_PKG_VERSION`.
 - **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 
+- **Docker rebuilds now warm layer cache from published GHCR images** via BuildKit `cache_from` (compose) and `cache-to=type=registry,mode=max` (publish workflow). Typical warm rebuild is under 5 min vs ~15-20 min cold, with the flash-attn FA2+FA3 compile pulled pre-built. Cache is keyed on `LLEM_PKG_VERSION` so it survives intra-milestone schema churn and only re-baselines at releases.
 - **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.
 
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -247,22 +247,25 @@ docker-builder-setup:
 docker-builder-rm:
 	docker buildx rm $(BUILDER_NAME) 2>/dev/null || true
 
+CACHE_HINT := @echo "First build pulls cache layers from ghcr.io; warm rebuilds < 5 min."
+
 # Build all backends (pytorch, vllm, tensorrt) — local images
 docker-build-all:
-	@echo "First build pulls ~5-15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build pytorch vllm tensorrt
 
 # Build PyTorch backend (default, recommended for most users)
 docker-build-pytorch:
-	@echo "First build pulls ~5 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build pytorch
+
 # Build specific backends — local images
 docker-build-vllm:
-	@echo "First build pulls ~10 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build vllm
 
 docker-build-tensorrt:
-	@echo "First build pulls ~15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build tensorrt
 
 # Pull versioned registry images (ghcr.io) instead of building locally

--- a/Makefile
+++ b/Makefile
@@ -249,16 +249,20 @@ docker-builder-rm:
 
 # Build all backends (pytorch, vllm, tensorrt) — local images
 docker-build-all:
+	@echo "First build pulls ~5-15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build pytorch vllm tensorrt
 
 # Build PyTorch backend (default, recommended for most users)
 docker-build-pytorch:
+	@echo "First build pulls ~5 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build pytorch
 # Build specific backends — local images
 docker-build-vllm:
+	@echo "First build pulls ~10 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build vllm
 
 docker-build-tensorrt:
+	@echo "First build pulls ~15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build tensorrt
 
 # Pull versioned registry images (ghcr.io) instead of building locally

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LLenergyMeasure is a Python framework for measuring the energy consumption, thro
 - **Multi-backend inference** — PyTorch, vLLM, TensorRT-LLM, SGLang (planned)
 - **GPU energy measurement** — NVML, Zeus, CodeCarbon, others 
 - **Smart sweep system** — define parameter grids, run Cartesian product experiments automatically; intelligently managed sweep hierarchy scopes available config fields to appropriate backend/component, and ensures invalid combinations are removed
-- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check). Rebuilds warm layer cache from GHCR automatically (<5 min warm vs ~20 min cold).
+- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check).
 - **Reproducibility** — fixed seeds, cycle ordering, thermal management, environment snapshots, effective config recorded (add others)
 - **Built-in datasets** — AI Energy Score benchmark prompts included; custom JSONL datasets also supported
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LLenergyMeasure is a Python framework for measuring the energy consumption, thro
 - **Multi-backend inference** — PyTorch, vLLM, TensorRT-LLM, SGLang (planned)
 - **GPU energy measurement** — NVML, Zeus, CodeCarbon, others 
 - **Smart sweep system** — define parameter grids, run Cartesian product experiments automatically; intelligently managed sweep hierarchy scopes available config fields to appropriate backend/component, and ensures invalid combinations are removed
-- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check).
+- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check). Rebuilds warm layer cache from GHCR automatically (<5 min warm vs ~20 min cold).
 - **Reproducibility** — fixed seeds, cycle ordering, thermal management, environment snapshots, effective config recorded (add others)
 - **Built-in datasets** — AI Energy Score benchmark prompts included; custom JSONL datasets also supported
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,24 @@
 #   docker compose --profile dev run --rm vllm-dev /bin/bash
 #   docker compose --profile dev run --rm tensorrt-dev /bin/bash
 
+# Per-backend BuildKit layer cache (shared across runtime + dev services).
+# When LLEM_PKG_VERSION is unset the first entry collapses to :latest and
+# buildx dedups against the second — no-op, not a bug.
+x-cache-pytorch: &cache-pytorch
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
+
+x-cache-vllm: &cache-vllm
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
+
+x-cache-tensorrt: &cache-tensorrt
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
+
 # Shared configuration anchor
 x-common: &common
   # PUID/PGID pattern for host permission mapping (like LinuxServer.io)
@@ -87,15 +105,13 @@ services:
       # Named volumes: container-managed (no permission issues)
       - hf-cache:/app/.cache/huggingface
     build:
+      <<: *cache-pytorch
       context: .
       dockerfile: docker/Dockerfile.pytorch
       target: runtime
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch
 
   pytorch-dev:
@@ -105,15 +121,13 @@ services:
       - hf-cache:/app/.cache/huggingface
     profiles: ["dev"]
     build:
+      <<: *cache-pytorch
       context: .
       dockerfile: docker/Dockerfile.pytorch
       target: dev
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -134,15 +148,13 @@ services:
       # Named volumes: container-managed (no permission issues)
       - hf-cache:/app/.cache/huggingface
     build:
+      <<: *cache-vllm
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: runtime
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm
 
   vllm-dev:
@@ -154,15 +166,13 @@ services:
       - hf-cache:/app/.cache/huggingface
     profiles: ["dev"]
     build:
+      <<: *cache-vllm
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: dev
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -184,15 +194,13 @@ services:
       - hf-cache:/app/.cache/huggingface
       - trt-engine-cache:/app/.cache/tensorrt-engines
     build:
+      <<: *cache-tensorrt
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: runtime
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt
 
   tensorrt-dev:
@@ -205,15 +213,13 @@ services:
       - trt-engine-cache:/app/.cache/tensorrt-engines
     profiles: ["dev"]
     build:
+      <<: *cache-tensorrt
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: dev
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch
 
   pytorch-dev:
@@ -108,6 +111,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -134,6 +140,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm
 
   vllm-dev:
@@ -151,6 +160,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -178,6 +190,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt
 
   tensorrt-dev:
@@ -196,6 +211,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -378,6 +378,44 @@ runners:
 SGLang (M5) images will follow the same naming convention, resolution logic, and auto-pull
 behaviour. No additional setup is needed when SGLang ships.
 
+### Layer cache sharing via GHCR registry
+
+Every `docker compose build` pulls pre-computed BuildKit layers from
+`ghcr.io/henrycgbaker/llenergymeasure/{backend}:latest` (and the matching
+versioned tag when available). CI populates the cache with
+`cache-to=type=registry,mode=max,ref=…:latest` on each release, which exports
+all intermediate layers — including the heavy flash-attn FA2+FA3 compile on
+the PyTorch image — so downstream builders can consume them without
+recompiling.
+
+```
++----------------+              +------------------+              +------------------+
+| CI (release)   |  cache-to    | GHCR :latest     |  cache-from  | Local / other CI |
+| build-push-act | -----------> | mode=max layers  | -----------> | docker compose   |
++----------------+              +------------------+              +------------------+
+```
+
+Key points:
+
+- `cache-to` pushes only to `:latest` (never to immutable version tags), so
+  storage growth is bounded by image drift between releases.
+- `cache-from` reads from both `:${LLEM_PKG_VERSION}` (strongest hit during a
+  dev cycle) and `:latest` (fallback for fresh branches).
+- `LLEM_PKG_VERSION` is the cache key. Phase PRs do not bump version, so the
+  cache is shared across an entire milestone of schema churn and only
+  re-baselined at milestone releases — the correct granularity.
+- No dedicated `:buildcache` tag: the runtime image already carries the layer
+  manifest BuildKit needs, so one tag set serves both purposes.
+
+Inspect what's cached on the active builder:
+
+```bash
+docker buildx du --builder llem-builder
+```
+
+If you need to reset the builder (rare), see
+`make docker-builder-rm && make docker-builder-setup` in the Makefile.
+
 ### Image labels and versioning
 
 Every backend image is stamped at build time with OCI labels that llem reads at

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -380,41 +380,16 @@ behaviour. No additional setup is needed when SGLang ships.
 
 ### Layer cache sharing via GHCR registry
 
-Every `docker compose build` pulls pre-computed BuildKit layers from
-`ghcr.io/henrycgbaker/llenergymeasure/{backend}:latest` (and the matching
-versioned tag when available). CI populates the cache with
-`cache-to=type=registry,mode=max,ref=…:latest` on each release, which exports
-all intermediate layers — including the heavy flash-attn FA2+FA3 compile on
-the PyTorch image — so downstream builders can consume them without
-recompiling.
+See [installation.md — Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost)
+for the user-facing walkthrough (mechanism, sizes, authentication, offline
+fallback).
 
-```
-+----------------+              +------------------+              +------------------+
-| CI (release)   |  cache-to    | GHCR :latest     |  cache-from  | Local / other CI |
-| build-push-act | -----------> | mode=max layers  | -----------> | docker compose   |
-+----------------+              +------------------+              +------------------+
-```
-
-Key points:
+Docker-setup-specific operator notes:
 
 - `cache-to` pushes only to `:latest` (never to immutable version tags), so
   storage growth is bounded by image drift between releases.
-- `cache-from` reads from both `:${LLEM_PKG_VERSION}` (strongest hit during a
-  dev cycle) and `:latest` (fallback for fresh branches).
-- `LLEM_PKG_VERSION` is the cache key. Phase PRs do not bump version, so the
-  cache is shared across an entire milestone of schema churn and only
-  re-baselined at milestone releases — the correct granularity.
-- No dedicated `:buildcache` tag: the runtime image already carries the layer
-  manifest BuildKit needs, so one tag set serves both purposes.
-
-Inspect what's cached on the active builder:
-
-```bash
-docker buildx du --builder llem-builder
-```
-
-If you need to reset the builder (rare), see
-`make docker-builder-rm && make docker-builder-setup` in the Makefile.
+- Inspect what's cached on the active builder: `docker buildx du --builder llem-builder`.
+- If the cache is corrupt, recreate it with `make docker-builder-rm && make docker-builder-setup`.
 
 ### Image labels and versioning
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,61 +130,60 @@ for the full resolution chain.
 | `make docker-images` | Show which image each backend resolves to (local vs registry) |
 | `make docker-check` | Validate `docker-compose.yml` configuration |
 
-### Build Cache (recommended)
+### Fast rebuilds and first-pull cost
 
-Docker image builds can be slow without caching. To speed them up, pull pre-compiled layers
-from GHCR:
+Every backend image declares `cache_from` entries pointing at the published
+GHCR tags. CI populates the cache on each release with
+`cache-to=type=registry,mode=max`, which exports intermediate layers — including
+the ~15-min flash-attn FA2+FA3 compile — so any fresh machine warm-builds in
+minutes instead of re-compiling from source.
 
-| Backend | Image Size | Cold Build | Cached Rebuild |
-|---------|-----------|------------|----------------|
-| PyTorch (FA3 on) | ~8.5 GB | ~30 min | ~30 sec |
-| vLLM | ~17 GB | ~30 min | ~5 min |
-| TensorRT-LLM | ~54 GB | ~40 min | ~10 min |
+| Backend | Image Size | Cold Build (no cache) | Warm Rebuild |
+|---------|-----------|-----------------------|--------------|
+| PyTorch (FA3 on) | ~6 GB | ~15-20 min | <5 min |
+| vLLM | ~10 GB | ~20-30 min | <5 min |
+| TensorRT-LLM | ~15 GB | ~30-40 min | <5 min |
 
-Cold build = no cache, compiling from scratch. Cached rebuild = `COMPOSE_BAKE=true` with
-local BuildKit cache populated. Times depend on network speed and hardware.
+"Cold build" = fresh buildx builder, no layers cached anywhere. "Warm rebuild"
+= same builder, local image wiped, cache pulled from GHCR.
 
-**1. Enable COMPOSE_BAKE in your `.env`:**
-
-```bash
-COMPOSE_BAKE=true
-```
-
-This is already set in `.env.example`. It tells Docker Compose to delegate builds to
-BuildKit's [bake](https://docs.docker.com/build/bake/) engine, which has full support for
-registry-based build cache.
-
-**2. Build as normal:**
+**Build as normal:**
 
 ```bash
-docker compose build pytorch
+make docker-build-pytorch        # or -vllm / -tensorrt
 ```
 
-Compose will pull cached layers from GHCR (written by CI on each release) and only rebuild
-layers that have changed locally. A cached PyTorch build completes in under a minute
-instead of ~30 minutes.
+On first invocation, BuildKit pulls cached layers from
+`ghcr.io/henrycgbaker/llenergymeasure/{backend}:latest` (and the exact version
+tag when available). Subsequent rebuilds only re-execute layers whose source
+changed.
 
 **How it works:**
 
-- CI pushes build cache to GHCR on each release (`ghcr.io/henrycgbaker/llenergymeasure/{backend}:buildcache`)
-- `docker-compose.yml` has `cache_from` entries that pull from these cache images
-- `COMPOSE_BAKE=true` enables BuildKit bake delegation, which supports registry cache
-- Users only pull cache - no write access or authentication is needed for public packages
-- If cache is unavailable (network issues, not yet published), the build proceeds
-  normally without errors
+- CI's `docker-publish.yml` runs `build-push-action` with
+  `cache-to=type=registry,...,mode=max` on `:latest`, exporting full layer
+  graphs to GHCR.
+- `docker-compose.yml` has `cache_from` entries for each backend pointing at
+  both `:${LLEM_PKG_VERSION}` and `:latest`.
+- `LLEM_PKG_VERSION` is the cache key: cache is shared across an entire
+  0.X.Y dev cycle and only re-baselined at milestone releases. This is the
+  correct granularity — we don't want to invalidate the flash-attn layer
+  every time `ExperimentConfig` gains a field.
+- Users only pull cache — no write access or authentication is needed for
+  public packages.
 
-**Authentication:** The build cache packages are public. No `docker login` is required to
-pull them. If you are behind a corporate proxy or encounter rate limits, logging in with
-`docker login ghcr.io` (using a
-[personal access token](https://github.com/settings/tokens) with `read:packages` scope)
-may help.
+**Authentication:** GHCR packages are public. No `docker login` is required to
+pull them. If you hit rate limits or are behind a corporate proxy,
+`docker login ghcr.io` with a
+[personal access token](https://github.com/settings/tokens) (scope
+`read:packages`) may help.
 
-**Requirements:** Docker Compose v2.32+ and Docker Buildx v0.17+ (`docker compose version`
-and `docker buildx version` to check). If you have older versions, see the upgrade
-instructions in the [Docker Setup Guide](docker-setup.md#step-1-install-docker).
+**Offline builds:** BuildKit degrades gracefully. When the registry is
+unreachable the `cache_from` entries are skipped and the build falls back to
+local layer cache (cold on a fresh builder). No errors, just slower.
 
-**Without COMPOSE_BAKE:** Builds work normally but don't use registry cache. The `cache_from`
-entries in `docker-compose.yml` are silently ignored. No errors, just slower builds.
+**First-pull cost:** the first build on any new machine downloads the full
+cache graph (sizes above). Subsequent builds are incremental.
 
 ### FlashAttention-3
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -257,6 +257,36 @@ Notes:
 
 ---
 
+## Docker rebuild is slow / recompiling flash-attn
+
+**Symptom:** `make docker-build-pytorch` takes 15-20 minutes and BuildKit logs
+show `flash-attn` source downloads and nvcc compilation for every build.
+
+**Cause:** BuildKit's `cache_from` registry pull was skipped. Either (a) you
+are on a fresh buildx builder with no local cache, (b) you are offline or
+GHCR is unreachable, or (c) your `LLEM_PKG_VERSION` does not match any tag in
+`ghcr.io/henrycgbaker/llenergymeasure/{backend}:*`, so neither
+`:${LLEM_PKG_VERSION}` nor `:latest` had usable layers.
+
+**Fix:**
+
+1. Inspect the builder cache: `docker buildx du --builder llem-builder`. If
+   it's near-empty, BuildKit has nothing to reuse locally and will pull from
+   the registry.
+2. Verify network: `curl -I https://ghcr.io/v2/henrycgbaker/llenergymeasure/pytorch/manifests/latest`
+   should return 200 or 401 (both fine; 000/timeout means no connectivity).
+3. If you recently bumped version but CI hasn't published yet, fall back to
+   `:latest` by unsetting `LLEM_PKG_VERSION` for the build:
+   `LLEM_PKG_VERSION= docker compose build pytorch`.
+4. If the cache is corrupt, recreate the builder:
+   `make docker-builder-rm && make docker-builder-setup`. Note this discards
+   all local layer cache; the first subsequent build will repopulate from
+   GHCR.
+5. Offline is expected-slow. BuildKit degrades gracefully to a cold build —
+   no errors, just minutes.
+
+---
+
 ## Schema skew between host and Docker image
 
 **Symptom:** `llem run study.yaml` aborts before any experiment with a message


### PR DESCRIPTION
## Summary

Warm-cache Docker rebuilds on any dev machine or CI runner by pulling BuildKit layers from GHCR instead of recompiling from scratch. Targets the ~15-min flash-attn FA2+FA3 compile hotspot so a fresh-builder rebuild of the PyTorch image drops from ~20 min to under 5 min.

- **`docker-compose.yml`**: every backend service (`pytorch`, `pytorch-dev`, `vllm`, `vllm-dev`, `tensorrt`, `tensorrt-dev`) now declares `cache_from` with two tags per backend — `ghcr.io/henrycgbaker/llenergymeasure/{backend}:\${LLEM_PKG_VERSION:-latest}` (strongest hit) and `:latest` (fallback for fresh branches).
- **`.github/workflows/docker-publish.yml`**: `build-push-action@v7` gains `cache-from` (both tags) and `cache-to=type=registry,mode=max` on `:latest`. `mode=max` exports intermediate layers including the flash-attn compile, which is the layer that actually matters. Writes go only to `:latest` (in-place overwrite); immutable version tags never receive cache pushes, so storage growth is bounded by image drift between releases.
- **`LLEM_PKG_VERSION` as cache key**: correct granularity because phase PRs don't bump version. Cache survives an entire milestone of `ExperimentConfig` schema churn and only re-baselines at releases — otherwise every schema tweak would invalidate the 15-min flash-attn layer, which is exactly what we want to avoid.
- **`Makefile`**: adds a `@echo` notice to each `docker-build-*` target warning users about first-pull cost (~5-15 GB) and warm-rebuild target (<5 min).
- **No dedicated `:buildcache` tag**: simpler mental model — the runtime image already carries the layer manifest BuildKit needs, so one tag set serves both purposes.

## Dependencies

Stacked on top of #256 (`feature/schema-skew-handshake`) which introduces the `LLEM_PKG_VERSION` env var and Makefile plumbing reused here as the cache-key parameter. Reviewable independently but must merge after #256.

## Test plan

No unit tests — all changes are config/YAML. Verification is manual timing on a fresh builder:

- [ ] \`make docker-builder-rm && make docker-builder-setup\` (fresh builder, no local cache)
- [ ] \`time make docker-build-pytorch\` — expect ~15-20 min cold (first run pulls full cache graph from GHCR)
- [ ] \`docker image rm llenergymeasure:pytorch && time make docker-build-pytorch\` — expect <5 min warm (cache hit on every unchanged layer)
- [ ] Offline test: disable network, \`make docker-build-pytorch\` — expect slow but successful (BuildKit degrades gracefully)
- [ ] \`llem doctor\` still reports OK after rebuild (PR 1 handshake still works)
- [ ] \`python3 -c "import yaml; ..."\` smoke check that all six services carry \`cache_from\` and the workflow carries \`cache-from\`/\`cache-to\` (already verified locally)

## Notes

- GHCR storage inflation risk from \`mode=max\` is bounded by the \`:latest\`-only write policy. Anonymous GHCR rate limits are generous for public packages.
- See \`.claude/plans/precious-sleeping-bonbon.md\` PR 2 section for full rationale and decisions (why not \`:buildcache\`, why \`LLEM_PKG_VERSION\` as key, etc.).