### PR TITLE
feat(config): add engine schema discovery, vendored schemas, SchemaLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ All notable changes to this project are documented here.
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.
 - **`llem doctor` CLI command.** Reports per-backend image status (OK / MISMATCH / UNVERIFIED / UNREACHABLE) and exits non-zero on mismatch for CI-friendly gating.
 - **Inline schema status in the image-prep progress line** (`schema: ok` / `schema: mismatch` / `schema: unverified` / `schema: bypassed`), rendered via the existing metadata display with no changes to the progress protocol.
+- **Engine parameter discovery (`scripts/discover_engine_schemas.py`).** Introspects installed engine packages inside their Docker images and emits JSON schemas describing every configurable parameter (types, defaults, descriptions where available, discovery limitations). Supports `vllm`, `tensorrt`, and `transformers`; `--all` discovers every engine found in the current image.
+- **Vendored engine schemas at `src/llenergymeasure/config/discovered_schemas/{vllm,tensorrt,transformers}.json`.** These are the canonical SSOT for "what CAN I configure per engine", shipped inside the wheel. Regenerate with `make discover-schema ENGINE=<engine>` (writes to the vendored path and prints `git diff`; committing is the review gate).
+- **`SchemaLoader` class (`llenergymeasure.config.SchemaLoader`).** Reads vendored schemas via `importlib.resources` with per-instance caching and major-version validation. Raises `UnsupportedSchemaVersionError` on envelope breaking changes. Exports include `DiscoveredSchema`, `DiscoveryLimitation`, and `UnsupportedSchemaVersionError` from `llenergymeasure.config`.
+- **`make discover-schema` / `make discover-schemas-all` targets.** Rebuild vendored engine schemas via `./scripts/update_engine_schema.sh`.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 .PHONY: docker-build-dev docker-check docker-builder-setup docker-builder-rm
 .PHONY: experiment datasets validate docker-shell docker-dev
 .PHONY: setup docker-setup lem-clean lem-clean-all lem-clean-state lem-clean-cache lem-clean-trt generate-docs check-docs
+.PHONY: discover-schema discover-schemas-all
 .PHONY: package-check docs-check docker-smoke docker-smoke-pytorch docker-smoke-vllm ci ci-all ci-docker
 .PHONY: gpu-ci gpu-ci-pytorch gpu-ci-vllm
 
@@ -121,6 +122,20 @@ generate-docs:
 
 # Check if generated docs are stale (CI validation)
 check-docs: docs-check
+
+# Rediscover a vendored engine schema by running introspection inside the
+# engine's Docker image. Writes to src/llenergymeasure/config/discovered_schemas/<engine>.json
+# and prints the git diff. Committing (or not) is the review gate.
+# Usage: make discover-schema ENGINE=vllm
+discover-schema:
+	@test -n "$(ENGINE)" || (echo "Usage: make discover-schema ENGINE={vllm|tensorrt|transformers}" && exit 1)
+	./scripts/update_engine_schema.sh $(ENGINE)
+
+# Rediscover all three engine schemas in sequence.
+discover-schemas-all:
+	./scripts/update_engine_schema.sh vllm
+	./scripts/update_engine_schema.sh tensorrt
+	./scripts/update_engine_schema.sh transformers
 
 docs-check:
 	@uv run python scripts/generate_config_docs.py > /dev/null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ llem = "llenergymeasure.cli:app"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/llenergymeasure"]
+# Hatchling includes non-Python files in package dirs by default, so
+# src/llenergymeasure/config/discovered_schemas/*.json ships automatically
+# in the wheel — no force-include needed (and adding one creates duplicates).
 
 [tool.ruff]
 line-length = 100

--- a/scripts/discover_engine_schemas.py
+++ b/scripts/discover_engine_schemas.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Discover engine parameter schemas from installed engine APIs.
+
+Runs inside an environment where the target engine package is installed
+(typically a Docker container). For each engine, introspects the native
+Python API surface and writes a JSON schema file with a common envelope.
+
+Expected discovery targets:
+    vllm         -> inside vllm/vllm-openai:<tag>
+    tensorrt     -> inside nvcr.io/nvidia/tensorrt-llm/release:<tag>
+    transformers -> inside llenergymeasure:transformers
+
+Usage:
+    python scripts/discover_engine_schemas.py vllm
+    python scripts/discover_engine_schemas.py tensorrt
+    python scripts/discover_engine_schemas.py transformers
+    python scripts/discover_engine_schemas.py --all
+    python scripts/discover_engine_schemas.py vllm --output /tmp/vllm.json
+    python scripts/discover_engine_schemas.py vllm --image-ref vllm/vllm-openai:v0.7.3
+
+The envelope is versioned separately from the engines (see SCHEMA_VERSION).
+Major bumps are breaking and SchemaLoader rejects them. Minor bumps add
+envelope keys; downstream loaders are expected to be forward-compatible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import inspect
+import json
+import re
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Union, get_args, get_origin
+
+SCHEMA_VERSION = "1.0.0"
+
+DOCKERFILE_PATHS = {
+    "vllm": "docker/Dockerfile.vllm",
+    "tensorrt": "docker/Dockerfile.tensorrt",
+    "transformers": "docker/Dockerfile.transformers",
+}
+
+DEFAULT_OUTPUT_DIR = "src/llenergymeasure/config/discovered_schemas"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _annotation_to_type_str(annotation: Any) -> str:
+    """Render a type annotation as a compact readable string.
+
+    Handles None, Optional[X], X | None, Union, Literal, generics, forward
+    refs, and inspect.Parameter.empty. Falls back to str(annotation) for
+    anything unrecognised so discovery never raises on exotic types.
+    """
+    if annotation is type(None):
+        return "None"
+    if annotation is inspect.Parameter.empty or annotation is inspect.Signature.empty:
+        return "unknown"
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    if origin is None:
+        return getattr(annotation, "__name__", str(annotation))
+
+    if origin is Union or origin is types.UnionType:
+        non_none = [a for a in args if a is not type(None)]
+        has_none = len(non_none) < len(args)
+        parts = [_annotation_to_type_str(a) for a in non_none]
+        if has_none:
+            parts.append("None")
+        return " | ".join(parts)
+
+    origin_str = str(origin)
+    if "Literal" in origin_str:
+        vals = ", ".join(repr(a) for a in args)
+        return f"Literal[{vals}]"
+
+    origin_name = getattr(origin, "__name__", origin_str)
+    arg_strs = ", ".join(_annotation_to_type_str(a) for a in args)
+    return f"{origin_name}[{arg_strs}]"
+
+
+def _read_dockerfile_from(dockerfile: Path) -> str:
+    """Extract the FROM tag from a Dockerfile, expanding the default ARG value.
+
+    For multi-stage Dockerfiles, prefers the ``AS runtime`` stage (convention
+    used by all llenergymeasure Dockerfiles). Falls back to the first FROM
+    line that references an external image (not a prior stage name). Only
+    default ARG values are substituted — no environment overrides.
+
+    Returns e.g. ``"vllm/vllm-openai:v0.7.3"`` for a Dockerfile with
+    ``ARG VLLM_VERSION=v0.7.3`` and ``FROM vllm/vllm-openai:${VLLM_VERSION}``.
+    """
+    text = dockerfile.read_text()
+    arg_defaults: dict[str, str] = {}
+    from_lines: list[tuple[str, str | None]] = []  # (ref, stage_alias)
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("ARG "):
+            m = re.match(r"ARG\s+(\w+)(?:=(.+))?", stripped)
+            if m:
+                arg_defaults[m.group(1)] = (m.group(2) or "").strip()
+            continue
+        if stripped.startswith("FROM "):
+            m = re.match(r"FROM\s+(\S+)(?:\s+AS\s+(\S+))?", stripped, re.IGNORECASE)
+            if m:
+                from_lines.append((m.group(1), m.group(2)))
+
+    if not from_lines:
+        raise ValueError(f"No FROM directive found in {dockerfile}")
+
+    stage_names = {alias for _, alias in from_lines if alias}
+
+    def _expand(ref: str) -> str:
+        return re.sub(
+            r"\$\{(\w+)\}",
+            lambda match: arg_defaults.get(match.group(1), match.group(0)),
+            ref,
+        )
+
+    for ref, alias in from_lines:
+        if alias == "runtime":
+            return _expand(ref)
+
+    for ref, _ in from_lines:
+        if ref not in stage_names:
+            return _expand(ref)
+
+    # All FROM lines reference prior stages — shouldn't happen in a valid Dockerfile
+    return _expand(from_lines[0][0])
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce a value into something json.dumps can handle without default=str.
+
+    Handles primitives, lists, tuples, dicts, sets, enums, and falls back to
+    str(value) for anything else. This keeps the output deterministic and
+    free of object repr noise.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, set):
+        return sorted(_jsonable(v) for v in value)
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, type):
+        return value.__name__
+    return str(value)
+
+
+def _make_envelope(
+    *,
+    engine: str,
+    engine_version: str,
+    engine_commit_sha: str | None,
+    image_ref: str,
+    base_image_ref: str,
+    discovery_method: str,
+    discovery_limitations: list[dict[str, Any]],
+    engine_params: dict[str, Any],
+    sampling_params: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "engine": engine,
+        "engine_version": engine_version,
+        "engine_commit_sha": engine_commit_sha,
+        "image_ref": image_ref,
+        "base_image_ref": base_image_ref,
+        "discovered_at": datetime.now(timezone.utc).isoformat(),
+        "discovery_method": discovery_method,
+        "discovery_limitations": discovery_limitations,
+        "engine_params": engine_params,
+        "sampling_params": sampling_params,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-engine discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_vllm(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
+    """Discover vLLM engine and sampling schemas.
+
+    engine_params:   dataclasses.fields(EngineArgs)  (~86 fields)
+    sampling_params: msgspec.json.schema(SamplingParams)  (~28 fields)
+    """
+    import vllm  # type: ignore[import-not-found]
+    from vllm.engine.arg_utils import EngineArgs  # type: ignore[import-not-found]
+
+    limitations: list[dict[str, Any]] = []
+    engine_params: dict[str, Any] = {}
+    for field in dataclasses.fields(EngineArgs):
+        default: Any = None
+        if field.default is not dataclasses.MISSING:
+            default = field.default
+        elif field.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            try:
+                default = field.default_factory()
+            except Exception:
+                default = None
+        engine_params[field.name] = {
+            "type": _annotation_to_type_str(field.type),
+            "default": _jsonable(default),
+        }
+
+    sampling_params: dict[str, Any] = {}
+    try:
+        import msgspec  # type: ignore[import-not-found]
+
+        raw_schema = msgspec.json.schema(vllm.SamplingParams)
+        props = raw_schema.get("properties")
+        if not props:
+            defs = raw_schema.get("$defs") or raw_schema.get("definitions") or {}
+            sp_def = defs.get("SamplingParams") or next(iter(defs.values()), {})
+            props = sp_def.get("properties", {}) if isinstance(sp_def, dict) else {}
+        for name, spec in (props or {}).items():
+            type_repr: Any = spec.get("type", "unknown")
+            if isinstance(type_repr, list):
+                type_repr = " | ".join(str(t) for t in type_repr)
+            sampling_params[name] = {
+                "type": type_repr,
+                "default": spec.get("default"),
+            }
+    except Exception as exc:
+        limitations.append(
+            {
+                "section": "sampling_params",
+                "fields": [],
+                "reason": f"msgspec.json.schema(SamplingParams) failed: {exc!r}",
+            }
+        )
+
+    limitations.append(
+        {
+            "section": "sampling_params",
+            "fields": [],
+            "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative "
+            "_verify_args() and are not introspectable from field metadata",
+        }
+    )
+    limitations.append(
+        {
+            "section": "engine_params",
+            "fields": [],
+            "reason": "per-field descriptions unavailable (vLLM EngineArgs has only a class docstring)",
+        }
+    )
+
+    base_image_ref = _read_dockerfile_from(repo_root / DOCKERFILE_PATHS["vllm"])
+    return _make_envelope(
+        engine="vllm",
+        engine_version=vllm.__version__,
+        engine_commit_sha=getattr(vllm, "__commit__", None),
+        image_ref=image_ref or base_image_ref,
+        base_image_ref=base_image_ref,
+        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+        discovery_limitations=limitations,
+        engine_params=engine_params,
+        sampling_params=sampling_params,
+    )
+
+
+def discover_tensorrt(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
+    """Discover TensorRT-LLM engine and sampling schemas.
+
+    Spike (2026-04-13, TRT-LLM 0.21.0 in pristine NGC image):
+      - TrtLlmArgs is a Pydantic v2 BaseModel with model_json_schema() (61 fields)
+      - LlmArgs is an alias for TrtLlmArgs
+      - BuildConfig is NOT Pydantic -> appears as Optional[object] in the schema
+      - KvCacheConfig / SchedulerConfig / CalibConfig / BuildCacheConfig are
+        Pydantic (fallback path, unused because primary path works)
+      - SamplingParams is a dataclass with 47 public fields
+      - tensorrt_llm.__commit__ is not exposed (null)
+
+    engine_params:   TrtLlmArgs.model_json_schema() properties (with description + deprecated)
+    sampling_params: dataclasses.fields(SamplingParams)
+    """
+    import tensorrt_llm  # type: ignore[import-not-found]
+    from tensorrt_llm import SamplingParams  # type: ignore[import-not-found]
+    from tensorrt_llm.llmapi.llm_args import TrtLlmArgs  # type: ignore[import-not-found]
+
+    limitations: list[dict[str, Any]] = []
+
+    raw_schema = TrtLlmArgs.model_json_schema()
+    engine_params: dict[str, Any] = {}
+    for name, spec in raw_schema.get("properties", {}).items():
+        if name.startswith("_"):
+            continue
+        type_repr: Any = spec.get("type")
+        if type_repr is None and "anyOf" in spec:
+            parts: list[str] = []
+            for sub in spec["anyOf"]:
+                if "type" in sub:
+                    part = "None" if sub["type"] == "null" else str(sub["type"])
+                elif "$ref" in sub:
+                    part = str(sub["$ref"]).rsplit("/", 1)[-1]
+                else:
+                    continue
+                if part not in parts:  # dedupe string | string etc.
+                    parts.append(part)
+            type_repr = " | ".join(parts) if parts else "unknown"
+        elif type_repr is None and "$ref" in spec:
+            type_repr = str(spec["$ref"]).rsplit("/", 1)[-1]
+        if isinstance(type_repr, list):
+            type_repr = " | ".join("None" if t == "null" else str(t) for t in type_repr)
+        elif type_repr == "null":
+            type_repr = "None"
+        engine_params[name] = {
+            "type": type_repr or "unknown",
+            "default": spec.get("default"),
+            "description": spec.get("description"),
+            "deprecated": spec.get("deprecated", False),
+        }
+
+    limitations.append(
+        {
+            "section": "engine_params",
+            "fields": ["build_config"],
+            "reason": "BuildConfig is not a Pydantic model; appears as Optional[object] in the schema",
+        }
+    )
+
+    sampling_params: dict[str, Any] = {}
+    for field in dataclasses.fields(SamplingParams):
+        if field.name.startswith("_"):
+            continue
+        default: Any = None
+        if field.default is not dataclasses.MISSING:
+            default = field.default
+        elif field.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            try:
+                default = field.default_factory()
+            except Exception:
+                default = None
+        sampling_params[field.name] = {
+            "type": _annotation_to_type_str(field.type),
+            "default": _jsonable(default),
+        }
+
+    limitations.append(
+        {
+            "section": "sampling_params",
+            "fields": [],
+            "reason": "SamplingParams is a dataclass; no per-field descriptions",
+        }
+    )
+
+    base_image_ref = _read_dockerfile_from(repo_root / DOCKERFILE_PATHS["tensorrt"])
+    return _make_envelope(
+        engine="tensorrt",
+        engine_version=tensorrt_llm.__version__,
+        engine_commit_sha=getattr(tensorrt_llm, "__commit__", None),
+        image_ref=image_ref or base_image_ref,
+        base_image_ref=base_image_ref,
+        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+        discovery_limitations=limitations,
+        engine_params=engine_params,
+        sampling_params=sampling_params,
+    )
+
+
+def discover_transformers(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
+    """Discover HuggingFace Transformers schemas.
+
+    engine_params:   best-effort inspect.signature(from_pretrained) scrape;
+                     **kwargs are opaque and recorded as a limitation
+    sampling_params: GenerationConfig().to_dict() (~69 fields); None defaults
+                     get type='unknown' and are listed in discovery_limitations
+    """
+    import transformers  # type: ignore[import-not-found]
+    from transformers import (  # type: ignore[import-not-found]
+        AutoModelForCausalLM,
+        GenerationConfig,
+        PreTrainedModel,
+    )
+
+    limitations: list[dict[str, Any]] = []
+    engine_params: dict[str, Any] = {}
+    kwargs_points: list[str] = []
+
+    for cls_name, cls in (
+        ("AutoModelForCausalLM", AutoModelForCausalLM),
+        ("PreTrainedModel", PreTrainedModel),
+    ):
+        try:
+            sig = inspect.signature(cls.from_pretrained)
+        except (TypeError, ValueError) as exc:
+            limitations.append(
+                {
+                    "section": "engine_params",
+                    "fields": [cls_name],
+                    "reason": f"inspect.signature({cls_name}.from_pretrained) failed: {exc!r}",
+                }
+            )
+            continue
+
+        for name, param in sig.parameters.items():
+            if name in ("self", "cls", "pretrained_model_name_or_path"):
+                continue
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                kwargs_points.append(f"{cls_name}.from_pretrained.**{name}")
+                continue
+            if name in engine_params:
+                continue  # prefer AutoModelForCausalLM over PreTrainedModel
+            default = None if param.default is inspect.Parameter.empty else param.default
+            engine_params[name] = {
+                "type": _annotation_to_type_str(param.annotation),
+                "default": _jsonable(default),
+            }
+
+    if kwargs_points:
+        limitations.append(
+            {
+                "section": "engine_params",
+                "fields": kwargs_points,
+                "reason": "from_pretrained accepts **kwargs; kwargs are not in the signature "
+                "(documented kwargs live in the class docstring only)",
+            }
+        )
+
+    sampling_params: dict[str, Any] = {}
+    none_default_fields: list[str] = []
+    gc = GenerationConfig()
+    for name, value in gc.to_dict().items():
+        if value is None:
+            sampling_params[name] = {"type": "unknown", "default": None}
+            none_default_fields.append(name)
+        elif isinstance(value, (list, tuple)):
+            sampling_params[name] = {"type": type(value).__name__, "default": _jsonable(value)}
+        elif isinstance(value, dict):
+            sampling_params[name] = {"type": "dict", "default": _jsonable(value)}
+        else:
+            sampling_params[name] = {
+                "type": type(value).__name__,
+                "default": _jsonable(value),
+            }
+
+    if none_default_fields:
+        limitations.append(
+            {
+                "section": "sampling_params",
+                "fields": none_default_fields,
+                "reason": "GenerationConfig has no type annotations; None defaults yield type='unknown'",
+            }
+        )
+
+    base_image_ref = _read_dockerfile_from(repo_root / DOCKERFILE_PATHS["transformers"])
+    return _make_envelope(
+        engine="transformers",
+        engine_version=transformers.__version__,
+        engine_commit_sha=getattr(transformers, "__commit__", None),
+        image_ref=image_ref or base_image_ref,
+        base_image_ref=base_image_ref,
+        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+        discovery_limitations=limitations,
+        engine_params=engine_params,
+        sampling_params=sampling_params,
+    )
+
+
+DISCOVERY_FUNCTIONS = {
+    "vllm": discover_vllm,
+    "tensorrt": discover_tensorrt,
+    "transformers": discover_transformers,
+}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _resolve_output_path(
+    *, engine: str, output_arg: Path | None, multi: bool, repo_root: Path
+) -> Path:
+    if output_arg is None:
+        return repo_root / DEFAULT_OUTPUT_DIR / f"{engine}.json"
+    if multi or output_arg.is_dir() or output_arg.suffix == "":
+        return output_arg / f"{engine}.json"
+    return output_arg
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Discover engine parameter schemas and write vendored JSON files."
+    )
+    parser.add_argument(
+        "engines",
+        nargs="*",
+        choices=list(DISCOVERY_FUNCTIONS),
+        default=[],
+        help="One or more engines to discover (vllm, tensorrt, transformers). "
+        "Omit when using --all.",
+    )
+    parser.add_argument("--all", action="store_true", help="Discover all known engines.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file (single engine) or directory (multiple engines). "
+        f"Default: {DEFAULT_OUTPUT_DIR}/<engine>.json relative to repo root.",
+    )
+    parser.add_argument(
+        "--image-ref",
+        default=None,
+        help="Image reference to record in envelope.image_ref. Defaults to the "
+        "Dockerfile FROM tag (also recorded as base_image_ref).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repo root (for Dockerfile lookup). Defaults to the parent of the scripts/ directory.",
+    )
+
+    args = parser.parse_args(argv)
+    requested: list[str] = list(DISCOVERY_FUNCTIONS) if args.all else args.engines
+    if not requested:
+        parser.error("Specify at least one engine, or use --all.")
+
+    repo_root = args.repo_root or Path(__file__).resolve().parent.parent
+
+    succeeded: list[str] = []
+    failed: list[tuple[str, str]] = []
+
+    for engine in requested:
+        try:
+            envelope = DISCOVERY_FUNCTIONS[engine](repo_root, args.image_ref)
+        except ImportError as exc:
+            print(f"[{engine}] SKIPPED (not importable): {exc}", file=sys.stderr)
+            failed.append((engine, "not importable"))
+            continue
+        except Exception as exc:
+            print(f"[{engine}] FAILED: {exc!r}", file=sys.stderr)
+            failed.append((engine, repr(exc)))
+            continue
+
+        out_path = _resolve_output_path(
+            engine=engine,
+            output_arg=args.output,
+            multi=len(requested) > 1,
+            repo_root=repo_root,
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(envelope, indent=2, sort_keys=False, default=_jsonable) + "\n"
+        )
+        print(
+            f"[{engine}] wrote {out_path} "
+            f"(version={envelope['engine_version']}, "
+            f"engine_params={len(envelope['engine_params'])}, "
+            f"sampling_params={len(envelope['sampling_params'])})"
+        )
+        succeeded.append(engine)
+
+    if not succeeded:
+        print(f"\nAll engines failed: {failed}", file=sys.stderr)
+        return 1
+    if failed:
+        print(
+            f"\nPartial success: {succeeded} ok, {[e for e, _ in failed]} skipped/failed.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/discover_engine_schemas.py
+++ b/scripts/discover_engine_schemas.py
@@ -159,6 +159,34 @@ def _jsonable(value: Any) -> Any:
     return str(value)
 
 
+def _dataclass_fields_to_specs(
+    cls: type, *, skip_private: bool = False
+) -> dict[str, dict[str, Any]]:
+    """Extract ``{name: {type, default}}`` specs from a dataclass.
+
+    Resolves ``default_factory`` by calling it (swallowing errors to ``None``)
+    so downstream JSON stays concrete. Types are rendered via
+    ``_annotation_to_type_str``.
+    """
+    specs: dict[str, dict[str, Any]] = {}
+    for fld in dataclasses.fields(cls):
+        if skip_private and fld.name.startswith("_"):
+            continue
+        default: Any = None
+        if fld.default is not dataclasses.MISSING:
+            default = fld.default
+        elif fld.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            try:
+                default = fld.default_factory()
+            except Exception:
+                default = None
+        specs[fld.name] = {
+            "type": _annotation_to_type_str(fld.type),
+            "default": _jsonable(default),
+        }
+    return specs
+
+
 def _make_envelope(
     *,
     engine: str,
@@ -201,20 +229,7 @@ def discover_vllm(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     from vllm.engine.arg_utils import EngineArgs  # type: ignore[import-not-found]
 
     limitations: list[dict[str, Any]] = []
-    engine_params: dict[str, Any] = {}
-    for field in dataclasses.fields(EngineArgs):
-        default: Any = None
-        if field.default is not dataclasses.MISSING:
-            default = field.default
-        elif field.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
-            try:
-                default = field.default_factory()
-            except Exception:
-                default = None
-        engine_params[field.name] = {
-            "type": _annotation_to_type_str(field.type),
-            "default": _jsonable(default),
-        }
+    engine_params = _dataclass_fields_to_specs(EngineArgs)
 
     sampling_params: dict[str, Any] = {}
     try:
@@ -333,22 +348,7 @@ def discover_tensorrt(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
-    sampling_params: dict[str, Any] = {}
-    for field in dataclasses.fields(SamplingParams):
-        if field.name.startswith("_"):
-            continue
-        default: Any = None
-        if field.default is not dataclasses.MISSING:
-            default = field.default
-        elif field.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
-            try:
-                default = field.default_factory()
-            except Exception:
-                default = None
-        sampling_params[field.name] = {
-            "type": _annotation_to_type_str(field.type),
-            "default": _jsonable(default),
-        }
+    sampling_params = _dataclass_fields_to_specs(SamplingParams, skip_private=True)
 
     limitations.append(
         {

--- a/scripts/update_engine_schema.sh
+++ b/scripts/update_engine_schema.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Rediscover a vendored engine schema by running discovery inside the
+# appropriate Docker image.
+#
+# Usage: ./scripts/update_engine_schema.sh {vllm|tensorrt|transformers}
+#
+# Always writes to src/llenergymeasure/config/discovered_schemas/<engine>.json
+# and prints the resulting `git diff`. Does NOT commit. The vendored JSON
+# file IS the canonical SSOT — authority comes from `git commit`, not from
+# who ran discovery.
+#
+# Legitimate refresh (e.g. you bumped a Dockerfile FROM tag):
+#   review the diff, `git add`, and open a PR.
+# Exploring a fork or stale image:
+#   `git checkout src/llenergymeasure/config/discovered_schemas/<engine>.json`
+#
+# Discovery image selection:
+#   vllm         -> pristine vllm/vllm-openai:<tag> (vllm pre-installed)
+#   tensorrt     -> pristine nvcr.io/nvidia/tensorrt-llm/release:<tag>
+#                   (works around llenergymeasure:tensorrt's cuKernelGetName bug)
+#   transformers -> llenergymeasure:transformers (base pytorch image has no
+#                   transformers package; our Dockerfile pip-installs it)
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/update_engine_schema.sh {vllm|tensorrt|transformers}
+
+Builds or pulls the engine's discovery image, runs discovery inside it,
+writes src/llenergymeasure/config/discovered_schemas/<engine>.json, and
+prints the git diff. Does NOT commit.
+EOF
+}
+
+if [[ $# -ne 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+    usage >&2
+    exit 1
+fi
+
+ENGINE="$1"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Extract ARG default value from a Dockerfile: _arg_default <file> <NAME>
+_arg_default() {
+    grep -oE "^ARG[[:space:]]+${2}=[^[:space:]]+" "$1" | head -1 | cut -d= -f2-
+}
+
+case "$ENGINE" in
+    vllm)
+        VER="$(_arg_default "$REPO_ROOT/docker/Dockerfile.vllm" VLLM_VERSION)"
+        IMAGE="vllm/vllm-openai:${VER}"
+        ;;
+    tensorrt)
+        VER="$(_arg_default "$REPO_ROOT/docker/Dockerfile.tensorrt" TRTLLM_VERSION)"
+        IMAGE="nvcr.io/nvidia/tensorrt-llm/release:${VER}"
+        ;;
+    transformers)
+        IMAGE="llenergymeasure:transformers"
+        if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "[$ENGINE] Image $IMAGE not found; building from docker/Dockerfile.transformers..." >&2
+            docker build -f "$REPO_ROOT/docker/Dockerfile.transformers" -t "$IMAGE" "$REPO_ROOT"
+        fi
+        ;;
+    *)
+        echo "Unknown engine: $ENGINE" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+if [[ -z "${IMAGE:-}" ]]; then
+    echo "Failed to resolve image for engine '$ENGINE'" >&2
+    exit 1
+fi
+
+OUTPUT_REL="src/llenergymeasure/config/discovered_schemas/${ENGINE}.json"
+
+echo "[$ENGINE] Running discovery inside $IMAGE..." >&2
+docker run --rm --gpus all \
+    --user "$(id -u):$(id -g)" \
+    --entrypoint python3 \
+    -v "$REPO_ROOT:/repo" \
+    -w /repo \
+    "$IMAGE" \
+    scripts/discover_engine_schemas.py "$ENGINE" \
+    --image-ref "$IMAGE" \
+    --output "/repo/$OUTPUT_REL"
+
+cd "$REPO_ROOT"
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "[$ENGINE] Not inside a git repo — skipping diff output." >&2
+    exit 0
+fi
+
+if git diff --quiet -- "$OUTPUT_REL" 2>/dev/null; then
+    if [[ -z "$(git status --porcelain -- "$OUTPUT_REL")" ]]; then
+        echo "[$ENGINE] No changes to vendored schema." >&2
+        exit 0
+    fi
+fi
+
+echo "" >&2
+echo "=== git diff --stat $OUTPUT_REL ===" >&2
+git diff --stat -- "$OUTPUT_REL" || true
+echo "" >&2
+echo "=== git diff $OUTPUT_REL (first 200 lines) ===" >&2
+git --no-pager diff -- "$OUTPUT_REL" | head -200 || true
+echo "" >&2
+cat <<EOF >&2
+Schema changed.
+  - Legitimate refresh? Review the diff, \`git add $OUTPUT_REL\`, and open a PR.
+  - Exploring a custom fork or stale image? Revert with:
+      git checkout -- $OUTPUT_REL
+EOF

--- a/src/llenergymeasure/config/__init__.py
+++ b/src/llenergymeasure/config/__init__.py
@@ -5,6 +5,7 @@ Public API:
 - load_experiment_config: Load from YAML/JSON with CLI override support
 - load_user_config: Load user preferences from XDG config dir
 - get_user_config_path: Return the XDG user config path
+- SchemaLoader / DiscoveredSchema: Access vendored engine parameter schemas
 """
 
 from llenergymeasure.config.loader import (
@@ -19,6 +20,12 @@ from llenergymeasure.config.models import (
     LoRAConfig,
     WarmupConfig,
 )
+from llenergymeasure.config.schema_loader import (
+    DiscoveredSchema,
+    DiscoveryLimitation,
+    SchemaLoader,
+    UnsupportedSchemaVersionError,
+)
 from llenergymeasure.config.user_config import (
     UserConfig,
     get_user_config_path,
@@ -29,8 +36,12 @@ __all__ = [
     "BaselineConfig",
     "DatasetConfig",
     "DecoderConfig",
+    "DiscoveredSchema",
+    "DiscoveryLimitation",
     "ExperimentConfig",
     "LoRAConfig",
+    "SchemaLoader",
+    "UnsupportedSchemaVersionError",
     "UserConfig",
     "WarmupConfig",
     "deep_merge",

--- a/src/llenergymeasure/config/discovered_schemas/__init__.py
+++ b/src/llenergymeasure/config/discovered_schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Vendored engine parameter schemas, produced by ``scripts/discover_engine_schemas.py``.
+
+One JSON file per engine; loaded via ``SchemaLoader`` in ``schema_loader.py``.
+Do not hand-edit — regenerate with ``make discover-schema ENGINE=<engine>``.
+"""

--- a/src/llenergymeasure/config/discovered_schemas/tensorrt.json
+++ b/src/llenergymeasure/config/discovered_schemas/tensorrt.json
@@ -1,0 +1,576 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "tensorrt",
+  "engine_version": "0.21.0",
+  "engine_commit_sha": null,
+  "image_ref": "nvcr.io/nvidia/tensorrt-llm/release:0.21.0",
+  "base_image_ref": "nvcr.io/nvidia/tensorrt-llm/release:0.21.0",
+  "discovered_at": "2026-04-13T22:06:21.484687+00:00",
+  "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+  "discovery_limitations": [
+    {
+      "section": "engine_params",
+      "fields": [
+        "build_config"
+      ],
+      "reason": "BuildConfig is not a Pydantic model; appears as Optional[object] in the schema"
+    },
+    {
+      "section": "sampling_params",
+      "fields": [],
+      "reason": "SamplingParams is a dataclass; no per-field descriptions"
+    }
+  ],
+  "engine_params": {
+    "model": {
+      "type": "string",
+      "default": null,
+      "description": "The path to the model checkpoint or the model name from the Hugging Face Hub.",
+      "deprecated": false
+    },
+    "tokenizer": {
+      "type": "string | None",
+      "default": null,
+      "description": "The path to the tokenizer checkpoint or the tokenizer name from the Hugging Face Hub.",
+      "deprecated": false
+    },
+    "tokenizer_mode": {
+      "type": "Literal['auto', 'slow']",
+      "default": "auto",
+      "description": "The mode to initialize the tokenizer.",
+      "deprecated": false
+    },
+    "skip_tokenizer_init": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to skip the tokenizer initialization.",
+      "deprecated": false
+    },
+    "trust_remote_code": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to trust the remote code.",
+      "deprecated": false
+    },
+    "tensor_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The tensor parallel size.",
+      "deprecated": false
+    },
+    "dtype": {
+      "type": "string",
+      "default": "auto",
+      "description": "The data type to use for the model.",
+      "deprecated": false
+    },
+    "revision": {
+      "type": "string | None",
+      "default": null,
+      "description": "The revision to use for the model.",
+      "deprecated": false
+    },
+    "tokenizer_revision": {
+      "type": "string | None",
+      "default": null,
+      "description": "The revision to use for the tokenizer.",
+      "deprecated": false
+    },
+    "pipeline_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The pipeline parallel size.",
+      "deprecated": false
+    },
+    "context_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The context parallel size.",
+      "deprecated": false
+    },
+    "gpus_per_node": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The number of GPUs per node.",
+      "deprecated": false
+    },
+    "moe_cluster_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The cluster parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "moe_tensor_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The tensor parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "moe_expert_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The expert parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "enable_attention_dp": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable attention data parallel.",
+      "deprecated": false
+    },
+    "cp_config": {
+      "type": "object | None",
+      "default": null,
+      "description": "Context parallel config.",
+      "deprecated": false
+    },
+    "load_format": {
+      "type": "Literal['auto', 'dummy']",
+      "default": "auto",
+      "description": "The format to load the model.",
+      "deprecated": false
+    },
+    "enable_lora": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable LoRA.",
+      "deprecated": false
+    },
+    "max_lora_rank": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum LoRA rank.",
+      "deprecated": true
+    },
+    "max_loras": {
+      "type": "integer",
+      "default": 4,
+      "description": "The maximum number of LoRA.",
+      "deprecated": true
+    },
+    "max_cpu_loras": {
+      "type": "integer",
+      "default": 4,
+      "description": "The maximum number of LoRA on CPU.",
+      "deprecated": true
+    },
+    "lora_config": {
+      "type": "LoraConfig | None",
+      "default": null,
+      "description": "LoRA configuration for the model.",
+      "deprecated": false
+    },
+    "enable_prompt_adapter": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable prompt adapter.",
+      "deprecated": false
+    },
+    "max_prompt_adapter_token": {
+      "type": "integer",
+      "default": 0,
+      "description": "The maximum number of prompt adapter tokens.",
+      "deprecated": false
+    },
+    "quant_config": {
+      "type": "QuantConfig | None",
+      "default": null,
+      "description": "Quantization config.",
+      "deprecated": false
+    },
+    "kv_cache_config": {
+      "type": "KvCacheConfig",
+      "default": null,
+      "description": "KV cache config.",
+      "deprecated": false
+    },
+    "enable_chunked_prefill": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable chunked prefill.",
+      "deprecated": false
+    },
+    "guided_decoding_backend": {
+      "type": "string | None",
+      "default": null,
+      "description": "Guided decoding backend.",
+      "deprecated": false
+    },
+    "batched_logits_processor": {
+      "type": "Optional[tensorrt_llm.sampling_params.BatchedLogitsProcessor]",
+      "default": null,
+      "description": "Batched logits processor.",
+      "deprecated": false
+    },
+    "iter_stats_max_iterations": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of iterations for iter stats.",
+      "deprecated": false
+    },
+    "request_stats_max_iterations": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of iterations for request stats.",
+      "deprecated": false
+    },
+    "peft_cache_config": {
+      "type": "PeftCacheConfig | None",
+      "default": null,
+      "description": "PEFT cache config.",
+      "deprecated": false
+    },
+    "scheduler_config": {
+      "type": "SchedulerConfig",
+      "default": null,
+      "description": "Scheduler config.",
+      "deprecated": false
+    },
+    "cache_transceiver_config": {
+      "type": "CacheTransceiverConfig | None",
+      "default": null,
+      "description": "Cache transceiver config.",
+      "deprecated": false
+    },
+    "speculative_config": {
+      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
+      "default": null,
+      "description": "Speculative decoding config.",
+      "deprecated": false
+    },
+    "batching_type": {
+      "type": "BatchingType | None",
+      "default": null,
+      "description": "Batching type.",
+      "deprecated": false
+    },
+    "normalize_log_probs": {
+      "type": "boolean",
+      "default": false,
+      "description": "Normalize log probabilities.",
+      "deprecated": false
+    },
+    "max_batch_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum batch size.",
+      "deprecated": false
+    },
+    "max_input_len": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum input length.",
+      "deprecated": false
+    },
+    "max_seq_len": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum sequence length.",
+      "deprecated": false
+    },
+    "max_beam_width": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum beam width.",
+      "deprecated": false
+    },
+    "max_num_tokens": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of tokens.",
+      "deprecated": false
+    },
+    "gather_generation_logits": {
+      "type": "boolean",
+      "default": false,
+      "description": "Gather generation logits.",
+      "deprecated": false
+    },
+    "num_postprocess_workers": {
+      "type": "integer",
+      "default": 0,
+      "description": "The number of processes used for postprocessing the generated tokens, including detokenization.",
+      "deprecated": false
+    },
+    "postprocess_tokenizer_dir": {
+      "type": "string | None",
+      "default": null,
+      "description": "The path to the tokenizer directory for postprocessing.",
+      "deprecated": false
+    },
+    "reasoning_parser": {
+      "type": "string | None",
+      "default": null,
+      "description": "The parser to separate reasoning content from output.",
+      "deprecated": false
+    },
+    "garbage_collection_gen0_threshold": {
+      "type": "integer",
+      "default": 20000,
+      "description": "Threshold for Python garbage collection of generation 0 objects.Lower values trigger more frequent garbage collection.",
+      "deprecated": false
+    },
+    "decoding_config": {
+      "type": "Optional[DecodingConfig]",
+      "default": null,
+      "description": "The decoding config.",
+      "deprecated": true
+    },
+    "backend": {
+      "type": "string | None",
+      "default": null,
+      "description": "The backend to use for this LLM instance.",
+      "deprecated": false
+    },
+    "auto_parallel": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable auto parallel mode.",
+      "deprecated": true
+    },
+    "auto_parallel_world_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The world size for auto parallel mode.",
+      "deprecated": true
+    },
+    "enable_tqdm": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable tqdm for progress bar.",
+      "deprecated": false
+    },
+    "workspace": {
+      "type": "string | None",
+      "default": null,
+      "description": "The workspace for the model.",
+      "deprecated": false
+    },
+    "enable_build_cache": {
+      "type": "Union[tensorrt_llm.llmapi.build_cache.BuildCacheConfig, bool]",
+      "default": false,
+      "description": "Enable build cache.",
+      "deprecated": false
+    },
+    "extended_runtime_perf_knob_config": {
+      "type": "ExtendedRuntimePerfKnobConfig | None",
+      "default": null,
+      "description": "Extended runtime perf knob config.",
+      "deprecated": false
+    },
+    "calib_config": {
+      "type": "CalibConfig | None",
+      "default": null,
+      "description": "Calibration config.",
+      "deprecated": false
+    },
+    "embedding_parallel_mode": {
+      "type": "string",
+      "default": "SHARDING_ALONG_VOCAB",
+      "description": "The embedding parallel mode.",
+      "deprecated": false
+    },
+    "fast_build": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable fast build.",
+      "deprecated": false
+    },
+    "build_config": {
+      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "default": null,
+      "description": "Build config.",
+      "deprecated": false
+    }
+  },
+  "sampling_params": {
+    "end_id": {
+      "type": "int | None",
+      "default": null
+    },
+    "pad_id": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_tokens": {
+      "type": "int",
+      "default": 32
+    },
+    "bad": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "bad_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "stop": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "stop_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "include_stop_str_in_output": {
+      "type": "bool",
+      "default": false
+    },
+    "embedding_bias": {
+      "type": "Tensor | None",
+      "default": null
+    },
+    "logits_processor": {
+      "type": "LogitsProcessor | list[LogitsProcessor] | None",
+      "default": null
+    },
+    "apply_batched_logits_processor": {
+      "type": "bool",
+      "default": false
+    },
+    "n": {
+      "type": "int",
+      "default": 1
+    },
+    "best_of": {
+      "type": "int | None",
+      "default": null
+    },
+    "use_beam_search": {
+      "type": "bool",
+      "default": false
+    },
+    "top_k": {
+      "type": "int | None",
+      "default": null
+    },
+    "top_p": {
+      "type": "float | None",
+      "default": null
+    },
+    "top_p_min": {
+      "type": "float | None",
+      "default": null
+    },
+    "top_p_reset_ids": {
+      "type": "int | None",
+      "default": null
+    },
+    "top_p_decay": {
+      "type": "float | None",
+      "default": null
+    },
+    "seed": {
+      "type": "int | None",
+      "default": null
+    },
+    "temperature": {
+      "type": "float | None",
+      "default": null
+    },
+    "min_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "beam_search_diversity_rate": {
+      "type": "float | None",
+      "default": null
+    },
+    "repetition_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "presence_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "frequency_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "length_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "early_stopping": {
+      "type": "int | None",
+      "default": null
+    },
+    "no_repeat_ngram_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "min_p": {
+      "type": "float | None",
+      "default": null
+    },
+    "beam_width_array": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "prompt_logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "return_context_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "return_generation_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "exclude_input_from_output": {
+      "type": "bool",
+      "default": true
+    },
+    "return_encoder_output": {
+      "type": "bool",
+      "default": false
+    },
+    "return_perf_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "additional_model_outputs": {
+      "type": "list[AdditionalModelOutput] | None",
+      "default": null
+    },
+    "lookahead_config": {
+      "type": "LookaheadDecodingConfig | None",
+      "default": null
+    },
+    "guided_decoding": {
+      "type": "GuidedDecodingParams | None",
+      "default": null
+    },
+    "ignore_eos": {
+      "type": "bool",
+      "default": false
+    },
+    "detokenize": {
+      "type": "bool",
+      "default": true
+    },
+    "add_special_tokens": {
+      "type": "bool",
+      "default": true
+    },
+    "truncate_prompt_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "skip_special_tokens": {
+      "type": "bool",
+      "default": true
+    },
+    "spaces_between_special_tokens": {
+      "type": "bool",
+      "default": true
+    }
+  }
+}

--- a/src/llenergymeasure/config/discovered_schemas/transformers.json
+++ b/src/llenergymeasure/config/discovered_schemas/transformers.json
@@ -1,0 +1,412 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "transformers",
+  "engine_version": "5.5.4",
+  "engine_commit_sha": null,
+  "image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime+transformers-pipinstall",
+  "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
+  "discovered_at": "2026-04-13T22:06:41.228246+00:00",
+  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+  "discovery_limitations": [
+    {
+      "section": "engine_params",
+      "fields": [
+        "AutoModelForCausalLM.from_pretrained.**model_args",
+        "AutoModelForCausalLM.from_pretrained.**kwargs",
+        "PreTrainedModel.from_pretrained.**model_args",
+        "PreTrainedModel.from_pretrained.**kwargs"
+      ],
+      "reason": "from_pretrained accepts **kwargs; kwargs are not in the signature (documented kwargs live in the class docstring only)"
+    },
+    {
+      "section": "sampling_params",
+      "fields": [
+        "max_length",
+        "max_new_tokens",
+        "min_length",
+        "min_new_tokens",
+        "early_stopping",
+        "max_time",
+        "stop_strings",
+        "do_sample",
+        "num_beams",
+        "use_cache",
+        "cache_implementation",
+        "cache_config",
+        "temperature",
+        "top_k",
+        "top_p",
+        "min_p",
+        "top_h",
+        "typical_p",
+        "epsilon_cutoff",
+        "eta_cutoff",
+        "repetition_penalty",
+        "encoder_repetition_penalty",
+        "length_penalty",
+        "no_repeat_ngram_size",
+        "bad_words_ids",
+        "renormalize_logits",
+        "forced_bos_token_id",
+        "forced_eos_token_id",
+        "remove_invalid_values",
+        "exponential_decay_length_penalty",
+        "suppress_tokens",
+        "begin_suppress_tokens",
+        "sequence_bias",
+        "token_healing",
+        "guidance_scale",
+        "watermarking_config",
+        "num_return_sequences",
+        "output_attentions",
+        "output_hidden_states",
+        "output_scores",
+        "output_logits",
+        "return_dict_in_generate",
+        "pad_token_id",
+        "bos_token_id",
+        "eos_token_id",
+        "encoder_no_repeat_ngram_size",
+        "decoder_start_token_id",
+        "is_assistant",
+        "num_assistant_tokens",
+        "num_assistant_tokens_schedule",
+        "assistant_confidence_threshold",
+        "prompt_lookup_num_tokens",
+        "max_matching_ngram_size",
+        "assistant_early_exit",
+        "assistant_lookbehind",
+        "target_lookbehind",
+        "compile_config",
+        "disable_compile",
+        "continuous_batching_config",
+        "low_memory",
+        "penalty_alpha",
+        "dola_layers",
+        "diversity_penalty",
+        "num_beam_groups",
+        "constraints",
+        "force_words_ids",
+        "prefill_chunk_size",
+        "_from_model_config"
+      ],
+      "reason": "GenerationConfig has no type annotations; None defaults yield type='unknown'"
+    }
+  ],
+  "engine_params": {
+    "config": {
+      "type": "PreTrainedConfig | str | PathLike | None",
+      "default": null
+    },
+    "cache_dir": {
+      "type": "str | PathLike | None",
+      "default": null
+    },
+    "ignore_mismatched_sizes": {
+      "type": "bool",
+      "default": false
+    },
+    "force_download": {
+      "type": "bool",
+      "default": false
+    },
+    "local_files_only": {
+      "type": "bool",
+      "default": false
+    },
+    "token": {
+      "type": "str | bool | None",
+      "default": null
+    },
+    "revision": {
+      "type": "str",
+      "default": "main"
+    },
+    "use_safetensors": {
+      "type": "bool | None",
+      "default": null
+    },
+    "weights_only": {
+      "type": "bool",
+      "default": true
+    }
+  },
+  "sampling_params": {
+    "max_length": {
+      "type": "unknown",
+      "default": null
+    },
+    "max_new_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "min_length": {
+      "type": "unknown",
+      "default": null
+    },
+    "min_new_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "early_stopping": {
+      "type": "unknown",
+      "default": null
+    },
+    "max_time": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop_strings": {
+      "type": "unknown",
+      "default": null
+    },
+    "do_sample": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_beams": {
+      "type": "unknown",
+      "default": null
+    },
+    "use_cache": {
+      "type": "unknown",
+      "default": null
+    },
+    "cache_implementation": {
+      "type": "unknown",
+      "default": null
+    },
+    "cache_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "temperature": {
+      "type": "unknown",
+      "default": null
+    },
+    "top_k": {
+      "type": "unknown",
+      "default": null
+    },
+    "top_p": {
+      "type": "unknown",
+      "default": null
+    },
+    "min_p": {
+      "type": "unknown",
+      "default": null
+    },
+    "top_h": {
+      "type": "unknown",
+      "default": null
+    },
+    "typical_p": {
+      "type": "unknown",
+      "default": null
+    },
+    "epsilon_cutoff": {
+      "type": "unknown",
+      "default": null
+    },
+    "eta_cutoff": {
+      "type": "unknown",
+      "default": null
+    },
+    "repetition_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "encoder_repetition_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "length_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "no_repeat_ngram_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "bad_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "renormalize_logits": {
+      "type": "unknown",
+      "default": null
+    },
+    "forced_bos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "forced_eos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "remove_invalid_values": {
+      "type": "unknown",
+      "default": null
+    },
+    "exponential_decay_length_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "begin_suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "sequence_bias": {
+      "type": "unknown",
+      "default": null
+    },
+    "token_healing": {
+      "type": "unknown",
+      "default": null
+    },
+    "guidance_scale": {
+      "type": "unknown",
+      "default": null
+    },
+    "watermarking_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_return_sequences": {
+      "type": "unknown",
+      "default": null
+    },
+    "output_attentions": {
+      "type": "unknown",
+      "default": null
+    },
+    "output_hidden_states": {
+      "type": "unknown",
+      "default": null
+    },
+    "output_scores": {
+      "type": "unknown",
+      "default": null
+    },
+    "output_logits": {
+      "type": "unknown",
+      "default": null
+    },
+    "return_dict_in_generate": {
+      "type": "unknown",
+      "default": null
+    },
+    "pad_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "bos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "eos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "encoder_no_repeat_ngram_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "decoder_start_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "is_assistant": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_assistant_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_assistant_tokens_schedule": {
+      "type": "unknown",
+      "default": null
+    },
+    "assistant_confidence_threshold": {
+      "type": "unknown",
+      "default": null
+    },
+    "prompt_lookup_num_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "max_matching_ngram_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "assistant_early_exit": {
+      "type": "unknown",
+      "default": null
+    },
+    "assistant_lookbehind": {
+      "type": "unknown",
+      "default": null
+    },
+    "target_lookbehind": {
+      "type": "unknown",
+      "default": null
+    },
+    "compile_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "disable_compile": {
+      "type": "unknown",
+      "default": null
+    },
+    "continuous_batching_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "low_memory": {
+      "type": "unknown",
+      "default": null
+    },
+    "penalty_alpha": {
+      "type": "unknown",
+      "default": null
+    },
+    "dola_layers": {
+      "type": "unknown",
+      "default": null
+    },
+    "diversity_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_beam_groups": {
+      "type": "unknown",
+      "default": null
+    },
+    "constraints": {
+      "type": "unknown",
+      "default": null
+    },
+    "force_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "prefill_chunk_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "_from_model_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "transformers_version": {
+      "type": "str",
+      "default": "5.5.4"
+    }
+  }
+}

--- a/src/llenergymeasure/config/discovered_schemas/vllm.json
+++ b/src/llenergymeasure/config/discovered_schemas/vllm.json
@@ -1,0 +1,566 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "vllm",
+  "engine_version": "0.7.3",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:vllm",
+  "base_image_ref": "vllm/vllm-openai:v0.7.3",
+  "discovered_at": "2026-04-13T22:05:56.672752+00:00",
+  "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+  "discovery_limitations": [
+    {
+      "section": "sampling_params",
+      "fields": [],
+      "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative _verify_args() and are not introspectable from field metadata"
+    },
+    {
+      "section": "engine_params",
+      "fields": [],
+      "reason": "per-field descriptions unavailable (vLLM EngineArgs has only a class docstring)"
+    }
+  ],
+  "engine_params": {
+    "model": {
+      "type": "str",
+      "default": "facebook/opt-125m"
+    },
+    "served_model_name": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "tokenizer": {
+      "type": "str | None",
+      "default": null
+    },
+    "task": {
+      "type": "Literal['auto', 'generate', 'embedding', 'embed', 'classify', 'score', 'reward', 'transcription']",
+      "default": "auto"
+    },
+    "skip_tokenizer_init": {
+      "type": "bool",
+      "default": false
+    },
+    "tokenizer_mode": {
+      "type": "str",
+      "default": "auto"
+    },
+    "trust_remote_code": {
+      "type": "bool",
+      "default": false
+    },
+    "allowed_local_media_path": {
+      "type": "str",
+      "default": ""
+    },
+    "download_dir": {
+      "type": "str | None",
+      "default": null
+    },
+    "load_format": {
+      "type": "str",
+      "default": "auto"
+    },
+    "config_format": {
+      "type": "ConfigFormat",
+      "default": "auto"
+    },
+    "dtype": {
+      "type": "str",
+      "default": "auto"
+    },
+    "kv_cache_dtype": {
+      "type": "str",
+      "default": "auto"
+    },
+    "seed": {
+      "type": "int",
+      "default": 0
+    },
+    "max_model_len": {
+      "type": "int | None",
+      "default": null
+    },
+    "distributed_executor_backend": {
+      "type": "str | type[ExecutorBase] | None",
+      "default": null
+    },
+    "pipeline_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "tensor_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "max_parallel_loading_workers": {
+      "type": "int | None",
+      "default": null
+    },
+    "block_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "enable_prefix_caching": {
+      "type": "bool | None",
+      "default": null
+    },
+    "disable_sliding_window": {
+      "type": "bool",
+      "default": false
+    },
+    "use_v2_block_manager": {
+      "type": "bool",
+      "default": true
+    },
+    "swap_space": {
+      "type": "float",
+      "default": 4
+    },
+    "cpu_offload_gb": {
+      "type": "float",
+      "default": 0
+    },
+    "gpu_memory_utilization": {
+      "type": "float",
+      "default": 0.9
+    },
+    "max_num_batched_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_num_partial_prefills": {
+      "type": "int | None",
+      "default": 1
+    },
+    "max_long_partial_prefills": {
+      "type": "int | None",
+      "default": 1
+    },
+    "long_prefill_token_threshold": {
+      "type": "int | None",
+      "default": 0
+    },
+    "max_num_seqs": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_logprobs": {
+      "type": "int",
+      "default": 20
+    },
+    "disable_log_stats": {
+      "type": "bool",
+      "default": false
+    },
+    "revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "code_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "rope_scaling": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "rope_theta": {
+      "type": "float | None",
+      "default": null
+    },
+    "hf_overrides": {
+      "type": "dict[str, Any] | Callable[[<class 'transformers.configuration_utils.PretrainedConfig'>], PretrainedConfig] | None",
+      "default": null
+    },
+    "tokenizer_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "quantization": {
+      "type": "str | None",
+      "default": null
+    },
+    "enforce_eager": {
+      "type": "bool | None",
+      "default": null
+    },
+    "max_seq_len_to_capture": {
+      "type": "int",
+      "default": 8192
+    },
+    "disable_custom_all_reduce": {
+      "type": "bool",
+      "default": false
+    },
+    "tokenizer_pool_size": {
+      "type": "int",
+      "default": 0
+    },
+    "tokenizer_pool_type": {
+      "type": "str | type[ForwardRef('BaseTokenizerGroup')]",
+      "default": "ray"
+    },
+    "tokenizer_pool_extra_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "limit_mm_per_prompt": {
+      "type": "Mapping[str, int] | None",
+      "default": null
+    },
+    "mm_processor_kwargs": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "disable_mm_preprocessor_cache": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_lora": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_lora_bias": {
+      "type": "bool",
+      "default": false
+    },
+    "max_loras": {
+      "type": "int",
+      "default": 1
+    },
+    "max_lora_rank": {
+      "type": "int",
+      "default": 16
+    },
+    "enable_prompt_adapter": {
+      "type": "bool",
+      "default": false
+    },
+    "max_prompt_adapters": {
+      "type": "int",
+      "default": 1
+    },
+    "max_prompt_adapter_token": {
+      "type": "int",
+      "default": 0
+    },
+    "fully_sharded_loras": {
+      "type": "bool",
+      "default": false
+    },
+    "lora_extra_vocab_size": {
+      "type": "int",
+      "default": 256
+    },
+    "long_lora_scaling_factors": {
+      "type": "tuple[float] | None",
+      "default": null
+    },
+    "lora_dtype": {
+      "type": "str | dtype | None",
+      "default": "auto"
+    },
+    "max_cpu_loras": {
+      "type": "int | None",
+      "default": null
+    },
+    "device": {
+      "type": "str",
+      "default": "auto"
+    },
+    "num_scheduler_steps": {
+      "type": "int",
+      "default": 1
+    },
+    "multi_step_stream_outputs": {
+      "type": "bool",
+      "default": true
+    },
+    "ray_workers_use_nsight": {
+      "type": "bool",
+      "default": false
+    },
+    "num_gpu_blocks_override": {
+      "type": "int | None",
+      "default": null
+    },
+    "num_lookahead_slots": {
+      "type": "int",
+      "default": 0
+    },
+    "model_loader_extra_config": {
+      "type": "dict | None",
+      "default": null
+    },
+    "ignore_patterns": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "preemption_mode": {
+      "type": "str | None",
+      "default": null
+    },
+    "scheduler_delay_factor": {
+      "type": "float",
+      "default": 0.0
+    },
+    "enable_chunked_prefill": {
+      "type": "bool | None",
+      "default": null
+    },
+    "guided_decoding_backend": {
+      "type": "str",
+      "default": "xgrammar"
+    },
+    "logits_processor_pattern": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_model": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_model_quantization": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_draft_tensor_parallel_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "num_speculative_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "speculative_disable_mqa_scorer": {
+      "type": "bool | None",
+      "default": false
+    },
+    "speculative_max_model_len": {
+      "type": "int | None",
+      "default": null
+    },
+    "speculative_disable_by_batch_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "ngram_prompt_lookup_max": {
+      "type": "int | None",
+      "default": null
+    },
+    "ngram_prompt_lookup_min": {
+      "type": "int | None",
+      "default": null
+    },
+    "spec_decoding_acceptance_method": {
+      "type": "str",
+      "default": "rejection_sampler"
+    },
+    "typical_acceptance_sampler_posterior_threshold": {
+      "type": "float | None",
+      "default": null
+    },
+    "typical_acceptance_sampler_posterior_alpha": {
+      "type": "float | None",
+      "default": null
+    },
+    "qlora_adapter_name_or_path": {
+      "type": "str | None",
+      "default": null
+    },
+    "disable_logprobs_during_spec_decoding": {
+      "type": "bool | None",
+      "default": null
+    },
+    "otlp_traces_endpoint": {
+      "type": "str | None",
+      "default": null
+    },
+    "collect_detailed_traces": {
+      "type": "str | None",
+      "default": null
+    },
+    "disable_async_output_proc": {
+      "type": "bool",
+      "default": false
+    },
+    "scheduling_policy": {
+      "type": "Literal['fcfs', 'priority']",
+      "default": "fcfs"
+    },
+    "scheduler_cls": {
+      "type": "str | type[object]",
+      "default": "vllm.core.scheduler.Scheduler"
+    },
+    "override_neuron_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "override_pooler_config": {
+      "type": "PoolerConfig | None",
+      "default": null
+    },
+    "compilation_config": {
+      "type": "CompilationConfig | None",
+      "default": null
+    },
+    "worker_cls": {
+      "type": "str",
+      "default": "auto"
+    },
+    "kv_transfer_config": {
+      "type": "KVTransferConfig | None",
+      "default": null
+    },
+    "generation_config": {
+      "type": "str | None",
+      "default": null
+    },
+    "override_generation_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "enable_sleep_mode": {
+      "type": "bool",
+      "default": false
+    },
+    "model_impl": {
+      "type": "str",
+      "default": "auto"
+    },
+    "calculate_kv_scales": {
+      "type": "bool | None",
+      "default": null
+    },
+    "additional_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    }
+  },
+  "sampling_params": {
+    "n": {
+      "type": "integer",
+      "default": 1
+    },
+    "best_of": {
+      "type": "unknown",
+      "default": null
+    },
+    "_real_n": {
+      "type": "unknown",
+      "default": null
+    },
+    "presence_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "frequency_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "repetition_penalty": {
+      "type": "number",
+      "default": 1.0
+    },
+    "temperature": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_p": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_k": {
+      "type": "integer",
+      "default": -1
+    },
+    "min_p": {
+      "type": "number",
+      "default": 0.0
+    },
+    "seed": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop_token_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "bad_words": {
+      "type": "unknown",
+      "default": null
+    },
+    "ignore_eos": {
+      "type": "boolean",
+      "default": false
+    },
+    "max_tokens": {
+      "type": "unknown",
+      "default": 16
+    },
+    "min_tokens": {
+      "type": "integer",
+      "default": 0
+    },
+    "logprobs": {
+      "type": "unknown",
+      "default": null
+    },
+    "prompt_logprobs": {
+      "type": "unknown",
+      "default": null
+    },
+    "detokenize": {
+      "type": "boolean",
+      "default": true
+    },
+    "skip_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "spaces_between_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "logits_processors": {
+      "type": "unknown",
+      "default": null
+    },
+    "include_stop_str_in_output": {
+      "type": "boolean",
+      "default": false
+    },
+    "truncate_prompt_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "output_kind": {
+      "type": "unknown",
+      "default": 0
+    },
+    "output_text_buffer_length": {
+      "type": "integer",
+      "default": 0
+    },
+    "_all_stop_token_ids": {
+      "type": "array",
+      "default": []
+    },
+    "guided_decoding": {
+      "type": "unknown",
+      "default": null
+    },
+    "logit_bias": {
+      "type": "unknown",
+      "default": null
+    },
+    "allowed_token_ids": {
+      "type": "unknown",
+      "default": null
+    }
+  }
+}

--- a/src/llenergymeasure/config/schema_loader.py
+++ b/src/llenergymeasure/config/schema_loader.py
@@ -1,0 +1,184 @@
+"""Load vendored engine schemas discovered by ``scripts/discover_engine_schemas.py``.
+
+The vendored JSON files in ``discovered_schemas/`` are the canonical SSOT for
+"what parameters CAN be configured per engine". They are produced by running
+introspection inside each engine's Docker image and committed to the repo.
+
+This loader reads them via ``importlib.resources`` so it works in both editable
+installs and installed wheels. Repeated loads are cached per-engine. Major
+version mismatches (envelope schema breaking changes) raise
+``UnsupportedSchemaVersionError``.
+
+Downstream consumers (doc generators, field-name alignment, CI drift guards)
+should load through this module rather than reading the JSON files directly.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from importlib import resources
+from typing import Any
+
+SUPPORTED_MAJOR_VERSION = 1
+
+# Engines known to ship a vendored schema. Hardcoded here; PR 48.3 will
+# source this from ssot.ALL_ENGINES once that constant exists.
+_KNOWN_ENGINES: tuple[str, ...] = ("vllm", "tensorrt", "transformers")
+
+_PACKAGE = "llenergymeasure.config.discovered_schemas"
+
+
+class UnsupportedSchemaVersionError(ValueError):
+    """Raised when a vendored schema's major version doesn't match this loader."""
+
+
+@dataclass(frozen=True)
+class DiscoveryLimitation:
+    """A single limitation recorded by the discovery script.
+
+    Fields that discovery could not recover (e.g. HF's None-default fields with
+    no type annotations, or kwargs that don't appear in an inspected signature)
+    are surfaced here rather than silently dropped.
+    """
+
+    section: str
+    fields: list[str]
+    reason: str
+
+
+@dataclass(frozen=True)
+class DiscoveredSchema:
+    """A parsed vendored engine schema.
+
+    ``engine_params`` and ``sampling_params`` are kept as raw dicts rather than
+    a typed FieldDescriptor because per-engine richness varies: TRT-LLM fields
+    carry ``description`` and ``deprecated`` from its Pydantic schema, while
+    vLLM and Transformers fields only have ``type`` and ``default``. Consumers
+    that need uniform shape should adapt at read time.
+    """
+
+    schema_version: str
+    engine: str
+    engine_version: str
+    engine_commit_sha: str | None
+    image_ref: str
+    base_image_ref: str
+    discovered_at: datetime
+    discovery_method: str
+    discovery_limitations: list[DiscoveryLimitation] = field(default_factory=list)
+    engine_params: dict[str, dict[str, Any]] = field(default_factory=dict)
+    sampling_params: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+class SchemaLoader:
+    """Load and cache vendored engine schemas.
+
+    Uses a per-instance dict cache (rather than ``functools.lru_cache``) so
+    multiple SchemaLoader instances don't share state — convenient for tests
+    and for isolating reloads after a schema refresh.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, DiscoveredSchema] = {}
+
+    def load_schema(self, engine: str) -> DiscoveredSchema:
+        """Load the vendored schema for ``engine``.
+
+        Raises:
+            ValueError: ``engine`` is not a known engine name.
+            FileNotFoundError: No vendored JSON exists for ``engine``.
+            UnsupportedSchemaVersionError: Vendored schema major version
+                doesn't match ``SUPPORTED_MAJOR_VERSION``.
+            json.JSONDecodeError: Vendored file is not valid JSON.
+        """
+        if engine not in _KNOWN_ENGINES:
+            raise ValueError(f"Unknown engine {engine!r}. Known engines: {list(_KNOWN_ENGINES)}.")
+
+        cached = self._cache.get(engine)
+        if cached is not None:
+            return cached
+
+        try:
+            raw_text = (resources.files(_PACKAGE) / f"{engine}.json").read_text()
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Vendored schema for engine {engine!r} not found. "
+                f"Run `./scripts/update_engine_schema.sh {engine}` to generate it."
+            ) from exc
+
+        parsed = _parse_envelope(engine=engine, raw_text=raw_text)
+        self._cache[engine] = parsed
+        return parsed
+
+    def load_all_schemas(self) -> dict[str, DiscoveredSchema]:
+        """Load all known engines' schemas.
+
+        Does not skip missing files — every engine in ``_KNOWN_ENGINES`` must
+        have a vendored schema. Callers that need tolerance should iterate and
+        catch ``FileNotFoundError`` themselves.
+        """
+        return {engine: self.load_schema(engine) for engine in _KNOWN_ENGINES}
+
+    def invalidate(self, engine: str | None = None) -> None:
+        """Drop cached schema(s). Useful after a schema refresh in-process."""
+        if engine is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(engine, None)
+
+
+def _parse_envelope(*, engine: str, raw_text: str) -> DiscoveredSchema:
+    data = json.loads(raw_text)
+
+    schema_version = data["schema_version"]
+    major = _major_version(schema_version)
+    if major != SUPPORTED_MAJOR_VERSION:
+        raise UnsupportedSchemaVersionError(
+            f"Vendored schema for {engine!r} has schema_version={schema_version!r} "
+            f"(major={major}); this SchemaLoader only supports major "
+            f"{SUPPORTED_MAJOR_VERSION}. Regenerate with a matching discovery script, "
+            f"or upgrade the loader."
+        )
+
+    limitations_raw = data.get("discovery_limitations", [])
+    limitations = [
+        DiscoveryLimitation(
+            section=item.get("section", ""),
+            fields=list(item.get("fields", [])),
+            reason=item.get("reason", ""),
+        )
+        for item in limitations_raw
+    ]
+
+    return DiscoveredSchema(
+        schema_version=schema_version,
+        engine=data["engine"],
+        engine_version=data["engine_version"],
+        engine_commit_sha=data.get("engine_commit_sha"),
+        image_ref=data["image_ref"],
+        base_image_ref=data.get("base_image_ref", data["image_ref"]),
+        discovered_at=_parse_iso(data["discovered_at"]),
+        discovery_method=data.get("discovery_method", ""),
+        discovery_limitations=limitations,
+        engine_params=data.get("engine_params", {}),
+        sampling_params=data.get("sampling_params", {}),
+    )
+
+
+def _major_version(version: str) -> int:
+    """Parse major from a semver-ish string. ``"1.0.0"`` -> ``1``."""
+    try:
+        return int(version.split(".", 1)[0])
+    except (ValueError, AttributeError) as exc:
+        raise UnsupportedSchemaVersionError(
+            f"Unparseable schema_version {version!r}: expected semver like '1.0.0'."
+        ) from exc
+
+
+def _parse_iso(value: str) -> datetime:
+    # Accept both "...+00:00" and "...Z" terminations.
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)

--- a/src/llenergymeasure/config/schema_loader.py
+++ b/src/llenergymeasure/config/schema_loader.py
@@ -21,11 +21,12 @@ from datetime import datetime
 from importlib import resources
 from typing import Any
 
+from llenergymeasure.config.ssot import ENGINE_TENSORRT, ENGINE_TRANSFORMERS, ENGINE_VLLM
+
 SUPPORTED_MAJOR_VERSION = 1
 
-# Engines known to ship a vendored schema. Hardcoded here; PR 48.3 will
-# source this from ssot.ALL_ENGINES once that constant exists.
-_KNOWN_ENGINES: tuple[str, ...] = ("vllm", "tensorrt", "transformers")
+# Engines known to ship a vendored schema.
+_KNOWN_ENGINES: tuple[str, ...] = (ENGINE_VLLM, ENGINE_TENSORRT, ENGINE_TRANSFORMERS)
 
 _PACKAGE = "llenergymeasure.config.discovered_schemas"
 

--- a/tests/unit/config/test_discover_engine_schemas.py
+++ b/tests/unit/config/test_discover_engine_schemas.py
@@ -1,0 +1,199 @@
+"""Tests for scripts/discover_engine_schemas.py — pure-Python helpers only.
+
+Container-gated end-to-end discovery tests would use @pytest.mark.docker and
+live in a separate test file if added later. This module tests the helpers
+that power the discovery script without requiring any engine package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+# Load scripts/discover_engine_schemas.py as a module.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = REPO_ROOT / "scripts" / "discover_engine_schemas.py"
+_spec = importlib.util.spec_from_file_location("_discover_engine_schemas", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+discover = importlib.util.module_from_spec(_spec)
+sys.modules["_discover_engine_schemas"] = discover
+_spec.loader.exec_module(discover)
+
+
+# ---------------------------------------------------------------------------
+# _annotation_to_type_str
+# ---------------------------------------------------------------------------
+
+
+def test_type_str_simple_primitives() -> None:
+    assert discover._annotation_to_type_str(int) == "int"
+    assert discover._annotation_to_type_str(str) == "str"
+    assert discover._annotation_to_type_str(bool) == "bool"
+
+
+def test_type_str_none_type() -> None:
+    assert discover._annotation_to_type_str(type(None)) == "None"
+
+
+def test_type_str_pep604_union() -> None:
+    assert discover._annotation_to_type_str(int | None) == "int | None"
+    assert discover._annotation_to_type_str(int | str | None) == "int | str | None"
+
+
+def test_type_str_typing_optional() -> None:
+    # Deliberately exercising the legacy typing.Optional form — discovery sees
+    # this syntax in third-party code even if we prefer X | None ourselves.
+    from typing import Optional
+
+    assert discover._annotation_to_type_str(Optional[int]) == "int | None"  # noqa: UP045
+
+
+def test_type_str_typing_union() -> None:
+    # Ditto for typing.Union — third-party engine packages still use it.
+    from typing import Union
+
+    assert discover._annotation_to_type_str(Union[int, str]) == "int | str"  # noqa: UP007
+
+
+def test_type_str_generic_list_dict() -> None:
+    assert discover._annotation_to_type_str(list[str]) == "list[str]"
+    assert discover._annotation_to_type_str(dict[str, int]) == "dict[str, int]"
+    assert discover._annotation_to_type_str(list[dict[str, int]]) == "list[dict[str, int]]"
+
+
+def test_type_str_literal() -> None:
+    assert discover._annotation_to_type_str(Literal["a", "b"]) == "Literal['a', 'b']"
+
+
+def test_type_str_empty_means_unknown() -> None:
+    import inspect
+
+    assert discover._annotation_to_type_str(inspect.Parameter.empty) == "unknown"
+    assert discover._annotation_to_type_str(inspect.Signature.empty) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _read_dockerfile_from
+# ---------------------------------------------------------------------------
+
+
+def test_read_dockerfile_single_stage(tmp_path: Path) -> None:
+    df = tmp_path / "Dockerfile"
+    df.write_text("ARG FOO_VERSION=1.2.3\nFROM foo/foo:${FOO_VERSION}\n")
+    assert discover._read_dockerfile_from(df) == "foo/foo:1.2.3"
+
+
+def test_read_dockerfile_prefers_runtime_stage(tmp_path: Path) -> None:
+    df = tmp_path / "Dockerfile"
+    df.write_text(
+        "ARG DEVEL=a:1-devel\n"
+        "ARG RUNTIME=a:1-runtime\n"
+        "FROM foo:${DEVEL} AS builder\n"
+        "FROM foo:${RUNTIME} AS runtime\n"
+        "FROM runtime AS dev\n"
+    )
+    assert discover._read_dockerfile_from(df) == "foo:a:1-runtime"
+
+
+def test_read_dockerfile_no_runtime_stage_falls_back(tmp_path: Path) -> None:
+    df = tmp_path / "Dockerfile"
+    df.write_text(
+        "FROM foo:1 AS builder\n"
+        "FROM bar:2 AS packager\n"
+        "FROM builder\n"  # references prior stage — should be skipped
+    )
+    # No `AS runtime` → first external FROM wins (foo:1)
+    assert discover._read_dockerfile_from(df) == "foo:1"
+
+
+def test_read_dockerfile_expands_only_default_args(tmp_path: Path, monkeypatch) -> None:
+    df = tmp_path / "Dockerfile"
+    df.write_text("ARG VER=default\nFROM foo:${VER} AS runtime\n")
+    monkeypatch.setenv("VER", "from-env")  # must be ignored
+    assert discover._read_dockerfile_from(df) == "foo:default"
+
+
+def test_read_dockerfile_no_from_raises(tmp_path: Path) -> None:
+    df = tmp_path / "Dockerfile"
+    df.write_text("ARG X=1\n# no FROM\n")
+    with pytest.raises(ValueError, match="No FROM directive"):
+        discover._read_dockerfile_from(df)
+
+
+def test_read_dockerfile_against_real_dockerfiles() -> None:
+    vllm_from = discover._read_dockerfile_from(REPO_ROOT / "docker/Dockerfile.vllm")
+    assert vllm_from.startswith("vllm/vllm-openai:")
+
+    trt_from = discover._read_dockerfile_from(REPO_ROOT / "docker/Dockerfile.tensorrt")
+    assert trt_from.startswith("nvcr.io/nvidia/tensorrt-llm/release:")
+
+    tx_from = discover._read_dockerfile_from(REPO_ROOT / "docker/Dockerfile.transformers")
+    # runtime stage uses non-devel tag
+    assert "pytorch/pytorch:" in tx_from and "devel" not in tx_from
+
+
+# ---------------------------------------------------------------------------
+# _jsonable
+# ---------------------------------------------------------------------------
+
+
+def test_jsonable_primitives_passthrough() -> None:
+    for v in (None, True, 1, 1.5, "x"):
+        assert discover._jsonable(v) == v
+
+
+def test_jsonable_sets_sorted_list() -> None:
+    assert discover._jsonable({3, 1, 2}) == [1, 2, 3]
+
+
+def test_jsonable_tuple_to_list() -> None:
+    assert discover._jsonable((1, "a", None)) == [1, "a", None]
+
+
+def test_jsonable_nested_dict() -> None:
+    got = discover._jsonable({"k": (1, {2, 3})})
+    assert got == {"k": [1, [2, 3]]}
+
+
+def test_jsonable_type_to_name() -> None:
+    assert discover._jsonable(int) == "int"
+
+
+def test_jsonable_fallback_to_str() -> None:
+    class Opaque:
+        def __repr__(self) -> str:
+            return "<opaque>"
+
+    assert discover._jsonable(Opaque()) == "<opaque>"
+
+
+# ---------------------------------------------------------------------------
+# Envelope shape
+# ---------------------------------------------------------------------------
+
+
+def test_make_envelope_fills_required_keys() -> None:
+    env = discover._make_envelope(
+        engine="vllm",
+        engine_version="0.7.3",
+        engine_commit_sha=None,
+        image_ref="foo:1",
+        base_image_ref="foo:1",
+        discovery_method="unit test",
+        discovery_limitations=[],
+        engine_params={"a": {"type": "int", "default": 0}},
+        sampling_params={"b": {"type": "str", "default": ""}},
+    )
+    assert env["schema_version"] == discover.SCHEMA_VERSION
+    assert env["engine"] == "vllm"
+    assert env["discovered_at"]  # ISO string
+    assert "engine_params" in env and "sampling_params" in env
+
+
+def test_schema_version_is_semver_with_major_one() -> None:
+    major = int(discover.SCHEMA_VERSION.split(".")[0])
+    assert major == 1, "PR 48.1 ships schema_version 1.x; bumping major requires loader update"

--- a/tests/unit/config/test_schema_loader.py
+++ b/tests/unit/config/test_schema_loader.py
@@ -1,0 +1,190 @@
+"""Tests for SchemaLoader — loads vendored engine schemas from discovered_schemas/."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from llenergymeasure.config import (
+    DiscoveredSchema,
+    DiscoveryLimitation,
+    SchemaLoader,
+    UnsupportedSchemaVersionError,
+)
+from llenergymeasure.config.schema_loader import _parse_envelope
+
+KNOWN_ENGINES = ("vllm", "tensorrt", "transformers")
+
+
+@pytest.mark.parametrize("engine", KNOWN_ENGINES)
+def test_load_schema_returns_discovered_schema(engine: str) -> None:
+    schema = SchemaLoader().load_schema(engine)
+
+    assert isinstance(schema, DiscoveredSchema)
+    assert schema.engine == engine
+    assert schema.schema_version.startswith("1.")
+    assert schema.engine_version
+    assert schema.image_ref
+    assert schema.base_image_ref
+    assert isinstance(schema.discovered_at, datetime)
+    assert schema.engine_params, f"{engine}.json has no engine_params"
+    assert schema.sampling_params, f"{engine}.json has no sampling_params"
+
+
+def test_load_schema_caches_per_instance() -> None:
+    loader = SchemaLoader()
+    first = loader.load_schema("vllm")
+    second = loader.load_schema("vllm")
+    assert first is second, "cached lookups should return the same object"
+
+
+def test_invalidate_drops_cache() -> None:
+    loader = SchemaLoader()
+    first = loader.load_schema("vllm")
+    loader.invalidate("vllm")
+    second = loader.load_schema("vllm")
+    assert first is not second, "after invalidate(engine), a reload produces a new object"
+    assert first == second, "the schemas' content should be equal"
+
+
+def test_invalidate_all() -> None:
+    loader = SchemaLoader()
+    loader.load_schema("vllm")
+    loader.load_schema("tensorrt")
+    loader.invalidate()
+    # Private cache inspection is acceptable in tests
+    assert not loader._cache
+
+
+def test_load_schema_unknown_engine_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown engine 'made-up'"):
+        SchemaLoader().load_schema("made-up")
+
+
+def test_load_schema_missing_file_raises_with_hint(tmp_path: Path) -> None:
+    # Point the loader at an empty resources package by patching the package constant
+    fake_pkg = tmp_path / "empty_pkg"
+    fake_pkg.mkdir()
+    (fake_pkg / "__init__.py").write_text("")
+
+    # Patch _KNOWN_ENGINES to include 'ghost' but no file exists for it
+    with (
+        patch("llenergymeasure.config.schema_loader._KNOWN_ENGINES", ("vllm", "ghost")),
+        pytest.raises(FileNotFoundError, match=r"update_engine_schema\.sh ghost"),
+    ):
+        loader = SchemaLoader()
+        loader.load_schema("ghost")
+
+
+def test_major_version_mismatch_raises() -> None:
+    envelope = _minimal_envelope(schema_version="2.0.0")
+    with pytest.raises(UnsupportedSchemaVersionError, match="major=2"):
+        _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+
+
+def test_unparseable_version_raises() -> None:
+    envelope = _minimal_envelope(schema_version="not-semver")
+    with pytest.raises(UnsupportedSchemaVersionError, match="Unparseable schema_version"):
+        _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+
+
+def test_minor_version_accepted() -> None:
+    envelope = _minimal_envelope(schema_version="1.7.3")
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.schema_version == "1.7.3"
+
+
+def test_iso_z_termination_accepted() -> None:
+    envelope = _minimal_envelope(discovered_at="2026-04-13T22:00:00Z")
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.discovered_at.isoformat().startswith("2026-04-13T22:00:00")
+
+
+def test_base_image_ref_falls_back_to_image_ref() -> None:
+    envelope = _minimal_envelope()
+    envelope.pop("base_image_ref")
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.base_image_ref == parsed.image_ref
+
+
+def test_discovery_limitations_parsed_into_dataclass() -> None:
+    envelope = _minimal_envelope()
+    envelope["discovery_limitations"] = [
+        {"section": "engine_params", "fields": ["foo", "bar"], "reason": "missing"}
+    ]
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert len(parsed.discovery_limitations) == 1
+    lim = parsed.discovery_limitations[0]
+    assert isinstance(lim, DiscoveryLimitation)
+    assert lim.section == "engine_params"
+    assert lim.fields == ["foo", "bar"]
+    assert lim.reason == "missing"
+
+
+def test_load_all_schemas_returns_all_known() -> None:
+    all_schemas = SchemaLoader().load_all_schemas()
+    assert set(all_schemas) == set(KNOWN_ENGINES)
+
+
+@pytest.mark.parametrize("engine", KNOWN_ENGINES)
+def test_vendored_schema_has_expected_shape(engine: str) -> None:
+    schema = SchemaLoader().load_schema(engine)
+    # Every param entry must be a dict with a 'type' key (common contract)
+    for name, spec in schema.engine_params.items():
+        assert isinstance(spec, dict), f"{engine}.engine_params[{name}] is not a dict"
+        assert "type" in spec, f"{engine}.engine_params[{name}] has no 'type' key"
+    for name, spec in schema.sampling_params.items():
+        assert isinstance(spec, dict), f"{engine}.sampling_params[{name}] is not a dict"
+        assert "type" in spec, f"{engine}.sampling_params[{name}] has no 'type' key"
+
+
+def test_vllm_has_expected_field_floor() -> None:
+    # Soft floors (upstream adds fields over time) to catch catastrophic loss
+    schema = SchemaLoader().load_schema("vllm")
+    assert len(schema.engine_params) >= 80, "vLLM EngineArgs should yield >=80 fields"
+    assert len(schema.sampling_params) >= 20, "vLLM SamplingParams should yield >=20 fields"
+
+
+def test_tensorrt_has_description_metadata() -> None:
+    schema = SchemaLoader().load_schema("tensorrt")
+    has_description = any(spec.get("description") for spec in schema.engine_params.values())
+    assert has_description, "TRT-LLM TrtLlmArgs Pydantic schema should yield per-field descriptions"
+
+
+def test_transformers_records_kwargs_as_limitations() -> None:
+    schema = SchemaLoader().load_schema("transformers")
+    kwargs_limitation = next(
+        (lim for lim in schema.discovery_limitations if any("**kwargs" in f for f in lim.fields)),
+        None,
+    )
+    assert kwargs_limitation is not None, (
+        "Transformers from_pretrained kwargs should be recorded as a limitation"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_envelope(**overrides: object) -> dict[str, object]:
+    """Produce a minimal but valid envelope for parser-targeted tests."""
+    envelope: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "engine": "vllm",
+        "engine_version": "0.7.3",
+        "engine_commit_sha": None,
+        "image_ref": "vllm/vllm-openai:v0.7.3",
+        "base_image_ref": "vllm/vllm-openai:v0.7.3",
+        "discovered_at": "2026-04-13T22:00:00+00:00",
+        "discovery_method": "unit test fixture",
+        "discovery_limitations": [],
+        "engine_params": {"dummy": {"type": "str", "default": None}},
+        "sampling_params": {"dummy": {"type": "str", "default": None}},
+    }
+    envelope.update(overrides)
+    return envelope


### PR DESCRIPTION
## Summary

First half of Phase 48 (parameter discovery). Replaces hand-maintained engine parameter dictionaries with **programmatic schema extraction + vendored JSON schemas** as the SSOT for "what CAN I configure per engine". Pydantic models remain the SSOT for "what SHOULD I configure".

No user-facing behaviour changes. This PR lands the infrastructure; downstream PRs (48.2 field renames, 48.4 CI automation) consume the vendored JSONs.

## What's in

- **`scripts/discover_engine_schemas.py`** — introspects engine packages inside their Docker images and emits schema JSONs
  - vLLM: `dataclasses.fields(EngineArgs)` + `msgspec.json.schema(SamplingParams)` → 104 engine + 31 sampling params
  - TensorRT-LLM: `TrtLlmArgs.model_json_schema()` (Pydantic v2, richest metadata — includes descriptions and deprecated markers) + `dataclasses.fields(SamplingParams)` → 60 engine + 47 sampling params
  - Transformers: best-effort `inspect.signature(from_pretrained)` scrape + `GenerationConfig().to_dict()` → 9 engine + 69 sampling params (kwargs opacity recorded in `discovery_limitations`)
- **Vendored schemas** at `src/llenergymeasure/config/discovered_schemas/{vllm,tensorrt,transformers}.json` — ship inside the wheel
- **`SchemaLoader`** (`llenergymeasure.config.SchemaLoader`) — loads vendored schemas via `importlib.resources` with per-instance caching and major-version envelope validation. Raises `UnsupportedSchemaVersionError` on envelope breaking changes
- **`make discover-schema ENGINE=<engine>` / `make discover-schemas-all`** — Makefile targets wrapping `scripts/update_engine_schema.sh`. Always write to the vendored path; `git diff` is the review gate
- **43 new unit tests** (loader + helpers), all pure-Python (no container required)

## Architectural calls

- **Discovery image selection per engine**
  - vLLM: pristine `vllm/vllm-openai:<tag>` (vLLM pre-installed)
  - TRT-LLM: pristine `nvcr.io/nvidia/tensorrt-llm/release:<tag>` (works around the known `cuKernelGetName` bug in our `llenergymeasure:tensorrt` image)
  - Transformers: our `llenergymeasure:transformers` image (pristine `pytorch/pytorch` base has no transformers package)
- **No `--inspect` mode** — single write path to the vendored file; user reviews `git diff` and decides whether to commit. The PR 48.4 drift guard enforces "vendored schema must match Dockerfile FROM tag" in CI.
- **Envelope records both `image_ref` (where discovery ran) and `base_image_ref` (Dockerfile FROM tag)** — keeps discovery honest about the transformers-in-our-image case while preserving reproducibility.
- **Native per-engine richness preserved** — TRT-LLM entries carry `description` + `deprecated` from its Pydantic schema; vLLM and HF entries have only `type` + `default`. `SchemaLoader` returns raw `dict[str, Any]` rather than a normalised `FieldDescriptor`, letting consumers adapt at read time.

## Test plan

- [x] `pytest tests/unit/config/test_schema_loader.py tests/unit/config/test_discover_engine_schemas.py -v` — 43/43 pass
- [x] `pytest tests/unit -q` — 1860/1860 pass
- [x] `uv run ruff check src/ tests/ scripts/` + `ruff format --check ...` — all clean
- [x] `uv run mypy src/llenergymeasure/config/schema_loader.py` — clean
- [x] `uv run lint-imports` — 3 architectural contracts kept (schema_loader stays in `config` foundation layer, imports only stdlib)
- [x] `uv build --wheel && unzip -l ...` — all three JSONs present in the wheel exactly once
- [x] Fresh venv install + `SchemaLoader().load_schema('vllm')` — works via `importlib.resources` from installed wheel

## Out of scope (deferred)

- PR 48.2: Pydantic field-name alignment with vendored schema names
- PR 48.3: `ALL_ENGINES` constant in `ssot.py`
- PR 48.4: Renovate + `schema-refresh.yml` + drift guard + semantic diff
- Phase 50: retirement of `DTYPE_SUPPORT` / `DECODING_SUPPORT` capability dicts (the runtime probe replaces them)

## Known follow-ups

- Our `llenergymeasure:tensorrt` image has a `cuKernelGetName` linkage bug (existing pending todo) — discovery sidesteps it via pristine NGC; the bug still blocks actually running TRT-LLM inference in our image and needs a separate fix.
- Our `llenergymeasure:transformers` image was built pre-48.0b and lacks the `transformers` extra — it should be rebuilt before anyone relies on it at runtime.