### PR TITLE
refactor(config): re-type tensorrt.backend as Literal["trt","pytorch","_autodeploy"]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ All notable changes to this project are documented here.
 ### Changed
 
 - **Per-experiment timeout is now configurable** via `study_execution.experiment_timeout_seconds` (default 600s). Replaces the previous `max(n_prompts*2, 600)` heuristic. Both the local subprocess path and the Docker container path honour the same field, and Docker-path timeouts are normalised to `TimeoutError` so the circuit breaker counts them consistently across both paths.
+- **Re-typed `tensorrt.backend` as `Literal["trt", "pytorch", "_autodeploy"] | None`.** Reverses the prior curation-pass drop for this one field — the original `D2 single-option enum` verdict was incorrect for TRT-LLM >= 0.13, where `backend` selects between three runtime paths with distinct measurement signatures (`trt` = AOT-compiled engine, `pytorch` = eager runtime with the same scheduler/KV cache, `_autodeploy` = experimental). Default `None` lets TRT-LLM auto-pick. The consumer side no longer hardcodes `"backend": "trt"`; the kwarg is only set when the typed field is explicitly provided.
 
 ### Fixed
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -363,7 +363,7 @@ Changing any **[recompile]** field invalidates the cached engine and triggers a 
 | `max_num_tokens` | int | auto | Maximum tokens the engine handles per iteration (scheduler throughput axis alongside `max_batch_size`). **[recompile]** |
 | `dtype` | `float16` \| `bfloat16` | auto | Model compute dtype. TRT-LLM is optimised for fp16/bf16; fp32 is not supported. **[recompile]** |
 | `fast_build` | bool | false | Enable fast engine build mode (reduced optimisation, faster compilation). **[recompile]** |
-| `engine` | `trt` | `trt` | TRT-LLM internal backend selector. This is the `LLM(backend=...)` parameter, not the `llem` engine field. Leave unset unless you have a specific reason to override. |
+| `backend` | `trt` \| `pytorch` \| `_autodeploy` | null (TRT-LLM auto-picks) | TRT-LLM runtime backend — a measurement axis, not a per-host knob. `trt` = AOT-compiled TensorRT engine (best steady-state, minutes-hours compile). `pytorch` = TRT-LLM's eager runtime (same scheduler/KV cache, no compile, supports newer archs without hand-written converters). `_autodeploy` = experimental model-porter. null → TRT-LLM auto-picks (respects `TLLM_USE_TRT_ENGINE` env). Distinct from the top-level `engine:` field. |
 | `engine_path` | str | null | Path to a pre-compiled engine directory. When set, skips compilation and loads the engine directly. See [Pre-Compiled Engine Loading](#pre-compiled-engine-loading) below. |
 
 ### tensorrt.quant: Quantization

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -891,10 +891,16 @@ class TensorRTConfig(BaseModel):
     live in DecoderConfig and are shared across all engines.
 
     Dropped (falls through extra="allow"):
-    - backend: Literal["trt"] — D2 single-option enum, no information content
     - engine_path — D1 deployment path, not a measurement axis
     - calib sub-config — D3 build-only PTQ calibration (we consume pre-quantised checkpoints)
     - build_cache sub-config — D1 engine-cache housekeeping
+
+    Re-added after audit:
+    - backend: Literal["trt","pytorch","_autodeploy"] — measurement-relevant
+      axis in TRT-LLM >=0.13. "trt" is the AOT-compiled engine; "pytorch" is
+      TRT-LLM's eager runtime (same scheduler/KV cache, no compile); "_autodeploy"
+      is the experimental model-porter. Original drop rubric (D2 single-option
+      enum) was incorrect for contemporary TRT-LLM.
 
     Example YAML:
         engine: tensorrt
@@ -955,6 +961,17 @@ class TensorRTConfig(BaseModel):
     fast_build: bool | None = Field(
         default=None,
         description="Enable fast engine build mode (reduced optimisation, None -> False)",
+    )
+    backend: Literal["trt", "pytorch", "_autodeploy"] | None = Field(
+        default=None,
+        description=(
+            "TRT-LLM runtime backend — a measurement axis, not a per-host knob. "
+            "'trt' = AOT-compiled TensorRT engine (best steady-state, minutes-hours "
+            "compile); 'pytorch' = TRT-LLM's eager runtime (same scheduler/KV cache, "
+            "no compile, supports newer model archs without hand-written converters); "
+            "'_autodeploy' = experimental autoporter. None -> TRT-LLM auto-picks "
+            "(respects TLLM_USE_TRT_ENGINE env)."
+        ),
     )
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -379,15 +379,18 @@ class TensorRTEngine:
     def _build_llm_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
         """Build kwargs dict for tensorrt_llm.LLM() constructor.
 
-        Starts with {"model": config.model, "backend": "trt"} and applies
-        all non-None fields from TensorRTConfig.
+        Starts with {"model": config.model} and applies all non-None fields
+        from TensorRTConfig, including the typed ``backend`` field when set.
+        When ``backend`` is unset (None), TRT-LLM auto-picks (respecting
+        ``TLLM_USE_TRT_ENGINE``) — the previous hardcoded ``"trt"`` default
+        is removed.
 
-        When engine_path is set, returns early with only {"model": engine_path, "backend": "trt"}.
-        Compile-time kwargs are baked into the engine and must not be re-specified.
+        When engine_path is set, returns early with only {"model": engine_path}
+        plus ``backend`` iff the typed field was supplied. Compile-time kwargs
+        are baked into the engine and must not be re-specified.
         """
         kwargs: dict[str, Any] = {
             "model": config.model,
-            "backend": "trt",
         }
 
         trt = config.tensorrt
@@ -404,7 +407,10 @@ class TensorRTEngine:
             # Pass engine dir as model - TRT-LLM auto-detects TLLM_ENGINE format.
             # Compile-time kwargs are baked into the engine; don't pass them.
             # enable_build_cache is not set - engine format bypasses it.
-            return {"model": str(raw_engine_path), "backend": "trt"}
+            early_kwargs: dict[str, Any] = {"model": str(raw_engine_path)}
+            if trt.backend is not None:
+                early_kwargs["backend"] = trt.backend
+            return early_kwargs
 
         if trt is None:
             # No tensorrt section — use defaults + enable build cache
@@ -428,11 +434,8 @@ class TensorRTEngine:
             kwargs["dtype"] = trt.dtype
         if trt.fast_build is not None:
             kwargs["fast_build"] = trt.fast_build
-
-        # TRT-LLM internal backend — no longer typed; accessed via extra="allow" if explicitly set.
-        raw_backend = getattr(trt, "backend", None)
-        if raw_backend is not None:
-            kwargs["backend"] = raw_backend
+        if trt.backend is not None:
+            kwargs["backend"] = trt.backend
 
         # Quantisation config
         if trt.quant is not None:

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -159,14 +159,51 @@ class TestProtocolCompliance:
 
 class TestBuildLlmKwargs:
     def test_build_llm_kwargs_minimal(self):
-        """No tensorrt config → kwargs has model and backend='trt' and enable_build_cache."""
+        """No tensorrt config → kwargs has model and enable_build_cache; no backend kwarg.
+
+        With the typed backend field absent, TRT-LLM auto-picks (respecting
+        TLLM_USE_TRT_ENGINE); the old hardcoded "trt" default is removed so
+        the kwarg is omitted.
+        """
         config = make_config(**_TRT_DEFAULTS)
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
         assert kwargs["model"] == "test-model"
-        assert kwargs["backend"] == "trt"
+        assert "backend" not in kwargs
         assert kwargs.get("enable_build_cache") is True
+
+    def test_build_llm_kwargs_backend_trt(self):
+        """tensorrt.backend='trt' → kwargs['backend'] == 'trt' (AOT-compiled engine path)."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(backend="trt"))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert kwargs["backend"] == "trt"
+
+    def test_build_llm_kwargs_backend_pytorch(self):
+        """tensorrt.backend='pytorch' → kwargs['backend'] == 'pytorch' (eager runtime, no compile)."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(backend="pytorch"))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert kwargs["backend"] == "pytorch"
+
+    def test_build_llm_kwargs_backend_autodeploy(self):
+        """tensorrt.backend='_autodeploy' → kwargs['backend'] == '_autodeploy' (experimental)."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(backend="_autodeploy"))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert kwargs["backend"] == "_autodeploy"
+
+    def test_build_llm_kwargs_backend_invalid_rejected_by_pydantic(self):
+        """Literal rejects non-enumerated values at config construction."""
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            TensorRTConfig(backend="invalid")
 
     def test_build_llm_kwargs_tensor_parallel_size(self):
         """tensor_parallel_size=2 maps to kwargs tensor_parallel_size=2."""
@@ -686,12 +723,28 @@ class TestValidateEngineDirectory:
 
 class TestBuildLlmKwargsEnginePath:
     def test_build_llm_kwargs_engine_path(self, tmp_path):
-        """engine_path set -> kwargs has model=engine_path as string and engine=trt."""
+        """engine_path set → kwargs has model=engine_path as string; backend kwarg absent unless typed field set."""
         config_data = {"pretrained_config": {"mapping": {"tp_size": 1}}, "build_config": {}}
         (tmp_path / "config.json").write_text(json.dumps(config_data))
         (tmp_path / "rank0.engine").write_bytes(b"fake")
 
         config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(engine_path=str(tmp_path)))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert kwargs["model"] == str(tmp_path)
+        assert "backend" not in kwargs
+
+    def test_build_llm_kwargs_engine_path_with_typed_backend(self, tmp_path):
+        """engine_path + typed backend → both present in the early-return kwargs."""
+        config_data = {"pretrained_config": {"mapping": {"tp_size": 1}}, "build_config": {}}
+        (tmp_path / "config.json").write_text(json.dumps(config_data))
+        (tmp_path / "rank0.engine").write_bytes(b"fake")
+
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt=TensorRTConfig(engine_path=str(tmp_path), backend="trt"),
+        )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 


### PR DESCRIPTION
## Summary

Reverses the prior curation-pass drop of `tensorrt.backend` after audit. The original `D2 single-option enum` rubric was incorrect for TRT-LLM >= 0.13: `backend` selects between three runtime paths with distinct measurement signatures, making it a legitimate sweepable measurement axis.

## The three backends

- **`trt`**: AOT-compiled TensorRT engine. Best steady-state throughput and energy. Minutes-hours compile. Model must have a hand-written TRT-LLM converter.
- **`pytorch`**: TRT-LLM's eager runtime. Same PagedKV scheduler and KV cache as the compiled path, but no AOT compile, so newer architectures work out of the box. Lower steady-state perf.
- **`_autodeploy`**: experimental autoporter for models without converter support.

Sweeping `{trt, pytorch}` isolates the AOT-compile variable while holding the rest of the TRT-LLM stack constant — a cleaner controlled comparison than cross-engine (vLLM vs TRT-LLM) sweeps.

## Why a typed Pydantic field (not an env var)

- It is a per-experiment **measurement axis**, not a per-host knob. YAML is the right home.
- The prior `pytorch`-equivalence concern (that this overlaps with the standalone `engine: transformers`) is **false** — TRT-LLM's pytorch backend keeps the TRT-LLM runtime/scheduler/KV cache; only the AOT compile step differs. HF Transformers is a different runtime stack.
- Default `None` already gives per-env overrides: TRT-LLM internally respects `TLLM_USE_TRT_ENGINE` when `backend=None`.

## Changes

- ``config/engine_configs.py``: adds `backend: Literal[...] | None = Field(default=None, description=...)` on `TensorRTConfig`. Updates the docstring ("Dropped" → "Re-added after audit").
- ``engines/tensorrt.py``: removes the hardcoded `"backend": "trt"` from both the initial-kwargs dict and the `engine_path` early-return. Replaces `getattr(trt, "backend", None)` extra-allow passthrough with typed-field read.
- ``tests/unit/engines/test_tensorrt_engine.py``: `test_build_llm_kwargs_minimal` now asserts `backend` is absent; new tests cover each Literal value, Pydantic rejection of invalid values, and the `engine_path` + typed-backend combination.
- ``docs/engines.md``: restores a `backend` row in the TensorRT field table.
- ``CHANGELOG.md``: entry under `### Changed`.

## Sequencing

Stacked on `feature/phase-48-2b-curation-adjust` (PR #270) so the re-add is a minimal diff over the curation pass. Once #270 lands, GitHub auto-retargets this PR to `main`. Orthogonal to the `.env`-based config PRs (#275 / #277) — no env var used here.

## Test plan

- [x] `uv run pytest tests/unit` — 1872 passed
- [x] `uv run ruff check`
- [x] `uv run mypy src/`
- [x] `uv run lint-imports`