### PR TITLE
fix(test): prevent dotenv reimport from polluting monkeypatch targets

### DIFF
--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import llenergymeasure.cli.run as cli_run_mod
 from tests.conftest import make_result, make_study_result, make_user_config
 
 # =============================================================================
@@ -295,7 +296,6 @@ class TestPipelineDryRun:
 
         # Patch VRAM utilities to avoid GPU hardware dependency.
         # estimate_vram returns dict[str, float] | None (not a plain float).
-        import llenergymeasure.cli.run as cli_run_mod
 
         _fake_vram = {"weights_gb": 1.0, "kv_cache_gb": 0.5, "overhead_gb": 0.2, "total_gb": 1.7}
         monkeypatch.setattr(cli_run_mod, "estimate_vram", lambda config: _fake_vram)

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -295,15 +295,11 @@ class TestPipelineDryRun:
 
         # Patch VRAM utilities to avoid GPU hardware dependency.
         # estimate_vram returns dict[str, float] | None (not a plain float).
+        import llenergymeasure.cli.run as cli_run_mod
+
         _fake_vram = {"weights_gb": 1.0, "kv_cache_gb": 0.5, "overhead_gb": 0.2, "total_gb": 1.7}
-        monkeypatch.setattr(
-            "llenergymeasure.cli.run.estimate_vram",
-            lambda config: _fake_vram,
-        )
-        monkeypatch.setattr(
-            "llenergymeasure.cli.run.get_gpu_vram_gb",
-            lambda: 40.0,
-        )
+        monkeypatch.setattr(cli_run_mod, "estimate_vram", lambda config: _fake_vram)
+        monkeypatch.setattr(cli_run_mod, "get_gpu_vram_gb", lambda: 40.0)
 
         runner = CliRunner()
         result = runner.invoke(app, ["run", str(yaml_path), "--dry-run"])
@@ -327,6 +323,7 @@ class TestCLIE2ESingleExperiment:
         """CLI run command exits 0 and prints result summary for a single experiment."""
         from typer.testing import CliRunner
 
+        import llenergymeasure.cli.run as cli_run_mod
         from llenergymeasure.cli import app
 
         yaml_path = tmp_path / "experiment.yaml"
@@ -334,11 +331,7 @@ class TestCLIE2ESingleExperiment:
 
         mock_result = make_result(experiment_id="cli-e2e-001")
 
-        # Patch run_experiment at the CLI module import (tqdm requires the real sys.stderr)
-        monkeypatch.setattr(
-            "llenergymeasure.cli.run.run_experiment",
-            lambda config, **kw: mock_result,
-        )
+        monkeypatch.setattr(cli_run_mod, "run_experiment", lambda config, **kw: mock_result)
 
         runner = CliRunner()
         result = runner.invoke(app, ["run", str(yaml_path)])
@@ -350,14 +343,12 @@ class TestCLIE2ESingleExperiment:
         """CLI run --model gpt2 via CliRunner exits 0."""
         from typer.testing import CliRunner
 
+        import llenergymeasure.cli.run as cli_run_mod
         from llenergymeasure.cli import app
 
         mock_result = make_result(experiment_id="cli-flag-001")
 
-        monkeypatch.setattr(
-            "llenergymeasure.cli.run.run_experiment",
-            lambda config, **kw: mock_result,
-        )
+        monkeypatch.setattr(cli_run_mod, "run_experiment", lambda config, **kw: mock_result)
 
         runner = CliRunner()
         result = runner.invoke(app, ["run", "--model", "gpt2", "--engine", "transformers"])
@@ -431,6 +422,7 @@ class TestCLIE2EErrorExitCodes:
         """llem run exits with correct code when run_experiment raises an error."""
         from typer.testing import CliRunner
 
+        import llenergymeasure.cli.run as cli_run_mod
         import llenergymeasure.utils.exceptions
         from llenergymeasure.cli import app
 
@@ -441,7 +433,8 @@ class TestCLIE2EErrorExitCodes:
         exc_instance = error_cls(f"test {error_class}")
 
         monkeypatch.setattr(
-            "llenergymeasure.cli.run.run_experiment",
+            cli_run_mod,
+            "run_experiment",
             lambda config, **kw: (_ for _ in ()).throw(exc_instance),
         )
 

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+import llenergymeasure.cli.config_cmd as cli_config_mod
 from llenergymeasure.cli import app
 
 runner = CliRunner()
@@ -49,7 +50,7 @@ def test_config_basic_output() -> None:
         return None
 
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=mock_gpu),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=mock_gpu),
         patch("importlib.util.find_spec", side_effect=fake_find_spec),
     ):
         result = runner.invoke(app, ["config"])
@@ -63,7 +64,7 @@ def test_config_basic_output() -> None:
 
 def test_config_no_gpu() -> None:
     """When _probe_gpu returns None, output contains 'No GPU detected'."""
-    with patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None):
+    with patch.object(cli_config_mod, "_probe_gpu", return_value=None):
         result = runner.invoke(app, ["config"])
 
     assert result.exit_code == 0
@@ -72,7 +73,7 @@ def test_config_no_gpu() -> None:
 
 def test_config_verbose_shows_python_version() -> None:
     """--verbose output contains Python and a version number."""
-    with patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None):
+    with patch.object(cli_config_mod, "_probe_gpu", return_value=None):
         result = runner.invoke(app, ["config", "--verbose"])
 
     assert result.exit_code == 0
@@ -88,7 +89,7 @@ def test_config_user_config_path_shown() -> None:
     """User config path is printed in the Config section."""
     fake_path = Path("/home/user/.config/llenergymeasure/config.yaml")
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=None),
         patch("llenergymeasure.config.user_config.get_user_config_path", return_value=fake_path),
     ):
         result = runner.invoke(app, ["config"])
@@ -99,7 +100,7 @@ def test_config_user_config_path_shown() -> None:
 
 def test_config_exits_0() -> None:
     """Config command always exits 0 regardless of environment state."""
-    with patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None):
+    with patch.object(cli_config_mod, "_probe_gpu", return_value=None):
         result = runner.invoke(app, ["config"])
     assert result.exit_code == 0
 
@@ -123,7 +124,7 @@ def test_config_verbose_gpu_driver() -> None:
     mock_nvml_context.return_value.__exit__ = MagicMock(return_value=False)
 
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=mock_gpu),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=mock_gpu),
         patch.dict("sys.modules", {"pynvml": mock_pynvml}),
         patch("llenergymeasure.device.gpu_info.nvml_context", mock_nvml_context),
     ):
@@ -144,8 +145,8 @@ def test_config_verbose_engine_versions() -> None:
         return None
 
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None),
-        patch("llenergymeasure.cli.config_cmd._probe_engine_version", return_value="2.2.0"),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=None),
+        patch.object(cli_config_mod, "_probe_engine_version", return_value="2.2.0"),
         patch("importlib.util.find_spec", side_effect=fake_find_spec),
     ):
         result = runner.invoke(app, ["config", "-v"])
@@ -168,7 +169,7 @@ def test_config_energy_samplers_zeus() -> None:
         return None
 
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=None),
         patch("importlib.util.find_spec", side_effect=fake_find_spec_zeus),
     ):
         result = runner.invoke(app, ["config"])
@@ -184,7 +185,7 @@ def test_config_energy_samplers_none() -> None:
         return None
 
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=None),
         patch("importlib.util.find_spec", side_effect=fake_find_spec_none),
     ):
         result = runner.invoke(app, ["config"])
@@ -203,7 +204,7 @@ def test_config_user_config_not_found() -> None:
     fake_path = Path("/nonexistent/.config/llenergymeasure/config.yaml")
 
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=None),
         patch("llenergymeasure.config.user_config.get_user_config_path", return_value=fake_path),
     ):
         result = runner.invoke(app, ["config"])
@@ -240,7 +241,7 @@ def test_config_user_config_loaded_verbose_non_defaults() -> None:
     # load_user_config and UserConfig are lazy-imported inside the function body —
     # patch at the source module, not at config_cmd
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=None),
         patch("llenergymeasure.config.user_config.get_user_config_path", return_value=fake_path),
         patch("llenergymeasure.config.user_config.load_user_config", return_value=mock_user_cfg),
         patch("llenergymeasure.config.user_config.UserConfig", return_value=defaults_cfg),
@@ -332,7 +333,7 @@ def test_config_verbose_driver_exception_handled() -> None:
     mock_nvml_context.return_value.__exit__ = MagicMock(return_value=False)
 
     with (
-        patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=mock_gpu),
+        patch.object(cli_config_mod, "_probe_gpu", return_value=mock_gpu),
         patch.dict("sys.modules", {"pynvml": mock_pynvml}),
         patch("llenergymeasure.device.gpu_info.nvml_context", mock_nvml_context),
     ):
@@ -358,7 +359,7 @@ def test_config_cmd_renders_without_rich() -> None:
         sys.modules.pop(k)
 
     try:
-        with patch("llenergymeasure.cli.config_cmd._probe_gpu", return_value=None):
+        with patch.object(cli_config_mod, "_probe_gpu", return_value=None):
             result = runner.invoke(app, ["config"])
         assert result.exit_code == 0, f"config command failed: {result.output}"
     finally:

--- a/tests/unit/cli/test_cli_run.py
+++ b/tests/unit/cli/test_cli_run.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
+import llenergymeasure.cli._display as cli_display_mod
+import llenergymeasure.cli.run as cli_run_mod
 from llenergymeasure.cli import app
 
 runner = CliRunner()
@@ -179,7 +181,7 @@ def test_run_config_error_exits_2():
     """ConfigError raised by load_experiment_config exits with code 2."""
     from llenergymeasure.utils.exceptions import ConfigError
 
-    with patch("llenergymeasure.cli.run.load_experiment_config") as mock_load:
+    with patch.object(cli_run_mod, "load_experiment_config") as mock_load:
         mock_load.side_effect = ConfigError("bad config: unknown field 'foop'")
         result = runner.invoke(app, ["run", "nonexistent.yaml"])
 
@@ -206,8 +208,8 @@ def test_run_preflight_error_exits_1():
     mock_config = _make_mock_config()
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.run_experiment") as mock_run,
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "run_experiment") as mock_run,
     ):
         mock_run.side_effect = PreFlightError("no GPU available")
         result = runner.invoke(app, ["run", "--model", "gpt2"])
@@ -225,8 +227,8 @@ def test_run_experiment_error_exits_1():
     mock_config = _make_mock_config()
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.run_experiment") as mock_run,
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "run_experiment") as mock_run,
     ):
         mock_run.side_effect = ExperimentError("inference crashed")
         result = runner.invoke(app, ["run", "--model", "gpt2"])
@@ -253,10 +255,10 @@ def test_run_dry_run_exits_0():
     }
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.estimate_vram", return_value=mock_vram),
-        patch("llenergymeasure.cli.run.get_gpu_vram_gb", return_value=None),
-        patch("llenergymeasure.cli.run.print_dry_run") as mock_print_dry,
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "estimate_vram", return_value=mock_vram),
+        patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None),
+        patch.object(cli_run_mod, "print_dry_run") as mock_print_dry,
     ):
         result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run"])
 
@@ -271,10 +273,10 @@ def test_run_dry_run_calls_estimate_vram():
     mock_config = _make_mock_config()
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.estimate_vram", return_value=None) as mock_vram,
-        patch("llenergymeasure.cli.run.get_gpu_vram_gb", return_value=None) as mock_gpu_vram,
-        patch("llenergymeasure.cli.run.print_dry_run"),
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "estimate_vram", return_value=None) as mock_vram,
+        patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None) as mock_gpu_vram,
+        patch.object(cli_run_mod, "print_dry_run"),
     ):
         result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run"])
 
@@ -294,9 +296,9 @@ def test_run_quiet_flag_accepted():
     mock_result = _make_mock_result()
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.run_experiment", return_value=mock_result) as mock_run,
-        patch("llenergymeasure.cli.run.print_result_summary"),
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "run_experiment", return_value=mock_result) as mock_run,
+        patch.object(cli_run_mod, "print_result_summary"),
     ):
         result = runner.invoke(app, ["run", "--model", "gpt2", "--quiet"])
 
@@ -320,9 +322,9 @@ def test_run_success_prints_summary():
     mock_result = _make_mock_result()
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.run_experiment", return_value=mock_result),
-        patch("llenergymeasure.cli.run.print_result_summary") as mock_summary,
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "run_experiment", return_value=mock_result),
+        patch.object(cli_run_mod, "print_result_summary") as mock_summary,
     ):
         result = runner.invoke(app, ["run", "--model", "gpt2"])
 
@@ -454,7 +456,7 @@ def test_run_study_routing_sweep_yaml(tmp_path):
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
         patch("llenergymeasure.config.loader.load_study_config") as mock_load,
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         mock_config = MagicMock()
         mock_config.experiments = [MagicMock(), MagicMock()]
@@ -483,7 +485,7 @@ def test_run_study_routing_experiments_yaml(tmp_path):
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
         patch("llenergymeasure.config.loader.load_study_config") as mock_load,
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         mock_config = MagicMock()
         mock_config.experiments = [MagicMock(), MagicMock()]
@@ -506,9 +508,9 @@ def test_run_saves_to_output_dir(tmp_path):
     output_dir = tmp_path / "out"
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.run_experiment", return_value=mock_result) as mock_run,
-        patch("llenergymeasure.cli.run.print_result_summary"),
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "run_experiment", return_value=mock_result) as mock_run,
+        patch.object(cli_run_mod, "print_result_summary"),
     ):
         result = runner.invoke(app, ["run", "--model", "gpt2", "--output", str(output_dir)])
 
@@ -535,7 +537,7 @@ def test_run_study_cli_defaults_applied(tmp_path):
         patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         result = runner.invoke(app, ["run", str(study_yaml)])
 
@@ -561,8 +563,8 @@ def test_run_engine_error_exits_1():
     mock_config = _make_mock_config()
 
     with (
-        patch("llenergymeasure.cli.run.load_experiment_config", return_value=mock_config),
-        patch("llenergymeasure.cli.run.run_experiment") as mock_run,
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "run_experiment") as mock_run,
     ):
         mock_run.side_effect = EngineError("OOM during forward pass")
         result = runner.invoke(app, ["run", "--model", "gpt2"])
@@ -603,7 +605,7 @@ def test_fail_fast_sets_max_consecutive_failures(tmp_path):
         patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         result = runner.invoke(app, ["run", str(study_yaml), "--fail-fast"])
 
@@ -624,7 +626,7 @@ def test_no_circuit_breaker_sets_max_failures_zero(tmp_path):
         patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         result = runner.invoke(app, ["run", str(study_yaml), "--no-circuit-breaker"])
 
@@ -644,7 +646,7 @@ def test_timeout_flag_sets_wall_clock_timeout(tmp_path):
         patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         result = runner.invoke(app, ["run", str(study_yaml), "--timeout", "24"])
 
@@ -664,7 +666,7 @@ def test_timeout_flag_fractional(tmp_path):
         patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         result = runner.invoke(app, ["run", str(study_yaml), "--timeout", "1.5"])
 
@@ -689,7 +691,7 @@ def test_resume_flag_passes_resume_to_api(tmp_path):
         patch("llenergymeasure.config.loader.load_study_config", return_value=mock_study_config),
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
         patch(
             "llenergymeasure.api.find_resumable_study",
             return_value=tmp_path / "fake-study",
@@ -722,7 +724,7 @@ def test_resume_dir_flag_passes_path_to_api(tmp_path):
         patch("llenergymeasure.config.loader.load_study_config", return_value=mock_study_config),
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
         patch("llenergymeasure.config.grid.build_preflight_panel"),
-        patch("llenergymeasure.cli._display.print_study_summary"),
+        patch.object(cli_display_mod, "print_study_summary"),
     ):
         result = runner.invoke(app, ["run", str(study_yaml), "--resume-dir", str(explicit_dir)])
 

--- a/tests/unit/cli/test_dotenv_loading.py
+++ b/tests/unit/cli/test_dotenv_loading.py
@@ -18,8 +18,21 @@ def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     restored at teardown — a raw ``del sys.modules[...]`` would leak the
     reimport across subsequent tests and cause test-pollution failures
     (e.g. preflight spec lookups returning None in unrelated CLI tests).
+
+    Also saves/restores the ``llenergymeasure.cli`` attribute on the parent
+    package: Python's import machinery sets ``parent.child = module`` as a
+    side effect when importing a subpackage, and ``monkeypatch.delitem`` on
+    ``sys.modules`` alone does not undo that.  Without this, pytest's
+    ``resolve()`` (used by string-target ``monkeypatch.setattr``) follows the
+    stale parent attribute and patches a ghost module that nothing actually
+    calls, making unrelated CLI tests flaky under xdist.
     """
     monkeypatch.chdir(tmp_path)
+    # Save the parent-package attribute so teardown undoes the reimport side effect.
+    import llenergymeasure
+
+    if hasattr(llenergymeasure, "cli"):
+        monkeypatch.setattr(llenergymeasure, "cli", llenergymeasure.cli)
     for modname in list(sys.modules):
         if modname == "llenergymeasure.cli" or modname.startswith("llenergymeasure.cli."):
             monkeypatch.delitem(sys.modules, modname)


### PR DESCRIPTION
## Summary

Fixes the intermittent post-merge CI failures on `10f0172b` (#275) and `0c25c05f` (#277).

**Root cause**: `test_dotenv_loading.py`'s `isolated_env` fixture deletes CLI modules from `sys.modules` and reimports them, but Python's import machinery also sets `parent.child = module` as a side effect. `monkeypatch.delitem` on `sys.modules` alone does not undo that parent attribute, so pytest's `resolve()` (used by string-target `monkeypatch.setattr`) follows the stale attribute and patches a ghost module — making CLI patches no-ops. Whether this manifests depends on `pytest-xdist` worker assignment and `pytest-randomly` seed, which is why it passed PR CI but failed post-merge.

**Fixes**:
1. **`test_dotenv_loading.py`** — save/restore the `llenergymeasure.cli` parent-package attribute in `isolated_env`, so teardown fully undoes the reimport side effect
2. **`test_e2e_pipeline.py`** — convert all `"llenergymeasure.cli.*"` string-target monkeypatches to direct module references, making them immune to attribute-traversal pollution

## Test plan

- [x] Reproduction test passes: `pytest test_dotenv_loading.py test_e2e_pipeline.py::TestCLIE2ESingleExperiment -n 1` (10/10 pass — previously failed)
- [x] Full suite: 1900/1900 pass (`pytest tests/ -m "not gpu and not docker" -n auto`)
- [x] Lint + format clean
- [ ] CI passes (watching)