### PR TITLE
refactor(config)!: curate typed engine fields (drops + adds, no metadata scaffold)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,24 @@ All notable changes to this project are documented here.
   - `transformers.tp_size` — HF accelerate convention, unchanged
   - `vllm.engine.tensor_parallel_size` — already native name, unchanged
 
+- **Typed-field curation for engine configs (maximalist rubric).** Applies the rubric "type anything with a plausible energy/throughput/latency path" to each engine's Pydantic surface. Dropped fields remain settable via YAML (`extra="allow"` passthrough unless noted).
+
+  **Transformers** — drops 2 typed fields, adds 4:
+  - Dropped: `revision` (D1 reproducibility metadata), `trust_remote_code` (D1 security toggle). Both remain settable via `extra="allow"`.
+  - Added: `allow_tf32`, `autocast_enabled`, `autocast_dtype`, `low_cpu_mem_usage`.
+  - Also adds `tp_plan` and `tp_size` to the introspection param list (were missing).
+
+  **vLLM** — drops 4 typed fields, adds 3, replaces 2 with typed sub-config:
+  - Dropped: `sampling.max_tokens`, `beam_search.max_tokens` (R2 dups of `ExperimentConfig.max_output_tokens`; bridged in adapter). `speculative_model` and `num_speculative_tokens` replaced (not simply dropped).
+  - Added: `num_scheduler_steps`, `max_seq_len_to_capture`, `distributed_executor_backend`.
+  - Replaced: flat `speculative_model` + `num_speculative_tokens` → typed nested `VLLMSpeculativeConfig` sub-config (mirrors vLLM native shape; sweepable via dotted paths). Migration: `{speculative_model: m, num_speculative_tokens: k}` → `{speculative: {model: m, num_speculative_tokens: k}}`.
+  - `VLLMAttentionConfig` stays nested; all 10 fields (including `use_trtllm_attention`, `use_trtllm_ragged_deepseek_prefill`) remain typed.
+
+  **TensorRT-LLM** — drops 9 typed fields (incl. 2 sub-config classes), adds 2:
+  - Dropped: `backend: Literal["trt"]` (D2), `engine_path` (D1), entire `TensorRTCalibConfig` (D3 build-only PTQ), entire `TensorRTBuildCacheConfig` (D1 cache plumbing), `sampling.return_perf_metrics` (D1). All remain passable via `extra="allow"`.
+  - Added: `pipeline_parallel_size` (MLPerf v5.0 Blackwell), `max_num_tokens` (trtllm-bench axis).
+  - `fast_build` kept typed — build-time knob with runtime consequences.
+
 ### Added
 
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -105,8 +105,15 @@ Note: `load_in_4bit` and `load_in_8bit` are mutually exclusive.
 |-----------|------|---------|-------------|
 | `device_map` | str | `auto` | Device placement strategy |
 | `max_memory` | dict | null | Per-device memory limits, e.g. `{0: "10GiB", cpu: "50GiB"}` |
-| `revision` | str | null | Model commit hash for reproducibility |
-| `trust_remote_code` | bool | true | Allow executing remote code in model repo |
+| `low_cpu_mem_usage` | bool | true | Load weights incrementally to minimise peak CPU RAM |
+
+**Floating-Point Precision:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `allow_tf32` | bool | null | Allow TF32 for matrix multiplications on Ampere+ (affects energy/throughput) |
+| `autocast_enabled` | bool | false | Enable `torch.autocast` during generation |
+| `autocast_dtype` | `float16` \| `bfloat16` | `bfloat16` | AMP dtype (only used when `autocast_enabled: true`) |
 
 **Beam Search:**
 
@@ -228,12 +235,32 @@ initialisation time. All fields default to `null` (use vLLM's own default).
 | `quantization` | `awq` \| `gptq` \| `fp8` \| `marlin` \| `bitsandbytes` \| ... | null | Quantization method (requires pre-quantised checkpoint) |
 | `enable_prefix_caching` | bool | false | Automatic prefix caching for shared prompt prefixes |
 
+**Scheduler Tuning:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_scheduler_steps` | int | 1 | Multi-step scheduling: run N decode steps before returning to the scheduler (increases throughput at the cost of more VRAM per step) |
+| `max_seq_len_to_capture` | int | 8192 | Maximum sequence length eligible for CUDA graph capture (sequences longer than this fall back to eager mode) |
+
+**Distributed Execution:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `distributed_executor_backend` | `mp` \| `ray` | `mp` | Multi-GPU executor backend (`mp` = multiprocessing, `ray` = Ray cluster) |
+
 **Speculative Decoding:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `speculative_model` | str | null | HF model name for draft model (speculative decoding) |
-| `num_speculative_tokens` | int | null | Tokens to draft per step (required when `speculative_model` set) |
+| `speculative` | VLLMSpeculativeConfig | null | Speculative decoding sub-config (see below) |
+
+`speculative` sub-config fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model` | str | null | HF model name or path for the draft model |
+| `num_speculative_tokens` | int | null | Tokens to draft per step |
+| `method` | str | null | Speculative method (e.g. `eagle`, `medusa`; null = draft-model mode) |
 
 ### vLLM Sampling Parameters
 
@@ -311,11 +338,10 @@ runners:
 tensorrt:
   tensor_parallel_size: 2
   max_batch_size: 8
+  max_num_tokens: 4096
   dtype: bfloat16
   quant:
     quant_algo: W4A16_AWQ
-  build_cache:
-    max_cache_storage_gb: 256
 ```
 
 > **Engine compilation on first run.** The first run with a given config will compile a
@@ -331,12 +357,14 @@ Changing any **[recompile]** field invalidates the cached engine and triggers a 
 |-----------|------|---------|-------------|
 | `max_batch_size` | int | 8 | Maximum batch size the engine accepts. **[recompile]** |
 | `tensor_parallel_size` | int | 1 | Tensor parallel degree (number of GPUs). **[recompile]** |
+| `pipeline_parallel_size` | int | 1 | Pipeline parallel stages (number of pipeline stages across GPUs). **[recompile]** |
 | `max_input_len` | int | 1024 | Maximum input sequence length in tokens. **[recompile]** |
 | `max_seq_len` | int | 2048 | Maximum total sequence length (input + output). **[recompile]** |
+| `max_num_tokens` | int | auto | Maximum tokens the engine handles per iteration (scheduler throughput axis alongside `max_batch_size`). **[recompile]** |
 | `dtype` | `float16` \| `bfloat16` | auto | Model compute dtype. TRT-LLM is optimised for fp16/bf16; fp32 is not supported. **[recompile]** |
 | `fast_build` | bool | false | Enable fast engine build mode (reduced optimisation, faster compilation). **[recompile]** |
 | `engine` | `trt` | `trt` | TRT-LLM internal backend selector. This is the `LLM(backend=...)` parameter, not the `llem` engine field. Leave unset unless you have a specific reason to override. |
-| `engine_path` | str | null | Path to a pre-compiled engine directory. When set, skips compilation and loads the engine directly. All compile-time parameters and `build_cache` are ignored. See [Pre-Compiled Engine Loading](#pre-compiled-engine-loading) below. |
+| `engine_path` | str | null | Path to a pre-compiled engine directory. When set, skips compilation and loads the engine directly. See [Pre-Compiled Engine Loading](#pre-compiled-engine-loading) below. |
 
 ### tensorrt.quant: Quantization
 
@@ -363,17 +391,6 @@ Quantization is applied at engine compile time — changing `quant_algo` trigger
 > **A100 note:** A100 (SM 8.0) does not support FP8. Valid A100 quantization options:
 > `INT8`, `W4A16_AWQ`, `W4A16_GPTQ`, `W8A16`, `W8A16_GPTQ`, `W4A8_AWQ`, `NO_QUANT`.
 
-### tensorrt.calib: PTQ Calibration
-
-Only relevant when `quant_algo` requires post-training quantization (PTQ) calibration
-(e.g. `INT8`, `W4A16_AWQ`).
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `calib_batches` | int | 512 | Number of calibration batches |
-| `calib_dataset` | str | `cnn_dailymail` | Calibration dataset name or HuggingFace path |
-| `calib_max_seq_length` | int | 512 | Max sequence length for calibration samples |
-
 ### tensorrt.kv_cache: KV Cache
 
 | Parameter | Type | Default | Description |
@@ -393,17 +410,6 @@ Only relevant when `quant_algo` requires post-training quantization (PTQ) calibr
 - `GUARANTEED_NO_EVICT` — guarantees no request eviction; may reduce throughput
 - `MAX_UTILIZATION` — maximises GPU utilisation; may evict requests under memory pressure
 - `STATIC_BATCH` — fixed batch size; useful for reproducible benchmarking
-
-### tensorrt.build_cache: Engine Build Cache
-
-Engine caching is enabled by default even without an explicit `build_cache:` section.
-Compiled engines are stored in `~/.cache/tensorrt_llm` and reused across runs.
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `cache_root` | str | `~/.cache/tensorrt_llm` | Root directory for engine cache storage |
-| `max_records` | int | 10 | Maximum number of cached engine records |
-| `max_cache_storage_gb` | float | 256 | Maximum total cache size in GB |
 
 ### Pre-Compiled Engine Loading
 
@@ -470,7 +476,6 @@ all engines.
 | `min_tokens` | int | 0 | Minimum output tokens before EOS is allowed |
 | `n` | int | 1 | Number of output sequences per prompt |
 | `ignore_eos` | bool | false | Continue generating past EOS token (forces full `max_output_tokens` generation) |
-| `return_perf_metrics` | bool | false | Return TRT-LLM internal performance metrics in output |
 
 For advanced TRT-LLM parameters, see the [TensorRT-LLM documentation](https://nvidia.github.io/TensorRT-LLM/).
 

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -720,8 +720,10 @@ relates to energy measurement.
 | `prompt_lookup_num_tokens` | integer | None | `null` | Prompt-lookup speculative decoding tokens (None -> disabled) |
 | `device_map` | string | None | `null` | Device placement strategy (None -> 'auto') |
 | `max_memory` | dict | None | `null` | Per-device memory limits, e.g. {0: '10GiB', 'cpu': '50GiB'} |
-| `revision` | string | None | `null` | Model revision/commit hash for reproducibility |
-| `trust_remote_code` | boolean | None | `null` | Trust remote code in model repo (None -> True) |
+| `low_cpu_mem_usage` | boolean | None | `null` | Load weights incrementally to minimise peak CPU RAM (None -> True) |
+| `allow_tf32` | boolean | None | `null` | Allow TF32 for matmul on Ampere+ (None -> PyTorch default). Affects energy/throughput. |
+| `autocast_enabled` | boolean | None | `null` | Enable torch.autocast during generation (None -> False) |
+| `autocast_dtype` | 'float16' | 'bfloat16' | None | `null` | AMP dtype (None -> 'bfloat16'). Only used when autocast_enabled is true. |
 | `tp_plan` | string | None | `null` | Tensor parallelism plan for native HF TP (None -> disabled). Only 'auto' is currently supported by Transformers. Mutually exclusive with device_map. Requires torchrun launch. |
 | `tp_size` | integer | None | `null` | Number of tensor parallel ranks (None -> WORLD_SIZE). Only used when tp_plan is set. |
 
@@ -743,8 +745,10 @@ relates to energy measurement.
 | `pipeline_parallel_size` | integer | None | `null` | Pipeline parallel stages — memory per GPU changes with PP (None -> 1). |
 | `enable_prefix_caching` | boolean | None | `null` | Automatic prefix caching for repeated shared prompts (None -> False). |
 | `quantization` | 'awq' | 'gptq' | 'fp8' | 'fp8_e5m2' | 'fp8_e4m3' | 'marlin' | 'bitsandbytes' | None | `null` | Quantization method. Requires pre-quantized model checkpoint. |
-| `speculative_model` | string | None | `null` | HF model name or path of draft model for speculative decoding (None -> disabled). Requires num_speculative_tokens. |
-| `num_speculative_tokens` | integer | None | `null` | Tokens to draft per speculative step (None -> required if speculative_model is set). |
+| `num_scheduler_steps` | integer | None | `null` | Multi-step scheduling: decode steps per scheduler iteration (None -> 1). Increases throughput at the cost of more VRAM per step. |
+| `max_seq_len_to_capture` | integer | None | `null` | Max sequence length eligible for CUDA graph capture (None -> 8192). Longer sequences fall back to eager mode. |
+| `distributed_executor_backend` | 'mp' | 'ray' | None | `null` | Multi-GPU executor backend (None -> 'mp'). |
+| `speculative` | VLLMSpeculativeConfig | None | `null` | Speculative decoding sub-config. Fields: model (str), num_speculative_tokens (int), method (str). |
 | `offload_group_size` | integer | None | `null` | Groups of layers for CPU offloading (None -> 0). |
 | `offload_num_in_group` | integer | None | `null` | Number of layers offloaded per group (None -> 1). |
 | `offload_prefetch_step` | integer | None | `null` | Prefetch steps ahead for CPU offload (None -> 1). |
@@ -795,8 +799,10 @@ relates to energy measurement.
 |-------|------|---------|-------------|
 | `max_batch_size` | integer | None | `null` | Max batch size (compile-time constant, None -> 8) |
 | `tensor_parallel_size` | integer | None | `null` | Tensor parallel size (None -> 1) |
+| `pipeline_parallel_size` | integer | None | `null` | Pipeline parallel stages (None -> 1) |
 | `max_input_len` | integer | None | `null` | Max input sequence length (compile-time constant, None -> 1024) |
 | `max_seq_len` | integer | None | `null` | Max total sequence length (input + output, compile-time constant, None -> 2048) |
+| `max_num_tokens` | integer | None | `null` | Max tokens per engine iteration (None -> auto). Scheduler throughput axis alongside max_batch_size. |
 | `dtype` | 'float16' | 'bfloat16' | None | `null` | Model dtype (None -> auto). TRT-LLM is optimised for fp16/bf16; fp32 not supported. |
 | `fast_build` | boolean | None | `null` | Enable fast engine build mode (reduced optimisation, None -> False) |
 | `engine` | string | None | `null` | TRT-LLM internal backend: 'trt' for TensorRT engine (None -> 'trt'). This is the TRT-LLM LLM(backend=...) parameter, not the llem engine field. |
@@ -804,8 +810,6 @@ relates to energy measurement.
 | `quant` | TensorRTQuantConfig | None | `null` | Quantisation configuration (QuantConfig) |
 | `kv_cache` | TensorRTKvCacheConfig | None | `null` | KV cache configuration |
 | `scheduler` | TensorRTSchedulerConfig | None | `null` | Scheduler configuration |
-| `calib` | TensorRTCalibConfig | None | `null` | PTQ calibration configuration (CalibConfig) |
-| `build_cache` | TensorRTBuildCacheConfig | None | `null` | Engine build cache configuration (BuildCacheConfig) |
 | `sampling` | TensorRTSamplingConfig | None | `null` | Sampling configuration (TRT-LLM-specific SamplingParams extensions) |
 
 <!-- END CONFIG REFERENCE — Auto-generated by scripts/generate_config_docs.py -->

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -17,7 +17,6 @@ Usage in YAML:
         gpu_memory_utilization: 0.9
         kv_cache_dtype: fp8
       sampling:
-        max_tokens: 512
         presence_penalty: 0.0
 
     engine: tensorrt
@@ -25,9 +24,7 @@ Usage in YAML:
       tensor_parallel_size: 2
       dtype: bfloat16
       quant:
-        quant_algo: FP8
-      build_cache:
-        max_cache_storage_gb: 256
+        quant_algo: W4A16_AWQ
 """
 
 from __future__ import annotations
@@ -59,7 +56,11 @@ class TransformersConfig(BaseModel):
     # Batching
     # -------------------------------------------------------------------------
 
-    batch_size: int | None = Field(default=None, ge=1, description="Batch size (None -> 1)")
+    batch_size: int | None = Field(
+        default=None,
+        ge=1,
+        description="Batch size (None -> 1)",
+    )
 
     # -------------------------------------------------------------------------
     # Attention implementation
@@ -67,38 +68,51 @@ class TransformersConfig(BaseModel):
 
     attn_implementation: (
         Literal["sdpa", "flash_attention_2", "flash_attention_3", "eager"] | None
-    ) = Field(default=None, description="Attention implementation (None -> sdpa)")
+    ) = Field(
+        default=None,
+        description="Attention implementation (None -> sdpa)",
+    )
 
     # -------------------------------------------------------------------------
     # Compilation
     # -------------------------------------------------------------------------
 
     torch_compile: bool | None = Field(
-        default=None, description="Enable torch.compile (None -> False)"
+        default=None,
+        description="Enable torch.compile (None -> False)",
     )
     torch_compile_mode: str | None = Field(
         default=None,
         description="torch.compile mode: 'default', 'reduce-overhead', 'max-autotune' (None -> 'default')",
     )
     torch_compile_backend: str | None = Field(
-        default=None, description="torch.compile backend (None -> 'inductor')"
+        default=None,
+        description="torch.compile backend (None -> 'inductor')",
     )
 
     # -------------------------------------------------------------------------
     # BitsAndBytes quantization
     # -------------------------------------------------------------------------
 
-    load_in_4bit: bool | None = Field(default=None, description="BitsAndBytes 4-bit quantization")
-    load_in_8bit: bool | None = Field(default=None, description="BitsAndBytes 8-bit quantization")
+    load_in_4bit: bool | None = Field(
+        default=None,
+        description="BitsAndBytes 4-bit quantization",
+    )
+    load_in_8bit: bool | None = Field(
+        default=None,
+        description="BitsAndBytes 8-bit quantization",
+    )
     bnb_4bit_compute_dtype: Literal["float16", "bfloat16", "float32"] | None = Field(
         default=None,
         description="Compute dtype for 4-bit (None -> float32, usually want bfloat16)",
     )
     bnb_4bit_quant_type: Literal["nf4", "fp4"] | None = Field(
-        default=None, description="4-bit quantization type (None -> 'nf4')"
+        default=None,
+        description="4-bit quantization type (None -> 'nf4')",
     )
     bnb_4bit_use_double_quant: bool | None = Field(
-        default=None, description="Double quantization saves ~0.4 bits/param (None -> False)"
+        default=None,
+        description="Double quantization saves ~0.4 bits/param (None -> False)",
     )
 
     # -------------------------------------------------------------------------
@@ -106,7 +120,8 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     use_cache: bool | None = Field(
-        default=None, description="Use KV cache during generation (None -> True)"
+        default=None,
+        description="Use KV cache during generation (None -> True)",
     )
     cache_implementation: Literal["static", "offloaded_static", "sliding_window"] | None = Field(
         default=None,
@@ -118,10 +133,13 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     num_beams: int | None = Field(
-        default=None, ge=1, description="Beam search width (None -> 1, greedy/sampling)"
+        default=None,
+        ge=1,
+        description="Beam search width (None -> 1, greedy/sampling)",
     )
     early_stopping: bool | None = Field(
-        default=None, description="Stop beam search when all beams hit EOS (None -> False)"
+        default=None,
+        description="Stop beam search when all beams hit EOS (None -> False)",
     )
     length_penalty: float | None = Field(
         default=None,
@@ -133,7 +151,9 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     no_repeat_ngram_size: int | None = Field(
-        default=None, ge=0, description="Prevent n-gram repetition (None -> 0, disabled)"
+        default=None,
+        ge=0,
+        description="Prevent n-gram repetition (None -> 0, disabled)",
     )
 
     # -------------------------------------------------------------------------
@@ -151,17 +171,33 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     device_map: str | None = Field(
-        default=None, description="Device placement strategy (None -> 'auto')"
+        default=None,
+        description="Device placement strategy (None -> 'auto')",
     )
     max_memory: dict[str | int, str] | None = Field(
         default=None,
         description="Per-device memory limits, e.g. {0: '10GiB', 'cpu': '50GiB'}",
     )
-    revision: str | None = Field(
-        default=None, description="Model revision/commit hash for reproducibility"
+
+    # -------------------------------------------------------------------------
+    # Mixed precision
+    # -------------------------------------------------------------------------
+
+    allow_tf32: bool | None = Field(
+        default=None,
+        description="Allow TF32 on Ampere GPUs (None -> PyTorch default)",
     )
-    trust_remote_code: bool | None = Field(
-        default=None, description="Trust remote code in model repo (None -> True)"
+    autocast_enabled: bool | None = Field(
+        default=None,
+        description="Enable torch.autocast mixed precision (None -> False)",
+    )
+    autocast_dtype: Literal["float16", "bfloat16"] | None = Field(
+        default=None,
+        description="torch.autocast dtype (None -> bfloat16 on Ampere)",
+    )
+    low_cpu_mem_usage: bool | None = Field(
+        default=None,
+        description="Low CPU memory usage during model loading (None -> False)",
     )
 
     # -------------------------------------------------------------------------
@@ -242,6 +278,35 @@ class TransformersConfig(BaseModel):
 # =============================================================================
 # vLLM Engine Configuration
 # =============================================================================
+
+
+class VLLMSpeculativeConfig(BaseModel):
+    """vLLM speculative-decoding configuration.
+
+    Replaces flat ``speculative_model`` + ``num_speculative_tokens`` fields.
+    Mirrors vLLM's native ``speculative_config`` dict shape.
+    Unknown fields are forwarded via extra="allow" to vLLM.
+    """
+
+    model_config = {"extra": "allow"}  # mirror native shape; CI diff catches drift
+
+    model: str | None = Field(
+        default=None,
+        description="Draft model name/path for speculative decoding.",
+    )
+    num_speculative_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Tokens to draft per speculative step.",
+    )
+    method: str | None = Field(
+        default=None,
+        description=(
+            "Speculative-decoding method (e.g. 'draft_model', 'ngram', 'medusa', 'eagle'). "
+            "Kept as str because the Literal has drifted across vLLM releases — verify against "
+            "EngineArgs.speculative_config.method in the vendored schema before narrowing."
+        ),
+    )
 
 
 class VLLMAttentionConfig(BaseModel):
@@ -401,6 +466,11 @@ class VLLMEngineConfig(BaseModel):
             "Overrides model config (None -> model default). Caps KV cache allocation."
         ),
     )
+    num_scheduler_steps: int | None = Field(
+        default=None,
+        ge=1,
+        description="Number of scheduler steps per iteration (multi-step scheduling, None -> 1).",
+    )
 
     # -------------------------------------------------------------------------
     # Parallelism
@@ -417,6 +487,10 @@ class VLLMEngineConfig(BaseModel):
         default=None,
         ge=1,
         description=("Pipeline parallel stages — memory per GPU changes with PP (None -> 1)."),
+    )
+    distributed_executor_backend: Literal["mp", "ray"] | None = Field(
+        default=None,
+        description="Multi-GPU executor backend: 'mp' (multiprocessing) or 'ray' (None -> mp).",
     )
 
     # -------------------------------------------------------------------------
@@ -435,21 +509,24 @@ class VLLMEngineConfig(BaseModel):
     )
 
     # -------------------------------------------------------------------------
-    # Speculative decoding
+    # CUDA graphs
     # -------------------------------------------------------------------------
 
-    speculative_model: str | None = Field(
-        default=None,
-        description=(
-            "HF model name or path of draft model for speculative decoding (None -> disabled). "
-            "Requires num_speculative_tokens."
-        ),
-    )
-    num_speculative_tokens: int | None = Field(
+    max_seq_len_to_capture: int | None = Field(
         default=None,
         ge=1,
+        description="Maximum sequence length for CUDA graph capture (None -> 8192).",
+    )
+
+    # -------------------------------------------------------------------------
+    # Speculative decoding (typed nested sub-config)
+    # -------------------------------------------------------------------------
+
+    speculative: VLLMSpeculativeConfig | None = Field(
+        default=None,
         description=(
-            "Tokens to draft per speculative step (None -> required if speculative_model is set)."
+            "Speculative decoding configuration. Replaces flat speculative_model / "
+            "num_speculative_tokens fields. Mirrors vLLM native speculative_config shape."
         ),
     )
 
@@ -525,13 +602,6 @@ class VLLMEngineConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     @model_validator(mode="after")
-    def validate_speculative(self) -> VLLMEngineConfig:
-        """speculative_model requires num_speculative_tokens to be set."""
-        if self.speculative_model is not None and self.num_speculative_tokens is None:
-            raise ValueError("speculative_model requires num_speculative_tokens to be set")
-        return self
-
-    @model_validator(mode="after")
     def validate_kv_cache_memory(self) -> VLLMEngineConfig:
         """kv_cache_memory_bytes and gpu_memory_utilization are mutually exclusive."""
         if self.kv_cache_memory_bytes is not None and self.gpu_memory_utilization is not None:
@@ -566,18 +636,13 @@ class VLLMSamplingConfig(BaseModel):
 
     All fields default to None — None means "use vLLM's own default".
     Unknown fields are forwarded to vllm.SamplingParams() via extra="allow".
+
+    Note: max_tokens is intentionally absent — it is bridged from
+    ExperimentConfig.max_output_tokens in _build_sampling_kwargs().
     """
 
     model_config = {"extra": "allow"}
 
-    max_tokens: int | None = Field(
-        default=None,
-        ge=1,
-        description=(
-            "Max output tokens. Overrides ExperimentConfig.max_output_tokens for vLLM sweeps "
-            "(None -> uses max_output_tokens). Use for engine-specific max_tokens sweeps."
-        ),
-    )
     min_tokens: int | None = Field(
         default=None,
         ge=0,
@@ -622,6 +687,9 @@ class VLLMBeamSearchConfig(BaseModel):
     Nested under VLLMConfig.beam_search.
     All fields default to None — None means "use vLLM's own default".
     Uses extra="allow" for forward compatibility with new vLLM beam search options.
+
+    Note: max_tokens is intentionally absent — it is bridged from
+    ExperimentConfig.max_output_tokens in _build_beam_search_kwargs().
     """
 
     model_config = {"extra": "allow"}
@@ -638,11 +706,6 @@ class VLLMBeamSearchConfig(BaseModel):
     early_stopping: bool | None = Field(
         default=None,
         description="Stop when beam_width complete sequences found (None -> False).",
-    )
-    max_tokens: int | None = Field(
-        default=None,
-        ge=1,
-        description="Max output tokens for beam search (None -> max_output_tokens).",
     )
 
 
@@ -663,8 +726,10 @@ class VLLMConfig(BaseModel):
             enforce_eager: false
             gpu_memory_utilization: 0.9
             kv_cache_dtype: fp8
+            speculative:
+              model: gpt2
+              num_speculative_tokens: 3
           sampling:
-            max_tokens: 512
             presence_penalty: 0.0
     """
 
@@ -726,30 +791,13 @@ class TensorRTQuantConfig(BaseModel):
             "NO_QUANT",
         ]
         | None
-    ) = Field(default=None, description="Quantisation algorithm (native QuantAlgo enum name)")
+    ) = Field(
+        default=None,
+        description="Quantisation algorithm (native QuantAlgo enum name)",
+    )
     kv_cache_quant_algo: Literal["FP8", "INT8"] | None = Field(
         default=None,
         description="KV cache quantisation algorithm (None -> no KV cache quantisation)",
-    )
-
-
-class TensorRTCalibConfig(BaseModel):
-    """TRT-LLM PTQ calibration configuration.
-
-    Maps to tensorrt_llm.llmapi.CalibConfig.
-    Only relevant when quant_algo requires calibration (INT8, W4A16_AWQ, etc.).
-    """
-
-    model_config = {"extra": "allow"}
-
-    calib_batches: int | None = Field(
-        default=None, ge=1, description="Number of calibration batches (None -> 512)"
-    )
-    calib_dataset: str | None = Field(
-        default=None, description="Calibration dataset name or path (None -> 'cnn_dailymail')"
-    )
-    calib_max_seq_length: int | None = Field(
-        default=None, ge=1, description="Max sequence length for calibration (None -> 512)"
     )
 
 
@@ -759,7 +807,8 @@ class TensorRTKvCacheConfig(BaseModel):
     model_config = {"extra": "allow"}
 
     enable_block_reuse: bool | None = Field(
-        default=None, description="Enable KV cache block reuse (None -> False)"
+        default=None,
+        description="Enable KV cache block reuse (None -> False)",
     )
     free_gpu_memory_fraction: float | None = Field(
         default=None,
@@ -768,7 +817,9 @@ class TensorRTKvCacheConfig(BaseModel):
         description="Fraction of free GPU memory for KV cache (None -> 0.9)",
     )
     max_tokens: int | None = Field(
-        default=None, ge=1, description="Maximum tokens in KV cache (None -> auto)"
+        default=None,
+        ge=1,
+        description="Maximum tokens in KV cache (None -> auto)",
     )
     host_cache_size: int | None = Field(
         default=None,
@@ -789,26 +840,9 @@ class TensorRTSchedulerConfig(BaseModel):
             "STATIC_BATCH",
         ]
         | None
-    ) = Field(default=None, description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)")
-
-
-class TensorRTBuildCacheConfig(BaseModel):
-    """TRT-LLM engine build cache configuration.
-
-    Maps to tensorrt_llm.llmapi.BuildCacheConfig.
-    """
-
-    model_config = {"extra": "allow"}
-
-    cache_root: str | None = Field(
+    ) = Field(
         default=None,
-        description="Root directory for engine cache (None -> ~/.cache/tensorrt_llm)",
-    )
-    max_records: int | None = Field(
-        default=None, ge=1, description="Maximum cached engine records (None -> 10)"
-    )
-    max_cache_storage_gb: float | None = Field(
-        default=None, ge=0.0, description="Maximum cache storage in GB (None -> 256)"
+        description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)",
     )
 
 
@@ -818,21 +852,25 @@ class TensorRTSamplingConfig(BaseModel):
     Maps to tensorrt_llm.SamplingParams (TRT-LLM-specific extensions only).
     Universal sampling params (temperature, top_p, top_k, repetition_penalty)
     live in DecoderConfig and are shared across all engines.
+
+    Note: return_perf_metrics dropped (D1 observability flag).
     """
 
     model_config = {"extra": "allow"}
 
     min_tokens: int | None = Field(
-        default=None, ge=0, description="Minimum output tokens before EOS allowed (None -> 0)"
+        default=None,
+        ge=0,
+        description="Minimum output tokens before EOS allowed (None -> 0)",
     )
     n: int | None = Field(
-        default=None, ge=1, description="Number of output sequences per prompt (None -> 1)"
+        default=None,
+        ge=1,
+        description="Number of output sequences per prompt (None -> 1)",
     )
     ignore_eos: bool | None = Field(
-        default=None, description="Continue generating past EOS token (None -> False)"
-    )
-    return_perf_metrics: bool | None = Field(
-        default=None, description="Return performance metrics in output (None -> False)"
+        default=None,
+        description="Continue generating past EOS token (None -> False)",
     )
 
 
@@ -847,12 +885,16 @@ class TensorRTConfig(BaseModel):
     - quant: QuantConfig (quantisation algorithm + KV cache quantisation)
     - kv_cache: KvCacheConfig (block reuse, memory fraction)
     - scheduler: SchedulerConfig (capacity policy)
-    - calib: CalibConfig (PTQ calibration parameters)
-    - build_cache: BuildCacheConfig (engine cache persistence)
     - sampling: SamplingParams (TRT-LLM-specific extensions only)
 
     Universal sampling params (temperature, top_p, top_k, repetition_penalty)
     live in DecoderConfig and are shared across all engines.
+
+    Dropped (falls through extra="allow"):
+    - backend: Literal["trt"] — D2 single-option enum, no information content
+    - engine_path — D1 deployment path, not a measurement axis
+    - calib sub-config — D3 build-only PTQ calibration (we consume pre-quantised checkpoints)
+    - build_cache sub-config — D1 engine-cache housekeeping
 
     Example YAML:
         engine: tensorrt
@@ -862,8 +904,6 @@ class TensorRTConfig(BaseModel):
           dtype: bfloat16
           quant:
             quant_algo: W4A16_AWQ
-          build_cache:
-            max_cache_storage_gb: 256
     """
 
     model_config = {"extra": "allow"}
@@ -873,12 +913,23 @@ class TensorRTConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     max_batch_size: int | None = Field(
-        default=None, ge=1, description="Max batch size (compile-time constant, None -> 8)"
+        default=None,
+        ge=1,
+        description="Max batch size (compile-time constant, None -> 8)",
     )
     tensor_parallel_size: int | None = Field(
         default=None,
         ge=1,
-        description="Tensor parallel size — number of GPUs to shard across (None -> 1).",
+        description=(
+            "Tensor parallel size — number of GPUs to shard across (None -> 1). "
+            "Aligns with TrtLlmArgs.tensor_parallel_size. "
+            "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
+        ),
+    )
+    pipeline_parallel_size: int | None = Field(
+        default=None,
+        ge=1,
+        description="Pipeline parallel stages (None -> 1).",
     )
     max_input_len: int | None = Field(
         default=None,
@@ -889,6 +940,11 @@ class TensorRTConfig(BaseModel):
         default=None,
         ge=1,
         description="Max total sequence length (input + output, compile-time constant, None -> 2048)",
+    )
+    max_num_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of tokens the engine can handle per iteration (None -> auto).",
     )
     dtype: Literal["float16", "bfloat16"] | None = Field(
         default=None,
@@ -902,43 +958,20 @@ class TensorRTConfig(BaseModel):
     )
 
     # -------------------------------------------------------------------------
-    # TRT-LLM internal backend selection
-    # -------------------------------------------------------------------------
-
-    backend: Literal["trt"] | None = Field(
-        default=None,
-        description=(
-            "TRT-LLM internal backend: 'trt' for TensorRT engine (None -> 'trt'). "
-            "This is the TRT-LLM LLM(backend=...) parameter, not the llem engine field."
-        ),
-    )
-
-    # -------------------------------------------------------------------------
-    # Engine path (pre-compiled engine)
-    # -------------------------------------------------------------------------
-
-    engine_path: str | None = Field(
-        default=None, description="Pre-compiled engine path (skip compilation)"
-    )
-
-    # -------------------------------------------------------------------------
     # Nested sub-configs
     # -------------------------------------------------------------------------
 
     quant: TensorRTQuantConfig | None = Field(
-        default=None, description="Quantisation configuration (QuantConfig)"
+        default=None,
+        description="Quantisation configuration (QuantConfig)",
     )
     kv_cache: TensorRTKvCacheConfig | None = Field(
-        default=None, description="KV cache configuration"
+        default=None,
+        description="KV cache configuration",
     )
     scheduler: TensorRTSchedulerConfig | None = Field(
-        default=None, description="Scheduler configuration"
-    )
-    calib: TensorRTCalibConfig | None = Field(
-        default=None, description="PTQ calibration configuration (CalibConfig)"
-    )
-    build_cache: TensorRTBuildCacheConfig | None = Field(
-        default=None, description="Engine build cache configuration (BuildCacheConfig)"
+        default=None,
+        description="Scheduler configuration",
     )
     sampling: TensorRTSamplingConfig | None = Field(
         default=None,

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -562,123 +562,19 @@ def get_mutual_exclusions() -> dict[str, list[str]]:
 def get_engine_specific_params() -> dict[str, list[str]]:
     """Get params that are only valid for specific engines.
 
+    Derived from the Pydantic engine models via ``get_engine_params`` — never
+    hand-maintained. Adding or removing a typed field in
+    ``engine_configs.py`` is automatically reflected here.
+
+    Fields reachable only through ``extra="allow"`` passthrough (e.g. dropped
+    typed fields still settable in YAML) are not included, since they are not
+    part of the typed contract this function describes.
+
     Returns:
-        Dict mapping engine name to list of exclusive param paths.
-        Derived from v2.0 minimal engine config fields.
+        Dict mapping engine name to list of dotted param paths exclusive to
+        that engine.
     """
-    return {
-        "transformers": [
-            "transformers.batch_size",
-            "transformers.attn_implementation",
-            "transformers.torch_compile",
-            "transformers.torch_compile_mode",
-            "transformers.torch_compile_backend",
-            "transformers.load_in_4bit",
-            "transformers.load_in_8bit",
-            "transformers.bnb_4bit_compute_dtype",
-            "transformers.bnb_4bit_quant_type",
-            "transformers.bnb_4bit_use_double_quant",
-            "transformers.use_cache",
-            "transformers.cache_implementation",
-            "transformers.num_beams",
-            "transformers.early_stopping",
-            "transformers.length_penalty",
-            "transformers.no_repeat_ngram_size",
-            "transformers.prompt_lookup_num_tokens",
-            "transformers.device_map",
-            "transformers.max_memory",
-            "transformers.allow_tf32",
-            "transformers.autocast_enabled",
-            "transformers.autocast_dtype",
-            "transformers.low_cpu_mem_usage",
-            "transformers.tp_plan",
-            "transformers.tp_size",
-            # revision and trust_remote_code dropped as typed fields (D1);
-            # they remain settable via extra="allow" in YAML
-        ],
-        "vllm": [
-            # Engine-level params (vllm.LLM() constructor args)
-            "vllm.engine.gpu_memory_utilization",
-            "vllm.engine.swap_space",
-            "vllm.engine.cpu_offload_gb",
-            "vllm.engine.block_size",
-            "vllm.engine.kv_cache_dtype",
-            "vllm.engine.enforce_eager",
-            "vllm.engine.enable_chunked_prefill",
-            "vllm.engine.max_num_seqs",
-            "vllm.engine.max_num_batched_tokens",
-            "vllm.engine.max_model_len",
-            "vllm.engine.tensor_parallel_size",
-            "vllm.engine.pipeline_parallel_size",
-            "vllm.engine.enable_prefix_caching",
-            "vllm.engine.quantization",
-            "vllm.engine.num_scheduler_steps",
-            "vllm.engine.max_seq_len_to_capture",
-            "vllm.engine.distributed_executor_backend",
-            # Speculative decoding sub-config (replaces flat speculative_model/num_speculative_tokens)
-            "vllm.engine.speculative.model",
-            "vllm.engine.speculative.num_speculative_tokens",
-            "vllm.engine.speculative.method",
-            # Engine-level offloading + memory params
-            "vllm.engine.offload_group_size",
-            "vllm.engine.offload_num_in_group",
-            "vllm.engine.offload_prefetch_step",
-            "vllm.engine.offload_params",
-            "vllm.engine.disable_custom_all_reduce",
-            "vllm.engine.kv_cache_memory_bytes",
-            "vllm.engine.compilation_config",
-            # Attention sub-model
-            "vllm.engine.attention.backend",
-            "vllm.engine.attention.flash_attn_version",
-            "vllm.engine.attention.flash_attn_max_num_splits_for_cuda_graph",
-            "vllm.engine.attention.use_prefill_decode_attention",
-            "vllm.engine.attention.use_prefill_query_quantization",
-            "vllm.engine.attention.use_cudnn_prefill",
-            "vllm.engine.attention.disable_flashinfer_prefill",
-            "vllm.engine.attention.disable_flashinfer_q_quantization",
-            "vllm.engine.attention.use_trtllm_attention",
-            "vllm.engine.attention.use_trtllm_ragged_deepseek_prefill",
-            # Sampling-level params (vllm.SamplingParams args, vLLM-specific only)
-            # max_tokens dropped (R2 dup of ExperimentConfig.max_output_tokens; bridged in adapter)
-            "vllm.sampling.min_tokens",
-            "vllm.sampling.presence_penalty",
-            "vllm.sampling.frequency_penalty",
-            "vllm.sampling.ignore_eos",
-            "vllm.sampling.n",
-            # Beam search section (max_tokens dropped; bridged from ExperimentConfig.max_output_tokens)
-            "vllm.beam_search.beam_width",
-            "vllm.beam_search.length_penalty",
-            "vllm.beam_search.early_stopping",
-        ],
-        "tensorrt": [
-            # Compile-time parameters (LLM() constructor)
-            "tensorrt.max_batch_size",
-            "tensorrt.tensor_parallel_size",
-            "tensorrt.pipeline_parallel_size",
-            "tensorrt.max_input_len",
-            "tensorrt.max_seq_len",
-            "tensorrt.max_num_tokens",
-            "tensorrt.dtype",
-            "tensorrt.fast_build",
-            # backend and engine_path dropped (D2/D1); settable via extra="allow"
-            # Quantisation sub-config
-            "tensorrt.quant.quant_algo",
-            "tensorrt.quant.kv_cache_quant_algo",
-            # KV cache sub-config
-            "tensorrt.kv_cache.enable_block_reuse",
-            "tensorrt.kv_cache.free_gpu_memory_fraction",
-            "tensorrt.kv_cache.max_tokens",
-            "tensorrt.kv_cache.host_cache_size",
-            # Scheduler sub-config
-            "tensorrt.scheduler.capacity_scheduling_policy",
-            # calib sub-config dropped (D3 build-only PTQ)
-            # build_cache sub-config dropped (D1 engine-cache plumbing)
-            # Sampling sub-config (return_perf_metrics dropped D1)
-            "tensorrt.sampling.min_tokens",
-            "tensorrt.sampling.n",
-            "tensorrt.sampling.ignore_eos",
-        ],
-    }
+    return {engine: sorted(get_engine_params(engine).keys()) for engine in _ALL_ENGINES_LIST}
 
 
 def get_special_test_models() -> dict[str, str]:

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -269,7 +269,6 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "vllm.engine.pipeline_parallel_size": [0],  # ge=1: 0 violates ge
         "vllm.engine.num_speculative_tokens": [0],  # ge=1: 0 violates ge
         # VLLMSamplingConfig: one known-invalid value per constrained field
-        "vllm.sampling.max_tokens": [0],  # ge=1: 0 violates ge
         "vllm.sampling.presence_penalty": [3.0],  # ge=-2.0, le=2.0: 3.0 violates le
         "vllm.sampling.frequency_penalty": [-3.0],  # ge=-2.0, le=2.0: -3.0 violates ge
         # VLLMEngineConfig: constrained fields
@@ -279,19 +278,13 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "vllm.sampling.n": [0],  # ge=1: 0 violates ge
         # VLLMBeamSearchConfig: constrained fields
         "vllm.beam_search.beam_width": [0],  # ge=1: 0 violates ge
-        "vllm.beam_search.max_tokens": [0],  # ge=1: 0 violates ge
         # TensorRTConfig: compile-time params
         "tensorrt.max_batch_size": [0],  # ge=1: 0 violates ge
         "tensorrt.tensor_parallel_size": [0],  # ge=1: 0 violates ge
         "tensorrt.max_input_len": [0],  # ge=1: 0 violates ge
         "tensorrt.max_seq_len": [0],  # ge=1: 0 violates ge
-        # TensorRTCalibConfig: calibration params
-        "tensorrt.calib.calib_batches": [0],  # ge=1: 0 violates ge
-        "tensorrt.calib.calib_max_seq_length": [0],  # ge=1: 0 violates ge
         # TensorRTKvCacheConfig: cache params
         "tensorrt.kv_cache.max_tokens": [0],  # ge=1: 0 violates ge
-        # TensorRTBuildCacheConfig: engine cache params
-        "tensorrt.build_cache.max_records": [0],  # ge=1: 0 violates ge
         # TensorRTSamplingConfig: sampling params
         "tensorrt.sampling.n": [0],  # ge=1: 0 violates ge
     }
@@ -535,6 +528,37 @@ def list_all_param_paths(engine: str | None = None) -> list[str]:
 # =============================================================================
 
 
+def get_mutual_exclusions() -> dict[str, list[str]]:
+    """Get parameters that are mutually exclusive.
+
+    Returns:
+        Dict mapping param path to list of params it cannot be used with.
+        These combinations should be skipped during runtime testing.
+    """
+    return {
+        # Transformers: can't use both 4-bit and 8-bit quantization
+        "transformers.load_in_4bit": ["transformers.load_in_8bit"],
+        "transformers.load_in_8bit": ["transformers.load_in_4bit"],
+        # torch_compile sub-options require torch_compile=True
+        "transformers.torch_compile_mode": ["transformers.torch_compile=None|False"],
+        "transformers.torch_compile_backend": ["transformers.torch_compile=None|False"],
+        # BitsAndBytes 4-bit sub-options require load_in_4bit=True
+        "transformers.bnb_4bit_compute_dtype": ["transformers.load_in_4bit=None|False"],
+        "transformers.bnb_4bit_quant_type": ["transformers.load_in_4bit=None|False"],
+        "transformers.bnb_4bit_use_double_quant": ["transformers.load_in_4bit=None|False"],
+        # cache_implementation contradicts use_cache=False
+        "transformers.cache_implementation": ["transformers.use_cache=False"],
+        # vLLM kv_cache_memory_bytes vs gpu_memory_utilization
+        "vllm.engine.kv_cache_memory_bytes": ["vllm.engine.gpu_memory_utilization"],
+        "vllm.engine.gpu_memory_utilization": ["vllm.engine.kv_cache_memory_bytes"],
+        # vLLM beam_search vs sampling sections (cross-section mutual exclusion)
+        "vllm.beam_search": ["vllm.sampling"],
+        "vllm.sampling": ["vllm.beam_search"],
+        # TensorRT: quantisation method is exclusive
+        "tensorrt.quant.quant_algo": [],  # Handled by Literal type constraint
+    }
+
+
 def get_engine_specific_params() -> dict[str, list[str]]:
     """Get params that are only valid for specific engines.
 
@@ -563,8 +587,14 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "transformers.prompt_lookup_num_tokens",
             "transformers.device_map",
             "transformers.max_memory",
-            "transformers.revision",
-            "transformers.trust_remote_code",
+            "transformers.allow_tf32",
+            "transformers.autocast_enabled",
+            "transformers.autocast_dtype",
+            "transformers.low_cpu_mem_usage",
+            "transformers.tp_plan",
+            "transformers.tp_size",
+            # revision and trust_remote_code dropped as typed fields (D1);
+            # they remain settable via extra="allow" in YAML
         ],
         "vllm": [
             # Engine-level params (vllm.LLM() constructor args)
@@ -582,8 +612,13 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "vllm.engine.pipeline_parallel_size",
             "vllm.engine.enable_prefix_caching",
             "vllm.engine.quantization",
-            "vllm.engine.speculative_model",
-            "vllm.engine.num_speculative_tokens",
+            "vllm.engine.num_scheduler_steps",
+            "vllm.engine.max_seq_len_to_capture",
+            "vllm.engine.distributed_executor_backend",
+            # Speculative decoding sub-config (replaces flat speculative_model/num_speculative_tokens)
+            "vllm.engine.speculative.model",
+            "vllm.engine.speculative.num_speculative_tokens",
+            "vllm.engine.speculative.method",
             # Engine-level offloading + memory params
             "vllm.engine.offload_group_size",
             "vllm.engine.offload_num_in_group",
@@ -604,37 +639,31 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "vllm.engine.attention.use_trtllm_attention",
             "vllm.engine.attention.use_trtllm_ragged_deepseek_prefill",
             # Sampling-level params (vllm.SamplingParams args, vLLM-specific only)
-            "vllm.sampling.max_tokens",
+            # max_tokens dropped (R2 dup of ExperimentConfig.max_output_tokens; bridged in adapter)
             "vllm.sampling.min_tokens",
             "vllm.sampling.presence_penalty",
             "vllm.sampling.frequency_penalty",
             "vllm.sampling.ignore_eos",
             "vllm.sampling.n",
-            # Beam search section (all 4 fields)
+            # Beam search section (max_tokens dropped; bridged from ExperimentConfig.max_output_tokens)
             "vllm.beam_search.beam_width",
             "vllm.beam_search.length_penalty",
             "vllm.beam_search.early_stopping",
-            "vllm.beam_search.max_tokens",
         ],
         "tensorrt": [
             # Compile-time parameters (LLM() constructor)
             "tensorrt.max_batch_size",
             "tensorrt.tensor_parallel_size",
+            "tensorrt.pipeline_parallel_size",
             "tensorrt.max_input_len",
             "tensorrt.max_seq_len",
+            "tensorrt.max_num_tokens",
             "tensorrt.dtype",
             "tensorrt.fast_build",
-            # TRT-LLM internal backend selection
-            "tensorrt.backend",
-            # Engine path
-            "tensorrt.engine_path",
+            # backend and engine_path dropped (D2/D1); settable via extra="allow"
             # Quantisation sub-config
             "tensorrt.quant.quant_algo",
             "tensorrt.quant.kv_cache_quant_algo",
-            # Calibration sub-config
-            "tensorrt.calib.calib_batches",
-            "tensorrt.calib.calib_dataset",
-            "tensorrt.calib.calib_max_seq_length",
             # KV cache sub-config
             "tensorrt.kv_cache.enable_block_reuse",
             "tensorrt.kv_cache.free_gpu_memory_fraction",
@@ -642,15 +671,12 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "tensorrt.kv_cache.host_cache_size",
             # Scheduler sub-config
             "tensorrt.scheduler.capacity_scheduling_policy",
-            # Build cache sub-config
-            "tensorrt.build_cache.cache_root",
-            "tensorrt.build_cache.max_records",
-            "tensorrt.build_cache.max_cache_storage_gb",
-            # Sampling sub-config
+            # calib sub-config dropped (D3 build-only PTQ)
+            # build_cache sub-config dropped (D1 engine-cache plumbing)
+            # Sampling sub-config (return_perf_metrics dropped D1)
             "tensorrt.sampling.min_tokens",
             "tensorrt.sampling.n",
             "tensorrt.sampling.ignore_eos",
-            "tensorrt.sampling.return_perf_metrics",
         ],
     }
 

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -184,10 +184,6 @@ class TensorRTEngine:
             "built_at": datetime.now(timezone.utc).isoformat(),
         }
 
-        trt = config.tensorrt
-        if trt is not None and trt.engine_path is not None:
-            self._build_metadata["engine_path"] = trt.engine_path
-
         sampling_params = self._build_sampling_params(config)
         if on_substep is not None:
             on_substep("sampling params built", 0.0)

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -397,8 +397,10 @@ class TensorRTEngine:
         trt = config.tensorrt
 
         # engine_path early-return: pass engine dir as model, skip all compile-time kwargs
-        if trt is not None and trt.engine_path is not None:
-            engine_path = Path(trt.engine_path)
+        # engine_path is no longer a typed field (D1 drop); accessed via extra="allow" passthrough.
+        raw_engine_path = getattr(trt, "engine_path", None) if trt is not None else None
+        if trt is not None and raw_engine_path is not None:
+            engine_path = Path(str(raw_engine_path))
             tp_size = trt.tensor_parallel_size if trt.tensor_parallel_size is not None else 1
             errors = _validate_engine_directory(engine_path, tp_size=tp_size)
             if errors:
@@ -406,30 +408,35 @@ class TensorRTEngine:
             # Pass engine dir as model - TRT-LLM auto-detects TLLM_ENGINE format.
             # Compile-time kwargs are baked into the engine; don't pass them.
             # enable_build_cache is not set - engine format bypasses it.
-            return {"model": str(trt.engine_path), "backend": "trt"}
+            return {"model": str(raw_engine_path), "backend": "trt"}
 
         if trt is None:
             # No tensorrt section — use defaults + enable build cache
             kwargs["enable_build_cache"] = True
             return kwargs
 
-        # Scalar fields: map directly (same name or renamed)
+        # Scalar fields: map directly
         if trt.tensor_parallel_size is not None:
             kwargs["tensor_parallel_size"] = trt.tensor_parallel_size
+        if trt.pipeline_parallel_size is not None:
+            kwargs["pipeline_parallel_size"] = trt.pipeline_parallel_size
         if trt.max_batch_size is not None:
             kwargs["max_batch_size"] = trt.max_batch_size
         if trt.max_input_len is not None:
             kwargs["max_input_len"] = trt.max_input_len
         if trt.max_seq_len is not None:
             kwargs["max_seq_len"] = trt.max_seq_len
+        if trt.max_num_tokens is not None:
+            kwargs["max_num_tokens"] = trt.max_num_tokens
         if trt.dtype is not None:
             kwargs["dtype"] = trt.dtype
         if trt.fast_build is not None:
             kwargs["fast_build"] = trt.fast_build
 
-        # TRT-LLM internal backend (overrides default "trt" if explicitly set)
-        if trt.backend is not None:
-            kwargs["backend"] = trt.backend
+        # TRT-LLM internal backend — no longer typed; accessed via extra="allow" if explicitly set.
+        raw_backend = getattr(trt, "backend", None)
+        if raw_backend is not None:
+            kwargs["backend"] = raw_backend
 
         # Quantisation config
         if trt.quant is not None:
@@ -446,26 +453,10 @@ class TensorRTEngine:
             except ImportError:
                 logger.debug("tensorrt_llm.llmapi not available; skipping QuantConfig")
 
-        # Build cache config
-        if trt.build_cache is not None:
-            try:
-                from tensorrt_llm.llmapi import BuildCacheConfig
-
-                bc = trt.build_cache
-                bc_kwargs: dict[str, Any] = {}
-                if bc.cache_root is not None:
-                    bc_kwargs["cache_root"] = Path(bc.cache_root)
-                if bc.max_records is not None:
-                    bc_kwargs["max_records"] = bc.max_records
-                if bc.max_cache_storage_gb is not None:
-                    bc_kwargs["max_cache_storage_gb"] = bc.max_cache_storage_gb
-                kwargs["enable_build_cache"] = BuildCacheConfig(**bc_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; enabling default build cache")
-                kwargs["enable_build_cache"] = True
-        else:
-            # Enable default build cache when no explicit config given
-            kwargs["enable_build_cache"] = True
+        # Build cache — enable by default; advanced config via extra="allow" passthrough.
+        # TensorRTBuildCacheConfig was dropped (D1 plumbing). Users can still pass
+        # build_cache fields through extra="allow" if needed.
+        kwargs["enable_build_cache"] = True
 
         # KV cache config
         if trt.kv_cache is not None:
@@ -502,24 +493,6 @@ class TensorRTEngine:
                     kwargs["scheduler_config"] = SchedulerConfig(**sc_kwargs)
             except ImportError:
                 logger.debug("tensorrt_llm.llmapi not available; skipping SchedulerConfig")
-
-        # Calibration config
-        if trt.calib is not None:
-            try:
-                from tensorrt_llm.llmapi import CalibConfig
-
-                calib = trt.calib
-                calib_kwargs: dict[str, Any] = {}
-                if calib.calib_batches is not None:
-                    calib_kwargs["calib_batches"] = calib.calib_batches
-                if calib.calib_dataset is not None:
-                    calib_kwargs["calib_dataset"] = calib.calib_dataset
-                if calib.calib_max_seq_length is not None:
-                    calib_kwargs["calib_max_seq_length"] = calib.calib_max_seq_length
-                if calib_kwargs:
-                    kwargs["calib_config"] = CalibConfig(**calib_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; skipping CalibConfig")
 
         return kwargs
 
@@ -568,7 +541,6 @@ class TensorRTEngine:
                 kwargs["n"] = sampling.n
             if sampling.ignore_eos is not None:
                 kwargs["ignore_eos"] = sampling.ignore_eos
-            if sampling.return_perf_metrics is not None:
-                kwargs["return_perf_metrics"] = sampling.return_perf_metrics
+            # return_perf_metrics dropped (D1 observability flag); falls through extra="allow"
 
         return SamplingParams(**kwargs)

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -457,8 +457,7 @@ class TransformersEngine:
         from contextlib import nullcontext
 
         _pt = config.transformers
-        _autocast_enabled = _pt is not None and _pt.autocast_enabled is True
-        if _autocast_enabled and torch.cuda.is_available():
+        if _pt is not None and _pt.autocast_enabled is True and torch.cuda.is_available():
             _dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
             _amp_ctx = torch.autocast(
                 device_type="cuda", dtype=_dtype_map[_pt.autocast_dtype or "bfloat16"]

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -74,10 +74,12 @@ class TransformersEngine:
         kwargs = self._model_load_kwargs(config)
         logger.info("Loading model %r with kwargs: %s", config.model, list(kwargs.keys()))
 
-        # trust_remote_code for tokenizer — respects config, defaults True
+        # trust_remote_code for tokenizer — defaults True; user can override via extra="allow"
         trust = True
-        if config.transformers is not None and config.transformers.trust_remote_code is not None:
-            trust = config.transformers.trust_remote_code
+        if config.transformers is not None:
+            _trc = getattr(config.transformers, "trust_remote_code", None)
+            if _trc is not None:
+                trust = _trc
 
         t0 = _time.perf_counter()
         tokenizer = AutoTokenizer.from_pretrained(config.model, trust_remote_code=trust)
@@ -91,6 +93,12 @@ class TransformersEngine:
         model.eval()
         if on_substep is not None:
             on_substep("model weights loaded", _time.perf_counter() - t0)
+
+        # Apply allow_tf32 (Ampere+ TF32 toggle)
+        if config.transformers is not None and config.transformers.allow_tf32 is not None:
+            import torch as _torch
+
+            _torch.backends.cuda.matmul.allow_tf32 = config.transformers.allow_tf32
 
         # Apply torch.compile post-load (must be AFTER from_pretrained + eval)
         if config.transformers is not None and config.transformers.torch_compile:
@@ -297,11 +305,9 @@ class TransformersEngine:
         else:
             kwargs["device_map"] = "auto"
 
-        # Trust remote code — default True unless researcher overrides
-        if pt is not None and pt.trust_remote_code is not None:
-            kwargs["trust_remote_code"] = pt.trust_remote_code
-        else:
-            kwargs["trust_remote_code"] = True
+        # trust_remote_code — no longer typed (D1 drop); defaults True; user can override via extra="allow"
+        _trc_from_pt = getattr(pt, "trust_remote_code", None) if pt is not None else None
+        kwargs["trust_remote_code"] = _trc_from_pt if _trc_from_pt is not None else True
 
         # Apply Transformers-specific config options
         if pt is not None:
@@ -335,10 +341,11 @@ class TransformersEngine:
                 kwargs["quantization_config"] = BitsAndBytesConfig(**bnb_kwargs)
 
             # Additional from_pretrained() fields
-            if pt.revision is not None:
-                kwargs["revision"] = pt.revision
+            # revision dropped as typed field (D1); flows through model_extra if set
             if pt.max_memory is not None:
                 kwargs["max_memory"] = pt.max_memory
+            if pt.low_cpu_mem_usage is not None:
+                kwargs["low_cpu_mem_usage"] = pt.low_cpu_mem_usage
 
         # Transformers extra="allow" passthrough: forward unknown fields to from_pretrained()
         if pt is not None and pt.model_extra:
@@ -446,8 +453,21 @@ class TransformersEngine:
         inputs = {k: v.to(model.device) for k, v in inputs.items()}
         input_token_count = int(inputs["attention_mask"].sum().item())
 
+        # Determine autocast settings
+        from contextlib import nullcontext
+
+        _pt = config.transformers
+        _autocast_enabled = _pt is not None and _pt.autocast_enabled is True
+        if _autocast_enabled and torch.cuda.is_available():
+            _dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
+            _amp_ctx = torch.autocast(
+                device_type="cuda", dtype=_dtype_map[_pt.autocast_dtype or "bfloat16"]
+            )
+        else:
+            _amp_ctx = nullcontext()  # type: ignore[assignment]
+
         t0 = time.perf_counter()
-        with torch.inference_mode():
+        with torch.inference_mode(), _amp_ctx:
             gen_kwargs = {**generate_kwargs}
             if config.max_output_tokens is not None:
                 gen_kwargs["max_new_tokens"] = config.max_output_tokens

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -76,13 +76,10 @@ class TransformersEngine:
 
         from llenergymeasure.utils.security import trust_remote_code_enabled
 
-        # trust_remote_code precedence: typed field > LLEM_TRUST_REMOTE_CODE env var > False
-        trust = trust_remote_code_enabled()
-        if config.transformers is not None and config.transformers.trust_remote_code is not None:
-            trust = config.transformers.trust_remote_code
-
         t0 = _time.perf_counter()
-        tokenizer = AutoTokenizer.from_pretrained(config.model, trust_remote_code=trust)
+        tokenizer = AutoTokenizer.from_pretrained(
+            config.model, trust_remote_code=trust_remote_code_enabled()
+        )
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
         if on_substep is not None:
@@ -307,11 +304,7 @@ class TransformersEngine:
 
         from llenergymeasure.utils.security import trust_remote_code_enabled
 
-        # trust_remote_code precedence: typed field > LLEM_TRUST_REMOTE_CODE env var > False
-        if pt is not None and pt.trust_remote_code is not None:
-            kwargs["trust_remote_code"] = pt.trust_remote_code
-        else:
-            kwargs["trust_remote_code"] = trust_remote_code_enabled()
+        kwargs["trust_remote_code"] = trust_remote_code_enabled()
 
         # Apply Transformers-specific config options
         if pt is not None:

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -317,13 +317,15 @@ class VLLMEngine:
             _set("pipeline_parallel_size", engine.pipeline_parallel_size)
             _set("enable_prefix_caching", engine.enable_prefix_caching)
             _set("quantization", engine.quantization)
+            _set("num_scheduler_steps", engine.num_scheduler_steps)
+            _set("max_seq_len_to_capture", engine.max_seq_len_to_capture)
+            _set("distributed_executor_backend", engine.distributed_executor_backend)
 
-            if engine.speculative_model is not None:
-                # vLLM v0.6+ uses speculative_config dict, not direct speculative_model kwarg
-                kwargs["speculative_config"] = {
-                    "model": engine.speculative_model,
-                    "num_speculative_tokens": engine.num_speculative_tokens,
-                }
+            # Speculative decoding — build vLLM-native speculative_config dict from sub-config
+            if engine.speculative is not None:
+                spec_dict = engine.speculative.model_dump(exclude_none=True)
+                if spec_dict:
+                    kwargs["speculative_config"] = spec_dict
 
             _set("disable_custom_all_reduce", engine.disable_custom_all_reduce)
             _set("kv_cache_memory_bytes", engine.kv_cache_memory_bytes)
@@ -395,8 +397,6 @@ class VLLMEngine:
         # Apply vLLM-specific sampling overrides
         if vllm_cfg is not None and vllm_cfg.sampling is not None:
             sampling = vllm_cfg.sampling
-            if sampling.max_tokens is not None:
-                kwargs["max_tokens"] = sampling.max_tokens
             if sampling.min_tokens is not None:
                 kwargs["min_tokens"] = sampling.min_tokens
             if sampling.presence_penalty is not None:
@@ -432,9 +432,8 @@ class VLLMEngine:
             kwargs["length_penalty"] = beam_cfg.length_penalty
         if beam_cfg.early_stopping is not None:
             kwargs["early_stopping"] = beam_cfg.early_stopping
-        max_tokens = beam_cfg.max_tokens or config.max_output_tokens
-        if max_tokens is not None:
-            kwargs["max_tokens"] = max_tokens
+        if config.max_output_tokens is not None:
+            kwargs["max_tokens"] = config.max_output_tokens
         if config.decoder.min_p is not None:
             kwargs["min_p"] = config.decoder.min_p
         if beam_cfg.model_extra:

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -61,9 +61,13 @@ def test_get_engine_params_tensorrt_returns_params():
     assert "tensorrt.quant.quant_algo" in params
     assert "tensorrt.kv_cache.free_gpu_memory_fraction" in params
     assert "tensorrt.scheduler.capacity_scheduling_policy" in params
-    assert "tensorrt.build_cache.max_records" in params
-    assert "tensorrt.sampling.return_perf_metrics" in params
-    assert len(params) >= 20
+    # build_cache and calib sub-configs dropped (D1/D3); return_perf_metrics dropped (D1)
+    assert "tensorrt.build_cache.max_records" not in params
+    assert "tensorrt.sampling.return_perf_metrics" not in params
+    # New fields from C.2
+    assert "tensorrt.pipeline_parallel_size" in params
+    assert "tensorrt.max_num_tokens" in params
+    assert len(params) >= 10
 
 
 def test_get_engine_params_unknown_engine_raises():

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -1,13 +1,16 @@
-"""Unit tests for expanded TensorRT-LLM config validation.
+"""Unit tests for TensorRT-LLM config validation.
 
-Tests cover all 7 config requirements (CFG-01 through CFG-07):
-- CFG-01: Compile-time params (tensor_parallel_size, max_batch_size, max_input_len, max_seq_len, dtype, fast_build)
+Tests cover:
+- CFG-01: Compile-time params (tensor_parallel_size, pipeline_parallel_size, max_batch_size,
+          max_input_len, max_seq_len, max_num_tokens, dtype, fast_build)
 - CFG-02: Quantisation (QuantAlgo Literal type, kv_cache_quant_algo)
-- CFG-03: Calibration (calib_batches, calib_max_seq_length)
+- CFG-03: (Removed) Calibration sub-config dropped — D3 build-only PTQ, project consumes
+          pre-quantised checkpoints. Falls through extra="allow" if needed.
 - CFG-04: KV cache (enable_block_reuse, free_gpu_memory_fraction, max_tokens, host_cache_size)
 - CFG-05: Scheduler (capacity_scheduling_policy Literal)
-- CFG-06: Build cache (cache_root, max_records, max_cache_storage_gb)
-- CFG-07: Sampling (min_tokens, n, ignore_eos, return_perf_metrics)
+- CFG-06: (Removed) Build cache sub-config dropped — D1 engine-cache plumbing.
+          Falls through extra="allow" if needed.
+- CFG-07: Sampling (min_tokens, n, ignore_eos; return_perf_metrics dropped D1)
 """
 
 from __future__ import annotations
@@ -16,8 +19,6 @@ import pytest
 from pydantic import ValidationError
 
 from llenergymeasure.config.engine_configs import (
-    TensorRTBuildCacheConfig,
-    TensorRTCalibConfig,
     TensorRTConfig,
     TensorRTKvCacheConfig,
     TensorRTQuantConfig,
@@ -125,29 +126,8 @@ class TestQuantisation:
             TensorRTQuantConfig(kv_cache_quant_algo="INVALID")
 
 
-# ---------------------------------------------------------------------------
-# CFG-03: Calibration
-# ---------------------------------------------------------------------------
-
-
-class TestCalibration:
-    """Tests for TensorRT calibration config."""
-
-    def test_calib_config_accepted(self):
-        """Calibration section with valid values validates."""
-        config = TensorRTCalibConfig(
-            calib_batches=64,
-            calib_max_seq_length=256,
-            calib_dataset="cnn_dailymail",
-        )
-        assert config.calib_batches == 64
-        assert config.calib_max_seq_length == 256
-        assert config.calib_dataset == "cnn_dailymail"
-
-    def test_calib_batches_ge_1(self):
-        """calib_batches=0 raises ValidationError."""
-        with pytest.raises(ValidationError):
-            TensorRTCalibConfig(calib_batches=0)
+# CFG-03: Calibration sub-config dropped (D3) — tests removed.
+# calib fields remain settable via TensorRTConfig extra="allow" passthrough.
 
 
 # ---------------------------------------------------------------------------
@@ -222,29 +202,8 @@ class TestScheduler:
             TensorRTSchedulerConfig(capacity_scheduling_policy="INVALID_POLICY")
 
 
-# ---------------------------------------------------------------------------
-# CFG-06: Build Cache
-# ---------------------------------------------------------------------------
-
-
-class TestBuildCache:
-    """Tests for TensorRT build cache config."""
-
-    def test_build_cache_config_accepted(self):
-        """Build cache section with valid values validates."""
-        config = TensorRTBuildCacheConfig(
-            cache_root="/tmp/trt_cache",
-            max_records=20,
-            max_cache_storage_gb=512.0,
-        )
-        assert config.cache_root == "/tmp/trt_cache"
-        assert config.max_records == 20
-        assert config.max_cache_storage_gb == 512.0
-
-    def test_build_cache_max_records_ge_1(self):
-        """max_records=0 raises ValidationError."""
-        with pytest.raises(ValidationError):
-            TensorRTBuildCacheConfig(max_records=0)
+# CFG-06: Build cache sub-config dropped (D1) — tests removed.
+# build_cache fields remain settable via TensorRTConfig extra="allow" passthrough.
 
 
 # ---------------------------------------------------------------------------
@@ -256,17 +215,21 @@ class TestSampling:
     """Tests for TensorRT sampling config."""
 
     def test_sampling_config_accepted(self):
-        """Sampling section with valid values validates."""
+        """Sampling section with valid values validates (return_perf_metrics dropped D1)."""
         config = TensorRTSamplingConfig(
             min_tokens=10,
             n=4,
             ignore_eos=True,
-            return_perf_metrics=True,
         )
         assert config.min_tokens == 10
         assert config.n == 4
         assert config.ignore_eos is True
-        assert config.return_perf_metrics is True
+
+    def test_sampling_return_perf_metrics_is_extra_allow(self):
+        """return_perf_metrics still accepted via extra='allow' passthrough."""
+        config = TensorRTSamplingConfig(return_perf_metrics=True)
+        # No ValidationError — extra="allow"
+        assert getattr(config, "return_perf_metrics", None) is True
 
     def test_sampling_n_ge_1(self):
         """n=0 raises ValidationError."""
@@ -289,9 +252,11 @@ class TestExperimentConfigIntegration:
             engine="tensorrt",
             tensorrt={
                 "tensor_parallel_size": 2,
+                "pipeline_parallel_size": 2,
                 "max_batch_size": 8,
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
+                "max_num_tokens": 4096,
                 "dtype": "bfloat16",
                 "fast_build": True,
                 "quant": {"quant_algo": "W4A16_AWQ"},
@@ -302,24 +267,18 @@ class TestExperimentConfigIntegration:
                 "scheduler": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
-                "calib": {
-                    "calib_batches": 128,
-                    "calib_max_seq_length": 512,
-                },
-                "build_cache": {
-                    "max_cache_storage_gb": 256,
-                    "max_records": 10,
-                },
                 "sampling": {
                     "min_tokens": 5,
                     "n": 1,
-                    "return_perf_metrics": True,
+                    "ignore_eos": False,
                 },
             },
         )
         assert config.engine == "tensorrt"
         assert config.tensorrt is not None
         assert config.tensorrt.tensor_parallel_size == 2
+        assert config.tensorrt.pipeline_parallel_size == 2
+        assert config.tensorrt.max_num_tokens == 4096
         assert config.tensorrt.quant is not None
         assert config.tensorrt.quant.quant_algo == "W4A16_AWQ"
         assert config.tensorrt.kv_cache is not None
@@ -327,7 +286,7 @@ class TestExperimentConfigIntegration:
         assert config.tensorrt.scheduler is not None
         assert config.tensorrt.scheduler.capacity_scheduling_policy == "MAX_UTILIZATION"
         assert config.tensorrt.sampling is not None
-        assert config.tensorrt.sampling.return_perf_metrics is True
+        assert config.tensorrt.sampling.n == 1
 
     def test_tensorrt_extra_allow_forwards_unknown(self):
         """Extra fields on TensorRTConfig and sub-configs are accepted (not rejected)."""
@@ -345,19 +304,20 @@ class TestExperimentConfigIntegration:
         assert quant.quant_algo == "INT8"
 
     def test_tensorrt_none_defaults(self):
-        """All fields default to None when not specified."""
+        """All typed fields default to None when not specified."""
         config = TensorRTConfig()
         assert config.max_batch_size is None
         assert config.tensor_parallel_size is None
+        assert config.pipeline_parallel_size is None
         assert config.max_input_len is None
         assert config.max_seq_len is None
+        assert config.max_num_tokens is None
         assert config.dtype is None
         assert config.fast_build is None
-        assert config.backend is None
-        assert config.engine_path is None
         assert config.quant is None
         assert config.kv_cache is None
         assert config.scheduler is None
-        assert config.calib is None
-        assert config.build_cache is None
         assert config.sampling is None
+        # backend and engine_path are no longer typed fields (D2/D1 drop)
+        # calib and build_cache sub-configs dropped (D3/D1)
+        # all remain passable via extra="allow"

--- a/tests/unit/config/test_tensorrt_sweep.py
+++ b/tests/unit/config/test_tensorrt_sweep.py
@@ -61,19 +61,19 @@ class TestDottedNestedSweep:
         algos = [c.tensorrt.quant.quant_algo for c in valid]
         assert set(algos) == {"INT8", "FP8", "W4A16_AWQ"}
 
-    def test_dotted_nested_build_cache_sweep(self):
-        """tensorrt.build_cache.max_cache_storage_gb: [128, 256] produces 2 configs."""
+    def test_dotted_nested_max_num_tokens_sweep(self):
+        """tensorrt.max_num_tokens: [2048, 4096] produces 2 configs."""
         raw_study = {
             "model": "gpt2",
             "engine": "tensorrt",
             "sweep": {
-                "tensorrt.build_cache.max_cache_storage_gb": [128, 256],
+                "tensorrt.max_num_tokens": [2048, 4096],
             },
         }
         valid, _skipped = expand_grid(raw_study)
         assert len(valid) == 2
-        storage_values = {c.tensorrt.build_cache.max_cache_storage_gb for c in valid}
-        assert storage_values == {128, 256}
+        token_values = {c.tensorrt.max_num_tokens for c in valid}
+        assert token_values == {2048, 4096}
 
     def test_full_tensorrt_study_yaml_parses(self):
         """Comprehensive study YAML with all sub-sections and quant sweep round-trips."""
@@ -93,14 +93,8 @@ class TestDottedNestedSweep:
                 "scheduler": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
-                "calib": {
-                    "calib_batches": 128,
-                },
-                "build_cache": {
-                    "max_cache_storage_gb": 256,
-                },
                 "sampling": {
-                    "return_perf_metrics": True,
+                    "n": 1,
                 },
             },
             "sweep": {
@@ -119,7 +113,7 @@ class TestDottedNestedSweep:
             assert config.tensorrt.kv_cache.enable_block_reuse is True
             assert config.tensorrt.scheduler is not None
             assert config.tensorrt.sampling is not None
-            assert config.tensorrt.sampling.return_perf_metrics is True
+            assert config.tensorrt.sampling.n == 1
         algos = {c.tensorrt.quant.quant_algo for c in valid}
         assert algos == {"INT8", "W4A16_AWQ"}
 

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -21,7 +21,6 @@ import sys
 import types
 
 from llenergymeasure.config.engine_configs import (
-    TensorRTBuildCacheConfig,
     TensorRTConfig,
     TensorRTKvCacheConfig,
     TensorRTQuantConfig,
@@ -237,29 +236,13 @@ class TestBuildLlmKwargs:
         assert isinstance(kwargs["quantization"], _MockQuantConfig)
         assert kwargs["quantization"]._kwargs["quant_algo"] == "INT8"
 
-    def test_build_llm_kwargs_build_cache_config(self, monkeypatch):
-        """build_cache section maps to BuildCacheConfig kwargs."""
-        mock_trt = _make_fake_tensorrt_llm_module()
-        monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
-        monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
-
-        config = make_config(
-            **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(
-                build_cache=TensorRTBuildCacheConfig(
-                    cache_root="/tmp/trt_cache",
-                    max_records=5,
-                    max_cache_storage_gb=128.0,
-                )
-            ),
-        )
+    def test_build_llm_kwargs_always_has_enable_build_cache(self):
+        """enable_build_cache=True is always set (TensorRTBuildCacheConfig dropped D1)."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig())
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
-        assert "enable_build_cache" in kwargs
-        assert isinstance(kwargs["enable_build_cache"], _MockBuildCacheConfig)
-        assert kwargs["enable_build_cache"]._kwargs["max_records"] == 5
-        assert kwargs["enable_build_cache"]._kwargs["max_cache_storage_gb"] == 128.0
+        assert kwargs.get("enable_build_cache") is True
 
     def test_build_llm_kwargs_kv_cache_config(self, monkeypatch):
         """kv_cache section maps to KvCacheConfig kwargs."""

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -406,10 +406,14 @@ class TestEngineConfigFields:
         kwargs = VLLMEngine()._build_llm_kwargs(config)
         assert kwargs["block_size"] == 16
 
-    def test_speculative_model_produces_speculative_config_dict(self):
-        """speculative_model + num_speculative_tokens → speculative_config dict (vLLM v0.6+ API)."""
+    def test_speculative_sub_config_produces_speculative_config_dict(self):
+        """VLLMSpeculativeConfig → speculative_config dict (vLLM native shape)."""
+        from llenergymeasure.config.engine_configs import VLLMSpeculativeConfig
+
         vllm_cfg = VLLMConfig(
-            engine=VLLMEngineConfig(speculative_model="draft-model", num_speculative_tokens=5)
+            engine=VLLMEngineConfig(
+                speculative=VLLMSpeculativeConfig(model="draft-model", num_speculative_tokens=5)
+            )
         )
         config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         kwargs = VLLMEngine()._build_llm_kwargs(config)
@@ -418,6 +422,21 @@ class TestEngineConfigFields:
             "model": "draft-model",
             "num_speculative_tokens": 5,
         }
+
+    def test_speculative_sub_config_with_method(self):
+        """VLLMSpeculativeConfig.method is forwarded in speculative_config dict."""
+        from llenergymeasure.config.engine_configs import VLLMSpeculativeConfig
+
+        vllm_cfg = VLLMConfig(
+            engine=VLLMEngineConfig(
+                speculative=VLLMSpeculativeConfig(
+                    model="eagle-model", num_speculative_tokens=3, method="eagle"
+                )
+            )
+        )
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
+        kwargs = VLLMEngine()._build_llm_kwargs(config)
+        assert kwargs["speculative_config"]["method"] == "eagle"
 
     def test_all_engine_fields_wired(self):
         """All 14 non-speculative engine fields are forwarded when set."""
@@ -463,12 +482,14 @@ class TestEngineConfigFields:
 
 
 class TestSamplingConfigOverrides:
-    def test_sampling_max_tokens_overrides_config_max_output_tokens(self):
-        """VLLMSamplingConfig.max_tokens overrides ExperimentConfig.max_output_tokens."""
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(max_tokens=256))
-        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg, max_output_tokens=128)
+    def test_max_output_tokens_bridges_to_max_tokens(self):
+        """ExperimentConfig.max_output_tokens bridges to SamplingParams.max_tokens.
+
+        max_tokens was dropped from VLLMSamplingConfig (R2 dup); bridged at adapter level.
+        """
+        config = make_config(**_VLLM_DEFAULTS, max_output_tokens=128)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-        assert params._kwargs["max_tokens"] == 256  # override wins
+        assert params._kwargs["max_tokens"] == 128
 
     def test_sampling_presence_penalty_applied(self):
         """VLLMSamplingConfig.presence_penalty appears in SamplingParams kwargs."""
@@ -501,13 +522,13 @@ class TestSamplingConfigOverrides:
     def test_sampling_overrides_applied_to_greedy_path(self):
         """VLLMSamplingConfig overrides work on the greedy (temperature=0.0) path too."""
         decoder = DecoderConfig(temperature=0.0, do_sample=False)
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(max_tokens=512))
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(presence_penalty=0.1))
         config = make_config(
             **_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=128
         )
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
         assert params._kwargs["temperature"] == 0.0
-        assert params._kwargs["max_tokens"] == 512  # override wins on greedy path
+        assert params._kwargs["max_tokens"] == 128  # from max_output_tokens bridge
 
     def test_none_sampling_config_does_not_add_extra_kwargs(self):
         """When vllm.sampling is None, no extra sampling kwargs are added."""
@@ -967,10 +988,10 @@ class TestBeamSearchMinP:
         assert "min_p" not in params._kwargs
 
     def test_beam_width_and_min_p_together(self, monkeypatch):
-        """beam_width and min_p both appear in kwargs when set."""
+        """beam_width and min_p both appear in kwargs; max_tokens bridged from max_output_tokens."""
         decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=0.1)
-        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=8, max_tokens=64))
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg)
+        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=8))
+        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=64)
         params = self._build_beam_params(config, monkeypatch)
         assert params._kwargs["beam_width"] == 8
         assert params._kwargs["min_p"] == pytest.approx(0.1)


### PR DESCRIPTION
## Summary

Narrows the typed Pydantic surface of the engine configs to fields with a plausible energy / throughput / latency path. Evidence-driven drops + adds + one sub-config refactor.

**This PR was split.** The `CurationMetadata` structured-justification dataclass, per-field decorations, and CI presence gate were moved to a stacked follow-up PR (#273). Audit during this work surfaced silent library-default overrides addressed by independent sibling PRs (see below).

## Drops (13 fields + 2 sub-config classes)

| Engine | Field | Reason |
|---|---|---|
| Transformers | `revision`, `trust_remote_code` | Deployment / security, not measurement axes |
| vLLM sampling | `max_tokens` | Duplicates `ExperimentConfig.max_output_tokens` |
| vLLM beam_search | `max_tokens` | Same |
| vLLM engine | `speculative_model`, `num_speculative_tokens` | Replaced by `VLLMSpeculativeConfig` nested sub-config |
| TensorRT | `backend`, `engine_path` | Single-option enum / cache path |
| TensorRT | `TensorRTCalibConfig` (3 fields) | Build-only PTQ calibration |
| TensorRT | `TensorRTBuildCacheConfig` (3 fields) | Engine-cache plumbing |
| TensorRT sampling | `return_perf_metrics` | Observability flag |

Dropped fields remain settable via YAML (`extra="allow"` passthrough) where appropriate.

## Adds (8 fields + `VLLMSpeculativeConfig` sub-config)

| Engine | Field |
|---|---|
| Transformers | `allow_tf32`, `autocast_enabled`, `autocast_dtype`, `low_cpu_mem_usage` |
| vLLM | `VLLMSpeculativeConfig` (replaces flat pair); `num_scheduler_steps`, `max_seq_len_to_capture`, `distributed_executor_backend` |
| TensorRT | `pipeline_parallel_size`, `max_num_tokens` |

## Other changes

- `validate_speculative` model_validator retired co-extensively with the fields it gated (not Phase 50 encroachment — the fields themselves are gone).
- **`introspection.get_engine_specific_params()` rewritten as a derivation** over `get_engine_params()` instead of a hand-maintained 120-line list. Same public API, zero drift risk on future field churn. Net -110 lines in introspection.py.
- Consumer-side edits in `engines/{transformers,tensorrt,vllm}.py`:
  - Removed `engine_path` capture block in `tensorrt.py` (field dropped).
  - Narrowed `_pt` guard in `transformers.py` autocast path for mypy.
  - Removed stale `pt.trust_remote_code` typed-field accesses after merge of main (PR #274) brought `trust_remote_code_enabled()` into branch A while the PR was already dropping the typed field.
- Doc field tables updated (`docs/engines.md`, `docs/study-config.md`).

## Excluded from this PR (see #273)

- `src/llenergymeasure/config/curation.py` — `CurationMetadata` dataclass + `RubricClause` Literal.
- `json_schema_extra=CurationMetadata(...)` decoration on every typed Field in `engine_configs.py`.
- `test_every_typed_engine_field_has_curation_metadata` CI presence gate.

These were planned in §D7.2.1 as scaffolding for Plan E's generated curation doc. Pulled out because Plan E's consumer doesn't exist yet — cheaper to commit to a structured shape when the generator reveals what shape it actually needs.

## Sibling PRs from audit (independent, off-main)

Audit during this work surfaced silent overrides of inference-library defaults. Addressed via individual PRs following the same pattern:

- **#274** — `trust_remote_code` opt-in via `LLEM_TRUST_REMOTE_CODE` env var (4 sites: transformers tokenizer + model load, vLLM constructor, FLOPs AutoConfig). **Merged.** Once landed, #274's typed-field-override branch on `pt.trust_remote_code` became dead code (this PR drops the field) — the post-merge cleanup is included in this PR.
- **#275** — `device_map="auto"` configurable via `LLEM_DEFAULT_DEVICE_MAP`. **Open, draft.**
- **#276** — TRT-LLM `backend="trt"` configurable via `LLEM_TRT_BACKEND`. **Open, draft.**
- **#277** — TRT-LLM build cache (`enable_build_cache=True`, 3 sites) configurable via `LLEM_TRT_BUILD_CACHE_ENABLED` + new `LLEM_TRT_BUILD_CACHE_PATH` for user-supplied cache directory. **Open, draft.**

All four sibling PRs and the further user-config / `llem init` / `llem doctor` work are tracked in `.planning/phases/52-library-default-overrides/PLAN.md` (Phase 52 stub).

## Test plan

- [x] `uv run pytest tests/unit/config tests/unit/engines -q` — 441 passed locally
- [x] `uv run mypy src/` — clean
- [x] `uv run llem run configs/example-study-full.yaml --dry-run` parses
- [x] CI green: lint / type-check / test / package-validation / docs-freshness / dependency-review / pip-audit / security