### PR TITLE
feat(security): make trust_remote_code opt-in via LLEM_TRUST_REMOTE_CODE env var

### DIFF
--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -74,8 +74,10 @@ class TransformersEngine:
         kwargs = self._model_load_kwargs(config)
         logger.info("Loading model %r with kwargs: %s", config.model, list(kwargs.keys()))
 
-        # trust_remote_code for tokenizer — respects config, defaults True
-        trust = True
+        from llenergymeasure.utils.security import trust_remote_code_enabled
+
+        # trust_remote_code precedence: typed field > LLEM_TRUST_REMOTE_CODE env var > False
+        trust = trust_remote_code_enabled()
         if config.transformers is not None and config.transformers.trust_remote_code is not None:
             trust = config.transformers.trust_remote_code
 
@@ -297,11 +299,13 @@ class TransformersEngine:
         else:
             kwargs["device_map"] = "auto"
 
-        # Trust remote code — default True unless researcher overrides
+        from llenergymeasure.utils.security import trust_remote_code_enabled
+
+        # trust_remote_code precedence: typed field > LLEM_TRUST_REMOTE_CODE env var > False
         if pt is not None and pt.trust_remote_code is not None:
             kwargs["trust_remote_code"] = pt.trust_remote_code
         else:
-            kwargs["trust_remote_code"] = True
+            kwargs["trust_remote_code"] = trust_remote_code_enabled()
 
         # Apply Transformers-specific config options
         if pt is not None:

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -287,10 +287,12 @@ class VLLMEngine:
 
     def _build_llm_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
         """Build kwargs dict for vllm.LLM() constructor."""
+        from llenergymeasure.utils.security import trust_remote_code_enabled
+
         kwargs: dict[str, Any] = {
             "model": config.model,
             "dtype": config.dtype,
-            "trust_remote_code": True,
+            "trust_remote_code": trust_remote_code_enabled(),
             "seed": config.random_seed,
         }
 

--- a/src/llenergymeasure/harness/flops.py
+++ b/src/llenergymeasure/harness/flops.py
@@ -77,7 +77,9 @@ def _count_params_from_config(model_name: str) -> int | None:
     try:
         from transformers import AutoConfig
 
-        cfg = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+        from llenergymeasure.utils.security import trust_remote_code_enabled
+
+        cfg = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code_enabled())
         h = cfg.hidden_size
         layers = cfg.num_hidden_layers
         intermediate = getattr(cfg, "intermediate_size", h * 4)

--- a/src/llenergymeasure/utils/security.py
+++ b/src/llenergymeasure/utils/security.py
@@ -1,8 +1,33 @@
 """Security utilities for llenergymeasure."""
 
+import os
 from pathlib import Path
+from typing import Final
 
 from llenergymeasure.utils.exceptions import ConfigError
+
+ENV_TRUST_REMOTE_CODE: Final = "LLEM_TRUST_REMOTE_CODE"
+"""Opt-in for HuggingFace `trust_remote_code=True`. Unset → HF default (False).
+
+Phase 51+ is expected to centralise env-var registration (likely in
+``config/ssot.py``) once layer rules permit; for now the constant lives here
+because ``utils/`` cannot import from ``config/``.
+"""
+
+
+def trust_remote_code_enabled() -> bool:
+    """Return whether HuggingFace `trust_remote_code` should be enabled.
+
+    Reads ``LLEM_TRUST_REMOTE_CODE`` from the environment. Treats
+    ``1``/``true``/``yes``/``on`` (case-insensitive) as True; anything else
+    (including unset) as False — matching HuggingFace's own default.
+
+    Setting True allows loading models that ship custom Python implementations
+    (Qwen, DeepSeek, ChatGLM, etc.) at the cost of executing repo-supplied
+    code. Phase 51+ is expected to surface this through a typed config field
+    or CLI flag; this helper is the interim single source of truth.
+    """
+    return os.environ.get(ENV_TRUST_REMOTE_CODE, "").lower() in {"1", "true", "yes", "on"}
 
 
 def validate_path(path: Path, must_exist: bool = False, allow_relative: bool = True) -> Path:

--- a/tests/unit/engines/test_engine_protocol.py
+++ b/tests/unit/engines/test_engine_protocol.py
@@ -155,6 +155,21 @@ def test_model_load_kwargs_contains_base_keys():
 
     assert "torch_dtype" in kwargs
     assert kwargs["device_map"] == "auto"
+    # HF default — env var LLEM_TRUST_REMOTE_CODE not set, no typed override
+    assert kwargs["trust_remote_code"] is False
+
+
+def test_model_load_kwargs_trust_remote_code_env_var_opt_in(monkeypatch):
+    """LLEM_TRUST_REMOTE_CODE=1 enables trust_remote_code=True at the model load."""
+    pytest.importorskip("torch")
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    monkeypatch.setenv("LLEM_TRUST_REMOTE_CODE", "1")
+    engine = TransformersEngine()
+    config = ExperimentConfig(model="gpt2")
+    kwargs = engine._model_load_kwargs(config)
+
     assert kwargs["trust_remote_code"] is True
 
 

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -130,9 +130,19 @@ class TestBuildLlmKwargs:
         kwargs = engine._build_llm_kwargs(config)
 
         assert kwargs["model"] == "test-model"
-        assert kwargs["trust_remote_code"] is True
+        # HF default — env var LLEM_TRUST_REMOTE_CODE not set
+        assert kwargs["trust_remote_code"] is False
         assert kwargs["seed"] == 42
         assert "dtype" in kwargs
+
+    def test_trust_remote_code_env_var_opt_in(self, monkeypatch):
+        """LLEM_TRUST_REMOTE_CODE=1 enables trust_remote_code=True."""
+        monkeypatch.setenv("LLEM_TRUST_REMOTE_CODE", "1")
+        config = make_config(**_VLLM_DEFAULTS)
+        engine = VLLMEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert kwargs["trust_remote_code"] is True
 
     def test_minimal_config_dtype_passthrough(self):
         """Default dtype (bfloat16) passes through in kwargs."""


### PR DESCRIPTION
## Summary

Removes silent override of HuggingFace's `trust_remote_code=False` default. The four sites that previously hardcoded `True` now read `LLEM_TRUST_REMOTE_CODE` from the environment.

**Why this PR exists.** Audit during PR #270 surfaced four hardcoded `trust_remote_code=True` sites in source. That defaulted the tool to permitting arbitrary code execution from any HF repo (custom-arch models like Qwen, DeepSeek, ChatGLM ship Python that gets `exec()`'d on load) without the user opting in. HF's own default is `False` precisely because it's RCE-on-load.

**Status: preparatory.** Phase 51+ will design proper env/user config (likely typed Pydantic + CLI flag + ssot constant). This is the interim single source of truth so there's one place to migrate from.

## What changes

- New helper `utils.security.trust_remote_code_enabled()` reads `LLEM_TRUST_REMOTE_CODE`. Truthy values (`1`, `true`, `yes`, `on`, case-insensitive) → True; anything else / unset → False (matches HF default).
- New constant `ENV_TRUST_REMOTE_CODE = "LLEM_TRUST_REMOTE_CODE"` lives in `utils/security.py` (not `config/ssot.py`) because import-linter forbids `utils/` → `config/`. Phase 51+ can re-home it.
- Four sites updated:
  - `engines/transformers.py` tokenizer load (preserves typed-field override precedence: `pt.trust_remote_code` > env var > False)
  - `engines/transformers.py` model load kwargs (same precedence)
  - `engines/vllm.py` `_build_llm_kwargs` (env var > False; vLLM has no typed field for this)
  - `harness/flops.py` `_compute_param_count_via_autoconfig` (env var > False)
- Two existing tests updated to expect the new default. Two new tests cover the env-var opt-in path.

## Behavior change

Users running **custom-architecture models** (Qwen, DeepSeek, ChatGLM, Phi-2, Yi, InternLM, many MoE / VLM models) must now either:
- Export `LLEM_TRUST_REMOTE_CODE=1` in their environment, or
- Set `trust_remote_code: true` under `transformers:` in their YAML (typed-field path).

Without one of these, HF will raise its standard `ValueError("Loading X requires you to execute custom code...")` at load time. The error is descriptive — users will know what to do.

**Built-in architectures** (Llama, Mistral, Gemma, GPT-2, etc.) are unaffected — they don't need `trust_remote_code` either way.

## Independence

Targets `main`. Doesn't depend on #270 or #273. Can land in any order. Once it lands and #270 lands too, the typed-field override logic on `transformers.trust_remote_code` becomes dead code (PR #270 drops the typed field) — at which point both consumer sites collapse to a single env-var read. That cleanup happens automatically as part of #270's drop.

## Test plan

- [x] `uv run pytest tests/unit -q` — full unit suite passes
- [x] `uv run mypy src/` — clean
- [x] `uv run lint-imports` — layer rules satisfied
- [x] `uv run ruff check src/ tests/` — clean
- [x] New tests verify both default-False and env-var-True paths