### PR TITLE
fix(docker): align Dockerfile.transformers with renamed transformers extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ All notable changes to this project are documented here.
   - `TensorRTConfig.backend` — TRT-LLM's internal `LLM(backend=...)` parameter
   - Energy measurement backends (Zeus, NVML, CodeCarbon)
 
+### Fixed
+
+- **`Dockerfile.transformers` stale references.** The Dockerfile was renamed in #261 but still installed the now-nonexistent `[pytorch]` extra and carried header comments referencing the old `Dockerfile.pytorch` file and `llenergymeasure-pytorch` tag. Updated to install `.[transformers]` and corrected all header comments. The `pytorch/pytorch:*` base image tags are preserved - PyTorch the library is unchanged, only the engine identifier was renamed.
+
 ### Added
 
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.

--- a/docker/Dockerfile.transformers
+++ b/docker/Dockerfile.transformers
@@ -1,12 +1,13 @@
 # syntax=docker/dockerfile:1
 # ============================================================
-# PyTorch engine — llenergymeasure on top of official PyTorch image
+# Transformers engine — llenergymeasure on PyTorch base image
 # ============================================================
-# Extends pytorch/pytorch with llenergymeasure installed.
+# Uses pytorch/pytorch as the tensor substrate, then installs llenergymeasure
+# with the HuggingFace Transformers engine on top.
 # CUDA and PyTorch compatibility is guaranteed by the upstream image.
 #
 # Usage:
-#   docker build -f docker/Dockerfile.pytorch -t llenergymeasure-pytorch .
+#   docker build -f docker/Dockerfile.transformers -t llenergymeasure-transformers .
 #
 # Version pin policy: update PYTORCH_VERSION on each milestone release.
 # Must be compatible with pyproject.toml torch>=2.5 constraint.
@@ -80,7 +81,7 @@ COPY --from=builder /flash-attn-staging/ /opt/conda/lib/python3.11/site-packages
 
 WORKDIR /app
 
-# Install llenergymeasure with pytorch extras from source (no PyPI yet).
+# Install llenergymeasure with transformers extras from source (no PyPI yet).
 # sentencepiece needed for Llama/Qwen tokenisers.
 # Bind mounts: pyproject.toml/uv.lock/README.md are build-only (not needed at runtime).
 # Cache mount: uv reuses cached wheels across rebuilds without bloating the image.
@@ -89,7 +90,7 @@ RUN --mount=type=bind,source=pyproject.toml,target=/app/pyproject.toml \
     --mount=type=bind,source=uv.lock,target=/app/uv.lock \
     --mount=type=bind,source=README.md,target=/app/README.md \
     --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system ".[pytorch]" sentencepiece einops
+    uv pip install --system ".[transformers]" sentencepiece einops
 
 # HuggingFace cache — writable for non-root users
 ENV HF_HOME=/app/.cache/huggingface


### PR DESCRIPTION
## Summary

PR #261 (`refactor!: rename pytorch engine identifier to transformers`) renamed the PyPI extra from `[pytorch]` to `[transformers]` in `pyproject.toml` and renamed `Dockerfile.pytorch` to `Dockerfile.transformers`. However, the Dockerfile itself was not fully updated — it still contained stale references that would cause a rebuild to fail.

## Symptom

A fresh rebuild of `docker/Dockerfile.transformers` fails at the install step because it attempts to install `.[pytorch]`, which no longer exists in `pyproject.toml`:

```
uv pip install --system ".[pytorch]" sentencepiece einops
# ERROR: extra 'pytorch' not found — renamed to 'transformers' in #261
```

## What #261 did

Renamed the `[pytorch]` optional-dependencies group to `[transformers]` in `pyproject.toml`, and renamed the file from `Dockerfile.pytorch` → `Dockerfile.transformers`. The Dockerfile's internal content was not updated.

## This fix

Three targeted changes only — no other lines touched:

- **Line 92**: `".[pytorch]"` → `".[transformers]"` (the failing install step)
- **Header line 3**: `PyTorch engine — llenergymeasure on top of official PyTorch image` → `Transformers engine — llenergymeasure on PyTorch base image`
- **Header line 5**: rephrased to clarify that `pytorch/pytorch` is the tensor substrate base image, while the engine added on top is HuggingFace Transformers
- **Header line 9**: `docker build -f docker/Dockerfile.pytorch -t llenergymeasure-pytorch .` → `Dockerfile.transformers` / `llenergymeasure-transformers`

## Verification

**1. Grep before/after — no stale `[pytorch]` extra, base image refs preserved:**

```
$ grep -n 'pytorch' docker/Dockerfile.transformers
5:# Uses pytorch/pytorch as the tensor substrate, then installs llenergymeasure
27:FROM pytorch/pytorch:${PYTORCH_DEVEL_VERSION} AS builder
68:FROM pytorch/pytorch:${PYTORCH_VERSION} AS runtime
```

The `pytorch/pytorch:*` Docker Hub base image references are correctly preserved — PyTorch the library and its Docker Hub image name are unchanged. Only the engine identifier was renamed.

**2. `pyproject.toml` has `[transformers]` extra at line 29:**
```
transformers = [
```

**3. `FROM` count unchanged — still 3 stages (builder, runtime, dev).**

Full build + runtime verification runs in CI post-merge. Local rebuild is out of scope (flash-attn builds from source take ~1 hour cold).

## Notes

The Dockerfile rename itself landed in #261 — this PR closes the residual comment and config drift only.