### PR TITLE
docs(config): schema refresh pipeline documentation

### DIFF
--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -510,6 +510,21 @@ llem run experiment.yaml --skip-preflight
 
 ---
 
+## Keeping Engine Schemas Fresh
+
+When you update an engine version (by bumping the `ARG` in a Dockerfile), the
+vendored parameter schemas must be regenerated. This happens automatically via
+the [Schema Refresh Pipeline](schema-refresh.md) for Renovate-managed bumps.
+For manual bumps, run:
+
+```bash
+./scripts/update_engine_schema.sh <engine>
+```
+
+See [Schema Refresh Pipeline](schema-refresh.md) for the full workflow.
+
+---
+
 ## Next Steps
 
 - [Getting Started](getting-started.md) — run your first vLLM or TensorRT-LLM experiment

--- a/docs/schema-refresh.md
+++ b/docs/schema-refresh.md
@@ -1,0 +1,169 @@
+# Schema Refresh Pipeline
+
+Engine parameter schemas are vendored as JSON files in
+`src/llenergymeasure/config/discovered_schemas/`. When an upstream engine
+releases a new version, these schemas must be regenerated so that config
+validation stays in sync with the engine's actual parameters.
+
+This pipeline automates that process end-to-end.
+
+---
+
+## Overview
+
+```
+Upstream releases new engine version (e.g. vLLM v0.8.0)
+                      |
+                      v
+Renovate detects new tag on Docker Hub / NGC
+(checks weekly, waits 3 days for stability)
+                      |
+                      v
+Renovate opens PR bumping ARG in Dockerfile
+e.g. ARG VLLM_VERSION=v0.7.3 -> v0.8.0
+                      |
+                      v
+schema-refresh.yml auto-fires
+(guarded: only for renovate[bot] PRs touching Dockerfiles)
+                      |
+                      v
++------------------------------------------+
+|  Runs on self-hosted GPU runner:         |
+|  1. Pulls/builds new engine image        |
+|  2. Runs discover_engine_schemas.py      |
+|     inside the container                 |
+|  3. Compares old vs new schema           |
+|     (scripts/diff_schemas.py)            |
+|  4. Commits updated schema to PR         |
+|  5. Posts diff summary as PR comment     |
+|  6. Labels: schema-safe / schema-breaking|
++------------------------------------------+
+                      |
+                      v
+Maintainer reviews PR:
+- schema-safe: review diff, merge
+- schema-breaking: update Pydantic models / tests, then merge
+```
+
+---
+
+## How It Works
+
+### Automated Flow (Renovate PRs)
+
+1. **Renovate** monitors `docker/Dockerfile.*` for upstream image tag bumps
+   (weekly schedule, 3-day stability window before opening a PR).
+2. When Renovate opens a PR, **schema-refresh.yml** auto-fires on the
+   self-hosted GPU runner.
+3. The workflow determines which engine(s) changed by inspecting the modified
+   Dockerfile paths, then runs `./scripts/update_engine_schema.sh <engine>`.
+4. After discovery, `scripts/diff_schemas.py` classifies changes as safe or
+   breaking, commits the updated schema to the PR branch, posts a diff comment,
+   and applies a label (`schema-safe` or `schema-breaking`).
+
+### Manual Version Bumps (CI version guard)
+
+If a developer bumps an engine version ARG in a Dockerfile without running
+discovery, the `schema-version-check` job in `ci.yml` catches it:
+
+```
+Developer bumps engine version in Dockerfile
+                      |
+                      v
+ci.yml schema-version-check job fires
+(path-filtered to docker/Dockerfile.*, skips Renovate PRs)
+                      |
+                      v
+Compares ARG version in Dockerfile vs engine_version in schema JSON
+- MATCH: pass (non-version changes like build opts are fine)
+- MISMATCH: fail with actionable message
+```
+
+On failure, the developer can either:
+- Run locally: `./scripts/update_engine_schema.sh <engine>`
+- Trigger remotely: `gh workflow run schema-refresh.yml --field engine=<engine> --field pr_number=<N>`
+
+### Manual Refresh (workflow_dispatch)
+
+For ad-hoc refreshes outside the Renovate flow:
+
+```bash
+gh workflow run schema-refresh.yml \
+  --field engine=vllm \
+  --field pr_number=123
+```
+
+---
+
+## Change Classification
+
+`scripts/diff_schemas.py` classifies parameter changes by comparing old and new
+schema JSONs:
+
+| Change type         | Classification | Example                              |
+|---------------------|----------------|--------------------------------------|
+| Field added         | safe           | New `enable_chunked_prefill` param   |
+| Description updated | safe           | Docstring clarification              |
+| Default changed     | safe           | `gpu_memory_utilization: 0.9 -> 0.95`|
+| Type widened        | safe           | `int` -> `int | None`                |
+| Field removed       | BREAKING       | Deprecated param dropped             |
+| Type narrowed       | BREAKING       | `int | None` -> `int`                |
+| Enum value removed  | BREAKING       | Quantisation mode dropped            |
+
+Metadata fields (`discovered_at`, `engine_commit_sha`, `image_ref`,
+`base_image_ref`) are excluded from classification as they change on every run.
+
+---
+
+## Handling Breaking Changes
+
+When schema-refresh labels a PR `schema-breaking`:
+
+1. Check which fields were removed/narrowed (see the PR comment diff)
+2. Update Pydantic models in `src/llenergymeasure/config/engine_configs.py`
+3. Update affected tests and YAML fixtures
+4. Add CHANGELOG entry under Breaking Changes
+5. Push fixes to the Renovate PR branch, re-run CI
+
+---
+
+## Adding a New Engine
+
+1. Create `docker/Dockerfile.<engine>` with an `ARG` version pin
+2. Add a discovery function in `scripts/discover_engine_schemas.py`
+3. Add a case to `scripts/update_engine_schema.sh`
+4. Run discovery: `./scripts/update_engine_schema.sh <engine>`
+5. Add a Renovate `packageRule` in `renovate.json`
+6. If the Dockerfile ARG maps directly to the engine version, add an entry to
+   `_ENGINE_SPECS` in `scripts/check_schema_versions.py`
+
+The schema-refresh workflow and version guard automatically cover new engines
+via path-based triggers (`docker/Dockerfile.*`).
+
+---
+
+## Prerequisites
+
+- [Mend Renovate](https://github.com/apps/renovate) GitHub App installed on the
+  repo (free for open-source)
+- Self-hosted GPU runner available for schema-refresh jobs
+- Docker + NVIDIA Container Toolkit on the runner
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Renovate not detecting bumps | `fileMatch` pattern doesn't cover the Dockerfile | Check Renovate dashboard, verify `docker/Dockerfile\\..*` matches |
+| schema-refresh fails to import engine | Needs `--gpus all` | Verify GPU runner has NVIDIA drivers + Container Toolkit |
+| Version guard fails on non-version change | Won't happen - guard only compares version ARGs | If it does, check `_parse_arg` regex in `check_schema_versions.py` |
+| NGC registry auth failure | Private image or rate-limited | Add `hostRules` to `renovate.json` |
+| Schema unchanged after discovery | Engine version didn't change params | Expected - workflow commits nothing and exits cleanly |
+
+---
+
+## Related
+
+- [Docker Setup](docker-setup.md) - building engine images locally
+- [Engine Configuration](engines.md) - configuring engine parameters


### PR DESCRIPTION
## Summary

- `docs/schema-refresh.md` - full pipeline documentation covering automated flow, manual refresh, change classification, handling breaking changes, adding new engines, prerequisites, and troubleshooting
- `docs/docker-setup.md` - added "Keeping Engine Schemas Fresh" cross-link section

## Dependencies

Lands after #279 (the implementation PR) merges so docs describe a working system.

## Test plan

- [ ] Links between docs resolve correctly
- [ ] Instructions match actual script interfaces