### PR TITLE
feat(config): add CurationMetadata scaffolding for typed engine fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- **`CurationMetadata` scaffolding for typed engine fields.** Every typed field in `engine_configs.py` now carries a structured `CurationMetadata` dataclass (clauses, rationale, native mapping) attached via `json_schema_extra`. The rubric is defined in `.product/research/parameter-curation-rubric.md`. A CI assertion test (`test_every_typed_engine_field_has_curation_metadata`) guards that every typed field carries non-empty metadata so new fields cannot be added without a rubric verdict.
+
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.
 - **`llem doctor` CLI command.** Reports per-backend image status (OK / MISMATCH / UNVERIFIED / UNREACHABLE) and exits non-zero on mismatch for CI-friendly gating.
 - **Inline schema status in the image-prep progress line** (`schema: ok` / `schema: mismatch` / `schema: unverified` / `schema: bypassed`), rendered via the existing metadata display with no changes to the progress protocol.

--- a/src/llenergymeasure/config/curation.py
+++ b/src/llenergymeasure/config/curation.py
@@ -23,7 +23,7 @@ Usage::
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Literal
+from typing import Any, Literal
 
 RubricClause = Literal[
     "R1",
@@ -68,6 +68,6 @@ class CurationMetadata:
     native_mapping: str | None = None
     notes: str | None = None
 
-    def to_schema_extra(self) -> dict[str, object]:
+    def to_schema_extra(self) -> dict[str, Any]:
         """Render to the dict shape Pydantic expects in ``json_schema_extra``."""
         return {"curation": asdict(self)}

--- a/src/llenergymeasure/config/curation.py
+++ b/src/llenergymeasure/config/curation.py
@@ -1,0 +1,73 @@
+"""Structured curation metadata for typed engine config fields.
+
+Every typed field in engine_configs.py carries a CurationMetadata instance attached
+via json_schema_extra. This makes the rubric verdict machine-readable and is the
+source of truth for the generated inclusion/exclusion table (Plan E).
+
+Usage::
+
+    from llenergymeasure.config.curation import CurationMetadata
+
+    some_field: int | None = Field(
+        default=None,
+        ge=1,
+        description="...",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="AMD MLPerf v5.1 multi-step throughput axis.",
+            native_mapping="EngineArgs.num_scheduler_steps",
+        ).to_schema_extra(),
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+RubricClause = Literal[
+    "R1",
+    "R2",  # required
+    "E1",
+    "E2",
+    "E3",
+    "E4",  # elevating
+    "D1",
+    "D2",
+    "D3",
+    "D4",  # demoting (for drop decisions recorded for posterity)
+    "T1",
+    "T2",
+    "T3",
+    "T4",
+    "T5",  # tie-breakers
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CurationMetadata:
+    """Structured justification attached to every typed field in engine_configs.py.
+
+    Becomes the source of truth for the generated inclusion/exclusion table (Plan E).
+
+    Attributes:
+        clauses:        Tuple of rubric clause codes that fired for this field.
+                        At minimum R1 (plausible measurement path) must be present
+                        unless R2 (non-duplication) caused a drop.
+        rationale:      One-line justification. This text appears verbatim in the
+                        generated curation doc as the "reason" column.
+        native_mapping: Dotted path to the corresponding native engine argument,
+                        e.g. "EngineArgs.num_scheduler_steps". None when the field
+                        is engine-local only (no direct native counterpart).
+        notes:          Optional caveats — e.g. "churn-prone, watch vLLM v0.8 release
+                        notes", or "defer — confirm HF deprecation before adding".
+    """
+
+    clauses: tuple[RubricClause, ...]
+    rationale: str
+    native_mapping: str | None = None
+    notes: str | None = None
+
+    def to_schema_extra(self) -> dict[str, object]:
+        """Render to the dict shape Pydantic expects in ``json_schema_extra``."""
+        return {"curation": asdict(self)}

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -181,7 +181,7 @@ class TransformersConfig(BaseModel):
         description="Use KV cache during generation (None -> True)",
         json_schema_extra=CurationMetadata(
             clauses=("R1", "R2", "E2"),
-            rationale="Turning it off changes inference from AR to prefill-only (~100× latency delta).",
+            rationale="Turning it off changes inference from AR to prefill-only (~100x latency delta).",
             native_mapping="GenerationConfig.use_cache",
         ).to_schema_extra(),
     )

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -4,6 +4,11 @@ Each engine section uses None-as-default: all fields default to None, meaning
 "use the engine's own default at execution time". This makes it explicit when
 a researcher has set a value versus when the engine's built-in default applies.
 
+Every typed field carries ``CurationMetadata`` via ``json_schema_extra``.
+This is the machine-readable rubric verdict used by the generated
+inclusion/exclusion table (Plan E). The rubric is defined in
+``.product/research/parameter-curation-rubric.md``.
+
 Usage in YAML:
     engine: transformers
     transformers:
@@ -33,6 +38,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from llenergymeasure.config.curation import CurationMetadata
+
 # =============================================================================
 # Transformers Engine Configuration (v2.0)
 # =============================================================================
@@ -60,6 +67,11 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description="Batch size (None -> 1)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Universal measurement axis; MLPerf, Optimum, LLM-Perf all split by it.",
+            native_mapping="AutoModelForCausalLM.generate batch dimension",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -71,6 +83,11 @@ class TransformersConfig(BaseModel):
     ) = Field(
         default=None,
         description="Attention implementation (None -> sdpa)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3"),
+            rationale="Kernel selection is a latency/energy regime switch; Optimum types it.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(attn_implementation=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -80,14 +97,29 @@ class TransformersConfig(BaseModel):
     torch_compile: bool | None = Field(
         default=None,
         description="Enable torch.compile (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Compile vs eager is a regime switch; Optimum/Databricks report splits.",
+            native_mapping="torch.compile(model)",
+        ).to_schema_extra(),
     )
     torch_compile_mode: str | None = Field(
         default=None,
         description="torch.compile mode: 'default', 'reduce-overhead', 'max-autotune' (None -> 'default')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E3"),
+            rationale="3-option enum with meaningful throughput deltas (default vs reduce-overhead vs max-autotune).",
+            native_mapping="torch.compile(model, mode=...)",
+        ).to_schema_extra(),
     )
     torch_compile_backend: str | None = Field(
         default=None,
         description="torch.compile backend (None -> 'inductor')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="Compile-backend selects different codegen → different kernels → measurable energy delta.",
+            native_mapping="torch.compile(model, backend=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -97,22 +129,47 @@ class TransformersConfig(BaseModel):
     load_in_4bit: bool | None = Field(
         default=None,
         description="BitsAndBytes 4-bit quantization",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Regime switch — 4-bit is its own measurement mode.",
+            native_mapping="BitsAndBytesConfig(load_in_4bit=True)",
+        ).to_schema_extra(),
     )
     load_in_8bit: bool | None = Field(
         default=None,
         description="BitsAndBytes 8-bit quantization",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Regime switch — 8-bit is its own measurement mode.",
+            native_mapping="BitsAndBytesConfig(load_in_8bit=True)",
+        ).to_schema_extra(),
     )
     bnb_4bit_compute_dtype: Literal["float16", "bfloat16", "float32"] | None = Field(
         default=None,
         description="Compute dtype for 4-bit (None -> float32, usually want bfloat16)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="Compute-path selection inside 4-bit; affects energy directly.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_compute_dtype=...)",
+        ).to_schema_extra(),
     )
     bnb_4bit_quant_type: Literal["nf4", "fp4"] | None = Field(
         default=None,
         description="4-bit quantization type (None -> 'nf4')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="nf4 vs fp4 selects different dequantisation kernels → different energy/token.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_quant_type=...)",
+        ).to_schema_extra(),
     )
     bnb_4bit_use_double_quant: bool | None = Field(
         default=None,
         description="Double quantization saves ~0.4 bits/param (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Double quantisation changes memory footprint and dequant arithmetic — regime toggle.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_use_double_quant=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -122,10 +179,20 @@ class TransformersConfig(BaseModel):
     use_cache: bool | None = Field(
         default=None,
         description="Use KV cache during generation (None -> True)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Turning it off changes inference from AR to prefill-only (~100× latency delta).",
+            native_mapping="GenerationConfig.use_cache",
+        ).to_schema_extra(),
     )
     cache_implementation: Literal["static", "offloaded_static", "sliding_window"] | None = Field(
         default=None,
         description="KV cache strategy; 'static' enables CUDA graphs (None -> dynamic)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="'static' enables CUDA graphs — regime-changing; stable 3-value enum.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(cache_implementation=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -136,14 +203,29 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description="Beam search width (None -> 1, greedy/sampling)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1", "E2"),
+            rationale="Linear compute scaling; beam search is its own measurement regime.",
+            native_mapping="GenerationConfig.num_beams",
+        ).to_schema_extra(),
     )
     early_stopping: bool | None = Field(
         default=None,
         description="Stop beam search when all beams hit EOS (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Couples to beam search; affects final token count.",
+            native_mapping="GenerationConfig.early_stopping",
+        ).to_schema_extra(),
     )
     length_penalty: float | None = Field(
         default=None,
         description="Beam length penalty: >1 shorter, <1 longer (None -> 1.0)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Tunes beam-search sequence length → FLOPs.",
+            native_mapping="GenerationConfig.length_penalty",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -154,6 +236,11 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=0,
         description="Prevent n-gram repetition (None -> 0, disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Affects generation length via repetition prevention → indirect throughput/energy delta.",
+            native_mapping="GenerationConfig.no_repeat_ngram_size",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -164,6 +251,11 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description="Prompt-lookup speculative decoding tokens (None -> disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="HF's speculative-decoding flavour (prompt-lookup); regime switch.",
+            native_mapping="GenerationConfig.prompt_lookup_num_tokens",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -173,10 +265,23 @@ class TransformersConfig(BaseModel):
     device_map: str | None = Field(
         default=None,
         description="Device placement strategy (None -> 'auto')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Offload strategy; Optimum types it. Mutually exclusive with tp_plan.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(device_map=...)",
+        ).to_schema_extra(),
     )
     max_memory: dict[str | int, str] | None = Field(
         default=None,
         description="Per-device memory limits, e.g. {0: '10GiB', 'cpu': '50GiB'}",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "T4"),
+            rationale=(
+                "Sets per-device memory budget; once exceeded forces weight offload CPU↔GPU "
+                "— major energy/latency regime change. Dict passthrough (T4)."
+            ),
+            native_mapping="AutoModelForCausalLM.from_pretrained(max_memory=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -186,18 +291,38 @@ class TransformersConfig(BaseModel):
     allow_tf32: bool | None = Field(
         default=None,
         description="Allow TF32 on Ampere GPUs (None -> PyTorch default)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Ampere TF32 toggle; accuracy/throughput tradeoff affecting GEMM energy.",
+            native_mapping="torch.backends.cuda.matmul.allow_tf32",
+        ).to_schema_extra(),
     )
     autocast_enabled: bool | None = Field(
         default=None,
         description="Enable torch.autocast mixed precision (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Mixed-precision runtime switch; determines whether AMP is applied during generation.",
+            native_mapping="torch.autocast(enabled=...)",
+        ).to_schema_extra(),
     )
     autocast_dtype: Literal["float16", "bfloat16"] | None = Field(
         default=None,
         description="torch.autocast dtype (None -> bfloat16 on Ampere)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="AMP compute dtype selector; different dtypes have distinct GEMM throughput.",
+            native_mapping="torch.autocast(dtype=...)",
+        ).to_schema_extra(),
     )
     low_cpu_mem_usage: bool | None = Field(
         default=None,
         description="Low CPU memory usage during model loading (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Affects load-time memory footprint; can trigger weight offload regime.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(low_cpu_mem_usage=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -211,6 +336,11 @@ class TransformersConfig(BaseModel):
             "Only 'auto' is currently supported by Transformers. "
             "Mutually exclusive with device_map. Requires torchrun launch."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Tensor parallelism enable; engine-native HF TP regime toggle.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(tp_plan=...)",
+        ).to_schema_extra(),
     )
     tp_size: int | None = Field(
         default=None,
@@ -220,6 +350,11 @@ class TransformersConfig(BaseModel):
             "Field name preserved to match HuggingFace accelerate convention "
             "(distinct from TensorRTConfig.tensor_parallel_size which aligns with TrtLlmArgs)."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="TP degree — universal measurement axis. Preserved as tp_size (accelerate convention).",
+            native_mapping="accelerate tp_size",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -293,11 +428,21 @@ class VLLMSpeculativeConfig(BaseModel):
     model: str | None = Field(
         default=None,
         description="Draft model name/path for speculative decoding.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Draft model identity — primary axis for speculative-decoding measurement.",
+            native_mapping="EngineArgs.speculative_config.model",
+        ).to_schema_extra(),
     )
     num_speculative_tokens: int | None = Field(
         default=None,
         ge=1,
         description="Tokens to draft per speculative step.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E2"),
+            rationale="Draft-token count determines speculation depth; strongly peer-validated.",
+            native_mapping="EngineArgs.speculative_config.num_speculative_tokens",
+        ).to_schema_extra(),
     )
     method: str | None = Field(
         default=None,
@@ -306,6 +451,12 @@ class VLLMSpeculativeConfig(BaseModel):
             "Kept as str because the Literal has drifted across vLLM releases — verify against "
             "EngineArgs.speculative_config.method in the vendored schema before narrowing."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Method enum selects qualitatively different speculative-decoding regimes.",
+            native_mapping="EngineArgs.speculative_config.method",
+            notes="Kept str | None; narrow to Literal once vendored vLLM schema confirms stable values.",
+        ).to_schema_extra(),
     )
 
 
@@ -322,42 +473,93 @@ class VLLMAttentionConfig(BaseModel):
     backend: str | None = Field(
         default=None,
         description="Attention backend: flash_attn, flashinfer, etc. (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E3"),
+            rationale="Attention kernel selection (flash_attn, flashinfer, triton, xformers); peer-validated.",
+            native_mapping="AttentionConfig.backend",
+            notes="Field name 'backend' preserved — sub-config is an abstraction layer, not a 1:1 EngineArgs mirror.",
+        ).to_schema_extra(),
     )
     flash_attn_version: int | None = Field(
         default=None,
         description="Flash attention version (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="v2 vs v3 differ in kernel structure → measurable energy delta.",
+            native_mapping="AttentionConfig.flash_attn_version",
+        ).to_schema_extra(),
     )
     flash_attn_max_num_splits_for_cuda_graph: int | None = Field(
         default=None,
         description="Max splits for CUDA graph with flash attention (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Controls CUDA-graph tiling of attention → throughput/energy tradeoff for long sequences.",
+            native_mapping="AttentionConfig.flash_attn_max_num_splits_for_cuda_graph",
+        ).to_schema_extra(),
     )
     use_prefill_decode_attention: bool | None = Field(
         default=None,
         description="Use prefill-decode attention (None -> True).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Routes prefill through decode kernel — different compute path, regime toggle.",
+            native_mapping="AttentionConfig.use_prefill_decode_attention",
+        ).to_schema_extra(),
     )
     use_prefill_query_quantization: bool | None = Field(
         default=None,
         description="Quantize queries during prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Quantises query tensor during prefill → energy/memory delta, regime toggle.",
+            native_mapping="AttentionConfig.use_prefill_query_quantization",
+        ).to_schema_extra(),
     )
     use_cudnn_prefill: bool | None = Field(
         default=None,
         description="Use cuDNN for prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Selects cuDNN vs FlashAttention for prefill — distinct kernel paths.",
+            native_mapping="AttentionConfig.use_cudnn_prefill",
+        ).to_schema_extra(),
     )
     disable_flashinfer_prefill: bool | None = Field(
         default=None,
         description="Disable FlashInfer for prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fallback when flashinfer prefill is active — changes kernel used.",
+            native_mapping="AttentionConfig.disable_flashinfer_prefill",
+        ).to_schema_extra(),
     )
     disable_flashinfer_q_quantization: bool | None = Field(
         default=None,
         description="Disable FlashInfer query quantization (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Disables an optimisation; straightforward energy/latency axis.",
+            native_mapping="AttentionConfig.disable_flashinfer_q_quantization",
+        ).to_schema_extra(),
     )
     use_trtllm_attention: bool | None = Field(
         default=None,
         description="Use TensorRT-LLM attention backend (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Routes attention through TRT-LLM kernel — regime-changing kernel path switch.",
+            native_mapping="AttentionConfig.use_trtllm_attention",
+        ).to_schema_extra(),
     )
     use_trtllm_ragged_deepseek_prefill: bool | None = Field(
         default=None,
         description="Use TRT-LLM ragged DeepSeek prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="TRT-LLM ragged prefill for DeepSeek architectures — distinct kernel path.",
+            native_mapping="AttentionConfig.use_trtllm_ragged_deepseek_prefill",
+        ).to_schema_extra(),
     )
 
 
@@ -382,6 +584,11 @@ class VLLMEngineConfig(BaseModel):
         description=(
             "GPU memory fraction for KV cache (None -> 0.9). Higher = more KV cache, less headroom."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary KV-cache sizing knob; MLPerf/AMD flag it. Mutually exclusive with kv_cache_memory_bytes.",
+            native_mapping="EngineArgs.gpu_memory_utilization",
+        ).to_schema_extra(),
     )
     swap_space: float | None = Field(
         default=None,
@@ -390,6 +597,11 @@ class VLLMEngineConfig(BaseModel):
             "CPU swap space in GiB for KV cache offloading (None -> 4). "
             "Enables model weight offload to prevent OOM."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="CPU-swap budget for KV cache — when exercised shifts KV blocks CPU↔GPU, real energy/latency regime.",
+            native_mapping="EngineArgs.swap_space",
+        ).to_schema_extra(),
     )
     cpu_offload_gb: float | None = Field(
         default=None,
@@ -398,6 +610,11 @@ class VLLMEngineConfig(BaseModel):
             "CPU RAM in GiB to offload model weights to (None -> 0, disabled). "
             "Reduces VRAM pressure at throughput cost."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Weight-offload regime — Optimum/Zhou flag offloading as a class.",
+            native_mapping="EngineArgs.cpu_offload_gb",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -410,6 +627,11 @@ class VLLMEngineConfig(BaseModel):
             "KV cache block size in tokens (None -> 16). "
             "Affects KV cache fragmentation and memory efficiency."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1", "E3"),
+            rationale="vLLM paper + KV survey; tractable 3-value enum.",
+            native_mapping="EngineArgs.block_size",
+        ).to_schema_extra(),
     )
     kv_cache_dtype: Literal["auto", "fp8", "fp8_e5m2", "fp8_e4m3"] | None = Field(
         default=None,
@@ -417,6 +639,13 @@ class VLLMEngineConfig(BaseModel):
             "KV cache storage dtype (None -> auto = model dtype). "
             "fp8 variants halve KV cache VRAM on Ampere+."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3", "E3"),
+            rationale=(
+                "Energy-NVML research flags as bias source (T3); MLPerf/AMD/vLLM/TRT all report it."
+            ),
+            native_mapping="EngineArgs.kv_cache_dtype",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -429,6 +658,11 @@ class VLLMEngineConfig(BaseModel):
             "Disable CUDA graphs, always use eager mode (None -> False). "
             "Eager mode: predictable latency, no graph compilation overhead."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="CUDA-graph regime switch.",
+            native_mapping="EngineArgs.enforce_eager",
+        ).to_schema_extra(),
     )
     enable_chunked_prefill: bool | None = Field(
         default=None,
@@ -436,6 +670,11 @@ class VLLMEngineConfig(BaseModel):
             "Chunk large prefills across multiple scheduler iterations (None -> False). "
             "Affects scheduling latency and throughput."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Scheduling regime switch; strong academic coverage (Yu/Orca, vLLM, Databricks).",
+            native_mapping="EngineArgs.enable_chunked_prefill",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -449,6 +688,11 @@ class VLLMEngineConfig(BaseModel):
             "Max concurrent sequences per scheduler iteration (None -> 256). "
             "Affects batch size and KV cache usage."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary scheduler axis in AMD-MLPerf vLLM submissions.",
+            native_mapping="EngineArgs.max_num_seqs",
+        ).to_schema_extra(),
     )
     max_num_batched_tokens: int | None = Field(
         default=None,
@@ -457,6 +701,11 @@ class VLLMEngineConfig(BaseModel):
             "Max tokens processed per scheduler iteration (None -> auto). "
             "Controls per-step compute budget."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary scheduler axis; controls per-step compute budget.",
+            native_mapping="EngineArgs.max_num_batched_tokens",
+        ).to_schema_extra(),
     )
     max_model_len: int | None = Field(
         default=None,
@@ -465,11 +714,21 @@ class VLLMEngineConfig(BaseModel):
             "Max sequence length in tokens (input + output). "
             "Overrides model config (None -> model default). Caps KV cache allocation."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="MLPerf core knob; caps KV-cache pre-allocation.",
+            native_mapping="EngineArgs.max_model_len",
+        ).to_schema_extra(),
     )
     num_scheduler_steps: int | None = Field(
         default=None,
         ge=1,
         description="Number of scheduler steps per iteration (multi-step scheduling, None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="AMD MLPerf v5.1 multi-step scheduling axis.",
+            native_mapping="EngineArgs.num_scheduler_steps",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -482,15 +741,30 @@ class VLLMEngineConfig(BaseModel):
         description=(
             "Tensor parallel degree — number of GPUs to shard the model across (None -> 1)."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3"),
+            rationale="Universal + energy-sampler-relevant (T3: must appear in results metadata).",
+            native_mapping="EngineArgs.tensor_parallel_size",
+        ).to_schema_extra(),
     )
     pipeline_parallel_size: int | None = Field(
         default=None,
         ge=1,
         description=("Pipeline parallel stages — memory per GPU changes with PP (None -> 1)."),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="NVIDIA MLPerf uses it; academic coverage.",
+            native_mapping="EngineArgs.pipeline_parallel_size",
+        ).to_schema_extra(),
     )
     distributed_executor_backend: Literal["mp", "ray"] | None = Field(
         default=None,
         description="Multi-GPU executor backend: 'mp' (multiprocessing) or 'ray' (None -> mp).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Multi-GPU dispatch regime toggle (mp vs ray) — different overhead profiles.",
+            native_mapping="EngineArgs.distributed_executor_backend",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -500,12 +774,22 @@ class VLLMEngineConfig(BaseModel):
     enable_prefix_caching: bool | None = Field(
         default=None,
         description="Automatic prefix caching for repeated shared prompts (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Strong academic + vLLM-paper evidence (SGLang RadixAttention parallel).",
+            native_mapping="EngineArgs.enable_prefix_caching",
+        ).to_schema_extra(),
     )
     quantization: (
         Literal["awq", "gptq", "fp8", "fp8_e5m2", "fp8_e4m3", "marlin", "bitsandbytes"] | None
     ) = Field(
         default=None,
         description="Quantization method. Requires pre-quantized model checkpoint.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3"),
+            rationale="Universal measurement axis; enum-validated.",
+            native_mapping="EngineArgs.quantization",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -516,6 +800,11 @@ class VLLMEngineConfig(BaseModel):
         default=None,
         ge=1,
         description="Maximum sequence length for CUDA graph capture (None -> 8192).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="CUDA-graph budget for long sequences; AMD MLPerf-derived.",
+            native_mapping="EngineArgs.max_seq_len_to_capture",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -528,6 +817,11 @@ class VLLMEngineConfig(BaseModel):
             "Speculative decoding configuration. Replaces flat speculative_model / "
             "num_speculative_tokens fields. Mirrors vLLM native speculative_config shape."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E2", "T5"),
+            rationale="Regime switch; typed sub-config for inner-field sweep discoverability (T5).",
+            native_mapping="EngineArgs.speculative_config",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -538,20 +832,40 @@ class VLLMEngineConfig(BaseModel):
         default=None,
         ge=0,
         description="Groups of layers for CPU offloading (None -> 0).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="CPU-offload grouping granularity — larger groups trade latency for throughput.",
+            native_mapping="EngineArgs.offload_group_size",
+        ).to_schema_extra(),
     )
     offload_num_in_group: int | None = Field(
         default=None,
         ge=1,
         description="Number of layers offloaded per group (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Controls how many params are offloaded per group — shifts memory/compute boundary.",
+            native_mapping="EngineArgs.offload_num_in_group",
+        ).to_schema_extra(),
     )
     offload_prefetch_step: int | None = Field(
         default=None,
         ge=0,
         description="Prefetch steps ahead for CPU offload (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Prefetch lookahead — directly affects hide-latency effectiveness of CPU offload.",
+            native_mapping="EngineArgs.offload_prefetch_step",
+        ).to_schema_extra(),
     )
     offload_params: list[str] | None = Field(
         default=None,
         description="Specific parameter names to offload to CPU (None -> all eligible).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Selects which parameter classes are offloaded — shifts the memory/compute boundary.",
+            native_mapping="EngineArgs.offload_params",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -561,6 +875,11 @@ class VLLMEngineConfig(BaseModel):
     disable_custom_all_reduce: bool | None = Field(
         default=None,
         description="Disable custom all-reduce for multi-GPU (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Forces fallback to NCCL-native all-reduce — affects collective-comm latency/energy on multi-GPU.",
+            native_mapping="EngineArgs.disable_custom_all_reduce",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -574,6 +893,12 @@ class VLLMEngineConfig(BaseModel):
             "Absolute KV cache size in bytes (None -> use gpu_memory_utilization). "
             "Mutually exclusive with gpu_memory_utilization."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E4"),
+            rationale="Alternative to gpu_memory_utilization; parse-time mutex already wired.",
+            native_mapping=None,
+            notes="Cross-cutting with validate_kv_cache_memory validator — coordinate changes.",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -586,6 +911,14 @@ class VLLMEngineConfig(BaseModel):
             "Full passthrough to vLLM CompilationConfig (~30 fields). "
             "No validation — passed directly."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "T4"),
+            rationale=(
+                "~30-field dict controlling CUDA-graph capture, fusions, what gets compiled "
+                "— major energy implications when varied. Opaque dict (T4)."
+            ),
+            native_mapping="EngineArgs.compilation_config",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -595,6 +928,11 @@ class VLLMEngineConfig(BaseModel):
     attention: VLLMAttentionConfig | None = Field(
         default=None,
         description="Attention implementation configuration.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="Attention backend and kernel toggles; nested for future flashinfer/cuDNN additions.",
+            native_mapping="EngineArgs.attention_backend (via sub-config mapping)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -647,6 +985,14 @@ class VLLMSamplingConfig(BaseModel):
         default=None,
         ge=0,
         description="Minimum output tokens before EOS is allowed (None -> 0, no minimum).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens "
+                "once Phase 49 migrates decoder per-engine."
+            ),
+            native_mapping="SamplingParams.min_tokens",
+        ).to_schema_extra(),
     )
     presence_penalty: float | None = Field(
         default=None,
@@ -656,6 +1002,11 @@ class VLLMSamplingConfig(BaseModel):
             "Presence penalty: penalises tokens that appear at all (None -> 0.0). "
             "Affects generation diversity."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="vLLM/TRT-native; not in DecoderConfig; routine in vLLM sampling studies.",
+            native_mapping="SamplingParams.presence_penalty",
+        ).to_schema_extra(),
     )
     frequency_penalty: float | None = Field(
         default=None,
@@ -665,6 +1016,11 @@ class VLLMSamplingConfig(BaseModel):
             "Frequency penalty: penalises tokens proportional to frequency (None -> 0.0). "
             "Affects repetition."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="vLLM/TRT-native; not in DecoderConfig.",
+            native_mapping="SamplingParams.frequency_penalty",
+        ).to_schema_extra(),
     )
     ignore_eos: bool | None = Field(
         default=None,
@@ -672,11 +1028,21 @@ class VLLMSamplingConfig(BaseModel):
             "Continue generating past EOS token (None -> False). "
             "Forces max_tokens generation every time — affects total token count."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fixed output length — measurement workload control.",
+            native_mapping="SamplingParams.ignore_eos",
+        ).to_schema_extra(),
     )
     n: int | None = Field(
         default=None,
         ge=1,
         description="Number of output sequences per prompt (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="n-sequences multiplier; vLLM-bench first-class.",
+            native_mapping="SamplingParams.n",
+        ).to_schema_extra(),
     )
 
 
@@ -698,14 +1064,29 @@ class VLLMBeamSearchConfig(BaseModel):
         default=None,
         ge=1,
         description="Number of beams (ge=1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Linear compute scaling; beam search is its own measurement regime.",
+            native_mapping="BeamSearchParams.beam_width",
+        ).to_schema_extra(),
     )
     length_penalty: float | None = Field(
         default=None,
         description="Length penalty: >1 favours shorter, <1 longer (None -> 1.0).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Tunes beam-search output length.",
+            native_mapping="BeamSearchParams.length_penalty",
+        ).to_schema_extra(),
     )
     early_stopping: bool | None = Field(
         default=None,
         description="Stop when beam_width complete sequences found (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Affects final token count.",
+            native_mapping="BeamSearchParams.early_stopping",
+        ).to_schema_extra(),
     )
 
 
@@ -794,10 +1175,21 @@ class TensorRTQuantConfig(BaseModel):
     ) = Field(
         default=None,
         description="Quantisation algorithm (native QuantAlgo enum name)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3", "E4"),
+            rationale="Universal axis + FP8-on-A100 hardware rail (E4); enum-validated.",
+            native_mapping="QuantConfig.quant_algo",
+            notes="FP8 requires SM >= 8.9 (Ada Lovelace+). A100 (SM80): use INT8/W4A16_AWQ/W8A16.",
+        ).to_schema_extra(),
     )
     kv_cache_quant_algo: Literal["FP8", "INT8"] | None = Field(
         default=None,
         description="KV cache quantisation algorithm (None -> no KV cache quantisation)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3", "E3"),
+            rationale="KV-cache quantisation; aligns with vLLM's kv_cache_dtype. Energy-measurement-biasing (T3).",
+            native_mapping="QuantConfig.kv_cache_quant_algo",
+        ).to_schema_extra(),
     )
 
 
@@ -809,22 +1201,42 @@ class TensorRTKvCacheConfig(BaseModel):
     enable_block_reuse: bool | None = Field(
         default=None,
         description="Enable KV cache block reuse (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="TRT's prefix-caching analog — regime toggle.",
+            native_mapping="KvCacheConfig.enable_block_reuse",
+        ).to_schema_extra(),
     )
     free_gpu_memory_fraction: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,
         description="Fraction of free GPU memory for KV cache (None -> 0.9)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="TRT's gpu_memory_utilization analog.",
+            native_mapping="KvCacheConfig.free_gpu_memory_fraction",
+        ).to_schema_extra(),
     )
     max_tokens: int | None = Field(
         default=None,
         ge=1,
         description="Maximum tokens in KV cache (None -> auto)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="KV-cache token cap → concurrency ceiling.",
+            native_mapping="KvCacheConfig.max_tokens",
+        ).to_schema_extra(),
     )
     host_cache_size: int | None = Field(
         default=None,
         ge=0,
         description="Host (CPU) cache size in bytes for KV cache offloading (None -> 0, disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="CPU KV-offload regime — cross-engine analog to vLLM swap_space.",
+            native_mapping="KvCacheConfig.host_cache_size",
+        ).to_schema_extra(),
     )
 
 
@@ -843,6 +1255,11 @@ class TensorRTSchedulerConfig(BaseModel):
     ) = Field(
         default=None,
         description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Scheduling regime (NO_EVICT vs MAX_UTIL vs STATIC_BATCH); stable 3-value enum.",
+            native_mapping="SchedulerConfig.capacity_scheduling_policy",
+        ).to_schema_extra(),
     )
 
 
@@ -862,15 +1279,33 @@ class TensorRTSamplingConfig(BaseModel):
         default=None,
         ge=0,
         description="Minimum output tokens before EOS allowed (None -> 0)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens "
+                "once Phase 49 migrates decoder per-engine."
+            ),
+            native_mapping="SamplingParams.min_tokens",
+        ).to_schema_extra(),
     )
     n: int | None = Field(
         default=None,
         ge=1,
         description="Number of output sequences per prompt (None -> 1)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="n-sequences multiplier.",
+            native_mapping="SamplingParams.n",
+        ).to_schema_extra(),
     )
     ignore_eos: bool | None = Field(
         default=None,
         description="Continue generating past EOS token (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fixed output length — measurement workload control.",
+            native_mapping="SamplingParams.ignore_eos",
+        ).to_schema_extra(),
     )
 
 
@@ -916,6 +1351,11 @@ class TensorRTConfig(BaseModel):
         default=None,
         ge=1,
         description="Max batch size (compile-time constant, None -> 8)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="MLPerf + trtllm-bench first-class; compile-time shape constant.",
+            native_mapping="TrtLlmArgs.max_batch_size",
+        ).to_schema_extra(),
     )
     tensor_parallel_size: int | None = Field(
         default=None,
@@ -925,36 +1365,74 @@ class TensorRTConfig(BaseModel):
             "Aligns with TrtLlmArgs.tensor_parallel_size. "
             "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3"),
+            rationale="Universal + energy-sampler-relevant (T3: must appear in results metadata).",
+            native_mapping="TrtLlmArgs.tensor_parallel_size",
+        ).to_schema_extra(),
     )
     pipeline_parallel_size: int | None = Field(
         default=None,
         ge=1,
         description="Pipeline parallel stages (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="NVIDIA MLPerf v5.0 Blackwell submissions surface PP size as a primary knob.",
+            native_mapping="TrtLlmArgs.pipeline_parallel_size",
+        ).to_schema_extra(),
     )
     max_input_len: int | None = Field(
         default=None,
         ge=1,
         description="Max input sequence length (compile-time constant, None -> 1024)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="Compile-time shape; MLPerf core knob.",
+            native_mapping="TrtLlmArgs.max_input_len",
+        ).to_schema_extra(),
     )
     max_seq_len: int | None = Field(
         default=None,
         ge=1,
         description="Max total sequence length (input + output, compile-time constant, None -> 2048)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="Compile-time shape; MLPerf core knob.",
+            native_mapping="TrtLlmArgs.max_seq_len",
+        ).to_schema_extra(),
     )
     max_num_tokens: int | None = Field(
         default=None,
         ge=1,
         description="Maximum number of tokens the engine can handle per iteration (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="trtllm-bench scheduler axis alongside max_batch_size.",
+            native_mapping="TrtLlmArgs.max_num_tokens",
+        ).to_schema_extra(),
     )
     dtype: Literal["float16", "bfloat16"] | None = Field(
         default=None,
         description=(
             "Model dtype (None -> auto). TRT-LLM is optimised for fp16/bf16; fp32 not supported."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("E4",),
+            rationale="TRT-LLM rejects fp32 — narrowed Literal is a parse-time safety rail (E4).",
+            native_mapping="TrtLlmArgs.dtype",
+        ).to_schema_extra(),
     )
     fast_build: bool | None = Field(
         default=None,
         description="Enable fast engine build mode (reduced optimisation, None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Skips some build-time optimisations → the produced engine may be less efficient "
+                "at runtime → measurable energy/throughput delta."
+            ),
+            native_mapping="TrtLlmArgs.fast_build",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -964,16 +1442,36 @@ class TensorRTConfig(BaseModel):
     quant: TensorRTQuantConfig | None = Field(
         default=None,
         description="Quantisation configuration (QuantConfig)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Quantisation algorithm and KV-cache quantisation sub-config.",
+            native_mapping="TrtLlmArgs.quant_config → QuantConfig",
+        ).to_schema_extra(),
     )
     kv_cache: TensorRTKvCacheConfig | None = Field(
         default=None,
         description="KV cache configuration",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="KV-cache configuration (memory fraction, block reuse, host offload).",
+            native_mapping="TrtLlmArgs.kv_cache_config → KvCacheConfig",
+        ).to_schema_extra(),
     )
     scheduler: TensorRTSchedulerConfig | None = Field(
         default=None,
         description="Scheduler configuration",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Scheduling capacity policy sub-config.",
+            native_mapping="TrtLlmArgs.scheduler_config → SchedulerConfig",
+        ).to_schema_extra(),
     )
     sampling: TensorRTSamplingConfig | None = Field(
         default=None,
         description="Sampling configuration (TRT-LLM-specific SamplingParams extensions)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="TRT-LLM-specific sampling parameters sub-config.",
+            native_mapping="TrtLlmArgs → SamplingParams",
+        ).to_schema_extra(),
     )

--- a/tests/unit/config/test_config_schema.py
+++ b/tests/unit/config/test_config_schema.py
@@ -632,3 +632,66 @@ def test_n_prompts_default_is_100() -> None:
     from llenergymeasure.config.models import DatasetConfig
 
     assert DatasetConfig().n_prompts == 100
+
+
+# ---------------------------------------------------------------------------
+# CurationMetadata presence assertion (C.2)
+# ---------------------------------------------------------------------------
+
+
+def test_every_typed_engine_field_has_curation_metadata() -> None:
+    """Every typed field in engine_configs.py carries CurationMetadata.
+
+    This is the CI gate introduced in Phase 48 Plan C.2. A field that lacks
+    CurationMetadata was added without a rubric verdict and must be fixed.
+    """
+    from llenergymeasure.config.engine_configs import (
+        TensorRTConfig,
+        TensorRTKvCacheConfig,
+        TensorRTQuantConfig,
+        TensorRTSamplingConfig,
+        TensorRTSchedulerConfig,
+        TransformersConfig,
+        VLLMAttentionConfig,
+        VLLMBeamSearchConfig,
+        VLLMEngineConfig,
+        VLLMSamplingConfig,
+        VLLMSpeculativeConfig,
+    )
+
+    engine_models = [
+        TransformersConfig,
+        VLLMSpeculativeConfig,
+        VLLMAttentionConfig,
+        VLLMEngineConfig,
+        VLLMSamplingConfig,
+        VLLMBeamSearchConfig,
+        TensorRTQuantConfig,
+        TensorRTKvCacheConfig,
+        TensorRTSchedulerConfig,
+        TensorRTSamplingConfig,
+        TensorRTConfig,
+    ]
+
+    missing: list[str] = []
+    for model_cls in engine_models:
+        for name, info in model_cls.model_fields.items():
+            extra = info.json_schema_extra
+            if not isinstance(extra, dict):
+                missing.append(
+                    f"{model_cls.__name__}.{name}: json_schema_extra not a dict ({extra!r})"
+                )
+                continue
+            curation = extra.get("curation")
+            if curation is None:
+                missing.append(f"{model_cls.__name__}.{name}: missing 'curation' key")
+                continue
+            if not curation.get("clauses"):
+                missing.append(f"{model_cls.__name__}.{name}: CurationMetadata.clauses is empty")
+            if not curation.get("rationale"):
+                missing.append(f"{model_cls.__name__}.{name}: CurationMetadata.rationale is empty")
+
+    assert not missing, (
+        f"{len(missing)} engine config field(s) missing CurationMetadata:\n"
+        + "\n".join(f"  {m}" for m in missing)
+    )


### PR DESCRIPTION
## Summary

Stacked on #270. Adds the `CurationMetadata` structured-justification dataclass and decorates every typed engine Field with a rubric verdict. Planned in §D7.2.1 of the Plan-C phase-48 design as scaffolding for Plan E's generated inclusion/exclusion doc.

**Status: draft — shape is intentionally open.** Plan E's generator does not exist yet, so the exact shape of the structured metadata (clauses enum, `native_mapping`, `notes` field, CI gate) should be revisited when the consumer lands, not frozen now. Keeping this as a draft review vehicle for the scaffolding pattern while the rest of Plan C lands on main.

## What this adds, on top of #270

- **`src/llenergymeasure/config/curation.py`** — `CurationMetadata` frozen dataclass (clauses, rationale, native_mapping, notes) + `RubricClause` Literal. Attached to Fields via `json_schema_extra`. Return type on `to_schema_extra()` is `dict[str, Any]` to satisfy Pydantic's `JsonDict` contract.
- **Decorations on every typed field** in `engine_configs.py` across Transformers / vLLM engine / attention / sampling / beam_search / speculative sub-configs, and TensorRT engine / quant / kv_cache / scheduler / sampling sub-configs.
- **CI gate**: `test_every_typed_engine_field_has_curation_metadata` asserts every typed field carries a non-empty `clauses` + `rationale`.
- **CHANGELOG entry** under Added.

## CI status

This PR currently targets `feature/phase-48-2b-curation-adjust` (branch A, PR #270), not `main`. The repo's CI workflows filter on `pull_request: branches: [main]`, so the standard CI suite does not fire on this PR while stacked. Once #270 merges to main, this PR's base auto-retargets to main and CI fires automatically.

Locally verified on this branch:
- [x] `uv run pytest tests/unit/config tests/unit/engines -q` — 442 passed (441 from #270 + the new gate test)
- [x] `uv run mypy src/` — clean
- [x] ruff lint + format clean

To force-run CI on this branch before #270 merges: `gh workflow run ci.yml --ref feature/phase-48-2c-curation-metadata -f job=all`.

## Depends on

- #270 (the narrowed drops/adds). Base will auto-retarget to `main` once #270 merges.

## Sibling: #274 (independent — `trust_remote_code` env var)

Independent off-main. Doesn't interact with this PR — #274 touches `engines/{transformers,vllm}.py`, `harness/flops.py`, and `utils/security.py`; this PR touches `config/{curation,engine_configs}.py` and `tests/unit/config/test_config_schema.py`. No file overlap.

## Open questions for Plan E / future review

1. Are the rubric `clauses` codes (R1/R2/E1-4/D1-4/T1-5) actually load-bearing for the downstream generator, or is free-text `rationale` sufficient? If the generator never filters by clause, the Literal is dead weight.
2. Is the CI presence gate useful without a quality gate, given `extra="allow"` bypasses it?
3. Should `native_mapping` live on every field (even engine-local ones where it's None) or only where there's an actual native counterpart?
4. Should the dataclass survive as-is, or collapse into a richer `description=` string once Plan E's shape is known?