### PR TITLE
fix: post-merge cleanup from PRs 274-276 simplify review

### DIFF
--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -54,11 +54,7 @@ class TransformersEngine:
         config: ExperimentConfig,
         on_substep: Callable[[str, float], None] | None = None,
     ) -> tuple[Any, Any]:
-        """Load model and tokenizer directly — no intermediate loader class.
-
-        The P0 fix: kwargs are built by _model_load_kwargs() and passed
-        directly to from_pretrained(). The v1.x bug was that _build_model_kwargs()
-        built the dict but loader.load(config) ignored it.
+        """Load model and tokenizer via from_pretrained().
 
         Args:
             config: Experiment configuration.
@@ -74,11 +70,9 @@ class TransformersEngine:
         kwargs = self._model_load_kwargs(config)
         logger.info("Loading model %r with kwargs: %s", config.model, list(kwargs.keys()))
 
-        from llenergymeasure.utils.security import trust_remote_code_enabled
-
         t0 = _time.perf_counter()
         tokenizer = AutoTokenizer.from_pretrained(
-            config.model, trust_remote_code=trust_remote_code_enabled()
+            config.model, trust_remote_code=kwargs.get("trust_remote_code", False)
         )
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
@@ -275,9 +269,6 @@ class TransformersEngine:
     def _model_load_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
         """Build the full kwargs dict for AutoModelForCausalLM.from_pretrained().
 
-        This is the P0 fix location: passthrough_kwargs and transformers config
-        options are ALL collected here and ALL passed to from_pretrained().
-
         Args:
             config: Experiment configuration.
 
@@ -303,9 +294,6 @@ class TransformersEngine:
         elif pt is not None and pt.device_map is not None:
             kwargs["device_map"] = pt.device_map
         else:
-            # Precedence: typed pt.device_map (above) > LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP
-            # env var (set by .env) > HF default (None = CPU). Helper is pure
-            # passthrough; .env.example ships `=auto` as the opinionated default.
             dm = default_device_map()
             if dm is not None:
                 kwargs["device_map"] = dm

--- a/src/llenergymeasure/utils/security.py
+++ b/src/llenergymeasure/utils/security.py
@@ -7,12 +7,7 @@ from typing import Final
 from llenergymeasure.utils.exceptions import ConfigError
 
 ENV_TRUST_REMOTE_CODE: Final = "LLEM_TRUST_REMOTE_CODE"
-"""Opt-in for HuggingFace `trust_remote_code=True`. Unset → HF default (False).
-
-Phase 51+ is expected to centralise env-var registration (likely in
-``config/ssot.py``) once layer rules permit; for now the constant lives here
-because ``utils/`` cannot import from ``config/``.
-"""
+"""Opt-in for HuggingFace `trust_remote_code=True`. Unset → HF default (False)."""
 
 
 def trust_remote_code_enabled() -> bool:
@@ -23,9 +18,7 @@ def trust_remote_code_enabled() -> bool:
     (including unset) as False — matching HuggingFace's own default.
 
     Setting True allows loading models that ship custom Python implementations
-    (Qwen, DeepSeek, ChatGLM, etc.) at the cost of executing repo-supplied
-    code. Phase 51+ is expected to surface this through a typed config field
-    or CLI flag; this helper is the interim single source of truth.
+    (Qwen, DeepSeek, ChatGLM, etc.) at the cost of executing repo-supplied code.
     """
     return os.environ.get(ENV_TRUST_REMOTE_CODE, "").lower() in {"1", "true", "yes", "on"}
 

--- a/tests/unit/cli/test_cli_display.py
+++ b/tests/unit/cli/test_cli_display.py
@@ -449,9 +449,10 @@ def test_print_study_dry_run_shows_configs(capsys, monkeypatch):
     ]
     study = StudyConfig(experiments=configs, study_name="test-sweep")
 
-    # Mock VRAM functions to avoid GPU dependency
-    monkeypatch.setattr("llenergymeasure.cli._vram.estimate_vram", lambda c: None)
-    monkeypatch.setattr("llenergymeasure.cli._vram.get_gpu_vram_gb", lambda: None)
+    import llenergymeasure.cli._vram as _vram_mod
+
+    monkeypatch.setattr(_vram_mod, "estimate_vram", lambda c: None)
+    monkeypatch.setattr(_vram_mod, "get_gpu_vram_gb", lambda: None)
 
     print_study_dry_run(study)
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary

Retrospective cleanup from `/simplify` review of merged PRs #274, #275, #276:

- **Fix brittle monkeypatch** (`test_cli_display.py`): Convert remaining string-target `monkeypatch.setattr("llenergymeasure.cli._vram.…")` to direct module reference — same xdist-reliability fix applied in `29e7e55` for the VRAM peak test
- **Remove stale comments** (`security.py`): Strip "Phase 51+" project-management references from docstrings
- **Remove narrative comments** (`transformers.py`): Strip "P0 fix" / "v1.x bug" PR-history narration from docstrings; trim verbose device_map precedence comment
- **Deduplicate trust_remote_code** (`transformers.py`): Reuse `kwargs["trust_remote_code"]` (already computed by `_model_load_kwargs()`) for tokenizer loading instead of a second `trust_remote_code_enabled()` call

Net: -18 lines, no behaviour change.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_cli_display.py tests/unit/engines/test_engine_protocol.py tests/unit/cli/test_dotenv_loading.py` — 101 passed
- [x] `uv run mypy src/llenergymeasure/engines/transformers.py src/llenergymeasure/utils/security.py` — clean
- [x] `uv run ruff check` — clean
- [ ] CI (lint, type-check, test, package-validation, docs-freshness)