### PR TITLE
feat(config): add transformers version monitoring to schema refresh pipeline

### DIFF
--- a/docker/Dockerfile.transformers
+++ b/docker/Dockerfile.transformers
@@ -10,10 +10,12 @@
 #   docker build -f docker/Dockerfile.transformers -t llenergymeasure-transformers .
 #
 # Version pin policy: update PYTORCH_VERSION on each milestone release.
-# Must be compatible with pyproject.toml torch>=2.5 constraint.
+# TRANSFORMERS_VERSION is monitored by Renovate (PyPI datasource).
+# Must be compatible with pyproject.toml torch>=2.5 / transformers>=4.49 constraints.
 # ============================================================
 ARG PYTORCH_VERSION=2.5.1-cuda12.4-cudnn9-runtime
 ARG PYTORCH_DEVEL_VERSION=2.5.1-cuda12.4-cudnn9-devel
+ARG TRANSFORMERS_VERSION=5.5.4
 
 # Build stage: compile flash-attn FA2 + FA3 (needs nvcc from devel image)
 # FA2 = standard flash-attn pip package.
@@ -86,11 +88,12 @@ WORKDIR /app
 # Bind mounts: pyproject.toml/uv.lock/README.md are build-only (not needed at runtime).
 # Cache mount: uv reuses cached wheels across rebuilds without bloating the image.
 COPY src/ ./src/
+ARG TRANSFORMERS_VERSION
 RUN --mount=type=bind,source=pyproject.toml,target=/app/pyproject.toml \
     --mount=type=bind,source=uv.lock,target=/app/uv.lock \
     --mount=type=bind,source=README.md,target=/app/README.md \
     --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system ".[transformers]" sentencepiece einops
+    uv pip install --system ".[transformers]" "transformers==${TRANSFORMERS_VERSION}" sentencepiece einops
 
 # HuggingFace cache — writable for non-root users
 ENV HF_HOME=/app/.cache/huggingface

--- a/docs/schema-refresh.md
+++ b/docs/schema-refresh.md
@@ -15,7 +15,7 @@ This pipeline automates that process end-to-end.
 Upstream releases new engine version (e.g. vLLM v0.8.0)
                       |
                       v
-Renovate detects new tag on Docker Hub / NGC
+Renovate detects new tag on Docker Hub / NGC / PyPI
 (checks weekly, waits 3 days for stability)
                       |
                       v
@@ -51,8 +51,10 @@ Maintainer reviews PR:
 
 ### Automated Flow (Renovate PRs)
 
-1. **Renovate** monitors `docker/Dockerfile.*` for upstream image tag bumps
-   (weekly schedule, 3-day stability window before opening a PR).
+1. **Renovate** monitors `docker/Dockerfile.*` for upstream version bumps:
+   Docker Hub image tags (vLLM), NGC image tags (TensorRT-LLM), and PyPI
+   package versions via `customManagers` regex (transformers). Weekly schedule,
+   3-day stability window before opening a PR.
 2. When Renovate opens a PR, **schema-refresh.yml** auto-fires on the
    self-hosted GPU runner.
 3. The workflow determines which engine(s) changed by inspecting the modified
@@ -137,6 +139,12 @@ When schema-refresh labels a PR `schema-breaking`:
 6. If the Dockerfile ARG maps directly to the engine version, add an entry to
    `_ENGINE_SPECS` in `scripts/check_schema_versions.py`
 
+For engines pre-installed in their upstream Docker image (vLLM, TensorRT-LLM),
+the `dockerfile` manager monitors image tag bumps automatically. For engines
+installed via pip on top of a base image (transformers), add a `customManagers`
+regex entry with `datasourceTemplate: "pypi"` to monitor PyPI releases against
+the Dockerfile `ARG` pin.
+
 The schema-refresh workflow and version guard automatically cover new engines
 via path-based triggers (`docker/Dockerfile.*`).
 
@@ -156,6 +164,7 @@ via path-based triggers (`docker/Dockerfile.*`).
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | Renovate not detecting bumps | `fileMatch` pattern doesn't cover the Dockerfile | Check Renovate dashboard, verify `docker/Dockerfile\\..*` matches |
+| Renovate not detecting transformers bumps | `customManagers` regex not matching | Verify `ARG TRANSFORMERS_VERSION=X.Y.Z` format in Dockerfile.transformers |
 | schema-refresh fails to import engine | Needs `--gpus all` | Verify GPU runner has NVIDIA drivers + Container Toolkit |
 | Version guard fails on non-version change | Won't happen - guard only compares version ARGs | If it does, check `_parse_arg` regex in `check_schema_versions.py` |
 | NGC registry auth failure | Private image or rate-limited | Add `hostRules` to `renovate.json` |

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["dockerfile"],
+  "enabledManagers": ["dockerfile", "custom.regex"],
   "dockerfile": {
     "fileMatch": ["docker/Dockerfile\\..*"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["docker/Dockerfile\\.transformers$"],
+      "matchStrings": ["ARG TRANSFORMERS_VERSION=(?<currentValue>\\S+)"],
+      "depNameTemplate": "transformers",
+      "datasourceTemplate": "pypi"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
@@ -24,6 +33,13 @@
     {
       "matchManagers": ["dockerfile"],
       "matchPackageNames": ["pytorch/pytorch"],
+      "labels": ["renovate", "engine-transformers"],
+      "automerge": false,
+      "stabilityDays": 3
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["transformers"],
       "labels": ["renovate", "engine-transformers"],
       "automerge": false,
       "stabilityDays": 3

--- a/scripts/check_schema_versions.py
+++ b/scripts/check_schema_versions.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 """Check that Dockerfile engine version ARGs match vendored schema engine_versions.
 
-Covers engines where the Dockerfile ARG directly corresponds to the engine
+Covers all engines where the Dockerfile ARG directly corresponds to the engine
 version tracked in the schema:
   - vllm: ARG VLLM_VERSION in docker/Dockerfile.vllm
   - tensorrt: ARG TRTLLM_VERSION in docker/Dockerfile.tensorrt
-
-Transformers is excluded because its Dockerfile pins PyTorch (the base image),
-while the schema tracks the pip-installed transformers library version.
+  - transformers: ARG TRANSFORMERS_VERSION in docker/Dockerfile.transformers
 
 Exit codes:
     0 = all versions match (or non-version Dockerfile change)
@@ -28,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 _ENGINE_SPECS = [
     ("vllm", "VLLM_VERSION"),
     ("tensorrt", "TRTLLM_VERSION"),
+    ("transformers", "TRANSFORMERS_VERSION"),
 ]
 
 

--- a/scripts/update_engine_schema.sh
+++ b/scripts/update_engine_schema.sh
@@ -18,8 +18,9 @@
 #   vllm         -> pristine vllm/vllm-openai:<tag> (vllm pre-installed)
 #   tensorrt     -> pristine nvcr.io/nvidia/tensorrt-llm/release:<tag>
 #                   (works around llenergymeasure:tensorrt's cuKernelGetName bug)
-#   transformers -> llenergymeasure:transformers (base pytorch image has no
-#                   transformers package; our Dockerfile pip-installs it)
+#   transformers -> llenergymeasure:transformers-<ver> (base pytorch image has no
+#                   transformers package; our Dockerfile pip-installs it at the
+#                   version pinned by ARG TRANSFORMERS_VERSION)
 set -euo pipefail
 
 usage() {
@@ -55,7 +56,8 @@ case "$ENGINE" in
         IMAGE="nvcr.io/nvidia/tensorrt-llm/release:${VER}"
         ;;
     transformers)
-        IMAGE="llenergymeasure:transformers"
+        VER="$(_arg_default "$REPO_ROOT/docker/Dockerfile.transformers" TRANSFORMERS_VERSION)"
+        IMAGE="llenergymeasure:transformers-${VER}"
         if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
             echo "[$ENGINE] Image $IMAGE not found; building from docker/Dockerfile.transformers..." >&2
             docker build -f "$REPO_ROOT/docker/Dockerfile.transformers" -t "$IMAGE" "$REPO_ROOT"

--- a/tests/unit/scripts/test_check_schema_versions.py
+++ b/tests/unit/scripts/test_check_schema_versions.py
@@ -18,6 +18,8 @@ def _setup_repo(
     vllm_schema_version: str = "0.7.3",
     trt_arg: str = "0.21.0",
     trt_schema_version: str = "0.21.0",
+    transformers_arg: str = "5.5.4",
+    transformers_schema_version: str = "5.5.4",
     skip_vllm_schema: bool = False,
 ) -> Path:
     """Create a minimal repo structure for the version check script."""
@@ -29,6 +31,9 @@ def _setup_repo(
     (docker / "Dockerfile.tensorrt").write_text(
         f"FROM ubuntu:22.04\nARG TRTLLM_VERSION={trt_arg}\n"
     )
+    (docker / "Dockerfile.transformers").write_text(
+        f"FROM ubuntu:22.04\nARG TRANSFORMERS_VERSION={transformers_arg}\n"
+    )
 
     schema_dir = repo / "src" / "llenergymeasure" / "config" / "discovered_schemas"
     schema_dir.mkdir(parents=True)
@@ -36,6 +41,9 @@ def _setup_repo(
     if not skip_vllm_schema:
         (schema_dir / "vllm.json").write_text(json.dumps({"engine_version": vllm_schema_version}))
     (schema_dir / "tensorrt.json").write_text(json.dumps({"engine_version": trt_schema_version}))
+    (schema_dir / "transformers.json").write_text(
+        json.dumps({"engine_version": transformers_schema_version})
+    )
 
     return repo
 
@@ -59,6 +67,18 @@ class TestMismatch:
         captured = capsys.readouterr()
         assert "MISMATCH" in captured.err
         assert "update_engine_schema.sh" in captured.err
+
+    def test_transformers_mismatch(self, tmp_path: Path, capsys):
+        repo = _setup_repo(
+            tmp_path,
+            transformers_arg="5.6.0",
+            transformers_schema_version="5.5.4",
+        )
+        code = main(repo_root=repo)
+        assert code == 1
+        captured = capsys.readouterr()
+        assert "MISMATCH" in captured.err
+        assert "transformers" in captured.err
 
 
 class TestErrors:


### PR DESCRIPTION
## Summary

- Pin `transformers` version in `Dockerfile.transformers` via `ARG TRANSFORMERS_VERSION=5.5.4`, monitored by Renovate `customManagers` (PyPI datasource)
- Extend `check_schema_versions.py` CI guard to cover all three engines (vLLM, TRT-LLM, transformers)
- Update `update_engine_schema.sh` to extract version and tag discovery images with version
- Document the PyPI monitoring pattern in `docs/schema-refresh.md`

Closes the gap where transformers schema could silently go stale when HuggingFace ships new releases. All three engines now follow the same Renovate -> schema-refresh -> version-guard pipeline.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_check_schema_versions.py -v` (5/5 pass)
- [x] `python3 scripts/check_schema_versions.py` exits 0 (all engines match)
- [ ] CI passes
- [ ] Verify Renovate dashboard picks up the new `customManagers` entry after merge