### PR TITLE
feat(config): add .env-based runtime config + configurable device_map default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,10 +85,10 @@ LLEM_TRUST_REMOTE_CODE=
 
 # ─── HuggingFace `device_map` (transformers engine) ──────────────────────────
 # Library default: None (model loads to CPU only). For a multi-GPU benchmark
-# tool we override this — without it, runs on multi-GPU rigs load to CPU and
+# tool we override this �� without it, runs on multi-GPU rigs load to CPU and
 # benchmark numbers are meaningless. Empty → library default. Other values:
 # "balanced", "balanced_low_0", "sequential".
-LLEM_DEFAULT_DEVICE_MAP=auto
+LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto
 
 # ─── TRT-LLM build cache (tensorrt engine) ───────────────────────────────────
 # Library default: disabled. We override to enabled — engine compilation takes

--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,39 @@ BUILDKIT_PROGRESS=plain
 # OMP_NUM_THREADS=4
 # TOKENIZERS_PARALLELISM=false
 # CODECARBON_LOG_LEVEL=warning
+
+# =============================================================================
+# LLenergyMeasure — library-default overrides (LLEM_*)
+# =============================================================================
+# These env vars override inference-library defaults that llem adjusts out-of-
+# the-box for benchmarking ergonomics. Helpers in src/llenergymeasure/utils/
+# env_config.py read these; empty / unset values fall through to the library's
+# own default (i.e. no override applied). Copy this file to `.env` to activate.
+#
+# For sweepable per-experiment knobs (dtype, max_batch_size, tensorrt.backend,
+# etc.) see docs/engines.md — those live in the YAML config, not here.
+# -----------------------------------------------------------------------------
+
+# ─── HuggingFace `trust_remote_code` ─────────────────────────────────────────
+# Library default: False (refuses to load custom-arch repos like Qwen,
+# DeepSeek, ChatGLM). We do NOT ship a permissive default — RCE consent
+# should be deliberate. Set to 1 to opt in for custom-architecture models.
+LLEM_TRUST_REMOTE_CODE=
+
+# ─── HuggingFace `device_map` (transformers engine) ──────────────────────────
+# Library default: None (model loads to CPU only). For a multi-GPU benchmark
+# tool we override this — without it, runs on multi-GPU rigs load to CPU and
+# benchmark numbers are meaningless. Empty → library default. Other values:
+# "balanced", "balanced_low_0", "sequential".
+LLEM_DEFAULT_DEVICE_MAP=auto
+
+# ─── TRT-LLM build cache (tensorrt engine) ───────────────────────────────────
+# Library default: disabled. We override to enabled — engine compilation takes
+# minutes; cache saves hours over a study. Set to 0 (or leave empty) to match
+# the library default.
+LLEM_TRT_BUILD_CACHE_ENABLED=1
+
+# Optional cache directory. Empty → TRT-LLM's internal default location
+# (~/.cache/tensorrt_llm/). Override when the default location is read-only
+# or full (shared filesystems, scratch dirs, etc.).
+LLEM_TRT_BUILD_CACHE_PATH=

--- a/src/llenergymeasure/cli/__init__.py
+++ b/src/llenergymeasure/cli/__init__.py
@@ -4,12 +4,22 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import Annotated
 
-import typer
+from dotenv import load_dotenv
 
-from llenergymeasure._version import __version__
-from llenergymeasure.config.ssot import ENV_LOG_LEVEL
+# Load `.env` from the user's CWD before any other imports read env vars
+# (e.g. logging setup reads LLEM_LOG_LEVEL). Anchoring to Path.cwd() rather
+# than dotenv's default walk-up-from-__file__ is deliberate: once llem is
+# pip-installed the module sits under site-packages and the walk-up never
+# reaches the user's project directory. override=False so shell env wins.
+load_dotenv(dotenv_path=Path.cwd() / ".env", override=False)
+
+import typer  # noqa: E402
+
+from llenergymeasure._version import __version__  # noqa: E402
+from llenergymeasure.config.ssot import ENV_LOG_LEVEL  # noqa: E402
 
 app = typer.Typer(
     name="llem",

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -303,7 +303,7 @@ class TransformersEngine:
         elif pt is not None and pt.device_map is not None:
             kwargs["device_map"] = pt.device_map
         else:
-            # Precedence: typed pt.device_map (above) > LLEM_DEFAULT_DEVICE_MAP
+            # Precedence: typed pt.device_map (above) > LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP
             # env var (set by .env) > HF default (None = CPU). Helper is pure
             # passthrough; .env.example ships `=auto` as the opinionated default.
             dm = default_device_map()

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -290,6 +290,9 @@ class TransformersEngine:
 
         pt = config.transformers
 
+        from llenergymeasure.utils.env_config import default_device_map
+        from llenergymeasure.utils.security import trust_remote_code_enabled
+
         # Device placement / tensor parallelism — mutually exclusive
         if pt is not None and pt.tp_plan is not None:
             # Tensor parallelism: tp_plan replaces device_map entirely
@@ -300,9 +303,12 @@ class TransformersEngine:
         elif pt is not None and pt.device_map is not None:
             kwargs["device_map"] = pt.device_map
         else:
-            kwargs["device_map"] = "auto"
-
-        from llenergymeasure.utils.security import trust_remote_code_enabled
+            # Precedence: typed pt.device_map (above) > LLEM_DEFAULT_DEVICE_MAP
+            # env var (set by .env) > HF default (None = CPU). Helper is pure
+            # passthrough; .env.example ships `=auto` as the opinionated default.
+            dm = default_device_map()
+            if dm is not None:
+                kwargs["device_map"] = dm
 
         kwargs["trust_remote_code"] = trust_remote_code_enabled()
 

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -1,0 +1,46 @@
+"""Env-var helpers for opinionated runtime defaults.
+
+This module is the canonical location for ``LLEM_*`` env-var constants and
+the thin passthrough helpers that read them. Helpers are pure — they return
+``os.environ.get(...)`` (or a parsed form) and return ``None`` / ``False``
+when unset, deferring to each inference library's own default.
+
+Opinionated defaults (e.g. ``LLEM_DEFAULT_DEVICE_MAP=auto``) live in the
+repo-root ``.env.example`` — the single reviewable source of truth for what
+llem overrides out-of-the-box. Users copy ``.env.example`` to ``.env`` (auto-
+loaded by the CLI) and edit to taste. Because helpers have no baked-in
+defaults, removing a line from ``.env`` always restores the library default.
+
+Layer: ``utils/`` (Layer 0). Cannot import ``config/``. This module is
+consumed by engine plugins in Layer 2.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+ENV_DEFAULT_DEVICE_MAP: Final = "LLEM_DEFAULT_DEVICE_MAP"
+"""Override for the HuggingFace ``device_map`` argument at model load.
+
+Unset / empty → ``None`` (caller omits the kwarg; HuggingFace's own default
+applies, which is CPU-only). Any non-empty value is forwarded as-is
+(e.g. ``auto``, ``balanced``, ``sequential``). The opinionated default
+``auto`` is shipped via ``.env.example`` — not baked into this helper.
+"""
+
+
+def default_device_map() -> str | None:
+    """Return the configured default ``device_map`` or ``None`` if unset.
+
+    Pure passthrough: no opinionated default is baked in. The repo-root
+    ``.env.example`` ships ``LLEM_DEFAULT_DEVICE_MAP=auto`` so that the
+    out-of-the-box experience on multi-GPU hosts is ``device_map="auto"``;
+    deleting the line from a user's ``.env`` reverts to HuggingFace's own
+    default (``None`` = CPU-only).
+
+    Callers typically apply typed-config precedence first (e.g. the
+    ``transformers.device_map`` field in YAML), then fall back to this
+    helper. If this returns ``None``, callers should omit the kwarg.
+    """
+    return os.environ.get(ENV_DEFAULT_DEVICE_MAP) or None

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -5,7 +5,7 @@ the thin passthrough helpers that read them. Helpers are pure — they return
 ``os.environ.get(...)`` (or a parsed form) and return ``None`` / ``False``
 when unset, deferring to each inference library's own default.
 
-Opinionated defaults (e.g. ``LLEM_DEFAULT_DEVICE_MAP=auto``) live in the
+Opinionated defaults (e.g. ``LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto``) live in the
 repo-root ``.env.example`` — the single reviewable source of truth for what
 llem overrides out-of-the-box. Users copy ``.env.example`` to ``.env`` (auto-
 loaded by the CLI) and edit to taste. Because helpers have no baked-in
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 from typing import Final
 
-ENV_DEFAULT_DEVICE_MAP: Final = "LLEM_DEFAULT_DEVICE_MAP"
+ENV_TRANSFORMERS_DEFAULT_DEVICE_MAP: Final = "LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP"
 """Override for the HuggingFace ``device_map`` argument at model load.
 
 Unset / empty → ``None`` (caller omits the kwarg; HuggingFace's own default
@@ -34,7 +34,7 @@ def default_device_map() -> str | None:
     """Return the configured default ``device_map`` or ``None`` if unset.
 
     Pure passthrough: no opinionated default is baked in. The repo-root
-    ``.env.example`` ships ``LLEM_DEFAULT_DEVICE_MAP=auto`` so that the
+    ``.env.example`` ships ``LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto`` so that the
     out-of-the-box experience on multi-GPU hosts is ``device_map="auto"``;
     deleting the line from a user's ``.env`` reverts to HuggingFace's own
     default (``None`` = CPU-only).
@@ -43,4 +43,4 @@ def default_device_map() -> str | None:
     ``transformers.device_map`` field in YAML), then fall back to this
     helper. If this returns ``None``, callers should omit the kwarg.
     """
-    return os.environ.get(ENV_DEFAULT_DEVICE_MAP) or None
+    return os.environ.get(ENV_TRANSFORMERS_DEFAULT_DEVICE_MAP) or None

--- a/tests/unit/cli/test_cli_display.py
+++ b/tests/unit/cli/test_cli_display.py
@@ -487,8 +487,10 @@ def test_print_study_dry_run_vram_peak(capsys, monkeypatch):
         call_count += 1
         return vram_small if call_count == 1 else vram_large
 
-    monkeypatch.setattr("llenergymeasure.cli._vram.estimate_vram", mock_estimate)
-    monkeypatch.setattr("llenergymeasure.cli._vram.get_gpu_vram_gb", lambda: 40.0)
+    import llenergymeasure.cli._vram as _vram_mod
+
+    monkeypatch.setattr(_vram_mod, "estimate_vram", mock_estimate)
+    monkeypatch.setattr(_vram_mod, "get_gpu_vram_gb", lambda: 40.0)
 
     print_study_dry_run(study)
     out = capsys.readouterr().out

--- a/tests/unit/cli/test_dotenv_loading.py
+++ b/tests/unit/cli/test_dotenv_loading.py
@@ -1,0 +1,60 @@
+"""Verify that the CLI module auto-loads `.env` at import time."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Chdir to a tmp dir, drop CLI modules from sys.modules for fresh reimport.
+
+    Uses ``monkeypatch.delitem`` so each touched ``sys.modules`` entry is
+    restored at teardown — a raw ``del sys.modules[...]`` would leak the
+    reimport across subsequent tests and cause test-pollution failures
+    (e.g. preflight spec lookups returning None in unrelated CLI tests).
+    """
+    monkeypatch.chdir(tmp_path)
+    for modname in list(sys.modules):
+        if modname == "llenergymeasure.cli" or modname.startswith("llenergymeasure.cli."):
+            monkeypatch.delitem(sys.modules, modname)
+    return tmp_path
+
+
+def test_cli_import_loads_dotenv_from_cwd(
+    isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `.env` in CWD should be loaded when the CLI module is imported."""
+    (isolated_env / ".env").write_text("LLEM_TEST_DOTENV_SENTINEL=loaded-from-file\n")
+    monkeypatch.delenv("LLEM_TEST_DOTENV_SENTINEL", raising=False)
+
+    importlib.import_module("llenergymeasure.cli")
+
+    assert os.environ.get("LLEM_TEST_DOTENV_SENTINEL") == "loaded-from-file"
+
+
+def test_shell_env_wins_over_dotenv_file(
+    isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """override=False means a pre-existing shell env var must win."""
+    (isolated_env / ".env").write_text("LLEM_TEST_DOTENV_OVERRIDE=from-file\n")
+    monkeypatch.setenv("LLEM_TEST_DOTENV_OVERRIDE", "from-shell")
+
+    importlib.import_module("llenergymeasure.cli")
+
+    assert os.environ["LLEM_TEST_DOTENV_OVERRIDE"] == "from-shell"
+
+
+def test_no_dotenv_file_does_not_raise(isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing `.env` must not fail CLI import."""
+    assert not (isolated_env / ".env").exists()
+    monkeypatch.delenv("LLEM_TEST_DOTENV_MISSING", raising=False)
+
+    importlib.import_module("llenergymeasure.cli")
+
+    assert "LLEM_TEST_DOTENV_MISSING" not in os.environ

--- a/tests/unit/engines/test_engine_protocol.py
+++ b/tests/unit/engines/test_engine_protocol.py
@@ -143,12 +143,18 @@ def test_detect_default_engine_error_message_has_install_hint():
 # =============================================================================
 
 
-def test_model_load_kwargs_contains_base_keys():
-    """_model_load_kwargs always includes torch_dtype, device_map, trust_remote_code."""
+def test_model_load_kwargs_contains_base_keys(monkeypatch):
+    """_model_load_kwargs always includes torch_dtype and trust_remote_code.
+
+    device_map is present only when LLEM_DEFAULT_DEVICE_MAP is set — simulate
+    the production default (``.env`` loaded, ``LLEM_DEFAULT_DEVICE_MAP=auto``)
+    via monkeypatch so the assertion does not depend on the test host's env.
+    """
     pytest.importorskip("torch")
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
+    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "auto")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2")
     kwargs = engine._model_load_kwargs(config)
@@ -157,6 +163,48 @@ def test_model_load_kwargs_contains_base_keys():
     assert kwargs["device_map"] == "auto"
     # HF default — env var LLEM_TRUST_REMOTE_CODE not set, no typed override
     assert kwargs["trust_remote_code"] is False
+
+
+def test_device_map_absent_when_env_unset(monkeypatch):
+    """With LLEM_DEFAULT_DEVICE_MAP unset, helper returns None and kwarg is omitted."""
+    pytest.importorskip("torch")
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    monkeypatch.delenv("LLEM_DEFAULT_DEVICE_MAP", raising=False)
+    engine = TransformersEngine()
+    config = ExperimentConfig(model="gpt2")
+    kwargs = engine._model_load_kwargs(config)
+
+    assert "device_map" not in kwargs
+
+
+def test_device_map_env_var_override(monkeypatch):
+    """LLEM_DEFAULT_DEVICE_MAP=balanced → kwargs['device_map'] == 'balanced'."""
+    pytest.importorskip("torch")
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "balanced")
+    engine = TransformersEngine()
+    config = ExperimentConfig(model="gpt2")
+    kwargs = engine._model_load_kwargs(config)
+
+    assert kwargs["device_map"] == "balanced"
+
+
+def test_device_map_env_var_empty_is_unset(monkeypatch):
+    """LLEM_DEFAULT_DEVICE_MAP='' is treated as unset: kwarg absent, HF default applies."""
+    pytest.importorskip("torch")
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "")
+    engine = TransformersEngine()
+    config = ExperimentConfig(model="gpt2")
+    kwargs = engine._model_load_kwargs(config)
+
+    assert "device_map" not in kwargs
 
 
 def test_model_load_kwargs_trust_remote_code_env_var_opt_in(monkeypatch):
@@ -201,12 +249,17 @@ def test_model_load_kwargs_passthrough_can_override_defaults():
     assert kwargs["device_map"] == "cpu"
 
 
-def test_model_load_kwargs_no_passthrough_when_none():
-    """No extra keys added when passthrough_kwargs is None."""
+def test_model_load_kwargs_no_passthrough_when_none(monkeypatch):
+    """No extra keys added when passthrough_kwargs is None.
+
+    Sets LLEM_DEFAULT_DEVICE_MAP=auto to mimic the production .env state so
+    device_map appears in the expected-keys set.
+    """
     pytest.importorskip("torch")
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
+    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "auto")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2")  # passthrough_kwargs=None by default
     kwargs = engine._model_load_kwargs(config)
@@ -619,13 +672,18 @@ def test_model_load_kwargs_tp_plan_and_tp_size_forwarded():
     assert "device_map" not in kwargs
 
 
-def test_model_load_kwargs_tp_size_without_tp_plan_ignored():
-    """With TransformersConfig(tp_size=4) and no tp_plan, tp_size is not in kwargs and device_map defaults."""
+def test_model_load_kwargs_tp_size_without_tp_plan_ignored(monkeypatch):
+    """With TransformersConfig(tp_size=4) and no tp_plan, tp_size is not in kwargs and device_map defaults.
+
+    Sets LLEM_DEFAULT_DEVICE_MAP=auto explicitly to mimic the production .env state,
+    since the helper is now pure passthrough (unset → None → kwarg omitted).
+    """
     pytest.importorskip("torch")
     from llenergymeasure.config.engine_configs import TransformersConfig
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
+    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "auto")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2", transformers=TransformersConfig(tp_size=4))
     kwargs = engine._model_load_kwargs(config)

--- a/tests/unit/engines/test_engine_protocol.py
+++ b/tests/unit/engines/test_engine_protocol.py
@@ -146,15 +146,15 @@ def test_detect_default_engine_error_message_has_install_hint():
 def test_model_load_kwargs_contains_base_keys(monkeypatch):
     """_model_load_kwargs always includes torch_dtype and trust_remote_code.
 
-    device_map is present only when LLEM_DEFAULT_DEVICE_MAP is set — simulate
-    the production default (``.env`` loaded, ``LLEM_DEFAULT_DEVICE_MAP=auto``)
+    device_map is present only when LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP is set — simulate
+    the production default (``.env`` loaded, ``LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto``)
     via monkeypatch so the assertion does not depend on the test host's env.
     """
     pytest.importorskip("torch")
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
-    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "auto")
+    monkeypatch.setenv("LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP", "auto")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2")
     kwargs = engine._model_load_kwargs(config)
@@ -166,12 +166,12 @@ def test_model_load_kwargs_contains_base_keys(monkeypatch):
 
 
 def test_device_map_absent_when_env_unset(monkeypatch):
-    """With LLEM_DEFAULT_DEVICE_MAP unset, helper returns None and kwarg is omitted."""
+    """With LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP unset, helper returns None and kwarg is omitted."""
     pytest.importorskip("torch")
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
-    monkeypatch.delenv("LLEM_DEFAULT_DEVICE_MAP", raising=False)
+    monkeypatch.delenv("LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP", raising=False)
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2")
     kwargs = engine._model_load_kwargs(config)
@@ -180,12 +180,12 @@ def test_device_map_absent_when_env_unset(monkeypatch):
 
 
 def test_device_map_env_var_override(monkeypatch):
-    """LLEM_DEFAULT_DEVICE_MAP=balanced → kwargs['device_map'] == 'balanced'."""
+    """LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=balanced → kwargs['device_map'] == 'balanced'."""
     pytest.importorskip("torch")
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
-    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "balanced")
+    monkeypatch.setenv("LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP", "balanced")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2")
     kwargs = engine._model_load_kwargs(config)
@@ -194,12 +194,12 @@ def test_device_map_env_var_override(monkeypatch):
 
 
 def test_device_map_env_var_empty_is_unset(monkeypatch):
-    """LLEM_DEFAULT_DEVICE_MAP='' is treated as unset: kwarg absent, HF default applies."""
+    """LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP='' is treated as unset: kwarg absent, HF default applies."""
     pytest.importorskip("torch")
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
-    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "")
+    monkeypatch.setenv("LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP", "")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2")
     kwargs = engine._model_load_kwargs(config)
@@ -252,14 +252,14 @@ def test_model_load_kwargs_passthrough_can_override_defaults():
 def test_model_load_kwargs_no_passthrough_when_none(monkeypatch):
     """No extra keys added when passthrough_kwargs is None.
 
-    Sets LLEM_DEFAULT_DEVICE_MAP=auto to mimic the production .env state so
+    Sets LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto to mimic the production .env state so
     device_map appears in the expected-keys set.
     """
     pytest.importorskip("torch")
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
-    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "auto")
+    monkeypatch.setenv("LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP", "auto")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2")  # passthrough_kwargs=None by default
     kwargs = engine._model_load_kwargs(config)
@@ -675,7 +675,7 @@ def test_model_load_kwargs_tp_plan_and_tp_size_forwarded():
 def test_model_load_kwargs_tp_size_without_tp_plan_ignored(monkeypatch):
     """With TransformersConfig(tp_size=4) and no tp_plan, tp_size is not in kwargs and device_map defaults.
 
-    Sets LLEM_DEFAULT_DEVICE_MAP=auto explicitly to mimic the production .env state,
+    Sets LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto explicitly to mimic the production .env state,
     since the helper is now pure passthrough (unset → None → kwarg omitted).
     """
     pytest.importorskip("torch")
@@ -683,7 +683,7 @@ def test_model_load_kwargs_tp_size_without_tp_plan_ignored(monkeypatch):
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
-    monkeypatch.setenv("LLEM_DEFAULT_DEVICE_MAP", "auto")
+    monkeypatch.setenv("LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP", "auto")
     engine = TransformersEngine()
     config = ExperimentConfig(model="gpt2", transformers=TransformersConfig(tp_size=4))
     kwargs = engine._model_load_kwargs(config)


### PR DESCRIPTION
## Summary

Establishes the foundation for the ``LLEM_*`` runtime-config pattern and ships the first helper: a configurable ``device_map`` default for the transformers engine.

### Design

```
.env.example ← SSOT for opinionated defaults (in git, reviewable)
.env         ← user-edited copy (gitignored), auto-loaded by CLI
helpers      ← pure passthrough (os.environ.get() or None)
library      ← receives None → applies its own default
```

Because helpers have no baked-in defaults, deleting a line from a user's ``.env`` always restores the underlying library's default.

### What's in this PR

- **``utils/env_config.py``** (new): canonical location for ``LLEM_*`` env-var helpers. Houses ``ENV_DEFAULT_DEVICE_MAP`` + ``default_device_map()`` (passthrough). Follow-up PRs will add more helpers here.
- **``.env.example``**: extended (not replaced) with new ``LLEM_*`` sections alongside the existing Docker/setup.sh content. Ships ``LLEM_DEFAULT_DEVICE_MAP=auto`` as the opinionated default.
- **``cli/__init__.py``**: auto-loads ``.env`` from the user's CWD at module import. ``override=False`` so shell env still wins. Anchored to ``Path.cwd()`` deliberately — dotenv's default walk-up from ``__file__`` never reaches the user's project once llem is pip-installed.
- **``engines/transformers.py``**: reads ``default_device_map()`` from ``utils/env_config``. Precedence: typed ``pt.device_map`` > env var > HF default (None = CPU).
- **``utils/security.py``**: stripped of the interim ``ENV_DEFAULT_DEVICE_MAP`` constant and helper — RCE consent (``trust_remote_code``) stays, convenience-defaults move out.

### Tests

- New ``tests/unit/cli/test_dotenv_loading.py``: verifies CLI auto-load, shell-wins-over-file precedence, and graceful handling of missing ``.env``. Fixture uses ``monkeypatch.delitem(sys.modules, ...)`` so sys.modules cleanup is restored at teardown (prevents test pollution).
- Updated pre-existing ``test_engine_protocol.py`` tests that assumed ``device_map == "auto"`` unconditionally to ``monkeypatch.setenv`` the env var explicitly, mimicking the production ``.env``-loaded state.
- New passthrough-semantics tests: unset → kwarg absent, empty → kwarg absent, non-empty → forwarded as-is.

## Follow-ups (separate PRs)

- **#277**: ``LLEM_TRT_BUILD_CACHE_{ENABLED,PATH}`` — will rebase on this branch and use ``env_config.py`` once this lands.
- **#276**: re-type ``tensorrt.backend`` as ``Literal[...]`` Pydantic field (no env var) — orthogonal, stacks on #270.

## Test plan

- [x] ``uv run pytest tests/unit`` — 1875 passed
- [x] ``uv run ruff check src/ tests/``
- [x] ``uv run mypy src/``
- [x] ``uv run lint-imports`` — layer contracts kept