### PR TITLE
refactor(config): export ALL_ENGINES from ssot and replace hardcoded engine lists

### DIFF
--- a/scripts/generate_invalid_combos_doc.py
+++ b/scripts/generate_invalid_combos_doc.py
@@ -26,7 +26,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 try:
     from llenergymeasure.config.introspection import (
         get_capability_matrix_markdown,
-        get_streaming_constraints,
         get_validation_rules,
     )
 
@@ -222,19 +221,8 @@ def generate_markdown() -> str:
         ]
     )
 
-    # Use introspection module if available (SSOT), otherwise fall back to static list
-    if USE_INTROSPECTION:
-        introspection_constraints = get_streaming_constraints()
-        for param, explanation in introspection_constraints.items():
-            engine = (
-                "transformers"
-                if param.startswith("transformers.")
-                else ("vllm" if param.startswith("vllm.") else "all")
-            )
-            lines.append(f"| {engine} | `{param}` | {explanation} | See docs |")
-    else:
-        for engine, param, behaviour, impact in STREAMING_CONSTRAINTS:
-            lines.append(f"| {engine} | `{param}` | {behaviour} | {impact} |")
+    for engine, param, behaviour, impact in STREAMING_CONSTRAINTS:
+        lines.append(f"| {engine} | `{param}` | {behaviour} | {impact} |")
 
     lines.extend(
         [

--- a/scripts/generate_param_matrix.py
+++ b/scripts/generate_param_matrix.py
@@ -27,14 +27,14 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from llenergymeasure.config.ssot import ENGINE_ORDER
+from llenergymeasure.config.ssot import Engine
 
 
 def load_test_results(results_dir: Path) -> dict[str, list[dict[str, Any]]]:
     """Load test results from JSON files."""
     results: dict[str, list[dict[str, Any]]] = {}
 
-    for engine in ENGINE_ORDER:
+    for engine in Engine:
         result_file = results_dir / f"test_results_{engine}.json"
         if result_file.exists():
             with open(result_file) as f:
@@ -143,7 +143,7 @@ def generate_markdown(
     ]
 
     # Summary stats
-    for engine in ENGINE_ORDER:
+    for engine in Engine:
         tests = results.get(engine, [])
         if tests:
             # Note: test_all_params.py uses "status" field with values "passed"/"failed"/"skipped"
@@ -189,7 +189,7 @@ def generate_markdown(
             row = [f"`{param}`"]
 
             notes = []
-            for engine in ENGINE_ORDER:
+            for engine in Engine:
                 if engine in engines_map:
                     status = engines_map[engine]
                     if status["passed"]:

--- a/scripts/generate_param_matrix.py
+++ b/scripts/generate_param_matrix.py
@@ -19,17 +19,22 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from llenergymeasure.config.ssot import ENGINE_ORDER
 
 
 def load_test_results(results_dir: Path) -> dict[str, list[dict[str, Any]]]:
     """Load test results from JSON files."""
     results: dict[str, list[dict[str, Any]]] = {}
 
-    for engine in ["transformers", "vllm", "tensorrt"]:
+    for engine in ENGINE_ORDER:
         result_file = results_dir / f"test_results_{engine}.json"
         if result_file.exists():
             with open(result_file) as f:
@@ -138,7 +143,7 @@ def generate_markdown(
     ]
 
     # Summary stats
-    for engine in ["transformers", "vllm", "tensorrt"]:
+    for engine in ENGINE_ORDER:
         tests = results.get(engine, [])
         if tests:
             # Note: test_all_params.py uses "status" field with values "passed"/"failed"/"skipped"
@@ -184,7 +189,7 @@ def generate_markdown(
             row = [f"`{param}`"]
 
             notes = []
-            for engine in ["transformers", "vllm", "tensorrt"]:
+            for engine in ENGINE_ORDER:
                 if engine in engines_map:
                     status = engines_map[engine]
                     if status["passed"]:

--- a/scripts/runtime-test-orchestrator.py
+++ b/scripts/runtime-test-orchestrator.py
@@ -47,7 +47,7 @@ SCRIPT_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
-from llenergymeasure.config.ssot import ENGINE_ORDER  # noqa: E402
+from llenergymeasure.config.ssot import Engine  # noqa: E402
 
 # =============================================================================
 # Configuration
@@ -58,7 +58,7 @@ TEST_SAMPLE_SIZE = 5
 TEST_MAX_OUTPUT = 32
 TEST_TIMEOUT_SECONDS = 300  # 5 minutes per test
 
-ENGINES = list(ENGINE_ORDER)
+ENGINES = [e.value for e in Engine]
 
 # Quick mode: reduced param set for faster iteration
 QUICK_PARAMS = {

--- a/scripts/runtime-test-orchestrator.py
+++ b/scripts/runtime-test-orchestrator.py
@@ -47,6 +47,7 @@ SCRIPT_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
+from llenergymeasure.config.ssot import ENGINE_ORDER  # noqa: E402
 
 # =============================================================================
 # Configuration
@@ -57,7 +58,7 @@ TEST_SAMPLE_SIZE = 5
 TEST_MAX_OUTPUT = 32
 TEST_TIMEOUT_SECONDS = 300  # 5 minutes per test
 
-ENGINES = ["transformers", "vllm", "tensorrt"]
+ENGINES = list(ENGINE_ORDER)
 
 # Quick mode: reduced param set for faster iteration
 QUICK_PARAMS = {

--- a/src/llenergymeasure/api/doctor.py
+++ b/src/llenergymeasure/api/doctor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from llenergymeasure._version import __version__
-from llenergymeasure.config.ssot import ENGINE_TENSORRT, ENGINE_TRANSFORMERS, ENGINE_VLLM
+from llenergymeasure.config.ssot import Engine
 from llenergymeasure.infra.image_registry import get_default_image
 from llenergymeasure.infra.version_handshake import (
     SchemaStatus,
@@ -23,7 +23,7 @@ __all__ = [
     "run_doctor_checks",
 ]
 
-SUPPORTED_ENGINES: tuple[str, ...] = (ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT)
+SUPPORTED_ENGINES: tuple[Engine, ...] = tuple(Engine)
 
 _DETAIL_FOR_STATUS: dict[SchemaStatus, str] = {
     SchemaStatus.OK: "",

--- a/src/llenergymeasure/cli/_display.py
+++ b/src/llenergymeasure/cli/_display.py
@@ -205,7 +205,7 @@ def format_validation_error(e: ValidationError) -> str:
     lines = [header]
 
     # Build a set of valid values for did-you-mean suggestions
-    valid_engines = list(DTYPE_SUPPORT.keys())
+    valid_engines: list[str] = [str(e) for e in DTYPE_SUPPORT]
     valid_dtypes = list({d for dtypes in DTYPE_SUPPORT.values() for d in dtypes})
 
     for err in errors:

--- a/src/llenergymeasure/cli/config_cmd.py
+++ b/src/llenergymeasure/cli/config_cmd.py
@@ -17,9 +17,7 @@ import typer
 
 from llenergymeasure.config.ssot import (
     ENGINE_PACKAGES,
-    ENGINE_TENSORRT,
-    ENGINE_TRANSFORMERS,
-    ENGINE_VLLM,
+    Engine,
 )
 
 # ---------------------------------------------------------------------------
@@ -52,15 +50,15 @@ def _probe_gpu() -> list[dict[str, Any]] | None:
 def _probe_engine_version(engine: str) -> str | None:
     """Try to retrieve version string for an installed inference engine."""
     try:
-        if engine == ENGINE_TRANSFORMERS:
+        if engine == Engine.TRANSFORMERS:
             import torch
 
             return str(torch.__version__)
-        elif engine == ENGINE_VLLM:
+        elif engine == Engine.VLLM:
             import vllm
 
             return str(vllm.__version__)
-        elif engine == ENGINE_TENSORRT:
+        elif engine == Engine.TENSORRT:
             import tensorrt_llm
 
             return str(tensorrt_llm.__version__)

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -21,9 +21,9 @@ from llenergymeasure.cli._display import (
 from llenergymeasure.cli._vram import estimate_vram, get_gpu_vram_gb
 from llenergymeasure.config.loader import load_experiment_config
 from llenergymeasure.config.ssot import (
-    ENGINE_TRANSFORMERS,
     RUNNER_DOCKER,
     RUNNER_LOCAL,
+    Engine,
 )
 from llenergymeasure.utils.exceptions import (
     ConfigError,
@@ -361,8 +361,8 @@ def _resolve_runner_tag(config: Any) -> str:
     if runner == RUNNER_DOCKER or (isinstance(runner, str) and runner.startswith("docker:")):
         return RUNNER_DOCKER
     # auto: pytorch defaults to local, vllm/tensorrt default to docker
-    engine = getattr(config, "engine", ENGINE_TRANSFORMERS)
-    return RUNNER_LOCAL if engine == ENGINE_TRANSFORMERS else RUNNER_DOCKER
+    engine = getattr(config, "engine", Engine.TRANSFORMERS)
+    return RUNNER_LOCAL if engine == Engine.TRANSFORMERS else RUNNER_DOCKER
 
 
 def _build_header(config: Any, runner_tag: str = RUNNER_LOCAL) -> str:

--- a/src/llenergymeasure/config/engine_detection.py
+++ b/src/llenergymeasure/config/engine_detection.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from llenergymeasure.config.ssot import ENGINE_TENSORRT, ENGINE_TRANSFORMERS, ENGINE_VLLM
+from llenergymeasure.config.ssot import Engine
 
-KNOWN_ENGINES: list[str] = [ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT]
+KNOWN_ENGINES: list[Engine] = list(Engine)
 
 
 def is_engine_available(engine: str) -> bool:
@@ -17,11 +17,11 @@ def is_engine_available(engine: str) -> bool:
         True if engine is importable, False otherwise.
     """
     try:
-        if engine == ENGINE_TRANSFORMERS:
+        if engine == Engine.TRANSFORMERS:
             import torch  # noqa: F401
-        elif engine == ENGINE_VLLM:
+        elif engine == Engine.VLLM:
             import vllm  # noqa: F401
-        elif engine == ENGINE_TENSORRT:
+        elif engine == Engine.TENSORRT:
             import tensorrt_llm  # noqa: F401
         else:
             # Unknown engine

--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -24,7 +24,7 @@ from llenergymeasure.config.introspection import (
     get_swept_field_paths,
 )
 from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
-from llenergymeasure.config.ssot import ENGINE_SECTION_KEYS, SOURCE_MULTI_ENGINE_ELEVATION
+from llenergymeasure.config.ssot import ALL_ENGINES, SOURCE_MULTI_ENGINE_ELEVATION
 from llenergymeasure.utils.exceptions import ConfigError
 
 if TYPE_CHECKING:
@@ -126,7 +126,7 @@ def expand_grid(
     for exp in explicit_entries:
         merged = {**merged_fixed, **exp}
         engine = merged.get("engine", merged_fixed.get("engine", "transformers"))
-        for key in ENGINE_SECTION_KEYS:
+        for key in ALL_ENGINES:
             if key != engine and key in merged and key not in exp:
                 del merged[key]
         explicit_raw_configs.append(merged)
@@ -670,7 +670,7 @@ def _strip_other_engine_sections(config_dict: dict[str, Any], engine: str) -> di
     assigns a different engine, those sections must be stripped before Pydantic
     validation - otherwise ``validate_engine_section_match`` rejects the config.
     """
-    return {k: v for k, v in config_dict.items() if k not in ENGINE_SECTION_KEYS or k == engine}
+    return {k: v for k, v in config_dict.items() if k not in ALL_ENGINES or k == engine}
 
 
 # =============================================================================
@@ -704,7 +704,7 @@ def _group_engine_scope(group_key: str) -> str | None:
     """Return engine name if a group key is engine-scoped, else None (universal)."""
     if "." in group_key:
         prefix = group_key.split(".", 1)[0]
-        if prefix in ENGINE_SECTION_KEYS:
+        if prefix in ALL_ENGINES:
             return prefix
     return None
 
@@ -764,7 +764,7 @@ def _route_key_value(
     """
     if "." in key:
         prefix, param = key.split(".", 1)
-        if prefix in ENGINE_SECTION_KEYS:
+        if prefix in ALL_ENGINES:
             engine_dict = config_dict.get(prefix, {})
             nested_update = _unflatten({param: value})
             config_dict[prefix] = deep_merge(engine_dict, nested_update)
@@ -838,7 +838,7 @@ def _expand_sweep(sweep: dict[str, Any], fixed: dict[str, Any]) -> list[dict[str
 
         if "." in key:
             prefix, _param = key.split(".", 1)
-            if prefix in ENGINE_SECTION_KEYS:
+            if prefix in ALL_ENGINES:
                 scoped_dims.setdefault(prefix, {})[_param] = values
             else:
                 universal_dims[key] = values

--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -24,7 +24,7 @@ from llenergymeasure.config.introspection import (
     get_swept_field_paths,
 )
 from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
-from llenergymeasure.config.ssot import SOURCE_MULTI_ENGINE_ELEVATION
+from llenergymeasure.config.ssot import ENGINE_SECTION_KEYS, SOURCE_MULTI_ENGINE_ELEVATION
 from llenergymeasure.utils.exceptions import ConfigError
 
 if TYPE_CHECKING:
@@ -126,7 +126,7 @@ def expand_grid(
     for exp in explicit_entries:
         merged = {**merged_fixed, **exp}
         engine = merged.get("engine", merged_fixed.get("engine", "transformers"))
-        for key in _ENGINE_SECTION_KEYS:
+        for key in ENGINE_SECTION_KEYS:
             if key != engine and key in merged and key not in exp:
                 del merged[key]
         explicit_raw_configs.append(merged)
@@ -662,9 +662,6 @@ def _load_base(base_path_str: str | None, study_yaml_path: Path | None) -> dict[
     return {k: v for k, v in raw.items() if k not in _STUDY_ONLY_KEYS}
 
 
-_ENGINE_SECTION_KEYS = frozenset({"transformers", "vllm", "tensorrt"})
-
-
 def _strip_other_engine_sections(config_dict: dict[str, Any], engine: str) -> dict[str, Any]:
     """Remove engine-specific sections that don't match *engine*.
 
@@ -673,7 +670,7 @@ def _strip_other_engine_sections(config_dict: dict[str, Any], engine: str) -> di
     assigns a different engine, those sections must be stripped before Pydantic
     validation - otherwise ``validate_engine_section_match`` rejects the config.
     """
-    return {k: v for k, v in config_dict.items() if k not in _ENGINE_SECTION_KEYS or k == engine}
+    return {k: v for k, v in config_dict.items() if k not in ENGINE_SECTION_KEYS or k == engine}
 
 
 # =============================================================================
@@ -707,7 +704,7 @@ def _group_engine_scope(group_key: str) -> str | None:
     """Return engine name if a group key is engine-scoped, else None (universal)."""
     if "." in group_key:
         prefix = group_key.split(".", 1)[0]
-        if prefix in _ENGINE_SECTION_KEYS:
+        if prefix in ENGINE_SECTION_KEYS:
             return prefix
     return None
 
@@ -767,7 +764,7 @@ def _route_key_value(
     """
     if "." in key:
         prefix, param = key.split(".", 1)
-        if prefix in _ENGINE_SECTION_KEYS:
+        if prefix in ENGINE_SECTION_KEYS:
             engine_dict = config_dict.get(prefix, {})
             nested_update = _unflatten({param: value})
             config_dict[prefix] = deep_merge(engine_dict, nested_update)
@@ -841,7 +838,7 @@ def _expand_sweep(sweep: dict[str, Any], fixed: dict[str, Any]) -> list[dict[str
 
         if "." in key:
             prefix, _param = key.split(".", 1)
-            if prefix in _ENGINE_SECTION_KEYS:
+            if prefix in ENGINE_SECTION_KEYS:
                 scoped_dims.setdefault(prefix, {})[_param] = values
             else:
                 universal_dims[key] = values

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
+from llenergymeasure.config.ssot import ALL_ENGINES
+
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
@@ -353,7 +355,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
     decoder_params = get_params_from_model(DecoderConfig, prefix="decoder")
     # Add engine_support to decoder params
     for param in decoder_params.values():
-        param["engine_support"] = ["transformers", "vllm", "tensorrt"]
+        param["engine_support"] = list(ALL_ENGINES)
     shared.update(decoder_params)
 
     # Top-level universal params — defined manually for explicit engine_support
@@ -367,7 +369,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": ["float32", "float16", "bfloat16"],
         "constraints": {},
         "optional": False,
-        "engine_support": ["transformers", "vllm", "tensorrt"],
+        "engine_support": list(ALL_ENGINES),
     }
     shared["dataset.source"] = {
         "path": "dataset.source",
@@ -379,7 +381,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": ["aienergyscore"],
         "constraints": {"min_length": 1},
         "optional": False,
-        "engine_support": ["transformers", "vllm", "tensorrt"],
+        "engine_support": list(ALL_ENGINES),
     }
     shared["dataset.n_prompts"] = {
         "path": "dataset.n_prompts",
@@ -391,7 +393,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": [10, 100, 500],
         "constraints": {"ge": 1},
         "optional": False,
-        "engine_support": ["transformers", "vllm", "tensorrt"],
+        "engine_support": list(ALL_ENGINES),
     }
     shared["dataset.order"] = {
         "path": "dataset.order",
@@ -403,7 +405,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": ["interleaved", "grouped", "shuffled"],
         "constraints": {},
         "optional": False,
-        "engine_support": ["transformers", "vllm", "tensorrt"],
+        "engine_support": list(ALL_ENGINES),
     }
     shared["max_input_tokens"] = {
         "path": "max_input_tokens",
@@ -418,7 +420,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": [64, 128, 256, None],
         "constraints": {"ge": 1},
         "optional": True,
-        "engine_support": ["transformers", "vllm", "tensorrt"],
+        "engine_support": list(ALL_ENGINES),
     }
     shared["max_output_tokens"] = {
         "path": "max_output_tokens",
@@ -433,7 +435,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": [32, 128, 256, None],
         "constraints": {"ge": 1},
         "optional": True,
-        "engine_support": ["transformers", "vllm", "tensorrt"],
+        "engine_support": list(ALL_ENGINES),
     }
 
     return shared
@@ -464,12 +466,7 @@ def get_all_params() -> dict[str, dict[str, dict[str, Any]]]:
             "tensorrt": {...},
         }
     """
-    return {
-        "shared": get_shared_params(),
-        "transformers": get_engine_params("transformers"),
-        "vllm": get_engine_params("vllm"),
-        "tensorrt": get_engine_params("tensorrt"),
-    }
+    return {"shared": get_shared_params(), **{e: get_engine_params(e) for e in ALL_ENGINES}}
 
 
 def get_param_test_values(param_path: str) -> list[Any]:
@@ -956,7 +953,7 @@ def get_capability_matrix_markdown() -> str:
         display_name = display_names.get(cap_key, cap_key)
         cells = []
 
-        for engine in ["transformers", "vllm", "tensorrt"]:
+        for engine in ALL_ENGINES:
             value = cap_values.get(engine, False)
             if value is True:
                 cells.append("Yes")

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -31,9 +31,9 @@ from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
-from llenergymeasure.config.ssot import ALL_ENGINES
+from llenergymeasure.config.ssot import ALL_ENGINES, Engine
 
-_ALL_ENGINES_LIST: list[str] = list(ALL_ENGINES)
+_ALL_ENGINES_LIST: list[Engine] = list(ALL_ENGINES)
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -33,6 +33,8 @@ from pydantic.fields import FieldInfo
 
 from llenergymeasure.config.ssot import ALL_ENGINES
 
+_ALL_ENGINES_LIST: list[str] = list(ALL_ENGINES)
+
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
@@ -355,7 +357,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
     decoder_params = get_params_from_model(DecoderConfig, prefix="decoder")
     # Add engine_support to decoder params
     for param in decoder_params.values():
-        param["engine_support"] = list(ALL_ENGINES)
+        param["engine_support"] = _ALL_ENGINES_LIST
     shared.update(decoder_params)
 
     # Top-level universal params — defined manually for explicit engine_support
@@ -369,7 +371,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": ["float32", "float16", "bfloat16"],
         "constraints": {},
         "optional": False,
-        "engine_support": list(ALL_ENGINES),
+        "engine_support": _ALL_ENGINES_LIST,
     }
     shared["dataset.source"] = {
         "path": "dataset.source",
@@ -381,7 +383,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": ["aienergyscore"],
         "constraints": {"min_length": 1},
         "optional": False,
-        "engine_support": list(ALL_ENGINES),
+        "engine_support": _ALL_ENGINES_LIST,
     }
     shared["dataset.n_prompts"] = {
         "path": "dataset.n_prompts",
@@ -393,7 +395,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": [10, 100, 500],
         "constraints": {"ge": 1},
         "optional": False,
-        "engine_support": list(ALL_ENGINES),
+        "engine_support": _ALL_ENGINES_LIST,
     }
     shared["dataset.order"] = {
         "path": "dataset.order",
@@ -405,7 +407,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": ["interleaved", "grouped", "shuffled"],
         "constraints": {},
         "optional": False,
-        "engine_support": list(ALL_ENGINES),
+        "engine_support": _ALL_ENGINES_LIST,
     }
     shared["max_input_tokens"] = {
         "path": "max_input_tokens",
@@ -420,7 +422,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": [64, 128, 256, None],
         "constraints": {"ge": 1},
         "optional": True,
-        "engine_support": list(ALL_ENGINES),
+        "engine_support": _ALL_ENGINES_LIST,
     }
     shared["max_output_tokens"] = {
         "path": "max_output_tokens",
@@ -435,7 +437,7 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
         "test_values": [32, 128, 256, None],
         "constraints": {"ge": 1},
         "optional": True,
-        "engine_support": list(ALL_ENGINES),
+        "engine_support": _ALL_ENGINES_LIST,
     }
 
     return shared
@@ -531,39 +533,6 @@ def list_all_param_paths(engine: str | None = None) -> list[str]:
 # =============================================================================
 # Constraint Metadata for SSOT Architecture Hardening
 # =============================================================================
-
-
-def get_mutual_exclusions() -> dict[str, list[str]]:
-    """Get parameters that are mutually exclusive.
-
-    Returns:
-        Dict mapping param path to list of params it cannot be used with.
-        These combinations should be skipped during runtime testing.
-    """
-    return {
-        # Transformers: can't use both 4-bit and 8-bit quantization
-        "transformers.load_in_4bit": ["transformers.load_in_8bit"],
-        "transformers.load_in_8bit": ["transformers.load_in_4bit"],
-        # torch_compile sub-options require torch_compile=True
-        "transformers.torch_compile_mode": ["transformers.torch_compile=None|False"],
-        "transformers.torch_compile_backend": ["transformers.torch_compile=None|False"],
-        # BitsAndBytes 4-bit sub-options require load_in_4bit=True
-        "transformers.bnb_4bit_compute_dtype": ["transformers.load_in_4bit=None|False"],
-        "transformers.bnb_4bit_quant_type": ["transformers.load_in_4bit=None|False"],
-        "transformers.bnb_4bit_use_double_quant": ["transformers.load_in_4bit=None|False"],
-        # cache_implementation contradicts use_cache=False
-        "transformers.cache_implementation": ["transformers.use_cache=False"],
-        # vLLM speculative decoding: speculative_model requires num_speculative_tokens
-        "vllm.engine.speculative_model": ["vllm.engine.num_speculative_tokens=None"],
-        # vLLM kv_cache_memory_bytes vs gpu_memory_utilization
-        "vllm.engine.kv_cache_memory_bytes": ["vllm.engine.gpu_memory_utilization"],
-        "vllm.engine.gpu_memory_utilization": ["vllm.engine.kv_cache_memory_bytes"],
-        # vLLM beam_search vs sampling sections (cross-section mutual exclusion)
-        "vllm.beam_search": ["vllm.sampling"],
-        "vllm.sampling": ["vllm.beam_search"],
-        # TensorRT: quantisation method is exclusive
-        "tensorrt.quant.quant_algo": [],  # Handled by Literal type constraint
-    }
 
 
 def get_engine_specific_params() -> dict[str, list[str]]:
@@ -765,24 +734,6 @@ def get_param_skip_conditions() -> dict[str, str]:
         # Prompt lookup speculative decoding
         "transformers.prompt_lookup_num_tokens": "Requires compatible model and sufficient prompt overlap",
     }
-
-
-def get_streaming_constraints() -> dict[str, str]:
-    """Streaming constraints (not yet implemented).
-
-    Returns:
-        Empty dict — streaming parameters are not in scope.
-    """
-    return {}
-
-
-def get_streaming_incompatible_tests() -> list[tuple[str, str]]:
-    """Streaming incompatible tests (not yet implemented).
-
-    Returns:
-        Empty list — streaming parameters are not in scope.
-    """
-    return []
 
 
 # =============================================================================

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from llenergymeasure.config.ssot import Engine
+
 #: Valid energy sampler names for ``energy_sampler`` fields.
 EnergySamplerName = Literal["auto", "nvml", "zeus", "codecarbon"]
 
@@ -341,8 +343,8 @@ class ExperimentConfig(BaseModel):
     )
 
     # Engine selection
-    engine: Literal["transformers", "vllm", "tensorrt"] = Field(
-        default="transformers",
+    engine: Engine = Field(
+        default=Engine.TRANSFORMERS,
         description="Inference engine",
         json_schema_extra={"display_label": "Engine", "role": "experimental"},
     )

--- a/src/llenergymeasure/config/schema_loader.py
+++ b/src/llenergymeasure/config/schema_loader.py
@@ -21,12 +21,13 @@ from datetime import datetime
 from importlib import resources
 from typing import Any
 
-from llenergymeasure.config.ssot import ENGINE_TENSORRT, ENGINE_TRANSFORMERS, ENGINE_VLLM
+from llenergymeasure.config.ssot import Engine
 
 SUPPORTED_MAJOR_VERSION = 1
 
-# Engines known to ship a vendored schema.
-_KNOWN_ENGINES: tuple[str, ...] = (ENGINE_VLLM, ENGINE_TENSORRT, ENGINE_TRANSFORMERS)
+# Engines known to ship a vendored schema. Test-patchable module attribute
+# (tests monkeypatch this to inject fake engines); derived from Engine SSOT.
+_KNOWN_ENGINES: tuple[str, ...] = tuple(Engine)
 
 _PACKAGE = "llenergymeasure.config.discovered_schemas"
 

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -29,6 +29,9 @@ EngineName = Literal["transformers", "vllm", "tensorrt"]
 ALL_ENGINES: Final[frozenset[str]] = frozenset({ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT})
 """All engine section keys."""
 
+ENGINE_ORDER: Final[tuple[str, ...]] = (ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT)
+"""Canonical display/iteration order for engines. Use when stable ordering matters (docs, parametrized tests, CLI output)."""
+
 # ---------------------------------------------------------------------------
 # Runner mode constants
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -14,7 +14,7 @@ import from here.
 
 from __future__ import annotations
 
-from enum import StrEnum
+from enum import Enum
 from typing import Final, Literal
 
 # ---------------------------------------------------------------------------
@@ -24,12 +24,21 @@ from typing import Final, Literal
 # ---------------------------------------------------------------------------
 
 
-class Engine(StrEnum):
-    """Supported inference backends. StrEnum so members compare/hash equal to their string values."""
+class Engine(str, Enum):
+    """Supported inference backends.
+
+    Uses (str, Enum) so members compare and hash equal to their string values
+    on Python 3.10+. The __str__ override ensures str(Engine.X) returns the
+    raw value (e.g. "transformers"), not "Engine.TRANSFORMERS".
+    StrEnum (3.11+) is intentionally avoided to keep requires-python = ">=3.10".
+    """
 
     TRANSFORMERS = "transformers"
     VLLM = "vllm"
     TENSORRT = "tensorrt"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 ALL_ENGINES: Final[frozenset[Engine]] = frozenset(Engine)

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -26,6 +26,12 @@ ENGINE_TENSORRT: Final = "tensorrt"
 
 EngineName = Literal["transformers", "vllm", "tensorrt"]
 
+ALL_ENGINES: Final[tuple[str, ...]] = (ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT)
+"""Ordered tuple of all engine names. Use instead of hardcoded lists when iterating or building sets."""
+
+ENGINE_SECTION_KEYS: Final[frozenset[str]] = frozenset(ALL_ENGINES)
+"""Frozenset of engine section names for O(1) membership tests in config parsing."""
+
 # ---------------------------------------------------------------------------
 # Runner mode constants
 # ---------------------------------------------------------------------------
@@ -166,12 +172,14 @@ ENGINE_PACKAGES: dict[str, str] = {
 }
 
 __all__ = [
+    "ALL_ENGINES",
     "CONTAINER_EXCHANGE_DIR",
     "DECODER_PARAM_SUPPORT",
     "DECODING_SUPPORT",
     "DOCKER_PULL_TIMEOUT",
     "DTYPE_SUPPORT",
     "ENGINE_PACKAGES",
+    "ENGINE_SECTION_KEYS",
     "ENGINE_TENSORRT",
     "ENGINE_TRANSFORMERS",
     "ENGINE_VLLM",

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -14,23 +14,26 @@ import from here.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Final, Literal
 
 # ---------------------------------------------------------------------------
-# Engine name constants — use these instead of raw string literals
+# Engine enum — the ONE source of truth for backend engine identifiers.
+# Add a new backend by adding a member here; everything else derives from it
+# (Pydantic validation, membership checks, ordered iteration, CLI choices).
 # ---------------------------------------------------------------------------
 
-ENGINE_TRANSFORMERS: Final = "transformers"
-ENGINE_VLLM: Final = "vllm"
-ENGINE_TENSORRT: Final = "tensorrt"
 
-EngineName = Literal["transformers", "vllm", "tensorrt"]
+class Engine(StrEnum):
+    """Supported inference backends. StrEnum so members compare/hash equal to their string values."""
 
-ALL_ENGINES: Final[frozenset[str]] = frozenset({ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT})
-"""All engine section keys."""
+    TRANSFORMERS = "transformers"
+    VLLM = "vllm"
+    TENSORRT = "tensorrt"
 
-ENGINE_ORDER: Final[tuple[str, ...]] = (ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT)
-"""Canonical display/iteration order for engines. Use when stable ordering matters (docs, parametrized tests, CLI output)."""
+
+ALL_ENGINES: Final[frozenset[Engine]] = frozenset(Engine)
+"""Unordered engine set — use for O(1) membership checks (``engine in ALL_ENGINES``)."""
 
 # ---------------------------------------------------------------------------
 # Runner mode constants
@@ -127,18 +130,18 @@ TIMEOUT_INTERRUPT_POLL: Final = 1
 # "float32" = full precision, "float16" = half, "bfloat16" = brain float16.
 # Note: fp16/bf16 require GPU. The cpu engine (future) would be fp32-only.
 # GPU detection and cpu-dtype cross-validation is handled at pre-flight.
-DTYPE_SUPPORT: dict[str, list[str]] = {
-    ENGINE_TRANSFORMERS: ["float32", "float16", "bfloat16"],
-    ENGINE_VLLM: ["float16", "bfloat16"],  # vLLM does not support fp32 inference
-    ENGINE_TENSORRT: ["float16", "bfloat16"],  # TRT-LLM does not support fp32 inference
+DTYPE_SUPPORT: dict[Engine, list[str]] = {
+    Engine.TRANSFORMERS: ["float32", "float16", "bfloat16"],
+    Engine.VLLM: ["float16", "bfloat16"],  # vLLM does not support fp32 inference
+    Engine.TENSORRT: ["float16", "bfloat16"],  # TRT-LLM does not support fp32 inference
 }
 
 # Decoding strategies supported by each engine.
 # "sampling" = do_sample=True path; "greedy" = do_sample=False path.
-DECODING_SUPPORT: dict[str, list[str]] = {
-    ENGINE_TRANSFORMERS: ["greedy", "sampling"],  # full HuggingFace generate() support
-    ENGINE_VLLM: ["greedy", "sampling"],  # vLLM supports both via SamplingParams
-    ENGINE_TENSORRT: ["greedy", "sampling"],  # TRT-LLM supports both
+DECODING_SUPPORT: dict[Engine, list[str]] = {
+    Engine.TRANSFORMERS: ["greedy", "sampling"],  # full HuggingFace generate() support
+    Engine.VLLM: ["greedy", "sampling"],  # vLLM supports both via SamplingParams
+    Engine.TENSORRT: ["greedy", "sampling"],  # TRT-LLM supports both
 }
 
 # Engines that support the full DecoderConfig temperature/top_k/top_p fields.
@@ -146,8 +149,8 @@ DECODING_SUPPORT: dict[str, list[str]] = {
 # engine additions explicit rather than implicit.
 # min_p and min_new_tokens: transformers and vLLM support them (identical semantics).
 # min_p/min_new_tokens: vLLM supports; TensorRT support varies by version.
-DECODER_PARAM_SUPPORT: dict[str, list[str]] = {
-    ENGINE_TRANSFORMERS: [
+DECODER_PARAM_SUPPORT: dict[Engine, list[str]] = {
+    Engine.TRANSFORMERS: [
         "temperature",
         "top_k",
         "top_p",
@@ -155,8 +158,8 @@ DECODER_PARAM_SUPPORT: dict[str, list[str]] = {
         "min_p",
         "min_new_tokens",
     ],
-    ENGINE_VLLM: ["temperature", "top_k", "top_p", "repetition_penalty"],
-    ENGINE_TENSORRT: [
+    Engine.VLLM: ["temperature", "top_k", "top_p", "repetition_penalty"],
+    Engine.TENSORRT: [
         "temperature",
         "top_k",
         "top_p",
@@ -165,10 +168,10 @@ DECODER_PARAM_SUPPORT: dict[str, list[str]] = {
 
 # Map from engine name to the Python package that provides it.
 # Used by preflight checks and CLI to verify engine availability.
-ENGINE_PACKAGES: dict[str, str] = {
-    ENGINE_TRANSFORMERS: "transformers",
-    ENGINE_VLLM: "vllm",
-    ENGINE_TENSORRT: "tensorrt_llm",
+ENGINE_PACKAGES: dict[Engine, str] = {
+    Engine.TRANSFORMERS: "transformers",
+    Engine.VLLM: "vllm",
+    Engine.TENSORRT: "tensorrt_llm",
 }
 
 __all__ = [
@@ -179,9 +182,6 @@ __all__ = [
     "DOCKER_PULL_TIMEOUT",
     "DTYPE_SUPPORT",
     "ENGINE_PACKAGES",
-    "ENGINE_TENSORRT",
-    "ENGINE_TRANSFORMERS",
-    "ENGINE_VLLM",
     "ENV_BASELINE_SPEC_PATH",
     "ENV_CARBON_INTENSITY",
     "ENV_CONFIG_PATH",
@@ -209,6 +209,6 @@ __all__ = [
     "TIMEOUT_NVIDIA_SMI",
     "TIMEOUT_SIGTERM_GRACE",
     "TIMEOUT_THREAD_JOIN",
-    "EngineName",
+    "Engine",
     "RunnerMode",
 ]

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -26,11 +26,8 @@ ENGINE_TENSORRT: Final = "tensorrt"
 
 EngineName = Literal["transformers", "vllm", "tensorrt"]
 
-ALL_ENGINES: Final[tuple[str, ...]] = (ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT)
-"""Ordered tuple of all engine names. Use instead of hardcoded lists when iterating or building sets."""
-
-ENGINE_SECTION_KEYS: Final[frozenset[str]] = frozenset(ALL_ENGINES)
-"""Frozenset of engine section names for O(1) membership tests in config parsing."""
+ALL_ENGINES: Final[frozenset[str]] = frozenset({ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT})
+"""All engine section keys."""
 
 # ---------------------------------------------------------------------------
 # Runner mode constants
@@ -179,7 +176,6 @@ __all__ = [
     "DOCKER_PULL_TIMEOUT",
     "DTYPE_SUPPORT",
     "ENGINE_PACKAGES",
-    "ENGINE_SECTION_KEYS",
     "ENGINE_TENSORRT",
     "ENGINE_TRANSFORMERS",
     "ENGINE_VLLM",

--- a/src/llenergymeasure/config/user_config.py
+++ b/src/llenergymeasure/config/user_config.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from llenergymeasure.config.models import EnergySamplerName
 from llenergymeasure.config.ssot import (
+    ALL_ENGINES,
     ENV_CARBON_INTENSITY,
     ENV_DATACENTER_PUE,
     ENV_NO_PROMPT,
@@ -58,7 +59,7 @@ class UserRunnersConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_runner_format(self) -> UserRunnersConfig:
-        for field_name in ("transformers", "vllm", "tensorrt"):
+        for field_name in ALL_ENGINES:
             value = getattr(self, field_name)
             if value.startswith("singularity:"):
                 raise ValueError(
@@ -161,7 +162,7 @@ def _apply_env_overrides(config: UserConfig) -> UserConfig:
     Returns updated UserConfig (Pydantic models are immutable; use model_copy).
     """
     runners_updates: dict[str, str] = {}
-    for engine in ("transformers", "vllm", "tensorrt"):
+    for engine in ALL_ENGINES:
         env_key = f"{ENV_RUNNER_PREFIX}{engine.upper()}"
         if val := os.environ.get(env_key):
             runners_updates[engine] = val

--- a/src/llenergymeasure/device/gpu_info.py
+++ b/src/llenergymeasure/device/gpu_info.py
@@ -16,10 +16,8 @@ if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
 from llenergymeasure.config.ssot import (
-    ENGINE_TENSORRT,
-    ENGINE_TRANSFORMERS,
-    ENGINE_VLLM,
     TIMEOUT_NVIDIA_SMI,
+    Engine,
 )
 
 logger = logging.getLogger(__name__)
@@ -547,7 +545,7 @@ def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
     For local runs this path is not yet implemented; for Docker each subprocess calls
     the harness independently.
     """
-    if config.engine == ENGINE_VLLM and config.vllm is not None:
+    if config.engine == Engine.VLLM and config.vllm is not None:
         tp = 1
         pp = 1
         if config.vllm.engine is not None:
@@ -556,12 +554,12 @@ def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
         total = tp * pp
         if total > 1:
             return list(range(total))
-    elif config.engine == ENGINE_TENSORRT and config.tensorrt is not None:
+    elif config.engine == Engine.TENSORRT and config.tensorrt is not None:
         tp = config.tensorrt.tp_size or 1
         if tp > 1:
             return list(range(tp))
     elif (
-        config.engine == ENGINE_TRANSFORMERS
+        config.engine == Engine.TRANSFORMERS
         and config.transformers is not None
         and config.transformers.device_map is not None
     ):

--- a/src/llenergymeasure/engines/__init__.py
+++ b/src/llenergymeasure/engines/__init__.py
@@ -1,14 +1,14 @@
 """Inference engines for llenergymeasure."""
 
 from llenergymeasure.config.engine_detection import is_engine_available
-from llenergymeasure.config.ssot import ENGINE_TENSORRT, ENGINE_TRANSFORMERS, ENGINE_VLLM
+from llenergymeasure.config.ssot import Engine
 from llenergymeasure.engines.protocol import EnginePlugin
 from llenergymeasure.utils.exceptions import EngineError
 
 __all__ = ["EnginePlugin", "detect_default_engine", "get_engine"]
 
 
-def detect_default_engine() -> str:
+def detect_default_engine() -> Engine:
     """Detect the default available inference engine.
 
     Returns 'transformers' if transformers is installed, 'tensorrt' if tensorrt_llm is
@@ -18,12 +18,12 @@ def detect_default_engine() -> str:
     Raises:
         EngineError: If no supported engine is installed.
     """
-    if is_engine_available(ENGINE_TRANSFORMERS):
-        return ENGINE_TRANSFORMERS
-    if is_engine_available(ENGINE_TENSORRT):
-        return ENGINE_TENSORRT
-    if is_engine_available(ENGINE_VLLM):
-        return ENGINE_VLLM
+    if is_engine_available(Engine.TRANSFORMERS):
+        return Engine.TRANSFORMERS
+    if is_engine_available(Engine.TENSORRT):
+        return Engine.TENSORRT
+    if is_engine_available(Engine.VLLM):
+        return Engine.VLLM
     raise EngineError(
         "No inference engine installed. Install one with: "
         "pip install llenergymeasure[transformers], "
@@ -44,16 +44,16 @@ def get_engine(name: str) -> EnginePlugin:
     Raises:
         EngineError: If the engine name is unknown.
     """
-    if name == ENGINE_TRANSFORMERS:
+    if name == Engine.TRANSFORMERS:
         from llenergymeasure.engines.transformers import TransformersEngine
 
         return TransformersEngine()
-    if name == ENGINE_VLLM:
+    if name == Engine.VLLM:
         from llenergymeasure.engines.vllm import VLLMEngine
 
         return VLLMEngine()
-    if name == ENGINE_TENSORRT:
+    if name == Engine.TENSORRT:
         from llenergymeasure.engines.tensorrt import TensorRTEngine
 
         return TensorRTEngine()
-    raise EngineError(f"Unknown engine: {name!r}. Available: transformers, vllm, tensorrt")
+    raise EngineError(f"Unknown engine: {name!r}. Available: {', '.join(Engine)}")

--- a/src/llenergymeasure/harness/preflight.py
+++ b/src/llenergymeasure/harness/preflight.py
@@ -13,7 +13,7 @@ import logging
 from pathlib import Path
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.config.ssot import ENGINE_PACKAGES
+from llenergymeasure.config.ssot import ENGINE_PACKAGES, Engine
 from llenergymeasure.utils.exceptions import PreFlightError
 
 logger = logging.getLogger(__name__)
@@ -38,9 +38,13 @@ def _check_cuda_available() -> bool:
 
 def _check_engine_installed(engine: str) -> bool:
     """Return True if the package that provides *engine* is importable."""
-    package = ENGINE_PACKAGES.get(engine)
-    if package is None:
+    try:
+        engine_key = Engine(engine)
+    except ValueError:
         # Unknown engine — Pydantic already blocked invalid values; treat as missing.
+        return False
+    package = ENGINE_PACKAGES.get(engine_key)
+    if package is None:
         return False
     return importlib.util.find_spec(package) is not None
 

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -36,7 +36,6 @@ from llenergymeasure._version import __version__
 from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
     DOCKER_PULL_TIMEOUT,
-    ENGINE_TENSORRT,
     ENV_CONFIG_PATH,
     ENV_HF_TOKEN,
     ENV_OUTPUT_DIR,
@@ -46,6 +45,7 @@ from llenergymeasure.config.ssot import (
     TEMP_PREFIX_TIMESERIES,
     TIMEOUT_DOCKER_INSPECT,
     TIMEOUT_THREAD_JOIN,
+    Engine,
 )
 from llenergymeasure.infra.docker_errors import (
     DockerContainerError,
@@ -607,7 +607,7 @@ class DockerRunner:
             cmd.extend(["--env-file", str(env_path)])
 
         # TRT-LLM engine cache: persist compiled engines across ephemeral containers
-        if config.engine == ENGINE_TENSORRT:
+        if config.engine == Engine.TENSORRT:
             cache_host = str(Path.home() / ".cache" / "trt-llm")
             cache_container = "/root/.cache/trt-llm"
             # Only add if not already in extra_mounts (user may override path)

--- a/src/llenergymeasure/infra/image_registry.py
+++ b/src/llenergymeasure/infra/image_registry.py
@@ -35,9 +35,7 @@ import subprocess
 from functools import lru_cache
 
 from llenergymeasure.config.ssot import (
-    ENGINE_TENSORRT,
-    ENGINE_TRANSFORMERS,
-    ENGINE_VLLM,
+    ALL_ENGINES,
     ENV_IMAGE_PREFIX,
     RUNNER_DOCKER,
     RUNNER_LOCAL,
@@ -66,9 +64,6 @@ DEFAULT_IMAGE_TEMPLATE = "ghcr.io/henrycgbaker/llenergymeasure/{engine}:v{versio
 
 # Local image tag produced by `docker compose build` (no registry prefix).
 LOCAL_IMAGE_TEMPLATE = "llenergymeasure:{engine}"
-
-# Engines that have a Docker image in the registry.
-_SUPPORTED_ENGINES = frozenset({ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT})
 
 
 # ---------------------------------------------------------------------------
@@ -276,7 +271,7 @@ def show_image_resolution() -> None:
     ``make docker-images`` for quick diagnostics.
     """
     print("=== Image resolution ===")
-    for engine in sorted(_SUPPORTED_ENGINES):
+    for engine in sorted(ALL_ENGINES):
         image, source = resolve_image(engine)
         print(f"  {engine:10s} -> {image}  ({source})")
 

--- a/tests/unit/config/test_schema_loader.py
+++ b/tests/unit/config/test_schema_loader.py
@@ -16,8 +16,7 @@ from llenergymeasure.config import (
     UnsupportedSchemaVersionError,
 )
 from llenergymeasure.config.schema_loader import _parse_envelope
-
-KNOWN_ENGINES = ("vllm", "tensorrt", "transformers")
+from llenergymeasure.config.ssot import ENGINE_ORDER as KNOWN_ENGINES
 
 
 @pytest.mark.parametrize("engine", KNOWN_ENGINES)

--- a/tests/unit/config/test_schema_loader.py
+++ b/tests/unit/config/test_schema_loader.py
@@ -16,7 +16,9 @@ from llenergymeasure.config import (
     UnsupportedSchemaVersionError,
 )
 from llenergymeasure.config.schema_loader import _parse_envelope
-from llenergymeasure.config.ssot import ENGINE_ORDER as KNOWN_ENGINES
+from llenergymeasure.config.ssot import Engine
+
+KNOWN_ENGINES = tuple(Engine)
 
 
 @pytest.mark.parametrize("engine", KNOWN_ENGINES)

--- a/tests/unit/config/test_ssot.py
+++ b/tests/unit/config/test_ssot.py
@@ -1,12 +1,15 @@
 """Unit tests for SSOT engine constants."""
 
-from enum import StrEnum
+from enum import Enum
 
 from llenergymeasure.config.ssot import ALL_ENGINES, Engine
 
 
 def test_engine_is_str_enum() -> None:
-    assert issubclass(Engine, StrEnum)
+    # Engine uses (str, Enum) for Python 3.10 compatibility — not StrEnum (3.11+).
+    # Assert the same behavioural guarantees: it is an Enum and a str subclass.
+    assert issubclass(Engine, Enum)
+    assert issubclass(Engine, str)
 
 
 def test_engine_members_are_strings() -> None:

--- a/tests/unit/config/test_ssot.py
+++ b/tests/unit/config/test_ssot.py
@@ -1,27 +1,38 @@
 """Unit tests for SSOT engine constants."""
 
-from llenergymeasure.config.ssot import (
-    ALL_ENGINES,
-    ENGINE_TENSORRT,
-    ENGINE_TRANSFORMERS,
-    ENGINE_VLLM,
-)
+from enum import StrEnum
+
+from llenergymeasure.config.ssot import ALL_ENGINES, Engine
+
+
+def test_engine_is_str_enum() -> None:
+    assert issubclass(Engine, StrEnum)
+
+
+def test_engine_members_are_strings() -> None:
+    assert Engine.TRANSFORMERS == "transformers"
+    assert Engine.VLLM == "vllm"
+    assert Engine.TENSORRT == "tensorrt"
+
+
+def test_engine_members_iterate_in_definition_order() -> None:
+    assert tuple(Engine) == (Engine.TRANSFORMERS, Engine.VLLM, Engine.TENSORRT)
 
 
 def test_all_engines_has_three_entries() -> None:
     assert len(ALL_ENGINES) == 3
 
 
-def test_all_engines_contents() -> None:
-    assert set(ALL_ENGINES) == {ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT}
+def test_all_engines_derives_from_engine_enum() -> None:
+    assert set(ALL_ENGINES) == set(Engine)
 
 
 def test_all_engines_is_frozenset() -> None:
     assert isinstance(ALL_ENGINES, frozenset)
 
 
-def test_all_engines_membership() -> None:
-    assert ENGINE_TRANSFORMERS in ALL_ENGINES
-    assert ENGINE_VLLM in ALL_ENGINES
-    assert ENGINE_TENSORRT in ALL_ENGINES
+def test_all_engines_membership_accepts_strings() -> None:
+    # StrEnum: string literals hash equal to members, so membership works for both
+    assert "transformers" in ALL_ENGINES
+    assert Engine.VLLM in ALL_ENGINES
     assert "unknown_engine" not in ALL_ENGINES

--- a/tests/unit/config/test_ssot.py
+++ b/tests/unit/config/test_ssot.py
@@ -1,0 +1,27 @@
+"""Unit tests for SSOT engine constants."""
+
+from llenergymeasure.config.ssot import (
+    ALL_ENGINES,
+    ENGINE_TENSORRT,
+    ENGINE_TRANSFORMERS,
+    ENGINE_VLLM,
+)
+
+
+def test_all_engines_has_three_entries() -> None:
+    assert len(ALL_ENGINES) == 3
+
+
+def test_all_engines_contents() -> None:
+    assert set(ALL_ENGINES) == {ENGINE_TRANSFORMERS, ENGINE_VLLM, ENGINE_TENSORRT}
+
+
+def test_all_engines_is_frozenset() -> None:
+    assert isinstance(ALL_ENGINES, frozenset)
+
+
+def test_all_engines_membership() -> None:
+    assert ENGINE_TRANSFORMERS in ALL_ENGINES
+    assert ENGINE_VLLM in ALL_ENGINES
+    assert ENGINE_TENSORRT in ALL_ENGINES
+    assert "unknown_engine" not in ALL_ENGINES

--- a/tests/unit/docker/test_image_registry.py
+++ b/tests/unit/docker/test_image_registry.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from llenergymeasure.config.ssot import ENV_IMAGE_PREFIX
+from llenergymeasure.config.ssot import ENGINE_ORDER, ENV_IMAGE_PREFIX
 
 
 @pytest.fixture(autouse=True)
@@ -97,7 +97,7 @@ class TestGetDefaultImage:
     def test_engine_name_included_in_image(self):
         from llenergymeasure.infra.image_registry import get_default_image
 
-        for engine in ("transformers", "vllm", "tensorrt"):
+        for engine in ENGINE_ORDER:
             image = get_default_image(engine)
             assert engine in image, f"Expected engine {engine!r} in image {image!r}"
 

--- a/tests/unit/docker/test_image_registry.py
+++ b/tests/unit/docker/test_image_registry.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from llenergymeasure.config.ssot import ENGINE_ORDER, ENV_IMAGE_PREFIX
+from llenergymeasure.config.ssot import ENV_IMAGE_PREFIX, Engine
 
 
 @pytest.fixture(autouse=True)
@@ -97,7 +97,7 @@ class TestGetDefaultImage:
     def test_engine_name_included_in_image(self):
         from llenergymeasure.infra.image_registry import get_default_image
 
-        for engine in ENGINE_ORDER:
+        for engine in Engine:
             image = get_default_image(engine)
             assert engine in image, f"Expected engine {engine!r} in image {image!r}"
 


### PR DESCRIPTION
## Summary

- Adds `ALL_ENGINES: Final[tuple[str, ...]]` and `ENGINE_SECTION_KEYS: Final[frozenset[str]]` to `config/ssot.py`.
- Replaces 5 hardcoded `("transformers", "vllm", "tensorrt")` tuples/lists/frozensets across `grid.py`, `introspection.py`, and `user_config.py` with imports from `ssot`.
- Adding a new engine (e.g. SGLang in M5) now requires a single edit in `ssot.py` rather than grep-hunting all call sites.

## Files changed

| File | Change |
|---|---|
| `config/ssot.py` | +`ALL_ENGINES`, `ENGINE_SECTION_KEYS` exported |
| `config/grid.py` | Local `_ENGINE_SECTION_KEYS` removed; replaced with `ssot.ENGINE_SECTION_KEYS` (3 sites) |
| `config/introspection.py` | 9 `["transformers", "vllm", "tensorrt"]` lists replaced; `get_all_params()` uses dict comprehension over `ALL_ENGINES` |
| `config/user_config.py` | 2 hardcoded tuples in validators/env-override loop replaced |

## Test plan

- [ ] `uv run pytest tests/unit/config/ tests/unit/engines/ -v` green
- [ ] No remaining `frozenset({"transformers", "vllm", "tensorrt"})` or raw tuple literals in the changed files