### PR TITLE
feat(config): add SchemaLoader for vendored engine schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project are documented here.
 - **Engine parameter discovery (`scripts/discover_engine_schemas.py`).** Introspects installed engine packages inside their Docker images and emits JSON schemas describing every configurable parameter (types, defaults, descriptions where available, discovery limitations). Supports `vllm`, `tensorrt`, and `transformers`; `--all` discovers every engine found in the current image.
 - **Vendored engine schemas at `src/llenergymeasure/config/discovered_schemas/{vllm,tensorrt,transformers}.json`.** These are the canonical SSOT for "what CAN I configure per engine", shipped inside the wheel. Regenerate with `make discover-schema ENGINE=<engine>` (writes to the vendored path and prints `git diff`; committing is the review gate).
 - **`make discover-schema` / `make discover-schemas-all` targets.** Rebuild vendored engine schemas via `./scripts/update_engine_schema.sh`.
+- **`SchemaLoader` class (`llenergymeasure.config.SchemaLoader`).** Reads vendored engine schemas via `importlib.resources` with per-instance caching and major-version envelope validation. Raises `UnsupportedSchemaVersionError` on envelope breaking changes. Exports `DiscoveredSchema`, `DiscoveryLimitation`, and `UnsupportedSchemaVersionError` from `llenergymeasure.config`.
 
 ### Changed
 

--- a/src/llenergymeasure/config/__init__.py
+++ b/src/llenergymeasure/config/__init__.py
@@ -5,6 +5,7 @@ Public API:
 - load_experiment_config: Load from YAML/JSON with CLI override support
 - load_user_config: Load user preferences from XDG config dir
 - get_user_config_path: Return the XDG user config path
+- SchemaLoader / DiscoveredSchema: Access vendored engine parameter schemas
 """
 
 from llenergymeasure.config.loader import (
@@ -19,6 +20,12 @@ from llenergymeasure.config.models import (
     LoRAConfig,
     WarmupConfig,
 )
+from llenergymeasure.config.schema_loader import (
+    DiscoveredSchema,
+    DiscoveryLimitation,
+    SchemaLoader,
+    UnsupportedSchemaVersionError,
+)
 from llenergymeasure.config.user_config import (
     UserConfig,
     get_user_config_path,
@@ -29,8 +36,12 @@ __all__ = [
     "BaselineConfig",
     "DatasetConfig",
     "DecoderConfig",
+    "DiscoveredSchema",
+    "DiscoveryLimitation",
     "ExperimentConfig",
     "LoRAConfig",
+    "SchemaLoader",
+    "UnsupportedSchemaVersionError",
     "UserConfig",
     "WarmupConfig",
     "deep_merge",

--- a/src/llenergymeasure/config/schema_loader.py
+++ b/src/llenergymeasure/config/schema_loader.py
@@ -1,0 +1,185 @@
+"""Load vendored engine schemas discovered by ``scripts/discover_engine_schemas.py``.
+
+The vendored JSON files in ``discovered_schemas/`` are the canonical SSOT for
+"what parameters CAN be configured per engine". They are produced by running
+introspection inside each engine's Docker image and committed to the repo.
+
+This loader reads them via ``importlib.resources`` so it works in both editable
+installs and installed wheels. Repeated loads are cached per-engine. Major
+version mismatches (envelope schema breaking changes) raise
+``UnsupportedSchemaVersionError``.
+
+Downstream consumers (doc generators, field-name alignment, CI drift guards)
+should load through this module rather than reading the JSON files directly.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from importlib import resources
+from typing import Any
+
+from llenergymeasure.config.ssot import ENGINE_TENSORRT, ENGINE_TRANSFORMERS, ENGINE_VLLM
+
+SUPPORTED_MAJOR_VERSION = 1
+
+# Engines known to ship a vendored schema.
+_KNOWN_ENGINES: tuple[str, ...] = (ENGINE_VLLM, ENGINE_TENSORRT, ENGINE_TRANSFORMERS)
+
+_PACKAGE = "llenergymeasure.config.discovered_schemas"
+
+
+class UnsupportedSchemaVersionError(ValueError):
+    """Raised when a vendored schema's major version doesn't match this loader."""
+
+
+@dataclass(frozen=True)
+class DiscoveryLimitation:
+    """A single limitation recorded by the discovery script.
+
+    Fields that discovery could not recover (e.g. HF's None-default fields with
+    no type annotations, or kwargs that don't appear in an inspected signature)
+    are surfaced here rather than silently dropped.
+    """
+
+    section: str
+    fields: list[str]
+    reason: str
+
+
+@dataclass(frozen=True)
+class DiscoveredSchema:
+    """A parsed vendored engine schema.
+
+    ``engine_params`` and ``sampling_params`` are kept as raw dicts rather than
+    a typed FieldDescriptor because per-engine richness varies: TRT-LLM fields
+    carry ``description`` and ``deprecated`` from its Pydantic schema, while
+    vLLM and Transformers fields only have ``type`` and ``default``. Consumers
+    that need uniform shape should adapt at read time.
+    """
+
+    schema_version: str
+    engine: str
+    engine_version: str
+    engine_commit_sha: str | None
+    image_ref: str
+    base_image_ref: str
+    discovered_at: datetime
+    discovery_method: str
+    discovery_limitations: list[DiscoveryLimitation] = field(default_factory=list)
+    engine_params: dict[str, dict[str, Any]] = field(default_factory=dict)
+    sampling_params: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+class SchemaLoader:
+    """Load and cache vendored engine schemas.
+
+    Uses a per-instance dict cache (rather than ``functools.lru_cache``) so
+    multiple SchemaLoader instances don't share state — convenient for tests
+    and for isolating reloads after a schema refresh.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, DiscoveredSchema] = {}
+
+    def load_schema(self, engine: str) -> DiscoveredSchema:
+        """Load the vendored schema for ``engine``.
+
+        Raises:
+            ValueError: ``engine`` is not a known engine name.
+            FileNotFoundError: No vendored JSON exists for ``engine``.
+            UnsupportedSchemaVersionError: Vendored schema major version
+                doesn't match ``SUPPORTED_MAJOR_VERSION``.
+            json.JSONDecodeError: Vendored file is not valid JSON.
+        """
+        if engine not in _KNOWN_ENGINES:
+            raise ValueError(f"Unknown engine {engine!r}. Known engines: {list(_KNOWN_ENGINES)}.")
+
+        cached = self._cache.get(engine)
+        if cached is not None:
+            return cached
+
+        try:
+            raw_text = (resources.files(_PACKAGE) / f"{engine}.json").read_text()
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Vendored schema for engine {engine!r} not found. "
+                f"Run `./scripts/update_engine_schema.sh {engine}` to generate it."
+            ) from exc
+
+        parsed = _parse_envelope(engine=engine, raw_text=raw_text)
+        self._cache[engine] = parsed
+        return parsed
+
+    def load_all_schemas(self) -> dict[str, DiscoveredSchema]:
+        """Load all known engines' schemas.
+
+        Does not skip missing files — every engine in ``_KNOWN_ENGINES`` must
+        have a vendored schema. Callers that need tolerance should iterate and
+        catch ``FileNotFoundError`` themselves.
+        """
+        return {engine: self.load_schema(engine) for engine in _KNOWN_ENGINES}
+
+    def invalidate(self, engine: str | None = None) -> None:
+        """Drop cached schema(s). Useful after a schema refresh in-process."""
+        if engine is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(engine, None)
+
+
+def _parse_envelope(*, engine: str, raw_text: str) -> DiscoveredSchema:
+    data = json.loads(raw_text)
+
+    schema_version = data["schema_version"]
+    major = _major_version(schema_version)
+    if major != SUPPORTED_MAJOR_VERSION:
+        raise UnsupportedSchemaVersionError(
+            f"Vendored schema for {engine!r} has schema_version={schema_version!r} "
+            f"(major={major}); this SchemaLoader only supports major "
+            f"{SUPPORTED_MAJOR_VERSION}. Regenerate with a matching discovery script, "
+            f"or upgrade the loader."
+        )
+
+    limitations_raw = data.get("discovery_limitations", [])
+    limitations = [
+        DiscoveryLimitation(
+            section=item.get("section", ""),
+            fields=list(item.get("fields", [])),
+            reason=item.get("reason", ""),
+        )
+        for item in limitations_raw
+    ]
+
+    return DiscoveredSchema(
+        schema_version=schema_version,
+        engine=data["engine"],
+        engine_version=data["engine_version"],
+        engine_commit_sha=data.get("engine_commit_sha"),
+        image_ref=data["image_ref"],
+        base_image_ref=data.get("base_image_ref", data["image_ref"]),
+        discovered_at=_parse_iso(data["discovered_at"]),
+        discovery_method=data.get("discovery_method", ""),
+        discovery_limitations=limitations,
+        engine_params=data.get("engine_params", {}),
+        sampling_params=data.get("sampling_params", {}),
+    )
+
+
+def _major_version(version: str) -> int:
+    """Parse major from a semver-ish string. ``"1.0.0"`` -> ``1``."""
+    try:
+        return int(version.split(".", 1)[0])
+    except (ValueError, AttributeError) as exc:
+        raise UnsupportedSchemaVersionError(
+            f"Unparseable schema_version {version!r}: expected semver like '1.0.0'."
+        ) from exc
+
+
+def _parse_iso(value: str) -> datetime:
+    # Accept both "...+00:00" and "...Z" terminations.
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)

--- a/tests/unit/config/test_schema_loader.py
+++ b/tests/unit/config/test_schema_loader.py
@@ -1,0 +1,190 @@
+"""Tests for SchemaLoader — loads vendored engine schemas from discovered_schemas/."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from llenergymeasure.config import (
+    DiscoveredSchema,
+    DiscoveryLimitation,
+    SchemaLoader,
+    UnsupportedSchemaVersionError,
+)
+from llenergymeasure.config.schema_loader import _parse_envelope
+
+KNOWN_ENGINES = ("vllm", "tensorrt", "transformers")
+
+
+@pytest.mark.parametrize("engine", KNOWN_ENGINES)
+def test_load_schema_returns_discovered_schema(engine: str) -> None:
+    schema = SchemaLoader().load_schema(engine)
+
+    assert isinstance(schema, DiscoveredSchema)
+    assert schema.engine == engine
+    assert schema.schema_version.startswith("1.")
+    assert schema.engine_version
+    assert schema.image_ref
+    assert schema.base_image_ref
+    assert isinstance(schema.discovered_at, datetime)
+    assert schema.engine_params, f"{engine}.json has no engine_params"
+    assert schema.sampling_params, f"{engine}.json has no sampling_params"
+
+
+def test_load_schema_caches_per_instance() -> None:
+    loader = SchemaLoader()
+    first = loader.load_schema("vllm")
+    second = loader.load_schema("vllm")
+    assert first is second, "cached lookups should return the same object"
+
+
+def test_invalidate_drops_cache() -> None:
+    loader = SchemaLoader()
+    first = loader.load_schema("vllm")
+    loader.invalidate("vllm")
+    second = loader.load_schema("vllm")
+    assert first is not second, "after invalidate(engine), a reload produces a new object"
+    assert first == second, "the schemas' content should be equal"
+
+
+def test_invalidate_all() -> None:
+    loader = SchemaLoader()
+    loader.load_schema("vllm")
+    loader.load_schema("tensorrt")
+    loader.invalidate()
+    # Private cache inspection is acceptable in tests
+    assert not loader._cache
+
+
+def test_load_schema_unknown_engine_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown engine 'made-up'"):
+        SchemaLoader().load_schema("made-up")
+
+
+def test_load_schema_missing_file_raises_with_hint(tmp_path: Path) -> None:
+    # Point the loader at an empty resources package by patching the package constant
+    fake_pkg = tmp_path / "empty_pkg"
+    fake_pkg.mkdir()
+    (fake_pkg / "__init__.py").write_text("")
+
+    # Patch _KNOWN_ENGINES to include 'ghost' but no file exists for it
+    with (
+        patch("llenergymeasure.config.schema_loader._KNOWN_ENGINES", ("vllm", "ghost")),
+        pytest.raises(FileNotFoundError, match=r"update_engine_schema\.sh ghost"),
+    ):
+        loader = SchemaLoader()
+        loader.load_schema("ghost")
+
+
+def test_major_version_mismatch_raises() -> None:
+    envelope = _minimal_envelope(schema_version="2.0.0")
+    with pytest.raises(UnsupportedSchemaVersionError, match="major=2"):
+        _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+
+
+def test_unparseable_version_raises() -> None:
+    envelope = _minimal_envelope(schema_version="not-semver")
+    with pytest.raises(UnsupportedSchemaVersionError, match="Unparseable schema_version"):
+        _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+
+
+def test_minor_version_accepted() -> None:
+    envelope = _minimal_envelope(schema_version="1.7.3")
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.schema_version == "1.7.3"
+
+
+def test_iso_z_termination_accepted() -> None:
+    envelope = _minimal_envelope(discovered_at="2026-04-13T22:00:00Z")
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.discovered_at.isoformat().startswith("2026-04-13T22:00:00")
+
+
+def test_base_image_ref_falls_back_to_image_ref() -> None:
+    envelope = _minimal_envelope()
+    envelope.pop("base_image_ref")
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.base_image_ref == parsed.image_ref
+
+
+def test_discovery_limitations_parsed_into_dataclass() -> None:
+    envelope = _minimal_envelope()
+    envelope["discovery_limitations"] = [
+        {"section": "engine_params", "fields": ["foo", "bar"], "reason": "missing"}
+    ]
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert len(parsed.discovery_limitations) == 1
+    lim = parsed.discovery_limitations[0]
+    assert isinstance(lim, DiscoveryLimitation)
+    assert lim.section == "engine_params"
+    assert lim.fields == ["foo", "bar"]
+    assert lim.reason == "missing"
+
+
+def test_load_all_schemas_returns_all_known() -> None:
+    all_schemas = SchemaLoader().load_all_schemas()
+    assert set(all_schemas) == set(KNOWN_ENGINES)
+
+
+@pytest.mark.parametrize("engine", KNOWN_ENGINES)
+def test_vendored_schema_has_expected_shape(engine: str) -> None:
+    schema = SchemaLoader().load_schema(engine)
+    # Every param entry must be a dict with a 'type' key (common contract)
+    for name, spec in schema.engine_params.items():
+        assert isinstance(spec, dict), f"{engine}.engine_params[{name}] is not a dict"
+        assert "type" in spec, f"{engine}.engine_params[{name}] has no 'type' key"
+    for name, spec in schema.sampling_params.items():
+        assert isinstance(spec, dict), f"{engine}.sampling_params[{name}] is not a dict"
+        assert "type" in spec, f"{engine}.sampling_params[{name}] has no 'type' key"
+
+
+def test_vllm_has_expected_field_floor() -> None:
+    # Soft floors (upstream adds fields over time) to catch catastrophic loss
+    schema = SchemaLoader().load_schema("vllm")
+    assert len(schema.engine_params) >= 80, "vLLM EngineArgs should yield >=80 fields"
+    assert len(schema.sampling_params) >= 20, "vLLM SamplingParams should yield >=20 fields"
+
+
+def test_tensorrt_has_description_metadata() -> None:
+    schema = SchemaLoader().load_schema("tensorrt")
+    has_description = any(spec.get("description") for spec in schema.engine_params.values())
+    assert has_description, "TRT-LLM TrtLlmArgs Pydantic schema should yield per-field descriptions"
+
+
+def test_transformers_records_kwargs_as_limitations() -> None:
+    schema = SchemaLoader().load_schema("transformers")
+    kwargs_limitation = next(
+        (lim for lim in schema.discovery_limitations if any("**kwargs" in f for f in lim.fields)),
+        None,
+    )
+    assert kwargs_limitation is not None, (
+        "Transformers from_pretrained kwargs should be recorded as a limitation"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_envelope(**overrides: object) -> dict[str, object]:
+    """Produce a minimal but valid envelope for parser-targeted tests."""
+    envelope: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "engine": "vllm",
+        "engine_version": "0.7.3",
+        "engine_commit_sha": None,
+        "image_ref": "vllm/vllm-openai:v0.7.3",
+        "base_image_ref": "vllm/vllm-openai:v0.7.3",
+        "discovered_at": "2026-04-13T22:00:00+00:00",
+        "discovery_method": "unit test fixture",
+        "discovery_limitations": [],
+        "engine_params": {"dummy": {"type": "str", "default": None}},
+        "sampling_params": {"dummy": {"type": "str", "default": None}},
+    }
+    envelope.update(overrides)
+    return envelope


### PR DESCRIPTION
## Summary

Second half of Phase 48.1 — the **consumer** side of engine schema discovery. Stacked on top of #266 (the producer / vendored JSONs). Adds a ``SchemaLoader`` class that reads the vendored schemas via ``importlib.resources``.

**Pure library code, ~400 lines including tests.** Stdlib-only runtime dependencies.

> 📦 **Base branch is ``feature/phase-48-1a-discovery`` (#266), not ``main``.** Rebased onto main once #266 merges.

## What's in

- **``src/llenergymeasure/config/schema_loader.py``** (~140 lines)
  - ``SchemaLoader.load_schema(engine) -> DiscoveredSchema`` — per-instance dict cache (avoids lru_cache's per-method reference cycle)
  - ``SchemaLoader.load_all_schemas()`` and ``.invalidate(engine=None)`` helpers
  - Frozen dataclasses: ``DiscoveredSchema``, ``DiscoveryLimitation``
  - ``UnsupportedSchemaVersionError`` (subclasses ``ValueError``) raised on envelope major-version mismatch
  - Known engines sourced from ``config.ssot`` constants (no hardcoded tuple)
- **``tests/unit/config/test_schema_loader.py``** (~190 lines, 21 tests)
  - Load / cache / invalidate behaviours
  - Version parsing: major mismatch raises, minor accepted, unparseable raises
  - ``base_image_ref`` falls back to ``image_ref`` if absent
  - ISO-8601 with ``Z`` termination
  - Shape contract: every param spec is a dict with a ``type`` key
  - Field-floor assertions to catch catastrophic field loss on upstream bumps
- **``src/llenergymeasure/config/__init__.py``** — re-exports ``SchemaLoader``, ``DiscoveredSchema``, ``DiscoveryLimitation``, ``UnsupportedSchemaVersionError``

## Design calls

- **``engine_params`` / ``sampling_params`` are ``dict[str, dict[str, Any]]``**, not a typed ``FieldDescriptor`` — per-engine richness genuinely varies (TRT-LLM has ``description`` / ``deprecated``, others don't). A typed dataclass would either lie about optional fields or flatten the native shape. Consumers adapt at read time.
- **Per-instance cache via ``self._cache``** rather than ``functools.lru_cache`` on a method — avoids the per-instance reference cycle, makes reload-after-refresh straightforward (``invalidate()``), and is friendly to tests.
- **``SUPPORTED_MAJOR_VERSION = 1`` hardcoded** — bumping the envelope major is a deliberate breaking change; the constant should update in lock-step with ``SCHEMA_VERSION`` in the discovery script.

## Verification

- [x] ``pytest tests/unit/config/test_schema_loader.py`` — 21/21 pass
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy`` on new module — clean
- [x] ``lint-imports`` — 3 contracts kept (``schema_loader`` stays in the ``config`` foundation layer, imports only stdlib + ``config.ssot``)
- [x] Wheel packaging: ``uv build --wheel`` → installed in a fresh venv → ``SchemaLoader().load_schema('vllm')`` round-trips from ``importlib.resources``

## Merge order

1. Merge #266 first (vendored JSONs land on main)
2. This PR's base auto-updates (GitHub changes base to ``main``) or we rebase; merge normally

## Supersedes

Part 2 of #263 (closed). The split gives reviewers two coherent units (producer / consumer) rather than one ~2900-line monolithic PR.