### PR TITLE
feat(config): add CurationMetadata scaffolding for typed engine fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- **`CurationMetadata` scaffolding for typed engine fields.** Every typed field in `engine_configs.py` now carries a structured `CurationMetadata` dataclass (clauses, rationale, native mapping) attached via `json_schema_extra`. The rubric is defined in `.product/research/parameter-curation-rubric.md`. A CI assertion test (`test_every_typed_engine_field_has_curation_metadata`) guards that every typed field carries non-empty metadata so new fields cannot be added without a rubric verdict.
+
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.
 - **`llem doctor` CLI command.** Reports per-backend image status (OK / MISMATCH / UNVERIFIED / UNREACHABLE) and exits non-zero on mismatch for CI-friendly gating.
 - **Inline schema status in the image-prep progress line** (`schema: ok` / `schema: mismatch` / `schema: unverified` / `schema: bypassed`), rendered via the existing metadata display with no changes to the progress protocol.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,24 @@ All notable changes to this project are documented here.
   - `transformers.tp_size` — HF accelerate convention, unchanged
   - `vllm.engine.tensor_parallel_size` — already native name, unchanged
 
+- **Typed-field curation for engine configs (maximalist rubric).** Applies the rubric "type anything with a plausible energy/throughput/latency path" to each engine's Pydantic surface. Dropped fields remain settable via YAML (`extra="allow"` passthrough unless noted).
+
+  **Transformers** — drops 2 typed fields, adds 4:
+  - Dropped: `revision` (D1 reproducibility metadata), `trust_remote_code` (D1 security toggle). Both remain settable via `extra="allow"`.
+  - Added: `allow_tf32`, `autocast_enabled`, `autocast_dtype`, `low_cpu_mem_usage`.
+  - Also adds `tp_plan` and `tp_size` to the introspection param list (were missing).
+
+  **vLLM** — drops 4 typed fields, adds 3, replaces 2 with typed sub-config:
+  - Dropped: `sampling.max_tokens`, `beam_search.max_tokens` (R2 dups of `ExperimentConfig.max_output_tokens`; bridged in adapter). `speculative_model` and `num_speculative_tokens` replaced (not simply dropped).
+  - Added: `num_scheduler_steps`, `max_seq_len_to_capture`, `distributed_executor_backend`.
+  - Replaced: flat `speculative_model` + `num_speculative_tokens` → typed nested `VLLMSpeculativeConfig` sub-config (mirrors vLLM native shape; sweepable via dotted paths). Migration: `{speculative_model: m, num_speculative_tokens: k}` → `{speculative: {model: m, num_speculative_tokens: k}}`.
+  - `VLLMAttentionConfig` stays nested; all 10 fields (including `use_trtllm_attention`, `use_trtllm_ragged_deepseek_prefill`) remain typed.
+
+  **TensorRT-LLM** — drops 9 typed fields (incl. 2 sub-config classes), adds 2:
+  - Dropped: `backend: Literal["trt"]` (D2), `engine_path` (D1), entire `TensorRTCalibConfig` (D3 build-only PTQ), entire `TensorRTBuildCacheConfig` (D1 cache plumbing), `sampling.return_perf_metrics` (D1). All remain passable via `extra="allow"`.
+  - Added: `pipeline_parallel_size` (MLPerf v5.0 Blackwell), `max_num_tokens` (trtllm-bench axis).
+  - `fast_build` kept typed — build-time knob with runtime consequences.
+
 ### Added
 
 - **Host/container schema fingerprint verification.** Docker images are now stamped at build time with a `llem.expconf.schema.fingerprint` OCI label (SHA-256 of `ExperimentConfig.model_json_schema()`) plus `org.opencontainers.image.version`. `StudyRunner._prepare_images` compares the label to the host fingerprint before any experiment runs and aborts with an actionable rebuild hint on mismatch. The check is bypassable via `LLEM_SKIP_IMAGE_CHECK=1`.

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -105,8 +105,15 @@ Note: `load_in_4bit` and `load_in_8bit` are mutually exclusive.
 |-----------|------|---------|-------------|
 | `device_map` | str | `auto` | Device placement strategy |
 | `max_memory` | dict | null | Per-device memory limits, e.g. `{0: "10GiB", cpu: "50GiB"}` |
-| `revision` | str | null | Model commit hash for reproducibility |
-| `trust_remote_code` | bool | true | Allow executing remote code in model repo |
+| `low_cpu_mem_usage` | bool | true | Load weights incrementally to minimise peak CPU RAM |
+
+**Floating-Point Precision:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `allow_tf32` | bool | null | Allow TF32 for matrix multiplications on Ampere+ (affects energy/throughput) |
+| `autocast_enabled` | bool | false | Enable `torch.autocast` during generation |
+| `autocast_dtype` | `float16` \| `bfloat16` | `bfloat16` | AMP dtype (only used when `autocast_enabled: true`) |
 
 **Beam Search:**
 
@@ -228,12 +235,32 @@ initialisation time. All fields default to `null` (use vLLM's own default).
 | `quantization` | `awq` \| `gptq` \| `fp8` \| `marlin` \| `bitsandbytes` \| ... | null | Quantization method (requires pre-quantised checkpoint) |
 | `enable_prefix_caching` | bool | false | Automatic prefix caching for shared prompt prefixes |
 
+**Scheduler Tuning:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_scheduler_steps` | int | 1 | Multi-step scheduling: run N decode steps before returning to the scheduler (increases throughput at the cost of more VRAM per step) |
+| `max_seq_len_to_capture` | int | 8192 | Maximum sequence length eligible for CUDA graph capture (sequences longer than this fall back to eager mode) |
+
+**Distributed Execution:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `distributed_executor_backend` | `mp` \| `ray` | `mp` | Multi-GPU executor backend (`mp` = multiprocessing, `ray` = Ray cluster) |
+
 **Speculative Decoding:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `speculative_model` | str | null | HF model name for draft model (speculative decoding) |
-| `num_speculative_tokens` | int | null | Tokens to draft per step (required when `speculative_model` set) |
+| `speculative` | VLLMSpeculativeConfig | null | Speculative decoding sub-config (see below) |
+
+`speculative` sub-config fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model` | str | null | HF model name or path for the draft model |
+| `num_speculative_tokens` | int | null | Tokens to draft per step |
+| `method` | str | null | Speculative method (e.g. `eagle`, `medusa`; null = draft-model mode) |
 
 ### vLLM Sampling Parameters
 
@@ -311,11 +338,10 @@ runners:
 tensorrt:
   tensor_parallel_size: 2
   max_batch_size: 8
+  max_num_tokens: 4096
   dtype: bfloat16
   quant:
     quant_algo: W4A16_AWQ
-  build_cache:
-    max_cache_storage_gb: 256
 ```
 
 > **Engine compilation on first run.** The first run with a given config will compile a
@@ -331,12 +357,14 @@ Changing any **[recompile]** field invalidates the cached engine and triggers a 
 |-----------|------|---------|-------------|
 | `max_batch_size` | int | 8 | Maximum batch size the engine accepts. **[recompile]** |
 | `tensor_parallel_size` | int | 1 | Tensor parallel degree (number of GPUs). **[recompile]** |
+| `pipeline_parallel_size` | int | 1 | Pipeline parallel stages (number of pipeline stages across GPUs). **[recompile]** |
 | `max_input_len` | int | 1024 | Maximum input sequence length in tokens. **[recompile]** |
 | `max_seq_len` | int | 2048 | Maximum total sequence length (input + output). **[recompile]** |
+| `max_num_tokens` | int | auto | Maximum tokens the engine handles per iteration (scheduler throughput axis alongside `max_batch_size`). **[recompile]** |
 | `dtype` | `float16` \| `bfloat16` | auto | Model compute dtype. TRT-LLM is optimised for fp16/bf16; fp32 is not supported. **[recompile]** |
 | `fast_build` | bool | false | Enable fast engine build mode (reduced optimisation, faster compilation). **[recompile]** |
 | `engine` | `trt` | `trt` | TRT-LLM internal backend selector. This is the `LLM(backend=...)` parameter, not the `llem` engine field. Leave unset unless you have a specific reason to override. |
-| `engine_path` | str | null | Path to a pre-compiled engine directory. When set, skips compilation and loads the engine directly. All compile-time parameters and `build_cache` are ignored. See [Pre-Compiled Engine Loading](#pre-compiled-engine-loading) below. |
+| `engine_path` | str | null | Path to a pre-compiled engine directory. When set, skips compilation and loads the engine directly. See [Pre-Compiled Engine Loading](#pre-compiled-engine-loading) below. |
 
 ### tensorrt.quant: Quantization
 
@@ -363,17 +391,6 @@ Quantization is applied at engine compile time — changing `quant_algo` trigger
 > **A100 note:** A100 (SM 8.0) does not support FP8. Valid A100 quantization options:
 > `INT8`, `W4A16_AWQ`, `W4A16_GPTQ`, `W8A16`, `W8A16_GPTQ`, `W4A8_AWQ`, `NO_QUANT`.
 
-### tensorrt.calib: PTQ Calibration
-
-Only relevant when `quant_algo` requires post-training quantization (PTQ) calibration
-(e.g. `INT8`, `W4A16_AWQ`).
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `calib_batches` | int | 512 | Number of calibration batches |
-| `calib_dataset` | str | `cnn_dailymail` | Calibration dataset name or HuggingFace path |
-| `calib_max_seq_length` | int | 512 | Max sequence length for calibration samples |
-
 ### tensorrt.kv_cache: KV Cache
 
 | Parameter | Type | Default | Description |
@@ -393,17 +410,6 @@ Only relevant when `quant_algo` requires post-training quantization (PTQ) calibr
 - `GUARANTEED_NO_EVICT` — guarantees no request eviction; may reduce throughput
 - `MAX_UTILIZATION` — maximises GPU utilisation; may evict requests under memory pressure
 - `STATIC_BATCH` — fixed batch size; useful for reproducible benchmarking
-
-### tensorrt.build_cache: Engine Build Cache
-
-Engine caching is enabled by default even without an explicit `build_cache:` section.
-Compiled engines are stored in `~/.cache/tensorrt_llm` and reused across runs.
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `cache_root` | str | `~/.cache/tensorrt_llm` | Root directory for engine cache storage |
-| `max_records` | int | 10 | Maximum number of cached engine records |
-| `max_cache_storage_gb` | float | 256 | Maximum total cache size in GB |
 
 ### Pre-Compiled Engine Loading
 
@@ -470,7 +476,6 @@ all engines.
 | `min_tokens` | int | 0 | Minimum output tokens before EOS is allowed |
 | `n` | int | 1 | Number of output sequences per prompt |
 | `ignore_eos` | bool | false | Continue generating past EOS token (forces full `max_output_tokens` generation) |
-| `return_perf_metrics` | bool | false | Return TRT-LLM internal performance metrics in output |
 
 For advanced TRT-LLM parameters, see the [TensorRT-LLM documentation](https://nvidia.github.io/TensorRT-LLM/).
 

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -720,8 +720,10 @@ relates to energy measurement.
 | `prompt_lookup_num_tokens` | integer | None | `null` | Prompt-lookup speculative decoding tokens (None -> disabled) |
 | `device_map` | string | None | `null` | Device placement strategy (None -> 'auto') |
 | `max_memory` | dict | None | `null` | Per-device memory limits, e.g. {0: '10GiB', 'cpu': '50GiB'} |
-| `revision` | string | None | `null` | Model revision/commit hash for reproducibility |
-| `trust_remote_code` | boolean | None | `null` | Trust remote code in model repo (None -> True) |
+| `low_cpu_mem_usage` | boolean | None | `null` | Load weights incrementally to minimise peak CPU RAM (None -> True) |
+| `allow_tf32` | boolean | None | `null` | Allow TF32 for matmul on Ampere+ (None -> PyTorch default). Affects energy/throughput. |
+| `autocast_enabled` | boolean | None | `null` | Enable torch.autocast during generation (None -> False) |
+| `autocast_dtype` | 'float16' | 'bfloat16' | None | `null` | AMP dtype (None -> 'bfloat16'). Only used when autocast_enabled is true. |
 | `tp_plan` | string | None | `null` | Tensor parallelism plan for native HF TP (None -> disabled). Only 'auto' is currently supported by Transformers. Mutually exclusive with device_map. Requires torchrun launch. |
 | `tp_size` | integer | None | `null` | Number of tensor parallel ranks (None -> WORLD_SIZE). Only used when tp_plan is set. |
 
@@ -743,8 +745,10 @@ relates to energy measurement.
 | `pipeline_parallel_size` | integer | None | `null` | Pipeline parallel stages — memory per GPU changes with PP (None -> 1). |
 | `enable_prefix_caching` | boolean | None | `null` | Automatic prefix caching for repeated shared prompts (None -> False). |
 | `quantization` | 'awq' | 'gptq' | 'fp8' | 'fp8_e5m2' | 'fp8_e4m3' | 'marlin' | 'bitsandbytes' | None | `null` | Quantization method. Requires pre-quantized model checkpoint. |
-| `speculative_model` | string | None | `null` | HF model name or path of draft model for speculative decoding (None -> disabled). Requires num_speculative_tokens. |
-| `num_speculative_tokens` | integer | None | `null` | Tokens to draft per speculative step (None -> required if speculative_model is set). |
+| `num_scheduler_steps` | integer | None | `null` | Multi-step scheduling: decode steps per scheduler iteration (None -> 1). Increases throughput at the cost of more VRAM per step. |
+| `max_seq_len_to_capture` | integer | None | `null` | Max sequence length eligible for CUDA graph capture (None -> 8192). Longer sequences fall back to eager mode. |
+| `distributed_executor_backend` | 'mp' | 'ray' | None | `null` | Multi-GPU executor backend (None -> 'mp'). |
+| `speculative` | VLLMSpeculativeConfig | None | `null` | Speculative decoding sub-config. Fields: model (str), num_speculative_tokens (int), method (str). |
 | `offload_group_size` | integer | None | `null` | Groups of layers for CPU offloading (None -> 0). |
 | `offload_num_in_group` | integer | None | `null` | Number of layers offloaded per group (None -> 1). |
 | `offload_prefetch_step` | integer | None | `null` | Prefetch steps ahead for CPU offload (None -> 1). |
@@ -795,8 +799,10 @@ relates to energy measurement.
 |-------|------|---------|-------------|
 | `max_batch_size` | integer | None | `null` | Max batch size (compile-time constant, None -> 8) |
 | `tensor_parallel_size` | integer | None | `null` | Tensor parallel size (None -> 1) |
+| `pipeline_parallel_size` | integer | None | `null` | Pipeline parallel stages (None -> 1) |
 | `max_input_len` | integer | None | `null` | Max input sequence length (compile-time constant, None -> 1024) |
 | `max_seq_len` | integer | None | `null` | Max total sequence length (input + output, compile-time constant, None -> 2048) |
+| `max_num_tokens` | integer | None | `null` | Max tokens per engine iteration (None -> auto). Scheduler throughput axis alongside max_batch_size. |
 | `dtype` | 'float16' | 'bfloat16' | None | `null` | Model dtype (None -> auto). TRT-LLM is optimised for fp16/bf16; fp32 not supported. |
 | `fast_build` | boolean | None | `null` | Enable fast engine build mode (reduced optimisation, None -> False) |
 | `engine` | string | None | `null` | TRT-LLM internal backend: 'trt' for TensorRT engine (None -> 'trt'). This is the TRT-LLM LLM(backend=...) parameter, not the llem engine field. |
@@ -804,8 +810,6 @@ relates to energy measurement.
 | `quant` | TensorRTQuantConfig | None | `null` | Quantisation configuration (QuantConfig) |
 | `kv_cache` | TensorRTKvCacheConfig | None | `null` | KV cache configuration |
 | `scheduler` | TensorRTSchedulerConfig | None | `null` | Scheduler configuration |
-| `calib` | TensorRTCalibConfig | None | `null` | PTQ calibration configuration (CalibConfig) |
-| `build_cache` | TensorRTBuildCacheConfig | None | `null` | Engine build cache configuration (BuildCacheConfig) |
 | `sampling` | TensorRTSamplingConfig | None | `null` | Sampling configuration (TRT-LLM-specific SamplingParams extensions) |
 
 <!-- END CONFIG REFERENCE — Auto-generated by scripts/generate_config_docs.py -->

--- a/src/llenergymeasure/config/curation.py
+++ b/src/llenergymeasure/config/curation.py
@@ -23,7 +23,7 @@ Usage::
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Literal
+from typing import Any, Literal
 
 RubricClause = Literal[
     "R1",
@@ -68,6 +68,6 @@ class CurationMetadata:
     native_mapping: str | None = None
     notes: str | None = None
 
-    def to_schema_extra(self) -> dict[str, object]:
+    def to_schema_extra(self) -> dict[str, Any]:
         """Render to the dict shape Pydantic expects in ``json_schema_extra``."""
         return {"curation": asdict(self)}

--- a/src/llenergymeasure/config/curation.py
+++ b/src/llenergymeasure/config/curation.py
@@ -1,0 +1,73 @@
+"""Structured curation metadata for typed engine config fields.
+
+Every typed field in engine_configs.py carries a CurationMetadata instance attached
+via json_schema_extra. This makes the rubric verdict machine-readable and is the
+source of truth for the generated inclusion/exclusion table (Plan E).
+
+Usage::
+
+    from llenergymeasure.config.curation import CurationMetadata
+
+    some_field: int | None = Field(
+        default=None,
+        ge=1,
+        description="...",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="AMD MLPerf v5.1 multi-step throughput axis.",
+            native_mapping="EngineArgs.num_scheduler_steps",
+        ).to_schema_extra(),
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+RubricClause = Literal[
+    "R1",
+    "R2",  # required
+    "E1",
+    "E2",
+    "E3",
+    "E4",  # elevating
+    "D1",
+    "D2",
+    "D3",
+    "D4",  # demoting (for drop decisions recorded for posterity)
+    "T1",
+    "T2",
+    "T3",
+    "T4",
+    "T5",  # tie-breakers
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CurationMetadata:
+    """Structured justification attached to every typed field in engine_configs.py.
+
+    Becomes the source of truth for the generated inclusion/exclusion table (Plan E).
+
+    Attributes:
+        clauses:        Tuple of rubric clause codes that fired for this field.
+                        At minimum R1 (plausible measurement path) must be present
+                        unless R2 (non-duplication) caused a drop.
+        rationale:      One-line justification. This text appears verbatim in the
+                        generated curation doc as the "reason" column.
+        native_mapping: Dotted path to the corresponding native engine argument,
+                        e.g. "EngineArgs.num_scheduler_steps". None when the field
+                        is engine-local only (no direct native counterpart).
+        notes:          Optional caveats — e.g. "churn-prone, watch vLLM v0.8 release
+                        notes", or "defer — confirm HF deprecation before adding".
+    """
+
+    clauses: tuple[RubricClause, ...]
+    rationale: str
+    native_mapping: str | None = None
+    notes: str | None = None
+
+    def to_schema_extra(self) -> dict[str, object]:
+        """Render to the dict shape Pydantic expects in ``json_schema_extra``."""
+        return {"curation": asdict(self)}

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -181,7 +181,7 @@ class TransformersConfig(BaseModel):
         description="Use KV cache during generation (None -> True)",
         json_schema_extra=CurationMetadata(
             clauses=("R1", "R2", "E2"),
-            rationale="Turning it off changes inference from AR to prefill-only (~100× latency delta).",
+            rationale="Turning it off changes inference from AR to prefill-only (~100x latency delta).",
             native_mapping="GenerationConfig.use_cache",
         ).to_schema_extra(),
     )

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -4,6 +4,11 @@ Each engine section uses None-as-default: all fields default to None, meaning
 "use the engine's own default at execution time". This makes it explicit when
 a researcher has set a value versus when the engine's built-in default applies.
 
+Every typed field carries ``CurationMetadata`` via ``json_schema_extra``.
+This is the machine-readable rubric verdict used by the generated
+inclusion/exclusion table (Plan E). The rubric is defined in
+``.product/research/parameter-curation-rubric.md``.
+
 Usage in YAML:
     engine: transformers
     transformers:
@@ -33,6 +38,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from llenergymeasure.config.curation import CurationMetadata
+
 # =============================================================================
 # Transformers Engine Configuration (v2.0)
 # =============================================================================
@@ -60,6 +67,11 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description="Batch size (None -> 1)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Universal measurement axis; MLPerf, Optimum, LLM-Perf all split by it.",
+            native_mapping="AutoModelForCausalLM.generate batch dimension",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -71,6 +83,11 @@ class TransformersConfig(BaseModel):
     ) = Field(
         default=None,
         description="Attention implementation (None -> sdpa)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3"),
+            rationale="Kernel selection is a latency/energy regime switch; Optimum types it.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(attn_implementation=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -80,14 +97,29 @@ class TransformersConfig(BaseModel):
     torch_compile: bool | None = Field(
         default=None,
         description="Enable torch.compile (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Compile vs eager is a regime switch; Optimum/Databricks report splits.",
+            native_mapping="torch.compile(model)",
+        ).to_schema_extra(),
     )
     torch_compile_mode: str | None = Field(
         default=None,
         description="torch.compile mode: 'default', 'reduce-overhead', 'max-autotune' (None -> 'default')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E3"),
+            rationale="3-option enum with meaningful throughput deltas (default vs reduce-overhead vs max-autotune).",
+            native_mapping="torch.compile(model, mode=...)",
+        ).to_schema_extra(),
     )
     torch_compile_backend: str | None = Field(
         default=None,
         description="torch.compile backend (None -> 'inductor')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="Compile-backend selects different codegen → different kernels → measurable energy delta.",
+            native_mapping="torch.compile(model, backend=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -97,22 +129,47 @@ class TransformersConfig(BaseModel):
     load_in_4bit: bool | None = Field(
         default=None,
         description="BitsAndBytes 4-bit quantization",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Regime switch — 4-bit is its own measurement mode.",
+            native_mapping="BitsAndBytesConfig(load_in_4bit=True)",
+        ).to_schema_extra(),
     )
     load_in_8bit: bool | None = Field(
         default=None,
         description="BitsAndBytes 8-bit quantization",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Regime switch — 8-bit is its own measurement mode.",
+            native_mapping="BitsAndBytesConfig(load_in_8bit=True)",
+        ).to_schema_extra(),
     )
     bnb_4bit_compute_dtype: Literal["float16", "bfloat16", "float32"] | None = Field(
         default=None,
         description="Compute dtype for 4-bit (None -> float32, usually want bfloat16)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="Compute-path selection inside 4-bit; affects energy directly.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_compute_dtype=...)",
+        ).to_schema_extra(),
     )
     bnb_4bit_quant_type: Literal["nf4", "fp4"] | None = Field(
         default=None,
         description="4-bit quantization type (None -> 'nf4')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="nf4 vs fp4 selects different dequantisation kernels → different energy/token.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_quant_type=...)",
+        ).to_schema_extra(),
     )
     bnb_4bit_use_double_quant: bool | None = Field(
         default=None,
         description="Double quantization saves ~0.4 bits/param (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Double quantisation changes memory footprint and dequant arithmetic — regime toggle.",
+            native_mapping="BitsAndBytesConfig(bnb_4bit_use_double_quant=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -122,10 +179,20 @@ class TransformersConfig(BaseModel):
     use_cache: bool | None = Field(
         default=None,
         description="Use KV cache during generation (None -> True)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Turning it off changes inference from AR to prefill-only (~100× latency delta).",
+            native_mapping="GenerationConfig.use_cache",
+        ).to_schema_extra(),
     )
     cache_implementation: Literal["static", "offloaded_static", "sliding_window"] | None = Field(
         default=None,
         description="KV cache strategy; 'static' enables CUDA graphs (None -> dynamic)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="'static' enables CUDA graphs — regime-changing; stable 3-value enum.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(cache_implementation=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -136,14 +203,29 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description="Beam search width (None -> 1, greedy/sampling)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1", "E2"),
+            rationale="Linear compute scaling; beam search is its own measurement regime.",
+            native_mapping="GenerationConfig.num_beams",
+        ).to_schema_extra(),
     )
     early_stopping: bool | None = Field(
         default=None,
         description="Stop beam search when all beams hit EOS (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Couples to beam search; affects final token count.",
+            native_mapping="GenerationConfig.early_stopping",
+        ).to_schema_extra(),
     )
     length_penalty: float | None = Field(
         default=None,
         description="Beam length penalty: >1 shorter, <1 longer (None -> 1.0)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Tunes beam-search sequence length → FLOPs.",
+            native_mapping="GenerationConfig.length_penalty",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -154,6 +236,11 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=0,
         description="Prevent n-gram repetition (None -> 0, disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Affects generation length via repetition prevention → indirect throughput/energy delta.",
+            native_mapping="GenerationConfig.no_repeat_ngram_size",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -164,6 +251,11 @@ class TransformersConfig(BaseModel):
         default=None,
         ge=1,
         description="Prompt-lookup speculative decoding tokens (None -> disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="HF's speculative-decoding flavour (prompt-lookup); regime switch.",
+            native_mapping="GenerationConfig.prompt_lookup_num_tokens",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -173,10 +265,23 @@ class TransformersConfig(BaseModel):
     device_map: str | None = Field(
         default=None,
         description="Device placement strategy (None -> 'auto')",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Offload strategy; Optimum types it. Mutually exclusive with tp_plan.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(device_map=...)",
+        ).to_schema_extra(),
     )
     max_memory: dict[str | int, str] | None = Field(
         default=None,
         description="Per-device memory limits, e.g. {0: '10GiB', 'cpu': '50GiB'}",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "T4"),
+            rationale=(
+                "Sets per-device memory budget; once exceeded forces weight offload CPU↔GPU "
+                "— major energy/latency regime change. Dict passthrough (T4)."
+            ),
+            native_mapping="AutoModelForCausalLM.from_pretrained(max_memory=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -186,18 +291,38 @@ class TransformersConfig(BaseModel):
     allow_tf32: bool | None = Field(
         default=None,
         description="Allow TF32 on Ampere GPUs (None -> PyTorch default)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Ampere TF32 toggle; accuracy/throughput tradeoff affecting GEMM energy.",
+            native_mapping="torch.backends.cuda.matmul.allow_tf32",
+        ).to_schema_extra(),
     )
     autocast_enabled: bool | None = Field(
         default=None,
         description="Enable torch.autocast mixed precision (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Mixed-precision runtime switch; determines whether AMP is applied during generation.",
+            native_mapping="torch.autocast(enabled=...)",
+        ).to_schema_extra(),
     )
     autocast_dtype: Literal["float16", "bfloat16"] | None = Field(
         default=None,
         description="torch.autocast dtype (None -> bfloat16 on Ampere)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E3"),
+            rationale="AMP compute dtype selector; different dtypes have distinct GEMM throughput.",
+            native_mapping="torch.autocast(dtype=...)",
+        ).to_schema_extra(),
     )
     low_cpu_mem_usage: bool | None = Field(
         default=None,
         description="Low CPU memory usage during model loading (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Affects load-time memory footprint; can trigger weight offload regime.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(low_cpu_mem_usage=...)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -211,6 +336,11 @@ class TransformersConfig(BaseModel):
             "Only 'auto' is currently supported by Transformers. "
             "Mutually exclusive with device_map. Requires torchrun launch."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Tensor parallelism enable; engine-native HF TP regime toggle.",
+            native_mapping="AutoModelForCausalLM.from_pretrained(tp_plan=...)",
+        ).to_schema_extra(),
     )
     tp_size: int | None = Field(
         default=None,
@@ -220,6 +350,11 @@ class TransformersConfig(BaseModel):
             "Field name preserved to match HuggingFace accelerate convention "
             "(distinct from TensorRTConfig.tensor_parallel_size which aligns with TrtLlmArgs)."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="TP degree — universal measurement axis. Preserved as tp_size (accelerate convention).",
+            native_mapping="accelerate tp_size",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -293,11 +428,21 @@ class VLLMSpeculativeConfig(BaseModel):
     model: str | None = Field(
         default=None,
         description="Draft model name/path for speculative decoding.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Draft model identity — primary axis for speculative-decoding measurement.",
+            native_mapping="EngineArgs.speculative_config.model",
+        ).to_schema_extra(),
     )
     num_speculative_tokens: int | None = Field(
         default=None,
         ge=1,
         description="Tokens to draft per speculative step.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E2"),
+            rationale="Draft-token count determines speculation depth; strongly peer-validated.",
+            native_mapping="EngineArgs.speculative_config.num_speculative_tokens",
+        ).to_schema_extra(),
     )
     method: str | None = Field(
         default=None,
@@ -306,6 +451,12 @@ class VLLMSpeculativeConfig(BaseModel):
             "Kept as str because the Literal has drifted across vLLM releases — verify against "
             "EngineArgs.speculative_config.method in the vendored schema before narrowing."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Method enum selects qualitatively different speculative-decoding regimes.",
+            native_mapping="EngineArgs.speculative_config.method",
+            notes="Kept str | None; narrow to Literal once vendored vLLM schema confirms stable values.",
+        ).to_schema_extra(),
     )
 
 
@@ -322,42 +473,93 @@ class VLLMAttentionConfig(BaseModel):
     backend: str | None = Field(
         default=None,
         description="Attention backend: flash_attn, flashinfer, etc. (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E3"),
+            rationale="Attention kernel selection (flash_attn, flashinfer, triton, xformers); peer-validated.",
+            native_mapping="AttentionConfig.backend",
+            notes="Field name 'backend' preserved — sub-config is an abstraction layer, not a 1:1 EngineArgs mirror.",
+        ).to_schema_extra(),
     )
     flash_attn_version: int | None = Field(
         default=None,
         description="Flash attention version (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="v2 vs v3 differ in kernel structure → measurable energy delta.",
+            native_mapping="AttentionConfig.flash_attn_version",
+        ).to_schema_extra(),
     )
     flash_attn_max_num_splits_for_cuda_graph: int | None = Field(
         default=None,
         description="Max splits for CUDA graph with flash attention (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Controls CUDA-graph tiling of attention → throughput/energy tradeoff for long sequences.",
+            native_mapping="AttentionConfig.flash_attn_max_num_splits_for_cuda_graph",
+        ).to_schema_extra(),
     )
     use_prefill_decode_attention: bool | None = Field(
         default=None,
         description="Use prefill-decode attention (None -> True).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Routes prefill through decode kernel — different compute path, regime toggle.",
+            native_mapping="AttentionConfig.use_prefill_decode_attention",
+        ).to_schema_extra(),
     )
     use_prefill_query_quantization: bool | None = Field(
         default=None,
         description="Quantize queries during prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Quantises query tensor during prefill → energy/memory delta, regime toggle.",
+            native_mapping="AttentionConfig.use_prefill_query_quantization",
+        ).to_schema_extra(),
     )
     use_cudnn_prefill: bool | None = Field(
         default=None,
         description="Use cuDNN for prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Selects cuDNN vs FlashAttention for prefill — distinct kernel paths.",
+            native_mapping="AttentionConfig.use_cudnn_prefill",
+        ).to_schema_extra(),
     )
     disable_flashinfer_prefill: bool | None = Field(
         default=None,
         description="Disable FlashInfer for prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fallback when flashinfer prefill is active — changes kernel used.",
+            native_mapping="AttentionConfig.disable_flashinfer_prefill",
+        ).to_schema_extra(),
     )
     disable_flashinfer_q_quantization: bool | None = Field(
         default=None,
         description="Disable FlashInfer query quantization (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Disables an optimisation; straightforward energy/latency axis.",
+            native_mapping="AttentionConfig.disable_flashinfer_q_quantization",
+        ).to_schema_extra(),
     )
     use_trtllm_attention: bool | None = Field(
         default=None,
         description="Use TensorRT-LLM attention backend (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Routes attention through TRT-LLM kernel — regime-changing kernel path switch.",
+            native_mapping="AttentionConfig.use_trtllm_attention",
+        ).to_schema_extra(),
     )
     use_trtllm_ragged_deepseek_prefill: bool | None = Field(
         default=None,
         description="Use TRT-LLM ragged DeepSeek prefill (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="TRT-LLM ragged prefill for DeepSeek architectures — distinct kernel path.",
+            native_mapping="AttentionConfig.use_trtllm_ragged_deepseek_prefill",
+        ).to_schema_extra(),
     )
 
 
@@ -382,6 +584,11 @@ class VLLMEngineConfig(BaseModel):
         description=(
             "GPU memory fraction for KV cache (None -> 0.9). Higher = more KV cache, less headroom."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary KV-cache sizing knob; MLPerf/AMD flag it. Mutually exclusive with kv_cache_memory_bytes.",
+            native_mapping="EngineArgs.gpu_memory_utilization",
+        ).to_schema_extra(),
     )
     swap_space: float | None = Field(
         default=None,
@@ -390,6 +597,11 @@ class VLLMEngineConfig(BaseModel):
             "CPU swap space in GiB for KV cache offloading (None -> 4). "
             "Enables model weight offload to prevent OOM."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="CPU-swap budget for KV cache — when exercised shifts KV blocks CPU↔GPU, real energy/latency regime.",
+            native_mapping="EngineArgs.swap_space",
+        ).to_schema_extra(),
     )
     cpu_offload_gb: float | None = Field(
         default=None,
@@ -398,6 +610,11 @@ class VLLMEngineConfig(BaseModel):
             "CPU RAM in GiB to offload model weights to (None -> 0, disabled). "
             "Reduces VRAM pressure at throughput cost."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Weight-offload regime — Optimum/Zhou flag offloading as a class.",
+            native_mapping="EngineArgs.cpu_offload_gb",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -410,6 +627,11 @@ class VLLMEngineConfig(BaseModel):
             "KV cache block size in tokens (None -> 16). "
             "Affects KV cache fragmentation and memory efficiency."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1", "E3"),
+            rationale="vLLM paper + KV survey; tractable 3-value enum.",
+            native_mapping="EngineArgs.block_size",
+        ).to_schema_extra(),
     )
     kv_cache_dtype: Literal["auto", "fp8", "fp8_e5m2", "fp8_e4m3"] | None = Field(
         default=None,
@@ -417,6 +639,13 @@ class VLLMEngineConfig(BaseModel):
             "KV cache storage dtype (None -> auto = model dtype). "
             "fp8 variants halve KV cache VRAM on Ampere+."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3", "E3"),
+            rationale=(
+                "Energy-NVML research flags as bias source (T3); MLPerf/AMD/vLLM/TRT all report it."
+            ),
+            native_mapping="EngineArgs.kv_cache_dtype",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -429,6 +658,11 @@ class VLLMEngineConfig(BaseModel):
             "Disable CUDA graphs, always use eager mode (None -> False). "
             "Eager mode: predictable latency, no graph compilation overhead."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="CUDA-graph regime switch.",
+            native_mapping="EngineArgs.enforce_eager",
+        ).to_schema_extra(),
     )
     enable_chunked_prefill: bool | None = Field(
         default=None,
@@ -436,6 +670,11 @@ class VLLMEngineConfig(BaseModel):
             "Chunk large prefills across multiple scheduler iterations (None -> False). "
             "Affects scheduling latency and throughput."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Scheduling regime switch; strong academic coverage (Yu/Orca, vLLM, Databricks).",
+            native_mapping="EngineArgs.enable_chunked_prefill",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -449,6 +688,11 @@ class VLLMEngineConfig(BaseModel):
             "Max concurrent sequences per scheduler iteration (None -> 256). "
             "Affects batch size and KV cache usage."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary scheduler axis in AMD-MLPerf vLLM submissions.",
+            native_mapping="EngineArgs.max_num_seqs",
+        ).to_schema_extra(),
     )
     max_num_batched_tokens: int | None = Field(
         default=None,
@@ -457,6 +701,11 @@ class VLLMEngineConfig(BaseModel):
             "Max tokens processed per scheduler iteration (None -> auto). "
             "Controls per-step compute budget."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Primary scheduler axis; controls per-step compute budget.",
+            native_mapping="EngineArgs.max_num_batched_tokens",
+        ).to_schema_extra(),
     )
     max_model_len: int | None = Field(
         default=None,
@@ -465,11 +714,21 @@ class VLLMEngineConfig(BaseModel):
             "Max sequence length in tokens (input + output). "
             "Overrides model config (None -> model default). Caps KV cache allocation."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="MLPerf core knob; caps KV-cache pre-allocation.",
+            native_mapping="EngineArgs.max_model_len",
+        ).to_schema_extra(),
     )
     num_scheduler_steps: int | None = Field(
         default=None,
         ge=1,
         description="Number of scheduler steps per iteration (multi-step scheduling, None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="AMD MLPerf v5.1 multi-step scheduling axis.",
+            native_mapping="EngineArgs.num_scheduler_steps",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -482,15 +741,30 @@ class VLLMEngineConfig(BaseModel):
         description=(
             "Tensor parallel degree — number of GPUs to shard the model across (None -> 1)."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3"),
+            rationale="Universal + energy-sampler-relevant (T3: must appear in results metadata).",
+            native_mapping="EngineArgs.tensor_parallel_size",
+        ).to_schema_extra(),
     )
     pipeline_parallel_size: int | None = Field(
         default=None,
         ge=1,
         description=("Pipeline parallel stages — memory per GPU changes with PP (None -> 1)."),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="NVIDIA MLPerf uses it; academic coverage.",
+            native_mapping="EngineArgs.pipeline_parallel_size",
+        ).to_schema_extra(),
     )
     distributed_executor_backend: Literal["mp", "ray"] | None = Field(
         default=None,
         description="Multi-GPU executor backend: 'mp' (multiprocessing) or 'ray' (None -> mp).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Multi-GPU dispatch regime toggle (mp vs ray) — different overhead profiles.",
+            native_mapping="EngineArgs.distributed_executor_backend",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -500,12 +774,22 @@ class VLLMEngineConfig(BaseModel):
     enable_prefix_caching: bool | None = Field(
         default=None,
         description="Automatic prefix caching for repeated shared prompts (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="Strong academic + vLLM-paper evidence (SGLang RadixAttention parallel).",
+            native_mapping="EngineArgs.enable_prefix_caching",
+        ).to_schema_extra(),
     )
     quantization: (
         Literal["awq", "gptq", "fp8", "fp8_e5m2", "fp8_e4m3", "marlin", "bitsandbytes"] | None
     ) = Field(
         default=None,
         description="Quantization method. Requires pre-quantized model checkpoint.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3"),
+            rationale="Universal measurement axis; enum-validated.",
+            native_mapping="EngineArgs.quantization",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -516,6 +800,11 @@ class VLLMEngineConfig(BaseModel):
         default=None,
         ge=1,
         description="Maximum sequence length for CUDA graph capture (None -> 8192).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="CUDA-graph budget for long sequences; AMD MLPerf-derived.",
+            native_mapping="EngineArgs.max_seq_len_to_capture",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -528,6 +817,11 @@ class VLLMEngineConfig(BaseModel):
             "Speculative decoding configuration. Replaces flat speculative_model / "
             "num_speculative_tokens fields. Mirrors vLLM native speculative_config shape."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1", "E2", "T5"),
+            rationale="Regime switch; typed sub-config for inner-field sweep discoverability (T5).",
+            native_mapping="EngineArgs.speculative_config",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -538,20 +832,40 @@ class VLLMEngineConfig(BaseModel):
         default=None,
         ge=0,
         description="Groups of layers for CPU offloading (None -> 0).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="CPU-offload grouping granularity — larger groups trade latency for throughput.",
+            native_mapping="EngineArgs.offload_group_size",
+        ).to_schema_extra(),
     )
     offload_num_in_group: int | None = Field(
         default=None,
         ge=1,
         description="Number of layers offloaded per group (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Controls how many params are offloaded per group — shifts memory/compute boundary.",
+            native_mapping="EngineArgs.offload_num_in_group",
+        ).to_schema_extra(),
     )
     offload_prefetch_step: int | None = Field(
         default=None,
         ge=0,
         description="Prefetch steps ahead for CPU offload (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Prefetch lookahead — directly affects hide-latency effectiveness of CPU offload.",
+            native_mapping="EngineArgs.offload_prefetch_step",
+        ).to_schema_extra(),
     )
     offload_params: list[str] | None = Field(
         default=None,
         description="Specific parameter names to offload to CPU (None -> all eligible).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Selects which parameter classes are offloaded — shifts the memory/compute boundary.",
+            native_mapping="EngineArgs.offload_params",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -561,6 +875,11 @@ class VLLMEngineConfig(BaseModel):
     disable_custom_all_reduce: bool | None = Field(
         default=None,
         description="Disable custom all-reduce for multi-GPU (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Forces fallback to NCCL-native all-reduce — affects collective-comm latency/energy on multi-GPU.",
+            native_mapping="EngineArgs.disable_custom_all_reduce",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -574,6 +893,12 @@ class VLLMEngineConfig(BaseModel):
             "Absolute KV cache size in bytes (None -> use gpu_memory_utilization). "
             "Mutually exclusive with gpu_memory_utilization."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E4"),
+            rationale="Alternative to gpu_memory_utilization; parse-time mutex already wired.",
+            native_mapping=None,
+            notes="Cross-cutting with validate_kv_cache_memory validator — coordinate changes.",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -586,6 +911,14 @@ class VLLMEngineConfig(BaseModel):
             "Full passthrough to vLLM CompilationConfig (~30 fields). "
             "No validation — passed directly."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "T4"),
+            rationale=(
+                "~30-field dict controlling CUDA-graph capture, fusions, what gets compiled "
+                "— major energy implications when varied. Opaque dict (T4)."
+            ),
+            native_mapping="EngineArgs.compilation_config",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -595,6 +928,11 @@ class VLLMEngineConfig(BaseModel):
     attention: VLLMAttentionConfig | None = Field(
         default=None,
         description="Attention implementation configuration.",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="Attention backend and kernel toggles; nested for future flashinfer/cuDNN additions.",
+            native_mapping="EngineArgs.attention_backend (via sub-config mapping)",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -647,6 +985,14 @@ class VLLMSamplingConfig(BaseModel):
         default=None,
         ge=0,
         description="Minimum output tokens before EOS is allowed (None -> 0, no minimum).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens "
+                "once Phase 49 migrates decoder per-engine."
+            ),
+            native_mapping="SamplingParams.min_tokens",
+        ).to_schema_extra(),
     )
     presence_penalty: float | None = Field(
         default=None,
@@ -656,6 +1002,11 @@ class VLLMSamplingConfig(BaseModel):
             "Presence penalty: penalises tokens that appear at all (None -> 0.0). "
             "Affects generation diversity."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="vLLM/TRT-native; not in DecoderConfig; routine in vLLM sampling studies.",
+            native_mapping="SamplingParams.presence_penalty",
+        ).to_schema_extra(),
     )
     frequency_penalty: float | None = Field(
         default=None,
@@ -665,6 +1016,11 @@ class VLLMSamplingConfig(BaseModel):
             "Frequency penalty: penalises tokens proportional to frequency (None -> 0.0). "
             "Affects repetition."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="vLLM/TRT-native; not in DecoderConfig.",
+            native_mapping="SamplingParams.frequency_penalty",
+        ).to_schema_extra(),
     )
     ignore_eos: bool | None = Field(
         default=None,
@@ -672,11 +1028,21 @@ class VLLMSamplingConfig(BaseModel):
             "Continue generating past EOS token (None -> False). "
             "Forces max_tokens generation every time — affects total token count."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fixed output length — measurement workload control.",
+            native_mapping="SamplingParams.ignore_eos",
+        ).to_schema_extra(),
     )
     n: int | None = Field(
         default=None,
         ge=1,
         description="Number of output sequences per prompt (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="n-sequences multiplier; vLLM-bench first-class.",
+            native_mapping="SamplingParams.n",
+        ).to_schema_extra(),
     )
 
 
@@ -698,14 +1064,29 @@ class VLLMBeamSearchConfig(BaseModel):
         default=None,
         ge=1,
         description="Number of beams (ge=1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="Linear compute scaling; beam search is its own measurement regime.",
+            native_mapping="BeamSearchParams.beam_width",
+        ).to_schema_extra(),
     )
     length_penalty: float | None = Field(
         default=None,
         description="Length penalty: >1 favours shorter, <1 longer (None -> 1.0).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Tunes beam-search output length.",
+            native_mapping="BeamSearchParams.length_penalty",
+        ).to_schema_extra(),
     )
     early_stopping: bool | None = Field(
         default=None,
         description="Stop when beam_width complete sequences found (None -> False).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="Affects final token count.",
+            native_mapping="BeamSearchParams.early_stopping",
+        ).to_schema_extra(),
     )
 
 
@@ -794,10 +1175,21 @@ class TensorRTQuantConfig(BaseModel):
     ) = Field(
         default=None,
         description="Quantisation algorithm (native QuantAlgo enum name)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2", "E3", "E4"),
+            rationale="Universal axis + FP8-on-A100 hardware rail (E4); enum-validated.",
+            native_mapping="QuantConfig.quant_algo",
+            notes="FP8 requires SM >= 8.9 (Ada Lovelace+). A100 (SM80): use INT8/W4A16_AWQ/W8A16.",
+        ).to_schema_extra(),
     )
     kv_cache_quant_algo: Literal["FP8", "INT8"] | None = Field(
         default=None,
         description="KV cache quantisation algorithm (None -> no KV cache quantisation)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3", "E3"),
+            rationale="KV-cache quantisation; aligns with vLLM's kv_cache_dtype. Energy-measurement-biasing (T3).",
+            native_mapping="QuantConfig.kv_cache_quant_algo",
+        ).to_schema_extra(),
     )
 
 
@@ -809,22 +1201,42 @@ class TensorRTKvCacheConfig(BaseModel):
     enable_block_reuse: bool | None = Field(
         default=None,
         description="Enable KV cache block reuse (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E2"),
+            rationale="TRT's prefix-caching analog — regime toggle.",
+            native_mapping="KvCacheConfig.enable_block_reuse",
+        ).to_schema_extra(),
     )
     free_gpu_memory_fraction: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,
         description="Fraction of free GPU memory for KV cache (None -> 0.9)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="TRT's gpu_memory_utilization analog.",
+            native_mapping="KvCacheConfig.free_gpu_memory_fraction",
+        ).to_schema_extra(),
     )
     max_tokens: int | None = Field(
         default=None,
         ge=1,
         description="Maximum tokens in KV cache (None -> auto)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="KV-cache token cap → concurrency ceiling.",
+            native_mapping="KvCacheConfig.max_tokens",
+        ).to_schema_extra(),
     )
     host_cache_size: int | None = Field(
         default=None,
         ge=0,
         description="Host (CPU) cache size in bytes for KV cache offloading (None -> 0, disabled)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="CPU KV-offload regime — cross-engine analog to vLLM swap_space.",
+            native_mapping="KvCacheConfig.host_cache_size",
+        ).to_schema_extra(),
     )
 
 
@@ -843,6 +1255,11 @@ class TensorRTSchedulerConfig(BaseModel):
     ) = Field(
         default=None,
         description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Scheduling regime (NO_EVICT vs MAX_UTIL vs STATIC_BATCH); stable 3-value enum.",
+            native_mapping="SchedulerConfig.capacity_scheduling_policy",
+        ).to_schema_extra(),
     )
 
 
@@ -862,15 +1279,33 @@ class TensorRTSamplingConfig(BaseModel):
         default=None,
         ge=0,
         description="Minimum output tokens before EOS allowed (None -> 0)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Minimum output tokens before EOS; future native slot for DecoderConfig.min_new_tokens "
+                "once Phase 49 migrates decoder per-engine."
+            ),
+            native_mapping="SamplingParams.min_tokens",
+        ).to_schema_extra(),
     )
     n: int | None = Field(
         default=None,
         ge=1,
         description="Number of output sequences per prompt (None -> 1)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="n-sequences multiplier.",
+            native_mapping="SamplingParams.n",
+        ).to_schema_extra(),
     )
     ignore_eos: bool | None = Field(
         default=None,
         description="Continue generating past EOS token (None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2"),
+            rationale="Forces fixed output length — measurement workload control.",
+            native_mapping="SamplingParams.ignore_eos",
+        ).to_schema_extra(),
     )
 
 
@@ -916,6 +1351,11 @@ class TensorRTConfig(BaseModel):
         default=None,
         ge=1,
         description="Max batch size (compile-time constant, None -> 8)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "E1"),
+            rationale="MLPerf + trtllm-bench first-class; compile-time shape constant.",
+            native_mapping="TrtLlmArgs.max_batch_size",
+        ).to_schema_extra(),
     )
     tensor_parallel_size: int | None = Field(
         default=None,
@@ -925,36 +1365,74 @@ class TensorRTConfig(BaseModel):
             "Aligns with TrtLlmArgs.tensor_parallel_size. "
             "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2", "T3"),
+            rationale="Universal + energy-sampler-relevant (T3: must appear in results metadata).",
+            native_mapping="TrtLlmArgs.tensor_parallel_size",
+        ).to_schema_extra(),
     )
     pipeline_parallel_size: int | None = Field(
         default=None,
         ge=1,
         description="Pipeline parallel stages (None -> 1).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="NVIDIA MLPerf v5.0 Blackwell submissions surface PP size as a primary knob.",
+            native_mapping="TrtLlmArgs.pipeline_parallel_size",
+        ).to_schema_extra(),
     )
     max_input_len: int | None = Field(
         default=None,
         ge=1,
         description="Max input sequence length (compile-time constant, None -> 1024)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="Compile-time shape; MLPerf core knob.",
+            native_mapping="TrtLlmArgs.max_input_len",
+        ).to_schema_extra(),
     )
     max_seq_len: int | None = Field(
         default=None,
         ge=1,
         description="Max total sequence length (input + output, compile-time constant, None -> 2048)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "R2"),
+            rationale="Compile-time shape; MLPerf core knob.",
+            native_mapping="TrtLlmArgs.max_seq_len",
+        ).to_schema_extra(),
     )
     max_num_tokens: int | None = Field(
         default=None,
         ge=1,
         description="Maximum number of tokens the engine can handle per iteration (None -> auto).",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E1"),
+            rationale="trtllm-bench scheduler axis alongside max_batch_size.",
+            native_mapping="TrtLlmArgs.max_num_tokens",
+        ).to_schema_extra(),
     )
     dtype: Literal["float16", "bfloat16"] | None = Field(
         default=None,
         description=(
             "Model dtype (None -> auto). TRT-LLM is optimised for fp16/bf16; fp32 not supported."
         ),
+        json_schema_extra=CurationMetadata(
+            clauses=("E4",),
+            rationale="TRT-LLM rejects fp32 — narrowed Literal is a parse-time safety rail (E4).",
+            native_mapping="TrtLlmArgs.dtype",
+        ).to_schema_extra(),
     )
     fast_build: bool | None = Field(
         default=None,
         description="Enable fast engine build mode (reduced optimisation, None -> False)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale=(
+                "Skips some build-time optimisations → the produced engine may be less efficient "
+                "at runtime → measurable energy/throughput delta."
+            ),
+            native_mapping="TrtLlmArgs.fast_build",
+        ).to_schema_extra(),
     )
 
     # -------------------------------------------------------------------------
@@ -964,16 +1442,36 @@ class TensorRTConfig(BaseModel):
     quant: TensorRTQuantConfig | None = Field(
         default=None,
         description="Quantisation configuration (QuantConfig)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Quantisation algorithm and KV-cache quantisation sub-config.",
+            native_mapping="TrtLlmArgs.quant_config → QuantConfig",
+        ).to_schema_extra(),
     )
     kv_cache: TensorRTKvCacheConfig | None = Field(
         default=None,
         description="KV cache configuration",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="KV-cache configuration (memory fraction, block reuse, host offload).",
+            native_mapping="TrtLlmArgs.kv_cache_config → KvCacheConfig",
+        ).to_schema_extra(),
     )
     scheduler: TensorRTSchedulerConfig | None = Field(
         default=None,
         description="Scheduler configuration",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1", "E2", "E3"),
+            rationale="Scheduling capacity policy sub-config.",
+            native_mapping="TrtLlmArgs.scheduler_config → SchedulerConfig",
+        ).to_schema_extra(),
     )
     sampling: TensorRTSamplingConfig | None = Field(
         default=None,
         description="Sampling configuration (TRT-LLM-specific SamplingParams extensions)",
+        json_schema_extra=CurationMetadata(
+            clauses=("R1",),
+            rationale="TRT-LLM-specific sampling parameters sub-config.",
+            native_mapping="TrtLlmArgs → SamplingParams",
+        ).to_schema_extra(),
     )

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -17,7 +17,6 @@ Usage in YAML:
         gpu_memory_utilization: 0.9
         kv_cache_dtype: fp8
       sampling:
-        max_tokens: 512
         presence_penalty: 0.0
 
     engine: tensorrt
@@ -25,9 +24,7 @@ Usage in YAML:
       tensor_parallel_size: 2
       dtype: bfloat16
       quant:
-        quant_algo: FP8
-      build_cache:
-        max_cache_storage_gb: 256
+        quant_algo: W4A16_AWQ
 """
 
 from __future__ import annotations
@@ -59,7 +56,11 @@ class TransformersConfig(BaseModel):
     # Batching
     # -------------------------------------------------------------------------
 
-    batch_size: int | None = Field(default=None, ge=1, description="Batch size (None -> 1)")
+    batch_size: int | None = Field(
+        default=None,
+        ge=1,
+        description="Batch size (None -> 1)",
+    )
 
     # -------------------------------------------------------------------------
     # Attention implementation
@@ -67,38 +68,51 @@ class TransformersConfig(BaseModel):
 
     attn_implementation: (
         Literal["sdpa", "flash_attention_2", "flash_attention_3", "eager"] | None
-    ) = Field(default=None, description="Attention implementation (None -> sdpa)")
+    ) = Field(
+        default=None,
+        description="Attention implementation (None -> sdpa)",
+    )
 
     # -------------------------------------------------------------------------
     # Compilation
     # -------------------------------------------------------------------------
 
     torch_compile: bool | None = Field(
-        default=None, description="Enable torch.compile (None -> False)"
+        default=None,
+        description="Enable torch.compile (None -> False)",
     )
     torch_compile_mode: str | None = Field(
         default=None,
         description="torch.compile mode: 'default', 'reduce-overhead', 'max-autotune' (None -> 'default')",
     )
     torch_compile_backend: str | None = Field(
-        default=None, description="torch.compile backend (None -> 'inductor')"
+        default=None,
+        description="torch.compile backend (None -> 'inductor')",
     )
 
     # -------------------------------------------------------------------------
     # BitsAndBytes quantization
     # -------------------------------------------------------------------------
 
-    load_in_4bit: bool | None = Field(default=None, description="BitsAndBytes 4-bit quantization")
-    load_in_8bit: bool | None = Field(default=None, description="BitsAndBytes 8-bit quantization")
+    load_in_4bit: bool | None = Field(
+        default=None,
+        description="BitsAndBytes 4-bit quantization",
+    )
+    load_in_8bit: bool | None = Field(
+        default=None,
+        description="BitsAndBytes 8-bit quantization",
+    )
     bnb_4bit_compute_dtype: Literal["float16", "bfloat16", "float32"] | None = Field(
         default=None,
         description="Compute dtype for 4-bit (None -> float32, usually want bfloat16)",
     )
     bnb_4bit_quant_type: Literal["nf4", "fp4"] | None = Field(
-        default=None, description="4-bit quantization type (None -> 'nf4')"
+        default=None,
+        description="4-bit quantization type (None -> 'nf4')",
     )
     bnb_4bit_use_double_quant: bool | None = Field(
-        default=None, description="Double quantization saves ~0.4 bits/param (None -> False)"
+        default=None,
+        description="Double quantization saves ~0.4 bits/param (None -> False)",
     )
 
     # -------------------------------------------------------------------------
@@ -106,7 +120,8 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     use_cache: bool | None = Field(
-        default=None, description="Use KV cache during generation (None -> True)"
+        default=None,
+        description="Use KV cache during generation (None -> True)",
     )
     cache_implementation: Literal["static", "offloaded_static", "sliding_window"] | None = Field(
         default=None,
@@ -118,10 +133,13 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     num_beams: int | None = Field(
-        default=None, ge=1, description="Beam search width (None -> 1, greedy/sampling)"
+        default=None,
+        ge=1,
+        description="Beam search width (None -> 1, greedy/sampling)",
     )
     early_stopping: bool | None = Field(
-        default=None, description="Stop beam search when all beams hit EOS (None -> False)"
+        default=None,
+        description="Stop beam search when all beams hit EOS (None -> False)",
     )
     length_penalty: float | None = Field(
         default=None,
@@ -133,7 +151,9 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     no_repeat_ngram_size: int | None = Field(
-        default=None, ge=0, description="Prevent n-gram repetition (None -> 0, disabled)"
+        default=None,
+        ge=0,
+        description="Prevent n-gram repetition (None -> 0, disabled)",
     )
 
     # -------------------------------------------------------------------------
@@ -151,17 +171,33 @@ class TransformersConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     device_map: str | None = Field(
-        default=None, description="Device placement strategy (None -> 'auto')"
+        default=None,
+        description="Device placement strategy (None -> 'auto')",
     )
     max_memory: dict[str | int, str] | None = Field(
         default=None,
         description="Per-device memory limits, e.g. {0: '10GiB', 'cpu': '50GiB'}",
     )
-    revision: str | None = Field(
-        default=None, description="Model revision/commit hash for reproducibility"
+
+    # -------------------------------------------------------------------------
+    # Mixed precision
+    # -------------------------------------------------------------------------
+
+    allow_tf32: bool | None = Field(
+        default=None,
+        description="Allow TF32 on Ampere GPUs (None -> PyTorch default)",
     )
-    trust_remote_code: bool | None = Field(
-        default=None, description="Trust remote code in model repo (None -> True)"
+    autocast_enabled: bool | None = Field(
+        default=None,
+        description="Enable torch.autocast mixed precision (None -> False)",
+    )
+    autocast_dtype: Literal["float16", "bfloat16"] | None = Field(
+        default=None,
+        description="torch.autocast dtype (None -> bfloat16 on Ampere)",
+    )
+    low_cpu_mem_usage: bool | None = Field(
+        default=None,
+        description="Low CPU memory usage during model loading (None -> False)",
     )
 
     # -------------------------------------------------------------------------
@@ -242,6 +278,35 @@ class TransformersConfig(BaseModel):
 # =============================================================================
 # vLLM Engine Configuration
 # =============================================================================
+
+
+class VLLMSpeculativeConfig(BaseModel):
+    """vLLM speculative-decoding configuration.
+
+    Replaces flat ``speculative_model`` + ``num_speculative_tokens`` fields.
+    Mirrors vLLM's native ``speculative_config`` dict shape.
+    Unknown fields are forwarded via extra="allow" to vLLM.
+    """
+
+    model_config = {"extra": "allow"}  # mirror native shape; CI diff catches drift
+
+    model: str | None = Field(
+        default=None,
+        description="Draft model name/path for speculative decoding.",
+    )
+    num_speculative_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Tokens to draft per speculative step.",
+    )
+    method: str | None = Field(
+        default=None,
+        description=(
+            "Speculative-decoding method (e.g. 'draft_model', 'ngram', 'medusa', 'eagle'). "
+            "Kept as str because the Literal has drifted across vLLM releases — verify against "
+            "EngineArgs.speculative_config.method in the vendored schema before narrowing."
+        ),
+    )
 
 
 class VLLMAttentionConfig(BaseModel):
@@ -401,6 +466,11 @@ class VLLMEngineConfig(BaseModel):
             "Overrides model config (None -> model default). Caps KV cache allocation."
         ),
     )
+    num_scheduler_steps: int | None = Field(
+        default=None,
+        ge=1,
+        description="Number of scheduler steps per iteration (multi-step scheduling, None -> 1).",
+    )
 
     # -------------------------------------------------------------------------
     # Parallelism
@@ -417,6 +487,10 @@ class VLLMEngineConfig(BaseModel):
         default=None,
         ge=1,
         description=("Pipeline parallel stages — memory per GPU changes with PP (None -> 1)."),
+    )
+    distributed_executor_backend: Literal["mp", "ray"] | None = Field(
+        default=None,
+        description="Multi-GPU executor backend: 'mp' (multiprocessing) or 'ray' (None -> mp).",
     )
 
     # -------------------------------------------------------------------------
@@ -435,21 +509,24 @@ class VLLMEngineConfig(BaseModel):
     )
 
     # -------------------------------------------------------------------------
-    # Speculative decoding
+    # CUDA graphs
     # -------------------------------------------------------------------------
 
-    speculative_model: str | None = Field(
-        default=None,
-        description=(
-            "HF model name or path of draft model for speculative decoding (None -> disabled). "
-            "Requires num_speculative_tokens."
-        ),
-    )
-    num_speculative_tokens: int | None = Field(
+    max_seq_len_to_capture: int | None = Field(
         default=None,
         ge=1,
+        description="Maximum sequence length for CUDA graph capture (None -> 8192).",
+    )
+
+    # -------------------------------------------------------------------------
+    # Speculative decoding (typed nested sub-config)
+    # -------------------------------------------------------------------------
+
+    speculative: VLLMSpeculativeConfig | None = Field(
+        default=None,
         description=(
-            "Tokens to draft per speculative step (None -> required if speculative_model is set)."
+            "Speculative decoding configuration. Replaces flat speculative_model / "
+            "num_speculative_tokens fields. Mirrors vLLM native speculative_config shape."
         ),
     )
 
@@ -525,13 +602,6 @@ class VLLMEngineConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     @model_validator(mode="after")
-    def validate_speculative(self) -> VLLMEngineConfig:
-        """speculative_model requires num_speculative_tokens to be set."""
-        if self.speculative_model is not None and self.num_speculative_tokens is None:
-            raise ValueError("speculative_model requires num_speculative_tokens to be set")
-        return self
-
-    @model_validator(mode="after")
     def validate_kv_cache_memory(self) -> VLLMEngineConfig:
         """kv_cache_memory_bytes and gpu_memory_utilization are mutually exclusive."""
         if self.kv_cache_memory_bytes is not None and self.gpu_memory_utilization is not None:
@@ -566,18 +636,13 @@ class VLLMSamplingConfig(BaseModel):
 
     All fields default to None — None means "use vLLM's own default".
     Unknown fields are forwarded to vllm.SamplingParams() via extra="allow".
+
+    Note: max_tokens is intentionally absent — it is bridged from
+    ExperimentConfig.max_output_tokens in _build_sampling_kwargs().
     """
 
     model_config = {"extra": "allow"}
 
-    max_tokens: int | None = Field(
-        default=None,
-        ge=1,
-        description=(
-            "Max output tokens. Overrides ExperimentConfig.max_output_tokens for vLLM sweeps "
-            "(None -> uses max_output_tokens). Use for engine-specific max_tokens sweeps."
-        ),
-    )
     min_tokens: int | None = Field(
         default=None,
         ge=0,
@@ -622,6 +687,9 @@ class VLLMBeamSearchConfig(BaseModel):
     Nested under VLLMConfig.beam_search.
     All fields default to None — None means "use vLLM's own default".
     Uses extra="allow" for forward compatibility with new vLLM beam search options.
+
+    Note: max_tokens is intentionally absent — it is bridged from
+    ExperimentConfig.max_output_tokens in _build_beam_search_kwargs().
     """
 
     model_config = {"extra": "allow"}
@@ -638,11 +706,6 @@ class VLLMBeamSearchConfig(BaseModel):
     early_stopping: bool | None = Field(
         default=None,
         description="Stop when beam_width complete sequences found (None -> False).",
-    )
-    max_tokens: int | None = Field(
-        default=None,
-        ge=1,
-        description="Max output tokens for beam search (None -> max_output_tokens).",
     )
 
 
@@ -663,8 +726,10 @@ class VLLMConfig(BaseModel):
             enforce_eager: false
             gpu_memory_utilization: 0.9
             kv_cache_dtype: fp8
+            speculative:
+              model: gpt2
+              num_speculative_tokens: 3
           sampling:
-            max_tokens: 512
             presence_penalty: 0.0
     """
 
@@ -726,30 +791,13 @@ class TensorRTQuantConfig(BaseModel):
             "NO_QUANT",
         ]
         | None
-    ) = Field(default=None, description="Quantisation algorithm (native QuantAlgo enum name)")
+    ) = Field(
+        default=None,
+        description="Quantisation algorithm (native QuantAlgo enum name)",
+    )
     kv_cache_quant_algo: Literal["FP8", "INT8"] | None = Field(
         default=None,
         description="KV cache quantisation algorithm (None -> no KV cache quantisation)",
-    )
-
-
-class TensorRTCalibConfig(BaseModel):
-    """TRT-LLM PTQ calibration configuration.
-
-    Maps to tensorrt_llm.llmapi.CalibConfig.
-    Only relevant when quant_algo requires calibration (INT8, W4A16_AWQ, etc.).
-    """
-
-    model_config = {"extra": "allow"}
-
-    calib_batches: int | None = Field(
-        default=None, ge=1, description="Number of calibration batches (None -> 512)"
-    )
-    calib_dataset: str | None = Field(
-        default=None, description="Calibration dataset name or path (None -> 'cnn_dailymail')"
-    )
-    calib_max_seq_length: int | None = Field(
-        default=None, ge=1, description="Max sequence length for calibration (None -> 512)"
     )
 
 
@@ -759,7 +807,8 @@ class TensorRTKvCacheConfig(BaseModel):
     model_config = {"extra": "allow"}
 
     enable_block_reuse: bool | None = Field(
-        default=None, description="Enable KV cache block reuse (None -> False)"
+        default=None,
+        description="Enable KV cache block reuse (None -> False)",
     )
     free_gpu_memory_fraction: float | None = Field(
         default=None,
@@ -768,7 +817,9 @@ class TensorRTKvCacheConfig(BaseModel):
         description="Fraction of free GPU memory for KV cache (None -> 0.9)",
     )
     max_tokens: int | None = Field(
-        default=None, ge=1, description="Maximum tokens in KV cache (None -> auto)"
+        default=None,
+        ge=1,
+        description="Maximum tokens in KV cache (None -> auto)",
     )
     host_cache_size: int | None = Field(
         default=None,
@@ -789,26 +840,9 @@ class TensorRTSchedulerConfig(BaseModel):
             "STATIC_BATCH",
         ]
         | None
-    ) = Field(default=None, description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)")
-
-
-class TensorRTBuildCacheConfig(BaseModel):
-    """TRT-LLM engine build cache configuration.
-
-    Maps to tensorrt_llm.llmapi.BuildCacheConfig.
-    """
-
-    model_config = {"extra": "allow"}
-
-    cache_root: str | None = Field(
+    ) = Field(
         default=None,
-        description="Root directory for engine cache (None -> ~/.cache/tensorrt_llm)",
-    )
-    max_records: int | None = Field(
-        default=None, ge=1, description="Maximum cached engine records (None -> 10)"
-    )
-    max_cache_storage_gb: float | None = Field(
-        default=None, ge=0.0, description="Maximum cache storage in GB (None -> 256)"
+        description="Scheduling capacity policy (None -> GUARANTEED_NO_EVICT)",
     )
 
 
@@ -818,21 +852,25 @@ class TensorRTSamplingConfig(BaseModel):
     Maps to tensorrt_llm.SamplingParams (TRT-LLM-specific extensions only).
     Universal sampling params (temperature, top_p, top_k, repetition_penalty)
     live in DecoderConfig and are shared across all engines.
+
+    Note: return_perf_metrics dropped (D1 observability flag).
     """
 
     model_config = {"extra": "allow"}
 
     min_tokens: int | None = Field(
-        default=None, ge=0, description="Minimum output tokens before EOS allowed (None -> 0)"
+        default=None,
+        ge=0,
+        description="Minimum output tokens before EOS allowed (None -> 0)",
     )
     n: int | None = Field(
-        default=None, ge=1, description="Number of output sequences per prompt (None -> 1)"
+        default=None,
+        ge=1,
+        description="Number of output sequences per prompt (None -> 1)",
     )
     ignore_eos: bool | None = Field(
-        default=None, description="Continue generating past EOS token (None -> False)"
-    )
-    return_perf_metrics: bool | None = Field(
-        default=None, description="Return performance metrics in output (None -> False)"
+        default=None,
+        description="Continue generating past EOS token (None -> False)",
     )
 
 
@@ -847,12 +885,16 @@ class TensorRTConfig(BaseModel):
     - quant: QuantConfig (quantisation algorithm + KV cache quantisation)
     - kv_cache: KvCacheConfig (block reuse, memory fraction)
     - scheduler: SchedulerConfig (capacity policy)
-    - calib: CalibConfig (PTQ calibration parameters)
-    - build_cache: BuildCacheConfig (engine cache persistence)
     - sampling: SamplingParams (TRT-LLM-specific extensions only)
 
     Universal sampling params (temperature, top_p, top_k, repetition_penalty)
     live in DecoderConfig and are shared across all engines.
+
+    Dropped (falls through extra="allow"):
+    - backend: Literal["trt"] — D2 single-option enum, no information content
+    - engine_path — D1 deployment path, not a measurement axis
+    - calib sub-config — D3 build-only PTQ calibration (we consume pre-quantised checkpoints)
+    - build_cache sub-config — D1 engine-cache housekeeping
 
     Example YAML:
         engine: tensorrt
@@ -862,8 +904,6 @@ class TensorRTConfig(BaseModel):
           dtype: bfloat16
           quant:
             quant_algo: W4A16_AWQ
-          build_cache:
-            max_cache_storage_gb: 256
     """
 
     model_config = {"extra": "allow"}
@@ -873,12 +913,23 @@ class TensorRTConfig(BaseModel):
     # -------------------------------------------------------------------------
 
     max_batch_size: int | None = Field(
-        default=None, ge=1, description="Max batch size (compile-time constant, None -> 8)"
+        default=None,
+        ge=1,
+        description="Max batch size (compile-time constant, None -> 8)",
     )
     tensor_parallel_size: int | None = Field(
         default=None,
         ge=1,
-        description="Tensor parallel size — number of GPUs to shard across (None -> 1).",
+        description=(
+            "Tensor parallel size — number of GPUs to shard across (None -> 1). "
+            "Aligns with TrtLlmArgs.tensor_parallel_size. "
+            "Note: TransformersConfig.tp_size follows accelerate convention and is preserved."
+        ),
+    )
+    pipeline_parallel_size: int | None = Field(
+        default=None,
+        ge=1,
+        description="Pipeline parallel stages (None -> 1).",
     )
     max_input_len: int | None = Field(
         default=None,
@@ -889,6 +940,11 @@ class TensorRTConfig(BaseModel):
         default=None,
         ge=1,
         description="Max total sequence length (input + output, compile-time constant, None -> 2048)",
+    )
+    max_num_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of tokens the engine can handle per iteration (None -> auto).",
     )
     dtype: Literal["float16", "bfloat16"] | None = Field(
         default=None,
@@ -902,43 +958,20 @@ class TensorRTConfig(BaseModel):
     )
 
     # -------------------------------------------------------------------------
-    # TRT-LLM internal backend selection
-    # -------------------------------------------------------------------------
-
-    backend: Literal["trt"] | None = Field(
-        default=None,
-        description=(
-            "TRT-LLM internal backend: 'trt' for TensorRT engine (None -> 'trt'). "
-            "This is the TRT-LLM LLM(backend=...) parameter, not the llem engine field."
-        ),
-    )
-
-    # -------------------------------------------------------------------------
-    # Engine path (pre-compiled engine)
-    # -------------------------------------------------------------------------
-
-    engine_path: str | None = Field(
-        default=None, description="Pre-compiled engine path (skip compilation)"
-    )
-
-    # -------------------------------------------------------------------------
     # Nested sub-configs
     # -------------------------------------------------------------------------
 
     quant: TensorRTQuantConfig | None = Field(
-        default=None, description="Quantisation configuration (QuantConfig)"
+        default=None,
+        description="Quantisation configuration (QuantConfig)",
     )
     kv_cache: TensorRTKvCacheConfig | None = Field(
-        default=None, description="KV cache configuration"
+        default=None,
+        description="KV cache configuration",
     )
     scheduler: TensorRTSchedulerConfig | None = Field(
-        default=None, description="Scheduler configuration"
-    )
-    calib: TensorRTCalibConfig | None = Field(
-        default=None, description="PTQ calibration configuration (CalibConfig)"
-    )
-    build_cache: TensorRTBuildCacheConfig | None = Field(
-        default=None, description="Engine build cache configuration (BuildCacheConfig)"
+        default=None,
+        description="Scheduler configuration",
     )
     sampling: TensorRTSamplingConfig | None = Field(
         default=None,

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -562,123 +562,19 @@ def get_mutual_exclusions() -> dict[str, list[str]]:
 def get_engine_specific_params() -> dict[str, list[str]]:
     """Get params that are only valid for specific engines.
 
+    Derived from the Pydantic engine models via ``get_engine_params`` — never
+    hand-maintained. Adding or removing a typed field in
+    ``engine_configs.py`` is automatically reflected here.
+
+    Fields reachable only through ``extra="allow"`` passthrough (e.g. dropped
+    typed fields still settable in YAML) are not included, since they are not
+    part of the typed contract this function describes.
+
     Returns:
-        Dict mapping engine name to list of exclusive param paths.
-        Derived from v2.0 minimal engine config fields.
+        Dict mapping engine name to list of dotted param paths exclusive to
+        that engine.
     """
-    return {
-        "transformers": [
-            "transformers.batch_size",
-            "transformers.attn_implementation",
-            "transformers.torch_compile",
-            "transformers.torch_compile_mode",
-            "transformers.torch_compile_backend",
-            "transformers.load_in_4bit",
-            "transformers.load_in_8bit",
-            "transformers.bnb_4bit_compute_dtype",
-            "transformers.bnb_4bit_quant_type",
-            "transformers.bnb_4bit_use_double_quant",
-            "transformers.use_cache",
-            "transformers.cache_implementation",
-            "transformers.num_beams",
-            "transformers.early_stopping",
-            "transformers.length_penalty",
-            "transformers.no_repeat_ngram_size",
-            "transformers.prompt_lookup_num_tokens",
-            "transformers.device_map",
-            "transformers.max_memory",
-            "transformers.allow_tf32",
-            "transformers.autocast_enabled",
-            "transformers.autocast_dtype",
-            "transformers.low_cpu_mem_usage",
-            "transformers.tp_plan",
-            "transformers.tp_size",
-            # revision and trust_remote_code dropped as typed fields (D1);
-            # they remain settable via extra="allow" in YAML
-        ],
-        "vllm": [
-            # Engine-level params (vllm.LLM() constructor args)
-            "vllm.engine.gpu_memory_utilization",
-            "vllm.engine.swap_space",
-            "vllm.engine.cpu_offload_gb",
-            "vllm.engine.block_size",
-            "vllm.engine.kv_cache_dtype",
-            "vllm.engine.enforce_eager",
-            "vllm.engine.enable_chunked_prefill",
-            "vllm.engine.max_num_seqs",
-            "vllm.engine.max_num_batched_tokens",
-            "vllm.engine.max_model_len",
-            "vllm.engine.tensor_parallel_size",
-            "vllm.engine.pipeline_parallel_size",
-            "vllm.engine.enable_prefix_caching",
-            "vllm.engine.quantization",
-            "vllm.engine.num_scheduler_steps",
-            "vllm.engine.max_seq_len_to_capture",
-            "vllm.engine.distributed_executor_backend",
-            # Speculative decoding sub-config (replaces flat speculative_model/num_speculative_tokens)
-            "vllm.engine.speculative.model",
-            "vllm.engine.speculative.num_speculative_tokens",
-            "vllm.engine.speculative.method",
-            # Engine-level offloading + memory params
-            "vllm.engine.offload_group_size",
-            "vllm.engine.offload_num_in_group",
-            "vllm.engine.offload_prefetch_step",
-            "vllm.engine.offload_params",
-            "vllm.engine.disable_custom_all_reduce",
-            "vllm.engine.kv_cache_memory_bytes",
-            "vllm.engine.compilation_config",
-            # Attention sub-model
-            "vllm.engine.attention.backend",
-            "vllm.engine.attention.flash_attn_version",
-            "vllm.engine.attention.flash_attn_max_num_splits_for_cuda_graph",
-            "vllm.engine.attention.use_prefill_decode_attention",
-            "vllm.engine.attention.use_prefill_query_quantization",
-            "vllm.engine.attention.use_cudnn_prefill",
-            "vllm.engine.attention.disable_flashinfer_prefill",
-            "vllm.engine.attention.disable_flashinfer_q_quantization",
-            "vllm.engine.attention.use_trtllm_attention",
-            "vllm.engine.attention.use_trtllm_ragged_deepseek_prefill",
-            # Sampling-level params (vllm.SamplingParams args, vLLM-specific only)
-            # max_tokens dropped (R2 dup of ExperimentConfig.max_output_tokens; bridged in adapter)
-            "vllm.sampling.min_tokens",
-            "vllm.sampling.presence_penalty",
-            "vllm.sampling.frequency_penalty",
-            "vllm.sampling.ignore_eos",
-            "vllm.sampling.n",
-            # Beam search section (max_tokens dropped; bridged from ExperimentConfig.max_output_tokens)
-            "vllm.beam_search.beam_width",
-            "vllm.beam_search.length_penalty",
-            "vllm.beam_search.early_stopping",
-        ],
-        "tensorrt": [
-            # Compile-time parameters (LLM() constructor)
-            "tensorrt.max_batch_size",
-            "tensorrt.tensor_parallel_size",
-            "tensorrt.pipeline_parallel_size",
-            "tensorrt.max_input_len",
-            "tensorrt.max_seq_len",
-            "tensorrt.max_num_tokens",
-            "tensorrt.dtype",
-            "tensorrt.fast_build",
-            # backend and engine_path dropped (D2/D1); settable via extra="allow"
-            # Quantisation sub-config
-            "tensorrt.quant.quant_algo",
-            "tensorrt.quant.kv_cache_quant_algo",
-            # KV cache sub-config
-            "tensorrt.kv_cache.enable_block_reuse",
-            "tensorrt.kv_cache.free_gpu_memory_fraction",
-            "tensorrt.kv_cache.max_tokens",
-            "tensorrt.kv_cache.host_cache_size",
-            # Scheduler sub-config
-            "tensorrt.scheduler.capacity_scheduling_policy",
-            # calib sub-config dropped (D3 build-only PTQ)
-            # build_cache sub-config dropped (D1 engine-cache plumbing)
-            # Sampling sub-config (return_perf_metrics dropped D1)
-            "tensorrt.sampling.min_tokens",
-            "tensorrt.sampling.n",
-            "tensorrt.sampling.ignore_eos",
-        ],
-    }
+    return {engine: sorted(get_engine_params(engine).keys()) for engine in _ALL_ENGINES_LIST}
 
 
 def get_special_test_models() -> dict[str, str]:

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -269,7 +269,6 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "vllm.engine.pipeline_parallel_size": [0],  # ge=1: 0 violates ge
         "vllm.engine.num_speculative_tokens": [0],  # ge=1: 0 violates ge
         # VLLMSamplingConfig: one known-invalid value per constrained field
-        "vllm.sampling.max_tokens": [0],  # ge=1: 0 violates ge
         "vllm.sampling.presence_penalty": [3.0],  # ge=-2.0, le=2.0: 3.0 violates le
         "vllm.sampling.frequency_penalty": [-3.0],  # ge=-2.0, le=2.0: -3.0 violates ge
         # VLLMEngineConfig: constrained fields
@@ -279,19 +278,13 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "vllm.sampling.n": [0],  # ge=1: 0 violates ge
         # VLLMBeamSearchConfig: constrained fields
         "vllm.beam_search.beam_width": [0],  # ge=1: 0 violates ge
-        "vllm.beam_search.max_tokens": [0],  # ge=1: 0 violates ge
         # TensorRTConfig: compile-time params
         "tensorrt.max_batch_size": [0],  # ge=1: 0 violates ge
         "tensorrt.tensor_parallel_size": [0],  # ge=1: 0 violates ge
         "tensorrt.max_input_len": [0],  # ge=1: 0 violates ge
         "tensorrt.max_seq_len": [0],  # ge=1: 0 violates ge
-        # TensorRTCalibConfig: calibration params
-        "tensorrt.calib.calib_batches": [0],  # ge=1: 0 violates ge
-        "tensorrt.calib.calib_max_seq_length": [0],  # ge=1: 0 violates ge
         # TensorRTKvCacheConfig: cache params
         "tensorrt.kv_cache.max_tokens": [0],  # ge=1: 0 violates ge
-        # TensorRTBuildCacheConfig: engine cache params
-        "tensorrt.build_cache.max_records": [0],  # ge=1: 0 violates ge
         # TensorRTSamplingConfig: sampling params
         "tensorrt.sampling.n": [0],  # ge=1: 0 violates ge
     }
@@ -535,6 +528,37 @@ def list_all_param_paths(engine: str | None = None) -> list[str]:
 # =============================================================================
 
 
+def get_mutual_exclusions() -> dict[str, list[str]]:
+    """Get parameters that are mutually exclusive.
+
+    Returns:
+        Dict mapping param path to list of params it cannot be used with.
+        These combinations should be skipped during runtime testing.
+    """
+    return {
+        # Transformers: can't use both 4-bit and 8-bit quantization
+        "transformers.load_in_4bit": ["transformers.load_in_8bit"],
+        "transformers.load_in_8bit": ["transformers.load_in_4bit"],
+        # torch_compile sub-options require torch_compile=True
+        "transformers.torch_compile_mode": ["transformers.torch_compile=None|False"],
+        "transformers.torch_compile_backend": ["transformers.torch_compile=None|False"],
+        # BitsAndBytes 4-bit sub-options require load_in_4bit=True
+        "transformers.bnb_4bit_compute_dtype": ["transformers.load_in_4bit=None|False"],
+        "transformers.bnb_4bit_quant_type": ["transformers.load_in_4bit=None|False"],
+        "transformers.bnb_4bit_use_double_quant": ["transformers.load_in_4bit=None|False"],
+        # cache_implementation contradicts use_cache=False
+        "transformers.cache_implementation": ["transformers.use_cache=False"],
+        # vLLM kv_cache_memory_bytes vs gpu_memory_utilization
+        "vllm.engine.kv_cache_memory_bytes": ["vllm.engine.gpu_memory_utilization"],
+        "vllm.engine.gpu_memory_utilization": ["vllm.engine.kv_cache_memory_bytes"],
+        # vLLM beam_search vs sampling sections (cross-section mutual exclusion)
+        "vllm.beam_search": ["vllm.sampling"],
+        "vllm.sampling": ["vllm.beam_search"],
+        # TensorRT: quantisation method is exclusive
+        "tensorrt.quant.quant_algo": [],  # Handled by Literal type constraint
+    }
+
+
 def get_engine_specific_params() -> dict[str, list[str]]:
     """Get params that are only valid for specific engines.
 
@@ -563,8 +587,14 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "transformers.prompt_lookup_num_tokens",
             "transformers.device_map",
             "transformers.max_memory",
-            "transformers.revision",
-            "transformers.trust_remote_code",
+            "transformers.allow_tf32",
+            "transformers.autocast_enabled",
+            "transformers.autocast_dtype",
+            "transformers.low_cpu_mem_usage",
+            "transformers.tp_plan",
+            "transformers.tp_size",
+            # revision and trust_remote_code dropped as typed fields (D1);
+            # they remain settable via extra="allow" in YAML
         ],
         "vllm": [
             # Engine-level params (vllm.LLM() constructor args)
@@ -582,8 +612,13 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "vllm.engine.pipeline_parallel_size",
             "vllm.engine.enable_prefix_caching",
             "vllm.engine.quantization",
-            "vllm.engine.speculative_model",
-            "vllm.engine.num_speculative_tokens",
+            "vllm.engine.num_scheduler_steps",
+            "vllm.engine.max_seq_len_to_capture",
+            "vllm.engine.distributed_executor_backend",
+            # Speculative decoding sub-config (replaces flat speculative_model/num_speculative_tokens)
+            "vllm.engine.speculative.model",
+            "vllm.engine.speculative.num_speculative_tokens",
+            "vllm.engine.speculative.method",
             # Engine-level offloading + memory params
             "vllm.engine.offload_group_size",
             "vllm.engine.offload_num_in_group",
@@ -604,37 +639,31 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "vllm.engine.attention.use_trtllm_attention",
             "vllm.engine.attention.use_trtllm_ragged_deepseek_prefill",
             # Sampling-level params (vllm.SamplingParams args, vLLM-specific only)
-            "vllm.sampling.max_tokens",
+            # max_tokens dropped (R2 dup of ExperimentConfig.max_output_tokens; bridged in adapter)
             "vllm.sampling.min_tokens",
             "vllm.sampling.presence_penalty",
             "vllm.sampling.frequency_penalty",
             "vllm.sampling.ignore_eos",
             "vllm.sampling.n",
-            # Beam search section (all 4 fields)
+            # Beam search section (max_tokens dropped; bridged from ExperimentConfig.max_output_tokens)
             "vllm.beam_search.beam_width",
             "vllm.beam_search.length_penalty",
             "vllm.beam_search.early_stopping",
-            "vllm.beam_search.max_tokens",
         ],
         "tensorrt": [
             # Compile-time parameters (LLM() constructor)
             "tensorrt.max_batch_size",
             "tensorrt.tensor_parallel_size",
+            "tensorrt.pipeline_parallel_size",
             "tensorrt.max_input_len",
             "tensorrt.max_seq_len",
+            "tensorrt.max_num_tokens",
             "tensorrt.dtype",
             "tensorrt.fast_build",
-            # TRT-LLM internal backend selection
-            "tensorrt.backend",
-            # Engine path
-            "tensorrt.engine_path",
+            # backend and engine_path dropped (D2/D1); settable via extra="allow"
             # Quantisation sub-config
             "tensorrt.quant.quant_algo",
             "tensorrt.quant.kv_cache_quant_algo",
-            # Calibration sub-config
-            "tensorrt.calib.calib_batches",
-            "tensorrt.calib.calib_dataset",
-            "tensorrt.calib.calib_max_seq_length",
             # KV cache sub-config
             "tensorrt.kv_cache.enable_block_reuse",
             "tensorrt.kv_cache.free_gpu_memory_fraction",
@@ -642,15 +671,12 @@ def get_engine_specific_params() -> dict[str, list[str]]:
             "tensorrt.kv_cache.host_cache_size",
             # Scheduler sub-config
             "tensorrt.scheduler.capacity_scheduling_policy",
-            # Build cache sub-config
-            "tensorrt.build_cache.cache_root",
-            "tensorrt.build_cache.max_records",
-            "tensorrt.build_cache.max_cache_storage_gb",
-            # Sampling sub-config
+            # calib sub-config dropped (D3 build-only PTQ)
+            # build_cache sub-config dropped (D1 engine-cache plumbing)
+            # Sampling sub-config (return_perf_metrics dropped D1)
             "tensorrt.sampling.min_tokens",
             "tensorrt.sampling.n",
             "tensorrt.sampling.ignore_eos",
-            "tensorrt.sampling.return_perf_metrics",
         ],
     }
 

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -184,10 +184,6 @@ class TensorRTEngine:
             "built_at": datetime.now(timezone.utc).isoformat(),
         }
 
-        trt = config.tensorrt
-        if trt is not None and trt.engine_path is not None:
-            self._build_metadata["engine_path"] = trt.engine_path
-
         sampling_params = self._build_sampling_params(config)
         if on_substep is not None:
             on_substep("sampling params built", 0.0)

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -397,8 +397,10 @@ class TensorRTEngine:
         trt = config.tensorrt
 
         # engine_path early-return: pass engine dir as model, skip all compile-time kwargs
-        if trt is not None and trt.engine_path is not None:
-            engine_path = Path(trt.engine_path)
+        # engine_path is no longer a typed field (D1 drop); accessed via extra="allow" passthrough.
+        raw_engine_path = getattr(trt, "engine_path", None) if trt is not None else None
+        if trt is not None and raw_engine_path is not None:
+            engine_path = Path(str(raw_engine_path))
             tp_size = trt.tensor_parallel_size if trt.tensor_parallel_size is not None else 1
             errors = _validate_engine_directory(engine_path, tp_size=tp_size)
             if errors:
@@ -406,30 +408,35 @@ class TensorRTEngine:
             # Pass engine dir as model - TRT-LLM auto-detects TLLM_ENGINE format.
             # Compile-time kwargs are baked into the engine; don't pass them.
             # enable_build_cache is not set - engine format bypasses it.
-            return {"model": str(trt.engine_path), "backend": "trt"}
+            return {"model": str(raw_engine_path), "backend": "trt"}
 
         if trt is None:
             # No tensorrt section — use defaults + enable build cache
             kwargs["enable_build_cache"] = True
             return kwargs
 
-        # Scalar fields: map directly (same name or renamed)
+        # Scalar fields: map directly
         if trt.tensor_parallel_size is not None:
             kwargs["tensor_parallel_size"] = trt.tensor_parallel_size
+        if trt.pipeline_parallel_size is not None:
+            kwargs["pipeline_parallel_size"] = trt.pipeline_parallel_size
         if trt.max_batch_size is not None:
             kwargs["max_batch_size"] = trt.max_batch_size
         if trt.max_input_len is not None:
             kwargs["max_input_len"] = trt.max_input_len
         if trt.max_seq_len is not None:
             kwargs["max_seq_len"] = trt.max_seq_len
+        if trt.max_num_tokens is not None:
+            kwargs["max_num_tokens"] = trt.max_num_tokens
         if trt.dtype is not None:
             kwargs["dtype"] = trt.dtype
         if trt.fast_build is not None:
             kwargs["fast_build"] = trt.fast_build
 
-        # TRT-LLM internal backend (overrides default "trt" if explicitly set)
-        if trt.backend is not None:
-            kwargs["backend"] = trt.backend
+        # TRT-LLM internal backend — no longer typed; accessed via extra="allow" if explicitly set.
+        raw_backend = getattr(trt, "backend", None)
+        if raw_backend is not None:
+            kwargs["backend"] = raw_backend
 
         # Quantisation config
         if trt.quant is not None:
@@ -446,26 +453,10 @@ class TensorRTEngine:
             except ImportError:
                 logger.debug("tensorrt_llm.llmapi not available; skipping QuantConfig")
 
-        # Build cache config
-        if trt.build_cache is not None:
-            try:
-                from tensorrt_llm.llmapi import BuildCacheConfig
-
-                bc = trt.build_cache
-                bc_kwargs: dict[str, Any] = {}
-                if bc.cache_root is not None:
-                    bc_kwargs["cache_root"] = Path(bc.cache_root)
-                if bc.max_records is not None:
-                    bc_kwargs["max_records"] = bc.max_records
-                if bc.max_cache_storage_gb is not None:
-                    bc_kwargs["max_cache_storage_gb"] = bc.max_cache_storage_gb
-                kwargs["enable_build_cache"] = BuildCacheConfig(**bc_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; enabling default build cache")
-                kwargs["enable_build_cache"] = True
-        else:
-            # Enable default build cache when no explicit config given
-            kwargs["enable_build_cache"] = True
+        # Build cache — enable by default; advanced config via extra="allow" passthrough.
+        # TensorRTBuildCacheConfig was dropped (D1 plumbing). Users can still pass
+        # build_cache fields through extra="allow" if needed.
+        kwargs["enable_build_cache"] = True
 
         # KV cache config
         if trt.kv_cache is not None:
@@ -502,24 +493,6 @@ class TensorRTEngine:
                     kwargs["scheduler_config"] = SchedulerConfig(**sc_kwargs)
             except ImportError:
                 logger.debug("tensorrt_llm.llmapi not available; skipping SchedulerConfig")
-
-        # Calibration config
-        if trt.calib is not None:
-            try:
-                from tensorrt_llm.llmapi import CalibConfig
-
-                calib = trt.calib
-                calib_kwargs: dict[str, Any] = {}
-                if calib.calib_batches is not None:
-                    calib_kwargs["calib_batches"] = calib.calib_batches
-                if calib.calib_dataset is not None:
-                    calib_kwargs["calib_dataset"] = calib.calib_dataset
-                if calib.calib_max_seq_length is not None:
-                    calib_kwargs["calib_max_seq_length"] = calib.calib_max_seq_length
-                if calib_kwargs:
-                    kwargs["calib_config"] = CalibConfig(**calib_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; skipping CalibConfig")
 
         return kwargs
 
@@ -568,7 +541,6 @@ class TensorRTEngine:
                 kwargs["n"] = sampling.n
             if sampling.ignore_eos is not None:
                 kwargs["ignore_eos"] = sampling.ignore_eos
-            if sampling.return_perf_metrics is not None:
-                kwargs["return_perf_metrics"] = sampling.return_perf_metrics
+            # return_perf_metrics dropped (D1 observability flag); falls through extra="allow"
 
         return SamplingParams(**kwargs)

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -457,8 +457,7 @@ class TransformersEngine:
         from contextlib import nullcontext
 
         _pt = config.transformers
-        _autocast_enabled = _pt is not None and _pt.autocast_enabled is True
-        if _autocast_enabled and torch.cuda.is_available():
+        if _pt is not None and _pt.autocast_enabled is True and torch.cuda.is_available():
             _dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
             _amp_ctx = torch.autocast(
                 device_type="cuda", dtype=_dtype_map[_pt.autocast_dtype or "bfloat16"]

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -74,10 +74,12 @@ class TransformersEngine:
         kwargs = self._model_load_kwargs(config)
         logger.info("Loading model %r with kwargs: %s", config.model, list(kwargs.keys()))
 
-        # trust_remote_code for tokenizer — respects config, defaults True
+        # trust_remote_code for tokenizer — defaults True; user can override via extra="allow"
         trust = True
-        if config.transformers is not None and config.transformers.trust_remote_code is not None:
-            trust = config.transformers.trust_remote_code
+        if config.transformers is not None:
+            _trc = getattr(config.transformers, "trust_remote_code", None)
+            if _trc is not None:
+                trust = _trc
 
         t0 = _time.perf_counter()
         tokenizer = AutoTokenizer.from_pretrained(config.model, trust_remote_code=trust)
@@ -91,6 +93,12 @@ class TransformersEngine:
         model.eval()
         if on_substep is not None:
             on_substep("model weights loaded", _time.perf_counter() - t0)
+
+        # Apply allow_tf32 (Ampere+ TF32 toggle)
+        if config.transformers is not None and config.transformers.allow_tf32 is not None:
+            import torch as _torch
+
+            _torch.backends.cuda.matmul.allow_tf32 = config.transformers.allow_tf32
 
         # Apply torch.compile post-load (must be AFTER from_pretrained + eval)
         if config.transformers is not None and config.transformers.torch_compile:
@@ -297,11 +305,9 @@ class TransformersEngine:
         else:
             kwargs["device_map"] = "auto"
 
-        # Trust remote code — default True unless researcher overrides
-        if pt is not None and pt.trust_remote_code is not None:
-            kwargs["trust_remote_code"] = pt.trust_remote_code
-        else:
-            kwargs["trust_remote_code"] = True
+        # trust_remote_code — no longer typed (D1 drop); defaults True; user can override via extra="allow"
+        _trc_from_pt = getattr(pt, "trust_remote_code", None) if pt is not None else None
+        kwargs["trust_remote_code"] = _trc_from_pt if _trc_from_pt is not None else True
 
         # Apply Transformers-specific config options
         if pt is not None:
@@ -335,10 +341,11 @@ class TransformersEngine:
                 kwargs["quantization_config"] = BitsAndBytesConfig(**bnb_kwargs)
 
             # Additional from_pretrained() fields
-            if pt.revision is not None:
-                kwargs["revision"] = pt.revision
+            # revision dropped as typed field (D1); flows through model_extra if set
             if pt.max_memory is not None:
                 kwargs["max_memory"] = pt.max_memory
+            if pt.low_cpu_mem_usage is not None:
+                kwargs["low_cpu_mem_usage"] = pt.low_cpu_mem_usage
 
         # Transformers extra="allow" passthrough: forward unknown fields to from_pretrained()
         if pt is not None and pt.model_extra:
@@ -446,8 +453,21 @@ class TransformersEngine:
         inputs = {k: v.to(model.device) for k, v in inputs.items()}
         input_token_count = int(inputs["attention_mask"].sum().item())
 
+        # Determine autocast settings
+        from contextlib import nullcontext
+
+        _pt = config.transformers
+        _autocast_enabled = _pt is not None and _pt.autocast_enabled is True
+        if _autocast_enabled and torch.cuda.is_available():
+            _dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
+            _amp_ctx = torch.autocast(
+                device_type="cuda", dtype=_dtype_map[_pt.autocast_dtype or "bfloat16"]
+            )
+        else:
+            _amp_ctx = nullcontext()  # type: ignore[assignment]
+
         t0 = time.perf_counter()
-        with torch.inference_mode():
+        with torch.inference_mode(), _amp_ctx:
             gen_kwargs = {**generate_kwargs}
             if config.max_output_tokens is not None:
                 gen_kwargs["max_new_tokens"] = config.max_output_tokens

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -76,13 +76,10 @@ class TransformersEngine:
 
         from llenergymeasure.utils.security import trust_remote_code_enabled
 
-        # trust_remote_code precedence: typed field > LLEM_TRUST_REMOTE_CODE env var > False
-        trust = trust_remote_code_enabled()
-        if config.transformers is not None and config.transformers.trust_remote_code is not None:
-            trust = config.transformers.trust_remote_code
-
         t0 = _time.perf_counter()
-        tokenizer = AutoTokenizer.from_pretrained(config.model, trust_remote_code=trust)
+        tokenizer = AutoTokenizer.from_pretrained(
+            config.model, trust_remote_code=trust_remote_code_enabled()
+        )
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
         if on_substep is not None:
@@ -307,11 +304,7 @@ class TransformersEngine:
 
         from llenergymeasure.utils.security import trust_remote_code_enabled
 
-        # trust_remote_code precedence: typed field > LLEM_TRUST_REMOTE_CODE env var > False
-        if pt is not None and pt.trust_remote_code is not None:
-            kwargs["trust_remote_code"] = pt.trust_remote_code
-        else:
-            kwargs["trust_remote_code"] = trust_remote_code_enabled()
+        kwargs["trust_remote_code"] = trust_remote_code_enabled()
 
         # Apply Transformers-specific config options
         if pt is not None:

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -317,13 +317,15 @@ class VLLMEngine:
             _set("pipeline_parallel_size", engine.pipeline_parallel_size)
             _set("enable_prefix_caching", engine.enable_prefix_caching)
             _set("quantization", engine.quantization)
+            _set("num_scheduler_steps", engine.num_scheduler_steps)
+            _set("max_seq_len_to_capture", engine.max_seq_len_to_capture)
+            _set("distributed_executor_backend", engine.distributed_executor_backend)
 
-            if engine.speculative_model is not None:
-                # vLLM v0.6+ uses speculative_config dict, not direct speculative_model kwarg
-                kwargs["speculative_config"] = {
-                    "model": engine.speculative_model,
-                    "num_speculative_tokens": engine.num_speculative_tokens,
-                }
+            # Speculative decoding — build vLLM-native speculative_config dict from sub-config
+            if engine.speculative is not None:
+                spec_dict = engine.speculative.model_dump(exclude_none=True)
+                if spec_dict:
+                    kwargs["speculative_config"] = spec_dict
 
             _set("disable_custom_all_reduce", engine.disable_custom_all_reduce)
             _set("kv_cache_memory_bytes", engine.kv_cache_memory_bytes)
@@ -395,8 +397,6 @@ class VLLMEngine:
         # Apply vLLM-specific sampling overrides
         if vllm_cfg is not None and vllm_cfg.sampling is not None:
             sampling = vllm_cfg.sampling
-            if sampling.max_tokens is not None:
-                kwargs["max_tokens"] = sampling.max_tokens
             if sampling.min_tokens is not None:
                 kwargs["min_tokens"] = sampling.min_tokens
             if sampling.presence_penalty is not None:
@@ -432,9 +432,8 @@ class VLLMEngine:
             kwargs["length_penalty"] = beam_cfg.length_penalty
         if beam_cfg.early_stopping is not None:
             kwargs["early_stopping"] = beam_cfg.early_stopping
-        max_tokens = beam_cfg.max_tokens or config.max_output_tokens
-        if max_tokens is not None:
-            kwargs["max_tokens"] = max_tokens
+        if config.max_output_tokens is not None:
+            kwargs["max_tokens"] = config.max_output_tokens
         if config.decoder.min_p is not None:
             kwargs["min_p"] = config.decoder.min_p
         if beam_cfg.model_extra:

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -61,9 +61,13 @@ def test_get_engine_params_tensorrt_returns_params():
     assert "tensorrt.quant.quant_algo" in params
     assert "tensorrt.kv_cache.free_gpu_memory_fraction" in params
     assert "tensorrt.scheduler.capacity_scheduling_policy" in params
-    assert "tensorrt.build_cache.max_records" in params
-    assert "tensorrt.sampling.return_perf_metrics" in params
-    assert len(params) >= 20
+    # build_cache and calib sub-configs dropped (D1/D3); return_perf_metrics dropped (D1)
+    assert "tensorrt.build_cache.max_records" not in params
+    assert "tensorrt.sampling.return_perf_metrics" not in params
+    # New fields from C.2
+    assert "tensorrt.pipeline_parallel_size" in params
+    assert "tensorrt.max_num_tokens" in params
+    assert len(params) >= 10
 
 
 def test_get_engine_params_unknown_engine_raises():

--- a/tests/unit/config/test_config_schema.py
+++ b/tests/unit/config/test_config_schema.py
@@ -632,3 +632,66 @@ def test_n_prompts_default_is_100() -> None:
     from llenergymeasure.config.models import DatasetConfig
 
     assert DatasetConfig().n_prompts == 100
+
+
+# ---------------------------------------------------------------------------
+# CurationMetadata presence assertion (C.2)
+# ---------------------------------------------------------------------------
+
+
+def test_every_typed_engine_field_has_curation_metadata() -> None:
+    """Every typed field in engine_configs.py carries CurationMetadata.
+
+    This is the CI gate introduced in Phase 48 Plan C.2. A field that lacks
+    CurationMetadata was added without a rubric verdict and must be fixed.
+    """
+    from llenergymeasure.config.engine_configs import (
+        TensorRTConfig,
+        TensorRTKvCacheConfig,
+        TensorRTQuantConfig,
+        TensorRTSamplingConfig,
+        TensorRTSchedulerConfig,
+        TransformersConfig,
+        VLLMAttentionConfig,
+        VLLMBeamSearchConfig,
+        VLLMEngineConfig,
+        VLLMSamplingConfig,
+        VLLMSpeculativeConfig,
+    )
+
+    engine_models = [
+        TransformersConfig,
+        VLLMSpeculativeConfig,
+        VLLMAttentionConfig,
+        VLLMEngineConfig,
+        VLLMSamplingConfig,
+        VLLMBeamSearchConfig,
+        TensorRTQuantConfig,
+        TensorRTKvCacheConfig,
+        TensorRTSchedulerConfig,
+        TensorRTSamplingConfig,
+        TensorRTConfig,
+    ]
+
+    missing: list[str] = []
+    for model_cls in engine_models:
+        for name, info in model_cls.model_fields.items():
+            extra = info.json_schema_extra
+            if not isinstance(extra, dict):
+                missing.append(
+                    f"{model_cls.__name__}.{name}: json_schema_extra not a dict ({extra!r})"
+                )
+                continue
+            curation = extra.get("curation")
+            if curation is None:
+                missing.append(f"{model_cls.__name__}.{name}: missing 'curation' key")
+                continue
+            if not curation.get("clauses"):
+                missing.append(f"{model_cls.__name__}.{name}: CurationMetadata.clauses is empty")
+            if not curation.get("rationale"):
+                missing.append(f"{model_cls.__name__}.{name}: CurationMetadata.rationale is empty")
+
+    assert not missing, (
+        f"{len(missing)} engine config field(s) missing CurationMetadata:\n"
+        + "\n".join(f"  {m}" for m in missing)
+    )

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -1,13 +1,16 @@
-"""Unit tests for expanded TensorRT-LLM config validation.
+"""Unit tests for TensorRT-LLM config validation.
 
-Tests cover all 7 config requirements (CFG-01 through CFG-07):
-- CFG-01: Compile-time params (tensor_parallel_size, max_batch_size, max_input_len, max_seq_len, dtype, fast_build)
+Tests cover:
+- CFG-01: Compile-time params (tensor_parallel_size, pipeline_parallel_size, max_batch_size,
+          max_input_len, max_seq_len, max_num_tokens, dtype, fast_build)
 - CFG-02: Quantisation (QuantAlgo Literal type, kv_cache_quant_algo)
-- CFG-03: Calibration (calib_batches, calib_max_seq_length)
+- CFG-03: (Removed) Calibration sub-config dropped — D3 build-only PTQ, project consumes
+          pre-quantised checkpoints. Falls through extra="allow" if needed.
 - CFG-04: KV cache (enable_block_reuse, free_gpu_memory_fraction, max_tokens, host_cache_size)
 - CFG-05: Scheduler (capacity_scheduling_policy Literal)
-- CFG-06: Build cache (cache_root, max_records, max_cache_storage_gb)
-- CFG-07: Sampling (min_tokens, n, ignore_eos, return_perf_metrics)
+- CFG-06: (Removed) Build cache sub-config dropped — D1 engine-cache plumbing.
+          Falls through extra="allow" if needed.
+- CFG-07: Sampling (min_tokens, n, ignore_eos; return_perf_metrics dropped D1)
 """
 
 from __future__ import annotations
@@ -16,8 +19,6 @@ import pytest
 from pydantic import ValidationError
 
 from llenergymeasure.config.engine_configs import (
-    TensorRTBuildCacheConfig,
-    TensorRTCalibConfig,
     TensorRTConfig,
     TensorRTKvCacheConfig,
     TensorRTQuantConfig,
@@ -125,29 +126,8 @@ class TestQuantisation:
             TensorRTQuantConfig(kv_cache_quant_algo="INVALID")
 
 
-# ---------------------------------------------------------------------------
-# CFG-03: Calibration
-# ---------------------------------------------------------------------------
-
-
-class TestCalibration:
-    """Tests for TensorRT calibration config."""
-
-    def test_calib_config_accepted(self):
-        """Calibration section with valid values validates."""
-        config = TensorRTCalibConfig(
-            calib_batches=64,
-            calib_max_seq_length=256,
-            calib_dataset="cnn_dailymail",
-        )
-        assert config.calib_batches == 64
-        assert config.calib_max_seq_length == 256
-        assert config.calib_dataset == "cnn_dailymail"
-
-    def test_calib_batches_ge_1(self):
-        """calib_batches=0 raises ValidationError."""
-        with pytest.raises(ValidationError):
-            TensorRTCalibConfig(calib_batches=0)
+# CFG-03: Calibration sub-config dropped (D3) — tests removed.
+# calib fields remain settable via TensorRTConfig extra="allow" passthrough.
 
 
 # ---------------------------------------------------------------------------
@@ -222,29 +202,8 @@ class TestScheduler:
             TensorRTSchedulerConfig(capacity_scheduling_policy="INVALID_POLICY")
 
 
-# ---------------------------------------------------------------------------
-# CFG-06: Build Cache
-# ---------------------------------------------------------------------------
-
-
-class TestBuildCache:
-    """Tests for TensorRT build cache config."""
-
-    def test_build_cache_config_accepted(self):
-        """Build cache section with valid values validates."""
-        config = TensorRTBuildCacheConfig(
-            cache_root="/tmp/trt_cache",
-            max_records=20,
-            max_cache_storage_gb=512.0,
-        )
-        assert config.cache_root == "/tmp/trt_cache"
-        assert config.max_records == 20
-        assert config.max_cache_storage_gb == 512.0
-
-    def test_build_cache_max_records_ge_1(self):
-        """max_records=0 raises ValidationError."""
-        with pytest.raises(ValidationError):
-            TensorRTBuildCacheConfig(max_records=0)
+# CFG-06: Build cache sub-config dropped (D1) — tests removed.
+# build_cache fields remain settable via TensorRTConfig extra="allow" passthrough.
 
 
 # ---------------------------------------------------------------------------
@@ -256,17 +215,21 @@ class TestSampling:
     """Tests for TensorRT sampling config."""
 
     def test_sampling_config_accepted(self):
-        """Sampling section with valid values validates."""
+        """Sampling section with valid values validates (return_perf_metrics dropped D1)."""
         config = TensorRTSamplingConfig(
             min_tokens=10,
             n=4,
             ignore_eos=True,
-            return_perf_metrics=True,
         )
         assert config.min_tokens == 10
         assert config.n == 4
         assert config.ignore_eos is True
-        assert config.return_perf_metrics is True
+
+    def test_sampling_return_perf_metrics_is_extra_allow(self):
+        """return_perf_metrics still accepted via extra='allow' passthrough."""
+        config = TensorRTSamplingConfig(return_perf_metrics=True)
+        # No ValidationError — extra="allow"
+        assert getattr(config, "return_perf_metrics", None) is True
 
     def test_sampling_n_ge_1(self):
         """n=0 raises ValidationError."""
@@ -289,9 +252,11 @@ class TestExperimentConfigIntegration:
             engine="tensorrt",
             tensorrt={
                 "tensor_parallel_size": 2,
+                "pipeline_parallel_size": 2,
                 "max_batch_size": 8,
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
+                "max_num_tokens": 4096,
                 "dtype": "bfloat16",
                 "fast_build": True,
                 "quant": {"quant_algo": "W4A16_AWQ"},
@@ -302,24 +267,18 @@ class TestExperimentConfigIntegration:
                 "scheduler": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
-                "calib": {
-                    "calib_batches": 128,
-                    "calib_max_seq_length": 512,
-                },
-                "build_cache": {
-                    "max_cache_storage_gb": 256,
-                    "max_records": 10,
-                },
                 "sampling": {
                     "min_tokens": 5,
                     "n": 1,
-                    "return_perf_metrics": True,
+                    "ignore_eos": False,
                 },
             },
         )
         assert config.engine == "tensorrt"
         assert config.tensorrt is not None
         assert config.tensorrt.tensor_parallel_size == 2
+        assert config.tensorrt.pipeline_parallel_size == 2
+        assert config.tensorrt.max_num_tokens == 4096
         assert config.tensorrt.quant is not None
         assert config.tensorrt.quant.quant_algo == "W4A16_AWQ"
         assert config.tensorrt.kv_cache is not None
@@ -327,7 +286,7 @@ class TestExperimentConfigIntegration:
         assert config.tensorrt.scheduler is not None
         assert config.tensorrt.scheduler.capacity_scheduling_policy == "MAX_UTILIZATION"
         assert config.tensorrt.sampling is not None
-        assert config.tensorrt.sampling.return_perf_metrics is True
+        assert config.tensorrt.sampling.n == 1
 
     def test_tensorrt_extra_allow_forwards_unknown(self):
         """Extra fields on TensorRTConfig and sub-configs are accepted (not rejected)."""
@@ -345,19 +304,20 @@ class TestExperimentConfigIntegration:
         assert quant.quant_algo == "INT8"
 
     def test_tensorrt_none_defaults(self):
-        """All fields default to None when not specified."""
+        """All typed fields default to None when not specified."""
         config = TensorRTConfig()
         assert config.max_batch_size is None
         assert config.tensor_parallel_size is None
+        assert config.pipeline_parallel_size is None
         assert config.max_input_len is None
         assert config.max_seq_len is None
+        assert config.max_num_tokens is None
         assert config.dtype is None
         assert config.fast_build is None
-        assert config.backend is None
-        assert config.engine_path is None
         assert config.quant is None
         assert config.kv_cache is None
         assert config.scheduler is None
-        assert config.calib is None
-        assert config.build_cache is None
         assert config.sampling is None
+        # backend and engine_path are no longer typed fields (D2/D1 drop)
+        # calib and build_cache sub-configs dropped (D3/D1)
+        # all remain passable via extra="allow"

--- a/tests/unit/config/test_tensorrt_sweep.py
+++ b/tests/unit/config/test_tensorrt_sweep.py
@@ -61,19 +61,19 @@ class TestDottedNestedSweep:
         algos = [c.tensorrt.quant.quant_algo for c in valid]
         assert set(algos) == {"INT8", "FP8", "W4A16_AWQ"}
 
-    def test_dotted_nested_build_cache_sweep(self):
-        """tensorrt.build_cache.max_cache_storage_gb: [128, 256] produces 2 configs."""
+    def test_dotted_nested_max_num_tokens_sweep(self):
+        """tensorrt.max_num_tokens: [2048, 4096] produces 2 configs."""
         raw_study = {
             "model": "gpt2",
             "engine": "tensorrt",
             "sweep": {
-                "tensorrt.build_cache.max_cache_storage_gb": [128, 256],
+                "tensorrt.max_num_tokens": [2048, 4096],
             },
         }
         valid, _skipped = expand_grid(raw_study)
         assert len(valid) == 2
-        storage_values = {c.tensorrt.build_cache.max_cache_storage_gb for c in valid}
-        assert storage_values == {128, 256}
+        token_values = {c.tensorrt.max_num_tokens for c in valid}
+        assert token_values == {2048, 4096}
 
     def test_full_tensorrt_study_yaml_parses(self):
         """Comprehensive study YAML with all sub-sections and quant sweep round-trips."""
@@ -93,14 +93,8 @@ class TestDottedNestedSweep:
                 "scheduler": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
-                "calib": {
-                    "calib_batches": 128,
-                },
-                "build_cache": {
-                    "max_cache_storage_gb": 256,
-                },
                 "sampling": {
-                    "return_perf_metrics": True,
+                    "n": 1,
                 },
             },
             "sweep": {
@@ -119,7 +113,7 @@ class TestDottedNestedSweep:
             assert config.tensorrt.kv_cache.enable_block_reuse is True
             assert config.tensorrt.scheduler is not None
             assert config.tensorrt.sampling is not None
-            assert config.tensorrt.sampling.return_perf_metrics is True
+            assert config.tensorrt.sampling.n == 1
         algos = {c.tensorrt.quant.quant_algo for c in valid}
         assert algos == {"INT8", "W4A16_AWQ"}
 

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -21,7 +21,6 @@ import sys
 import types
 
 from llenergymeasure.config.engine_configs import (
-    TensorRTBuildCacheConfig,
     TensorRTConfig,
     TensorRTKvCacheConfig,
     TensorRTQuantConfig,
@@ -237,29 +236,13 @@ class TestBuildLlmKwargs:
         assert isinstance(kwargs["quantization"], _MockQuantConfig)
         assert kwargs["quantization"]._kwargs["quant_algo"] == "INT8"
 
-    def test_build_llm_kwargs_build_cache_config(self, monkeypatch):
-        """build_cache section maps to BuildCacheConfig kwargs."""
-        mock_trt = _make_fake_tensorrt_llm_module()
-        monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
-        monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
-
-        config = make_config(
-            **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(
-                build_cache=TensorRTBuildCacheConfig(
-                    cache_root="/tmp/trt_cache",
-                    max_records=5,
-                    max_cache_storage_gb=128.0,
-                )
-            ),
-        )
+    def test_build_llm_kwargs_always_has_enable_build_cache(self):
+        """enable_build_cache=True is always set (TensorRTBuildCacheConfig dropped D1)."""
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig())
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
-        assert "enable_build_cache" in kwargs
-        assert isinstance(kwargs["enable_build_cache"], _MockBuildCacheConfig)
-        assert kwargs["enable_build_cache"]._kwargs["max_records"] == 5
-        assert kwargs["enable_build_cache"]._kwargs["max_cache_storage_gb"] == 128.0
+        assert kwargs.get("enable_build_cache") is True
 
     def test_build_llm_kwargs_kv_cache_config(self, monkeypatch):
         """kv_cache section maps to KvCacheConfig kwargs."""

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -406,10 +406,14 @@ class TestEngineConfigFields:
         kwargs = VLLMEngine()._build_llm_kwargs(config)
         assert kwargs["block_size"] == 16
 
-    def test_speculative_model_produces_speculative_config_dict(self):
-        """speculative_model + num_speculative_tokens → speculative_config dict (vLLM v0.6+ API)."""
+    def test_speculative_sub_config_produces_speculative_config_dict(self):
+        """VLLMSpeculativeConfig → speculative_config dict (vLLM native shape)."""
+        from llenergymeasure.config.engine_configs import VLLMSpeculativeConfig
+
         vllm_cfg = VLLMConfig(
-            engine=VLLMEngineConfig(speculative_model="draft-model", num_speculative_tokens=5)
+            engine=VLLMEngineConfig(
+                speculative=VLLMSpeculativeConfig(model="draft-model", num_speculative_tokens=5)
+            )
         )
         config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         kwargs = VLLMEngine()._build_llm_kwargs(config)
@@ -418,6 +422,21 @@ class TestEngineConfigFields:
             "model": "draft-model",
             "num_speculative_tokens": 5,
         }
+
+    def test_speculative_sub_config_with_method(self):
+        """VLLMSpeculativeConfig.method is forwarded in speculative_config dict."""
+        from llenergymeasure.config.engine_configs import VLLMSpeculativeConfig
+
+        vllm_cfg = VLLMConfig(
+            engine=VLLMEngineConfig(
+                speculative=VLLMSpeculativeConfig(
+                    model="eagle-model", num_speculative_tokens=3, method="eagle"
+                )
+            )
+        )
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
+        kwargs = VLLMEngine()._build_llm_kwargs(config)
+        assert kwargs["speculative_config"]["method"] == "eagle"
 
     def test_all_engine_fields_wired(self):
         """All 14 non-speculative engine fields are forwarded when set."""
@@ -463,12 +482,14 @@ class TestEngineConfigFields:
 
 
 class TestSamplingConfigOverrides:
-    def test_sampling_max_tokens_overrides_config_max_output_tokens(self):
-        """VLLMSamplingConfig.max_tokens overrides ExperimentConfig.max_output_tokens."""
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(max_tokens=256))
-        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg, max_output_tokens=128)
+    def test_max_output_tokens_bridges_to_max_tokens(self):
+        """ExperimentConfig.max_output_tokens bridges to SamplingParams.max_tokens.
+
+        max_tokens was dropped from VLLMSamplingConfig (R2 dup); bridged at adapter level.
+        """
+        config = make_config(**_VLLM_DEFAULTS, max_output_tokens=128)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-        assert params._kwargs["max_tokens"] == 256  # override wins
+        assert params._kwargs["max_tokens"] == 128
 
     def test_sampling_presence_penalty_applied(self):
         """VLLMSamplingConfig.presence_penalty appears in SamplingParams kwargs."""
@@ -501,13 +522,13 @@ class TestSamplingConfigOverrides:
     def test_sampling_overrides_applied_to_greedy_path(self):
         """VLLMSamplingConfig overrides work on the greedy (temperature=0.0) path too."""
         decoder = DecoderConfig(temperature=0.0, do_sample=False)
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(max_tokens=512))
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(presence_penalty=0.1))
         config = make_config(
             **_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=128
         )
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
         assert params._kwargs["temperature"] == 0.0
-        assert params._kwargs["max_tokens"] == 512  # override wins on greedy path
+        assert params._kwargs["max_tokens"] == 128  # from max_output_tokens bridge
 
     def test_none_sampling_config_does_not_add_extra_kwargs(self):
         """When vllm.sampling is None, no extra sampling kwargs are added."""
@@ -967,10 +988,10 @@ class TestBeamSearchMinP:
         assert "min_p" not in params._kwargs
 
     def test_beam_width_and_min_p_together(self, monkeypatch):
-        """beam_width and min_p both appear in kwargs when set."""
+        """beam_width and min_p both appear in kwargs; max_tokens bridged from max_output_tokens."""
         decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=0.1)
-        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=8, max_tokens=64))
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg)
+        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=8))
+        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=64)
         params = self._build_beam_params(config, monkeypatch)
         assert params._kwargs["beam_width"] == 8
         assert params._kwargs["min_p"] == pytest.approx(0.1)


### PR DESCRIPTION
## Context

Reopened from #273 (closed accidentally during branch cleanup). Deferred work - design when Plan E's consumer (generated doc) is built.

Original PR: #273