### PR TITLE
refactor(config)!: rename TensorRTConfig.tp_size to tensor_parallel_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,23 @@ All notable changes to this project are documented here.
 
 - **`Dockerfile.transformers` stale references.** The Dockerfile was renamed in #261 but still installed the now-nonexistent `[pytorch]` extra and carried header comments referencing the old `Dockerfile.pytorch` file and `llenergymeasure-pytorch` tag. Updated to install `.[transformers]` and corrected all header comments. The `pytorch/pytorch:*` base image tags are preserved - PyTorch the library is unchanged, only the engine identifier was renamed.
 
+- **`tensorrt.tp_size` → `tensorrt.tensor_parallel_size`.** Aligns the TensorRT-LLM Pydantic field name with `TrtLlmArgs.tensor_parallel_size`. `transformers.tp_size` is **preserved** — it follows the `accelerate` convention and HF has no single native `tensor_parallel_size` equivalent.
+
+  **Migrate YAML configs** (scope-limited — renames only inside `tensorrt:` blocks):
+  ```bash
+  # Manual edit is safer: 'tp_size' also appears legitimately under 'transformers:'
+  # In your tensorrt section, rename:  tp_size: N  →  tensor_parallel_size: N
+  ```
+
+  **Affected identifiers:**
+  - YAML field: `tensorrt.tp_size` → `tensorrt.tensor_parallel_size`
+  - Python: `TensorRTConfig(tp_size=N)` → `TensorRTConfig(tensor_parallel_size=N)`
+  - Sweep key: `"tensorrt.tp_size"` → `"tensorrt.tensor_parallel_size"`
+
+  **Preserved:**
+  - `transformers.tp_size` — HF accelerate convention, unchanged
+  - `vllm.engine.tensor_parallel_size` — already native name, unchanged
+
 ### Added
 
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,7 @@ All notable changes to this project are documented here.
 
 - **`tensorrt.tp_size` → `tensorrt.tensor_parallel_size`.** Aligns the TensorRT-LLM Pydantic field name with `TrtLlmArgs.tensor_parallel_size`. `transformers.tp_size` is **preserved** — it follows the `accelerate` convention and HF has no single native `tensor_parallel_size` equivalent.
 
-  **Migrate YAML configs** (scope-limited — renames only inside `tensorrt:` blocks):
-  ```bash
-  # Manual edit is safer: 'tp_size' also appears legitimately under 'transformers:'
-  # In your tensorrt section, rename:  tp_size: N  →  tensor_parallel_size: N
-  ```
+  **Migrate YAML configs** (scope-limited — manual edit is safer as `tp_size` also appears legitimately under `transformers:`; in your `tensorrt:` section rename `tp_size: N` → `tensor_parallel_size: N`).
 
   **Affected identifiers:**
   - YAML field: `tensorrt.tp_size` → `tensorrt.tensor_parallel_size`

--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -235,7 +235,7 @@ sweep: # TODO: maybe shared_sweep or global_sweep?
   # TODO: is this not tensorrt.dtype??
   tensorrt.max_input_len: [512, 1024]
   tensorrt.scheduler.capacity_scheduling_policy: [MAX_UTILIZATION, STATIC_BATCH]
-  # tensorrt.tp_size: [1, 2, 4]     # Tensor parallel (requires multi-GPU hardware)
+  # tensorrt.tensor_parallel_size: [1, 2, 4]     # Tensor parallel (requires multi-GPU hardware)
 
   # --- TensorRT: dependent groups ─────────────────────────────────
 
@@ -563,7 +563,7 @@ experiments:
   #     max_batch_size: 8
   #     max_input_len: 1024
   #     max_seq_len: 2048
-  #     tp_size: 2
+  #     tensor_parallel_size: 2
   #     build_cache:
   #       max_cache_storage_gb: 256
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -309,7 +309,7 @@ dtype: bfloat16
 runners:
   tensorrt: docker
 tensorrt:
-  tp_size: 2
+  tensor_parallel_size: 2
   max_batch_size: 8
   dtype: bfloat16
   quant:
@@ -330,7 +330,7 @@ Changing any **[recompile]** field invalidates the cached engine and triggers a 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `max_batch_size` | int | 8 | Maximum batch size the engine accepts. **[recompile]** |
-| `tp_size` | int | 1 | Tensor parallel degree (number of GPUs). **[recompile]** |
+| `tensor_parallel_size` | int | 1 | Tensor parallel degree (number of GPUs). **[recompile]** |
 | `max_input_len` | int | 1024 | Maximum input sequence length in tokens. **[recompile]** |
 | `max_seq_len` | int | 2048 | Maximum total sequence length (input + output). **[recompile]** |
 | `dtype` | `float16` \| `bfloat16` | auto | Model compute dtype. TRT-LLM is optimised for fp16/bf16; fp32 is not supported. **[recompile]** |
@@ -429,14 +429,14 @@ directly, skipping engine compilation entirely. This is useful when:
 
 1. Directory exists
 2. `config.json` exists and is valid JSON
-3. `tp_size` in `config.json` matches `tensorrt.tp_size` (if detectable)
-4. `rank{N}.engine` files exist for each rank (0 to tp_size-1)
+3. `tp_size` in `config.json` matches `tensorrt.tensor_parallel_size` (if detectable)
+4. `rank{N}.engine` files exist for each rank (0 to `tensor_parallel_size-1`)
 
 **What happens when `engine_path` is set:**
 
 - `model` field is still required but used only as a fallback tokeniser source
   (if the engine directory lacks tokeniser files)
-- All compile-time parameters (`max_batch_size`, `tp_size`, `max_input_len`,
+- All compile-time parameters (`max_batch_size`, `tensor_parallel_size`, `max_input_len`,
   `max_seq_len`, `dtype`, `fast_build`) are **ignored** - they are baked into
   the engine
 - `build_cache` is **ignored** - no compilation occurs, so caching is irrelevant
@@ -619,7 +619,7 @@ These parameters live in `ExperimentConfig` and are shared across all engines:
 | Parameter | Transformers | vLLM | TensorRT-LLM | Notes |
 |-----------|---------|------|--------------|-------|
 | `tensorrt.max_batch_size` | N/A | N/A | Yes | Compile-time constant |
-| `tensorrt.tp_size` | N/A | N/A | Yes | Tensor parallel size (compile-time) |
+| `tensorrt.tensor_parallel_size` | N/A | N/A | Yes | Tensor parallel size (compile-time) |
 | `tensorrt.max_input_len` | N/A | N/A | Yes | Max input tokens (compile-time) |
 | `tensorrt.max_seq_len` | N/A | N/A | Yes | Max total sequence length (compile-time) |
 | `tensorrt.dtype` | N/A | N/A | Yes | Model compute dtype (compile-time) |

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -448,7 +448,7 @@ directly, skipping engine compilation entirely. This is useful when:
 ```yaml
 tensorrt:
   engine_path: /engines/llama-7b-fp16-tp1
-  tp_size: 1  # Must match the engine's tp_size
+  tensor_parallel_size: 1  # Must match the engine's tensor_parallel_size
 ```
 
 > **Note:** Engines are not portable across GPU architectures. An engine compiled

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -794,7 +794,7 @@ relates to energy measurement.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `max_batch_size` | integer | None | `null` | Max batch size (compile-time constant, None -> 8) |
-| `tp_size` | integer | None | `null` | Tensor parallel size (None -> 1) |
+| `tensor_parallel_size` | integer | None | `null` | Tensor parallel size (None -> 1) |
 | `max_input_len` | integer | None | `null` | Max input sequence length (compile-time constant, None -> 1024) |
 | `max_seq_len` | integer | None | `null` | Max total sequence length (input + output, compile-time constant, None -> 2048) |
 | `dtype` | 'float16' | 'bfloat16' | None | `null` | Model dtype (None -> auto). TRT-LLM is optimised for fp16/bf16; fp32 not supported. |

--- a/scripts/test_multi_gpu_parallelization.py
+++ b/scripts/test_multi_gpu_parallelization.py
@@ -62,7 +62,7 @@ vllm:
 
 
 def create_tensorrt_config(config_dir: Path) -> Path:
-    """Create TensorRT config with tp_size=4."""
+    """Create TensorRT config with tensor_parallel_size=4."""
     config = config_dir / "tensorrt_tp4.yaml"
     config.write_text("""
 # TensorRT-LLM with tensor parallelism across 4 GPUs
@@ -77,7 +77,7 @@ parallelism:
   degree: 4
 
 tensorrt:
-  tp_size: 4
+  tensor_parallel_size: 4
   max_batch_size: 4
 """)
     return config
@@ -154,7 +154,6 @@ def check_gpu_utilization(output: str, expected_gpus: int = 4) -> bool:
         "GPUs: [0, 1, 2, 3]",
         f"Processes: {expected_gpus}",
         "tensor_parallel",
-        f"tp_size: {expected_gpus}",
         f"tensor_parallel_size: {expected_gpus}",
     ]
 

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -180,7 +180,9 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description=(
-            "Number of tensor parallel ranks (None -> WORLD_SIZE). Only used when tp_plan is set."
+            "Number of tensor parallel ranks (None -> WORLD_SIZE). Only used when tp_plan is set. "
+            "Field name preserved to match HuggingFace accelerate convention "
+            "(distinct from TensorRTConfig.tensor_parallel_size which aligns with TrtLlmArgs)."
         ),
     )
 
@@ -876,11 +878,7 @@ class TensorRTConfig(BaseModel):
     tensor_parallel_size: int | None = Field(
         default=None,
         ge=1,
-        description=(
-            "Tensor parallel size — number of GPUs to shard across (None -> 1). "
-            "Aligns with TrtLlmArgs.tensor_parallel_size. "
-            "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
-        ),
+        description="Tensor parallel size — number of GPUs to shard across (None -> 1).",
     )
     max_input_len: int | None = Field(
         default=None,

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -22,7 +22,7 @@ Usage in YAML:
 
     engine: tensorrt
     tensorrt:
-      tp_size: 2
+      tensor_parallel_size: 2
       dtype: bfloat16
       quant:
         quant_algo: FP8
@@ -855,7 +855,7 @@ class TensorRTConfig(BaseModel):
     Example YAML:
         engine: tensorrt
         tensorrt:
-          tp_size: 2
+          tensor_parallel_size: 2
           max_batch_size: 8
           dtype: bfloat16
           quant:
@@ -873,7 +873,15 @@ class TensorRTConfig(BaseModel):
     max_batch_size: int | None = Field(
         default=None, ge=1, description="Max batch size (compile-time constant, None -> 8)"
     )
-    tp_size: int | None = Field(default=None, ge=1, description="Tensor parallel size (None -> 1)")
+    tensor_parallel_size: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Tensor parallel size — number of GPUs to shard across (None -> 1). "
+            "Aligns with TrtLlmArgs.tensor_parallel_size. "
+            "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
+        ),
+    )
     max_input_len: int | None = Field(
         default=None,
         ge=1,

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -282,7 +282,7 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "vllm.beam_search.max_tokens": [0],  # ge=1: 0 violates ge
         # TensorRTConfig: compile-time params
         "tensorrt.max_batch_size": [0],  # ge=1: 0 violates ge
-        "tensorrt.tp_size": [0],  # ge=1: 0 violates ge
+        "tensorrt.tensor_parallel_size": [0],  # ge=1: 0 violates ge
         "tensorrt.max_input_len": [0],  # ge=1: 0 violates ge
         "tensorrt.max_seq_len": [0],  # ge=1: 0 violates ge
         # TensorRTCalibConfig: calibration params
@@ -619,7 +619,7 @@ def get_engine_specific_params() -> dict[str, list[str]]:
         "tensorrt": [
             # Compile-time parameters (LLM() constructor)
             "tensorrt.max_batch_size",
-            "tensorrt.tp_size",
+            "tensorrt.tensor_parallel_size",
             "tensorrt.max_input_len",
             "tensorrt.max_seq_len",
             "tensorrt.dtype",
@@ -708,7 +708,7 @@ def get_param_skip_conditions() -> dict[str, str]:
     return {
         # Multi-GPU params - skip if single GPU
         "vllm.engine.tensor_parallel_size>1": "Requires 2+ GPUs",
-        "tensorrt.tp_size>1": "Requires 2+ GPUs",
+        "tensorrt.tensor_parallel_size>1": "Requires 2+ GPUs",
         # Flash Attention 2 - requires flash-attn package
         "transformers.attn_implementation=flash_attention_2": "Requires flash-attn package",
         # Flash Attention 3 - requires flash_attn_3 package (built from flash-attn hopper/)
@@ -793,7 +793,7 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
             # Transformers does NOT support tensor parallelism for HuggingFace models
             "transformers": False,
             "vllm": "tensor_parallel_size" in vllm_fields,
-            "tensorrt": "tp_size" in tensorrt_fields,
+            "tensorrt": "tensor_parallel_size" in tensorrt_fields,
         },
         "data_parallel": {
             # Transformers data parallelism via Accelerate is not supported in this version

--- a/src/llenergymeasure/device/gpu_info.py
+++ b/src/llenergymeasure/device/gpu_info.py
@@ -538,7 +538,7 @@ def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
       NVML-visible GPUs. Model sharding is determined at load time inside
       harness.run(), but gpu_indices must be passed *before* load. Using all
       visible GPUs is correct and safe.
-    - **TensorRT-LLM**: tp_size GPUs. Known from config before harness runs.
+    - **TensorRT-LLM**: tensor_parallel_size GPUs. Known from config before harness runs.
     - **Otherwise**: [0] (single-GPU default, backward compatible).
 
     Note: num_processes > 1 (data parallelism via Accelerate) is not handled here.
@@ -555,7 +555,7 @@ def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
         if total > 1:
             return list(range(total))
     elif config.engine == Engine.TENSORRT and config.tensorrt is not None:
-        tp = config.tensorrt.tp_size or 1
+        tp = config.tensorrt.tensor_parallel_size or 1
         if tp > 1:
             return list(range(tp))
     elif (

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -399,7 +399,7 @@ class TensorRTEngine:
         # engine_path early-return: pass engine dir as model, skip all compile-time kwargs
         if trt is not None and trt.engine_path is not None:
             engine_path = Path(trt.engine_path)
-            tp_size = trt.tp_size if trt.tp_size is not None else 1
+            tp_size = trt.tensor_parallel_size if trt.tensor_parallel_size is not None else 1
             errors = _validate_engine_directory(engine_path, tp_size=tp_size)
             if errors:
                 raise ConfigError(f"engine_path validation failed: {'; '.join(errors)}")
@@ -414,8 +414,8 @@ class TensorRTEngine:
             return kwargs
 
         # Scalar fields: map directly (same name or renamed)
-        if trt.tp_size is not None:
-            kwargs["tensor_parallel_size"] = trt.tp_size
+        if trt.tensor_parallel_size is not None:
+            kwargs["tensor_parallel_size"] = trt.tensor_parallel_size
         if trt.max_batch_size is not None:
             kwargs["max_batch_size"] = trt.max_batch_size
         if trt.max_input_len is not None:

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -570,14 +570,14 @@ class DockerRunner:
     ) -> list[str]:
         """Build the ``docker run`` command list.
 
-        For TRT-LLM tensor parallelism (tp_size > 1), ``mpirun -n {tp_size}
+        For TRT-LLM tensor parallelism (tensor_parallel_size > 1), ``mpirun -n {n}
         --allow-run-as-root`` is injected between the image name and ``python3``.
         MPI worker ranks re-import the module but do not call ``main()`` because
         ``container_entrypoint.py`` is guarded by ``if __name__ == "__main__"``.
 
         Args:
             config:       ExperimentConfig for the current experiment. Used to
-                          detect TRT-LLM engine and read ``tensorrt.tp_size``.
+                          detect TRT-LLM engine and read ``tensorrt.tensor_parallel_size``.
             config_hash:  Hash prefix for config/result file names.
             exchange_dir: Host path of the temporary exchange directory.
             env_path:     Path to a temp env-file (written by ``_env_file``), or None.
@@ -628,7 +628,7 @@ class DockerRunner:
         # Determine TRT-LLM tensor parallel size for MPI injection
         tp_size = None
         if config.engine == "tensorrt" and config.tensorrt is not None:
-            tp_size = config.tensorrt.tp_size
+            tp_size = config.tensorrt.tensor_parallel_size
 
         cmd.append(self.image)
 

--- a/tests/unit/api/test_gpu.py
+++ b/tests/unit/api/test_gpu.py
@@ -103,30 +103,30 @@ def test_tensorrt_no_config_returns_single_gpu():
 
 
 def test_tensorrt_tp1_returns_single_gpu():
-    """tensorrt with tp_size=1 returns [0]."""
+    """tensorrt with tensor_parallel_size=1 returns [0]."""
     from llenergymeasure.config.engine_configs import TensorRTConfig
 
-    trt_cfg = TensorRTConfig(tp_size=1)
+    trt_cfg = TensorRTConfig(tensor_parallel_size=1)
     config = ExperimentConfig(model="gpt2", engine="tensorrt", tensorrt=trt_cfg)
     result = _resolve_gpu_indices(config)
     assert result == [0]
 
 
 def test_tensorrt_tp4_returns_four_gpus():
-    """tensorrt with tp_size=4 returns [0, 1, 2, 3]."""
+    """tensorrt with tensor_parallel_size=4 returns [0, 1, 2, 3]."""
     from llenergymeasure.config.engine_configs import TensorRTConfig
 
-    trt_cfg = TensorRTConfig(tp_size=4)
+    trt_cfg = TensorRTConfig(tensor_parallel_size=4)
     config = ExperimentConfig(model="gpt2", engine="tensorrt", tensorrt=trt_cfg)
     result = _resolve_gpu_indices(config)
     assert result == [0, 1, 2, 3]
 
 
 def test_tensorrt_none_tp_size_returns_single_gpu():
-    """tensorrt with tp_size=None falls through to [0]."""
+    """tensorrt with tensor_parallel_size=None falls through to [0]."""
     from llenergymeasure.config.engine_configs import TensorRTConfig
 
-    trt_cfg = TensorRTConfig(tp_size=None)
+    trt_cfg = TensorRTConfig(tensor_parallel_size=None)
     config = ExperimentConfig(model="gpt2", engine="tensorrt", tensorrt=trt_cfg)
     result = _resolve_gpu_indices(config)
     assert result == [0]

--- a/tests/unit/api/test_gpu.py
+++ b/tests/unit/api/test_gpu.py
@@ -90,7 +90,7 @@ def test_vllm_none_engine_vllm_config_returns_single_gpu():
 
 
 # ---------------------------------------------------------------------------
-# TensorRT engine: uses tp_size
+# TensorRT engine: uses tensor_parallel_size
 # ---------------------------------------------------------------------------
 
 
@@ -122,7 +122,7 @@ def test_tensorrt_tp4_returns_four_gpus():
     assert result == [0, 1, 2, 3]
 
 
-def test_tensorrt_none_tp_size_returns_single_gpu():
+def test_tensorrt_none_tensor_parallel_size_returns_single_gpu():
     """tensorrt with tensor_parallel_size=None falls through to [0]."""
     from llenergymeasure.config.engine_configs import TensorRTConfig
 

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -1,7 +1,7 @@
 """Unit tests for expanded TensorRT-LLM config validation.
 
 Tests cover all 7 config requirements (CFG-01 through CFG-07):
-- CFG-01: Compile-time params (tp_size, max_batch_size, max_input_len, max_seq_len, dtype, fast_build)
+- CFG-01: Compile-time params (tensor_parallel_size, max_batch_size, max_input_len, max_seq_len, dtype, fast_build)
 - CFG-02: Quantisation (QuantAlgo Literal type, kv_cache_quant_algo)
 - CFG-03: Calibration (calib_batches, calib_max_seq_length)
 - CFG-04: KV cache (enable_block_reuse, free_gpu_memory_fraction, max_tokens, host_cache_size)
@@ -40,14 +40,14 @@ class TestCompileTimeParams:
             max_batch_size=8,
             max_input_len=1024,
             max_seq_len=2048,
-            tp_size=2,
+            tensor_parallel_size=2,
             dtype="float16",
             fast_build=True,
         )
         assert config.max_batch_size == 8
         assert config.max_input_len == 1024
         assert config.max_seq_len == 2048
-        assert config.tp_size == 2
+        assert config.tensor_parallel_size == 2
         assert config.dtype == "float16"
         assert config.fast_build is True
 
@@ -61,10 +61,10 @@ class TestCompileTimeParams:
         config = TensorRTConfig(dtype="bfloat16")
         assert config.dtype == "bfloat16"
 
-    def test_tensorrt_tp_size_ge_1(self):
-        """tp_size=0 raises ValidationError."""
+    def test_tensorrt_tensor_parallel_size_ge_1(self):
+        """tensor_parallel_size=0 raises ValidationError."""
         with pytest.raises(ValidationError):
-            TensorRTConfig(tp_size=0)
+            TensorRTConfig(tensor_parallel_size=0)
 
     def test_tensorrt_max_batch_size_ge_1(self):
         """max_batch_size=0 raises ValidationError."""
@@ -288,7 +288,7 @@ class TestExperimentConfigIntegration:
             model="gpt2",
             engine="tensorrt",
             tensorrt={
-                "tp_size": 2,
+                "tensor_parallel_size": 2,
                 "max_batch_size": 8,
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
@@ -319,7 +319,7 @@ class TestExperimentConfigIntegration:
         )
         assert config.engine == "tensorrt"
         assert config.tensorrt is not None
-        assert config.tensorrt.tp_size == 2
+        assert config.tensorrt.tensor_parallel_size == 2
         assert config.tensorrt.quant is not None
         assert config.tensorrt.quant.quant_algo == "W4A16_AWQ"
         assert config.tensorrt.kv_cache is not None
@@ -332,11 +332,11 @@ class TestExperimentConfigIntegration:
     def test_tensorrt_extra_allow_forwards_unknown(self):
         """Extra fields on TensorRTConfig and sub-configs are accepted (not rejected)."""
         config = TensorRTConfig(
-            tp_size=1,
+            tensor_parallel_size=1,
             custom_future_field="value",
         )
         # Should not raise - extra="allow"
-        assert config.tp_size == 1
+        assert config.tensor_parallel_size == 1
 
         quant = TensorRTQuantConfig(
             quant_algo="INT8",
@@ -348,7 +348,7 @@ class TestExperimentConfigIntegration:
         """All fields default to None when not specified."""
         config = TensorRTConfig()
         assert config.max_batch_size is None
-        assert config.tp_size is None
+        assert config.tensor_parallel_size is None
         assert config.max_input_len is None
         assert config.max_seq_len is None
         assert config.dtype is None

--- a/tests/unit/config/test_tensorrt_sweep.py
+++ b/tests/unit/config/test_tensorrt_sweep.py
@@ -25,22 +25,22 @@ class TestEngineSweepAxis:
         assert {c.engine for c in valid} == {"transformers", "tensorrt"}
 
     def test_engine_sweep_with_trt_scoped_params(self):
-        """engine: [pytorch, tensorrt] with tensorrt.tp_size: [1, 2] produces 3 configs."""
+        """engine: [transformers, tensorrt] with tensorrt.tensor_parallel_size: [1, 2] produces 3 configs."""
         raw_study = {
             "model": "gpt2",
             "engine": ["transformers", "tensorrt"],
             "sweep": {
-                "tensorrt.tp_size": [1, 2],
+                "tensorrt.tensor_parallel_size": [1, 2],
             },
         }
         valid, _skipped = expand_grid(raw_study)
-        # pytorch: 1 config (no scoped dims), tensorrt: 2 configs (tp_size=[1,2])
+        # transformers: 1 config (no scoped dims), tensorrt: 2 configs (tensor_parallel_size=[1,2])
         assert len(valid) == 3
         pytorch_configs = [c for c in valid if c.engine == "transformers"]
         tensorrt_configs = [c for c in valid if c.engine == "tensorrt"]
         assert len(pytorch_configs) == 1
         assert len(tensorrt_configs) == 2
-        tp_sizes = {c.tensorrt.tp_size for c in tensorrt_configs}
+        tp_sizes = {c.tensorrt.tensor_parallel_size for c in tensorrt_configs}
         assert tp_sizes == {1, 2}
 
 
@@ -81,7 +81,7 @@ class TestDottedNestedSweep:
             "model": "gpt2",
             "engine": "tensorrt",
             "tensorrt": {
-                "tp_size": 2,
+                "tensor_parallel_size": 2,
                 "max_batch_size": 8,
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
@@ -112,7 +112,7 @@ class TestDottedNestedSweep:
         for config in valid:
             assert config.engine == "tensorrt"
             assert config.tensorrt is not None
-            assert config.tensorrt.tp_size == 2
+            assert config.tensorrt.tensor_parallel_size == 2
             assert config.tensorrt.max_batch_size == 8
             assert config.tensorrt.dtype == "bfloat16"
             assert config.tensorrt.kv_cache is not None

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -747,7 +747,7 @@ class TestHFTokenSecure:
 
 
 class TestMpirunInjection:
-    """Verify mpirun is injected iff engine=tensorrt and tp_size > 1."""
+    """Verify mpirun is injected iff engine=tensorrt and tensor_parallel_size > 1."""
 
     def _capture_cmd(self, config, tmp_path) -> list[str]:
         """Run DockerRunner.run() with a fake subprocess and capture the docker cmd."""

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -777,10 +777,10 @@ class TestMpirunInjection:
         return captured_cmds[0]
 
     def test_mpirun_injected_for_tensorrt_tp2(self, tmp_path):
-        """TRT-LLM with tp_size=2 gets mpirun -n 2 --allow-run-as-root before python3."""
+        """TRT-LLM with tensor_parallel_size=2 gets mpirun -n 2 --allow-run-as-root before python3."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=2))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=2))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" in cmd
@@ -795,10 +795,10 @@ class TestMpirunInjection:
         assert image_idx < mpirun_idx < python_idx
 
     def test_mpirun_injected_for_tensorrt_tp4(self, tmp_path):
-        """TRT-LLM with tp_size=4 gets mpirun -n 4 with correct stringified count."""
+        """TRT-LLM with tensor_parallel_size=4 gets mpirun -n 4 with correct stringified count."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=4))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=4))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" in cmd
@@ -806,19 +806,19 @@ class TestMpirunInjection:
         assert cmd[n_idx + 1] == "4"
 
     def test_no_mpirun_for_tensorrt_tp1(self, tmp_path):
-        """TRT-LLM with tp_size=1 does NOT get mpirun (single-GPU path)."""
+        """TRT-LLM with tensor_parallel_size=1 does NOT get mpirun (single-GPU path)."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" not in cmd
 
     def test_no_mpirun_for_tensorrt_tp_none(self, tmp_path):
-        """TRT-LLM with tp_size=None (default) does NOT get mpirun."""
+        """TRT-LLM with tensor_parallel_size=None (default) does NOT get mpirun."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=None))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=None))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" not in cmd
@@ -891,7 +891,7 @@ class TestExtraMounts:
         """TRT-LLM engine auto-mounts ~/.cache/trt-llm:/root/.cache/trt-llm."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
         runner = DockerRunner(image=IMAGE)
 
         with patch(
@@ -907,7 +907,7 @@ class TestExtraMounts:
         """User's custom /root/.cache/trt-llm path prevents auto-mount duplication."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
         runner = DockerRunner(
             image=IMAGE,
             extra_mounts=[("/custom/cache", "/root/.cache/trt-llm")],

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -169,9 +169,9 @@ class TestBuildLlmKwargs:
         assert kwargs["backend"] == "trt"
         assert kwargs.get("enable_build_cache") is True
 
-    def test_build_llm_kwargs_tp_size(self):
-        """tp_size=2 maps to tensor_parallel_size=2."""
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tp_size=2))
+    def test_build_llm_kwargs_tensor_parallel_size(self):
+        """tensor_parallel_size=2 maps to kwargs tensor_parallel_size=2."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=2))
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
@@ -215,7 +215,7 @@ class TestBuildLlmKwargs:
 
     def test_build_llm_kwargs_default_build_cache_when_no_build_cache_section(self):
         """When no build_cache section, enable_build_cache=True is set."""
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
@@ -601,7 +601,9 @@ class TestBuildMetadata:
         import hashlib
         import json
 
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tp_size=2, max_batch_size=8))
+        config = make_config(
+            **_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=2, max_batch_size=8)
+        )
         engine = TensorRTEngine()
 
         # Reproduce the hash computation from load_model
@@ -714,7 +716,7 @@ class TestBuildLlmKwargsEnginePath:
         assert kwargs["backend"] == "trt"
 
     def test_build_llm_kwargs_engine_path_skips_compile_kwargs(self, tmp_path):
-        """engine_path set -> no compile-time kwargs (tp_size, max_batch_size, etc.)."""
+        """engine_path set -> no compile-time kwargs (tensor_parallel_size, max_batch_size, etc.)."""
         config_data = {"pretrained_config": {"mapping": {"tp_size": 2}}, "build_config": {}}
         (tmp_path / "config.json").write_text(json.dumps(config_data))
         (tmp_path / "rank0.engine").write_bytes(b"fake")
@@ -722,7 +724,9 @@ class TestBuildLlmKwargsEnginePath:
 
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(engine_path=str(tmp_path), tp_size=2, max_batch_size=16),
+            tensorrt=TensorRTConfig(
+                engine_path=str(tmp_path), tensor_parallel_size=2, max_batch_size=16
+            ),
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1051,35 +1051,35 @@ class TestResolveGpuIndices:
 # With _resolve_gpu_indices returning correct indices for TRT-LLM,
 # multi-GPU energy is automatically summed across all TP ranks.
 # No methodology_notes string needed - data is self-documenting:
-#   effective_config.tensorrt.tp_size + multi_gpu.num_gpus + multi_gpu.energy_per_gpu_j
+#   effective_config.tensorrt.tensor_parallel_size + multi_gpu.num_gpus + multi_gpu.energy_per_gpu_j
 
 
 class TestResolveGpuIndicesTensorrt:
     """Unit tests for _resolve_gpu_indices() tensorrt branch."""
 
     def test_tensorrt_tp1_returns_single_index(self):
-        """tp_size=1 -> [0] (single GPU)."""
+        """tensor_parallel_size=1 -> [0] (single GPU)."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
-        config = make_config(engine="tensorrt", tensorrt={"tp_size": 1})
+        config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 1})
         assert _resolve_gpu_indices(config) == [0]
 
     def test_tensorrt_tp2_returns_two_indices(self):
-        """tp_size=2 -> [0, 1] (two GPUs for energy monitoring)."""
+        """tensor_parallel_size=2 -> [0, 1] (two GPUs for energy monitoring)."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
-        config = make_config(engine="tensorrt", tensorrt={"tp_size": 2})
+        config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 2})
         assert _resolve_gpu_indices(config) == [0, 1]
 
     def test_tensorrt_tp4_returns_four_indices(self):
-        """tp_size=4 -> [0, 1, 2, 3]."""
+        """tensor_parallel_size=4 -> [0, 1, 2, 3]."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
-        config = make_config(engine="tensorrt", tensorrt={"tp_size": 4})
+        config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 4})
         assert _resolve_gpu_indices(config) == [0, 1, 2, 3]
 
     def test_tensorrt_tp_none_returns_single_index(self):
-        """tp_size=None (default) -> [0] (single GPU)."""
+        """tensor_parallel_size=None (default) -> [0] (single GPU)."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
         config = make_config(engine="tensorrt", tensorrt={})


### PR DESCRIPTION
## Summary

- Renames `TensorRTConfig.tp_size` → `tensor_parallel_size` to align with the upstream `TrtLlmArgs.tensor_parallel_size` native name.
- `TransformersConfig.tp_size` is **preserved** — HF has no single native `tensor_parallel_size`; `tp_size` follows the `accelerate` convention.
- All consumers updated: source, tests, fixtures, docs, CHANGELOG.

## Breaking change

YAML configs using `tensorrt.tp_size:` must be updated to `tensorrt.tensor_parallel_size:`. `transformers.tp_size:` is unchanged.

## Test plan

- [ ] `uv run pytest tests/unit/config tests/unit/engines -v` green
- [ ] `grep -rn '\btp_size\b' src/llenergymeasure/engines/tensorrt.py src/llenergymeasure/config/engine_configs.py` — zero hits outside `TransformersConfig`
- [ ] `uv run llem run configs/example-study-full.yaml --dry-run` parses successfully