### PR TITLE
feat(config): make TRT-LLM build cache configurable via LLEM_TRT_BUILD_CACHE_{ENABLED,PATH}

### DIFF
--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -79,6 +79,44 @@ def _validate_engine_directory(engine_path: Path, tp_size: int) -> list[str]:
     return errors
 
 
+def _apply_default_build_cache(kwargs: dict[str, Any]) -> None:
+    """Apply the env-var-gated default TRT-LLM build cache to ``kwargs``.
+
+    The opinionated llenergymeasure default is enabled (engine compilation is
+    expensive; the cache is a large time-saver for repeat runs) — shipped via
+    ``LLEM_TRT_BUILD_CACHE_ENABLED=1`` in ``.env.example``. The helpers are
+    pure passthrough (see :mod:`llenergymeasure.utils.env_config`), so
+    removing the line reverts to TRT-LLM's disabled default.
+
+    - Disabled by env → ``enable_build_cache`` is not set (TRT-LLM default is
+      False, matching the discovered schema).
+    - Enabled with a user-supplied path → build a ``BuildCacheConfig`` whose
+      ``cache_root`` is that path. Falls back to bare ``True`` if the
+      ``tensorrt_llm.llmapi`` import is unavailable (mirrors the behaviour of
+      the explicit YAML-driven path).
+    - Enabled without a path → set ``enable_build_cache = True`` (preserves the
+      pre-env-var behaviour).
+    """
+    from llenergymeasure.utils.env_config import trt_build_cache_enabled, trt_build_cache_path
+
+    if not trt_build_cache_enabled():
+        return
+
+    cache_root = trt_build_cache_path()
+    if cache_root is not None:
+        try:
+            from tensorrt_llm.llmapi import BuildCacheConfig
+
+            kwargs["enable_build_cache"] = BuildCacheConfig(cache_root=cache_root)
+            return
+        except ImportError:
+            logger.debug(
+                "tensorrt_llm.llmapi not available; falling back to bare enable_build_cache=True"
+            )
+
+    kwargs["enable_build_cache"] = True
+
+
 class TensorRTEngine:
     """TensorRT-LLM inference engine — offline batch mode, thin plugin.
 
@@ -413,8 +451,8 @@ class TensorRTEngine:
             return early_kwargs
 
         if trt is None:
-            # No tensorrt section — use defaults + enable build cache
-            kwargs["enable_build_cache"] = True
+            # No tensorrt section — apply env-var-gated default build cache.
+            _apply_default_build_cache(kwargs)
             return kwargs
 
         # Scalar fields: map directly
@@ -452,10 +490,9 @@ class TensorRTEngine:
             except ImportError:
                 logger.debug("tensorrt_llm.llmapi not available; skipping QuantConfig")
 
-        # Build cache — enable by default; advanced config via extra="allow" passthrough.
-        # TensorRTBuildCacheConfig was dropped (D1 plumbing). Users can still pass
-        # build_cache fields through extra="allow" if needed.
-        kwargs["enable_build_cache"] = True
+        # Build cache — env-var-gated default.
+        # TensorRTBuildCacheConfig was dropped (D1); advanced config via extra="allow".
+        _apply_default_build_cache(kwargs)
 
         # KV cache config
         if trt.kv_cache is not None:

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
 import subprocess
 from dataclasses import dataclass
 from functools import cache
@@ -155,6 +154,7 @@ def rebuild_hint(engine: str) -> str:
 
 
 def skip_check_enabled() -> bool:
-    """True iff ``LLEM_SKIP_IMAGE_CHECK`` is set to ``1``/``true``/``yes``."""
-    raw = os.environ.get(ENV_SKIP_IMAGE_CHECK, "")
-    return raw.strip().lower() in {"1", "true", "yes"}
+    """True iff ``LLEM_SKIP_IMAGE_CHECK`` is set to a truthy value."""
+    from llenergymeasure.utils.env_config import parse_bool_env
+
+    return parse_bool_env(ENV_SKIP_IMAGE_CHECK)

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -21,6 +21,14 @@ import os
 from pathlib import Path
 from typing import Final
 
+_TRUTHY: Final = frozenset({"1", "true", "yes", "on"})
+
+
+def parse_bool_env(var: str) -> bool:
+    """Parse an env var as a boolean (``1``/``true``/``yes``/``on`` -> True)."""
+    return os.environ.get(var, "").strip().lower() in _TRUTHY
+
+
 ENV_TRANSFORMERS_DEFAULT_DEVICE_MAP: Final = "LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP"
 """Override for the HuggingFace ``device_map`` argument at model load.
 
@@ -74,7 +82,7 @@ def trt_build_cache_enabled() -> bool:
     out-of-the-box experience preserves the cache (engine compilation takes
     minutes); deleting the line reverts to TRT-LLM's disabled default.
     """
-    return os.environ.get(ENV_TRT_BUILD_CACHE_ENABLED, "").lower() in {"1", "true", "yes", "on"}
+    return parse_bool_env(ENV_TRT_BUILD_CACHE_ENABLED)
 
 
 def trt_build_cache_path() -> Path | None:

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -18,6 +18,7 @@ consumed by engine plugins in Layer 2.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Final
 
 ENV_TRANSFORMERS_DEFAULT_DEVICE_MAP: Final = "LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP"
@@ -44,3 +45,43 @@ def default_device_map() -> str | None:
     helper. If this returns ``None``, callers should omit the kwarg.
     """
     return os.environ.get(ENV_TRANSFORMERS_DEFAULT_DEVICE_MAP) or None
+
+
+ENV_TRT_BUILD_CACHE_ENABLED: Final = "LLEM_TRT_BUILD_CACHE_ENABLED"
+"""Toggle for TRT-LLM on-disk engine build cache.
+
+Unset / empty / any falsy value (``0``, ``false``, ``no``, ``off``) → False,
+matching TRT-LLM's own default. Truthy values (``1``, ``true``, ``yes``,
+``on``, case-insensitive) → True. The opinionated default ``1`` is shipped
+via ``.env.example`` — not baked into this helper.
+"""
+
+
+ENV_TRT_BUILD_CACHE_PATH: Final = "LLEM_TRT_BUILD_CACHE_PATH"
+"""User-supplied cache directory for TRT-LLM engine build cache.
+
+If set and non-empty, the engine plugin wraps it into TRT-LLM's
+``BuildCacheConfig.cache_root``. Unset / empty leaves TRT-LLM's internal
+default cache location in place.
+"""
+
+
+def trt_build_cache_enabled() -> bool:
+    """Return whether TRT-LLM on-disk engine build cache should be enabled.
+
+    Pure passthrough: no opinionated default is baked in. The repo-root
+    ``.env.example`` ships ``LLEM_TRT_BUILD_CACHE_ENABLED=1`` so the
+    out-of-the-box experience preserves the cache (engine compilation takes
+    minutes); deleting the line reverts to TRT-LLM's disabled default.
+    """
+    return os.environ.get(ENV_TRT_BUILD_CACHE_ENABLED, "").lower() in {"1", "true", "yes", "on"}
+
+
+def trt_build_cache_path() -> Path | None:
+    """Return the user-supplied TRT-LLM build cache root, if any.
+
+    Returns a ``Path`` when set to a non-empty value; otherwise ``None`` so
+    TRT-LLM uses its internal default location (``~/.cache/tensorrt_llm/``).
+    """
+    raw = os.environ.get(ENV_TRT_BUILD_CACHE_PATH)
+    return Path(raw) if raw else None

--- a/src/llenergymeasure/utils/security.py
+++ b/src/llenergymeasure/utils/security.py
@@ -1,9 +1,9 @@
 """Security utilities for llenergymeasure."""
 
-import os
 from pathlib import Path
 from typing import Final
 
+from llenergymeasure.utils.env_config import parse_bool_env
 from llenergymeasure.utils.exceptions import ConfigError
 
 ENV_TRUST_REMOTE_CODE: Final = "LLEM_TRUST_REMOTE_CODE"
@@ -20,7 +20,7 @@ def trust_remote_code_enabled() -> bool:
     Setting True allows loading models that ship custom Python implementations
     (Qwen, DeepSeek, ChatGLM, etc.) at the cost of executing repo-supplied code.
     """
-    return os.environ.get(ENV_TRUST_REMOTE_CODE, "").lower() in {"1", "true", "yes", "on"}
+    return parse_bool_env(ENV_TRUST_REMOTE_CODE)
 
 
 def validate_path(path: Path, must_exist: bool = False, allow_relative: bool = True) -> Path:

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -158,13 +158,13 @@ class TestProtocolCompliance:
 
 
 class TestBuildLlmKwargs:
-    def test_build_llm_kwargs_minimal(self):
+    def test_build_llm_kwargs_minimal(self, monkeypatch):
         """No tensorrt config → kwargs has model and enable_build_cache; no backend kwarg.
 
-        With the typed backend field absent, TRT-LLM auto-picks (respecting
-        TLLM_USE_TRT_ENGINE); the old hardcoded "trt" default is removed so
-        the kwarg is omitted.
+        Sets LLEM_TRT_BUILD_CACHE_ENABLED=1 to mimic the production .env state,
+        since the helper is now pure passthrough (unset → False → kwarg omitted).
         """
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
         config = make_config(**_TRT_DEFAULTS)
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -249,8 +249,9 @@ class TestBuildLlmKwargs:
         assert "max_seq_len" not in kwargs
         assert "fast_build" not in kwargs
 
-    def test_build_llm_kwargs_default_build_cache_when_no_build_cache_section(self):
-        """When no build_cache section, enable_build_cache=True is set."""
+    def test_build_llm_kwargs_default_build_cache_when_no_build_cache_section(self, monkeypatch):
+        """When no build_cache section and .env ships LLEM_TRT_BUILD_CACHE_ENABLED=1, enable_build_cache=True."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
         config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -273,13 +274,77 @@ class TestBuildLlmKwargs:
         assert isinstance(kwargs["quantization"], _MockQuantConfig)
         assert kwargs["quantization"]._kwargs["quant_algo"] == "INT8"
 
-    def test_build_llm_kwargs_always_has_enable_build_cache(self):
-        """enable_build_cache=True is always set (TensorRTBuildCacheConfig dropped D1)."""
+    def test_build_llm_kwargs_enable_build_cache_when_env_set(self, monkeypatch):
+        """LLEM_TRT_BUILD_CACHE_ENABLED=1 with tensorrt section → enable_build_cache=True."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
         config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig())
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
         assert kwargs.get("enable_build_cache") is True
+
+    def test_trt_build_cache_absent_when_env_unset(self, monkeypatch):
+        """Pure passthrough: LLEM_TRT_BUILD_CACHE_ENABLED unset → kwarg absent (TRT-LLM default)."""
+        monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_ENABLED", raising=False)
+        monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_PATH", raising=False)
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert "enable_build_cache" not in kwargs
+
+    def test_trt_build_cache_disabled_by_env_var(self, monkeypatch):
+        """LLEM_TRT_BUILD_CACHE_ENABLED=0 → kwarg absent."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "0")
+        monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_PATH", raising=False)
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert "enable_build_cache" not in kwargs
+
+        # Also covers the no-tensorrt-section branch.
+        config_no_trt = make_config(**_TRT_DEFAULTS)
+        kwargs_no_trt = engine._build_llm_kwargs(config_no_trt)
+        assert "enable_build_cache" not in kwargs_no_trt
+
+    def test_trt_build_cache_path_used_when_both_env_vars_set(self, monkeypatch):
+        """LLEM_TRT_BUILD_CACHE_ENABLED=1 + LLEM_TRT_BUILD_CACHE_PATH=... → BuildCacheConfig(cache_root=path)."""
+        mock_trt = _make_fake_tensorrt_llm_module()
+        monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
+        monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_PATH", "/tmp/test")
+
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        from pathlib import Path as _Path
+
+        assert "enable_build_cache" in kwargs
+        assert isinstance(kwargs["enable_build_cache"], _MockBuildCacheConfig)
+        assert kwargs["enable_build_cache"]._kwargs["cache_root"] == _Path("/tmp/test")
+
+    def test_trt_build_cache_enabled_alone_is_bare_true(self, monkeypatch):
+        """LLEM_TRT_BUILD_CACHE_ENABLED=1, path unset → enable_build_cache is bare True."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_PATH", raising=False)
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert kwargs["enable_build_cache"] is True
+
+    def test_trt_build_cache_path_requires_enabled(self, monkeypatch):
+        """LLEM_TRT_BUILD_CACHE_PATH set but ENABLED unset → kwarg absent (passthrough rule)."""
+        monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_ENABLED", raising=False)
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_PATH", "/tmp/test")
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(tensor_parallel_size=1))
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert "enable_build_cache" not in kwargs
 
     def test_build_llm_kwargs_kv_cache_config(self, monkeypatch):
         """kv_cache section maps to KvCacheConfig kwargs."""


### PR DESCRIPTION
## Summary

Makes the TRT-LLM on-disk engine build cache configurable via env vars, using the ``utils/env_config.py`` foundation introduced in #275.

### Design

Helpers are pure passthrough — no opinionated default is baked into code. The opinionated ``ENABLED=1`` ships in ``.env.example`` (the single reviewable SSOT for llem overrides); a user deleting the line reverts transparently to TRT-LLM's own default (disabled).

### Files

- ``utils/env_config.py``: adds ``ENV_TRT_BUILD_CACHE_ENABLED`` + ``ENV_TRT_BUILD_CACHE_PATH`` + ``trt_build_cache_enabled()`` + ``trt_build_cache_path()``.
- ``utils/security.py``: strips the interim TRT-cache constants/helpers that the prior version placed there. ``security.py`` keeps only ``validate_path`` + ``trust_remote_code_enabled``.
- ``engines/tensorrt.py``: imports helpers from ``utils.env_config`` (behaviour unchanged when ``.env`` is present).

### Tests

- Pre-existing tests that assumed the old baked-in ``unset → True`` default now ``monkeypatch.setenv(``ENABLED``, "1")`` explicitly to mimic the production ``.env`` state.
- New passthrough-semantics tests:
  - unset → kwarg absent
  - ``ENABLED=0`` → absent
  - ``ENABLED=1`` alone → bare ``True``
  - ``ENABLED=1`` + ``PATH=/tmp/test`` → ``BuildCacheConfig(cache_root=...)``
  - ``PATH`` alone (no ``ENABLED``) → absent (path requires enabled)

## Dependency

Rebased on #275 (``.env``-based config foundation). Must merge after #275 — ``utils/env_config.py`` is introduced there.

## Test plan

- [x] ``uv run pytest tests/unit`` — 1880 passed
- [x] ``uv run ruff check``
- [x] ``uv run mypy src/``
- [x] ``uv run lint-imports`` — layer contracts kept