### PR TITLE
feat(ci): add automated schema refresh pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,3 +210,15 @@ jobs:
         run: |
           docker run --rm smoke-${{ matrix.dockerfile }} llem --version
           docker run --rm smoke-${{ matrix.dockerfile }} llem config
+
+  schema-version-check:
+    needs: filter
+    if: >-
+      always()
+      && needs.filter.outputs.docker == 'true'
+      && !contains(github.event.pull_request.labels.*.name, 'renovate')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check schema versions match Dockerfiles
+        run: python3 scripts/check_schema_versions.py

--- a/.github/workflows/schema-refresh.yml
+++ b/.github/workflows/schema-refresh.yml
@@ -1,0 +1,172 @@
+name: Schema Refresh
+
+# Automatically refreshes vendored engine schemas when Renovate bumps a
+# Dockerfile version. Also supports manual dispatch for ad-hoc refreshes.
+#
+# Runs on self-hosted GPU runner (same as gpu-ci.yml) because vLLM and
+# TensorRT-LLM may require CUDA device access at import time.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "docker/Dockerfile.*"
+  workflow_dispatch:
+    inputs:
+      engine:
+        description: "Engine to refresh"
+        required: true
+        type: choice
+        options:
+          - vllm
+          - tensorrt
+          - transformers
+          - all
+      pr_number:
+        description: "PR number to comment on and label (optional)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: schema-refresh-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    # Auto-trigger: only for Renovate PRs. Manual dispatch: always run.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: self-hosted
+    timeout-minutes: 90
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Determine engines to refresh
+        id: engines
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ENGINES="${{ inputs.engine }}"
+          else
+            # Parse changed Dockerfile paths to determine engines.
+            CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD -- 'docker/Dockerfile.*')
+            ENGINES=""
+            for f in $CHANGED; do
+              engine=$(basename "$f" | sed 's/Dockerfile\.//')
+              ENGINES="${ENGINES:+$ENGINES }$engine"
+            done
+            ENGINES="${ENGINES:-all}"
+          fi
+
+          # Normalise "all" once; downstream steps use the expanded list.
+          if [[ "$ENGINES" == "all" ]]; then
+            ENGINES="vllm tensorrt transformers"
+          fi
+          echo "engines=$ENGINES" >> "$GITHUB_OUTPUT"
+
+      - name: Run schema refresh
+        run: |
+          for engine in ${{ steps.engines.outputs.engines }}; do
+            echo "::group::Refreshing $engine schema"
+
+            # Save old schema for diffing.
+            OLD_SCHEMA="src/llenergymeasure/config/discovered_schemas/${engine}.json"
+            if [[ -f "$OLD_SCHEMA" ]]; then
+              cp "$OLD_SCHEMA" "/tmp/${engine}_old.json"
+            else
+              echo '{}' > "/tmp/${engine}_old.json"
+            fi
+
+            # Run discovery.
+            ./scripts/update_engine_schema.sh "$engine" || {
+              echo "::error::Discovery failed for $engine"
+              exit 1
+            }
+
+            echo "::endgroup::"
+          done
+
+      - name: Diff and classify changes
+        id: diff
+        run: |
+          IS_BREAKING=false
+          DIFF_BODY=""
+
+          for engine in ${{ steps.engines.outputs.engines }}; do
+            SCHEMA="src/llenergymeasure/config/discovered_schemas/${engine}.json"
+            OLD="/tmp/${engine}_old.json"
+
+            if [[ ! -f "$SCHEMA" ]]; then
+              continue
+            fi
+
+            OUTPUT=$(python3 scripts/diff_schemas.py "$OLD" "$SCHEMA" 2>/dev/null) || true
+            read -r BREAKING SUMMARY < <(echo "$OUTPUT" | python3 -c "
+          import sys, json
+          d = json.load(sys.stdin)
+          print(d.get('is_breaking', False), d.get('summary', 'unknown'))
+          " 2>/dev/null || echo "False unknown")
+
+            if [[ "$BREAKING" == "True" ]]; then
+              IS_BREAKING=true
+            fi
+
+            DIFF_BODY="${DIFF_BODY}### ${engine}\n${SUMMARY}\n\n"
+          done
+
+          echo "is_breaking=$IS_BREAKING" >> "$GITHUB_OUTPUT"
+          printf '%b' "$DIFF_BODY" > /tmp/diff_body.md
+
+      - name: Commit schema updates
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add src/llenergymeasure/config/discovered_schemas/*.json
+
+          if git diff --cached --quiet; then
+            echo "No schema changes to commit."
+            exit 0
+          fi
+
+          ENGINES="${{ steps.engines.outputs.engines }}"
+          git commit -m "chore(config): refresh ${ENGINES} schema(s)"
+          git push
+
+      - name: Post diff comment
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "No PR number available, skipping comment."
+            exit 0
+          fi
+
+          BODY="## Schema Diff\n\n$(cat /tmp/diff_body.md)"
+          printf '%b' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -
+
+      - name: Apply label
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+
+          if [[ "${{ steps.diff.outputs.is_breaking }}" == "true" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "schema-breaking" --remove-label "schema-safe" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --add-label "schema-safe" --remove-label "schema-breaking" 2>/dev/null || true
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["dockerfile"],
+  "dockerfile": {
+    "fileMatch": ["docker/Dockerfile\\..*"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["vllm/vllm-openai"],
+      "labels": ["renovate", "engine-vllm"],
+      "automerge": false,
+      "stabilityDays": 3
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["nvcr.io/nvidia/tensorrt-llm/release"],
+      "labels": ["renovate", "engine-tensorrt"],
+      "registryUrls": ["https://nvcr.io"],
+      "automerge": false,
+      "stabilityDays": 3
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["pytorch/pytorch"],
+      "labels": ["renovate", "engine-transformers"],
+      "automerge": false,
+      "stabilityDays": 3
+    }
+  ],
+  "schedule": ["before 9am on Monday"],
+  "labels": ["renovate"]
+}

--- a/scripts/check_schema_versions.py
+++ b/scripts/check_schema_versions.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Check that Dockerfile engine version ARGs match vendored schema engine_versions.
+
+Covers engines where the Dockerfile ARG directly corresponds to the engine
+version tracked in the schema:
+  - vllm: ARG VLLM_VERSION in docker/Dockerfile.vllm
+  - tensorrt: ARG TRTLLM_VERSION in docker/Dockerfile.tensorrt
+
+Transformers is excluded because its Dockerfile pins PyTorch (the base image),
+while the schema tracks the pip-installed transformers library version.
+
+Exit codes:
+    0 = all versions match (or non-version Dockerfile change)
+    1 = mismatch detected
+    2 = error (missing file, parse failure)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# (engine_name, arg_name)
+_ENGINE_SPECS = [
+    ("vllm", "VLLM_VERSION"),
+    ("tensorrt", "TRTLLM_VERSION"),
+]
+
+
+def _normalize_version(version: str) -> str:
+    """Strip leading 'v' prefix for comparison."""
+    return version.lstrip("v")
+
+
+def _parse_arg(dockerfile: Path, arg_name: str) -> str | None:
+    """Extract ARG default value from a Dockerfile."""
+    pattern = re.compile(rf"^ARG\s+{re.escape(arg_name)}=(\S+)")
+    for line in dockerfile.read_text().splitlines():
+        m = pattern.match(line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _parse_schema_version(schema_path: Path) -> str | None:
+    """Extract engine_version from a vendored schema JSON."""
+    data = json.loads(schema_path.read_text())
+    return data.get("engine_version")
+
+
+def main(repo_root: Path | None = None) -> int:
+    root = repo_root or REPO_ROOT
+    schema_dir = root / "src" / "llenergymeasure" / "config" / "discovered_schemas"
+
+    errors: list[str] = []
+    mismatches: list[str] = []
+
+    for engine, arg_name in _ENGINE_SPECS:
+        dockerfile = root / "docker" / f"Dockerfile.{engine}"
+        if not dockerfile.exists():
+            errors.append(f"{engine}: Dockerfile not found: {dockerfile}")
+            continue
+
+        schema_path = schema_dir / f"{engine}.json"
+        if not schema_path.exists():
+            errors.append(f"{engine}: schema not found: {schema_path}")
+            continue
+
+        dockerfile_version = _parse_arg(dockerfile, arg_name)
+        if dockerfile_version is None:
+            errors.append(f"{engine}: ARG {arg_name} not found in {dockerfile.name}")
+            continue
+
+        schema_version = _parse_schema_version(schema_path)
+        if schema_version is None:
+            errors.append(f"{engine}: engine_version not found in {schema_path.name}")
+            continue
+
+        if _normalize_version(dockerfile_version) != _normalize_version(schema_version):
+            mismatches.append(
+                f"MISMATCH: {dockerfile.name} pins {arg_name}={dockerfile_version} "
+                f"but schema was discovered against {schema_version}\n"
+                f"  Run: ./scripts/update_engine_schema.sh {engine}"
+            )
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    if mismatches:
+        for m in mismatches:
+            print(m, file=sys.stderr)
+        return 1
+
+    print("All schema versions match Dockerfile ARGs.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/diff_schemas.py
+++ b/scripts/diff_schemas.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Semantic differ for vendored engine schema JSONs.
+
+Classifies changes between two schema versions as safe or breaking.
+
+Usage:
+    python scripts/diff_schemas.py old.json new.json
+
+Exit codes:
+    0 = identical or safe changes only
+    1 = breaking changes detected
+    2 = error (malformed input, missing file, etc.)
+
+stdout: JSON with structured diff
+stderr: human-readable summary
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Param sections to diff (metadata fields like discovered_at are excluded
+# implicitly by only diffing these sections).
+_PARAM_SECTIONS = ("engine_params", "sampling_params")
+
+
+@dataclass
+class Change:
+    section: str
+    field: str
+    kind: str  # added, removed, type_changed, default_changed, description_changed
+    severity: str  # safe or breaking
+    detail: str = ""
+
+
+@dataclass
+class DiffResult:
+    safe: list[Change] = field(default_factory=list)
+    breaking: list[Change] = field(default_factory=list)
+    metadata_changes: dict[str, dict[str, str]] = field(default_factory=dict)
+    is_breaking: bool = False
+    summary: str = ""
+
+
+def _is_type_narrowed(old_type: str, new_type: str) -> bool:
+    """Return True if new_type is strictly narrower than old_type."""
+    old_parts = {t.strip() for t in old_type.split("|")}
+    new_parts = {t.strip() for t in new_type.split("|")}
+    # Narrowed if new is a strict subset of old.
+    return new_parts < old_parts
+
+
+def _is_type_widened(old_type: str, new_type: str) -> bool:
+    """Return True if new_type is strictly wider than old_type."""
+    old_parts = {t.strip() for t in old_type.split("|")}
+    new_parts = {t.strip() for t in new_type.split("|")}
+    # Widened if old is a strict subset of new.
+    return old_parts < new_parts
+
+
+def diff_schemas(old: dict, new: dict) -> DiffResult:
+    """Compare two schema dicts and classify changes."""
+    result = DiffResult()
+
+    # Check metadata changes.
+    for key in ("engine_version", "schema_version"):
+        old_val = old.get(key)
+        new_val = new.get(key)
+        if old_val != new_val:
+            result.metadata_changes[key] = {"old": str(old_val), "new": str(new_val)}
+
+    # Diff param sections.
+    for section in _PARAM_SECTIONS:
+        old_params = old.get(section, {})
+        new_params = new.get(section, {})
+
+        old_keys = set(old_params.keys())
+        new_keys = set(new_params.keys())
+
+        # Added fields.
+        for key in sorted(new_keys - old_keys):
+            change = Change(section=section, field=key, kind="added", severity="safe")
+            result.safe.append(change)
+
+        # Removed fields.
+        for key in sorted(old_keys - new_keys):
+            change = Change(section=section, field=key, kind="removed", severity="breaking")
+            result.breaking.append(change)
+
+        # Changed fields.
+        for key in sorted(old_keys & new_keys):
+            old_field = old_params[key]
+            new_field = new_params[key]
+
+            old_type = old_field.get("type", "")
+            new_type = new_field.get("type", "")
+
+            if old_type != new_type:
+                if _is_type_narrowed(old_type, new_type):
+                    change = Change(
+                        section=section,
+                        field=key,
+                        kind="type_narrowed",
+                        severity="breaking",
+                        detail=f"{old_type} -> {new_type}",
+                    )
+                    result.breaking.append(change)
+                elif _is_type_widened(old_type, new_type):
+                    change = Change(
+                        section=section,
+                        field=key,
+                        kind="type_widened",
+                        severity="safe",
+                        detail=f"{old_type} -> {new_type}",
+                    )
+                    result.safe.append(change)
+                else:
+                    change = Change(
+                        section=section,
+                        field=key,
+                        kind="type_changed",
+                        severity="breaking",
+                        detail=f"{old_type} -> {new_type}",
+                    )
+                    result.breaking.append(change)
+
+            old_default = old_field.get("default")
+            new_default = new_field.get("default")
+            if old_default != new_default:
+                change = Change(
+                    section=section,
+                    field=key,
+                    kind="default_changed",
+                    severity="safe",
+                    detail=f"{old_default!r} -> {new_default!r}",
+                )
+                result.safe.append(change)
+
+            old_desc = old_field.get("description", "")
+            new_desc = new_field.get("description", "")
+            if old_desc != new_desc and old_desc and new_desc:
+                change = Change(
+                    section=section,
+                    field=key,
+                    kind="description_changed",
+                    severity="safe",
+                )
+                result.safe.append(change)
+
+    result.is_breaking = len(result.breaking) > 0
+
+    # Build summary.
+    parts = []
+    if result.metadata_changes:
+        for k, v in result.metadata_changes.items():
+            parts.append(f"{k}: {v['old']} -> {v['new']}")
+    if result.safe:
+        parts.append(f"{len(result.safe)} safe change(s)")
+    if result.breaking:
+        parts.append(f"{len(result.breaking)} BREAKING change(s)")
+    if not parts:
+        parts.append("No changes")
+    result.summary = "; ".join(parts)
+
+    return result
+
+
+def _change_to_dict(c: Change) -> dict:
+    d = {"section": c.section, "field": c.field, "kind": c.kind}
+    if c.detail:
+        d["detail"] = c.detail
+    return d
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: diff_schemas.py <old.json> <new.json>", file=sys.stderr)
+        return 2
+
+    old_path = Path(sys.argv[1])
+    new_path = Path(sys.argv[2])
+
+    try:
+        old = json.loads(old_path.read_text())
+        new = json.loads(new_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error reading schemas: {e}", file=sys.stderr)
+        return 2
+
+    result = diff_schemas(old, new)
+
+    # Structured output to stdout.
+    output = {
+        "safe": [_change_to_dict(c) for c in result.safe],
+        "breaking": [_change_to_dict(c) for c in result.breaking],
+        "metadata_changes": result.metadata_changes,
+        "is_breaking": result.is_breaking,
+        "summary": result.summary,
+    }
+    print(json.dumps(output, indent=2))
+
+    # Human-readable to stderr.
+    print(f"\n{result.summary}", file=sys.stderr)
+    if result.breaking:
+        print("\nBreaking changes:", file=sys.stderr)
+        for c in result.breaking:
+            detail = f" ({c.detail})" if c.detail else ""
+            print(f"  - [{c.section}] {c.field}: {c.kind}{detail}", file=sys.stderr)
+
+    return 1 if result.is_breaking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_schema_versions.py
+++ b/tests/unit/scripts/test_check_schema_versions.py
@@ -1,0 +1,70 @@
+"""Tests for scripts/check_schema_versions.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Import the script's main function directly.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+from check_schema_versions import main
+
+
+def _setup_repo(
+    tmp_path: Path,
+    *,
+    vllm_arg: str = "v0.7.3",
+    vllm_schema_version: str = "0.7.3",
+    trt_arg: str = "0.21.0",
+    trt_schema_version: str = "0.21.0",
+    skip_vllm_schema: bool = False,
+) -> Path:
+    """Create a minimal repo structure for the version check script."""
+    repo = tmp_path / "repo"
+    docker = repo / "docker"
+    docker.mkdir(parents=True)
+
+    (docker / "Dockerfile.vllm").write_text(f"FROM ubuntu:22.04\nARG VLLM_VERSION={vllm_arg}\n")
+    (docker / "Dockerfile.tensorrt").write_text(
+        f"FROM ubuntu:22.04\nARG TRTLLM_VERSION={trt_arg}\n"
+    )
+
+    schema_dir = repo / "src" / "llenergymeasure" / "config" / "discovered_schemas"
+    schema_dir.mkdir(parents=True)
+
+    if not skip_vllm_schema:
+        (schema_dir / "vllm.json").write_text(json.dumps({"engine_version": vllm_schema_version}))
+    (schema_dir / "tensorrt.json").write_text(json.dumps({"engine_version": trt_schema_version}))
+
+    return repo
+
+
+class TestVersionsMatch:
+    def test_all_match(self, tmp_path: Path):
+        repo = _setup_repo(tmp_path)
+        assert main(repo_root=repo) == 0
+
+    def test_v_prefix_normalised(self, tmp_path: Path):
+        """v0.7.3 in Dockerfile should match 0.7.3 in schema."""
+        repo = _setup_repo(tmp_path, vllm_arg="v0.7.3", vllm_schema_version="0.7.3")
+        assert main(repo_root=repo) == 0
+
+
+class TestMismatch:
+    def test_version_mismatch(self, tmp_path: Path, capsys):
+        repo = _setup_repo(tmp_path, vllm_arg="v0.8.0", vllm_schema_version="0.7.3")
+        code = main(repo_root=repo)
+        assert code == 1
+        captured = capsys.readouterr()
+        assert "MISMATCH" in captured.err
+        assert "update_engine_schema.sh" in captured.err
+
+
+class TestErrors:
+    def test_missing_schema_file(self, tmp_path: Path, capsys):
+        repo = _setup_repo(tmp_path, skip_vllm_schema=True)
+        code = main(repo_root=repo)
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err

--- a/tests/unit/scripts/test_diff_schemas.py
+++ b/tests/unit/scripts/test_diff_schemas.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/diff_schemas.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "diff_schemas.py"
+
+
+def _make_schema(
+    engine_params: dict | None = None,
+    sampling_params: dict | None = None,
+    engine_version: str = "0.7.3",
+) -> dict:
+    """Build a minimal schema dict."""
+    return {
+        "schema_version": "1.0.0",
+        "engine": "test",
+        "engine_version": engine_version,
+        "engine_commit_sha": None,
+        "image_ref": "test:latest",
+        "base_image_ref": "test:latest",
+        "discovered_at": "2026-01-01T00:00:00Z",
+        "discovery_method": "test",
+        "discovery_limitations": [],
+        "engine_params": engine_params or {},
+        "sampling_params": sampling_params or {},
+    }
+
+
+def _run_diff(old: dict, new: dict, tmp_path: Path) -> tuple[int, dict, str]:
+    """Run the differ and return (exit_code, stdout_json, stderr)."""
+    old_file = tmp_path / "old.json"
+    new_file = tmp_path / "new.json"
+    old_file.write_text(json.dumps(old))
+    new_file.write_text(json.dumps(new))
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(old_file), str(new_file)],
+        capture_output=True,
+        text=True,
+    )
+    stdout_data = json.loads(result.stdout) if result.stdout.strip() else {}
+    return result.returncode, stdout_data, result.stderr
+
+
+class TestIdenticalSchemas:
+    def test_no_changes(self, tmp_path: Path):
+        schema = _make_schema(engine_params={"model": {"type": "str", "default": "gpt2"}})
+        code, output, _ = _run_diff(schema, schema, tmp_path)
+        assert code == 0
+        assert output["is_breaking"] is False
+        assert output["safe"] == []
+        assert output["breaking"] == []
+
+
+class TestSafeChanges:
+    def test_field_added(self, tmp_path: Path):
+        old = _make_schema(engine_params={"model": {"type": "str", "default": "gpt2"}})
+        new = _make_schema(
+            engine_params={
+                "model": {"type": "str", "default": "gpt2"},
+                "new_param": {"type": "int", "default": 0},
+            }
+        )
+        code, output, _ = _run_diff(old, new, tmp_path)
+        assert code == 0
+        assert output["is_breaking"] is False
+        assert any(c["kind"] == "added" and c["field"] == "new_param" for c in output["safe"])
+
+    def test_type_widened(self, tmp_path: Path):
+        old = _make_schema(engine_params={"x": {"type": "int", "default": 0}})
+        new = _make_schema(engine_params={"x": {"type": "int | None", "default": 0}})
+        code, output, _ = _run_diff(old, new, tmp_path)
+        assert code == 0
+        assert any(c["kind"] == "type_widened" for c in output["safe"])
+
+    def test_default_changed(self, tmp_path: Path):
+        old = _make_schema(engine_params={"x": {"type": "float", "default": 0.9}})
+        new = _make_schema(engine_params={"x": {"type": "float", "default": 0.95}})
+        code, output, _ = _run_diff(old, new, tmp_path)
+        assert code == 0
+        assert any(c["kind"] == "default_changed" for c in output["safe"])
+
+    def test_description_changed(self, tmp_path: Path):
+        old = _make_schema(engine_params={"x": {"type": "int", "default": 0, "description": "old"}})
+        new = _make_schema(engine_params={"x": {"type": "int", "default": 0, "description": "new"}})
+        code, output, _ = _run_diff(old, new, tmp_path)
+        assert code == 0
+        assert any(c["kind"] == "description_changed" for c in output["safe"])
+
+
+class TestBreakingChanges:
+    def test_field_removed(self, tmp_path: Path):
+        old = _make_schema(
+            engine_params={
+                "model": {"type": "str", "default": "gpt2"},
+                "old_param": {"type": "int", "default": 0},
+            }
+        )
+        new = _make_schema(engine_params={"model": {"type": "str", "default": "gpt2"}})
+        code, output, _ = _run_diff(old, new, tmp_path)
+        assert code == 1
+        assert output["is_breaking"] is True
+        assert any(c["kind"] == "removed" and c["field"] == "old_param" for c in output["breaking"])
+
+    def test_type_narrowed(self, tmp_path: Path):
+        old = _make_schema(engine_params={"x": {"type": "int | None", "default": None}})
+        new = _make_schema(engine_params={"x": {"type": "int", "default": 0}})
+        code, output, _ = _run_diff(old, new, tmp_path)
+        assert code == 1
+        assert any(c["kind"] == "type_narrowed" for c in output["breaking"])
+
+
+class TestMetadata:
+    def test_metadata_excluded_from_classification(self, tmp_path: Path):
+        """discovered_at changes should not appear as safe/breaking."""
+        old = _make_schema()
+        new = _make_schema()
+        new["discovered_at"] = "2026-12-31T00:00:00Z"
+        code, output, _ = _run_diff(old, new, tmp_path)
+        assert code == 0
+        assert output["safe"] == []
+        assert output["breaking"] == []
+
+    def test_engine_version_change_reported(self, tmp_path: Path):
+        old = _make_schema(engine_version="0.7.3")
+        new = _make_schema(engine_version="0.8.0")
+        _code, output, _ = _run_diff(old, new, tmp_path)
+        assert "engine_version" in output["metadata_changes"]
+        assert output["metadata_changes"]["engine_version"]["old"] == "0.7.3"
+        assert output["metadata_changes"]["engine_version"]["new"] == "0.8.0"
+
+
+class TestErrors:
+    def test_malformed_json(self, tmp_path: Path):
+        old_file = tmp_path / "old.json"
+        new_file = tmp_path / "new.json"
+        old_file.write_text("not json")
+        new_file.write_text("{}")
+
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(old_file), str(new_file)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+
+    def test_missing_file(self, tmp_path: Path):
+        new_file = tmp_path / "new.json"
+        new_file.write_text("{}")
+
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(tmp_path / "nope.json"), str(new_file)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+
+    def test_missing_section_graceful(self, tmp_path: Path):
+        """Schema with no engine_params section should not crash."""
+        old = {"schema_version": "1.0.0", "engine": "test", "engine_version": "1.0"}
+        new = {"schema_version": "1.0.0", "engine": "test", "engine_version": "1.0"}
+        code, _output, _ = _run_diff(old, new, tmp_path)
+        assert code == 0


### PR DESCRIPTION
## Summary

- **`scripts/diff_schemas.py`** - semantic differ classifying schema changes as safe (field added, type widened, default changed) or breaking (field removed, type narrowed). Structured JSON stdout + human-readable stderr.
- **`scripts/check_schema_versions.py`** - lightweight version guard comparing Dockerfile `ARG` version pins to vendored schema `engine_version` fields. Covers vllm and tensorrt (transformers excluded - Dockerfile pins PyTorch, schema tracks transformers pip version).
- **`.github/workflows/schema-refresh.yml`** - runs on self-hosted GPU runner. Auto-fires on Renovate PRs touching Dockerfiles (guarded to `renovate[bot]` only). Discovers new schema, commits to PR, posts diff comment, labels `schema-safe`/`schema-breaking`. Also supports `workflow_dispatch` for manual refreshes.
- **`ci.yml` schema-version-check job** - path-filtered to `docker/Dockerfile.*`, skips Renovate PRs. Catches human version bumps that forgot to regenerate schemas. Runs in <5s on ubuntu-latest.
- **`renovate.json`** - monitors vllm, tensorrt, and transformers Dockerfiles for upstream version bumps. Weekly schedule, 3-day stability window, no automerge.

## Architecture

```
Renovate                     schema-refresh.yml              ci.yml version guard
  |                               |                               |
  | detects Dockerfile             | auto-fires on Renovate PR     | non-Renovate PR
  | FROM tag bump                  | (also: manual dispatch)       | touches Dockerfile.*
  |                               |                               |
  v                               v                               v
Opens PR with          Runs on self-hosted GPU:        Lightweight version check:
version bump --------> builds image                   compares Dockerfile ARG
                       -> runs discovery               vs schema engine_version.
                       -> commits schema to PR         Runs on ubuntu-latest (<5s).
                       -> posts diff comment           Fails only on mismatch.
                       -> labels safe/breaking
```

## Test plan

- [x] `pytest tests/unit/scripts/ -v` - 16 tests pass (diff classification + version guard)
- [x] `python scripts/check_schema_versions.py` - exit 0 against current repo (versions match)
- [x] `python scripts/diff_schemas.py vllm.json vllm.json` - exit 0, no changes
- [ ] CI passes on this PR
- [ ] After merge: verify version guard fires on a draft PR that bumps a Dockerfile ARG
- [ ] After Renovate App install: verify schema-refresh auto-triggers

## Prerequisites (post-merge)

- Install [Mend Renovate](https://github.com/apps/renovate) GitHub App on the repo
- Ensure self-hosted GPU runner is available for schema-refresh jobs