### PR TITLE
fix(docker): correct libcuda search order in tensorrt image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ All notable changes to this project are documented here.
 
 - **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.
 
+### Fixed
+
+- **`ImportError: cuKernelGetName` when importing `tensorrt_llm` in our image.** `docker/Dockerfile.tensorrt` prepended `/usr/local/tensorrt/lib` to `LD_LIBRARY_PATH` but left the NGC-inherited ordering intact, placing `/usr/local/cuda/compat/lib.real` (the image-bundled compat library, CUDA 12.2) ahead of `/usr/local/cuda/compat/lib` (where nvidia-container-toolkit bind-mounts the host driver at `--gpus` time). `libtensorrt_llm.so` therefore resolved `libcuda.so.1` against the bundled library and failed to find `cuKernelGetName`, a symbol added in CUDA 12.4. Fix: prepend `/usr/local/cuda/compat/lib` so the host-driver mount takes precedence.
+
 ### Removed
 
 - Internal helper `llenergymeasure.study.runner._calculate_timeout` (replaced by direct config reads; also removes a layer-boundary import from `api/_impl.py`).

--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -22,7 +22,14 @@ ENTRYPOINT []
 # NGC sets TensorRT/CUDA library paths in shell profiles (.bashrc) rather
 # than Docker ENV.  Our CMD runs python3 directly (no shell), so we must
 # ensure LD_LIBRARY_PATH includes the TRT and CUDA directories explicitly.
-ENV LD_LIBRARY_PATH="/usr/local/tensorrt/lib:${LD_LIBRARY_PATH}"
+#
+# /usr/local/cuda/compat/lib must appear BEFORE /usr/local/cuda/compat/lib.real
+# so that nvidia-container-toolkit's host-driver bind-mount (placed in
+# /usr/local/cuda/compat/lib at --gpus time) takes precedence over the
+# image's bundled compat fallback.  Without this ordering libtensorrt_llm.so
+# resolves libcuda.so.1 against the bundled library and fails to find CUDA
+# 12.4+ symbols (e.g. cuKernelGetName) when the host driver is CUDA 12.2.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib:${LD_LIBRARY_PATH}"
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 


### PR DESCRIPTION
## Symptom

Importing `tensorrt_llm` in our built image fails:

```
ImportError: /usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/libtensorrt_llm.so: undefined symbol: cuKernelGetName
```

The pristine NGC base image (`nvcr.io/nvidia/tensorrt-llm/release:0.21.0`) imports fine under identical conditions.

## Root cause

`docker/Dockerfile.tensorrt` line 25 set:

```dockerfile
ENV LD_LIBRARY_PATH="/usr/local/tensorrt/lib:${LD_LIBRARY_PATH}"
```

This preserved the NGC-inherited ordering where `/usr/local/cuda/compat/lib.real` (the image-bundled compat library, built against CUDA 12.2) appears **before** `/usr/local/cuda/compat/lib` (the directory where `nvidia-container-toolkit` bind-mounts the host driver at `--gpus` time).

`libtensorrt_llm.so` resolved `libcuda.so.1` against the bundled library and failed to find `cuKernelGetName`, a symbol added in CUDA 12.4. TRT-LLM 0.21.0 requires that symbol.

## Fix

Prepend `/usr/local/cuda/compat/lib` so the host-driver bind-mount takes precedence:

```dockerfile
# Before:
ENV LD_LIBRARY_PATH="/usr/local/tensorrt/lib:${LD_LIBRARY_PATH}"

# After:
ENV LD_LIBRARY_PATH="/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib:${LD_LIBRARY_PATH}"
```

## Verification

**Before (current image, must fail):**

```
$ docker run --rm --gpus all --entrypoint python3 llenergymeasure:tensorrt \
    -c "import tensorrt_llm; print('OK')"

ImportError: .../libtensorrt_llm.so: undefined symbol: cuKernelGetName
EXIT:1
```

**After (fix simulated via `-e LD_LIBRARY_PATH=...` override, must succeed):**

```
$ docker run --rm --gpus all \
  -e LD_LIBRARY_PATH="/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib:/usr/local/cuda/lib64:/usr/local/cuda/compat/lib.real:/usr/local/lib/python3.12/dist-packages/torch/lib:/usr/local/lib/python3.12/dist-packages/torch_tensorrt/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64" \
  --entrypoint python3 llenergymeasure:tensorrt \
  -c "import tensorrt_llm; print('OK', tensorrt_llm.__version__)"

[TensorRT-LLM] TensorRT-LLM version: 0.21.0
OK 0.21.0
EXIT:0
```

Full rebuild and experiment-level verification will run in CI.