### PR TITLE
ci(docker): share build cache via GHCR registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,11 +41,18 @@ HF_TOKEN=
 # -----------------------------------------------------------------------------
 # OPTIONAL: Build Performance
 # -----------------------------------------------------------------------------
-# Enable BuildKit bake delegation for faster Docker builds.
-# Pulls cached layers from GHCR instead of compiling locally.
-# Requires Docker Compose v2.32+. No login needed (public cache).
-# Without this, builds work fine but don't use registry cache.
-COMPOSE_BAKE=true
+# Route docker compose build through buildx bake for parallel multi-engine
+# builds and a cleaner progress UI. The GHCR layer cache works without this
+# (cache_from is honoured on the native compose build path too); leave it on
+# if you ever run `make docker-build-all`.
+# COMPOSE_BAKE=true
+
+# Surface BuildKit's per-step output (including "importing cache manifest"
+# and per-stage "CACHED" lines) so you can see whether the GHCR cache is
+# actually being used. The Makefile build targets force this on for their
+# post-build summary; export it here if you invoke `docker compose build`
+# directly and want the same visibility.
+BUILDKIT_PROGRESS=plain
 
 # -----------------------------------------------------------------------------
 # OPTIONAL: Performance/Debug

--- a/.env.example
+++ b/.env.example
@@ -39,19 +39,22 @@ HF_TOKEN=
 # LEM_ENGINE=pytorch
 
 # -----------------------------------------------------------------------------
-# OPTIONAL: Build Performance
+# OPTIONAL: Docker Build Cache
 # -----------------------------------------------------------------------------
-# Route docker compose build through buildx bake for parallel multi-engine
-# builds and a cleaner progress UI. The GHCR layer cache works without this
-# (cache_from is honoured on the native compose build path too); leave it on
-# if you ever run `make docker-build-all`.
-# COMPOSE_BAKE=true
+# These are only needed if you build images locally (most users just pull
+# from GHCR — `make docker-pull` — and never build).
+#
+# REQUIRED for the GHCR layer cache to work. The default `docker` buildx
+# driver cannot import registry cache; only the `docker-container` driver
+# can, and that's what `make docker-builder-setup` provisions. Without this
+# variable, `make docker-build-{engine}` silently falls back to a cold build
+# (0 layers reused). See docs/installation.md for the full mechanism.
+BUILDX_BUILDER=llem-builder
 
 # Surface BuildKit's per-step output (including "importing cache manifest"
-# and per-stage "CACHED" lines) so you can see whether the GHCR cache is
-# actually being used. The Makefile build targets force this on for their
-# post-build summary; export it here if you invoke `docker compose build`
-# directly and want the same visibility.
+# and per-stage "CACHED" lines). The Makefile build targets force this on
+# for their post-build summary; export it here if you invoke
+# `docker compose build` directly and want the same visibility.
 BUILDKIT_PROGRESS=plain
 
 # -----------------------------------------------------------------------------

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -47,4 +47,5 @@ jobs:
           target: runtime
           push: false
           build-args: ${{ matrix.build-args }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.engine }}:buildcache
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.engine }}:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,17 @@ jobs:
     strategy:
       matrix:
         engine: [transformers, vllm, tensorrt]
+        include:
+          # Cap nvcc parallelism on the 4-core/16 GB hosted runner. The default
+          # MAX_JOBS=32 (set in Dockerfile.transformers for developer hardware)
+          # asks for ~128 GB of peak RAM during the FA3 hopper compile,
+          # which causes the runner agent to lose its heartbeat under
+          # memory pressure and the job ends as "runner lost communication
+          # with the server". Leaving 2 cores free keeps the agent
+          # schedulable. vllm/tensorrt don't compile FA3 and ignore this arg.
+          - engine: transformers
+            extra_build_args: |
+              MAX_JOBS=2
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,6 +44,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.version }}
+
+      # The default `docker` buildx driver does not support
+      # cache-to=type=registry. Switching to `docker-container` is required
+      # for the mode=max cache export below to work — without this, the
+      # build-push-action step fails with:
+      #   ERROR: failed to build: Cache export is not supported for the
+      #   docker driver.
+      - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v4
         with:
@@ -68,3 +87,12 @@ jobs:
           build-args: |
             LLEM_PKG_VERSION=${{ inputs.version }}
             LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
+            ${{ matrix.extra_build_args }}
+          # mode=max exports intermediate layers (including the flash-attn
+          # compile) so downstream builders can reuse them, not just the final
+          # image layers.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.engine }}:latest
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.engine }}:${{ inputs.version }}
+          cache-to: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.engine }}:latest,mode=max

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: format lint lint-fix typecheck check test test-unit test-integration test-all install dev clean
 .PHONY: test-runtime test-runtime-vllm test-runtime-tensorrt test-runtime-all
 .PHONY: test-runtime-quick test-runtime-local test-runtime-docker
-.PHONY: docker-build docker-build-all docker-build-transformers docker-build-vllm docker-build-tensorrt
+.PHONY: docker-build docker-build-all docker-build-transformers docker-build-vllm docker-build-tensorrt docker-seed-transformers
 .PHONY: docker-build-dev docker-check docker-builder-setup docker-builder-rm
 .PHONY: experiment datasets validate docker-shell docker-dev
 .PHONY: setup docker-setup lem-clean lem-clean-all lem-clean-state lem-clean-cache lem-clean-trt generate-docs check-docs
@@ -271,6 +271,31 @@ docker-build-vllm:
 docker-build-tensorrt:
 	$(CACHE_HINT)
 	$(BUILD_WITH_REPORT) tensorrt
+
+# Seed GHCR build cache from a local machine with sufficient RAM.
+# Intended for seeding the Transformers image cache (FA3 Hopper compile,
+# ~30 min but memory-intensive) when the CI hosted runner cannot complete
+# the build. Requires: docker login ghcr.io, llem-builder buildx builder.
+# Set MAX_JOBS to suit your machine (8 = good default for dev hardware).
+docker-seed-transformers:
+	@version=$$(python3 -c "from llenergymeasure._version import __version__; print(__version__)" 2>/dev/null || echo "dev"); \
+	fingerprint=$$(python3 scripts/compute_expconf_fingerprint.py 2>/dev/null || echo "unknown"); \
+	max_jobs=$${MAX_JOBS:-8}; \
+	ref=ghcr.io/henrycgbaker/llenergymeasure/transformers; \
+	echo "Seeding GHCR cache for transformers (MAX_JOBS=$$max_jobs, version=$$version)"; \
+	docker buildx build \
+	  --builder $(BUILDER_NAME) \
+	  -f docker/Dockerfile.transformers \
+	  --build-arg LLEM_PKG_VERSION=$$version \
+	  --build-arg LLEM_EXPCONF_SCHEMA_FINGERPRINT=$$fingerprint \
+	  --build-arg MAX_JOBS=$$max_jobs \
+	  --cache-from type=registry,ref=$$ref:v$$version \
+	  --cache-from type=registry,ref=$$ref:latest \
+	  --cache-to   type=registry,ref=$$ref:latest,mode=max \
+	  --push \
+	  --tag $$ref:v$$version \
+	  --tag $$ref:latest \
+	  .
 
 # Pull versioned registry images (ghcr.io) instead of building locally
 docker-pull:

--- a/Makefile
+++ b/Makefile
@@ -276,19 +276,18 @@ docker-build-tensorrt:
 # Intended for seeding the Transformers image cache (FA3 Hopper compile,
 # ~30 min but memory-intensive) when the CI hosted runner cannot complete
 # the build. Requires: docker login ghcr.io, llem-builder buildx builder.
-# Set MAX_JOBS to suit your machine (8 = good default for dev hardware).
+# Uses Dockerfile default MAX_JOBS=32 — matches local layer cache so FA3
+# is not recompiled if already built locally.
 docker-seed-transformers:
 	@version=$$(python3 -c "from llenergymeasure._version import __version__; print(__version__)" 2>/dev/null || echo "dev"); \
 	fingerprint=$$(python3 scripts/compute_expconf_fingerprint.py 2>/dev/null || echo "unknown"); \
-	max_jobs=$${MAX_JOBS:-8}; \
 	ref=ghcr.io/henrycgbaker/llenergymeasure/transformers; \
-	echo "Seeding GHCR cache for transformers (MAX_JOBS=$$max_jobs, version=$$version)"; \
+	echo "Seeding GHCR cache for transformers (version=$$version)"; \
 	docker buildx build \
 	  --builder $(BUILDER_NAME) \
 	  -f docker/Dockerfile.transformers \
 	  --build-arg LLEM_PKG_VERSION=$$version \
 	  --build-arg LLEM_EXPCONF_SCHEMA_FINGERPRINT=$$fingerprint \
-	  --build-arg MAX_JOBS=$$max_jobs \
 	  --cache-from type=registry,ref=$$ref:v$$version \
 	  --cache-from type=registry,ref=$$ref:latest \
 	  --cache-to   type=registry,ref=$$ref:latest,mode=max \

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,9 @@ gpu-ci-vllm:
 # =============================================================================
 
 
-# Builder name used by COMPOSE_BAKE for registry-cached builds
+# Builder name read by docker compose / buildx via BUILDX_BUILDER for
+# registry-cached builds. The docker-container driver is required to import
+# cache_from registry refs (the default `docker` driver cannot).
 BUILDER_NAME := llem-builder
 
 # Create the BuildKit builder with tuned GC limits (200 GiB).

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: format lint lint-fix typecheck check test test-unit test-integration test-all install dev clean
 .PHONY: test-runtime test-runtime-vllm test-runtime-tensorrt test-runtime-all
 .PHONY: test-runtime-quick test-runtime-local test-runtime-docker
-.PHONY: docker-build docker-build-all docker-build-vllm docker-build-tensorrt
+.PHONY: docker-build docker-build-all docker-build-transformers docker-build-vllm docker-build-tensorrt
 .PHONY: docker-build-dev docker-check docker-builder-setup docker-builder-rm
 .PHONY: experiment datasets validate docker-shell docker-dev
 .PHONY: setup docker-setup lem-clean lem-clean-all lem-clean-state lem-clean-cache lem-clean-trt generate-docs check-docs
@@ -247,24 +247,35 @@ docker-builder-setup:
 docker-builder-rm:
 	docker buildx rm $(BUILDER_NAME) 2>/dev/null || true
 
-# Build all engines (pytorch, vllm, tensorrt) — local images
-docker-build-all:
-	docker compose build pytorch vllm tensorrt
+CACHE_HINT := @echo "First build pulls cache layers from ghcr.io; warm rebuilds < 5 min."
+BUILD_WITH_REPORT := scripts/docker_build_with_cache_report.sh
 
-# Build PyTorch engine (default, recommended for most users)
-docker-build-pytorch:
-	docker compose build pytorch
+# Build all engines (transformers, vllm, tensorrt) — local images.
+# Calls compose directly so all three can build in parallel;
+# per-engine cache-import summary is only emitted for single-engine targets
+# below. For per-engine diagnostics, run `make docker-build-{engine}`.
+docker-build-all:
+	$(CACHE_HINT)
+	BUILDKIT_PROGRESS=$${BUILDKIT_PROGRESS:-plain} docker compose build transformers vllm tensorrt
+
+# Build Transformers engine (default, recommended for most users)
+docker-build-transformers:
+	$(CACHE_HINT)
+	$(BUILD_WITH_REPORT) transformers
+
 # Build specific engines — local images
 docker-build-vllm:
-	docker compose build vllm
+	$(CACHE_HINT)
+	$(BUILD_WITH_REPORT) vllm
 
 docker-build-tensorrt:
-	docker compose build tensorrt
+	$(CACHE_HINT)
+	$(BUILD_WITH_REPORT) tensorrt
 
 # Pull versioned registry images (ghcr.io) instead of building locally
 docker-pull:
 	@version=$$(python3 -c "from llenergymeasure._version import __version__; print(__version__)" 2>/dev/null || echo "latest"); \
-	for engine in pytorch vllm tensorrt; do \
+	for engine in transformers vllm tensorrt; do \
 		echo "Pulling ghcr.io/henrycgbaker/llenergymeasure/$$engine:v$$version"; \
 		docker pull "ghcr.io/henrycgbaker/llenergymeasure/$$engine:v$$version"; \
 	done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,30 @@
 #   docker compose --profile dev run --rm vllm-dev /bin/bash
 #   docker compose --profile dev run --rm tensorrt-dev /bin/bash
 
+# Per-engine BuildKit layer cache (shared across runtime + dev services).
+# Two sources, in priority order:
+#   1. :v${LLEM_PKG_VERSION} — exact-version image layers from the matching
+#      release. Note the literal `v`: published tags carry a `v` prefix (set by
+#      release.yml) but LLEM_PKG_VERSION is bare semver (from _version.py), so
+#      we have to add the prefix here. On dev versions (`vdev`) this entry
+#      silently misses, which is fine — the next entry catches it.
+#   2. :latest — rolling cache published by docker-publish.yml with mode=max,
+#      which exports intermediate layers (including the flash-attn compile).
+x-cache-transformers: &cache-transformers
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/transformers:v${LLEM_PKG_VERSION:-dev}
+    - ghcr.io/henrycgbaker/llenergymeasure/transformers:latest
+
+x-cache-vllm: &cache-vllm
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/vllm:v${LLEM_PKG_VERSION:-dev}
+    - ghcr.io/henrycgbaker/llenergymeasure/vllm:latest
+
+x-cache-tensorrt: &cache-tensorrt
+  cache_from:
+    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:v${LLEM_PKG_VERSION:-dev}
+    - ghcr.io/henrycgbaker/llenergymeasure/tensorrt:latest
+
 # Shared configuration anchor
 x-common: &common
   # PUID/PGID pattern for host permission mapping (like LinuxServer.io)
@@ -87,6 +111,7 @@ services:
       # Named volumes: container-managed (no permission issues)
       - hf-cache:/app/.cache/huggingface
     build:
+      <<: *cache-transformers
       context: .
       dockerfile: docker/Dockerfile.transformers
       target: runtime
@@ -102,6 +127,7 @@ services:
       - hf-cache:/app/.cache/huggingface
     profiles: ["dev"]
     build:
+      <<: *cache-transformers
       context: .
       dockerfile: docker/Dockerfile.transformers
       target: dev
@@ -128,6 +154,7 @@ services:
       # Named volumes: container-managed (no permission issues)
       - hf-cache:/app/.cache/huggingface
     build:
+      <<: *cache-vllm
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: runtime
@@ -145,6 +172,7 @@ services:
       - hf-cache:/app/.cache/huggingface
     profiles: ["dev"]
     build:
+      <<: *cache-vllm
       context: .
       dockerfile: docker/Dockerfile.vllm
       target: dev
@@ -172,6 +200,7 @@ services:
       - hf-cache:/app/.cache/huggingface
       - trt-engine-cache:/app/.cache/tensorrt-engines
     build:
+      <<: *cache-tensorrt
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: runtime
@@ -190,6 +219,7 @@ services:
       - trt-engine-cache:/app/.cache/tensorrt-engines
     profiles: ["dev"]
     build:
+      <<: *cache-tensorrt
       context: .
       dockerfile: docker/Dockerfile.tensorrt
       target: dev

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -48,7 +48,7 @@ sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plug
 ```
 
 **Verify Docker Compose and Buildx versions** (v2.32+ and v0.17+ recommended for
-[build cache](installation.md#build-cache-recommended)):
+[fast rebuilds](installation.md#fast-rebuilds-and-first-pull-cost)):
 
 ```bash
 docker compose version   # need v2.32+
@@ -355,9 +355,12 @@ make docker-build-vllm
 make docker-build-tensorrt
 ```
 
-These targets use `docker compose build` under the hood. If `COMPOSE_BAKE=true` is set in
-your `.env`, builds use the GHCR registry cache for dramatically faster builds (see
-[Build Cache](installation.md#build-cache-recommended) for details).
+These targets use `docker compose build` under the hood and pull cached layers from the
+GHCR registry on first build (see
+[Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost)
+for the full mechanism). Setting `COMPOSE_BAKE=true` in your `.env` additionally routes
+builds through `buildx bake` for parallel multi-engine builds and a cleaner progress UI;
+it is not required for the cache itself.
 
 > **When to rebuild.** Images bundle the `llenergymeasure` source at build time. If you
 > modify config models, engines, or the container entrypoint, rebuild for changes to take
@@ -377,6 +380,18 @@ runners:
 
 SGLang (M5) images will follow the same naming convention, resolution logic, and auto-pull
 behaviour. No additional setup is needed when SGLang ships.
+
+### Layer cache sharing via GHCR registry
+
+See [installation.md — Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost)
+for the user-facing walkthrough (mechanism, sizes, authentication, offline fallback).
+
+Operator notes:
+
+- `cache-to` pushes only to `:latest` (never to immutable version tags), so
+  storage growth is bounded by image drift between releases.
+- Inspect what's cached on the active builder: `docker buildx du --builder llem-builder`.
+- If the cache is corrupt, recreate it with `make docker-builder-rm && make docker-builder-setup`.
 
 ### Image labels and versioning
 
@@ -495,4 +510,4 @@ llem run experiment.yaml --skip-preflight
 
 - [Getting Started](getting-started.md) — run your first vLLM or TensorRT-LLM experiment
 - [Engine Configuration](engines.md) — configure vLLM, TensorRT-LLM, and switch between engines
-- [Build Cache](installation.md#build-cache-recommended) — speed up local Docker builds with GHCR registry cache
+- [Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost) — how the GHCR layer cache speeds up local Docker builds

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -358,9 +358,13 @@ make docker-build-tensorrt
 These targets use `docker compose build` under the hood and pull cached layers from the
 GHCR registry on first build (see
 [Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost)
-for the full mechanism). Setting `COMPOSE_BAKE=true` in your `.env` additionally routes
-builds through `buildx bake` for parallel multi-engine builds and a cleaner progress UI;
-it is not required for the cache itself.
+for the full mechanism).
+
+> **Advanced.** Setting `COMPOSE_BAKE=true` routes builds through `buildx bake` for
+> parallel multi-engine builds. With the current cache architecture this is rarely
+> worth enabling — vLLM/TRT cold builds are already 4–13 min and warm rebuilds are
+> seconds, so the parallelism gain is small. Left out of `.env.example` to avoid
+> noise; opt in only if you frequently run `make docker-build-all` from cold.
 
 > **When to rebuild.** Images bundle the `llenergymeasure` source at build time. If you
 > modify config models, engines, or the container entrypoint, rebuild for changes to take

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,68 +130,71 @@ for the full resolution chain.
 | `make docker-images` | Show which image each engine resolves to (local vs registry) |
 | `make docker-check` | Validate `docker-compose.yml` configuration |
 
-### Build Cache (recommended)
+### Fast rebuilds and first-pull cost
 
-Docker image builds can be slow without caching. To speed them up, pull pre-compiled layers
-from GHCR:
+Every engine image declares `cache_from` entries pointing at the published GHCR tags.
+CI populates the cache on each release with `cache-to=type=registry,mode=max`, which
+exports intermediate layers — including the ~15-min flash-attn FA2+FA3 compile — so
+any fresh machine warm-builds in minutes instead of re-compiling from source.
 
-| Engine | Image Size | Cold Build | Cached Rebuild |
-|---------|-----------|------------|----------------|
-| Transformers (FA3 on) | ~8.5 GB | ~30 min | ~30 sec |
-| vLLM | ~17 GB | ~30 min | ~5 min |
+| Engine | Image Size | Cold Build | Warm Rebuild |
+|---------|-----------|------------|--------------|
+| Transformers (FA3 on) | ~8.5 GB | ~30 min | <5 min |
+| vLLM | ~17 GB | ~30 min | <5 min |
 | TensorRT-LLM | ~54 GB | ~40 min | ~10 min |
 
-Cold build = no cache, compiling from scratch. Cached rebuild = `COMPOSE_BAKE=true` with
-local BuildKit cache populated. Times depend on network speed and hardware.
+"Cold build" = fresh buildx builder, no layers cached anywhere. "Warm rebuild"
+= local image wiped, cache layers pulled from GHCR.
 
-**1. Enable COMPOSE_BAKE in your `.env`:**
-
-```bash
-COMPOSE_BAKE=true
-```
-
-This is already set in `.env.example`. It tells Docker Compose to delegate builds to
-BuildKit's [bake](https://docs.docker.com/build/bake/) engine, which has full support for
-registry-based build cache.
-
-**2. Build as normal:**
+**Build as normal:**
 
 ```bash
-docker compose build pytorch
+make docker-build-transformers   # or docker-build-vllm / docker-build-tensorrt
 ```
 
-Compose will pull cached layers from GHCR (written by CI on each release) and only rebuild
-layers that have changed locally. A cached Transformers build completes in under a minute
-instead of ~30 minutes.
+On first invocation, BuildKit pulls cached layers from
+`ghcr.io/henrycgbaker/llenergymeasure/{engine}:latest` (and the exact version tag when
+available). Subsequent rebuilds only re-execute layers whose source changed.
 
 **How it works:**
 
-- CI pushes build cache to GHCR on each release (`ghcr.io/henrycgbaker/llenergymeasure/{engine}:buildcache`)
-- `docker-compose.yml` has `cache_from` entries that pull from these cache images
-- `COMPOSE_BAKE=true` enables BuildKit bake delegation, which supports registry cache
-- Users only pull cache - no write access or authentication is needed for public packages
-- If cache is unavailable (network issues, not yet published), the build proceeds
-  normally without errors
+- CI's `docker-publish.yml` runs `build-push-action` with `cache-to=type=registry,...,mode=max`
+  on `:latest`, exporting full layer graphs including intermediate compile steps to GHCR.
+- `docker-compose.yml` has `cache_from` entries for each engine pointing at
+  both `:v${LLEM_PKG_VERSION}` and `:latest`.
+- `LLEM_PKG_VERSION` is the cache key: shared across an entire 0.X.Y dev cycle and only
+  re-baselined at milestone releases — the flash-attn layer survives `ExperimentConfig`
+  field additions between releases.
+- Users only pull cache — no write access or authentication is needed for public packages.
 
-**Authentication:** The build cache packages are public. No `docker login` is required to
-pull them. If you are behind a corporate proxy or encounter rate limits, logging in with
-`docker login ghcr.io` (using a
-[personal access token](https://github.com/settings/tokens) with `read:packages` scope)
-may help.
+**How to tell if the cache actually warmed:** `make docker-build-{engine}` runs the build
+under `BUILDKIT_PROGRESS=plain` and emits a one-line summary when it finishes:
 
-**Requirements:** Docker Compose v2.32+ and Docker Buildx v0.17+ (`docker compose version`
-and `docker buildx version` to check). If you have older versions, see the upgrade
-instructions in the [Docker Setup Guide](docker-setup.md#step-1-install-docker).
+- `✓ transformers build: 4m 18s — GHCR cache imported, 27 layers reused` — cache hit,
+  FA3 layer not recompiled.
+- `⚠ transformers build: 18m 03s — no GHCR cache imported (cold build)` — silent fallback.
+  Cross-check [troubleshooting → Docker rebuild is slow](troubleshooting.md#docker-rebuild-is-slow--recompiling-flash-attn).
 
-**Without COMPOSE_BAKE:** Builds work normally but don't use registry cache. The `cache_from`
-entries in `docker-compose.yml` are silently ignored. No errors, just slower builds.
+The full BuildKit log for the most recent build is at `/tmp/llem-build-{engine}.log`.
+
+**Authentication:** GHCR packages are public. No `docker login` is required to pull them.
+If you hit rate limits or are behind a corporate proxy, `docker login ghcr.io` with a
+[personal access token](https://github.com/settings/tokens) (scope `read:packages`) may help.
+
+**Offline builds:** BuildKit degrades gracefully. When the registry is unreachable the
+`cache_from` entries are skipped and the build falls back to local layer cache (cold on a
+fresh builder). No errors, just slower.
+
+**First-pull cost:** the first build on any new machine downloads the full cache graph
+(sizes above). Subsequent builds are incremental.
 
 ### FlashAttention-3
 
 The Transformers Docker image ships with both FlashAttention-2 (FA2) and FlashAttention-3 (FA3)
 pre-built. FA3 is compiled from source during the image build, which is the slowest build
-step (~20 min). With the build cache enabled (`COMPOSE_BAKE=true`), FA3 layers are pulled
-pre-compiled and the build completes in under a minute.
+step (~20 min). On warm rebuilds the FA3 layer is reused from the GHCR cache (see
+[Fast rebuilds and first-pull cost](#fast-rebuilds-and-first-pull-cost) above) and the
+build completes in minutes.
 
 FA3 provides Hopper-optimised attention kernels. Use it via
 `transformers.attn_implementation: flash_attention_3` in your experiment configs.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -217,6 +217,18 @@ The full BuildKit log for the most recent build is at `/tmp/llem-build-{engine}.
 If you hit rate limits or are behind a corporate proxy, `docker login ghcr.io` with a
 [personal access token](https://github.com/settings/tokens) (scope `read:packages`) may help.
 
+**Push access (contributors).** You do not need push access to develop on this project —
+contributors only ever pull cache. Cache publication on releases is fully automated by
+`docker-publish.yml` using the repo's auto-issued `GITHUB_TOKEN`, so any merged release
+PR ships a fresh cache without human intervention. Manual seeding via
+`make docker-seed-transformers` is restricted to the package owner (the packages live
+under the `henrycgbaker` user namespace, not an org); this is the standard OSS pattern
+for solo-maintained projects and reflects the supply-chain principle that manual pushes
+should bypass neither code review nor CI. If you have a legitimate need to push the
+cache manually (e.g. infra recovery, base-image emergency reseed), open an issue and
+the maintainer can either publish on your behalf or grant per-package collaborator
+access in GHCR settings.
+
 **Offline builds:** BuildKit degrades gracefully. When the registry is unreachable the
 `cache_from` entries are skipped and the build falls back to local layer cache (cold on a
 fresh builder). No errors, just slower.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,19 +132,50 @@ for the full resolution chain.
 
 ### Fast rebuilds and first-pull cost
 
+> **Most users never need to build.** `make docker-pull` (or letting `llem run`
+> resolve the registry image automatically) gives you a working environment with
+> no compilation. Building from source is for contributors and for hosts where
+> you've modified `src/llenergymeasure/`.
+
 Every engine image declares `cache_from` entries pointing at the published GHCR tags.
 CI populates the cache on each release with `cache-to=type=registry,mode=max`, which
-exports intermediate layers — including the ~15-min flash-attn FA2+FA3 compile — so
-any fresh machine warm-builds in minutes instead of re-compiling from source.
+exports intermediate layers to `ghcr.io/henrycgbaker/llenergymeasure/{engine}:latest`
+(and the immutable `:v${LLEM_PKG_VERSION}` tag). For Transformers this lets fresh
+machines skip the ~30-min flash-attn FA3 Hopper compile.
 
-| Engine | Image Size | Cold Build | Warm Rebuild |
-|---------|-----------|------------|--------------|
-| Transformers (FA3 on) | ~8.5 GB | ~30 min | <5 min |
-| vLLM | ~17 GB | ~30 min | <5 min |
-| TensorRT-LLM | ~54 GB | ~40 min | ~10 min |
+Measured on `ds01` (AMD EPYC 7742, 128 cores, 504 GB RAM — Docker 27.0.3 / Buildx
+v0.32.1 / llenergymeasure 0.9.0):
 
-"Cold build" = fresh buildx builder, no layers cached anywhere. "Warm rebuild"
-= local image wiped, cache layers pulled from GHCR.
+| Engine | Image size | Cold build | First GHCR pull | Warm local rebuild |
+|--------|-----------|------------|-----------------|--------------------|
+| Transformers | 7.9 GB | 33m 56s | 2m 33s (10 layers reused) | seconds |
+| vLLM | 15.6 GB | 4m 12s | 4m 16s (0 layers reused) | seconds |
+| TensorRT-LLM | 50.6 GB | 13m 24s | 13m 32s (0 layers reused) | seconds |
+
+**Reading the table.** Times are measured on a 128-core/504 GB host; on smaller
+machines cold builds scale roughly with `MAX_JOBS` (FA3 compile is CPU-bound).
+
+- **Cold build** — fresh builder, `--no-cache`, no GHCR. Simulates an offline
+  first-ever build.
+- **First GHCR pull** — fresh builder, `cache_from` populated. What a new
+  contributor gets after `make docker-builder-setup`.
+- **Warm local rebuild** — second and subsequent local builds. Stable layers
+  (FA3, base deps) sit before `COPY src/` in the Dockerfiles, so source-only
+  edits typically rebuild in seconds for all three engines.
+
+**Why does the GHCR cache only help Transformers?** The vLLM and TensorRT-LLM
+images are thin layers (`COPY src/` + one `pip install`) on top of heavy
+upstream bases (`vllm/vllm-openai`, `nvcr.io/nvidia/tensorrt-llm/release`).
+The dominant cost on a fresh machine is pulling that upstream base from Docker
+Hub / NGC, which BuildKit's `cache_from` cannot accelerate — only layers from
+*our* Dockerfile are eligible. Our own steps add ~30 s on top, so even a perfect
+cache hit caps the saving at ~30 s. The cache is still wired up (and works for
+`:v${LLEM_PKG_VERSION}`-pinned rebuilds within a release) but the architecture
+limits its impact for these two engines. Transformers benefits because the FA3
+compile is in our Dockerfile, ahead of `COPY src/`, so it gets cached.
+
+Once the upstream base is in local Docker storage (after the first build),
+subsequent rebuilds for vLLM/TRT are seconds — the slow part doesn't repeat.
 
 **Build as normal:**
 
@@ -152,20 +183,25 @@ any fresh machine warm-builds in minutes instead of re-compiling from source.
 make docker-build-transformers   # or docker-build-vllm / docker-build-tensorrt
 ```
 
-On first invocation, BuildKit pulls cached layers from
-`ghcr.io/henrycgbaker/llenergymeasure/{engine}:latest` (and the exact version tag when
-available). Subsequent rebuilds only re-execute layers whose source changed.
+**How the cache pipeline is wired:**
 
-**How it works:**
-
-- CI's `docker-publish.yml` runs `build-push-action` with `cache-to=type=registry,...,mode=max`
-  on `:latest`, exporting full layer graphs including intermediate compile steps to GHCR.
-- `docker-compose.yml` has `cache_from` entries for each engine pointing at
-  both `:v${LLEM_PKG_VERSION}` and `:latest`.
-- `LLEM_PKG_VERSION` is the cache key: shared across an entire 0.X.Y dev cycle and only
-  re-baselined at milestone releases — the flash-attn layer survives `ExperimentConfig`
-  field additions between releases.
-- Users only pull cache — no write access or authentication is needed for public packages.
+- CI's `docker-publish.yml` runs `build-push-action` with
+  `cache-to=type=registry,...,mode=max` on each release, exporting the full layer
+  graph (including FA3 intermediates) to two refs:
+  `ghcr.io/henrycgbaker/llenergymeasure/{engine}:v${LLEM_PKG_VERSION}` (immutable
+  per release) and `:latest` (rolling).
+- `docker-compose.yml` declares `cache_from: [:v${LLEM_PKG_VERSION}, :latest]`
+  for every engine — version-pinned first (best layer match within a release),
+  rolling-latest as fallback.
+- `make docker-builder-setup` provisions a `docker-container` BuildKit driver
+  with a 200 GiB GC limit; the default `docker` driver cannot import registry
+  caches at all.
+- The Transformers FA3 compile (the only layer where caching is load-bearing)
+  exceeds GitHub-hosted runner capacity (4 cores / 16 GB), so the seed step is
+  manual: `make docker-seed-transformers` from a host with ≥32 cores and
+  `docker login ghcr.io` (`write:packages`). After the seed, CI rebuilds warm
+  off `:latest` for every subsequent release.
+- Pulling the cache is unauthenticated for public packages.
 
 **How to tell if the cache actually warmed:** `make docker-build-{engine}` runs the build
 under `BUILDKIT_PROGRESS=plain` and emits a one-line summary when it finishes:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -264,12 +264,22 @@ summary line reports `⚠ no GHCR cache imported (cold build)` (or BuildKit
 output shows `flash-attn` source downloads and nvcc compilation for every
 build).
 
-**Cause:** BuildKit's `cache_from` registry pull was skipped. Either (a) you
-are on a fresh buildx builder with no local cache, (b) you are offline or
-GHCR is unreachable, or (c) your `LLEM_PKG_VERSION` does not match any
-published tag (cache_from resolves to `:v${LLEM_PKG_VERSION}` and falls
-through to `:latest` — if neither has usable layers, BuildKit silently
-cold-builds).
+**Cause:** BuildKit's `cache_from` registry pull was skipped. In rough order
+of likelihood:
+
+(a) **`BUILDX_BUILDER` is unset or pointing at the default `docker` driver.**
+    The default driver cannot import registry caches at all — `cache_from`
+    entries are silently ignored. Confirm with `docker buildx ls`: the row
+    marked with `*` (current builder) must show driver `docker-container`,
+    not `docker`. Fix by adding `BUILDX_BUILDER=llem-builder` to your `.env`
+    (it ships in `.env.example`) and re-running `make docker-builder-setup`
+    if the builder doesn't exist yet.
+(b) You are on a fresh buildx builder with no local cache (this is normal
+    on the very first build — first-pull cost is paid once).
+(c) You are offline or GHCR is unreachable.
+(d) Your `LLEM_PKG_VERSION` does not match any published tag (cache_from
+    resolves to `:v${LLEM_PKG_VERSION}` and falls through to `:latest` —
+    if neither has usable layers, BuildKit silently cold-builds).
 
 The full BuildKit log for the most recent attempt is at
 `/tmp/llem-build-{engine}.log` — grep it for `importing cache manifest` to
@@ -277,6 +287,10 @@ see whether the registry was even reached.
 
 **Fix:**
 
+0. Confirm the builder driver: `docker buildx ls`. The active builder
+   (marked `*`) must be `docker-container`. If it's `docker`, run
+   `make docker-builder-setup` and ensure `BUILDX_BUILDER=llem-builder` is
+   in your `.env` (or exported in the shell).
 1. Inspect the builder cache: `docker buildx du --builder llem-builder`. If
    it's near-empty, BuildKit has nothing to reuse locally and will pull from
    the registry.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -257,6 +257,43 @@ Notes:
 
 ---
 
+## Docker rebuild is slow / recompiling flash-attn
+
+**Symptom:** `make docker-build-transformers` takes 15-20 minutes and the post-build
+summary line reports `⚠ no GHCR cache imported (cold build)` (or BuildKit
+output shows `flash-attn` source downloads and nvcc compilation for every
+build).
+
+**Cause:** BuildKit's `cache_from` registry pull was skipped. Either (a) you
+are on a fresh buildx builder with no local cache, (b) you are offline or
+GHCR is unreachable, or (c) your `LLEM_PKG_VERSION` does not match any
+published tag (cache_from resolves to `:v${LLEM_PKG_VERSION}` and falls
+through to `:latest` — if neither has usable layers, BuildKit silently
+cold-builds).
+
+The full BuildKit log for the most recent attempt is at
+`/tmp/llem-build-{engine}.log` — grep it for `importing cache manifest` to
+see whether the registry was even reached.
+
+**Fix:**
+
+1. Inspect the builder cache: `docker buildx du --builder llem-builder`. If
+   it's near-empty, BuildKit has nothing to reuse locally and will pull from
+   the registry.
+2. Verify network: `curl -I https://ghcr.io/v2/henrycgbaker/llenergymeasure/transformers/manifests/latest`
+   should return 200 or 401 (both fine; 000/timeout means no connectivity).
+3. If you recently bumped version but CI hasn't published yet, fall back to
+   `:latest` by unsetting `LLEM_PKG_VERSION` for the build:
+   `LLEM_PKG_VERSION= docker compose build transformers`.
+4. If the cache is corrupt, recreate the builder:
+   `make docker-builder-rm && make docker-builder-setup`. Note this discards
+   all local layer cache; the first subsequent build will repopulate from
+   GHCR.
+5. Offline is expected-slow. BuildKit degrades gracefully to a cold build —
+   no errors, just minutes.
+
+---
+
 ## Schema skew between host and Docker image
 
 **Symptom:** `llem run study.yaml` aborts before any experiment with a message

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -298,7 +298,7 @@ runner. Seed the GHCR cache once from a developer machine with more resources:
 
 ```bash
 docker login ghcr.io           # needs write:packages scope
-make docker-seed-transformers  # builds + pushes cache to ghcr.io (MAX_JOBS=8 default)
+make docker-seed-transformers  # builds + pushes cache to ghcr.io (~minutes if locally cached)
 ```
 
 After seeding, CI warm-rebuilds from the GHCR cache in <5 min.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -292,6 +292,17 @@ see whether the registry was even reached.
 5. Offline is expected-slow. BuildKit degrades gracefully to a cold build —
    no errors, just minutes.
 
+**CI can't build the Transformers image (FA3 compile OOM / heartbeat loss):**
+The FA3 Hopper compile requires ~8-16 GB RAM and multiple hours on a 4-core
+runner. Seed the GHCR cache once from a developer machine with more resources:
+
+```bash
+docker login ghcr.io           # needs write:packages scope
+make docker-seed-transformers  # builds + pushes cache to ghcr.io (MAX_JOBS=8 default)
+```
+
+After seeding, CI warm-rebuilds from the GHCR cache in <5 min.
+
 ---
 
 ## Schema skew between host and Docker image

--- a/scripts/benchmark_docker_builds.sh
+++ b/scripts/benchmark_docker_builds.sh
@@ -77,14 +77,18 @@ run_build() {
     BUILDKIT_PROGRESS=plain docker compose build "$@" "$engine" >"$log" 2>&1
     t1=$(date +%s)
     local secs=$(( t1 - t0 ))
-    local cached; cached=$(grep -cE "^#[0-9]+ CACHED$" "$log" 2>/dev/null || true)
-    local imported; imported=$(grep -c "importing cache manifest from ghcr.io" "$log" 2>/dev/null || true)
+    # grep -c exits 1 on zero matches; || echo 0 keeps the value numeric
+    # (|| true would leave an empty string under set -euo pipefail).
+    local cached; cached=$(grep -cE "^#[0-9]+ CACHED$" "$log" 2>/dev/null || echo 0)
+    local imported; imported=$(grep -c "importing cache manifest from ghcr.io" "$log" 2>/dev/null || echo 0)
     echo "$secs $cached $imported"
 }
 
 image_size() {
-    docker image inspect "llenergymeasure:${1}" --format '{{.Size}}' 2>/dev/null \
-        | awk '{printf "%.1f GB", $1/1073741824}' || echo "not built"
+    local bytes
+    bytes=$(docker image inspect "llenergymeasure:${1}" --format '{{.Size}}' 2>/dev/null) \
+        || { echo "not built"; return; }
+    awk -v b="$bytes" 'BEGIN {printf "%.1f GB", b/1073741824}'
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/benchmark_docker_builds.sh
+++ b/scripts/benchmark_docker_builds.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Benchmark Docker build times for documentation.
+#
+# Measures two scenarios:
+#   1. Cold build     — no cache anywhere (--no-cache); simulates offline / first-ever build
+#   2. First GHCR pull — fresh builder, layers pulled from GHCR registry cache
+#
+# Warm local rebuild is intentionally NOT benchmarked: it depends entirely on which
+# layers changed and is documented in prose (only changed layers re-execute; stable
+# expensive layers like FA3 are placed early in the Dockerfile by design).
+#
+# Usage:
+#   scripts/benchmark_docker_builds.sh                         # GHCR pull only (fast)
+#   scripts/benchmark_docker_builds.sh --cold                  # also cold build (slow!)
+#   scripts/benchmark_docker_builds.sh --engines transformers  # single engine
+#   scripts/benchmark_docker_builds.sh --engines vllm,tensorrt # subset
+#
+# Output: markdown suitable for pasting into docs/installation.md
+#
+# Requirements:
+#   - llem-builder buildx builder (make docker-builder-setup)
+#   - GHCR cache seeded (make docker-seed-transformers + CI published vllm/tensorrt)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+ENGINES="transformers vllm tensorrt"
+RUN_COLD=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --engines) ENGINES="${2//,/ }"; shift 2 ;;
+        --cold)    RUN_COLD=true; shift ;;
+        *)         echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+BUILDER_NAME="${BUILDX_BUILDER:-llem-builder}"
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+
+# ---------------------------------------------------------------------------
+# System info
+# ---------------------------------------------------------------------------
+cpu_model=$(grep -m1 "model name" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | xargs || echo "unknown")
+cpu_cores=$(nproc)
+ram_gb=$(awk '/MemTotal/ {printf "%.0f", $2/1024/1024}' /proc/meminfo 2>/dev/null || echo "unknown")
+docker_ver=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "unknown")
+buildx_ver=$(docker buildx version 2>/dev/null | awk '{print $2}' || echo "unknown")
+pkg_ver=$(python3 -c "from llenergymeasure._version import __version__; print(__version__)" 2>/dev/null || echo "unknown")
+hostname_str=$(hostname -s 2>/dev/null || echo "unknown")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+fmt_time() { printf "%dm %02ds" $(($1 / 60)) $(($1 % 60)); }
+
+builder_reset() {
+    echo "  [resetting builder '${BUILDER_NAME}'...]" >&2
+    docker buildx rm "$BUILDER_NAME" 2>/dev/null || true
+    docker buildx create \
+        --name "$BUILDER_NAME" \
+        --driver docker-container \
+        --driver-opt network=host \
+        --buildkitd-flags '--allow-insecure-entitlement network.host' \
+        >/dev/null 2>&1 || true
+    docker buildx use "$BUILDER_NAME"
+}
+
+run_build() {
+    # run_build <engine> [extra compose flags]
+    local engine=$1; shift
+    local log="/tmp/llem-bench-${engine}-$$.log"
+    local t0 t1
+    t0=$(date +%s)
+    BUILDKIT_PROGRESS=plain docker compose build "$@" "$engine" >"$log" 2>&1
+    t1=$(date +%s)
+    local secs=$(( t1 - t0 ))
+    local cached; cached=$(grep -cE "^#[0-9]+ CACHED$" "$log" 2>/dev/null || true)
+    local imported; imported=$(grep -c "importing cache manifest from ghcr.io" "$log" 2>/dev/null || true)
+    echo "$secs $cached $imported"
+}
+
+image_size() {
+    docker image inspect "llenergymeasure:${1}" --format '{{.Size}}' 2>/dev/null \
+        | awk '{printf "%.1f GB", $1/1073741824}' || echo "not built"
+}
+
+# ---------------------------------------------------------------------------
+# Storage for results
+# ---------------------------------------------------------------------------
+declare -A COLD_SECS GHCR_SECS GHCR_LAYERS SIZE
+
+# ---------------------------------------------------------------------------
+# Scenario 2: First GHCR pull  (always run)
+# ---------------------------------------------------------------------------
+echo "" >&2
+echo "=== Scenario 2: First GHCR pull ===" >&2
+for engine in $ENGINES; do
+    echo "  $engine..." >&2
+    builder_reset
+    read -r secs cached imported <<< "$(run_build "$engine")"
+    GHCR_SECS[$engine]=$secs
+    GHCR_LAYERS[$engine]=$cached
+    echo "  → $(fmt_time $secs), ${cached} layers reused, registry_hit=${imported}" >&2
+done
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Cold build  (opt-in — slow)
+# ---------------------------------------------------------------------------
+if $RUN_COLD; then
+    echo "" >&2
+    echo "=== Scenario 1: Cold build (--no-cache) ===" >&2
+    for engine in $ENGINES; do
+        echo "  $engine  (this may take 20-60+ min for transformers)..." >&2
+        builder_reset
+        read -r secs cached imported <<< "$(run_build "$engine" "--no-cache")"
+        COLD_SECS[$engine]=$secs
+        echo "  → $(fmt_time $secs)" >&2
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Image sizes  (post-build)
+# ---------------------------------------------------------------------------
+for engine in $ENGINES; do
+    SIZE[$engine]=$(image_size "$engine")
+done
+
+# ---------------------------------------------------------------------------
+# Markdown output
+# ---------------------------------------------------------------------------
+echo ""
+echo "<!-- benchmark output — paste into docs/installation.md -->"
+echo ""
+echo "Measured on **\`$hostname_str\`** — $cpu_model, $cpu_cores cores,"
+echo "${ram_gb} GB RAM — Docker $docker_ver / Buildx $buildx_ver / llenergymeasure $pkg_ver"
+echo ""
+
+if $RUN_COLD; then
+    echo "| Engine | Image size | Cold build | First GHCR pull |"
+    echo "|--------|-----------|------------|-----------------|"
+    for engine in $ENGINES; do
+        echo "| ${engine^} | ${SIZE[$engine]} | $(fmt_time ${COLD_SECS[$engine]:-0}) | $(fmt_time ${GHCR_SECS[$engine]}) (${GHCR_LAYERS[$engine]} layers reused) |"
+    done
+else
+    echo "| Engine | Image size | First GHCR pull |"
+    echo "|--------|-----------|-----------------|"
+    for engine in $ENGINES; do
+        echo "| ${engine^} | ${SIZE[$engine]} | $(fmt_time ${GHCR_SECS[$engine]}) (${GHCR_LAYERS[$engine]} layers reused) |"
+    done
+    echo ""
+    echo "> Cold build times not included in this run (use \`--cold\` to measure;"
+    echo "> expect 20-60+ min for Transformers, hardware-dependent)."
+fi
+
+echo ""
+echo "**Scenarios:**"
+echo ""
+echo "- **Cold build** — no cache anywhere; simulates a new machine with GHCR offline or"
+echo "  the very first build before any cache exists. Time is dominated by flash-attn FA3"
+echo "  Hopper compilation (~80 nvcc invocations at MAX_JOBS=$(nproc))."
+echo "- **First GHCR pull** — fresh builder, all layers pulled from the GHCR registry cache"
+echo "  seeded by CI on each release. What a new developer gets after \`make docker-builder-setup\`."
+echo "- **Warm local rebuild** — after the first build, only layers whose inputs changed"
+echo "  are re-executed. The Dockerfile places stable expensive layers (FA3 compile, base"
+echo "  deps) before application code by design, so a source-only edit typically rebuilds"
+echo "  in seconds regardless of engine."

--- a/scripts/docker_build_with_cache_report.sh
+++ b/scripts/docker_build_with_cache_report.sh
@@ -29,10 +29,10 @@ mins=$(( elapsed / 60 ))
 secs=$(( elapsed % 60 ))
 human=$(printf "%dm %02ds" "${mins}" "${secs}")
 
-# These two markers are stable BuildKit conventions documented in the
-# build-push-action and buildx repos; they have not changed in years.
-imported=$(grep -c "importing cache manifest from ghcr.io" "${log}" 2>/dev/null || true)
-cached_steps=$(grep -cE "^#[0-9]+ CACHED$" "${log}" 2>/dev/null || true)
+# grep -c exits 1 on zero matches; || echo 0 keeps the value numeric for the
+# arithmetic tests below (|| true would leave an empty string under set -e).
+imported=$(grep -c "importing cache manifest from ghcr.io" "${log}" 2>/dev/null || echo 0)
+cached_steps=$(grep -cE "^#[0-9]+ CACHED$" "${log}" 2>/dev/null || echo 0)
 
 echo
 if [[ "${rc}" -ne 0 ]]; then

--- a/scripts/docker_build_with_cache_report.sh
+++ b/scripts/docker_build_with_cache_report.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Wraps `docker compose build <engine>` with BuildKit progress=plain so the
+# cache-import status is visible in real time, then emits a single-line ✓/⚠
+# summary post-build that says whether the GHCR cache was actually used.
+#
+# Silent fallback to a cold build is BuildKit's documented behaviour when
+# cache_from cannot resolve. This wrapper exists so contributors notice when
+# a "warm" rebuild is actually cold instead of tolerating 20-minute builds.
+#
+# Usage: scripts/docker_build_with_cache_report.sh <engine>
+#        e.g. scripts/docker_build_with_cache_report.sh transformers
+
+set -euo pipefail
+
+engine="${1:?usage: $0 <engine>}"
+log="/tmp/llem-build-${engine}.log"
+
+# progress=plain exposes per-step output including "importing cache manifest"
+# and per-stage "CACHED" markers; auto/tty hides them behind a collapsed UI.
+export BUILDKIT_PROGRESS="${BUILDKIT_PROGRESS:-plain}"
+
+start=$(date +%s)
+# tee preserves the on-screen build log; PIPESTATUS captures compose's exit.
+docker compose build "${engine}" 2>&1 | tee "${log}"
+rc=${PIPESTATUS[0]}
+elapsed=$(( $(date +%s) - start ))
+
+mins=$(( elapsed / 60 ))
+secs=$(( elapsed % 60 ))
+human=$(printf "%dm %02ds" "${mins}" "${secs}")
+
+# These two markers are stable BuildKit conventions documented in the
+# build-push-action and buildx repos; they have not changed in years.
+imported=$(grep -c "importing cache manifest from ghcr.io" "${log}" 2>/dev/null || true)
+cached_steps=$(grep -cE "^#[0-9]+ CACHED$" "${log}" 2>/dev/null || true)
+
+echo
+if [[ "${rc}" -ne 0 ]]; then
+    echo "✗ ${engine} build FAILED after ${human} (exit ${rc}) — see ${log}"
+elif [[ "${imported}" -gt 0 && "${cached_steps}" -gt 0 ]]; then
+    echo "✓ ${engine} build: ${human} — GHCR cache imported, ${cached_steps} layers reused"
+elif [[ "${imported}" -gt 0 ]]; then
+    echo "✓ ${engine} build: ${human} — GHCR cache reachable but no layers reused (source changed)"
+else
+    echo "⚠ ${engine} build: ${human} — no GHCR cache imported (cold build)"
+    echo "  see docs/troubleshooting.md → 'Docker rebuild is slow' for diagnosis"
+fi
+
+exit "${rc}"

--- a/src/llenergymeasure/infra/README.md
+++ b/src/llenergymeasure/infra/README.md
@@ -109,15 +109,14 @@ is already present in the local Docker cache (from a prior pull), the source is
 ### Building local images
 
 ```bash
-make docker-build-all          # all 3 engines
-make docker-build-pytorch      # just pytorch
-make docker-build-vllm         # just vllm
-make docker-build-tensorrt     # just tensorrt
+make docker-build-all            # all 3 engines
+make docker-build-transformers   # just transformers
+make docker-build-vllm           # just vllm
+make docker-build-tensorrt       # just tensorrt
 ```
 
-These use `docker compose build`. With `COMPOSE_BAKE=true` in `.env`, builds use the GHCR
-registry build cache for dramatically faster builds (e.g. PyTorch: ~2 min cached vs ~1 hour
-cold). See `docs/installation.md#build-cache-recommended` for details.
+These pull cached layers from GHCR on first build (Transformers: <5 min warm vs ~30 min cold).
+See `docs/installation.md#fast-rebuilds-and-first-pull-cost` for the full mechanism.
 
 ### Study-level image preparation
 

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -1270,11 +1270,11 @@ class StudyRunner:
 
                 raise DockerImagePullError(
                     message=f"Image pull timed out: {image}",
-                    fix_suggestion=f"COMPOSE_BAKE=true docker compose build {engine_name}",
+                    fix_suggestion=f"docker compose build {engine_name}",
                 ) from exc
 
             if pull.returncode != 0:
-                tip = f"COMPOSE_BAKE=true docker compose build {engine_name}"
+                tip = f"docker compose build {engine_name}"
                 if self._progress:
                     self._progress.image_failed(engine_name, image, f"not found \u2014 run: {tip}")
                     self._progress.end_image_prep()


### PR DESCRIPTION
## Summary

- Adds `cache-to=type=registry,mode=max` to `docker-publish.yml` so CI exports full BuildKit layer graphs (including FA3 flash-attn compile) to GHCR on each release
- Wires `cache_from` YAML anchors into all 6 build sections in `docker-compose.yml` (two-tier: `:v${LLEM_PKG_VERSION}` + `:latest`, with `v` prefix to match published tag convention)
- Updates `docker-build-check.yml` to pull from `:latest` (not defunct `:buildcache`)
- Adds `scripts/docker_build_with_cache_report.sh` — wraps compose build with `BUILDKIT_PROGRESS=plain` and emits a one-line cache-hit summary post-build
- Adds `make docker-seed-transformers` for seeding GHCR cache locally (FA3 compile exceeds 4-core/16 GB hosted runner capacity)
- Updates `docs/installation.md` with measured benchmark figures, a "most users just pull" preamble, and an explanation of where the cache helps vs. where it can't

## Context

Replaces the old `COMPOSE_BAKE=true` approach (which required the compose-bake driver and only pushed to `:buildcache`) with the standard `build-push-action` registry cache path. The new approach:
- Works on the native `docker compose build` path (no bake delegation)
- Exports intermediate layers via `mode=max` so the FA3 compile is actually cached
- Requires `docker/setup-buildx-action@v3` to switch from the `docker` driver (which cannot export registry cache) to `docker-container`

## Benchmark results

Measured on `ds01` — AMD EPYC 7742 64-Core, 128 cores, 504 GB RAM — Docker 27.0.3 / Buildx v0.32.1 / llenergymeasure 0.9.0.

| Engine | Image size | Cold build | First GHCR pull | Warm local rebuild |
|--------|-----------|------------|-----------------|--------------------|
| Transformers | 7.9 GB | 33m 56s | **2m 33s** (10 layers reused) | seconds |
| vLLM | 15.6 GB | 4m 12s | 4m 16s (0 layers reused) | seconds |
| TensorRT-LLM | 50.6 GB | 13m 24s | 13m 32s (0 layers reused) | seconds |

**Where the cache earns its keep:** Transformers cold→warm is **33m 56s → 2m 33s**, a ~13× speedup. The FA3 Hopper compile (~80 nvcc invocations) lives in our Dockerfile *before* `COPY src/`, so GHCR caches it and source edits don't invalidate it.

**Why vLLM/TRT show 0 layers reused — and why this is OK:** Both Dockerfiles are thin (`COPY src/` + one `pip install` + mkdir + labels) on top of heavy upstream bases (`vllm/vllm-openai` 15 GB, `nvcr.io/nvidia/tensorrt-llm/release` 50 GB). The dominant first-machine cost is pulling that upstream base from Docker Hub / NGC, which BuildKit's `cache_from` cannot accelerate — only layers from *our* Dockerfile are eligible. Our own steps add only ~30s on top, so even a perfect cache hit would cap the saving at ~30s on a 4–13 min total. Not worth pursuing further: warm local rebuilds are seconds anyway because the upstream base stays in local Docker storage after the first pull.

The 0-layer hit (rather than the ~30s win we could theoretically have) is a separate, minor issue: cache invalidation cascades from the first miss, which is probably `COPY src/` (src changed since v0.9.0) or the upstream `FROM` floating tag. Pinning `FROM ...@sha256:...` would let the early steps hit, but it's a 30s ceiling either way.

**Warm local rebuild:** the second and subsequent local builds for any engine complete in seconds — the Dockerfiles intentionally place stable layers (FA3, base deps) before `COPY src/`, so source-only edits only re-execute the trailing layer.

**Most users won't see any of this:** `make docker-pull` (or letting `llem run` resolve the registry image automatically) gives a working environment with no compilation. The build cache is for contributors and users with local source modifications. The new docs section makes this explicit.

## Test plan

- [x] `make docker-seed-transformers` on developer hardware — `:latest` cache manifest published to GHCR
- [x] `make docker-builder-rm && make docker-builder-setup` (cold builder)
- [x] `scripts/benchmark_docker_builds.sh --cold` — confirms Transformers warm-rebuilds in 2m 33s from GHCR
- [ ] CI `docker-build-check` passes on this branch