### PR TITLE
docs(examples): maximalist showcase config covering full typed surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,24 @@ All notable changes to this project are documented here.
   - `transformers.tp_size` — HF accelerate convention, unchanged
   - `vllm.engine.tensor_parallel_size` — already native name, unchanged
 
+- **Typed-field curation for engine configs (maximalist rubric, Phase 48 Plan C.2).** Applies the rubric "type anything with a plausible energy/throughput/latency path" to each engine's Pydantic surface. Every typed field carries `CurationMetadata` (structured dataclass in `json_schema_extra`) with rubric clauses, rationale, and native mapping. Dropped fields remain settable via YAML (`extra="allow"` passthrough unless noted). A new CI assertion test verifies all typed fields carry `CurationMetadata`.
+
+  **Transformers** — drops 2 typed fields, adds 4:
+  - Dropped: `revision` (D1 reproducibility metadata), `trust_remote_code` (D1 security toggle). Both remain settable via `extra="allow"`.
+  - Added: `allow_tf32`, `autocast_enabled`, `autocast_dtype`, `low_cpu_mem_usage`.
+  - Also adds `tp_plan` and `tp_size` to the introspection param list (were missing).
+
+  **vLLM** — drops 4 typed fields, adds 3, replaces 2 with typed sub-config:
+  - Dropped: `sampling.max_tokens`, `beam_search.max_tokens` (R2 dups of `ExperimentConfig.max_output_tokens`; bridged in adapter). `speculative_model` and `num_speculative_tokens` replaced (not simply dropped).
+  - Added: `num_scheduler_steps`, `max_seq_len_to_capture`, `distributed_executor_backend`.
+  - Replaced: flat `speculative_model` + `num_speculative_tokens` → typed nested `VLLMSpeculativeConfig` sub-config (mirrors vLLM native shape; sweepable via dotted paths). Migration: `{speculative_model: m, num_speculative_tokens: k}` → `{speculative: {model: m, num_speculative_tokens: k}}`.
+  - `VLLMAttentionConfig` stays nested; all 10 fields (including `use_trtllm_attention`, `use_trtllm_ragged_deepseek_prefill`) remain typed.
+
+  **TensorRT-LLM** — drops 9 typed fields (incl. 2 sub-config classes), adds 2:
+  - Dropped: `backend: Literal["trt"]` (D2), `engine_path` (D1), entire `TensorRTCalibConfig` (D3 build-only PTQ), entire `TensorRTBuildCacheConfig` (D1 cache plumbing), `sampling.return_perf_metrics` (D1). All remain passable via `extra="allow"`.
+  - Added: `pipeline_parallel_size` (MLPerf v5.0 Blackwell), `max_num_tokens` (trtllm-bench axis).
+  - `fast_build` kept typed — build-time knob with runtime consequences.
+
 ### Added
 
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ All notable changes to this project are documented here.
   - `TensorRTConfig.backend` — TRT-LLM's internal `LLM(backend=...)` parameter
   - Energy measurement backends (Zeus, NVML, CodeCarbon)
 
+- **`tensorrt.tp_size` → `tensorrt.tensor_parallel_size`.** Aligns the TensorRT-LLM Pydantic field name with `TrtLlmArgs.tensor_parallel_size`. `transformers.tp_size` is **preserved** — it follows the `accelerate` convention and HF has no single native `tensor_parallel_size` equivalent.
+
+  **Migrate YAML configs** (scope-limited — renames only inside `tensorrt:` blocks):
+  ```bash
+  # Manual edit is safer: 'tp_size' also appears legitimately under 'transformers:'
+  # In your tensorrt section, rename:  tp_size: N  →  tensor_parallel_size: N
+  ```
+
+  **Affected identifiers:**
+  - YAML field: `tensorrt.tp_size` → `tensorrt.tensor_parallel_size`
+  - Python: `TensorRTConfig(tp_size=N)` → `TensorRTConfig(tensor_parallel_size=N)`
+  - Sweep key: `"tensorrt.tp_size"` → `"tensorrt.tensor_parallel_size"`
+
+  **Preserved:**
+  - `transformers.tp_size` — HF accelerate convention, unchanged
+  - `vllm.engine.tensor_parallel_size` — already native name, unchanged
+
 ### Added
 
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,29 @@
+# configs/
+
+Example YAML configs for `llem run`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `example-study-full.yaml` | **Maximalist showcase** — every curated typed field, once. Not runnable as-is. |
+| `test.yaml` | Ad-hoc scratch config (not committed). |
+
+## Showcase vs practical configs
+
+`example-study-full.yaml` is a **full-surface reference**, not a starting point for real
+runs. It populates all three engine backends simultaneously (Transformers, vLLM,
+TensorRT-LLM), which is invalid for an actual study — a real run uses one engine per
+experiment. Its purpose is discoverability and CI coverage.
+
+For a practical starting point, use the minimal YAML patterns in `docs/study-config.md`.
+
+## Coverage verifier
+
+```bash
+uv run python scripts/verify_example_coverage.py
+```
+
+Asserts that every curated typed field (94 total across all engines) appears in
+`example-study-full.yaml`. Exits 1 if any field is missing or if no curated fields
+are found (indicating a broken `CurationMetadata` setup).

--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -1,600 +1,364 @@
-# Full-suite multi-engine study - comprehensive coverage across all engines
-# Run: llem run configs/example-study-full.yaml
+# =============================================================================
+# MAXIMALIST SHOWCASE CONFIG  —  NOT a runnable sweep
+# =============================================================================
 #
-# Reference config - not intended for end-to-end execution.
-# Experiment counts depend on sweep axes and groups; run `llem run --dry-run`
-# to see the exact expansion for your configuration.
+# Purpose: Every typed field from the post-C.2 Pydantic surface appears exactly
+# once with a representative value and an inline comment.
+#
+# Use cases:
+#   Discoverability  — researchers can see all available knobs at a glance.
+#   CI coverage      — `python scripts/verify_example_coverage.py` asserts
+#                      every typed field path is present here.
+#   Doc generation   — Plan E cross-references entries here for the
+#                      inclusion/exclusion table.
+#
+# This is NOT a practical study config:
+#   - All three engine sections are populated even though a real run uses one.
+#   - The Cartesian product of all axes would be enormous.
+#   - Use `llem run configs/example-study-full.yaml --dry-run` to validate parse.
+#
+# Run: uv run llem run configs/example-study-full.yaml --dry-run
+# Coverage: uv run python scripts/verify_example_coverage.py
 
-study_name: full-suite-all-engines
+study_name: maximalist-showcase-all-typed-fields
 
 # =====================================================================
 # Runner configuration
 # =====================================================================
-# Multi-engine runners auto-elevate to docker by default for better isolation and consistency (auto-elevation is configurable (TODO) but recommended).
-
 runners:
-  transformers: local                 # local | docker | Custom image override (e.g. "docker:ghcr.io/henrycgbaker/llenergymeasure/vllm:v0.9.0")
+  transformers: local                 # local | docker
   vllm: docker
   tensorrt: docker
 
 # =====================================================================
 # Execution controls (study-level)
 # =====================================================================
-# Study-level metadata and scheduling parameters.
-# Apply globally to all experiments. Non-sweepable.
-
 study_execution:
-  n_cycles: 3
-  experiment_order: shuffle       # sequential | interleave | shuffle | reverse | latin_square
-  shuffle_seed: null              # Explicit override for experiment shuffle order (null = derived from study_design_hash)
-  experiment_gap_seconds: 10.0    # Gap for thermal stabilisation
-  cycle_gap_seconds: 10.0
-  skip_preflight: false           # Skip Docker pre-flight checks (not recommended)
-  max_consecutive_failures: 10    # Circuit breaker: 0=disabled, 1=fail-fast, N=threshold
-  circuit_breaker_cooldown_seconds: 60.0  # Pause before half-open probe
-  wall_clock_timeout_hours: null  # Hard time limit in hours (null = no limit)
-  experiment_timeout_seconds: 600.0  # Per-experiment kill timeout (10 min). Raise for large n_prompts or slow engine builds.
+  n_cycles: 1
+  experiment_order: sequential        # sequential | interleave | shuffle | reverse | latin_square
+  shuffle_seed: null
+  experiment_gap_seconds: 5.0
+  cycle_gap_seconds: 5.0
+  skip_preflight: false
+  max_consecutive_failures: 3
+  circuit_breaker_cooldown_seconds: 30.0
+  wall_clock_timeout_hours: null
+  experiment_timeout_seconds: 300.0
 
 # =====================================================================
-# Shared fields (experiment-level)
+# Universal ExperimentConfig fields
 # =====================================================================
-# Experiment-level shared parameters.
-# Apply globally to all experiments, unless overridden by sweep or explicit experiments.
-# De facto treated as constant controls/defaults, but sweepable.
-# Add to sweep if you want to compare across different values of these fields
-# (e.g. random_seed for sampling variability, or max_tokens to test throughput scaling).
-
-random_seed: 42 # per-experiment stochasticity, consumed by (i) inference RNG, (ii) prompt ordering (when dataset.order: shuffled)
+# These apply to all experiments unless overridden.
 
 model: Qwen/Qwen2.5-0.5B
 
-# --- Dataset ---
 dataset:
-  source: aienergyscore          # Built-in alias or .jsonl file path
-  n_prompts: 50                  # Number of prompts to load or generate
-  order: interleaved             # interleaved | grouped | shuffled
+  source: aienergyscore
+  n_prompts: 10
+  order: interleaved
 
-# Token limits - for FLOPs/computational workload control
-max_input_tokens: 256            # null = prompts keep natural length / model generates to EOS; FLOPs uncontrolled between experiments
-max_output_tokens: 256
+max_input_tokens: 128                 # Caps input token count; controls prefill FLOPs
+max_output_tokens: 128                # Caps output token count; controls decode FLOPs
+dtype: bfloat16                       # Global dtype (overridden per-engine if needed)
+random_seed: 42                       # Per-experiment RNG seed for prompt ordering + inference
 
-# --- Energy measurement ---
-energy_sampler: auto             # auto | nvml | zeus | codecarbon | null (disables)
+energy_sampler: auto                  # auto | nvml | zeus | codecarbon | null
 
-# --- Baseline power measurement ---
 baseline:
   enabled: true
-  duration_seconds: 30.0         # 5.0 - 120.0
+  duration_seconds: 30.0
 
-# --- Warmup ---
-# Two modes: fixed (default) or CV convergence (opt-in).
-# Fixed mode: runs exactly n_warmup prompts. CV computed for info only.
-# CV mode: replaces n_warmup; runs until CV < cv_threshold (up to max_prompts).
-# After warmup, thermal_floor_seconds wait lets GPU temperature plateau before measurement.
 warmup:
   enabled: true
-  n_warmup: 3                      # Fixed mode iteration count (default: 5)
-  thermal_floor_seconds: 30.0     # Post-warmup stabilisation wait. Minimum 30s (default: 60s)
-  #convergence_detection: true   # Enable CV-based warmup (replaces n_warmup). Default: false
-  #cv_threshold: 0.05            # Stop when CV < 5%. Default: 0.05
-  #max_prompts: 20               # Safety cap for CV mode. Default: 20
-  #window_size: 3                # Sliding window for CV calculation. Default: 3
-  #min_prompts: 5                # Minimum prompts before checking CV. Default: 5
+  n_warmup: 3
+  thermal_floor_seconds: 30.0
 
-# --- Decoder / sampling (universal, shared across engines) ---
 decoder:
-  # preset: deterministic          # Presets override individual params below. Available: deterministic | standard | creative | factual
-  temperature: 1.0               # 0.0 (greedy) to 2.0
+  temperature: 1.0
   do_sample: true
-  top_k: 50                      # 0 = disabled
-  top_p: 1.0                     # 1.0 = disabled (nucleus sampling)
-  repetition_penalty: 1.0        # 1.0 = no penalty
-  min_p: null                    # Min probability filter (null = disabled)
-  min_new_tokens: null            # Minimum output tokens (null = no minimum)
-  #TODO: validate this works + how incompataible params resolution is handled
-  #TODO: consider moving this to sweep
-
-# --- LoRA adapter (optional, applies to all experiments) ---
-# lora:
-#   adapter_id: my-org/my-lora-adapter
-#   merge_weights: false
-# TODO: VALUDATE that this works as intended - does this apply to all engines? if not, need to clarify in docs and potentially add engine-specific lora config using dotted notation (e.g. lora.transformers.adapter_id, lora.vllm.adapter_id, etc.)
-
-# --- Passthrough kwargs ---
-# passthrough_kwargs:
-#   use_safetensors: true
-
-# =====================================================================
-# Output configuration (study-level)
-# =====================================================================
-# Controls where results are written and what auxiliary artefacts are persisted.
-# These are operational concerns, not part of the scientific specification.
+  top_k: 50
+  top_p: 1.0
+  repetition_penalty: 1.0
+  min_p: null
+  min_new_tokens: null
 
 output:
-  results_dir: ./results           # Base directory for study results (timestamped subdirectory created within)
-  save_timeseries: true            # Persist GPU power/thermal/memory timeseries as Parquet sidecar
+  results_dir: ./results
+  save_timeseries: true
 
 # =====================================================================
-# Sweep configuration (axes + dependent groups)
+# Experiments — one per engine section; each section is illustrative
 # =====================================================================
-# Two entry types under sweep:
-#   - Independent axes (list of scalars): Cartesian product across all axes.
-#   - Dependent groups (list of dicts): Union of variant dicts. Groups are
-#     crossed with each other and with independent axes, but entries *within*
-#     a group are alternatives (unioned, not crossed).
-#
-# Type-based disambiguation: list[scalar] = axis, list[dict] = group.
-# YAML anchors (&name) + merge keys (<<: *name) reduce repetition in groups.
-# See .product/designs/sweep-constraints.md for full design rationale.
-#
-# KNOWN-BAD CROSSES (do not add as independent axes):
-#   - transformers.torch_compile=true  x  bitsandbytes load_in_{4,8}bit
-#     (dequant ops trigger per-call recompilation; see transformers.compile_quant group)
-#   - transformers.torch_compile_mode=max-autotune  x  transformers.cache_implementation=static/sliding_window
-#     (per-shape kernel autotune on every cache reshape; slow but correct — follow-up)
-#   - Any engine x dataset.n_prompts > ~200 without raising
-#     study_execution.experiment_timeout_seconds above its 600s default
-# When in doubt, merge axes into a single group with hand-picked variants:
-# within-group variants are unioned (not crossed) while inter-group axes are.
-
-sweep: # TODO: maybe shared_sweep or global_sweep?
-  # --- Universal (applies to all three engines) ---
-  dtype: [float32, float16, bfloat16]
-
-  # --- Transformers parameter space ---
-  transformers.batch_size: [1, 4, 8, 16, 32]
-  transformers.attn_implementation: [sdpa, flash_attention_2, flash_attention_3, eager]
-
-  # --- Transformers: dependent groups ─────────────────────────────────
-
-  # torch.compile and bitsandbytes quantisation are merged into one group
-  # because their cross-product is pathological: bitsandbytes inserts dynamic
-  # dequant ops that trigger torch.compile recompilation on every call, and
-  # max-autotune compounds this with per-shape kernel search. Within-group
-  # variants are unioned (not crossed), so the variants below are exactly
-  # what runs — no bnb-with-compile cells exist.
-  transformers.compile_quant:
-    # Baseline: no compile, no quantisation
-    - {}
-    # bitsandbytes 8-bit (no compile)
-    - transformers.load_in_8bit: true
-    # bitsandbytes 4-bit, nf4 and fp4 (no compile)
-    - transformers.load_in_4bit: true
-      transformers.bnb_4bit_compute_dtype: float16
-      transformers.bnb_4bit_quant_type: [nf4, fp4]
-    # bitsandbytes 4-bit + double-quant (no compile)
-    - transformers.load_in_4bit: true
-      transformers.bnb_4bit_compute_dtype: float16
-      transformers.bnb_4bit_quant_type: nf4
-      transformers.bnb_4bit_use_double_quant: true
-    # torch.compile on unquantised weights — all three modes safe here
-    - transformers.torch_compile: true
-      transformers.torch_compile_backend: inductor
-      transformers.torch_compile_mode: [default, reduce-overhead, max-autotune]
-
-  # cache_implementation requires use_cache: true
-  transformers.caching:
-    - {}                                          # baseline: default caching
-    - transformers.use_cache: true
-      transformers.cache_implementation: [static, offloaded_static, sliding_window]
-
-  # beam search requires decoder.do_sample: false (cross-section dependency)
-  transformers.decoding:
-    - {}                                          # baseline: use shared decoder settings
-    - decoder.do_sample: false
-      decoder.temperature: 0.0
-      transformers.num_beams: 4
-      transformers.early_stopping: true
-      transformers.length_penalty: 1.0
-      transformers.no_repeat_ngram_size: 3
-
-  # --- vLLM parameter space ---
-  # (vLLM uses continuous batching - no user-facing batch_size parameter)
-  vllm.engine.gpu_memory_utilization: [0.7, 0.85, 0.95]
-  vllm.engine.enforce_eager: [true, false]
-  vllm.engine.max_num_seqs: [64, 128, 256]
-  vllm.engine.enable_chunked_prefill: [true, false]
-  # Moved from explicit experiments: these are independent single-axis variations
-  vllm.engine.enable_prefix_caching: [true, false]
-  vllm.engine.block_size: [8, 16, 32]
-  vllm.engine.kv_cache_dtype: [auto]  # fp8 requires SM >= 8.9 (Ada Lovelace / Hopper); add fp8 if hardware supports it
-  vllm.engine.quantization: [null]  # fp8 requires SM >= 8.9; awq/gptq/marlin/bitsandbytes require pre-quantised checkpoint
-  vllm.attention.backend: [flash_attn, flashinfer]  # xformers legacy, deprecated
-
-  # --- vLLM: dependent groups ─────────────────────────────────────
-
-  # vLLM requires max_num_batched_tokens >= max_model_len;
-  # independent axes would produce invalid combos (e.g. 2048 < 4096)
-  vllm.token_limits:
-    - vllm.engine.max_num_batched_tokens: 2048
-      vllm.engine.max_model_len: [1024, 2048]
-    - vllm.engine.max_num_batched_tokens: 4096
-      vllm.engine.max_model_len: [1024, 2048, 4096]
-    - vllm.engine.max_num_batched_tokens: 8192
-      vllm.engine.max_model_len: [1024, 2048, 4096]
-
-  # beam_search and sampling sections are mutually exclusive;
-  # beam search requires decoder.do_sample: false
-  vllm.decoding:
-    - {}                                          # baseline: use shared decoder settings
-    # beam_search requires vLLM >= 0.8; uncomment if installed version supports it:
-    # - decoder.do_sample: false
-    #   decoder.temperature: 0.0
-    #   vllm.beam_search.beam_width: 4
-    #   vllm.beam_search.early_stopping: true
-    #   vllm.beam_search.length_penalty: 1.0
-    #   vllm.beam_search.max_tokens: 256
-    - vllm.sampling.presence_penalty: 0.6
-      vllm.sampling.frequency_penalty: 0.6
-
-  # --- TensorRT parameter space ---
-  tensorrt.max_batch_size: [1, 4, 8, 16, 32]
-  tensorrt.max_seq_len: [1536, 2048]
-  # tensorrt.quant.quant_algo moved to tensorrt.quant_config group below
-  # (quant_algo has dependent sub-params: kv_cache_quant_algo, calib.*)
-  # TODO: is this not tensorrt.dtype??
-  tensorrt.max_input_len: [512, 1024]
-  tensorrt.scheduler.capacity_scheduling_policy: [MAX_UTILIZATION, STATIC_BATCH]
-  # tensorrt.tensor_parallel_size: [1, 2, 4]     # Tensor parallel (requires multi-GPU hardware)
-
-  # --- TensorRT: dependent groups ─────────────────────────────────
-
-  # kv_cache_quant_algo requires quant_algo; calib requires quant_algo
-  # FP8 quantisation (commented out - requires SM >= 8.9 / Ada Lovelace / Hopper)
-  tensorrt.quant_config:
-    - {}                                          # baseline: no quantisation
-    - tensorrt.quant.quant_algo: INT8
-    - tensorrt.quant.quant_algo: INT8
-      tensorrt.quant.kv_cache_quant_algo: INT8
-    - tensorrt.quant.quant_algo: INT8
-      tensorrt.calib.calib_batches: 512
-      tensorrt.calib.calib_dataset: cnn_dailymail
-      tensorrt.calib.calib_max_seq_length: 512
-    - tensorrt.quant.quant_algo: [W4A16_AWQ, W8A16]
-    # - tensorrt.quant.quant_algo: FP8  # Requires SM >= 8.9 (Ada Lovelace / Hopper)
-
-  # KV cache compound settings (block_reuse + memory_fraction travel together)
-  tensorrt.kv_cache_config:
-    - {}                                          # baseline: default KV cache
-    - tensorrt.kv_cache.enable_block_reuse: true
-      tensorrt.kv_cache.free_gpu_memory_fraction: 0.9
-    - tensorrt.kv_cache.host_cache_size: 1073741824
-    - tensorrt.kv_cache.max_tokens: 8192
-      tensorrt.kv_cache.free_gpu_memory_fraction: 0.85
-
-    # --- Shared TRT-LLM engine settings ---
-# Applied to all TensorRT sweep experiments. Explicit TRT experiments
-# override these where needed.
-tensorrt: #TODO - IM LEAVING THIS HERE AS REMINDER TO WORK OUT WHART THIS WAS AND WHY IT WAS HERE -> REMOVE AND ASSOCIATED PATHS WITHIN THE TOOL.
-  max_input_len: 1024
-
-# =====================================================================
-# Explicit experiments (truly unique overrides only)
-# =====================================================================
-# Most dependent experiments are now handled by sweep groups above.
-# This section is reserved for experiments that:
-#   - Override sweep axes (e.g. batch_size: 1 for speculative decoding)
-#   - Use params not in any sweep axis or group (e.g. cpu_offload_gb)
-#   - Require unique combinations spanning multiple unrelated groups
-# See .product/designs/sweep-constraints.md for the design.
+# All three engine blocks (transformers, vllm, tensorrt) are populated here.
+# In a real study you pick ONE engine per experiment. These are shown
+# together purely to exercise every typed field in a single parse.
 
 experiments:
 
-  # =================================================================
-  # TRANSFORMERS - unique experiments
-  # =================================================================
-  # torch.compile, quantisation, caching, and beam search are now handled
-  # by sweep groups above (transformers.compilation, transformers.quantization,
-  # transformers.caching, transformers.decoding).
-
-  # -----------------------------------------------------------------
-  # Transformers speculative decoding (prompt-lookup)
-  # -----------------------------------------------------------------
-  # Requires batch_size=1, overriding the sweep axis - must remain explicit.
+  # ===================================================================
+  # [ILLUSTRATIVE] TRANSFORMERS — all typed TransformersConfig fields
+  # ===================================================================
+  # clauses = rubric codes that justify inclusion (R=required, E=elevating,
+  # T=tie-breaker); rationale = one-line justification from CurationMetadata.
   - model: Qwen/Qwen2.5-0.5B
     engine: transformers
     dtype: bfloat16
-    dataset:
-      n_prompts: 50
     transformers:
-      batch_size: 1
-      prompt_lookup_num_tokens: 3
-      device_map: auto
-      trust_remote_code: true
 
-  # -----------------------------------------------------------------
-  # Tensor parallelism (requires multi-GPU; tp_plan and device_map are
-  # mutually exclusive, so this is a dependent experiment)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: transformers
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   transformers:
-  #     batch_size: 4
-  #     tp_plan: auto
-  #     tp_size: 2
-  #     trust_remote_code: true
+      # --- Batching ---
+      batch_size: 4               # [R1,R2,E1] Universal measurement axis; MLPerf/Optimum/LLM-Perf all split by it.
 
-  # -----------------------------------------------------------------
-  # Model loading with revision pin + memory limits
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: transformers
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   transformers:
-  #     batch_size: 4
-  #     revision: main
-  #     max_memory:
-  #       0: "10GiB"
-  #       cpu: "50GiB"
-  #     device_map: auto
-  #     trust_remote_code: true
+      # --- Attention implementation ---
+      attn_implementation: sdpa   # [R1,R2,E2,E3] Kernel selection is a latency/energy regime switch; Optimum types it.
+                                  # Literal: sdpa | flash_attention_2 | flash_attention_3 | eager
 
-  # Transformers LoRA adapter (commented out - requires a real adapter TODO: remove - isn't this above????)
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: transformers
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   lora:
-  #     adapter_id: my-org/my-lora-adapter
-  #     merge_weights: false
-  #   transformers:
-  #     batch_size: 4
-  #     device_map: auto
-  #     trust_remote_code: true
+      # --- Compilation ---
+      torch_compile: true         # [R1,R2,E2] Compile vs eager is a regime switch; Optimum/Databricks report splits.
+      torch_compile_mode: default # [R1,R2,E3] 3-option enum with meaningful throughput deltas (default vs reduce-overhead vs max-autotune).
+                                  # Literal: default | reduce-overhead | max-autotune
+      torch_compile_backend: inductor  # [R1,E3] Compile-backend selects different codegen -> different kernels -> measurable energy delta.
 
-  # =================================================================
-  # VLLM - unique experiments
-  # =================================================================
-  # Beam search and sampling penalties are now handled by the
-  # vllm.decoding sweep group above.
+      # --- BitsAndBytes quantization ---
+      # Note: load_in_4bit and load_in_8bit are mutually exclusive; load_in_8bit shown commented.
+      load_in_4bit: true          # [R1,R2,E2] Regime switch -- 4-bit is its own measurement mode.
+      bnb_4bit_compute_dtype: bfloat16  # [R1,E3] Compute-path selection inside 4-bit; affects energy directly.
+                                        # Literal: float16 | bfloat16 | float32
+      bnb_4bit_quant_type: nf4    # [R1,E3] nf4 vs fp4 selects different dequantisation kernels -> different energy/token.
+                                  # Literal: nf4 | fp4
+      bnb_4bit_use_double_quant: false  # [R1,E2] Double quantisation changes memory footprint and dequant arithmetic -- regime toggle.
+      load_in_8bit: false         # [R1,R2,E2] Regime switch -- 8-bit is its own measurement mode. (false here; mutually exclusive with load_in_4bit=true)
 
-  # -----------------------------------------------------------------
-  # Tensor parallel (special: requires multi-GPU hardware)
-  # -----------------------------------------------------------------
+      # --- KV caching ---
+      use_cache: true             # [R1,R2,E2] Turning it off changes inference from AR to prefill-only (~100x latency delta).
+      cache_implementation: static  # [R1,E2,E3] 'static' enables CUDA graphs -- regime-changing; stable 3-value enum.
+                                    # Literal: static | offloaded_static | sliding_window
+
+      # --- Beam search ---
+      num_beams: 4                # [R1,R2,E1,E2] Linear compute scaling; beam search is its own measurement regime.
+      early_stopping: true        # [R1] Couples to beam search; affects final token count.
+      length_penalty: 1.0         # [R1] Tunes beam-search sequence length -> FLOPs.
+
+      # --- N-gram repetition ---
+      no_repeat_ngram_size: 3     # [R1] Affects generation length via repetition prevention -> indirect throughput/energy delta.
+
+      # --- Speculative decoding (prompt-lookup) ---
+      prompt_lookup_num_tokens: 3  # [R1,R2,E2] HF's speculative-decoding flavour (prompt-lookup); regime switch.
+
+      # --- Model loading ---
+      device_map: auto            # [R1,E2] Offload strategy; Optimum types it. Mutually exclusive with tp_plan.
+      max_memory:                 # [R1,E2,T4] Sets per-device memory budget; forces weight offload CPU<->GPU when exceeded.
+        "0": "10GiB"             # quote GPU index key to avoid mixed int/str JSON serialisation
+        cpu: "50GiB"
+
+      # --- Mixed precision ---
+      allow_tf32: true            # [R1] Ampere TF32 toggle; accuracy/throughput tradeoff affecting GEMM energy.
+      autocast_enabled: false     # [R1,E2] Mixed-precision runtime switch; determines whether AMP is applied during generation.
+      autocast_dtype: bfloat16    # [R1,E3] AMP compute dtype selector; different dtypes have distinct GEMM throughput.
+                                  # Literal: float16 | bfloat16
+      low_cpu_mem_usage: true     # [R1,E2] Affects load-time memory footprint; can trigger weight offload regime.
+
+      # --- Tensor parallelism (HF Transformers >=4.50) ---
+      # Note: tp_plan and device_map are mutually exclusive. tp_plan has its own
+      # experiment below to avoid the cross-validator error.
+      tp_size: 2                  # [R1,R2,E1] TP degree -- universal measurement axis. Preserved as tp_size (accelerate convention).
+
+  # ===================================================================
+  # [ILLUSTRATIVE] TRANSFORMERS tp_plan — mutually exclusive with device_map
+  # ===================================================================
+  # Separate experiment because tp_plan and device_map are mutually exclusive.
+  - model: Qwen/Qwen2.5-0.5B
+    engine: transformers
+    dtype: bfloat16
+    transformers:
+      tp_plan: auto               # [R1,R2,E2] Tensor parallelism enable; engine-native HF TP regime toggle. Mutually exclusive with device_map.
+                                  # Literal: auto
+
+  # ===================================================================
+  # [ILLUSTRATIVE] VLLM — all typed VLLMConfig fields
+  # ===================================================================
+  # Sub-configs: engine (VLLMEngineConfig), sampling (VLLMSamplingConfig),
+  # beam_search (VLLMBeamSearchConfig). Note: sampling and beam_search are
+  # mutually exclusive; beam_search fields shown commented out below.
   - model: Qwen/Qwen2.5-0.5B
     engine: vllm
     dtype: bfloat16
-    dataset:
-      n_prompts: 50
     vllm:
+
+      # -----------------------------------------------------------------
+      # engine: VLLMEngineConfig  (vllm.LLM() constructor arguments)
+      # -----------------------------------------------------------------
       engine:
-        tensor_parallel_size: 2
-        disable_custom_all_reduce: false  # Disable custom all-reduce for multi-GPU
-        gpu_memory_utilization: 0.9
 
-  # -----------------------------------------------------------------
-  # Attention backend fine-tuning (advanced: sub-fields of attention config)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: vllm
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   vllm:
-  #     attention:
-  #       backend: flash_attn
-  #       flash_attn_version: 2            # Flash attention version (auto-detected)
-  #       flash_attn_max_num_splits_for_cuda_graph: 0  # Max splits for CUDA graph
-  #       use_prefill_decode_attention: true
-  #       use_prefill_query_quantization: false
-  #       use_cudnn_prefill: false
-  #       disable_flashinfer_prefill: false
-  #       disable_flashinfer_q_quantization: false
-  #       use_trtllm_attention: false      # Use TensorRT-LLM attention backend
-  #       use_trtllm_ragged_deepseek_prefill: false
-  #     engine:
-  #       enforce_eager: false
+        # --- Memory management ---
+        gpu_memory_utilization: 0.9   # [R1,R2,E1] Primary KV-cache sizing knob; MLPerf/AMD flag it. Mutually exclusive with kv_cache_memory_bytes.
+        swap_space: 4.0               # [R1,E2] CPU-swap budget for KV cache -- when exercised shifts KV blocks CPU<->GPU.
+        cpu_offload_gb: 4.0           # [R1,R2,E2] Weight-offload regime -- Optimum/Zhou flag offloading as a class.
 
-  # -----------------------------------------------------------------
-  # Speculative decoding (dependent: speculative_model requires
-  # num_speculative_tokens; commented out - requires a real draft model)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: vllm
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   vllm:
-  #     engine:
-  #       speculative_model: my-org/my-draft-model
-  #       num_speculative_tokens: 5
-  #       gpu_memory_utilization: 0.9
+        # --- KV cache ---
+        block_size: 16                # [R1,R2,E1,E3] vLLM paper + KV survey; tractable 3-value enum.
+                                      # Literal: 8 | 16 | 32
+        kv_cache_dtype: auto          # [R1,R2,T3,E3] Energy-NVML research flags as bias source (T3); MLPerf/AMD/vLLM/TRT all report it.
+                                      # Literal: auto | fp8 | fp8_e5m2 | fp8_e4m3
 
-  # -----------------------------------------------------------------
-  # Pipeline parallel (special: requires multi-GPU hardware)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: vllm
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   vllm:
-  #     engine:
-  #       pipeline_parallel_size: 2
-  #       gpu_memory_utilization: 0.9
+        # --- Execution mode ---
+        enforce_eager: false          # [R1,R2,E2] CUDA-graph regime switch.
+        enable_chunked_prefill: false # [R1,R2,E2] Scheduling regime switch; strong academic coverage (Yu/Orca, vLLM, Databricks).
 
-  # -----------------------------------------------------------------
-  # CPU offload (offloads model weight layers to CPU RAM)
-  # -----------------------------------------------------------------
+        # --- Scheduler / batching ---
+        max_num_seqs: 256             # [R1,R2,E1] Primary scheduler axis in AMD-MLPerf vLLM submissions.
+        max_num_batched_tokens: 4096  # [R1,R2,E1] Primary scheduler axis; controls per-step compute budget.
+        max_model_len: 4096           # [R1,R2] MLPerf core knob; caps KV-cache pre-allocation.
+        num_scheduler_steps: 1        # [R1,E1] AMD MLPerf v5.1 multi-step scheduling axis.
+
+        # --- Parallelism ---
+        tensor_parallel_size: 1       # [R1,R2,T3] Universal + energy-sampler-relevant (T3: must appear in results metadata).
+        pipeline_parallel_size: 1     # [R1,R2] NVIDIA MLPerf uses it; academic coverage.
+        distributed_executor_backend: mp  # [R1,E2] Multi-GPU dispatch regime toggle (mp vs ray) -- different overhead profiles.
+                                          # Literal: mp | ray
+
+        # --- Prefix caching and quantization ---
+        enable_prefix_caching: false  # [R1,R2,E2] Strong academic + vLLM-paper evidence (SGLang RadixAttention parallel).
+        quantization: null            # [R1,R2,E2,E3] Universal measurement axis; enum-validated.
+                                      # Literal: awq | gptq | fp8 | fp8_e5m2 | fp8_e4m3 | marlin | bitsandbytes
+
+        # --- CUDA graphs ---
+        max_seq_len_to_capture: 8192  # [R1,E1] CUDA-graph budget for long sequences; AMD MLPerf-derived.
+
+        # --- Speculative decoding (typed nested sub-config: VLLMSpeculativeConfig) ---
+        speculative:                  # [R1,E1,E2,T5] Regime switch; typed sub-config for inner-field sweep discoverability (T5).
+          model: gpt2                 # [R1,E2] Draft model identity -- primary axis for speculative-decoding measurement.
+          num_speculative_tokens: 3   # [R1,E1,E2] Draft-token count determines speculation depth; strongly peer-validated.
+          method: draft_model         # [R1,E2,E3] Method enum selects qualitatively different speculative-decoding regimes.
+
+        # --- CPU offload ---
+        offload_group_size: 4         # [R1] CPU-offload grouping granularity -- larger groups trade latency for throughput.
+        offload_num_in_group: 2       # [R1] Controls how many params are offloaded per group -- shifts memory/compute boundary.
+        offload_prefetch_step: 1      # [R1] Prefetch lookahead -- directly affects hide-latency effectiveness of CPU offload.
+        offload_params:               # [R1] Selects which parameter classes are offloaded -- shifts the memory/compute boundary.
+          - lm_head
+
+        # --- Multi-GPU ---
+        disable_custom_all_reduce: false  # [R1] Forces fallback to NCCL-native all-reduce -- affects collective-comm latency/energy on multi-GPU.
+
+        # Note: kv_cache_memory_bytes is mutually exclusive with gpu_memory_utilization.
+        # It appears in the dedicated experiment below; not set here.
+
+        # --- Compilation (opaque dict passthrough to vLLM CompilationConfig) ---
+        compilation_config:           # [R1,E2,T4] ~30-field dict controlling CUDA-graph capture, fusions -- major energy implications (T4).
+          level: 3
+
+        # --- Attention sub-config (VLLMAttentionConfig) ---
+        attention:                    # [R1,E1] Attention backend and kernel toggles; nested for future flashinfer/cuDNN additions.
+          backend: flash_attn         # [R1,E1,E3] Attention kernel selection (flash_attn, flashinfer, triton, xformers); peer-validated.
+          flash_attn_version: 2       # [R1] v2 vs v3 differ in kernel structure -> measurable energy delta.
+          flash_attn_max_num_splits_for_cuda_graph: 0  # [R1] Controls CUDA-graph tiling of attention -> throughput/energy tradeoff.
+          use_prefill_decode_attention: true  # [R1,E2] Routes prefill through decode kernel -- different compute path, regime toggle.
+          use_prefill_query_quantization: false  # [R1,E2] Quantises query tensor during prefill -> energy/memory delta, regime toggle.
+          use_cudnn_prefill: false    # [R1,E2] Selects cuDNN vs FlashAttention for prefill -- distinct kernel paths.
+          disable_flashinfer_prefill: false  # [R1,E2] Forces fallback when flashinfer prefill is active -- changes kernel used.
+          disable_flashinfer_q_quantization: false  # [R1] Disables an optimisation; straightforward energy/latency axis.
+          use_trtllm_attention: false  # [R1,E2] Routes attention through TRT-LLM kernel -- regime-changing kernel path switch.
+          use_trtllm_ragged_deepseek_prefill: false  # [R1,E2] TRT-LLM ragged prefill for DeepSeek architectures -- distinct kernel path.
+
+      # -----------------------------------------------------------------
+      # sampling: VLLMSamplingConfig  (vLLM-specific SamplingParams extensions)
+      # Note: beam_search section is mutually exclusive with sampling.
+      # -----------------------------------------------------------------
+      sampling:
+        min_tokens: 10              # [R1] Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens.
+        presence_penalty: 0.0       # [R1,R2] vLLM/TRT-native; not in DecoderConfig; routine in vLLM sampling studies.
+        frequency_penalty: 0.0      # [R1,R2] vLLM/TRT-native; not in DecoderConfig.
+        ignore_eos: false           # [R1,E2] Forces fixed output length -- measurement workload control.
+        n: 1                        # [R1,R2,E1] n-sequences multiplier; vLLM-bench first-class.
+
+      # Beam search section (mutually exclusive with sampling above):
+      # To exercise VLLMBeamSearchConfig fields, use a separate experiment with
+      # beam_search instead of sampling, and decoder.do_sample: false.
+      #
+      # beam_search:
+      #   beam_width: 4             # [R1,R2,E1] Linear compute scaling; beam search is its own measurement regime.
+      #   length_penalty: 1.0       # [R1] Tunes beam-search output length.
+      #   early_stopping: false     # [R1] Affects final token count.
+
+  # ===================================================================
+  # [ILLUSTRATIVE] VLLM beam_search — VLLMBeamSearchConfig typed fields
+  # ===================================================================
+  # Separate experiment because beam_search and sampling are mutually exclusive.
   - model: Qwen/Qwen2.5-0.5B
     engine: vllm
     dtype: bfloat16
-    dataset:
-      n_prompts: 50
-    vllm:
-      engine:
-        cpu_offload_gb: 4
-        gpu_memory_utilization: 0.9
-
-  # -----------------------------------------------------------------
-  # CPU offload fine-tuning (layer-level control over offloading)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: vllm
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   vllm:
-  #     engine:
-  #       cpu_offload_gb: 8
-  #       offload_group_size: 4          # Groups of layers for CPU offloading
-  #       offload_num_in_group: 2        # Layers offloaded per group
-  #       offload_prefetch_step: 1       # Prefetch steps ahead
-  #       # offload_params: ["lm_head"]  # Specific parameter names to offload
-  #       gpu_memory_utilization: 0.9
-
-  # -----------------------------------------------------------------
-  # Swap space for KV cache offloading
-  # -----------------------------------------------------------------
-  - model: Qwen/Qwen2.5-0.5B
-    engine: vllm
-    dtype: bfloat16
-    dataset:
-      n_prompts: 50
-    vllm:
-      engine:
-        swap_space: 8
-        gpu_memory_utilization: 0.85
-
-  # -----------------------------------------------------------------
-  # Sampling extensions (min_tokens, ignore_eos, multi-sequence)
-  # -----------------------------------------------------------------
-  - model: Qwen/Qwen2.5-0.5B
-    engine: vllm
-    dtype: bfloat16
-    dataset:
-      n_prompts: 50
     decoder:
-      temperature: 0.8
-      do_sample: true
+      do_sample: false
+      temperature: 0.0
     vllm:
-      sampling:
-        max_tokens: 256              # Overrides universal max_output_tokens for this experiment
-        min_tokens: 10
-        ignore_eos: false
-        n: 1
+      beam_search:
+        beam_width: 4               # [R1,R2,E1] Linear compute scaling; beam search is its own measurement regime.
+        length_penalty: 1.0         # [R1] Tunes beam-search output length.
+        early_stopping: false       # [R1] Affects final token count.
 
-  # -----------------------------------------------------------------
-  # Compilation config (advanced: full vLLM compilation passthrough)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: vllm
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   vllm:
-  #     engine:
-  #       compilation_config:
-  #         level: 3
-  #       enforce_eager: false
+  # ===================================================================
+  # [ILLUSTRATIVE] VLLM kv_cache_memory_bytes — mutually exclusive with gpu_memory_utilization
+  # ===================================================================
+  # Separate experiment because kv_cache_memory_bytes and gpu_memory_utilization are mutually exclusive.
+  - model: Qwen/Qwen2.5-0.5B
+    engine: vllm
+    dtype: bfloat16
+    vllm:
+      engine:
+        kv_cache_memory_bytes: 4294967296  # [R1,E4] Alternative to gpu_memory_utilization; parse-time mutex already wired.
+                                           # 4 GiB expressed as bytes. Mutually exclusive with gpu_memory_utilization.
 
-  # -----------------------------------------------------------------
-  # Absolute KV cache memory (mutually exclusive with gpu_memory_utilization)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: vllm
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   vllm:
-  #     engine:
-  #       kv_cache_memory_bytes: 4294967296    # 4 GiB
-  #       enforce_eager: false
-
-  # =================================================================
-  # TENSORRT - unique experiments
-  # =================================================================
-  # Quantisation configs and KV cache variants are now handled by the
-  # tensorrt.quant_config and tensorrt.kv_cache_config sweep groups above.
-
-  # -----------------------------------------------------------------
-  # Fast build mode (single flag, not part of any group)
-  # -----------------------------------------------------------------
+  # ===================================================================
+  # [ILLUSTRATIVE] TENSORRT — all typed TensorRTConfig fields
+  # ===================================================================
+  # Sub-configs: quant (TensorRTQuantConfig), kv_cache (TensorRTKvCacheConfig),
+  # scheduler (TensorRTSchedulerConfig), sampling (TensorRTSamplingConfig).
+  # Note: FP8 quant requires SM >= 8.9 (Ada Lovelace+); A100 use INT8/W4A16_AWQ/W8A16.
   - model: Qwen/Qwen2.5-0.5B
     engine: tensorrt
-    dtype: bfloat16
-    dataset:
-      n_prompts: 50
     tensorrt:
-      max_batch_size: 8
-      max_input_len: 1024
-      max_seq_len: 2048
-      fast_build: true
-      build_cache:
-        max_cache_storage_gb: 256
 
-  # PTQ calibration is now handled by tensorrt.quant_config sweep group above.
+      # --- Compile-time parameters (LLM() constructor) ---
+      max_batch_size: 8             # [R1,R2,E1] MLPerf + trtllm-bench first-class; compile-time shape constant.
+      tensor_parallel_size: 1       # [R1,R2,T3] Universal + energy-sampler-relevant (T3: must appear in results metadata).
+      pipeline_parallel_size: 1     # [R1,E1] NVIDIA MLPerf v5.0 Blackwell submissions surface PP size as a primary knob.
+      max_input_len: 1024           # [R1,R2] Compile-time shape; MLPerf core knob.
+      max_seq_len: 2048             # [R1,R2] Compile-time shape; MLPerf core knob.
+      max_num_tokens: 4096          # [R1,E1] trtllm-bench scheduler axis alongside max_batch_size.
+      dtype: bfloat16               # [E4] TRT-LLM rejects fp32 -- narrowed Literal is a parse-time safety rail (E4).
+                                    # Literal: float16 | bfloat16
+      fast_build: false             # [R1] Skips some build-time optimisations -> produced engine may be less efficient.
 
-  # -----------------------------------------------------------------
-  # TRT-LLM sampling extensions (min_tokens, multi-sequence, perf metrics)
-  # -----------------------------------------------------------------
-  - model: Qwen/Qwen2.5-0.5B
-    engine: tensorrt
-    dtype: bfloat16
-    dataset:
-      n_prompts: 50
-    tensorrt:
-      max_batch_size: 8
-      max_input_len: 1024
-      max_seq_len: 2048
-      sampling:
-        min_tokens: 10
-        ignore_eos: false
-        return_perf_metrics: true
-        n: 1
-      build_cache:
-        max_cache_storage_gb: 256
+      # -----------------------------------------------------------------
+      # quant: TensorRTQuantConfig
+      # -----------------------------------------------------------------
+      quant:                        # [R1,E2,E3] Quantisation algorithm and KV-cache quantisation sub-config.
+        quant_algo: W4A16_AWQ       # [R1,R2,E2,E3,E4] Universal axis + FP8-on-A100 hardware rail (E4); enum-validated.
+                                    # Literal: FP8 | INT8 | W4A16_AWQ | W4A16_GPTQ | W8A16 | W8A16_GPTQ | W4A8_AWQ | NO_QUANT
+                                    # Note: FP8 requires SM >= 8.9; A100 (SM80): use INT8/W4A16_AWQ/W8A16.
+        kv_cache_quant_algo: INT8   # [R1,R2,T3,E3] KV-cache quantisation; aligns with vLLM's kv_cache_dtype. Energy-biasing (T3).
+                                    # Literal: FP8 | INT8
 
-  # -----------------------------------------------------------------
-  # Tensor parallel (special: requires multi-GPU hardware)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: tensorrt
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   tensorrt:
-  #     max_batch_size: 8
-  #     max_input_len: 1024
-  #     max_seq_len: 2048
-  #     tensor_parallel_size: 2
-  #     build_cache:
-  #       max_cache_storage_gb: 256
+      # -----------------------------------------------------------------
+      # kv_cache: TensorRTKvCacheConfig
+      # -----------------------------------------------------------------
+      kv_cache:                     # [R1] KV-cache configuration (memory fraction, block reuse, host offload).
+        enable_block_reuse: false   # [R1,R2,E2] TRT's prefix-caching analog -- regime toggle.
+        free_gpu_memory_fraction: 0.9  # [R1,R2] TRT's gpu_memory_utilization analog.
+        max_tokens: 8192            # [R1] KV-cache token cap -> concurrency ceiling.
+        host_cache_size: 0          # [R1,E2] CPU KV-offload regime -- cross-engine analog to vLLM swap_space.
 
-  # -----------------------------------------------------------------
-  # Pre-compiled engine (skip compilation, load existing engine)
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: tensorrt
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   tensorrt:
-  #     engine_path: /path/to/precompiled/engine
-  #     max_batch_size: 8
-  #     max_seq_len: 2048
+      # -----------------------------------------------------------------
+      # scheduler: TensorRTSchedulerConfig
+      # -----------------------------------------------------------------
+      scheduler:                    # [R1,E2,E3] Scheduling capacity policy sub-config.
+        capacity_scheduling_policy: GUARANTEED_NO_EVICT  # [R1,E2,E3] Scheduling regime; stable 3-value enum.
+                                                         # Literal: GUARANTEED_NO_EVICT | MAX_UTILIZATION | STATIC_BATCH
 
-  # KV cache max_tokens is now handled by tensorrt.kv_cache_config sweep group above.
-
-  # -----------------------------------------------------------------
-  # Build cache with custom root and record limits
-  # -----------------------------------------------------------------
-  # - model: Qwen/Qwen2.5-0.5B
-  #   engine: tensorrt
-  #   dtype: bfloat16
-  #   dataset:
-  #     n_prompts: 50
-  #   tensorrt:
-  #     max_batch_size: 8
-  #     max_input_len: 1024
-  #     max_seq_len: 2048
-  #     build_cache:
-  #       cache_root: /tmp/trt_cache
-  #       max_records: 5
-  #       max_cache_storage_gb: 128
+      # -----------------------------------------------------------------
+      # sampling: TensorRTSamplingConfig  (TRT-LLM-specific SamplingParams extensions)
+      # -----------------------------------------------------------------
+      sampling:                     # [R1] TRT-LLM-specific sampling parameters sub-config.
+        min_tokens: 10              # [R1] Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens.
+        n: 1                        # [R1,R2] n-sequences multiplier.
+        ignore_eos: false           # [R1,E2] Forces fixed output length -- measurement workload control.

--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -235,7 +235,7 @@ sweep: # TODO: maybe shared_sweep or global_sweep?
   # TODO: is this not tensorrt.dtype??
   tensorrt.max_input_len: [512, 1024]
   tensorrt.scheduler.capacity_scheduling_policy: [MAX_UTILIZATION, STATIC_BATCH]
-  # tensorrt.tp_size: [1, 2, 4]     # Tensor parallel (requires multi-GPU hardware)
+  # tensorrt.tensor_parallel_size: [1, 2, 4]     # Tensor parallel (requires multi-GPU hardware)
 
   # --- TensorRT: dependent groups ─────────────────────────────────
 
@@ -563,7 +563,7 @@ experiments:
   #     max_batch_size: 8
   #     max_input_len: 1024
   #     max_seq_len: 2048
-  #     tp_size: 2
+  #     tensor_parallel_size: 2
   #     build_cache:
   #       max_cache_storage_gb: 256
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -309,7 +309,7 @@ dtype: bfloat16
 runners:
   tensorrt: docker
 tensorrt:
-  tp_size: 2
+  tensor_parallel_size: 2
   max_batch_size: 8
   dtype: bfloat16
   quant:
@@ -330,7 +330,7 @@ Changing any **[recompile]** field invalidates the cached engine and triggers a 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `max_batch_size` | int | 8 | Maximum batch size the engine accepts. **[recompile]** |
-| `tp_size` | int | 1 | Tensor parallel degree (number of GPUs). **[recompile]** |
+| `tensor_parallel_size` | int | 1 | Tensor parallel degree (number of GPUs). **[recompile]** |
 | `max_input_len` | int | 1024 | Maximum input sequence length in tokens. **[recompile]** |
 | `max_seq_len` | int | 2048 | Maximum total sequence length (input + output). **[recompile]** |
 | `dtype` | `float16` \| `bfloat16` | auto | Model compute dtype. TRT-LLM is optimised for fp16/bf16; fp32 is not supported. **[recompile]** |
@@ -429,14 +429,14 @@ directly, skipping engine compilation entirely. This is useful when:
 
 1. Directory exists
 2. `config.json` exists and is valid JSON
-3. `tp_size` in `config.json` matches `tensorrt.tp_size` (if detectable)
-4. `rank{N}.engine` files exist for each rank (0 to tp_size-1)
+3. `tp_size` in `config.json` matches `tensorrt.tensor_parallel_size` (if detectable)
+4. `rank{N}.engine` files exist for each rank (0 to `tensor_parallel_size-1`)
 
 **What happens when `engine_path` is set:**
 
 - `model` field is still required but used only as a fallback tokeniser source
   (if the engine directory lacks tokeniser files)
-- All compile-time parameters (`max_batch_size`, `tp_size`, `max_input_len`,
+- All compile-time parameters (`max_batch_size`, `tensor_parallel_size`, `max_input_len`,
   `max_seq_len`, `dtype`, `fast_build`) are **ignored** - they are baked into
   the engine
 - `build_cache` is **ignored** - no compilation occurs, so caching is irrelevant
@@ -619,7 +619,7 @@ These parameters live in `ExperimentConfig` and are shared across all engines:
 | Parameter | Transformers | vLLM | TensorRT-LLM | Notes |
 |-----------|---------|------|--------------|-------|
 | `tensorrt.max_batch_size` | N/A | N/A | Yes | Compile-time constant |
-| `tensorrt.tp_size` | N/A | N/A | Yes | Tensor parallel size (compile-time) |
+| `tensorrt.tensor_parallel_size` | N/A | N/A | Yes | Tensor parallel size (compile-time) |
 | `tensorrt.max_input_len` | N/A | N/A | Yes | Max input tokens (compile-time) |
 | `tensorrt.max_seq_len` | N/A | N/A | Yes | Max total sequence length (compile-time) |
 | `tensorrt.dtype` | N/A | N/A | Yes | Model compute dtype (compile-time) |

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -836,3 +836,29 @@ measurement:
 
 Run `llem config` to display the current effective configuration and check which engines
 are installed. Use `llem config --verbose` for detailed environment information.
+
+---
+
+## Maximalist Showcase Config
+
+`configs/example-study-full.yaml` is a **full-surface reference config** covering every
+curated typed field across all three engine backends (Transformers, vLLM, TensorRT-LLM).
+It is not a practical run config — all three engine sections are populated simultaneously,
+which would be invalid for an actual sweep — but it serves as a single authoritative
+reference for every knob the library exposes.
+
+**Use cases:**
+- Discoverability: see all available parameters and their accepted values at a glance.
+- CI coverage: `scripts/verify_example_coverage.py` asserts all 94 curated fields appear.
+- Doc generation: cross-referenced by the parameter inclusion/exclusion table.
+
+**It is not intended to be run directly.** Use `llem run configs/example-study-full.yaml
+--dry-run` to validate that the YAML parses correctly.
+
+To verify the config covers the full typed field surface:
+
+```bash
+uv run python scripts/verify_example_coverage.py
+```
+
+For practical runnable examples, see `configs/README.md`.

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -794,7 +794,7 @@ relates to energy measurement.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `max_batch_size` | integer | None | `null` | Max batch size (compile-time constant, None -> 8) |
-| `tp_size` | integer | None | `null` | Tensor parallel size (None -> 1) |
+| `tensor_parallel_size` | integer | None | `null` | Tensor parallel size (None -> 1) |
 | `max_input_len` | integer | None | `null` | Max input sequence length (compile-time constant, None -> 1024) |
 | `max_seq_len` | integer | None | `null` | Max total sequence length (input + output, compile-time constant, None -> 2048) |
 | `dtype` | 'float16' | 'bfloat16' | None | `null` | Model dtype (None -> auto). TRT-LLM is optimised for fp16/bf16; fp32 not supported. |

--- a/scripts/verify_example_coverage.py
+++ b/scripts/verify_example_coverage.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
-"""Verify that configs/example-study-full.yaml covers every typed engine field.
+"""Verify that configs/example-study-full.yaml covers every curated engine field.
 
-Walk all engine Pydantic model classes, collect every typed field's full YAML
+Walk all engine Pydantic model classes, collect every curated field's full YAML
 path, then assert each one appears in the showcase config.
 
+A curated field is one with CurationMetadata (i.e. a ``curation`` key in its
+``json_schema_extra`` dict). Uses :func:`llenergymeasure.config.introspection.is_curated_field`
+as the single source of truth for that predicate.
+
 Usage:
-    python scripts/verify_example_coverage.py
     uv run python scripts/verify_example_coverage.py
+    python -m scripts.verify_example_coverage  (editable install)
 
 Exit codes:
-    0  All typed paths present in the YAML.
-    1  One or more typed paths missing from the YAML.
+    0  All curated paths present in the YAML.
+    1  One or more curated paths missing, or no curated fields found.
 """
 
 from __future__ import annotations
@@ -20,13 +24,7 @@ from pathlib import Path
 
 import yaml
 
-# ---------------------------------------------------------------------------
-# Path setup — allow running from the repo root without installing the package.
-# ---------------------------------------------------------------------------
-REPO_ROOT = Path(__file__).parent.parent
-sys.path.insert(0, str(REPO_ROOT / "src"))
-
-from llenergymeasure.config.engine_configs import (  # noqa: E402
+from llenergymeasure.config.engine_configs import (
     TensorRTConfig,
     TensorRTKvCacheConfig,
     TensorRTQuantConfig,
@@ -39,81 +37,47 @@ from llenergymeasure.config.engine_configs import (  # noqa: E402
     VLLMSamplingConfig,
     VLLMSpeculativeConfig,
 )
+from llenergymeasure.config.introspection import is_curated_field
 
+REPO_ROOT = Path(__file__).parent.parent
 CONFIG_PATH = REPO_ROOT / "configs" / "example-study-full.yaml"
 
 # ---------------------------------------------------------------------------
-# Field path collection
+# Expected curated-field paths (engine -> list[str])
+# Each tuple is (prefix, model_class) — prefix is the YAML path segment.
 # ---------------------------------------------------------------------------
 
-
-def _is_typed_field(model_class, field_name: str) -> bool:
-    """Return True if the field has CurationMetadata (i.e. is a typed field)."""
-    field = model_class.model_fields.get(field_name)
-    if field is None:
-        return False
-    extra = field.json_schema_extra
-    if not isinstance(extra, dict):
-        return False
-    return "curation" in extra
-
-
-def _collect_typed_paths(prefix: str, model_class) -> list[str]:
-    """Recursively collect dot-separated YAML paths for all typed fields."""
-    paths: list[str] = []
-    for field_name in model_class.model_fields:
-        if not _is_typed_field(model_class, field_name):
-            continue
-        full_path = f"{prefix}.{field_name}" if prefix else field_name
-        paths.append(full_path)
-    return paths
+_ENGINE_SEGMENTS: dict[str, list[tuple[str, type]]] = {
+    "transformers": [
+        ("transformers", TransformersConfig),
+    ],
+    "vllm": [
+        ("vllm.engine", VLLMEngineConfig),
+        ("vllm.engine.speculative", VLLMSpeculativeConfig),
+        ("vllm.engine.attention", VLLMAttentionConfig),
+        ("vllm.sampling", VLLMSamplingConfig),
+        ("vllm.beam_search", VLLMBeamSearchConfig),
+    ],
+    "tensorrt": [
+        ("tensorrt", TensorRTConfig),
+        ("tensorrt.quant", TensorRTQuantConfig),
+        ("tensorrt.kv_cache", TensorRTKvCacheConfig),
+        ("tensorrt.scheduler", TensorRTSchedulerConfig),
+        ("tensorrt.sampling", TensorRTSamplingConfig),
+    ],
+}
 
 
-def collect_all_typed_paths() -> dict[str, list[str]]:
-    """Return a dict mapping engine name -> list of expected YAML paths."""
+def collect_expected_paths() -> dict[str, list[str]]:
+    """Return engine -> sorted list of expected curated YAML paths."""
     result: dict[str, list[str]] = {}
-
-    # --- Transformers ---
-    result["transformers"] = _collect_typed_paths("transformers", TransformersConfig)
-
-    # --- vLLM ---
-    vllm_paths: list[str] = []
-    # VLLMEngineConfig fields under vllm.engine.*
-    for path in _collect_typed_paths("vllm.engine", VLLMEngineConfig):
-        vllm_paths.append(path)
-    # VLLMSpeculativeConfig fields under vllm.engine.speculative.*
-    for path in _collect_typed_paths("vllm.engine.speculative", VLLMSpeculativeConfig):
-        vllm_paths.append(path)
-    # VLLMAttentionConfig fields under vllm.engine.attention.*
-    for path in _collect_typed_paths("vllm.engine.attention", VLLMAttentionConfig):
-        vllm_paths.append(path)
-    # VLLMSamplingConfig fields under vllm.sampling.*
-    for path in _collect_typed_paths("vllm.sampling", VLLMSamplingConfig):
-        vllm_paths.append(path)
-    # VLLMBeamSearchConfig fields under vllm.beam_search.*
-    for path in _collect_typed_paths("vllm.beam_search", VLLMBeamSearchConfig):
-        vllm_paths.append(path)
-    result["vllm"] = vllm_paths
-
-    # --- TensorRT ---
-    trt_paths: list[str] = []
-    # TensorRTConfig top-level fields under tensorrt.*
-    for path in _collect_typed_paths("tensorrt", TensorRTConfig):
-        trt_paths.append(path)
-    # TensorRTQuantConfig fields under tensorrt.quant.*
-    for path in _collect_typed_paths("tensorrt.quant", TensorRTQuantConfig):
-        trt_paths.append(path)
-    # TensorRTKvCacheConfig fields under tensorrt.kv_cache.*
-    for path in _collect_typed_paths("tensorrt.kv_cache", TensorRTKvCacheConfig):
-        trt_paths.append(path)
-    # TensorRTSchedulerConfig fields under tensorrt.scheduler.*
-    for path in _collect_typed_paths("tensorrt.scheduler", TensorRTSchedulerConfig):
-        trt_paths.append(path)
-    # TensorRTSamplingConfig fields under tensorrt.sampling.*
-    for path in _collect_typed_paths("tensorrt.sampling", TensorRTSamplingConfig):
-        trt_paths.append(path)
-    result["tensorrt"] = trt_paths
-
+    for engine, segments in _ENGINE_SEGMENTS.items():
+        paths: list[str] = []
+        for prefix, model_class in segments:
+            for field_name, field_info in model_class.model_fields.items():
+                if is_curated_field(field_info):
+                    paths.append(f"{prefix}.{field_name}")
+        result[engine] = sorted(paths)
     return result
 
 
@@ -137,21 +101,20 @@ def _collect_yaml_paths(obj: object, prefix: str = "") -> set[str]:
 
 
 def collect_yaml_paths(config_path: Path) -> set[str]:
-    """Load the YAML and return all set paths from all experiment entries."""
+    """Load the YAML and return all dot-separated paths across all experiment entries.
+
+    Paths are collected relative to each experiment entry so that engine-scoped
+    keys like ``transformers.batch_size`` are found regardless of their position
+    in the experiments list.
+    """
     with config_path.open() as f:
         data = yaml.safe_load(f)
 
     all_paths: set[str] = set()
-
-    # Top-level keys
-    all_paths.update(_collect_yaml_paths(data))
-
-    # Walk experiments list for per-experiment engine keys
-    experiments = data.get("experiments", [])
-    for exp in experiments:
+    # Walk each experiment entry with an empty prefix so paths are experiment-relative.
+    for exp in data.get("experiments", []):
         if isinstance(exp, dict):
             all_paths.update(_collect_yaml_paths(exp))
-
     return all_paths
 
 
@@ -161,16 +124,25 @@ def collect_yaml_paths(config_path: Path) -> set[str]:
 
 
 def verify_coverage() -> bool:
-    """Check every typed path appears in the YAML. Return True if all present."""
+    """Check every curated path appears in the YAML. Return True if all present."""
     if not CONFIG_PATH.exists():
         print(f"ERROR: Config not found: {CONFIG_PATH}", file=sys.stderr)
         return False
 
-    expected_by_engine = collect_all_typed_paths()
+    expected_by_engine = collect_expected_paths()
+    grand_total = sum(len(v) for v in expected_by_engine.values())
+
+    # Guard: if no curated fields found, CurationMetadata is likely missing.
+    if grand_total == 0:
+        print(
+            "ERROR: No curated fields found — is CurationMetadata present in engine_configs.py?",
+            file=sys.stderr,
+        )
+        return False
+
     yaml_paths = collect_yaml_paths(CONFIG_PATH)
 
     all_ok = True
-    grand_total = 0
     grand_covered = 0
 
     print(f"\nCoverage report: {CONFIG_PATH.relative_to(REPO_ROOT)}")
@@ -179,11 +151,10 @@ def verify_coverage() -> bool:
     for engine, paths in expected_by_engine.items():
         missing = [p for p in paths if p not in yaml_paths]
         covered = len(paths) - len(missing)
-        grand_total += len(paths)
         grand_covered += covered
 
         status = "PASS" if not missing else "FAIL"
-        print(f"\n  [{status}] {engine}: {covered}/{len(paths)} typed fields covered")
+        print(f"\n  [{status}] {engine}: {covered}/{len(paths)} curated fields covered")
 
         if missing:
             all_ok = False
@@ -191,10 +162,15 @@ def verify_coverage() -> bool:
                 print(f"        MISSING: {p}")
 
     print("\n" + "=" * 70)
-    pct = (grand_covered / grand_total * 100) if grand_total else 0.0
+    pct = grand_covered / grand_total * 100
     overall = "PASS" if all_ok else "FAIL"
     print(f"  [{overall}] Overall: {grand_covered}/{grand_total} ({pct:.0f}%)")
     print()
+
+    # TODO: comment-drift check — verify that inline `# curation_reason` YAML
+    # comments match CurationMetadata.rationale for each field.
+    # Deferred: YAML comment parsing requires ruamel.yaml round-trip mode, which
+    # adds a dependency and significant complexity. Track as a follow-up task.
 
     return all_ok
 

--- a/scripts/verify_example_coverage.py
+++ b/scripts/verify_example_coverage.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Verify that configs/example-study-full.yaml covers every typed engine field.
+
+Walk all engine Pydantic model classes, collect every typed field's full YAML
+path, then assert each one appears in the showcase config.
+
+Usage:
+    python scripts/verify_example_coverage.py
+    uv run python scripts/verify_example_coverage.py
+
+Exit codes:
+    0  All typed paths present in the YAML.
+    1  One or more typed paths missing from the YAML.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running from the repo root without installing the package.
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from llenergymeasure.config.engine_configs import (  # noqa: E402
+    TensorRTConfig,
+    TensorRTKvCacheConfig,
+    TensorRTQuantConfig,
+    TensorRTSamplingConfig,
+    TensorRTSchedulerConfig,
+    TransformersConfig,
+    VLLMAttentionConfig,
+    VLLMBeamSearchConfig,
+    VLLMEngineConfig,
+    VLLMSamplingConfig,
+    VLLMSpeculativeConfig,
+)
+
+CONFIG_PATH = REPO_ROOT / "configs" / "example-study-full.yaml"
+
+# ---------------------------------------------------------------------------
+# Field path collection
+# ---------------------------------------------------------------------------
+
+
+def _is_typed_field(model_class, field_name: str) -> bool:
+    """Return True if the field has CurationMetadata (i.e. is a typed field)."""
+    field = model_class.model_fields.get(field_name)
+    if field is None:
+        return False
+    extra = field.json_schema_extra
+    if not isinstance(extra, dict):
+        return False
+    return "curation" in extra
+
+
+def _collect_typed_paths(prefix: str, model_class) -> list[str]:
+    """Recursively collect dot-separated YAML paths for all typed fields."""
+    paths: list[str] = []
+    for field_name in model_class.model_fields:
+        if not _is_typed_field(model_class, field_name):
+            continue
+        full_path = f"{prefix}.{field_name}" if prefix else field_name
+        paths.append(full_path)
+    return paths
+
+
+def collect_all_typed_paths() -> dict[str, list[str]]:
+    """Return a dict mapping engine name -> list of expected YAML paths."""
+    result: dict[str, list[str]] = {}
+
+    # --- Transformers ---
+    result["transformers"] = _collect_typed_paths("transformers", TransformersConfig)
+
+    # --- vLLM ---
+    vllm_paths: list[str] = []
+    # VLLMEngineConfig fields under vllm.engine.*
+    for path in _collect_typed_paths("vllm.engine", VLLMEngineConfig):
+        vllm_paths.append(path)
+    # VLLMSpeculativeConfig fields under vllm.engine.speculative.*
+    for path in _collect_typed_paths("vllm.engine.speculative", VLLMSpeculativeConfig):
+        vllm_paths.append(path)
+    # VLLMAttentionConfig fields under vllm.engine.attention.*
+    for path in _collect_typed_paths("vllm.engine.attention", VLLMAttentionConfig):
+        vllm_paths.append(path)
+    # VLLMSamplingConfig fields under vllm.sampling.*
+    for path in _collect_typed_paths("vllm.sampling", VLLMSamplingConfig):
+        vllm_paths.append(path)
+    # VLLMBeamSearchConfig fields under vllm.beam_search.*
+    for path in _collect_typed_paths("vllm.beam_search", VLLMBeamSearchConfig):
+        vllm_paths.append(path)
+    result["vllm"] = vllm_paths
+
+    # --- TensorRT ---
+    trt_paths: list[str] = []
+    # TensorRTConfig top-level fields under tensorrt.*
+    for path in _collect_typed_paths("tensorrt", TensorRTConfig):
+        trt_paths.append(path)
+    # TensorRTQuantConfig fields under tensorrt.quant.*
+    for path in _collect_typed_paths("tensorrt.quant", TensorRTQuantConfig):
+        trt_paths.append(path)
+    # TensorRTKvCacheConfig fields under tensorrt.kv_cache.*
+    for path in _collect_typed_paths("tensorrt.kv_cache", TensorRTKvCacheConfig):
+        trt_paths.append(path)
+    # TensorRTSchedulerConfig fields under tensorrt.scheduler.*
+    for path in _collect_typed_paths("tensorrt.scheduler", TensorRTSchedulerConfig):
+        trt_paths.append(path)
+    # TensorRTSamplingConfig fields under tensorrt.sampling.*
+    for path in _collect_typed_paths("tensorrt.sampling", TensorRTSamplingConfig):
+        trt_paths.append(path)
+    result["tensorrt"] = trt_paths
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# YAML path collection
+# ---------------------------------------------------------------------------
+
+
+def _collect_yaml_paths(obj: object, prefix: str = "") -> set[str]:
+    """Recursively collect all dot-separated key paths from a parsed YAML object."""
+    paths: set[str] = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            full_key = f"{prefix}.{k}" if prefix else k
+            paths.add(full_key)
+            paths.update(_collect_yaml_paths(v, full_key))
+    elif isinstance(obj, list):
+        for item in obj:
+            paths.update(_collect_yaml_paths(item, prefix))
+    return paths
+
+
+def collect_yaml_paths(config_path: Path) -> set[str]:
+    """Load the YAML and return all set paths from all experiment entries."""
+    with config_path.open() as f:
+        data = yaml.safe_load(f)
+
+    all_paths: set[str] = set()
+
+    # Top-level keys
+    all_paths.update(_collect_yaml_paths(data))
+
+    # Walk experiments list for per-experiment engine keys
+    experiments = data.get("experiments", [])
+    for exp in experiments:
+        if isinstance(exp, dict):
+            all_paths.update(_collect_yaml_paths(exp))
+
+    return all_paths
+
+
+# ---------------------------------------------------------------------------
+# Coverage verification
+# ---------------------------------------------------------------------------
+
+
+def verify_coverage() -> bool:
+    """Check every typed path appears in the YAML. Return True if all present."""
+    if not CONFIG_PATH.exists():
+        print(f"ERROR: Config not found: {CONFIG_PATH}", file=sys.stderr)
+        return False
+
+    expected_by_engine = collect_all_typed_paths()
+    yaml_paths = collect_yaml_paths(CONFIG_PATH)
+
+    all_ok = True
+    grand_total = 0
+    grand_covered = 0
+
+    print(f"\nCoverage report: {CONFIG_PATH.relative_to(REPO_ROOT)}")
+    print("=" * 70)
+
+    for engine, paths in expected_by_engine.items():
+        missing = [p for p in paths if p not in yaml_paths]
+        covered = len(paths) - len(missing)
+        grand_total += len(paths)
+        grand_covered += covered
+
+        status = "PASS" if not missing else "FAIL"
+        print(f"\n  [{status}] {engine}: {covered}/{len(paths)} typed fields covered")
+
+        if missing:
+            all_ok = False
+            for p in sorted(missing):
+                print(f"        MISSING: {p}")
+
+    print("\n" + "=" * 70)
+    pct = (grand_covered / grand_total * 100) if grand_total else 0.0
+    overall = "PASS" if all_ok else "FAIL"
+    print(f"  [{overall}] Overall: {grand_covered}/{grand_total} ({pct:.0f}%)")
+    print()
+
+    return all_ok
+
+
+if __name__ == "__main__":
+    ok = verify_coverage()
+    sys.exit(0 if ok else 1)

--- a/src/llenergymeasure/config/curation.py
+++ b/src/llenergymeasure/config/curation.py
@@ -1,0 +1,73 @@
+"""Structured curation metadata for typed engine config fields.
+
+Every typed field in engine_configs.py carries a CurationMetadata instance attached
+via json_schema_extra. This makes the rubric verdict machine-readable and is the
+source of truth for the generated inclusion/exclusion table (Plan E).
+
+Usage::
+
+    from llenergymeasure.config.curation import CurationMetadata
+
+    some_field: int | None = Field(
+        default=None,
+        ge=1,
+        description="...",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="AMD MLPerf v5.1 multi-step throughput axis.",
+            native_mapping="EngineArgs.num_scheduler_steps",
+        ).to_schema_extra(),
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+RubricClause = Literal[
+    "R1",
+    "R2",  # required
+    "E1",
+    "E2",
+    "E3",
+    "E4",  # elevating
+    "D1",
+    "D2",
+    "D3",
+    "D4",  # demoting (for drop decisions recorded for posterity)
+    "T1",
+    "T2",
+    "T3",
+    "T4",
+    "T5",  # tie-breakers
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CurationMetadata:
+    """Structured justification attached to every typed field in engine_configs.py.
+
+    Becomes the source of truth for the generated inclusion/exclusion table (Plan E).
+
+    Attributes:
+        clauses:        Tuple of rubric clause codes that fired for this field.
+                        At minimum R1 (plausible measurement path) must be present
+                        unless R2 (non-duplication) caused a drop.
+        rationale:      One-line justification. This text appears verbatim in the
+                        generated curation doc as the "reason" column.
+        native_mapping: Dotted path to the corresponding native engine argument,
+                        e.g. "EngineArgs.num_scheduler_steps". None when the field
+                        is engine-local only (no direct native counterpart).
+        notes:          Optional caveats — e.g. "churn-prone, watch vLLM v0.8 release
+                        notes", or "defer — confirm HF deprecation before adding".
+    """
+
+    clauses: tuple[RubricClause, ...]
+    rationale: str
+    native_mapping: str | None = None
+    notes: str | None = None
+
+    def to_schema_extra(self) -> dict[str, object]:
+        """Render to the dict shape Pydantic expects in ``json_schema_extra``."""
+        return {"curation": asdict(self)}

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -4,6 +4,11 @@ Each engine section uses None-as-default: all fields default to None, meaning
 "use the engine's own default at execution time". This makes it explicit when
 a researcher has set a value versus when the engine's built-in default applies.
 
+Every typed field carries ``CurationMetadata`` via ``json_schema_extra``.
+This is the machine-readable rubric verdict used by the generated
+inclusion/exclusion table (Plan E). The rubric is defined in
+``.product/research/parameter-curation-rubric.md``.
+
 Usage in YAML:
     engine: transformers
     transformers:
@@ -17,7 +22,6 @@ Usage in YAML:
         gpu_memory_utilization: 0.9
         kv_cache_dtype: fp8
       sampling:
-        max_tokens: 512
         presence_penalty: 0.0
 
     engine: tensorrt
@@ -25,9 +29,7 @@ Usage in YAML:
       tensor_parallel_size: 2
       dtype: bfloat16
       quant:
-        quant_algo: FP8
-      build_cache:
-        max_cache_storage_gb: 256
+        quant_algo: W4A16_AWQ
 """
 
 from __future__ import annotations
@@ -35,6 +37,8 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
+
+from llenergymeasure.config.curation import CurationMetadata
 
 # =============================================================================
 # Transformers Engine Configuration (v2.0)
@@ -59,7 +63,16 @@ class TransformersConfig(BaseModel):
     # Batching
     # -------------------------------------------------------------------------
 
-    batch_size: int | None = Field(default=None, ge=1, description="Batch size (None -> 1)")
+    batch_size: int | None = Field(
+        default=None,
+        ge=1,
+        description="Batch size (None -> 1)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Universal measurement axis; MLPerf, Optimum, LLM-Perf all split by it.",
+            native_mapping="AutoModelForCausalLM.generate batch dimension",
+        ).to_schema_extra(),
+    )
 
     # -------------------------------------------------------------------------
     # Attention implementation
@@ -67,38 +80,96 @@ class TransformersConfig(BaseModel):
 
     attn_implementation: (
         Literal["sdpa", "flash_attention_2", "flash_attention_3", "eager"] | None
-    ) = Field(default=None, description="Attention implementation (None -> sdpa)")
+    ) = Field(
+        default=None,
+        description="Attention implementation (None -> sdpa)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3"),
+            rationale="Kernel selection is a latency/energy regime switch; Optimum types it.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(attn_implementation=...)",
+        ).to_schema_extra(),
+    )
 
     # -------------------------------------------------------------------------
     # Compilation
     # -------------------------------------------------------------------------
 
     torch_compile: bool | None = Field(
-        default=None, description="Enable torch.compile (None -> False)"
+        default=None,
+        description="Enable torch.compile (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Compile vs eager is a regime switch; Optimum/Databricks report splits.",
+            native_mapping="torch.compile(model)",
+        ).to_schema_extra(),
     )
     torch_compile_mode: str | None = Field(
         default=None,
         description="torch.compile mode: 'default', 'reduce-overhead', 'max-autotune' (None -> 'default')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E3"),
+            rationale="3-option enum with meaningful throughput deltas (default vs reduce-overhead vs max-autotune).",
+            native_mapping="torch.compile(model, mode=...)",
+        ).to_schema_extra(),
     )
     torch_compile_backend: str | None = Field(
-        default=None, description="torch.compile backend (None -> 'inductor')"
+        default=None,
+        description="torch.compile backend (None -> 'inductor')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="Compile-backend selects different codegen → different kernels → measurable energy delta.",
+            native_mapping="torch.compile(model, backend=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
     # BitsAndBytes quantization
     # -------------------------------------------------------------------------
 
-    load_in_4bit: bool | None = Field(default=None, description="BitsAndBytes 4-bit quantization")
-    load_in_8bit: bool | None = Field(default=None, description="BitsAndBytes 8-bit quantization")
+    load_in_4bit: bool | None = Field(
+        default=None,
+        description="BitsAndBytes 4-bit quantization",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Regime switch — 4-bit is its own measurement mode.",
+            native_mapping="BitsAndBytesConfig(load_in_4bit=True)",
+        ).to_schema_extra(),
+    )
+    load_in_8bit: bool | None = Field(
+        default=None,
+        description="BitsAndBytes 8-bit quantization",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Regime switch — 8-bit is its own measurement mode.",
+            native_mapping="BitsAndBytesConfig(load_in_8bit=True)",
+        ).to_schema_extra(),
+    )
     bnb_4bit_compute_dtype: Literal["float16", "bfloat16", "float32"] | None = Field(
         default=None,
         description="Compute dtype for 4-bit (None -> float32, usually want bfloat16)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="Compute-path selection inside 4-bit; affects energy directly.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_compute_dtype=...)",
+        ).to_schema_extra(),
     )
     bnb_4bit_quant_type: Literal["nf4", "fp4"] | None = Field(
-        default=None, description="4-bit quantization type (None -> 'nf4')"
+        default=None,
+        description="4-bit quantization type (None -> 'nf4')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="nf4 vs fp4 selects different dequantisation kernels → different energy/token.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_quant_type=...)",
+        ).to_schema_extra(),
     )
     bnb_4bit_use_double_quant: bool | None = Field(
-        default=None, description="Double quantization saves ~0.4 bits/param (None -> False)"
+        default=None,
+        description="Double quantization saves ~0.4 bits/param (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Double quantisation changes memory footprint and dequant arithmetic — regime toggle.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_use_double_quant=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -106,11 +177,22 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     use_cache: bool | None = Field(
-        default=None, description="Use KV cache during generation (None -> True)"
+        default=None,
+        description="Use KV cache during generation (None -> True)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Turning it off changes inference from AR to prefill-only (~100× latency delta).",
+            native_mapping="GenerationConfig.use_cache",
+        ).to_schema_extra(),
     )
     cache_implementation: Literal["static", "offloaded_static", "sliding_window"] | None = Field(
         default=None,
         description="KV cache strategy; 'static' enables CUDA graphs (None -> dynamic)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="'static' enables CUDA graphs — regime-changing; stable 3-value enum.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(cache_implementation=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -118,14 +200,32 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     num_beams: int | None = Field(
-        default=None, ge=1, description="Beam search width (None -> 1, greedy/sampling)"
+        default=None,
+        ge=1,
+        description="Beam search width (None -> 1, greedy/sampling)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1", "E2"),
+            rationale="Linear compute scaling; beam search is its own measurement regime.",
+            native_mapping="GenerationConfig.num_beams",
+        ).to_schema_extra(),
     )
     early_stopping: bool | None = Field(
-        default=None, description="Stop beam search when all beams hit EOS (None -> False)"
+        default=None,
+        description="Stop beam search when all beams hit EOS (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Couples to beam search; affects final token count.",
+            native_mapping="GenerationConfig.early_stopping",
+        ).to_schema_extra(),
     )
     length_penalty: float | None = Field(
         default=None,
         description="Beam length penalty: >1 shorter, <1 longer (None -> 1.0)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Tunes beam-search sequence length → FLOPs.",
+            native_mapping="GenerationConfig.length_penalty",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -133,7 +233,14 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     no_repeat_ngram_size: int | None = Field(
-        default=None, ge=0, description="Prevent n-gram repetition (None -> 0, disabled)"
+        default=None,
+        ge=0,
+        description="Prevent n-gram repetition (None -> 0, disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Affects generation length via repetition prevention → indirect throughput/energy delta.",
+            native_mapping="GenerationConfig.no_repeat_ngram_size",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -144,6 +251,11 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description="Prompt-lookup speculative decoding tokens (None -> disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="HF's speculative-decoding flavour (prompt-lookup); regime switch.",
+            native_mapping="GenerationConfig.prompt_lookup_num_tokens",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -151,17 +263,66 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     device_map: str | None = Field(
-        default=None, description="Device placement strategy (None -> 'auto')"
+        default=None,
+        description="Device placement strategy (None -> 'auto')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Offload strategy; Optimum types it. Mutually exclusive with tp_plan.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(device_map=...)",
+        ).to_schema_extra(),
     )
     max_memory: dict[str | int, str] | None = Field(
         default=None,
         description="Per-device memory limits, e.g. {0: '10GiB', 'cpu': '50GiB'}",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "T4"),
+            rationale=(
+                "Sets per-device memory budget; once exceeded forces weight offload CPU↔GPU "
+                "— major energy/latency regime change. Dict passthrough (T4)."
+            ),
+            native_mapping="AutoModelForCausalLM.from_pretrained(max_memory=...)",
+        ).to_schema_extra(),
     )
-    revision: str | None = Field(
-        default=None, description="Model revision/commit hash for reproducibility"
+
+    # -------------------------------------------------------------------------
+    # Mixed precision
+    # -------------------------------------------------------------------------
+
+    allow_tf32: bool | None = Field(
+        default=None,
+        description="Allow TF32 on Ampere GPUs (None -> PyTorch default)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Ampere TF32 toggle; accuracy/throughput tradeoff affecting GEMM energy.",
+            native_mapping="torch.backends.cuda.matmul.allow_tf32",
+        ).to_schema_extra(),
     )
-    trust_remote_code: bool | None = Field(
-        default=None, description="Trust remote code in model repo (None -> True)"
+    autocast_enabled: bool | None = Field(
+        default=None,
+        description="Enable torch.autocast mixed precision (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Mixed-precision runtime switch; determines whether AMP is applied during generation.",
+            native_mapping="torch.autocast(enabled=...)",
+        ).to_schema_extra(),
+    )
+    autocast_dtype: Literal["float16", "bfloat16"] | None = Field(
+        default=None,
+        description="torch.autocast dtype (None -> bfloat16 on Ampere)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="AMP compute dtype selector; different dtypes have distinct GEMM throughput.",
+            native_mapping="torch.autocast(dtype=...)",
+        ).to_schema_extra(),
+    )
+    low_cpu_mem_usage: bool | None = Field(
+        default=None,
+        description="Low CPU memory usage during model loading (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Affects load-time memory footprint; can trigger weight offload regime.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(low_cpu_mem_usage=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -175,13 +336,24 @@ class TransformersConfig(BaseModel):
             "Only 'auto' is currently supported by Transformers. "
             "Mutually exclusive with device_map. Requires torchrun launch."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Tensor parallelism enable; engine-native HF TP regime toggle.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(tp_plan=...)",
+        ).to_schema_extra(),
     )
     tp_size: int | None = Field(
         default=None,
         ge=1,
         description=(
-            "Number of tensor parallel ranks (None -> WORLD_SIZE). Only used when tp_plan is set."
+            "Number of tensor parallel ranks (None -> WORLD_SIZE). Only used when tp_plan is set. "
+            "Follows accelerate convention; HF has no single native 'tensor_parallel_size' equivalent."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="TP degree — universal measurement axis. Preserved as tp_size (accelerate convention).",
+            native_mapping="accelerate tp_size",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -242,6 +414,51 @@ class TransformersConfig(BaseModel):
 # =============================================================================
 
 
+class VLLMSpeculativeConfig(BaseModel):
+    """vLLM speculative-decoding configuration.
+
+    Replaces flat ``speculative_model`` + ``num_speculative_tokens`` fields.
+    Mirrors vLLM's native ``speculative_config`` dict shape.
+    Unknown fields are forwarded via extra="allow" to vLLM.
+    """
+
+    model_config = {"extra": "allow"}  # mirror native shape; CI diff catches drift
+
+    model: str | None = Field(
+        default=None,
+        description="Draft model name/path for speculative decoding.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Draft model identity — primary axis for speculative-decoding measurement.",
+            native_mapping="EngineArgs.speculative_config.model",
+        ).to_schema_extra(),
+    )
+    num_speculative_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Tokens to draft per speculative step.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E2"),
+            rationale="Draft-token count determines speculation depth; strongly peer-validated.",
+            native_mapping="EngineArgs.speculative_config.num_speculative_tokens",
+        ).to_schema_extra(),
+    )
+    method: str | None = Field(
+        default=None,
+        description=(
+            "Speculative-decoding method (e.g. 'draft_model', 'ngram', 'medusa', 'eagle'). "
+            "Kept as str because the Literal has drifted across vLLM releases — verify against "
+            "EngineArgs.speculative_config.method in the vendored schema before narrowing."
+        ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Method enum selects qualitatively different speculative-decoding regimes.",
+            native_mapping="EngineArgs.speculative_config.method",
+            notes="Kept str | None; narrow to Literal once vendored vLLM schema confirms stable values.",
+        ).to_schema_extra(),
+    )
+
+
 class VLLMAttentionConfig(BaseModel):
     """vLLM attention implementation configuration.
 
@@ -255,42 +472,93 @@ class VLLMAttentionConfig(BaseModel):
     backend: str | None = Field(
         default=None,
         description="Attention backend: flash_attn, flashinfer, etc. (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E3"),
+            rationale="Attention kernel selection (flash_attn, flashinfer, triton, xformers); peer-validated.",
+            native_mapping="AttentionConfig.backend",
+            notes="Field name 'backend' preserved — sub-config is an abstraction layer, not a 1:1 EngineArgs mirror.",
+        ).to_schema_extra(),
     )
     flash_attn_version: int | None = Field(
         default=None,
         description="Flash attention version (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="v2 vs v3 differ in kernel structure → measurable energy delta.",
+            native_mapping="AttentionConfig.flash_attn_version",
+        ).to_schema_extra(),
     )
     flash_attn_max_num_splits_for_cuda_graph: int | None = Field(
         default=None,
         description="Max splits for CUDA graph with flash attention (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Controls CUDA-graph tiling of attention → throughput/energy tradeoff for long sequences.",
+            native_mapping="AttentionConfig.flash_attn_max_num_splits_for_cuda_graph",
+        ).to_schema_extra(),
     )
     use_prefill_decode_attention: bool | None = Field(
         default=None,
         description="Use prefill-decode attention (None -> True).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Routes prefill through decode kernel — different compute path, regime toggle.",
+            native_mapping="AttentionConfig.use_prefill_decode_attention",
+        ).to_schema_extra(),
     )
     use_prefill_query_quantization: bool | None = Field(
         default=None,
         description="Quantize queries during prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Quantises query tensor during prefill → energy/memory delta, regime toggle.",
+            native_mapping="AttentionConfig.use_prefill_query_quantization",
+        ).to_schema_extra(),
     )
     use_cudnn_prefill: bool | None = Field(
         default=None,
         description="Use cuDNN for prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Selects cuDNN vs FlashAttention for prefill — distinct kernel paths.",
+            native_mapping="AttentionConfig.use_cudnn_prefill",
+        ).to_schema_extra(),
     )
     disable_flashinfer_prefill: bool | None = Field(
         default=None,
         description="Disable FlashInfer for prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fallback when flashinfer prefill is active — changes kernel used.",
+            native_mapping="AttentionConfig.disable_flashinfer_prefill",
+        ).to_schema_extra(),
     )
     disable_flashinfer_q_quantization: bool | None = Field(
         default=None,
         description="Disable FlashInfer query quantization (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Disables an optimisation; straightforward energy/latency axis.",
+            native_mapping="AttentionConfig.disable_flashinfer_q_quantization",
+        ).to_schema_extra(),
     )
     use_trtllm_attention: bool | None = Field(
         default=None,
         description="Use TensorRT-LLM attention backend (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Routes attention through TRT-LLM kernel — regime-changing kernel path switch.",
+            native_mapping="AttentionConfig.use_trtllm_attention",
+        ).to_schema_extra(),
     )
     use_trtllm_ragged_deepseek_prefill: bool | None = Field(
         default=None,
         description="Use TRT-LLM ragged DeepSeek prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="TRT-LLM ragged prefill for DeepSeek architectures — distinct kernel path.",
+            native_mapping="AttentionConfig.use_trtllm_ragged_deepseek_prefill",
+        ).to_schema_extra(),
     )
 
 
@@ -315,6 +583,11 @@ class VLLMEngineConfig(BaseModel):
         description=(
             "GPU memory fraction for KV cache (None -> 0.9). Higher = more KV cache, less headroom."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary KV-cache sizing knob; MLPerf/AMD flag it. Mutually exclusive with kv_cache_memory_bytes.",
+            native_mapping="EngineArgs.gpu_memory_utilization",
+        ).to_schema_extra(),
     )
     swap_space: float | None = Field(
         default=None,
@@ -323,6 +596,11 @@ class VLLMEngineConfig(BaseModel):
             "CPU swap space in GiB for KV cache offloading (None -> 4). "
             "Enables model weight offload to prevent OOM."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="CPU-swap budget for KV cache — when exercised shifts KV blocks CPU↔GPU, real energy/latency regime.",
+            native_mapping="EngineArgs.swap_space",
+        ).to_schema_extra(),
     )
     cpu_offload_gb: float | None = Field(
         default=None,
@@ -331,6 +609,11 @@ class VLLMEngineConfig(BaseModel):
             "CPU RAM in GiB to offload model weights to (None -> 0, disabled). "
             "Reduces VRAM pressure at throughput cost."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Weight-offload regime — Optimum/Zhou flag offloading as a class.",
+            native_mapping="EngineArgs.cpu_offload_gb",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -343,6 +626,11 @@ class VLLMEngineConfig(BaseModel):
             "KV cache block size in tokens (None -> 16). "
             "Affects KV cache fragmentation and memory efficiency."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1", "E3"),
+            rationale="vLLM paper + KV survey; tractable 3-value enum.",
+            native_mapping="EngineArgs.block_size",
+        ).to_schema_extra(),
     )
     kv_cache_dtype: Literal["auto", "fp8", "fp8_e5m2", "fp8_e4m3"] | None = Field(
         default=None,
@@ -350,6 +638,13 @@ class VLLMEngineConfig(BaseModel):
             "KV cache storage dtype (None -> auto = model dtype). "
             "fp8 variants halve KV cache VRAM on Ampere+."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3", "E3"),
+            rationale=(
+                "Energy-NVML research flags as bias source (T3); MLPerf/AMD/vLLM/TRT all report it."
+            ),
+            native_mapping="EngineArgs.kv_cache_dtype",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -362,6 +657,11 @@ class VLLMEngineConfig(BaseModel):
             "Disable CUDA graphs, always use eager mode (None -> False). "
             "Eager mode: predictable latency, no graph compilation overhead."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="CUDA-graph regime switch.",
+            native_mapping="EngineArgs.enforce_eager",
+        ).to_schema_extra(),
     )
     enable_chunked_prefill: bool | None = Field(
         default=None,
@@ -369,6 +669,11 @@ class VLLMEngineConfig(BaseModel):
             "Chunk large prefills across multiple scheduler iterations (None -> False). "
             "Affects scheduling latency and throughput."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Scheduling regime switch; strong academic coverage (Yu/Orca, vLLM, Databricks).",
+            native_mapping="EngineArgs.enable_chunked_prefill",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -382,6 +687,11 @@ class VLLMEngineConfig(BaseModel):
             "Max concurrent sequences per scheduler iteration (None -> 256). "
             "Affects batch size and KV cache usage."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary scheduler axis in AMD-MLPerf vLLM submissions.",
+            native_mapping="EngineArgs.max_num_seqs",
+        ).to_schema_extra(),
     )
     max_num_batched_tokens: int | None = Field(
         default=None,
@@ -390,6 +700,11 @@ class VLLMEngineConfig(BaseModel):
             "Max tokens processed per scheduler iteration (None -> auto). "
             "Controls per-step compute budget."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary scheduler axis; controls per-step compute budget.",
+            native_mapping="EngineArgs.max_num_batched_tokens",
+        ).to_schema_extra(),
     )
     max_model_len: int | None = Field(
         default=None,
@@ -398,6 +713,21 @@ class VLLMEngineConfig(BaseModel):
             "Max sequence length in tokens (input + output). "
             "Overrides model config (None -> model default). Caps KV cache allocation."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="MLPerf core knob; caps KV-cache pre-allocation.",
+            native_mapping="EngineArgs.max_model_len",
+        ).to_schema_extra(),
+    )
+    num_scheduler_steps: int | None = Field(
+        default=None,
+        ge=1,
+        description="Number of scheduler steps per iteration (multi-step scheduling, None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="AMD MLPerf v5.1 multi-step scheduling axis.",
+            native_mapping="EngineArgs.num_scheduler_steps",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -410,11 +740,30 @@ class VLLMEngineConfig(BaseModel):
         description=(
             "Tensor parallel degree — number of GPUs to shard the model across (None -> 1)."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3"),
+            rationale="Universal + energy-sampler-relevant (T3: must appear in results metadata).",
+            native_mapping="EngineArgs.tensor_parallel_size",
+        ).to_schema_extra(),
     )
     pipeline_parallel_size: int | None = Field(
         default=None,
         ge=1,
         description=("Pipeline parallel stages — memory per GPU changes with PP (None -> 1)."),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="NVIDIA MLPerf uses it; academic coverage.",
+            native_mapping="EngineArgs.pipeline_parallel_size",
+        ).to_schema_extra(),
+    )
+    distributed_executor_backend: Literal["mp", "ray"] | None = Field(
+        default=None,
+        description="Multi-GPU executor backend: 'mp' (multiprocessing) or 'ray' (None -> mp).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Multi-GPU dispatch regime toggle (mp vs ray) — different overhead profiles.",
+            native_mapping="EngineArgs.distributed_executor_backend",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -424,31 +773,54 @@ class VLLMEngineConfig(BaseModel):
     enable_prefix_caching: bool | None = Field(
         default=None,
         description="Automatic prefix caching for repeated shared prompts (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Strong academic + vLLM-paper evidence (SGLang RadixAttention parallel).",
+            native_mapping="EngineArgs.enable_prefix_caching",
+        ).to_schema_extra(),
     )
     quantization: (
         Literal["awq", "gptq", "fp8", "fp8_e5m2", "fp8_e4m3", "marlin", "bitsandbytes"] | None
     ) = Field(
         default=None,
         description="Quantization method. Requires pre-quantized model checkpoint.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3"),
+            rationale="Universal measurement axis; enum-validated.",
+            native_mapping="EngineArgs.quantization",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
-    # Speculative decoding
+    # CUDA graphs
     # -------------------------------------------------------------------------
 
-    speculative_model: str | None = Field(
-        default=None,
-        description=(
-            "HF model name or path of draft model for speculative decoding (None -> disabled). "
-            "Requires num_speculative_tokens."
-        ),
-    )
-    num_speculative_tokens: int | None = Field(
+    max_seq_len_to_capture: int | None = Field(
         default=None,
         ge=1,
+        description="Maximum sequence length for CUDA graph capture (None -> 8192).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="CUDA-graph budget for long sequences; AMD MLPerf-derived.",
+            native_mapping="EngineArgs.max_seq_len_to_capture",
+        ).to_schema_extra(),
+    )
+
+    # -------------------------------------------------------------------------
+    # Speculative decoding (typed nested sub-config)
+    # -------------------------------------------------------------------------
+
+    speculative: VLLMSpeculativeConfig | None = Field(
+        default=None,
         description=(
-            "Tokens to draft per speculative step (None -> required if speculative_model is set)."
+            "Speculative decoding configuration. Replaces flat speculative_model / "
+            "num_speculative_tokens fields. Mirrors vLLM native speculative_config shape."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E2", "T5"),
+            rationale="Regime switch; typed sub-config for inner-field sweep discoverability (T5).",
+            native_mapping="EngineArgs.speculative_config",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -459,20 +831,40 @@ class VLLMEngineConfig(BaseModel):
         default=None,
         ge=0,
         description="Groups of layers for CPU offloading (None -> 0).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="CPU-offload grouping granularity — larger groups trade latency for throughput.",
+            native_mapping="EngineArgs.offload_group_size",
+        ).to_schema_extra(),
     )
     offload_num_in_group: int | None = Field(
         default=None,
         ge=1,
         description="Number of layers offloaded per group (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Controls how many params are offloaded per group — shifts memory/compute boundary.",
+            native_mapping="EngineArgs.offload_num_in_group",
+        ).to_schema_extra(),
     )
     offload_prefetch_step: int | None = Field(
         default=None,
         ge=0,
         description="Prefetch steps ahead for CPU offload (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Prefetch lookahead — directly affects hide-latency effectiveness of CPU offload.",
+            native_mapping="EngineArgs.offload_prefetch_step",
+        ).to_schema_extra(),
     )
     offload_params: list[str] | None = Field(
         default=None,
         description="Specific parameter names to offload to CPU (None -> all eligible).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Selects which parameter classes are offloaded — shifts the memory/compute boundary.",
+            native_mapping="EngineArgs.offload_params",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -482,6 +874,11 @@ class VLLMEngineConfig(BaseModel):
     disable_custom_all_reduce: bool | None = Field(
         default=None,
         description="Disable custom all-reduce for multi-GPU (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Forces fallback to NCCL-native all-reduce — affects collective-comm latency/energy on multi-GPU.",
+            native_mapping="EngineArgs.disable_custom_all_reduce",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -495,6 +892,15 @@ class VLLMEngineConfig(BaseModel):
             "Absolute KV cache size in bytes (None -> use gpu_memory_utilization). "
             "Mutually exclusive with gpu_memory_utilization."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E4"),
+            rationale=(
+                "Alternative to gpu_memory_utilization; parse-time mutex already wired. "
+                "⚠ Verify validate_kv_cache_memory still correct after Phase 50."
+            ),
+            native_mapping=None,
+            notes="Phase 50 boundary: do not move/modify validate_kv_cache_memory in C.2.",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -507,6 +913,14 @@ class VLLMEngineConfig(BaseModel):
             "Full passthrough to vLLM CompilationConfig (~30 fields). "
             "No validation — passed directly."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "T4"),
+            rationale=(
+                "~30-field dict controlling CUDA-graph capture, fusions, what gets compiled "
+                "— major energy implications when varied. Opaque dict (T4)."
+            ),
+            native_mapping="EngineArgs.compilation_config",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -516,18 +930,16 @@ class VLLMEngineConfig(BaseModel):
     attention: VLLMAttentionConfig | None = Field(
         default=None,
         description="Attention implementation configuration.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="Attention backend and kernel toggles; nested for future flashinfer/cuDNN additions.",
+            native_mapping="EngineArgs.attention_backend (via sub-config mapping)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
     # Cross-validators
     # -------------------------------------------------------------------------
-
-    @model_validator(mode="after")
-    def validate_speculative(self) -> VLLMEngineConfig:
-        """speculative_model requires num_speculative_tokens to be set."""
-        if self.speculative_model is not None and self.num_speculative_tokens is None:
-            raise ValueError("speculative_model requires num_speculative_tokens to be set")
-        return self
 
     @model_validator(mode="after")
     def validate_kv_cache_memory(self) -> VLLMEngineConfig:
@@ -564,22 +976,25 @@ class VLLMSamplingConfig(BaseModel):
 
     All fields default to None — None means "use vLLM's own default".
     Unknown fields are forwarded to vllm.SamplingParams() via extra="allow".
+
+    Note: max_tokens is intentionally absent — it is bridged from
+    ExperimentConfig.max_output_tokens in _build_sampling_kwargs().
     """
 
     model_config = {"extra": "allow"}
 
-    max_tokens: int | None = Field(
-        default=None,
-        ge=1,
-        description=(
-            "Max output tokens. Overrides ExperimentConfig.max_output_tokens for vLLM sweeps "
-            "(None -> uses max_output_tokens). Use for engine-specific max_tokens sweeps."
-        ),
-    )
     min_tokens: int | None = Field(
         default=None,
         ge=0,
         description="Minimum output tokens before EOS is allowed (None -> 0, no minimum).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens "
+                "once Phase 49 migrates decoder per-engine."
+            ),
+            native_mapping="SamplingParams.min_tokens",
+        ).to_schema_extra(),
     )
     presence_penalty: float | None = Field(
         default=None,
@@ -589,6 +1004,11 @@ class VLLMSamplingConfig(BaseModel):
             "Presence penalty: penalises tokens that appear at all (None -> 0.0). "
             "Affects generation diversity."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="vLLM/TRT-native; not in DecoderConfig; routine in vLLM sampling studies.",
+            native_mapping="SamplingParams.presence_penalty",
+        ).to_schema_extra(),
     )
     frequency_penalty: float | None = Field(
         default=None,
@@ -598,6 +1018,11 @@ class VLLMSamplingConfig(BaseModel):
             "Frequency penalty: penalises tokens proportional to frequency (None -> 0.0). "
             "Affects repetition."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="vLLM/TRT-native; not in DecoderConfig.",
+            native_mapping="SamplingParams.frequency_penalty",
+        ).to_schema_extra(),
     )
     ignore_eos: bool | None = Field(
         default=None,
@@ -605,11 +1030,21 @@ class VLLMSamplingConfig(BaseModel):
             "Continue generating past EOS token (None -> False). "
             "Forces max_tokens generation every time — affects total token count."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fixed output length — measurement workload control.",
+            native_mapping="SamplingParams.ignore_eos",
+        ).to_schema_extra(),
     )
     n: int | None = Field(
         default=None,
         ge=1,
         description="Number of output sequences per prompt (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="n-sequences multiplier; vLLM-bench first-class.",
+            native_mapping="SamplingParams.n",
+        ).to_schema_extra(),
     )
 
 
@@ -620,6 +1055,9 @@ class VLLMBeamSearchConfig(BaseModel):
     Nested under VLLMConfig.beam_search.
     All fields default to None — None means "use vLLM's own default".
     Uses extra="allow" for forward compatibility with new vLLM beam search options.
+
+    Note: max_tokens is intentionally absent — it is bridged from
+    ExperimentConfig.max_output_tokens in _build_beam_search_kwargs().
     """
 
     model_config = {"extra": "allow"}
@@ -628,19 +1066,29 @@ class VLLMBeamSearchConfig(BaseModel):
         default=None,
         ge=1,
         description="Number of beams (ge=1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Linear compute scaling; beam search is its own measurement regime.",
+            native_mapping="BeamSearchParams.beam_width",
+        ).to_schema_extra(),
     )
     length_penalty: float | None = Field(
         default=None,
         description="Length penalty: >1 favours shorter, <1 longer (None -> 1.0).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Tunes beam-search output length.",
+            native_mapping="BeamSearchParams.length_penalty",
+        ).to_schema_extra(),
     )
     early_stopping: bool | None = Field(
         default=None,
         description="Stop when beam_width complete sequences found (None -> False).",
-    )
-    max_tokens: int | None = Field(
-        default=None,
-        ge=1,
-        description="Max output tokens for beam search (None -> max_output_tokens).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Affects final token count.",
+            native_mapping="BeamSearchParams.early_stopping",
+        ).to_schema_extra(),
     )
 
 
@@ -661,8 +1109,10 @@ class VLLMConfig(BaseModel):
             enforce_eager: false
             gpu_memory_utilization: 0.9
             kv_cache_dtype: fp8
+            speculative:
+              model: gpt2
+              num_speculative_tokens: 3
           sampling:
-            max_tokens: 512
             presence_penalty: 0.0
     """
 
@@ -724,30 +1174,24 @@ class TensorRTQuantConfig(BaseModel):
             "NO_QUANT",
         ]
         | None
-    ) = Field(default=None, description="Quantisation algorithm (native QuantAlgo enum name)")
+    ) = Field(
+        default=None,
+        description="Quantisation algorithm (native QuantAlgo enum name)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3", "E4"),
+            rationale="Universal axis + FP8-on-A100 hardware rail (E4); enum-validated.",
+            native_mapping="QuantConfig.quant_algo",
+            notes="FP8 requires SM >= 8.9 (Ada Lovelace+). A100 (SM80): use INT8/W4A16_AWQ/W8A16.",
+        ).to_schema_extra(),
+    )
     kv_cache_quant_algo: Literal["FP8", "INT8"] | None = Field(
         default=None,
         description="KV cache quantisation algorithm (None -> no KV cache quantisation)",
-    )
-
-
-class TensorRTCalibConfig(BaseModel):
-    """TRT-LLM PTQ calibration configuration.
-
-    Maps to tensorrt_llm.llmapi.CalibConfig.
-    Only relevant when quant_algo requires calibration (INT8, W4A16_AWQ, etc.).
-    """
-
-    model_config = {"extra": "allow"}
-
-    calib_batches: int | None = Field(
-        default=None, ge=1, description="Number of calibration batches (None -> 512)"
-    )
-    calib_dataset: str | None = Field(
-        default=None, description="Calibration dataset name or path (None -> 'cnn_dailymail')"
-    )
-    calib_max_seq_length: int | None = Field(
-        default=None, ge=1, description="Max sequence length for calibration (None -> 512)"
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3", "E3"),
+            rationale="KV-cache quantisation; aligns with vLLM's kv_cache_dtype. Energy-measurement-biasing (T3).",
+            native_mapping="QuantConfig.kv_cache_quant_algo",
+        ).to_schema_extra(),
     )
 
 
@@ -757,21 +1201,44 @@ class TensorRTKvCacheConfig(BaseModel):
     model_config = {"extra": "allow"}
 
     enable_block_reuse: bool | None = Field(
-        default=None, description="Enable KV cache block reuse (None -> False)"
+        default=None,
+        description="Enable KV cache block reuse (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="TRT's prefix-caching analog — regime toggle.",
+            native_mapping="KvCacheConfig.enable_block_reuse",
+        ).to_schema_extra(),
     )
     free_gpu_memory_fraction: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,
         description="Fraction of free GPU memory for KV cache (None -> 0.9)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="TRT's gpu_memory_utilization analog.",
+            native_mapping="KvCacheConfig.free_gpu_memory_fraction",
+        ).to_schema_extra(),
     )
     max_tokens: int | None = Field(
-        default=None, ge=1, description="Maximum tokens in KV cache (None -> auto)"
+        default=None,
+        ge=1,
+        description="Maximum tokens in KV cache (None -> auto)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="KV-cache token cap → concurrency ceiling.",
+            native_mapping="KvCacheConfig.max_tokens",
+        ).to_schema_extra(),
     )
     host_cache_size: int | None = Field(
         default=None,
         ge=0,
         description="Host (CPU) cache size in bytes for KV cache offloading (None -> 0, disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="CPU KV-offload regime — cross-engine analog to vLLM swap_space.",
+            native_mapping="KvCacheConfig.host_cache_size",
+        ).to_schema_extra(),
     )
 
 
@@ -787,26 +1254,14 @@ class TensorRTSchedulerConfig(BaseModel):
             "STATIC_BATCH",
         ]
         | None
-    ) = Field(default=None, description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)")
-
-
-class TensorRTBuildCacheConfig(BaseModel):
-    """TRT-LLM engine build cache configuration.
-
-    Maps to tensorrt_llm.llmapi.BuildCacheConfig.
-    """
-
-    model_config = {"extra": "allow"}
-
-    cache_root: str | None = Field(
+    ) = Field(
         default=None,
-        description="Root directory for engine cache (None -> ~/.cache/tensorrt_llm)",
-    )
-    max_records: int | None = Field(
-        default=None, ge=1, description="Maximum cached engine records (None -> 10)"
-    )
-    max_cache_storage_gb: float | None = Field(
-        default=None, ge=0.0, description="Maximum cache storage in GB (None -> 256)"
+        description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Scheduling regime (NO_EVICT vs MAX_UTIL vs STATIC_BATCH); stable 3-value enum.",
+            native_mapping="SchedulerConfig.capacity_scheduling_policy",
+        ).to_schema_extra(),
     )
 
 
@@ -816,21 +1271,43 @@ class TensorRTSamplingConfig(BaseModel):
     Maps to tensorrt_llm.SamplingParams (TRT-LLM-specific extensions only).
     Universal sampling params (temperature, top_p, top_k, repetition_penalty)
     live in DecoderConfig and are shared across all engines.
+
+    Note: return_perf_metrics dropped (D1 observability flag).
     """
 
     model_config = {"extra": "allow"}
 
     min_tokens: int | None = Field(
-        default=None, ge=0, description="Minimum output tokens before EOS allowed (None -> 0)"
+        default=None,
+        ge=0,
+        description="Minimum output tokens before EOS allowed (None -> 0)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens "
+                "once Phase 49 migrates decoder per-engine."
+            ),
+            native_mapping="SamplingParams.min_tokens",
+        ).to_schema_extra(),
     )
     n: int | None = Field(
-        default=None, ge=1, description="Number of output sequences per prompt (None -> 1)"
+        default=None,
+        ge=1,
+        description="Number of output sequences per prompt (None -> 1)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="n-sequences multiplier.",
+            native_mapping="SamplingParams.n",
+        ).to_schema_extra(),
     )
     ignore_eos: bool | None = Field(
-        default=None, description="Continue generating past EOS token (None -> False)"
-    )
-    return_perf_metrics: bool | None = Field(
-        default=None, description="Return performance metrics in output (None -> False)"
+        default=None,
+        description="Continue generating past EOS token (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fixed output length — measurement workload control.",
+            native_mapping="SamplingParams.ignore_eos",
+        ).to_schema_extra(),
     )
 
 
@@ -845,12 +1322,16 @@ class TensorRTConfig(BaseModel):
     - quant: QuantConfig (quantisation algorithm + KV cache quantisation)
     - kv_cache: KvCacheConfig (block reuse, memory fraction)
     - scheduler: SchedulerConfig (capacity policy)
-    - calib: CalibConfig (PTQ calibration parameters)
-    - build_cache: BuildCacheConfig (engine cache persistence)
     - sampling: SamplingParams (TRT-LLM-specific extensions only)
 
     Universal sampling params (temperature, top_p, top_k, repetition_penalty)
     live in DecoderConfig and are shared across all engines.
+
+    Dropped (falls through extra="allow"):
+    - backend: Literal["trt"] — D2 single-option enum, no information content
+    - engine_path — D1 deployment path, not a measurement axis
+    - calib sub-config — D3 build-only PTQ calibration (we consume pre-quantised checkpoints)
+    - build_cache sub-config — D1 engine-cache housekeeping
 
     Example YAML:
         engine: tensorrt
@@ -860,8 +1341,6 @@ class TensorRTConfig(BaseModel):
           dtype: bfloat16
           quant:
             quant_algo: W4A16_AWQ
-          build_cache:
-            max_cache_storage_gb: 256
     """
 
     model_config = {"extra": "allow"}
@@ -871,7 +1350,14 @@ class TensorRTConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     max_batch_size: int | None = Field(
-        default=None, ge=1, description="Max batch size (compile-time constant, None -> 8)"
+        default=None,
+        ge=1,
+        description="Max batch size (compile-time constant, None -> 8)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="MLPerf + trtllm-bench first-class; compile-time shape constant.",
+            native_mapping="TrtLlmArgs.max_batch_size",
+        ).to_schema_extra(),
     )
     tensor_parallel_size: int | None = Field(
         default=None,
@@ -881,46 +1367,74 @@ class TensorRTConfig(BaseModel):
             "Aligns with TrtLlmArgs.tensor_parallel_size. "
             "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3"),
+            rationale="Universal + energy-sampler-relevant (T3: must appear in results metadata).",
+            native_mapping="TrtLlmArgs.tensor_parallel_size",
+        ).to_schema_extra(),
+    )
+    pipeline_parallel_size: int | None = Field(
+        default=None,
+        ge=1,
+        description="Pipeline parallel stages (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="NVIDIA MLPerf v5.0 Blackwell submissions surface PP size as a primary knob.",
+            native_mapping="TrtLlmArgs.pipeline_parallel_size",
+        ).to_schema_extra(),
     )
     max_input_len: int | None = Field(
         default=None,
         ge=1,
         description="Max input sequence length (compile-time constant, None -> 1024)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="Compile-time shape; MLPerf core knob.",
+            native_mapping="TrtLlmArgs.max_input_len",
+        ).to_schema_extra(),
     )
     max_seq_len: int | None = Field(
         default=None,
         ge=1,
         description="Max total sequence length (input + output, compile-time constant, None -> 2048)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="Compile-time shape; MLPerf core knob.",
+            native_mapping="TrtLlmArgs.max_seq_len",
+        ).to_schema_extra(),
+    )
+    max_num_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of tokens the engine can handle per iteration (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="trtllm-bench scheduler axis alongside max_batch_size.",
+            native_mapping="TrtLlmArgs.max_num_tokens",
+        ).to_schema_extra(),
     )
     dtype: Literal["float16", "bfloat16"] | None = Field(
         default=None,
         description=(
             "Model dtype (None -> auto). TRT-LLM is optimised for fp16/bf16; fp32 not supported."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("E4",),
+            rationale="TRT-LLM rejects fp32 — narrowed Literal is a parse-time safety rail (E4).",
+            native_mapping="TrtLlmArgs.dtype",
+        ).to_schema_extra(),
     )
     fast_build: bool | None = Field(
         default=None,
         description="Enable fast engine build mode (reduced optimisation, None -> False)",
-    )
-
-    # -------------------------------------------------------------------------
-    # TRT-LLM internal backend selection
-    # -------------------------------------------------------------------------
-
-    backend: Literal["trt"] | None = Field(
-        default=None,
-        description=(
-            "TRT-LLM internal backend: 'trt' for TensorRT engine (None -> 'trt'). "
-            "This is the TRT-LLM LLM(backend=...) parameter, not the llem engine field."
-        ),
-    )
-
-    # -------------------------------------------------------------------------
-    # Engine path (pre-compiled engine)
-    # -------------------------------------------------------------------------
-
-    engine_path: str | None = Field(
-        default=None, description="Pre-compiled engine path (skip compilation)"
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Skips some build-time optimisations → the produced engine may be less efficient "
+                "at runtime → measurable energy/throughput delta."
+            ),
+            native_mapping="TrtLlmArgs.fast_build",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -928,21 +1442,38 @@ class TensorRTConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     quant: TensorRTQuantConfig | None = Field(
-        default=None, description="Quantisation configuration (QuantConfig)"
+        default=None,
+        description="Quantisation configuration (QuantConfig)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Quantisation algorithm and KV-cache quantisation sub-config.",
+            native_mapping="TrtLlmArgs.quant_config → QuantConfig",
+        ).to_schema_extra(),
     )
     kv_cache: TensorRTKvCacheConfig | None = Field(
-        default=None, description="KV cache configuration"
+        default=None,
+        description="KV cache configuration",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="KV-cache configuration (memory fraction, block reuse, host offload).",
+            native_mapping="TrtLlmArgs.kv_cache_config → KvCacheConfig",
+        ).to_schema_extra(),
     )
     scheduler: TensorRTSchedulerConfig | None = Field(
-        default=None, description="Scheduler configuration"
-    )
-    calib: TensorRTCalibConfig | None = Field(
-        default=None, description="PTQ calibration configuration (CalibConfig)"
-    )
-    build_cache: TensorRTBuildCacheConfig | None = Field(
-        default=None, description="Engine build cache configuration (BuildCacheConfig)"
+        default=None,
+        description="Scheduler configuration",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Scheduling capacity policy sub-config.",
+            native_mapping="TrtLlmArgs.scheduler_config → SchedulerConfig",
+        ).to_schema_extra(),
     )
     sampling: TensorRTSamplingConfig | None = Field(
         default=None,
         description="Sampling configuration (TRT-LLM-specific SamplingParams extensions)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="TRT-LLM-specific sampling parameters sub-config.",
+            native_mapping="TrtLlmArgs → SamplingParams",
+        ).to_schema_extra(),
     )

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -22,7 +22,7 @@ Usage in YAML:
 
     engine: tensorrt
     tensorrt:
-      tp_size: 2
+      tensor_parallel_size: 2
       dtype: bfloat16
       quant:
         quant_algo: FP8
@@ -855,7 +855,7 @@ class TensorRTConfig(BaseModel):
     Example YAML:
         engine: tensorrt
         tensorrt:
-          tp_size: 2
+          tensor_parallel_size: 2
           max_batch_size: 8
           dtype: bfloat16
           quant:
@@ -873,7 +873,15 @@ class TensorRTConfig(BaseModel):
     max_batch_size: int | None = Field(
         default=None, ge=1, description="Max batch size (compile-time constant, None -> 8)"
     )
-    tp_size: int | None = Field(default=None, ge=1, description="Tensor parallel size (None -> 1)")
+    tensor_parallel_size: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Tensor parallel size — number of GPUs to shard across (None -> 1). "
+            "Aligns with TrtLlmArgs.tensor_parallel_size. "
+            "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
+        ),
+    )
     max_input_len: int | None = Field(
         default=None,
         ge=1,

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -181,7 +181,7 @@ class TransformersConfig(BaseModel):
         description="Use KV cache during generation (None -> True)",
         json_schema_extra=CurationMetadata(
             clauses=("R1", "R2", "E2"),
-            rationale="Turning it off changes inference from AR to prefill-only (~100× latency delta).",
+            rationale="Turning it off changes inference from AR to prefill-only (~100x latency delta).",
             native_mapping="GenerationConfig.use_cache",
         ).to_schema_extra(),
     )

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -281,13 +281,8 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "tensorrt.tensor_parallel_size": [0],  # ge=1: 0 violates ge
         "tensorrt.max_input_len": [0],  # ge=1: 0 violates ge
         "tensorrt.max_seq_len": [0],  # ge=1: 0 violates ge
-        # TensorRTCalibConfig: calibration params
-        "tensorrt.calib.calib_batches": [0],  # ge=1: 0 violates ge
-        "tensorrt.calib.calib_max_seq_length": [0],  # ge=1: 0 violates ge
         # TensorRTKvCacheConfig: cache params
         "tensorrt.kv_cache.max_tokens": [0],  # ge=1: 0 violates ge
-        # TensorRTBuildCacheConfig: engine cache params
-        "tensorrt.build_cache.max_records": [0],  # ge=1: 0 violates ge
         # TensorRTSamplingConfig: sampling params
         "tensorrt.sampling.n": [0],  # ge=1: 0 violates ge
     }
@@ -556,8 +551,6 @@ def get_mutual_exclusions() -> dict[str, list[str]]:
         "transformers.bnb_4bit_use_double_quant": ["transformers.load_in_4bit=None|False"],
         # cache_implementation contradicts use_cache=False
         "transformers.cache_implementation": ["transformers.use_cache=False"],
-        # vLLM speculative decoding: speculative_model requires num_speculative_tokens
-        "vllm.engine.speculative_model": ["vllm.engine.num_speculative_tokens=None"],
         # vLLM kv_cache_memory_bytes vs gpu_memory_utilization
         "vllm.engine.kv_cache_memory_bytes": ["vllm.engine.gpu_memory_utilization"],
         "vllm.engine.gpu_memory_utilization": ["vllm.engine.kv_cache_memory_bytes"],
@@ -597,8 +590,14 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "transformers.prompt_lookup_num_tokens",
             "transformers.device_map",
             "transformers.max_memory",
-            "transformers.revision",
-            "transformers.trust_remote_code",
+            "transformers.allow_tf32",
+            "transformers.autocast_enabled",
+            "transformers.autocast_dtype",
+            "transformers.low_cpu_mem_usage",
+            "transformers.tp_plan",
+            "transformers.tp_size",
+            # revision and trust_remote_code dropped as typed fields (D1);
+            # they remain settable via extra="allow" in YAML
         ],
         "vllm": [
             # Engine-level params (vllm.LLM() constructor args)
@@ -616,8 +615,13 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "vllm.engine.pipeline_parallel_size",
             "vllm.engine.enable_prefix_caching",
             "vllm.engine.quantization",
-            "vllm.engine.speculative_model",
-            "vllm.engine.num_speculative_tokens",
+            "vllm.engine.num_scheduler_steps",
+            "vllm.engine.max_seq_len_to_capture",
+            "vllm.engine.distributed_executor_backend",
+            # Speculative decoding sub-config (replaces flat speculative_model/num_speculative_tokens)
+            "vllm.engine.speculative.model",
+            "vllm.engine.speculative.num_speculative_tokens",
+            "vllm.engine.speculative.method",
             # Engine-level offloading + memory params
             "vllm.engine.offload_group_size",
             "vllm.engine.offload_num_in_group",
@@ -638,37 +642,31 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "vllm.engine.attention.use_trtllm_attention",
             "vllm.engine.attention.use_trtllm_ragged_deepseek_prefill",
             # Sampling-level params (vllm.SamplingParams args, vLLM-specific only)
-            "vllm.sampling.max_tokens",
+            # max_tokens dropped (R2 dup of ExperimentConfig.max_output_tokens; bridged in adapter)
             "vllm.sampling.min_tokens",
             "vllm.sampling.presence_penalty",
             "vllm.sampling.frequency_penalty",
             "vllm.sampling.ignore_eos",
             "vllm.sampling.n",
-            # Beam search section (all 4 fields)
+            # Beam search section (max_tokens dropped; bridged from ExperimentConfig.max_output_tokens)
             "vllm.beam_search.beam_width",
             "vllm.beam_search.length_penalty",
             "vllm.beam_search.early_stopping",
-            "vllm.beam_search.max_tokens",
         ],
         "tensorrt": [
             # Compile-time parameters (LLM() constructor)
             "tensorrt.max_batch_size",
             "tensorrt.tensor_parallel_size",
+            "tensorrt.pipeline_parallel_size",
             "tensorrt.max_input_len",
             "tensorrt.max_seq_len",
+            "tensorrt.max_num_tokens",
             "tensorrt.dtype",
             "tensorrt.fast_build",
-            # TRT-LLM internal backend selection
-            "tensorrt.backend",
-            # Engine path
-            "tensorrt.engine_path",
+            # backend and engine_path dropped (D2/D1); settable via extra="allow"
             # Quantisation sub-config
             "tensorrt.quant.quant_algo",
             "tensorrt.quant.kv_cache_quant_algo",
-            # Calibration sub-config
-            "tensorrt.calib.calib_batches",
-            "tensorrt.calib.calib_dataset",
-            "tensorrt.calib.calib_max_seq_length",
             # KV cache sub-config
             "tensorrt.kv_cache.enable_block_reuse",
             "tensorrt.kv_cache.free_gpu_memory_fraction",
@@ -676,15 +674,12 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "tensorrt.kv_cache.host_cache_size",
             # Scheduler sub-config
             "tensorrt.scheduler.capacity_scheduling_policy",
-            # Build cache sub-config
-            "tensorrt.build_cache.cache_root",
-            "tensorrt.build_cache.max_records",
-            "tensorrt.build_cache.max_cache_storage_gb",
-            # Sampling sub-config
+            # calib sub-config dropped (D3 build-only PTQ)
+            # build_cache sub-config dropped (D1 engine-cache plumbing)
+            # Sampling sub-config (return_perf_metrics dropped D1)
             "tensorrt.sampling.min_tokens",
             "tensorrt.sampling.n",
             "tensorrt.sampling.ignore_eos",
-            "tensorrt.sampling.return_perf_metrics",
         ],
     }
 

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -39,6 +39,18 @@ if TYPE_CHECKING:
 # =============================================================================
 
 
+def is_curated_field(field_info: FieldInfo) -> bool:
+    """Return True if the field carries CurationMetadata (i.e. is a typed/curated field).
+
+    A curated field has a ``curation`` key in its ``json_schema_extra`` dict,
+    populated by :class:`llenergymeasure.config.curation.CurationMetadata`.
+    Use this as a single source of truth rather than duplicating the ``curation``
+    key check across scripts.
+    """
+    extra = field_info.json_schema_extra
+    return isinstance(extra, dict) and "curation" in extra
+
+
 def get_display_label(field_info: FieldInfo, field_name: str) -> str:
     """Return display label from json_schema_extra, falling back to title-cased name."""
     extra = field_info.json_schema_extra

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -278,7 +278,7 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "vllm.beam_search.max_tokens": [0],  # ge=1: 0 violates ge
         # TensorRTConfig: compile-time params
         "tensorrt.max_batch_size": [0],  # ge=1: 0 violates ge
-        "tensorrt.tp_size": [0],  # ge=1: 0 violates ge
+        "tensorrt.tensor_parallel_size": [0],  # ge=1: 0 violates ge
         "tensorrt.max_input_len": [0],  # ge=1: 0 violates ge
         "tensorrt.max_seq_len": [0],  # ge=1: 0 violates ge
         # TensorRTCalibConfig: calibration params
@@ -653,7 +653,7 @@ def get_engine_specific_params() -> dict[str, list[str]]:
         "tensorrt": [
             # Compile-time parameters (LLM() constructor)
             "tensorrt.max_batch_size",
-            "tensorrt.tp_size",
+            "tensorrt.tensor_parallel_size",
             "tensorrt.max_input_len",
             "tensorrt.max_seq_len",
             "tensorrt.dtype",
@@ -742,7 +742,7 @@ def get_param_skip_conditions() -> dict[str, str]:
     return {
         # Multi-GPU params - skip if single GPU
         "vllm.engine.tensor_parallel_size>1": "Requires 2+ GPUs",
-        "tensorrt.tp_size>1": "Requires 2+ GPUs",
+        "tensorrt.tensor_parallel_size>1": "Requires 2+ GPUs",
         # Flash Attention 2 - requires flash-attn package
         "transformers.attn_implementation=flash_attention_2": "Requires flash-attn package",
         # Flash Attention 3 - requires flash_attn_3 package (built from flash-attn hopper/)
@@ -845,7 +845,7 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
             # Transformers does NOT support tensor parallelism for HuggingFace models
             "transformers": False,
             "vllm": "tensor_parallel_size" in vllm_fields,
-            "tensorrt": "tp_size" in tensorrt_fields,
+            "tensorrt": "tensor_parallel_size" in tensorrt_fields,
         },
         "data_parallel": {
             # Transformers data parallelism via Accelerate is not supported in this version

--- a/src/llenergymeasure/device/gpu_info.py
+++ b/src/llenergymeasure/device/gpu_info.py
@@ -540,7 +540,7 @@ def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
       NVML-visible GPUs. Model sharding is determined at load time inside
       harness.run(), but gpu_indices must be passed *before* load. Using all
       visible GPUs is correct and safe.
-    - **TensorRT-LLM**: tp_size GPUs. Known from config before harness runs.
+    - **TensorRT-LLM**: tensor_parallel_size GPUs. Known from config before harness runs.
     - **Otherwise**: [0] (single-GPU default, backward compatible).
 
     Note: num_processes > 1 (data parallelism via Accelerate) is not handled here.
@@ -557,7 +557,7 @@ def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
         if total > 1:
             return list(range(total))
     elif config.engine == ENGINE_TENSORRT and config.tensorrt is not None:
-        tp = config.tensorrt.tp_size or 1
+        tp = config.tensorrt.tensor_parallel_size or 1
         if tp > 1:
             return list(range(tp))
     elif (

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -399,7 +399,7 @@ class TensorRTEngine:
         # engine_path early-return: pass engine dir as model, skip all compile-time kwargs
         if trt is not None and trt.engine_path is not None:
             engine_path = Path(trt.engine_path)
-            tp_size = trt.tp_size if trt.tp_size is not None else 1
+            tp_size = trt.tensor_parallel_size if trt.tensor_parallel_size is not None else 1
             errors = _validate_engine_directory(engine_path, tp_size=tp_size)
             if errors:
                 raise ConfigError(f"engine_path validation failed: {'; '.join(errors)}")
@@ -414,8 +414,8 @@ class TensorRTEngine:
             return kwargs
 
         # Scalar fields: map directly (same name or renamed)
-        if trt.tp_size is not None:
-            kwargs["tensor_parallel_size"] = trt.tp_size
+        if trt.tensor_parallel_size is not None:
+            kwargs["tensor_parallel_size"] = trt.tensor_parallel_size
         if trt.max_batch_size is not None:
             kwargs["max_batch_size"] = trt.max_batch_size
         if trt.max_input_len is not None:

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -397,8 +397,10 @@ class TensorRTEngine:
         trt = config.tensorrt
 
         # engine_path early-return: pass engine dir as model, skip all compile-time kwargs
-        if trt is not None and trt.engine_path is not None:
-            engine_path = Path(trt.engine_path)
+        # engine_path is no longer a typed field (D1 drop); accessed via extra="allow" passthrough.
+        raw_engine_path = getattr(trt, "engine_path", None) if trt is not None else None
+        if trt is not None and raw_engine_path is not None:
+            engine_path = Path(str(raw_engine_path))
             tp_size = trt.tensor_parallel_size if trt.tensor_parallel_size is not None else 1
             errors = _validate_engine_directory(engine_path, tp_size=tp_size)
             if errors:
@@ -406,30 +408,35 @@ class TensorRTEngine:
             # Pass engine dir as model - TRT-LLM auto-detects TLLM_ENGINE format.
             # Compile-time kwargs are baked into the engine; don't pass them.
             # enable_build_cache is not set - engine format bypasses it.
-            return {"model": str(trt.engine_path), "backend": "trt"}
+            return {"model": str(raw_engine_path), "backend": "trt"}
 
         if trt is None:
             # No tensorrt section — use defaults + enable build cache
             kwargs["enable_build_cache"] = True
             return kwargs
 
-        # Scalar fields: map directly (same name or renamed)
+        # Scalar fields: map directly
         if trt.tensor_parallel_size is not None:
             kwargs["tensor_parallel_size"] = trt.tensor_parallel_size
+        if trt.pipeline_parallel_size is not None:
+            kwargs["pipeline_parallel_size"] = trt.pipeline_parallel_size
         if trt.max_batch_size is not None:
             kwargs["max_batch_size"] = trt.max_batch_size
         if trt.max_input_len is not None:
             kwargs["max_input_len"] = trt.max_input_len
         if trt.max_seq_len is not None:
             kwargs["max_seq_len"] = trt.max_seq_len
+        if trt.max_num_tokens is not None:
+            kwargs["max_num_tokens"] = trt.max_num_tokens
         if trt.dtype is not None:
             kwargs["dtype"] = trt.dtype
         if trt.fast_build is not None:
             kwargs["fast_build"] = trt.fast_build
 
-        # TRT-LLM internal backend (overrides default "trt" if explicitly set)
-        if trt.backend is not None:
-            kwargs["backend"] = trt.backend
+        # TRT-LLM internal backend — no longer typed; accessed via extra="allow" if explicitly set.
+        raw_backend = getattr(trt, "backend", None)
+        if raw_backend is not None:
+            kwargs["backend"] = raw_backend
 
         # Quantisation config
         if trt.quant is not None:
@@ -446,26 +453,10 @@ class TensorRTEngine:
             except ImportError:
                 logger.debug("tensorrt_llm.llmapi not available; skipping QuantConfig")
 
-        # Build cache config
-        if trt.build_cache is not None:
-            try:
-                from tensorrt_llm.llmapi import BuildCacheConfig
-
-                bc = trt.build_cache
-                bc_kwargs: dict[str, Any] = {}
-                if bc.cache_root is not None:
-                    bc_kwargs["cache_root"] = Path(bc.cache_root)
-                if bc.max_records is not None:
-                    bc_kwargs["max_records"] = bc.max_records
-                if bc.max_cache_storage_gb is not None:
-                    bc_kwargs["max_cache_storage_gb"] = bc.max_cache_storage_gb
-                kwargs["enable_build_cache"] = BuildCacheConfig(**bc_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; enabling default build cache")
-                kwargs["enable_build_cache"] = True
-        else:
-            # Enable default build cache when no explicit config given
-            kwargs["enable_build_cache"] = True
+        # Build cache — enable by default; advanced config via extra="allow" passthrough.
+        # TensorRTBuildCacheConfig was dropped (D1 plumbing). Users can still pass
+        # build_cache fields through extra="allow" if needed.
+        kwargs["enable_build_cache"] = True
 
         # KV cache config
         if trt.kv_cache is not None:
@@ -502,24 +493,6 @@ class TensorRTEngine:
                     kwargs["scheduler_config"] = SchedulerConfig(**sc_kwargs)
             except ImportError:
                 logger.debug("tensorrt_llm.llmapi not available; skipping SchedulerConfig")
-
-        # Calibration config
-        if trt.calib is not None:
-            try:
-                from tensorrt_llm.llmapi import CalibConfig
-
-                calib = trt.calib
-                calib_kwargs: dict[str, Any] = {}
-                if calib.calib_batches is not None:
-                    calib_kwargs["calib_batches"] = calib.calib_batches
-                if calib.calib_dataset is not None:
-                    calib_kwargs["calib_dataset"] = calib.calib_dataset
-                if calib.calib_max_seq_length is not None:
-                    calib_kwargs["calib_max_seq_length"] = calib.calib_max_seq_length
-                if calib_kwargs:
-                    kwargs["calib_config"] = CalibConfig(**calib_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; skipping CalibConfig")
 
         return kwargs
 
@@ -568,7 +541,6 @@ class TensorRTEngine:
                 kwargs["n"] = sampling.n
             if sampling.ignore_eos is not None:
                 kwargs["ignore_eos"] = sampling.ignore_eos
-            if sampling.return_perf_metrics is not None:
-                kwargs["return_perf_metrics"] = sampling.return_perf_metrics
+            # return_perf_metrics dropped (D1 observability flag); falls through extra="allow"
 
         return SamplingParams(**kwargs)

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -74,10 +74,12 @@ class TransformersEngine:
         kwargs = self._model_load_kwargs(config)
         logger.info("Loading model %r with kwargs: %s", config.model, list(kwargs.keys()))
 
-        # trust_remote_code for tokenizer — respects config, defaults True
+        # trust_remote_code for tokenizer — defaults True; user can override via extra="allow"
         trust = True
-        if config.transformers is not None and config.transformers.trust_remote_code is not None:
-            trust = config.transformers.trust_remote_code
+        if config.transformers is not None:
+            _trc = getattr(config.transformers, "trust_remote_code", None)
+            if _trc is not None:
+                trust = _trc
 
         t0 = _time.perf_counter()
         tokenizer = AutoTokenizer.from_pretrained(config.model, trust_remote_code=trust)
@@ -91,6 +93,12 @@ class TransformersEngine:
         model.eval()
         if on_substep is not None:
             on_substep("model weights loaded", _time.perf_counter() - t0)
+
+        # Apply allow_tf32 (Ampere+ TF32 toggle)
+        if config.transformers is not None and config.transformers.allow_tf32 is not None:
+            import torch as _torch
+
+            _torch.backends.cuda.matmul.allow_tf32 = config.transformers.allow_tf32
 
         # Apply torch.compile post-load (must be AFTER from_pretrained + eval)
         if config.transformers is not None and config.transformers.torch_compile:
@@ -297,11 +305,9 @@ class TransformersEngine:
         else:
             kwargs["device_map"] = "auto"
 
-        # Trust remote code — default True unless researcher overrides
-        if pt is not None and pt.trust_remote_code is not None:
-            kwargs["trust_remote_code"] = pt.trust_remote_code
-        else:
-            kwargs["trust_remote_code"] = True
+        # trust_remote_code — no longer typed (D1 drop); defaults True; user can override via extra="allow"
+        _trc_from_pt = getattr(pt, "trust_remote_code", None) if pt is not None else None
+        kwargs["trust_remote_code"] = _trc_from_pt if _trc_from_pt is not None else True
 
         # Apply Transformers-specific config options
         if pt is not None:
@@ -335,10 +341,11 @@ class TransformersEngine:
                 kwargs["quantization_config"] = BitsAndBytesConfig(**bnb_kwargs)
 
             # Additional from_pretrained() fields
-            if pt.revision is not None:
-                kwargs["revision"] = pt.revision
+            # revision dropped as typed field (D1); flows through model_extra if set
             if pt.max_memory is not None:
                 kwargs["max_memory"] = pt.max_memory
+            if pt.low_cpu_mem_usage is not None:
+                kwargs["low_cpu_mem_usage"] = pt.low_cpu_mem_usage
 
         # Transformers extra="allow" passthrough: forward unknown fields to from_pretrained()
         if pt is not None and pt.model_extra:
@@ -446,8 +453,22 @@ class TransformersEngine:
         inputs = {k: v.to(model.device) for k, v in inputs.items()}
         input_token_count = int(inputs["attention_mask"].sum().item())
 
+        # Determine autocast settings
+        from contextlib import nullcontext
+
+        _pt = config.transformers
+        _autocast_enabled = _pt is not None and _pt.autocast_enabled is True
+        if _autocast_enabled and torch.cuda.is_available():
+            _autocast_dtype_str = (_pt.autocast_dtype if _pt is not None else None) or "bfloat16"
+            _dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
+            _amp_ctx = torch.autocast(
+                device_type="cuda", dtype=_dtype_map.get(_autocast_dtype_str, torch.bfloat16)
+            )
+        else:
+            _amp_ctx = nullcontext()  # type: ignore[assignment]
+
         t0 = time.perf_counter()
-        with torch.inference_mode():
+        with torch.inference_mode(), _amp_ctx:
             gen_kwargs = {**generate_kwargs}
             if config.max_output_tokens is not None:
                 gen_kwargs["max_new_tokens"] = config.max_output_tokens

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -317,13 +317,25 @@ class VLLMEngine:
             _set("pipeline_parallel_size", engine.pipeline_parallel_size)
             _set("enable_prefix_caching", engine.enable_prefix_caching)
             _set("quantization", engine.quantization)
+            _set("num_scheduler_steps", engine.num_scheduler_steps)
+            _set("max_seq_len_to_capture", engine.max_seq_len_to_capture)
+            _set("distributed_executor_backend", engine.distributed_executor_backend)
 
-            if engine.speculative_model is not None:
-                # vLLM v0.6+ uses speculative_config dict, not direct speculative_model kwarg
-                kwargs["speculative_config"] = {
-                    "model": engine.speculative_model,
-                    "num_speculative_tokens": engine.num_speculative_tokens,
-                }
+            # Speculative decoding — build vLLM-native speculative_config dict from sub-config
+            if engine.speculative is not None:
+                spec = engine.speculative
+                spec_dict: dict[str, Any] = {}
+                if spec.model is not None:
+                    spec_dict["model"] = spec.model
+                if spec.num_speculative_tokens is not None:
+                    spec_dict["num_speculative_tokens"] = spec.num_speculative_tokens
+                if spec.method is not None:
+                    spec_dict["method"] = spec.method
+                # Forward any extra sub-fields the user passed through extra="allow"
+                if spec.model_extra:
+                    spec_dict.update(spec.model_extra)
+                if spec_dict:
+                    kwargs["speculative_config"] = spec_dict
 
             _set("disable_custom_all_reduce", engine.disable_custom_all_reduce)
             _set("kv_cache_memory_bytes", engine.kv_cache_memory_bytes)
@@ -395,8 +407,6 @@ class VLLMEngine:
         # Apply vLLM-specific sampling overrides
         if vllm_cfg is not None and vllm_cfg.sampling is not None:
             sampling = vllm_cfg.sampling
-            if sampling.max_tokens is not None:
-                kwargs["max_tokens"] = sampling.max_tokens
             if sampling.min_tokens is not None:
                 kwargs["min_tokens"] = sampling.min_tokens
             if sampling.presence_penalty is not None:
@@ -432,9 +442,8 @@ class VLLMEngine:
             kwargs["length_penalty"] = beam_cfg.length_penalty
         if beam_cfg.early_stopping is not None:
             kwargs["early_stopping"] = beam_cfg.early_stopping
-        max_tokens = beam_cfg.max_tokens or config.max_output_tokens
-        if max_tokens is not None:
-            kwargs["max_tokens"] = max_tokens
+        if config.max_output_tokens is not None:
+            kwargs["max_tokens"] = config.max_output_tokens
         if config.decoder.min_p is not None:
             kwargs["min_p"] = config.decoder.min_p
         if beam_cfg.model_extra:

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -570,14 +570,14 @@ class DockerRunner:
     ) -> list[str]:
         """Build the ``docker run`` command list.
 
-        For TRT-LLM tensor parallelism (tp_size > 1), ``mpirun -n {tp_size}
+        For TRT-LLM tensor parallelism (tensor_parallel_size > 1), ``mpirun -n {n}
         --allow-run-as-root`` is injected between the image name and ``python3``.
         MPI worker ranks re-import the module but do not call ``main()`` because
         ``container_entrypoint.py`` is guarded by ``if __name__ == "__main__"``.
 
         Args:
             config:       ExperimentConfig for the current experiment. Used to
-                          detect TRT-LLM engine and read ``tensorrt.tp_size``.
+                          detect TRT-LLM engine and read ``tensorrt.tensor_parallel_size``.
             config_hash:  Hash prefix for config/result file names.
             exchange_dir: Host path of the temporary exchange directory.
             env_path:     Path to a temp env-file (written by ``_env_file``), or None.
@@ -628,7 +628,7 @@ class DockerRunner:
         # Determine TRT-LLM tensor parallel size for MPI injection
         tp_size = None
         if config.engine == "tensorrt" and config.tensorrt is not None:
-            tp_size = config.tensorrt.tp_size
+            tp_size = config.tensorrt.tensor_parallel_size
 
         cmd.append(self.image)
 

--- a/tests/unit/api/test_gpu.py
+++ b/tests/unit/api/test_gpu.py
@@ -103,30 +103,30 @@ def test_tensorrt_no_config_returns_single_gpu():
 
 
 def test_tensorrt_tp1_returns_single_gpu():
-    """tensorrt with tp_size=1 returns [0]."""
+    """tensorrt with tensor_parallel_size=1 returns [0]."""
     from llenergymeasure.config.engine_configs import TensorRTConfig
 
-    trt_cfg = TensorRTConfig(tp_size=1)
+    trt_cfg = TensorRTConfig(tensor_parallel_size=1)
     config = ExperimentConfig(model="gpt2", engine="tensorrt", tensorrt=trt_cfg)
     result = _resolve_gpu_indices(config)
     assert result == [0]
 
 
 def test_tensorrt_tp4_returns_four_gpus():
-    """tensorrt with tp_size=4 returns [0, 1, 2, 3]."""
+    """tensorrt with tensor_parallel_size=4 returns [0, 1, 2, 3]."""
     from llenergymeasure.config.engine_configs import TensorRTConfig
 
-    trt_cfg = TensorRTConfig(tp_size=4)
+    trt_cfg = TensorRTConfig(tensor_parallel_size=4)
     config = ExperimentConfig(model="gpt2", engine="tensorrt", tensorrt=trt_cfg)
     result = _resolve_gpu_indices(config)
     assert result == [0, 1, 2, 3]
 
 
 def test_tensorrt_none_tp_size_returns_single_gpu():
-    """tensorrt with tp_size=None falls through to [0]."""
+    """tensorrt with tensor_parallel_size=None falls through to [0]."""
     from llenergymeasure.config.engine_configs import TensorRTConfig
 
-    trt_cfg = TensorRTConfig(tp_size=None)
+    trt_cfg = TensorRTConfig(tensor_parallel_size=None)
     config = ExperimentConfig(model="gpt2", engine="tensorrt", tensorrt=trt_cfg)
     result = _resolve_gpu_indices(config)
     assert result == [0]

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -61,9 +61,13 @@ def test_get_engine_params_tensorrt_returns_params():
     assert "tensorrt.quant.quant_algo" in params
     assert "tensorrt.kv_cache.free_gpu_memory_fraction" in params
     assert "tensorrt.scheduler.capacity_scheduling_policy" in params
-    assert "tensorrt.build_cache.max_records" in params
-    assert "tensorrt.sampling.return_perf_metrics" in params
-    assert len(params) >= 20
+    # build_cache and calib sub-configs dropped (D1/D3); return_perf_metrics dropped (D1)
+    assert "tensorrt.build_cache.max_records" not in params
+    assert "tensorrt.sampling.return_perf_metrics" not in params
+    # New fields from C.2
+    assert "tensorrt.pipeline_parallel_size" in params
+    assert "tensorrt.max_num_tokens" in params
+    assert len(params) >= 10
 
 
 def test_get_engine_params_unknown_engine_raises():

--- a/tests/unit/config/test_config_schema.py
+++ b/tests/unit/config/test_config_schema.py
@@ -632,3 +632,66 @@ def test_n_prompts_default_is_100() -> None:
     from llenergymeasure.config.models import DatasetConfig
 
     assert DatasetConfig().n_prompts == 100
+
+
+# ---------------------------------------------------------------------------
+# CurationMetadata presence assertion (C.2)
+# ---------------------------------------------------------------------------
+
+
+def test_every_typed_engine_field_has_curation_metadata() -> None:
+    """Every typed field in engine_configs.py carries CurationMetadata.
+
+    This is the CI gate introduced in Phase 48 Plan C.2. A field that lacks
+    CurationMetadata was added without a rubric verdict and must be fixed.
+    """
+    from llenergymeasure.config.engine_configs import (
+        TensorRTConfig,
+        TensorRTKvCacheConfig,
+        TensorRTQuantConfig,
+        TensorRTSamplingConfig,
+        TensorRTSchedulerConfig,
+        TransformersConfig,
+        VLLMAttentionConfig,
+        VLLMBeamSearchConfig,
+        VLLMEngineConfig,
+        VLLMSamplingConfig,
+        VLLMSpeculativeConfig,
+    )
+
+    engine_models = [
+        TransformersConfig,
+        VLLMSpeculativeConfig,
+        VLLMAttentionConfig,
+        VLLMEngineConfig,
+        VLLMSamplingConfig,
+        VLLMBeamSearchConfig,
+        TensorRTQuantConfig,
+        TensorRTKvCacheConfig,
+        TensorRTSchedulerConfig,
+        TensorRTSamplingConfig,
+        TensorRTConfig,
+    ]
+
+    missing: list[str] = []
+    for model_cls in engine_models:
+        for name, info in model_cls.model_fields.items():
+            extra = info.json_schema_extra
+            if not isinstance(extra, dict):
+                missing.append(
+                    f"{model_cls.__name__}.{name}: json_schema_extra not a dict ({extra!r})"
+                )
+                continue
+            curation = extra.get("curation")
+            if curation is None:
+                missing.append(f"{model_cls.__name__}.{name}: missing 'curation' key")
+                continue
+            if not curation.get("clauses"):
+                missing.append(f"{model_cls.__name__}.{name}: CurationMetadata.clauses is empty")
+            if not curation.get("rationale"):
+                missing.append(f"{model_cls.__name__}.{name}: CurationMetadata.rationale is empty")
+
+    assert not missing, (
+        f"{len(missing)} engine config field(s) missing CurationMetadata:\n"
+        + "\n".join(f"  {m}" for m in missing)
+    )

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -1,13 +1,16 @@
-"""Unit tests for expanded TensorRT-LLM config validation.
+"""Unit tests for TensorRT-LLM config validation.
 
-Tests cover all 7 config requirements (CFG-01 through CFG-07):
-- CFG-01: Compile-time params (tensor_parallel_size, max_batch_size, max_input_len, max_seq_len, dtype, fast_build)
+Tests cover:
+- CFG-01: Compile-time params (tensor_parallel_size, pipeline_parallel_size, max_batch_size,
+          max_input_len, max_seq_len, max_num_tokens, dtype, fast_build)
 - CFG-02: Quantisation (QuantAlgo Literal type, kv_cache_quant_algo)
-- CFG-03: Calibration (calib_batches, calib_max_seq_length)
+- CFG-03: (Removed) Calibration sub-config dropped — D3 build-only PTQ, project consumes
+          pre-quantised checkpoints. Falls through extra="allow" if needed.
 - CFG-04: KV cache (enable_block_reuse, free_gpu_memory_fraction, max_tokens, host_cache_size)
 - CFG-05: Scheduler (capacity_scheduling_policy Literal)
-- CFG-06: Build cache (cache_root, max_records, max_cache_storage_gb)
-- CFG-07: Sampling (min_tokens, n, ignore_eos, return_perf_metrics)
+- CFG-06: (Removed) Build cache sub-config dropped — D1 engine-cache plumbing.
+          Falls through extra="allow" if needed.
+- CFG-07: Sampling (min_tokens, n, ignore_eos; return_perf_metrics dropped D1)
 """
 
 from __future__ import annotations
@@ -16,8 +19,6 @@ import pytest
 from pydantic import ValidationError
 
 from llenergymeasure.config.engine_configs import (
-    TensorRTBuildCacheConfig,
-    TensorRTCalibConfig,
     TensorRTConfig,
     TensorRTKvCacheConfig,
     TensorRTQuantConfig,
@@ -125,29 +126,8 @@ class TestQuantisation:
             TensorRTQuantConfig(kv_cache_quant_algo="INVALID")
 
 
-# ---------------------------------------------------------------------------
-# CFG-03: Calibration
-# ---------------------------------------------------------------------------
-
-
-class TestCalibration:
-    """Tests for TensorRT calibration config."""
-
-    def test_calib_config_accepted(self):
-        """Calibration section with valid values validates."""
-        config = TensorRTCalibConfig(
-            calib_batches=64,
-            calib_max_seq_length=256,
-            calib_dataset="cnn_dailymail",
-        )
-        assert config.calib_batches == 64
-        assert config.calib_max_seq_length == 256
-        assert config.calib_dataset == "cnn_dailymail"
-
-    def test_calib_batches_ge_1(self):
-        """calib_batches=0 raises ValidationError."""
-        with pytest.raises(ValidationError):
-            TensorRTCalibConfig(calib_batches=0)
+# CFG-03: Calibration sub-config dropped (D3) — tests removed.
+# calib fields remain settable via TensorRTConfig extra="allow" passthrough.
 
 
 # ---------------------------------------------------------------------------
@@ -222,29 +202,8 @@ class TestScheduler:
             TensorRTSchedulerConfig(capacity_scheduling_policy="INVALID_POLICY")
 
 
-# ---------------------------------------------------------------------------
-# CFG-06: Build Cache
-# ---------------------------------------------------------------------------
-
-
-class TestBuildCache:
-    """Tests for TensorRT build cache config."""
-
-    def test_build_cache_config_accepted(self):
-        """Build cache section with valid values validates."""
-        config = TensorRTBuildCacheConfig(
-            cache_root="/tmp/trt_cache",
-            max_records=20,
-            max_cache_storage_gb=512.0,
-        )
-        assert config.cache_root == "/tmp/trt_cache"
-        assert config.max_records == 20
-        assert config.max_cache_storage_gb == 512.0
-
-    def test_build_cache_max_records_ge_1(self):
-        """max_records=0 raises ValidationError."""
-        with pytest.raises(ValidationError):
-            TensorRTBuildCacheConfig(max_records=0)
+# CFG-06: Build cache sub-config dropped (D1) — tests removed.
+# build_cache fields remain settable via TensorRTConfig extra="allow" passthrough.
 
 
 # ---------------------------------------------------------------------------
@@ -256,17 +215,21 @@ class TestSampling:
     """Tests for TensorRT sampling config."""
 
     def test_sampling_config_accepted(self):
-        """Sampling section with valid values validates."""
+        """Sampling section with valid values validates (return_perf_metrics dropped D1)."""
         config = TensorRTSamplingConfig(
             min_tokens=10,
             n=4,
             ignore_eos=True,
-            return_perf_metrics=True,
         )
         assert config.min_tokens == 10
         assert config.n == 4
         assert config.ignore_eos is True
-        assert config.return_perf_metrics is True
+
+    def test_sampling_return_perf_metrics_is_extra_allow(self):
+        """return_perf_metrics still accepted via extra='allow' passthrough."""
+        config = TensorRTSamplingConfig(return_perf_metrics=True)
+        # No ValidationError — extra="allow"
+        assert getattr(config, "return_perf_metrics", None) is True
 
     def test_sampling_n_ge_1(self):
         """n=0 raises ValidationError."""
@@ -289,9 +252,11 @@ class TestExperimentConfigIntegration:
             engine="tensorrt",
             tensorrt={
                 "tensor_parallel_size": 2,
+                "pipeline_parallel_size": 2,
                 "max_batch_size": 8,
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
+                "max_num_tokens": 4096,
                 "dtype": "bfloat16",
                 "fast_build": True,
                 "quant": {"quant_algo": "W4A16_AWQ"},
@@ -302,24 +267,18 @@ class TestExperimentConfigIntegration:
                 "scheduler": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
-                "calib": {
-                    "calib_batches": 128,
-                    "calib_max_seq_length": 512,
-                },
-                "build_cache": {
-                    "max_cache_storage_gb": 256,
-                    "max_records": 10,
-                },
                 "sampling": {
                     "min_tokens": 5,
                     "n": 1,
-                    "return_perf_metrics": True,
+                    "ignore_eos": False,
                 },
             },
         )
         assert config.engine == "tensorrt"
         assert config.tensorrt is not None
         assert config.tensorrt.tensor_parallel_size == 2
+        assert config.tensorrt.pipeline_parallel_size == 2
+        assert config.tensorrt.max_num_tokens == 4096
         assert config.tensorrt.quant is not None
         assert config.tensorrt.quant.quant_algo == "W4A16_AWQ"
         assert config.tensorrt.kv_cache is not None
@@ -327,7 +286,7 @@ class TestExperimentConfigIntegration:
         assert config.tensorrt.scheduler is not None
         assert config.tensorrt.scheduler.capacity_scheduling_policy == "MAX_UTILIZATION"
         assert config.tensorrt.sampling is not None
-        assert config.tensorrt.sampling.return_perf_metrics is True
+        assert config.tensorrt.sampling.n == 1
 
     def test_tensorrt_extra_allow_forwards_unknown(self):
         """Extra fields on TensorRTConfig and sub-configs are accepted (not rejected)."""
@@ -345,19 +304,20 @@ class TestExperimentConfigIntegration:
         assert quant.quant_algo == "INT8"
 
     def test_tensorrt_none_defaults(self):
-        """All fields default to None when not specified."""
+        """All typed fields default to None when not specified."""
         config = TensorRTConfig()
         assert config.max_batch_size is None
         assert config.tensor_parallel_size is None
+        assert config.pipeline_parallel_size is None
         assert config.max_input_len is None
         assert config.max_seq_len is None
+        assert config.max_num_tokens is None
         assert config.dtype is None
         assert config.fast_build is None
-        assert config.backend is None
-        assert config.engine_path is None
         assert config.quant is None
         assert config.kv_cache is None
         assert config.scheduler is None
-        assert config.calib is None
-        assert config.build_cache is None
         assert config.sampling is None
+        # backend and engine_path are no longer typed fields (D2/D1 drop)
+        # calib and build_cache sub-configs dropped (D3/D1)
+        # all remain passable via extra="allow"

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -1,7 +1,7 @@
 """Unit tests for expanded TensorRT-LLM config validation.
 
 Tests cover all 7 config requirements (CFG-01 through CFG-07):
-- CFG-01: Compile-time params (tp_size, max_batch_size, max_input_len, max_seq_len, dtype, fast_build)
+- CFG-01: Compile-time params (tensor_parallel_size, max_batch_size, max_input_len, max_seq_len, dtype, fast_build)
 - CFG-02: Quantisation (QuantAlgo Literal type, kv_cache_quant_algo)
 - CFG-03: Calibration (calib_batches, calib_max_seq_length)
 - CFG-04: KV cache (enable_block_reuse, free_gpu_memory_fraction, max_tokens, host_cache_size)
@@ -40,14 +40,14 @@ class TestCompileTimeParams:
             max_batch_size=8,
             max_input_len=1024,
             max_seq_len=2048,
-            tp_size=2,
+            tensor_parallel_size=2,
             dtype="float16",
             fast_build=True,
         )
         assert config.max_batch_size == 8
         assert config.max_input_len == 1024
         assert config.max_seq_len == 2048
-        assert config.tp_size == 2
+        assert config.tensor_parallel_size == 2
         assert config.dtype == "float16"
         assert config.fast_build is True
 
@@ -61,10 +61,10 @@ class TestCompileTimeParams:
         config = TensorRTConfig(dtype="bfloat16")
         assert config.dtype == "bfloat16"
 
-    def test_tensorrt_tp_size_ge_1(self):
-        """tp_size=0 raises ValidationError."""
+    def test_tensorrt_tensor_parallel_size_ge_1(self):
+        """tensor_parallel_size=0 raises ValidationError."""
         with pytest.raises(ValidationError):
-            TensorRTConfig(tp_size=0)
+            TensorRTConfig(tensor_parallel_size=0)
 
     def test_tensorrt_max_batch_size_ge_1(self):
         """max_batch_size=0 raises ValidationError."""
@@ -288,7 +288,7 @@ class TestExperimentConfigIntegration:
             model="gpt2",
             engine="tensorrt",
             tensorrt={
-                "tp_size": 2,
+                "tensor_parallel_size": 2,
                 "max_batch_size": 8,
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
@@ -319,7 +319,7 @@ class TestExperimentConfigIntegration:
         )
         assert config.engine == "tensorrt"
         assert config.tensorrt is not None
-        assert config.tensorrt.tp_size == 2
+        assert config.tensorrt.tensor_parallel_size == 2
         assert config.tensorrt.quant is not None
         assert config.tensorrt.quant.quant_algo == "W4A16_AWQ"
         assert config.tensorrt.kv_cache is not None
@@ -332,11 +332,11 @@ class TestExperimentConfigIntegration:
     def test_tensorrt_extra_allow_forwards_unknown(self):
         """Extra fields on TensorRTConfig and sub-configs are accepted (not rejected)."""
         config = TensorRTConfig(
-            tp_size=1,
+            tensor_parallel_size=1,
             custom_future_field="value",
         )
         # Should not raise - extra="allow"
-        assert config.tp_size == 1
+        assert config.tensor_parallel_size == 1
 
         quant = TensorRTQuantConfig(
             quant_algo="INT8",
@@ -348,7 +348,7 @@ class TestExperimentConfigIntegration:
         """All fields default to None when not specified."""
         config = TensorRTConfig()
         assert config.max_batch_size is None
-        assert config.tp_size is None
+        assert config.tensor_parallel_size is None
         assert config.max_input_len is None
         assert config.max_seq_len is None
         assert config.dtype is None

--- a/tests/unit/config/test_tensorrt_sweep.py
+++ b/tests/unit/config/test_tensorrt_sweep.py
@@ -25,22 +25,22 @@ class TestEngineSweepAxis:
         assert {c.engine for c in valid} == {"transformers", "tensorrt"}
 
     def test_engine_sweep_with_trt_scoped_params(self):
-        """engine: [pytorch, tensorrt] with tensorrt.tp_size: [1, 2] produces 3 configs."""
+        """engine: [transformers, tensorrt] with tensorrt.tensor_parallel_size: [1, 2] produces 3 configs."""
         raw_study = {
             "model": "gpt2",
             "engine": ["transformers", "tensorrt"],
             "sweep": {
-                "tensorrt.tp_size": [1, 2],
+                "tensorrt.tensor_parallel_size": [1, 2],
             },
         }
         valid, _skipped = expand_grid(raw_study)
-        # pytorch: 1 config (no scoped dims), tensorrt: 2 configs (tp_size=[1,2])
+        # transformers: 1 config (no scoped dims), tensorrt: 2 configs (tensor_parallel_size=[1,2])
         assert len(valid) == 3
         pytorch_configs = [c for c in valid if c.engine == "transformers"]
         tensorrt_configs = [c for c in valid if c.engine == "tensorrt"]
         assert len(pytorch_configs) == 1
         assert len(tensorrt_configs) == 2
-        tp_sizes = {c.tensorrt.tp_size for c in tensorrt_configs}
+        tp_sizes = {c.tensorrt.tensor_parallel_size for c in tensorrt_configs}
         assert tp_sizes == {1, 2}
 
 
@@ -81,7 +81,7 @@ class TestDottedNestedSweep:
             "model": "gpt2",
             "engine": "tensorrt",
             "tensorrt": {
-                "tp_size": 2,
+                "tensor_parallel_size": 2,
                 "max_batch_size": 8,
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
@@ -112,7 +112,7 @@ class TestDottedNestedSweep:
         for config in valid:
             assert config.engine == "tensorrt"
             assert config.tensorrt is not None
-            assert config.tensorrt.tp_size == 2
+            assert config.tensorrt.tensor_parallel_size == 2
             assert config.tensorrt.max_batch_size == 8
             assert config.tensorrt.dtype == "bfloat16"
             assert config.tensorrt.kv_cache is not None

--- a/tests/unit/config/test_tensorrt_sweep.py
+++ b/tests/unit/config/test_tensorrt_sweep.py
@@ -61,19 +61,19 @@ class TestDottedNestedSweep:
         algos = [c.tensorrt.quant.quant_algo for c in valid]
         assert set(algos) == {"INT8", "FP8", "W4A16_AWQ"}
 
-    def test_dotted_nested_build_cache_sweep(self):
-        """tensorrt.build_cache.max_cache_storage_gb: [128, 256] produces 2 configs."""
+    def test_dotted_nested_max_num_tokens_sweep(self):
+        """tensorrt.max_num_tokens: [2048, 4096] produces 2 configs."""
         raw_study = {
             "model": "gpt2",
             "engine": "tensorrt",
             "sweep": {
-                "tensorrt.build_cache.max_cache_storage_gb": [128, 256],
+                "tensorrt.max_num_tokens": [2048, 4096],
             },
         }
         valid, _skipped = expand_grid(raw_study)
         assert len(valid) == 2
-        storage_values = {c.tensorrt.build_cache.max_cache_storage_gb for c in valid}
-        assert storage_values == {128, 256}
+        token_values = {c.tensorrt.max_num_tokens for c in valid}
+        assert token_values == {2048, 4096}
 
     def test_full_tensorrt_study_yaml_parses(self):
         """Comprehensive study YAML with all sub-sections and quant sweep round-trips."""
@@ -93,14 +93,8 @@ class TestDottedNestedSweep:
                 "scheduler": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
-                "calib": {
-                    "calib_batches": 128,
-                },
-                "build_cache": {
-                    "max_cache_storage_gb": 256,
-                },
                 "sampling": {
-                    "return_perf_metrics": True,
+                    "n": 1,
                 },
             },
             "sweep": {
@@ -119,7 +113,7 @@ class TestDottedNestedSweep:
             assert config.tensorrt.kv_cache.enable_block_reuse is True
             assert config.tensorrt.scheduler is not None
             assert config.tensorrt.sampling is not None
-            assert config.tensorrt.sampling.return_perf_metrics is True
+            assert config.tensorrt.sampling.n == 1
         algos = {c.tensorrt.quant.quant_algo for c in valid}
         assert algos == {"INT8", "W4A16_AWQ"}
 

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -777,10 +777,10 @@ class TestMpirunInjection:
         return captured_cmds[0]
 
     def test_mpirun_injected_for_tensorrt_tp2(self, tmp_path):
-        """TRT-LLM with tp_size=2 gets mpirun -n 2 --allow-run-as-root before python3."""
+        """TRT-LLM with tensor_parallel_size=2 gets mpirun -n 2 --allow-run-as-root before python3."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=2))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=2))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" in cmd
@@ -795,10 +795,10 @@ class TestMpirunInjection:
         assert image_idx < mpirun_idx < python_idx
 
     def test_mpirun_injected_for_tensorrt_tp4(self, tmp_path):
-        """TRT-LLM with tp_size=4 gets mpirun -n 4 with correct stringified count."""
+        """TRT-LLM with tensor_parallel_size=4 gets mpirun -n 4 with correct stringified count."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=4))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=4))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" in cmd
@@ -806,19 +806,19 @@ class TestMpirunInjection:
         assert cmd[n_idx + 1] == "4"
 
     def test_no_mpirun_for_tensorrt_tp1(self, tmp_path):
-        """TRT-LLM with tp_size=1 does NOT get mpirun (single-GPU path)."""
+        """TRT-LLM with tensor_parallel_size=1 does NOT get mpirun (single-GPU path)."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" not in cmd
 
     def test_no_mpirun_for_tensorrt_tp_none(self, tmp_path):
-        """TRT-LLM with tp_size=None (default) does NOT get mpirun."""
+        """TRT-LLM with tensor_parallel_size=None (default) does NOT get mpirun."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=None))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=None))
         cmd = self._capture_cmd(config, tmp_path)
 
         assert "mpirun" not in cmd
@@ -891,7 +891,7 @@ class TestExtraMounts:
         """TRT-LLM engine auto-mounts ~/.cache/trt-llm:/root/.cache/trt-llm."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
         runner = DockerRunner(image=IMAGE)
 
         with patch(
@@ -907,7 +907,7 @@ class TestExtraMounts:
         """User's custom /root/.cache/trt-llm path prevents auto-mount duplication."""
         from llenergymeasure.config.engine_configs import TensorRTConfig
 
-        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
         runner = DockerRunner(
             image=IMAGE,
             extra_mounts=[("/custom/cache", "/root/.cache/trt-llm")],

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -21,7 +21,6 @@ import sys
 import types
 
 from llenergymeasure.config.engine_configs import (
-    TensorRTBuildCacheConfig,
     TensorRTConfig,
     TensorRTKvCacheConfig,
     TensorRTQuantConfig,
@@ -237,29 +236,13 @@ class TestBuildLlmKwargs:
         assert isinstance(kwargs["quantization"], _MockQuantConfig)
         assert kwargs["quantization"]._kwargs["quant_algo"] == "INT8"
 
-    def test_build_llm_kwargs_build_cache_config(self, monkeypatch):
-        """build_cache section maps to BuildCacheConfig kwargs."""
-        mock_trt = _make_fake_tensorrt_llm_module()
-        monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
-        monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
-
-        config = make_config(
-            **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(
-                build_cache=TensorRTBuildCacheConfig(
-                    cache_root="/tmp/trt_cache",
-                    max_records=5,
-                    max_cache_storage_gb=128.0,
-                )
-            ),
-        )
+    def test_build_llm_kwargs_always_has_enable_build_cache(self):
+        """enable_build_cache=True is always set (TensorRTBuildCacheConfig dropped D1)."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig())
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
-        assert "enable_build_cache" in kwargs
-        assert isinstance(kwargs["enable_build_cache"], _MockBuildCacheConfig)
-        assert kwargs["enable_build_cache"]._kwargs["max_records"] == 5
-        assert kwargs["enable_build_cache"]._kwargs["max_cache_storage_gb"] == 128.0
+        assert kwargs.get("enable_build_cache") is True
 
     def test_build_llm_kwargs_kv_cache_config(self, monkeypatch):
         """kv_cache section maps to KvCacheConfig kwargs."""

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -169,9 +169,9 @@ class TestBuildLlmKwargs:
         assert kwargs["backend"] == "trt"
         assert kwargs.get("enable_build_cache") is True
 
-    def test_build_llm_kwargs_tp_size(self):
-        """tp_size=2 maps to tensor_parallel_size=2."""
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tp_size=2))
+    def test_build_llm_kwargs_tensor_parallel_size(self):
+        """tensor_parallel_size=2 maps to kwargs tensor_parallel_size=2."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=2))
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
@@ -215,7 +215,7 @@ class TestBuildLlmKwargs:
 
     def test_build_llm_kwargs_default_build_cache_when_no_build_cache_section(self):
         """When no build_cache section, enable_build_cache=True is set."""
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tp_size=1))
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
@@ -601,7 +601,9 @@ class TestBuildMetadata:
         import hashlib
         import json
 
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tp_size=2, max_batch_size=8))
+        config = make_config(
+            **_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=2, max_batch_size=8)
+        )
         engine = TensorRTEngine()
 
         # Reproduce the hash computation from load_model
@@ -714,7 +716,7 @@ class TestBuildLlmKwargsEnginePath:
         assert kwargs["backend"] == "trt"
 
     def test_build_llm_kwargs_engine_path_skips_compile_kwargs(self, tmp_path):
-        """engine_path set -> no compile-time kwargs (tp_size, max_batch_size, etc.)."""
+        """engine_path set -> no compile-time kwargs (tensor_parallel_size, max_batch_size, etc.)."""
         config_data = {"pretrained_config": {"mapping": {"tp_size": 2}}, "build_config": {}}
         (tmp_path / "config.json").write_text(json.dumps(config_data))
         (tmp_path / "rank0.engine").write_bytes(b"fake")
@@ -722,7 +724,9 @@ class TestBuildLlmKwargsEnginePath:
 
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(engine_path=str(tmp_path), tp_size=2, max_batch_size=16),
+            tensorrt=TensorRTConfig(
+                engine_path=str(tmp_path), tensor_parallel_size=2, max_batch_size=16
+            ),
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -406,10 +406,14 @@ class TestEngineConfigFields:
         kwargs = VLLMEngine()._build_llm_kwargs(config)
         assert kwargs["block_size"] == 16
 
-    def test_speculative_model_produces_speculative_config_dict(self):
-        """speculative_model + num_speculative_tokens → speculative_config dict (vLLM v0.6+ API)."""
+    def test_speculative_sub_config_produces_speculative_config_dict(self):
+        """VLLMSpeculativeConfig → speculative_config dict (vLLM native shape)."""
+        from llenergymeasure.config.engine_configs import VLLMSpeculativeConfig
+
         vllm_cfg = VLLMConfig(
-            engine=VLLMEngineConfig(speculative_model="draft-model", num_speculative_tokens=5)
+            engine=VLLMEngineConfig(
+                speculative=VLLMSpeculativeConfig(model="draft-model", num_speculative_tokens=5)
+            )
         )
         config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         kwargs = VLLMEngine()._build_llm_kwargs(config)
@@ -418,6 +422,21 @@ class TestEngineConfigFields:
             "model": "draft-model",
             "num_speculative_tokens": 5,
         }
+
+    def test_speculative_sub_config_with_method(self):
+        """VLLMSpeculativeConfig.method is forwarded in speculative_config dict."""
+        from llenergymeasure.config.engine_configs import VLLMSpeculativeConfig
+
+        vllm_cfg = VLLMConfig(
+            engine=VLLMEngineConfig(
+                speculative=VLLMSpeculativeConfig(
+                    model="eagle-model", num_speculative_tokens=3, method="eagle"
+                )
+            )
+        )
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
+        kwargs = VLLMEngine()._build_llm_kwargs(config)
+        assert kwargs["speculative_config"]["method"] == "eagle"
 
     def test_all_engine_fields_wired(self):
         """All 14 non-speculative engine fields are forwarded when set."""
@@ -463,12 +482,14 @@ class TestEngineConfigFields:
 
 
 class TestSamplingConfigOverrides:
-    def test_sampling_max_tokens_overrides_config_max_output_tokens(self):
-        """VLLMSamplingConfig.max_tokens overrides ExperimentConfig.max_output_tokens."""
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(max_tokens=256))
-        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg, max_output_tokens=128)
+    def test_max_output_tokens_bridges_to_max_tokens(self):
+        """ExperimentConfig.max_output_tokens bridges to SamplingParams.max_tokens.
+
+        max_tokens was dropped from VLLMSamplingConfig (R2 dup); bridged at adapter level.
+        """
+        config = make_config(**_VLLM_DEFAULTS, max_output_tokens=128)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-        assert params._kwargs["max_tokens"] == 256  # override wins
+        assert params._kwargs["max_tokens"] == 128
 
     def test_sampling_presence_penalty_applied(self):
         """VLLMSamplingConfig.presence_penalty appears in SamplingParams kwargs."""
@@ -501,13 +522,13 @@ class TestSamplingConfigOverrides:
     def test_sampling_overrides_applied_to_greedy_path(self):
         """VLLMSamplingConfig overrides work on the greedy (temperature=0.0) path too."""
         decoder = DecoderConfig(temperature=0.0, do_sample=False)
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(max_tokens=512))
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(presence_penalty=0.1))
         config = make_config(
             **_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=128
         )
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
         assert params._kwargs["temperature"] == 0.0
-        assert params._kwargs["max_tokens"] == 512  # override wins on greedy path
+        assert params._kwargs["max_tokens"] == 128  # from max_output_tokens bridge
 
     def test_none_sampling_config_does_not_add_extra_kwargs(self):
         """When vllm.sampling is None, no extra sampling kwargs are added."""
@@ -967,10 +988,10 @@ class TestBeamSearchMinP:
         assert "min_p" not in params._kwargs
 
     def test_beam_width_and_min_p_together(self, monkeypatch):
-        """beam_width and min_p both appear in kwargs when set."""
+        """beam_width and min_p both appear in kwargs; max_tokens bridged from max_output_tokens."""
         decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=0.1)
-        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=8, max_tokens=64))
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg)
+        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=8))
+        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=64)
         params = self._build_beam_params(config, monkeypatch)
         assert params._kwargs["beam_width"] == 8
         assert params._kwargs["min_p"] == pytest.approx(0.1)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1051,35 +1051,35 @@ class TestResolveGpuIndices:
 # With _resolve_gpu_indices returning correct indices for TRT-LLM,
 # multi-GPU energy is automatically summed across all TP ranks.
 # No methodology_notes string needed - data is self-documenting:
-#   effective_config.tensorrt.tp_size + multi_gpu.num_gpus + multi_gpu.energy_per_gpu_j
+#   effective_config.tensorrt.tensor_parallel_size + multi_gpu.num_gpus + multi_gpu.energy_per_gpu_j
 
 
 class TestResolveGpuIndicesTensorrt:
     """Unit tests for _resolve_gpu_indices() tensorrt branch."""
 
     def test_tensorrt_tp1_returns_single_index(self):
-        """tp_size=1 -> [0] (single GPU)."""
+        """tensor_parallel_size=1 -> [0] (single GPU)."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
-        config = make_config(engine="tensorrt", tensorrt={"tp_size": 1})
+        config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 1})
         assert _resolve_gpu_indices(config) == [0]
 
     def test_tensorrt_tp2_returns_two_indices(self):
-        """tp_size=2 -> [0, 1] (two GPUs for energy monitoring)."""
+        """tensor_parallel_size=2 -> [0, 1] (two GPUs for energy monitoring)."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
-        config = make_config(engine="tensorrt", tensorrt={"tp_size": 2})
+        config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 2})
         assert _resolve_gpu_indices(config) == [0, 1]
 
     def test_tensorrt_tp4_returns_four_indices(self):
-        """tp_size=4 -> [0, 1, 2, 3]."""
+        """tensor_parallel_size=4 -> [0, 1, 2, 3]."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
-        config = make_config(engine="tensorrt", tensorrt={"tp_size": 4})
+        config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 4})
         assert _resolve_gpu_indices(config) == [0, 1, 2, 3]
 
     def test_tensorrt_tp_none_returns_single_index(self):
-        """tp_size=None (default) -> [0] (single GPU)."""
+        """tensor_parallel_size=None (default) -> [0] (single GPU)."""
         from llenergymeasure.api._impl import _resolve_gpu_indices
 
         config = make_config(engine="tensorrt", tensorrt={})


### PR DESCRIPTION
## Summary

- Rewrites `configs/example-study-full.yaml` as a maximalist showcase of all 94 typed engine fields from the post-C.2 Pydantic surface (25 `TransformersConfig`, 47 `VLLMConfig`, 22 `TensorRTConfig`).
- Every typed field appears exactly once with an inline comment citing rubric clauses and one-line rationale from `CurationMetadata`.
- Adds `scripts/verify_example_coverage.py`: walks all Pydantic model trees, collects every typed-field YAML path, asserts 100% coverage. Exits non-zero on missing fields.

## What's in the showcase

- 7 experiments covering all three engines.
- Mutually exclusive pairs each get their own experiment:
  - `transformers.tp_plan` vs `device_map`
  - `vllm.engine.kv_cache_memory_bytes` vs `gpu_memory_utilization`
  - `vllm.beam_search` vs `vllm.sampling`
- Non-typed (`extra="allow"` passthrough) fields are explicitly excluded.

## Verification

- `uv run llem run configs/example-study-full.yaml --dry-run` → exits 0 (7 valid configs)
- `uv run python scripts/verify_example_coverage.py` → exits 0 (94/94, 100%)
- `uv run pytest tests/unit/config/ -x -q` → 208 passed

## Base branch note

Base is `feature/phase-48-2b-curation-adjust` (C.2). Will be retargeted to `main` once PR #270 (C.2) merges.