### PR TITLE
ci(docker): share build cache via GHCR registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,11 +41,18 @@ HF_TOKEN=
 # -----------------------------------------------------------------------------
 # OPTIONAL: Build Performance
 # -----------------------------------------------------------------------------
-# Enable BuildKit bake delegation for faster Docker builds.
-# Pulls cached layers from GHCR instead of compiling locally.
-# Requires Docker Compose v2.32+. No login needed (public cache).
-# Without this, builds work fine but don't use registry cache.
+# Route docker compose build through buildx bake for parallel multi-backend
+# builds and a cleaner progress UI. The GHCR layer cache works without this
+# (cache_from is honoured on the native compose build path too); leave it on
+# if you ever run `make docker-build-all`.
 COMPOSE_BAKE=true
+
+# Surface BuildKit's per-step output (including "importing cache manifest"
+# and per-stage "CACHED" lines) so you can see whether the GHCR cache is
+# actually being used. The Makefile build targets force this on for their
+# post-build summary; export it here if you invoke `docker compose build`
+# directly and want the same visibility.
+BUILDKIT_PROGRESS=plain
 
 # -----------------------------------------------------------------------------
 # OPTIONAL: Performance/Debug

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -47,4 +47,5 @@ jobs:
           target: runtime
           push: false
           build-args: ${{ matrix.build-args }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.backend }}:buildcache
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.backend }}:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,3 +68,13 @@ jobs:
           build-args: |
             LLEM_PKG_VERSION=${{ inputs.version }}
             LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
+          # Share BuildKit layer cache across machines via GHCR. Pulling the
+          # :latest layers turns a cold flash-attn FA2+FA3 rebuild (~15 min)
+          # into a warm rebuild (<5 min) on any dev box or fresh runner.
+          # mode=max exports intermediate layers too (including the heavy
+          # flash-attn compile) so downstream builders actually hit them.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:latest
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:${{ inputs.version }}
+          cache-to: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:latest,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,11 +68,9 @@ jobs:
           build-args: |
             LLEM_PKG_VERSION=${{ inputs.version }}
             LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
-          # Share BuildKit layer cache across machines via GHCR. Pulling the
-          # :latest layers turns a cold flash-attn FA2+FA3 rebuild (~15 min)
-          # into a warm rebuild (<5 min) on any dev box or fresh runner.
-          # mode=max exports intermediate layers too (including the heavy
-          # flash-attn compile) so downstream builders actually hit them.
+          # mode=max exports intermediate layers (including the flash-attn
+          # compile) so downstream builders can reuse them, not just the final
+          # image layers.
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:latest
             type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.backend }}:${{ inputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           ref: ${{ inputs.version }}
 
+      # The default `docker` buildx driver does not support
+      # cache-to=type=registry. Switching to `docker-container` is required
+      # for the mode=max cache export below to work — without this, the
+      # build-push-action step fails with:
+      #   ERROR: failed to build: Cache export is not supported for the
+      #   docker driver.
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,17 @@ jobs:
     strategy:
       matrix:
         backend: [pytorch, vllm, tensorrt]
+        include:
+          # Cap nvcc parallelism on the 4-core/16 GB hosted runner. The default
+          # MAX_JOBS=32 (set in Dockerfile.pytorch for developer hardware)
+          # asks for ~128 GB of peak RAM during the FA3 hopper compile,
+          # which causes the runner agent to lose its heartbeat under
+          # memory pressure and the job ends as "runner lost communication
+          # with the server". Leaving 2 cores free keeps the agent
+          # schedulable. vllm/tensorrt don't compile FA3 and ignore this arg.
+          - backend: pytorch
+            extra_build_args: |
+              MAX_JOBS=2
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,6 +87,7 @@ jobs:
           build-args: |
             LLEM_PKG_VERSION=${{ inputs.version }}
             LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
+            ${{ matrix.extra_build_args }}
           # mode=max exports intermediate layers (including the flash-attn
           # compile) so downstream builders can reuse them, not just the final
           # image layers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 
-- **Docker rebuilds now warm layer cache from published GHCR images** via BuildKit `cache_from` (compose) and `cache-to=type=registry,mode=max` (publish workflow). Typical warm rebuild is under 5 min vs ~15-20 min cold, with the flash-attn FA2+FA3 compile pulled pre-built. Cache is keyed on `LLEM_PKG_VERSION` so it survives intra-milestone schema churn and only re-baselines at releases.
+- **Docker rebuilds pull BuildKit layer cache from GHCR.** Publish workflow uses `cache-to=type=registry,mode=max` and `docker-compose.yml` consumes it via `cache_from`, cutting warm rebuilds from ~15-20 min to under 5 min (flash-attn compile included). Cache is keyed on `LLEM_PKG_VERSION`.
 - **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 
+- **Docker rebuilds now warm layer cache from published GHCR images** via BuildKit `cache_from` (compose) and `cache-to=type=registry,mode=max` (publish workflow). Typical warm rebuild is under 5 min vs ~15-20 min cold, with the flash-attn FA2+FA3 compile pulled pre-built. Cache is keyed on `LLEM_PKG_VERSION` so it survives intra-milestone schema churn and only re-baselines at releases.
 - **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.
 
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -248,25 +248,29 @@ docker-builder-rm:
 	docker buildx rm $(BUILDER_NAME) 2>/dev/null || true
 
 CACHE_HINT := @echo "First build pulls cache layers from ghcr.io; warm rebuilds < 5 min."
+BUILD_WITH_REPORT := scripts/docker_build_with_cache_report.sh
 
-# Build all backends (pytorch, vllm, tensorrt) — local images
+# Build all backends (pytorch, vllm, tensorrt) — local images.
+# Calls compose directly so COMPOSE_BAKE=true can build all three in parallel;
+# per-backend cache-import summary is only emitted for single-backend targets
+# below. For per-backend diagnostics, run `make docker-build-{backend}`.
 docker-build-all:
 	$(CACHE_HINT)
-	docker compose build pytorch vllm tensorrt
+	BUILDKIT_PROGRESS=$${BUILDKIT_PROGRESS:-plain} docker compose build pytorch vllm tensorrt
 
 # Build PyTorch backend (default, recommended for most users)
 docker-build-pytorch:
 	$(CACHE_HINT)
-	docker compose build pytorch
+	$(BUILD_WITH_REPORT) pytorch
 
 # Build specific backends — local images
 docker-build-vllm:
 	$(CACHE_HINT)
-	docker compose build vllm
+	$(BUILD_WITH_REPORT) vllm
 
 docker-build-tensorrt:
 	$(CACHE_HINT)
-	docker compose build tensorrt
+	$(BUILD_WITH_REPORT) tensorrt
 
 # Pull versioned registry images (ghcr.io) instead of building locally
 docker-pull:

--- a/Makefile
+++ b/Makefile
@@ -247,22 +247,25 @@ docker-builder-setup:
 docker-builder-rm:
 	docker buildx rm $(BUILDER_NAME) 2>/dev/null || true
 
+CACHE_HINT := @echo "First build pulls cache layers from ghcr.io; warm rebuilds < 5 min."
+
 # Build all backends (pytorch, vllm, tensorrt) — local images
 docker-build-all:
-	@echo "First build pulls ~5-15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build pytorch vllm tensorrt
 
 # Build PyTorch backend (default, recommended for most users)
 docker-build-pytorch:
-	@echo "First build pulls ~5 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build pytorch
+
 # Build specific backends — local images
 docker-build-vllm:
-	@echo "First build pulls ~10 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build vllm
 
 docker-build-tensorrt:
-	@echo "First build pulls ~15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
+	$(CACHE_HINT)
 	docker compose build tensorrt
 
 # Pull versioned registry images (ghcr.io) instead of building locally

--- a/Makefile
+++ b/Makefile
@@ -249,16 +249,20 @@ docker-builder-rm:
 
 # Build all backends (pytorch, vllm, tensorrt) — local images
 docker-build-all:
+	@echo "First build pulls ~5-15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build pytorch vllm tensorrt
 
 # Build PyTorch backend (default, recommended for most users)
 docker-build-pytorch:
+	@echo "First build pulls ~5 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build pytorch
 # Build specific backends — local images
 docker-build-vllm:
+	@echo "First build pulls ~10 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build vllm
 
 docker-build-tensorrt:
+	@echo "First build pulls ~15 GB of cache layers from ghcr.io (warm rebuilds: <5 min)"
 	docker compose build tensorrt
 
 # Pull versioned registry images (ghcr.io) instead of building locally

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LLenergyMeasure is a Python framework for measuring the energy consumption, thro
 - **Multi-backend inference** — PyTorch, vLLM, TensorRT-LLM, SGLang (planned)
 - **GPU energy measurement** — NVML, Zeus, CodeCarbon, others 
 - **Smart sweep system** — define parameter grids, run Cartesian product experiments automatically; intelligently managed sweep hierarchy scopes available config fields to appropriate backend/component, and ensures invalid combinations are removed
-- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check). Rebuilds warm layer cache from GHCR automatically (<5 min warm vs ~20 min cold).
+- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check).
 - **Reproducibility** — fixed seeds, cycle ordering, thermal management, environment snapshots, effective config recorded (add others)
 - **Built-in datasets** — AI Energy Score benchmark prompts included; custom JSONL datasets also supported
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LLenergyMeasure is a Python framework for measuring the energy consumption, thro
 - **Multi-backend inference** — PyTorch, vLLM, TensorRT-LLM, SGLang (planned)
 - **GPU energy measurement** — NVML, Zeus, CodeCarbon, others 
 - **Smart sweep system** — define parameter grids, run Cartesian product experiments automatically; intelligently managed sweep hierarchy scopes available config fields to appropriate backend/component, and ensures invalid combinations are removed
-- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check).
+- **Docker isolation** — launches per-experiment containers with full GPU passthrough; latest docker images for each backend in registry with full runnder configurability and local mode also available. Every study pre-flight now verifies that each image's `ExperimentConfig` schema fingerprint matches the host's, aborting with an actionable rebuild hint on drift (`llem doctor` for a one-shot check). Rebuilds warm layer cache from GHCR automatically (<5 min warm vs ~20 min cold).
 - **Reproducibility** — fixed seeds, cycle ordering, thermal management, environment snapshots, effective config recorded (add others)
 - **Built-in datasets** — AI Energy Score benchmark prompts included; custom JSONL datasets also supported
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,24 @@
 #   docker compose --profile dev run --rm vllm-dev /bin/bash
 #   docker compose --profile dev run --rm tensorrt-dev /bin/bash
 
+# Per-backend BuildKit layer cache (shared across runtime + dev services).
+# When LLEM_PKG_VERSION is unset the first entry collapses to :latest and
+# buildx dedups against the second — no-op, not a bug.
+x-cache-pytorch: &cache-pytorch
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
+
+x-cache-vllm: &cache-vllm
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
+
+x-cache-tensorrt: &cache-tensorrt
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
+
 # Shared configuration anchor
 x-common: &common
   # PUID/PGID pattern for host permission mapping (like LinuxServer.io)
@@ -87,15 +105,13 @@ services:
       # Named volumes: container-managed (no permission issues)
       - hf-cache:/app/.cache/huggingface
     build:
+      <<: *cache-pytorch
       context: .
       dockerfile: docker/Dockerfile.pytorch
       target: runtime
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch
 
   pytorch-dev:
@@ -105,15 +121,13 @@ services:
       - hf-cache:/app/.cache/huggingface
     profiles: ["dev"]
     build:
+      <<: *cache-pytorch
       context: .
       dockerfile: docker/Dockerfile.pytorch
       target: dev
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -134,15 +148,13 @@ services:
       # Named volumes: container-managed (no permission issues)
       - hf-cache:/app/.cache/huggingface
     build:
+      <<: *cache-vllm
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: runtime
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm
 
   vllm-dev:
@@ -154,15 +166,13 @@ services:
       - hf-cache:/app/.cache/huggingface
     profiles: ["dev"]
     build:
+      <<: *cache-vllm
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: dev
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -184,15 +194,13 @@ services:
       - hf-cache:/app/.cache/huggingface
       - trt-engine-cache:/app/.cache/tensorrt-engines
     build:
+      <<: *cache-tensorrt
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: runtime
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt
 
   tensorrt-dev:
@@ -205,15 +213,13 @@ services:
       - trt-engine-cache:/app/.cache/tensorrt-engines
     profiles: ["dev"]
     build:
+      <<: *cache-tensorrt
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: dev
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
-      cache_from:
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
-        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,21 +26,27 @@
 #   docker compose --profile dev run --rm tensorrt-dev /bin/bash
 
 # Per-backend BuildKit layer cache (shared across runtime + dev services).
-# When LLEM_PKG_VERSION is unset the first entry collapses to :latest and
-# buildx dedups against the second — no-op, not a bug.
+# Two sources, in priority order:
+#   1. :v${LLEM_PKG_VERSION} — exact-version image layers from the matching
+#      release. Note the literal `v`: published tags carry a `v` prefix (set by
+#      release.yml) but LLEM_PKG_VERSION is bare semver (from _version.py), so
+#      we have to add the prefix here. On dev versions (`vdev`) this entry
+#      silently misses, which is fine — the next entry catches it.
+#   2. :latest — rolling cache published by docker-publish.yml with mode=max,
+#      which exports intermediate layers (including the flash-attn compile).
 x-cache-pytorch: &cache-pytorch
   cache_from:
-    - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/pytorch:v${LLEM_PKG_VERSION:-dev}
     - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
 
 x-cache-vllm: &cache-vllm
   cache_from:
-    - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/vllm:v${LLEM_PKG_VERSION:-dev}
     - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
 
 x-cache-tensorrt: &cache-tensorrt
   cache_from:
-    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
+    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:v${LLEM_PKG_VERSION:-dev}
     - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
 
 # Shared configuration anchor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch
 
   pytorch-dev:
@@ -108,6 +111,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/pytorch:latest
     image: llenergymeasure:pytorch-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -134,6 +140,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm
 
   vllm-dev:
@@ -151,6 +160,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
     image: llenergymeasure:vllm-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []
@@ -178,6 +190,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt
 
   tensorrt-dev:
@@ -196,6 +211,9 @@ services:
       args:
         LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
         LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+      cache_from:
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:${LLEM_PKG_VERSION:-latest}
+        - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
     image: llenergymeasure:tensorrt-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -378,6 +378,44 @@ runners:
 SGLang (M5) images will follow the same naming convention, resolution logic, and auto-pull
 behaviour. No additional setup is needed when SGLang ships.
 
+### Layer cache sharing via GHCR registry
+
+Every `docker compose build` pulls pre-computed BuildKit layers from
+`ghcr.io/henrycgbaker/llenergymeasure/{backend}:latest` (and the matching
+versioned tag when available). CI populates the cache with
+`cache-to=type=registry,mode=max,ref=…:latest` on each release, which exports
+all intermediate layers — including the heavy flash-attn FA2+FA3 compile on
+the PyTorch image — so downstream builders can consume them without
+recompiling.
+
+```
++----------------+              +------------------+              +------------------+
+| CI (release)   |  cache-to    | GHCR :latest     |  cache-from  | Local / other CI |
+| build-push-act | -----------> | mode=max layers  | -----------> | docker compose   |
++----------------+              +------------------+              +------------------+
+```
+
+Key points:
+
+- `cache-to` pushes only to `:latest` (never to immutable version tags), so
+  storage growth is bounded by image drift between releases.
+- `cache-from` reads from both `:${LLEM_PKG_VERSION}` (strongest hit during a
+  dev cycle) and `:latest` (fallback for fresh branches).
+- `LLEM_PKG_VERSION` is the cache key. Phase PRs do not bump version, so the
+  cache is shared across an entire milestone of schema churn and only
+  re-baselined at milestone releases — the correct granularity.
+- No dedicated `:buildcache` tag: the runtime image already carries the layer
+  manifest BuildKit needs, so one tag set serves both purposes.
+
+Inspect what's cached on the active builder:
+
+```bash
+docker buildx du --builder llem-builder
+```
+
+If you need to reset the builder (rare), see
+`make docker-builder-rm && make docker-builder-setup` in the Makefile.
+
 ### Image labels and versioning
 
 Every backend image is stamped at build time with OCI labels that llem reads at

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -48,7 +48,7 @@ sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plug
 ```
 
 **Verify Docker Compose and Buildx versions** (v2.32+ and v0.17+ recommended for
-[build cache](installation.md#build-cache-recommended)):
+[fast rebuilds](installation.md#fast-rebuilds-and-first-pull-cost)):
 
 ```bash
 docker compose version   # need v2.32+
@@ -355,9 +355,12 @@ make docker-build-vllm
 make docker-build-tensorrt
 ```
 
-These targets use `docker compose build` under the hood. If `COMPOSE_BAKE=true` is set in
-your `.env`, builds use the GHCR registry cache for dramatically faster builds (see
-[Build Cache](installation.md#build-cache-recommended) for details).
+These targets use `docker compose build` under the hood and pull cached layers from the
+GHCR registry on first build (see
+[Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost)
+for the full mechanism). Setting `COMPOSE_BAKE=true` in your `.env` additionally routes
+builds through `buildx bake` for parallel multi-backend builds and a cleaner progress UI;
+it is not required for the cache itself.
 
 > **When to rebuild.** Images bundle the `llenergymeasure` source at build time. If you
 > modify config models, backends, or the container entrypoint, rebuild for changes to take
@@ -508,4 +511,4 @@ llem run experiment.yaml --skip-preflight
 
 - [Getting Started](getting-started.md) — run your first vLLM or TensorRT-LLM experiment
 - [Backend Configuration](backends.md) — configure vLLM, TensorRT-LLM, and switch between backends
-- [Build Cache](installation.md#build-cache-recommended) — speed up local Docker builds with GHCR registry cache
+- [Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost) — how the GHCR layer cache speeds up local Docker builds

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -380,41 +380,16 @@ behaviour. No additional setup is needed when SGLang ships.
 
 ### Layer cache sharing via GHCR registry
 
-Every `docker compose build` pulls pre-computed BuildKit layers from
-`ghcr.io/henrycgbaker/llenergymeasure/{backend}:latest` (and the matching
-versioned tag when available). CI populates the cache with
-`cache-to=type=registry,mode=max,ref=…:latest` on each release, which exports
-all intermediate layers — including the heavy flash-attn FA2+FA3 compile on
-the PyTorch image — so downstream builders can consume them without
-recompiling.
+See [installation.md — Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost)
+for the user-facing walkthrough (mechanism, sizes, authentication, offline
+fallback).
 
-```
-+----------------+              +------------------+              +------------------+
-| CI (release)   |  cache-to    | GHCR :latest     |  cache-from  | Local / other CI |
-| build-push-act | -----------> | mode=max layers  | -----------> | docker compose   |
-+----------------+              +------------------+              +------------------+
-```
-
-Key points:
+Docker-setup-specific operator notes:
 
 - `cache-to` pushes only to `:latest` (never to immutable version tags), so
   storage growth is bounded by image drift between releases.
-- `cache-from` reads from both `:${LLEM_PKG_VERSION}` (strongest hit during a
-  dev cycle) and `:latest` (fallback for fresh branches).
-- `LLEM_PKG_VERSION` is the cache key. Phase PRs do not bump version, so the
-  cache is shared across an entire milestone of schema churn and only
-  re-baselined at milestone releases — the correct granularity.
-- No dedicated `:buildcache` tag: the runtime image already carries the layer
-  manifest BuildKit needs, so one tag set serves both purposes.
-
-Inspect what's cached on the active builder:
-
-```bash
-docker buildx du --builder llem-builder
-```
-
-If you need to reset the builder (rare), see
-`make docker-builder-rm && make docker-builder-setup` in the Makefile.
+- Inspect what's cached on the active builder: `docker buildx du --builder llem-builder`.
+- If the cache is corrupt, recreate it with `make docker-builder-rm && make docker-builder-setup`.
 
 ### Image labels and versioning
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -185,12 +185,27 @@ local layer cache (cold on a fresh builder). No errors, just slower.
 **First-pull cost:** the first build on any new machine downloads the full
 cache graph (sizes above). Subsequent builds are incremental.
 
+**How to tell if the cache actually warmed:** `make docker-build-{backend}`
+runs the build under `BUILDKIT_PROGRESS=plain` and emits a one-line summary
+when it finishes:
+
+- `✓ pytorch build: 4m 18s — GHCR cache imported, 27 layers reused` — cache
+  hit, FA3 layer not recompiled.
+- `⚠ pytorch build: 18m 03s — no GHCR cache imported (cold build)` — silent
+  fallback. Cross-check
+  [troubleshooting → Docker rebuild is slow](troubleshooting.md#docker-rebuild-is-slow--recompiling-flash-attn).
+
+The summary is computed from BuildKit's own progress markers
+(`importing cache manifest …` and `CACHED` per-stage lines), so it reflects
+actual cache behaviour, not just intent.
+
 ### FlashAttention-3
 
 The PyTorch Docker image ships with both FlashAttention-2 (FA2) and FlashAttention-3 (FA3)
 pre-built. FA3 is compiled from source during the image build, which is the slowest build
-step (~20 min). With the build cache enabled (`COMPOSE_BAKE=true`), FA3 layers are pulled
-pre-compiled and the build completes in under a minute.
+step (~20 min). On warm rebuilds the FA3 layer is reused from the GHCR cache (see
+[Fast rebuilds and first-pull cost](#fast-rebuilds-and-first-pull-cost) above) and the
+build completes in minutes.
 
 FA3 provides Hopper-optimised attention kernels. Use it via
 `pytorch.attn_implementation: flash_attention_3` in your experiment configs.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,61 +130,60 @@ for the full resolution chain.
 | `make docker-images` | Show which image each backend resolves to (local vs registry) |
 | `make docker-check` | Validate `docker-compose.yml` configuration |
 
-### Build Cache (recommended)
+### Fast rebuilds and first-pull cost
 
-Docker image builds can be slow without caching. To speed them up, pull pre-compiled layers
-from GHCR:
+Every backend image declares `cache_from` entries pointing at the published
+GHCR tags. CI populates the cache on each release with
+`cache-to=type=registry,mode=max`, which exports intermediate layers — including
+the ~15-min flash-attn FA2+FA3 compile — so any fresh machine warm-builds in
+minutes instead of re-compiling from source.
 
-| Backend | Image Size | Cold Build | Cached Rebuild |
-|---------|-----------|------------|----------------|
-| PyTorch (FA3 on) | ~8.5 GB | ~30 min | ~30 sec |
-| vLLM | ~17 GB | ~30 min | ~5 min |
-| TensorRT-LLM | ~54 GB | ~40 min | ~10 min |
+| Backend | Image Size | Cold Build (no cache) | Warm Rebuild |
+|---------|-----------|-----------------------|--------------|
+| PyTorch (FA3 on) | ~6 GB | ~15-20 min | <5 min |
+| vLLM | ~10 GB | ~20-30 min | <5 min |
+| TensorRT-LLM | ~15 GB | ~30-40 min | <5 min |
 
-Cold build = no cache, compiling from scratch. Cached rebuild = `COMPOSE_BAKE=true` with
-local BuildKit cache populated. Times depend on network speed and hardware.
+"Cold build" = fresh buildx builder, no layers cached anywhere. "Warm rebuild"
+= same builder, local image wiped, cache pulled from GHCR.
 
-**1. Enable COMPOSE_BAKE in your `.env`:**
-
-```bash
-COMPOSE_BAKE=true
-```
-
-This is already set in `.env.example`. It tells Docker Compose to delegate builds to
-BuildKit's [bake](https://docs.docker.com/build/bake/) engine, which has full support for
-registry-based build cache.
-
-**2. Build as normal:**
+**Build as normal:**
 
 ```bash
-docker compose build pytorch
+make docker-build-pytorch        # or -vllm / -tensorrt
 ```
 
-Compose will pull cached layers from GHCR (written by CI on each release) and only rebuild
-layers that have changed locally. A cached PyTorch build completes in under a minute
-instead of ~30 minutes.
+On first invocation, BuildKit pulls cached layers from
+`ghcr.io/henrycgbaker/llenergymeasure/{backend}:latest` (and the exact version
+tag when available). Subsequent rebuilds only re-execute layers whose source
+changed.
 
 **How it works:**
 
-- CI pushes build cache to GHCR on each release (`ghcr.io/henrycgbaker/llenergymeasure/{backend}:buildcache`)
-- `docker-compose.yml` has `cache_from` entries that pull from these cache images
-- `COMPOSE_BAKE=true` enables BuildKit bake delegation, which supports registry cache
-- Users only pull cache - no write access or authentication is needed for public packages
-- If cache is unavailable (network issues, not yet published), the build proceeds
-  normally without errors
+- CI's `docker-publish.yml` runs `build-push-action` with
+  `cache-to=type=registry,...,mode=max` on `:latest`, exporting full layer
+  graphs to GHCR.
+- `docker-compose.yml` has `cache_from` entries for each backend pointing at
+  both `:${LLEM_PKG_VERSION}` and `:latest`.
+- `LLEM_PKG_VERSION` is the cache key: cache is shared across an entire
+  0.X.Y dev cycle and only re-baselined at milestone releases. This is the
+  correct granularity — we don't want to invalidate the flash-attn layer
+  every time `ExperimentConfig` gains a field.
+- Users only pull cache — no write access or authentication is needed for
+  public packages.
 
-**Authentication:** The build cache packages are public. No `docker login` is required to
-pull them. If you are behind a corporate proxy or encounter rate limits, logging in with
-`docker login ghcr.io` (using a
-[personal access token](https://github.com/settings/tokens) with `read:packages` scope)
-may help.
+**Authentication:** GHCR packages are public. No `docker login` is required to
+pull them. If you hit rate limits or are behind a corporate proxy,
+`docker login ghcr.io` with a
+[personal access token](https://github.com/settings/tokens) (scope
+`read:packages`) may help.
 
-**Requirements:** Docker Compose v2.32+ and Docker Buildx v0.17+ (`docker compose version`
-and `docker buildx version` to check). If you have older versions, see the upgrade
-instructions in the [Docker Setup Guide](docker-setup.md#step-1-install-docker).
+**Offline builds:** BuildKit degrades gracefully. When the registry is
+unreachable the `cache_from` entries are skipped and the build falls back to
+local layer cache (cold on a fresh builder). No errors, just slower.
 
-**Without COMPOSE_BAKE:** Builds work normally but don't use registry cache. The `cache_from`
-entries in `docker-compose.yml` are silently ignored. No errors, just slower builds.
+**First-pull cost:** the first build on any new machine downloads the full
+cache graph (sizes above). Subsequent builds are incremental.
 
 ### FlashAttention-3
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -257,6 +257,36 @@ Notes:
 
 ---
 
+## Docker rebuild is slow / recompiling flash-attn
+
+**Symptom:** `make docker-build-pytorch` takes 15-20 minutes and BuildKit logs
+show `flash-attn` source downloads and nvcc compilation for every build.
+
+**Cause:** BuildKit's `cache_from` registry pull was skipped. Either (a) you
+are on a fresh buildx builder with no local cache, (b) you are offline or
+GHCR is unreachable, or (c) your `LLEM_PKG_VERSION` does not match any tag in
+`ghcr.io/henrycgbaker/llenergymeasure/{backend}:*`, so neither
+`:${LLEM_PKG_VERSION}` nor `:latest` had usable layers.
+
+**Fix:**
+
+1. Inspect the builder cache: `docker buildx du --builder llem-builder`. If
+   it's near-empty, BuildKit has nothing to reuse locally and will pull from
+   the registry.
+2. Verify network: `curl -I https://ghcr.io/v2/henrycgbaker/llenergymeasure/pytorch/manifests/latest`
+   should return 200 or 401 (both fine; 000/timeout means no connectivity).
+3. If you recently bumped version but CI hasn't published yet, fall back to
+   `:latest` by unsetting `LLEM_PKG_VERSION` for the build:
+   `LLEM_PKG_VERSION= docker compose build pytorch`.
+4. If the cache is corrupt, recreate the builder:
+   `make docker-builder-rm && make docker-builder-setup`. Note this discards
+   all local layer cache; the first subsequent build will repopulate from
+   GHCR.
+5. Offline is expected-slow. BuildKit degrades gracefully to a cold build —
+   no errors, just minutes.
+
+---
+
 ## Schema skew between host and Docker image
 
 **Symptom:** `llem run study.yaml` aborts before any experiment with a message

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,14 +259,21 @@ Notes:
 
 ## Docker rebuild is slow / recompiling flash-attn
 
-**Symptom:** `make docker-build-pytorch` takes 15-20 minutes and BuildKit logs
-show `flash-attn` source downloads and nvcc compilation for every build.
+**Symptom:** `make docker-build-pytorch` takes 15-20 minutes and the post-build
+summary line reports `⚠ no GHCR cache imported (cold build)` (or BuildKit
+output shows `flash-attn` source downloads and nvcc compilation for every
+build).
 
 **Cause:** BuildKit's `cache_from` registry pull was skipped. Either (a) you
 are on a fresh buildx builder with no local cache, (b) you are offline or
-GHCR is unreachable, or (c) your `LLEM_PKG_VERSION` does not match any tag in
-`ghcr.io/henrycgbaker/llenergymeasure/{backend}:*`, so neither
-`:${LLEM_PKG_VERSION}` nor `:latest` had usable layers.
+GHCR is unreachable, or (c) your `LLEM_PKG_VERSION` does not match any
+published tag (cache_from resolves to `:v${LLEM_PKG_VERSION}` and falls
+through to `:latest` — if neither has usable layers, BuildKit silently
+cold-builds).
+
+The full BuildKit log for the most recent attempt is at
+`/tmp/llem-build-{backend}.log` — grep it for `importing cache manifest` to
+see whether the registry was even reached.
 
 **Fix:**
 

--- a/scripts/docker_build_with_cache_report.sh
+++ b/scripts/docker_build_with_cache_report.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Wraps `docker compose build <backend>` with BuildKit progress=plain so the
+# cache-import status is visible in real time, then emits a single-line ✓/⚠
+# summary post-build that says whether the GHCR cache was actually used.
+#
+# Silent fallback to a cold build is BuildKit's documented behaviour when
+# cache_from cannot resolve. This wrapper exists so contributors notice when
+# a "warm" rebuild is actually cold instead of tolerating 20-minute builds.
+#
+# Usage: scripts/docker_build_with_cache_report.sh <backend>
+#        e.g. scripts/docker_build_with_cache_report.sh pytorch
+
+set -euo pipefail
+
+backend="${1:?usage: $0 <backend>}"
+log="/tmp/llem-build-${backend}.log"
+
+# progress=plain exposes per-step output including "importing cache manifest"
+# and per-stage "CACHED" markers; auto/tty hides them behind a collapsed UI.
+export BUILDKIT_PROGRESS="${BUILDKIT_PROGRESS:-plain}"
+
+start=$(date +%s)
+# tee preserves the on-screen build log; PIPESTATUS captures compose's exit.
+docker compose build "${backend}" 2>&1 | tee "${log}"
+rc=${PIPESTATUS[0]}
+elapsed=$(( $(date +%s) - start ))
+
+mins=$(( elapsed / 60 ))
+secs=$(( elapsed % 60 ))
+human=$(printf "%dm %02ds" "${mins}" "${secs}")
+
+# These two markers are stable BuildKit conventions documented in the
+# build-push-action and buildx repos; they have not changed in years.
+imported=$(grep -c "importing cache manifest from ghcr.io" "${log}" 2>/dev/null || true)
+cached_steps=$(grep -cE "^#[0-9]+ CACHED$" "${log}" 2>/dev/null || true)
+
+echo
+if [[ "${rc}" -ne 0 ]]; then
+    echo "✗ ${backend} build FAILED after ${human} (exit ${rc}) — see ${log}"
+elif [[ "${imported}" -gt 0 && "${cached_steps}" -gt 0 ]]; then
+    echo "✓ ${backend} build: ${human} — GHCR cache imported, ${cached_steps} layers reused"
+elif [[ "${imported}" -gt 0 ]]; then
+    echo "✓ ${backend} build: ${human} — GHCR cache reachable but no layers reused (source changed)"
+else
+    echo "⚠ ${backend} build: ${human} — no GHCR cache imported (cold build)"
+    echo "  see docs/troubleshooting.md → 'Docker rebuild is slow' for diagnosis"
+fi
+
+exit "${rc}"

--- a/src/llenergymeasure/infra/README.md
+++ b/src/llenergymeasure/infra/README.md
@@ -115,9 +115,10 @@ make docker-build-vllm         # just vllm
 make docker-build-tensorrt     # just tensorrt
 ```
 
-These use `docker compose build`. With `COMPOSE_BAKE=true` in `.env`, builds use the GHCR
-registry build cache for dramatically faster builds (e.g. PyTorch: ~2 min cached vs ~1 hour
-cold). See `docs/installation.md#build-cache-recommended` for details.
+These use `docker compose build` and pull cached layers from GHCR on first build
+(PyTorch: <5 min warm vs ~15-20 min cold). `COMPOSE_BAKE=true` in `.env` additionally
+enables parallel multi-backend builds via `buildx bake` but is not required for the
+cache. See `docs/installation.md#fast-rebuilds-and-first-pull-cost` for details.
 
 ### Study-level image preparation
 

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -1270,11 +1270,11 @@ class StudyRunner:
 
                 raise DockerImagePullError(
                     message=f"Image pull timed out: {image}",
-                    fix_suggestion=f"COMPOSE_BAKE=true docker compose build {backend}",
+                    fix_suggestion=f"docker compose build {backend}",
                 ) from exc
 
             if pull.returncode != 0:
-                tip = f"COMPOSE_BAKE=true docker compose build {backend}"
+                tip = f"docker compose build {backend}"
                 if self._progress:
                     self._progress.image_failed(backend, image, f"not found \u2014 run: {tip}")
                     self._progress.end_image_prep()


### PR DESCRIPTION
Warm-cache Docker rebuilds on any dev machine or CI runner by pulling BuildKit layers from GHCR. Drops fresh-builder pytorch rebuild from ~20 min to under 5 min by caching the flash-attn FA2+FA3 compile layer. Reopens the closed #257 after rebase onto main (original PR auto-closed when its stacked base was deleted).