### PR TITLE
refactor(config,engines): migrate dtype into per-engine configs

### DIFF
--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -126,8 +126,10 @@ output:
 # within-group variants are unioned (not crossed) while inter-group axes are.
 
 sweep: # TODO: maybe shared_sweep or global_sweep?
-  # --- Universal (applies to all three engines) ---
-  dtype: [float32, float16, bfloat16]
+  # --- dtype per engine (each axis applies only when its engine is active) ---
+  transformers.dtype: [float32, float16, bfloat16]
+  vllm.dtype: [float16, bfloat16]  # vLLM rejects float32
+  tensorrt.dtype: [float16, bfloat16]  # TRT-LLM rejects float32
 
   # --- Transformers parameter space ---
   transformers.batch_size: [1, 4, 8, 16, 32]
@@ -281,10 +283,10 @@ experiments:
   # Requires batch_size=1, overriding the sweep axis - must remain explicit.
   - model: Qwen/Qwen2.5-0.5B
     engine: transformers
-    dtype: bfloat16
     dataset:
       n_prompts: 50
     transformers:
+      dtype: bfloat16
       batch_size: 1
       prompt_lookup_num_tokens: 3
       device_map: auto
@@ -296,10 +298,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: transformers
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   transformers:
+  #     dtype: bfloat16
   #     batch_size: 4
   #     tp_plan: auto
   #     tp_size: 2
@@ -310,10 +312,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: transformers
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   transformers:
+  #     dtype: bfloat16
   #     batch_size: 4
   #     revision: main
   #     max_memory:
@@ -325,13 +327,13 @@ experiments:
   # Transformers LoRA adapter (commented out - requires a real adapter TODO: remove - isn't this above????)
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: transformers
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   lora:
   #     adapter_id: my-org/my-lora-adapter
   #     merge_weights: false
   #   transformers:
+  #     dtype: bfloat16
   #     batch_size: 4
   #     device_map: auto
   #     trust_remote_code: true
@@ -347,10 +349,10 @@ experiments:
   # -----------------------------------------------------------------
   - model: Qwen/Qwen2.5-0.5B
     engine: vllm
-    dtype: bfloat16
     dataset:
       n_prompts: 50
     vllm:
+      dtype: bfloat16
       engine:
         tensor_parallel_size: 2
         disable_custom_all_reduce: false  # Disable custom all-reduce for multi-GPU
@@ -361,10 +363,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: vllm
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   vllm:
+  #     dtype: bfloat16
   #     attention:
   #       backend: flash_attn
   #       flash_attn_version: 2            # Flash attention version (auto-detected)
@@ -385,10 +387,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: vllm
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   vllm:
+  #     dtype: bfloat16
   #     engine:
   #       speculative_model: my-org/my-draft-model
   #       num_speculative_tokens: 5
@@ -399,10 +401,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: vllm
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   vllm:
+  #     dtype: bfloat16
   #     engine:
   #       pipeline_parallel_size: 2
   #       gpu_memory_utilization: 0.9
@@ -412,10 +414,10 @@ experiments:
   # -----------------------------------------------------------------
   - model: Qwen/Qwen2.5-0.5B
     engine: vllm
-    dtype: bfloat16
     dataset:
       n_prompts: 50
     vllm:
+      dtype: bfloat16
       engine:
         cpu_offload_gb: 4
         gpu_memory_utilization: 0.9
@@ -425,10 +427,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: vllm
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   vllm:
+  #     dtype: bfloat16
   #     engine:
   #       cpu_offload_gb: 8
   #       offload_group_size: 4          # Groups of layers for CPU offloading
@@ -442,10 +444,10 @@ experiments:
   # -----------------------------------------------------------------
   - model: Qwen/Qwen2.5-0.5B
     engine: vllm
-    dtype: bfloat16
     dataset:
       n_prompts: 50
     vllm:
+      dtype: bfloat16
       engine:
         swap_space: 8
         gpu_memory_utilization: 0.85
@@ -455,10 +457,10 @@ experiments:
   # -----------------------------------------------------------------
   - model: Qwen/Qwen2.5-0.5B
     engine: vllm
-    dtype: bfloat16
     dataset:
       n_prompts: 50
     vllm:
+      dtype: bfloat16
       sampling:
         temperature: 0.8
         max_tokens: 256              # Overrides universal max_output_tokens for this experiment
@@ -471,10 +473,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: vllm
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   vllm:
+  #     dtype: bfloat16
   #     engine:
   #       compilation_config:
   #         level: 3
@@ -485,10 +487,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: vllm
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   vllm:
+  #     dtype: bfloat16
   #     engine:
   #       kv_cache_memory_bytes: 4294967296    # 4 GiB
   #       enforce_eager: false
@@ -504,10 +506,10 @@ experiments:
   # -----------------------------------------------------------------
   - model: Qwen/Qwen2.5-0.5B
     engine: tensorrt
-    dtype: bfloat16
     dataset:
       n_prompts: 50
     tensorrt:
+      dtype: bfloat16
       max_batch_size: 8
       max_input_len: 1024
       max_seq_len: 2048
@@ -522,10 +524,10 @@ experiments:
   # -----------------------------------------------------------------
   - model: Qwen/Qwen2.5-0.5B
     engine: tensorrt
-    dtype: bfloat16
     dataset:
       n_prompts: 50
     tensorrt:
+      dtype: bfloat16
       max_batch_size: 8
       max_input_len: 1024
       max_seq_len: 2048
@@ -542,10 +544,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: tensorrt
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   tensorrt:
+  #     dtype: bfloat16
   #     max_batch_size: 8
   #     max_input_len: 1024
   #     max_seq_len: 2048
@@ -558,10 +560,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: tensorrt
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   tensorrt:
+  #     dtype: bfloat16
   #     engine_path: /path/to/precompiled/engine
   #     max_batch_size: 8
   #     max_seq_len: 2048
@@ -573,10 +575,10 @@ experiments:
   # -----------------------------------------------------------------
   # - model: Qwen/Qwen2.5-0.5B
   #   engine: tensorrt
-  #   dtype: bfloat16
   #   dataset:
   #     n_prompts: 50
   #   tensorrt:
+  #     dtype: bfloat16
   #     max_batch_size: 8
   #     max_input_len: 1024
   #     max_seq_len: 2048

--- a/scripts/check_pydantic_matches_discovered.py
+++ b/scripts/check_pydantic_matches_discovered.py
@@ -36,6 +36,9 @@ LLEM_NATIVE_FIELDS: set[tuple[str, str]] = {
     # -- transformers --
     # Quantization params surfaced at engine level for consistent interface
     ("transformers", "batch_size"),
+    # dtype is HF-native (torch_dtype is a deprecated BC alias). Passed via
+    # from_pretrained **kwargs, so signature-based discovery misses it.
+    ("transformers", "dtype"),
     ("transformers", "batching_strategy"),
     ("transformers", "load_in_4bit"),
     ("transformers", "load_in_8bit"),

--- a/src/llenergymeasure/cli/_display.py
+++ b/src/llenergymeasure/cli/_display.py
@@ -109,7 +109,7 @@ def print_dry_run(
     # Determine non-default fields for annotations
     defaults = {
         "engine": "transformers",
-        "dtype": "bfloat16",
+        "dtype": None,
         "n": 100,
         "dataset": "aienergyscore",
     }
@@ -123,10 +123,14 @@ def print_dry_run(
             return f" ({field} default)" if field not in ("engine", "dtype") else " (default)"
         return ""
 
+    engine_section = getattr(config, config.engine, None)
+    engine_dtype = getattr(engine_section, "dtype", None)
+
     print("Config (resolved)")
     print(f"  Model          {config.task.model}")
     print(f"  Engine         {config.engine}{_annotate('engine', config.engine)}")
-    print(f"  Dtype          {config.dtype}{_annotate('dtype', config.dtype)}")
+    dtype_display = engine_dtype or "-"
+    print(f"  Dtype          {dtype_display}{_annotate('dtype', engine_dtype)}")
 
     # Batch size — from pytorch section if present
     batch_size: int | None = None
@@ -149,7 +153,7 @@ def print_dry_run(
     if vram is None:
         print("  (unavailable)")
     else:
-        weights_line = f"  Weights        {_sig3(vram['weights_gb'])} GB ({config.dtype})"
+        weights_line = f"  Weights        {_sig3(vram['weights_gb'])} GB ({engine_dtype or '-'})"
         print(weights_line)
         print(f"  KV cache       {_sig3(vram['kv_cache_gb'])} GB")
         print(f"  Overhead       {_sig3(vram['overhead_gb'])} GB")
@@ -299,7 +303,9 @@ def print_study_dry_run(
 
     print("VRAM estimate (peak)")
     if peak_vram is not None and peak_config is not None:
-        print(f"  Weights        {_sig3(peak_vram['weights_gb'])} GB ({peak_config.dtype})")
+        peak_section = getattr(peak_config, peak_config.engine, None)
+        peak_dtype = getattr(peak_section, "dtype", None)
+        print(f"  Weights        {_sig3(peak_vram['weights_gb'])} GB ({peak_dtype or '-'})")
         print(f"  KV cache       {_sig3(peak_vram['kv_cache_gb'])} GB")
         print(f"  Overhead       {_sig3(peak_vram['overhead_gb'])} GB")
         total_line = f"  Total          ~{_sig3(peak_vram['total_gb'])} GB"

--- a/src/llenergymeasure/cli/_vram.py
+++ b/src/llenergymeasure/cli/_vram.py
@@ -87,7 +87,9 @@ def estimate_vram(config: ExperimentConfig) -> dict[str, float] | None:
         return None
 
     # Weights memory
-    bytes_per_param = DTYPE_BYTES.get(config.dtype, 2)
+    engine_section = getattr(config, config.engine, None)
+    dtype = getattr(engine_section, "dtype", None)
+    bytes_per_param = DTYPE_BYTES.get(dtype or "bfloat16", 2)
     weights_gb = (param_count * bytes_per_param) / 1e9
 
     # KV cache estimation (sequence length 1 = single inference pass)

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -356,20 +356,21 @@ def _build_header(config: Any, runner_tag: str = RUNNER_LOCAL) -> str:
         config: ExperimentConfig with model, engine, dtype, dataset fields.
         runner_tag: Runner tag string ("local" or "docker").
     """
-    from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
+    from llenergymeasure.config.models import DatasetConfig
 
-    _fields = ExperimentConfig.model_fields
     _ds_fields = DatasetConfig.model_fields
-    default_dtype = _fields["dtype"].default
     default_n = _ds_fields["n_prompts"].default
     default_source = _ds_fields["source"].default
 
     # Strip HuggingFace org prefix (meta-llama/Llama-3.2-1B-Instruct -> Llama-3.2-1B-Instruct)
     model = config.task.model.split("/")[-1] if "/" in config.task.model else config.task.model
     parts = [f"{model} | {config.engine}"]
-    # Deviation fields (only when non-default)
-    if config.dtype != default_dtype:
-        parts.append(config.dtype)
+    # Deviation fields (only when non-default/explicit)
+    # dtype now lives per-engine; only show when set explicitly.
+    engine_section = getattr(config, config.engine, None)
+    engine_dtype = getattr(engine_section, "dtype", None)
+    if engine_dtype is not None:
+        parts.append(engine_dtype)
     if config.task.dataset.n_prompts != default_n:
         parts.append(f"n_prompts={config.task.dataset.n_prompts}")
     if config.task.dataset.source != default_source:

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -104,6 +104,15 @@ class TransformersConfig(BaseModel):
     )
 
     # -------------------------------------------------------------------------
+    # Dtype
+    # -------------------------------------------------------------------------
+
+    dtype: Literal["float32", "float16", "bfloat16"] | None = Field(
+        default=None,
+        description="Model dtype for inference (None -> bfloat16).",
+    )
+
+    # -------------------------------------------------------------------------
     # Attention implementation
     # -------------------------------------------------------------------------
 
@@ -805,6 +814,13 @@ class VLLMConfig(BaseModel):
 
     model_config = {"extra": "allow"}
 
+    dtype: Literal["float16", "bfloat16", "auto"] | None = Field(
+        default=None,
+        description=(
+            "Model dtype for inference (None -> bfloat16). vLLM accepts 'auto' to "
+            "infer from model weights. float32 is not supported."
+        ),
+    )
     engine: VLLMEngineConfig | None = Field(
         default=None,
         description="Engine-level configuration: vllm.LLM() constructor args",

--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -75,9 +75,10 @@ class SkippedConfig:
 
     @property
     def short_label(self) -> str:
-        """Short label for display: 'engine, dtype'."""
+        """Short label for display: 'engine, dtype'. dtype lives under the engine section."""
         engine = self.raw_config.get("engine", "unknown")
-        dtype = self.raw_config.get("dtype", "?")
+        section = self.raw_config.get(engine) if isinstance(engine, str) else None
+        dtype = section.get("dtype", "?") if isinstance(section, dict) else "?"
         return f"{engine}, {dtype}"
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -73,7 +73,7 @@ def get_swept_field_paths(experiments: list[ExperimentConfig]) -> set[str]:
         experiments: List of resolved ExperimentConfig objects from a study.
 
     Returns:
-        Set of dotted field paths (e.g. {"dtype", "task.dataset.n_prompts"}).
+        Set of dotted field paths (e.g. {"engine", "task.dataset.n_prompts"}).
     """
     if len(experiments) <= 1:
         return set()
@@ -335,28 +335,15 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
     """Get shared/universal parameters from ExperimentConfig sub-models.
 
     Returns params that are universal across all engines:
-    - Top-level: dtype, n, max_input_tokens, max_output_tokens, random_seed
+    - Top-level: n, max_input_tokens, max_output_tokens, random_seed
     - Dataset: source, n_prompts, order
 
-    Sampling params (temperature, top_k, top_p, etc.) are not shared — they
-    live per-engine on ``TransformersSamplingConfig`` / ``VLLMSamplingConfig`` /
-    ``TensorRTSamplingConfig`` and are discovered via ``get_engine_params``.
+    Note: dtype and sampling params (temperature, top_k, top_p, etc.) are not
+    shared — they live per-engine on each engine's config section and are
+    discovered via :func:`get_engine_params`.
     """
     shared: dict[str, dict[str, Any]] = {}
 
-    # Top-level universal params — defined manually for explicit engine_support
-    shared["dtype"] = {
-        "path": "dtype",
-        "name": "dtype",
-        "type_str": "literal",
-        "default": "bfloat16",
-        "description": "Model dtype for inference",
-        "options": ["float32", "float16", "bfloat16"],
-        "test_values": ["float32", "float16", "bfloat16"],
-        "constraints": {},
-        "optional": False,
-        "engine_support": _ALL_ENGINES_LIST,
-    }
     shared["dataset.source"] = {
         "path": "dataset.source",
         "name": "source",

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -343,13 +343,6 @@ class ExperimentConfig(BaseModel):
         description="Measurement methodology: warmup, baseline, energy sampling",
     )
 
-    # Hardware
-    dtype: Literal["float32", "float16", "bfloat16"] = Field(
-        default="bfloat16",
-        description="Model dtype for inference",
-        json_schema_extra={"display_label": "Dtype"},
-    )
-
     # Sampling preset — expands into the active engine's sampling section
     sampling_preset: SamplingPreset | None = Field(
         default=None,
@@ -422,7 +415,6 @@ class ExperimentConfig(BaseModel):
     # Cross-validators
     # -------------------------------------------------------------------------
 
-    _FP8_QUANTIZATIONS: ClassVar[set[str]] = {"fp8", "fp8_e5m2", "fp8_e4m3"}
     _FLASH_ATTENTION_IMPLS: ClassVar[set[str]] = {"flash_attention_2", "flash_attention_3"}
 
     @model_validator(mode="after")
@@ -467,37 +459,9 @@ class ExperimentConfig(BaseModel):
                 )
         return self
 
-    @model_validator(mode="after")
-    def validate_vllm_fp8_dtype_compat(self) -> ExperimentConfig:
-        """fp8 quantization requires float16 or bfloat16 dtype (not float32)."""
-        if (
-            self.engine == "vllm"
-            and self.vllm is not None
-            and self.vllm.engine is not None
-            and self.vllm.engine.quantization in self._FP8_QUANTIZATIONS
-            and self.dtype == "float32"
-        ):
-            raise ValueError(
-                "quantization='fp8' is incompatible with dtype='float32'. "
-                "Use dtype='float16' or dtype='bfloat16' for fp8 quantization."
-            )
-        return self
-
-    @model_validator(mode="after")
-    def validate_trt_fp8_dtype_compat(self) -> ExperimentConfig:
-        """FP8 quantization on TensorRT requires float16 or bfloat16 dtype (not float32)."""
-        if (
-            self.engine == "tensorrt"
-            and self.tensorrt is not None
-            and self.tensorrt.quant is not None
-            and self.tensorrt.quant.quant_algo == "FP8"
-            and self.dtype == "float32"
-        ):
-            raise ValueError(
-                "quantization='FP8' is incompatible with dtype='float32'. "
-                "Use dtype='float16' or dtype='bfloat16' for FP8 quantization."
-            )
-        return self
+    # vLLM fp8 + float32 and TRT FP8 + float32 are rejected by the respective
+    # VLLMConfig.dtype / TensorRTConfig.dtype Literal types at field validation
+    # (neither engine accepts float32). No separate cross-validator needed.
 
     @model_validator(mode="after")
     def validate_transformers_flash_attn_dtype(self) -> ExperimentConfig:
@@ -506,7 +470,7 @@ class ExperimentConfig(BaseModel):
             self.engine == "transformers"
             and self.transformers is not None
             and self.transformers.attn_implementation in self._FLASH_ATTENTION_IMPLS
-            and self.dtype == "float32"
+            and (self.transformers.dtype or "bfloat16") == "float32"
         ):
             raise ValueError(
                 f"attn_implementation='{self.transformers.attn_implementation}' requires "

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -275,11 +275,11 @@ class TransformersEngine:
         Returns:
             Dict of kwargs ready for from_pretrained().
         """
-        kwargs: dict[str, Any] = {
-            "torch_dtype": self._resolve_torch_dtype(config.dtype),
-        }
-
         pt = config.transformers
+        dtype = pt.dtype if pt is not None else None
+        kwargs: dict[str, Any] = {
+            "torch_dtype": self._resolve_torch_dtype(dtype or "bfloat16"),
+        }
 
         from llenergymeasure.utils.env_config import default_device_map
         from llenergymeasure.utils.security import trust_remote_code_enabled

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -289,15 +289,16 @@ class VLLMEngine:
         """Build kwargs dict for vllm.LLM() constructor."""
         from llenergymeasure.utils.security import trust_remote_code_enabled
 
+        vllm_cfg = config.vllm
         kwargs: dict[str, Any] = {
             "model": config.task.model,
-            "dtype": config.dtype,
             "trust_remote_code": trust_remote_code_enabled(),
             "seed": config.task.random_seed,
         }
+        if vllm_cfg is not None and vllm_cfg.dtype is not None:
+            kwargs["dtype"] = vllm_cfg.dtype
 
         # Apply VLLMEngineConfig fields if provided — only set non-None values
-        vllm_cfg = config.vllm
         if vllm_cfg is not None and vllm_cfg.engine is not None:
             engine = vllm_cfg.engine
 

--- a/src/llenergymeasure/study/_progress.py
+++ b/src/llenergymeasure/study/_progress.py
@@ -37,7 +37,15 @@ def print_study_progress(
     icons = {"running": "...", "completed": "OK", "failed": "FAIL"}
     icon = icons.get(status, "?")
 
-    parts = [f"[{index}/{total}]", icon, config.task.model, config.engine, config.dtype]
+    engine_section = getattr(config, config.engine, None)
+    engine_dtype = getattr(engine_section, "dtype", None)
+    parts = [
+        f"[{index}/{total}]",
+        icon,
+        config.task.model,
+        config.engine,
+        engine_dtype or "-",
+    ]
 
     if elapsed is not None:
         parts.append("--")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,9 +48,13 @@ def make_config(**overrides) -> ExperimentConfig:
 
     Tests override only what they care about. Task-level fields (model, dataset,
     max_input_tokens, max_output_tokens, random_seed) are routed into task={}.
+    A top-level dtype= kwarg is routed into the active engine's config section
+    (dtype now lives per-engine on TransformersConfig/VLLMConfig/TensorRTConfig).
     """
     _TASK_FIELDS = {"model", "dataset", "max_input_tokens", "max_output_tokens", "random_seed"}
     _MEASUREMENT_FIELDS = {"warmup", "baseline", "energy_sampler"}
+
+    dtype = overrides.pop("dtype", None)
 
     task_defaults: dict = {"model": TEST_MODEL}
     ec_defaults: dict = {"engine": TEST_ENGINE}
@@ -71,6 +75,18 @@ def make_config(**overrides) -> ExperimentConfig:
     ec = {**ec_defaults, **ec_overrides, "task": task}
     if measurement_overrides:
         ec["measurement"] = measurement_overrides
+
+    if dtype is not None:
+        engine_name = ec.get("engine", TEST_ENGINE)
+        engine_key = engine_name.value if hasattr(engine_name, "value") else str(engine_name)
+        existing = ec.get(engine_key)
+        if hasattr(existing, "model_copy"):
+            ec[engine_key] = existing.model_copy(update={"dtype": dtype})
+        elif isinstance(existing, dict):
+            ec[engine_key] = {**existing, "dtype": dtype}
+        else:
+            ec[engine_key] = {"dtype": dtype}
+
     return ExperimentConfig(**ec)
 
 

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -169,8 +169,9 @@ class TestPipelineMultiExperimentSweep:
         yaml_content = """\
 task:
   model: gpt2
+engine: transformers
 sweep:
-  dtype: [float16, bfloat16]
+  transformers.dtype: [float16, bfloat16]
 study_execution:
   n_cycles: 1
   experiment_order: sequential
@@ -188,7 +189,7 @@ measurement:
 
         # Sweep over 2 dtypes, n_cycles=1 → 2 experiments total
         assert len(study_config.experiments) == 2
-        dtypes_set = {exp.dtype for exp in study_config.experiments}
+        dtypes_set = {exp.transformers.dtype for exp in study_config.experiments}
         assert dtypes_set == {"float16", "bfloat16"}
 
     def test_study_yaml_model_sweep(self, tmp_path: Path) -> None:
@@ -374,7 +375,8 @@ class TestCLIE2EStudy:
 
         yaml_path = tmp_path / "study.yaml"
         yaml_path.write_text(
-            "task:\n  model: gpt2\nsweep:\n  dtype: [float16, bfloat16]\n"
+            "task:\n  model: gpt2\nengine: transformers\n"
+            "sweep:\n  transformers.dtype: [float16, bfloat16]\n"
             "study_execution:\n  n_cycles: 1\n  experiment_order: sequential\n"
         )
 

--- a/tests/unit/cli/test_cli_display.py
+++ b/tests/unit/cli/test_cli_display.py
@@ -508,17 +508,19 @@ def test_print_study_dry_run_vram_peak(capsys, monkeypatch):
 
 
 def test_print_experiment_header_defaults(capsys):
-    """Header with default config shows model and engine (defaults omitted)."""
+    """Header with default config shows model and engine (per-engine dtype unset, so omitted)."""
     from tests.conftest import make_config
 
-    config = make_config(model="gpt2", engine="transformers", dtype="bfloat16")
+    # No dtype override -> per-engine dtype stays None -> header should omit it
+    config = make_config(model="gpt2", engine="transformers")
     print_experiment_header(config)
     err = capsys.readouterr().err
 
     assert "gpt2" in err
     assert "transformers" in err
-    # Default dtype bfloat16 is omitted from the header
+    # With dtype unset on the engine section, the header omits it entirely
     assert "bfloat16" not in err
+    assert "float" not in err
 
 
 def test_print_experiment_header_non_default_n(capsys):

--- a/tests/unit/cli/test_cli_run.py
+++ b/tests/unit/cli/test_cli_run.py
@@ -58,8 +58,7 @@ def _make_mock_config() -> MagicMock:
 
     config = MagicMock(spec=ExperimentConfig)
     config.engine = "transformers"
-    config.dtype = "bfloat16"
-    config.transformers = None
+    config.transformers = None  # no engine section → dtype is None (engine default)
 
     # task sub-model
     config.task = MagicMock()
@@ -109,7 +108,7 @@ def test_build_header_strips_hf_org_prefix():
     config = _make_mock_config()
     config.task.model = "meta-llama/Llama-3.2-1B-Instruct"
     config.engine = "vllm"
-    config.dtype = "bfloat16"
+    config.vllm = None  # no engine section → dtype is None (engine default)
     config.task.dataset.n_prompts = 100  # default — should not appear
 
     header = _build_header(config, runner_tag="docker")
@@ -119,13 +118,13 @@ def test_build_header_strips_hf_org_prefix():
 
 
 def test_build_header_default_dtype_omitted():
-    """_build_header omits dtype when it is the default 'bfloat16'."""
+    """_build_header omits dtype when no explicit per-engine dtype is set."""
     from llenergymeasure.cli.run import _build_header
 
     config = _make_mock_config()
     config.task.model = "gpt2"
     config.engine = "transformers"
-    config.dtype = "bfloat16"  # default — should not appear
+    config.transformers = None  # engine default — should not appear
     config.task.dataset.n_prompts = 100  # default — should not appear
 
     header = _build_header(config, runner_tag="local")
@@ -134,13 +133,15 @@ def test_build_header_default_dtype_omitted():
 
 
 def test_build_header_nondefault_fields_shown():
-    """_build_header includes dtype and n when non-default."""
+    """_build_header includes dtype (when set per-engine) and n_prompts (when non-default)."""
     from llenergymeasure.cli.run import _build_header
 
     config = _make_mock_config()
     config.task.model = "gpt2"
     config.engine = "transformers"
-    config.dtype = "float16"
+    transformers_section = MagicMock()
+    transformers_section.dtype = "float16"
+    config.transformers = transformers_section
     config.task.dataset.n_prompts = 50  # non-default — should appear
 
     header = _build_header(config, runner_tag="local")
@@ -352,7 +353,7 @@ def test_study_detection_with_sweep_key(tmp_path):
 name: test
 model: test/model
 sweep:
-  dtype: [float32, float16]
+  transformers.dtype: [float32, float16]
 """)
     import yaml
 
@@ -452,7 +453,7 @@ def test_run_study_routing_sweep_yaml(tmp_path):
 
     study_yaml = tmp_path / "study.yaml"
     study_yaml.write_text(
-        "name: test\nmodel: test/model\nengine: transformers\nsweep:\n  dtype: [float32, float16]\n"
+        "name: test\nmodel: test/model\nengine: transformers\nsweep:\n  transformers.dtype: [float32, float16]\n"
     )
     mock_study_result = make_study_result()
 
@@ -532,7 +533,7 @@ def test_run_study_cli_defaults_applied(tmp_path):
 
     study_yaml = tmp_path / "study.yaml"
     study_yaml.write_text(
-        "name: test\nmodel: test/model\nengine: transformers\nsweep:\n  dtype: [float32, float16]\n"
+        "name: test\nmodel: test/model\nengine: transformers\nsweep:\n  transformers.dtype: [float32, float16]\n"
     )
     mock_study_result = make_study_result()
     _capture_load, captured_overrides = _make_capture_load()
@@ -589,7 +590,7 @@ def _make_study_yaml(tmp_path, content: str | None = None) -> Path:
 
     study_yaml = tmp_path / "study.yaml"
     if content is None:
-        content = "name: test\nmodel: test/model\nengine: transformers\nsweep:\n  dtype: [float32, float16]\n"
+        content = "name: test\nmodel: test/model\nengine: transformers\nsweep:\n  transformers.dtype: [float32, float16]\n"
     study_yaml.write_text(content)
     return study_yaml
 

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -82,23 +82,21 @@ def test_get_engine_params_unknown_engine_raises():
 
 
 def test_get_shared_params_returns_model_field():
-    """get_shared_params() contains 'model' — wait, 'model' is not in shared.
+    """get_shared_params() returns dataset and decoder params.
 
-    Actually shared params are dtype, n, max_input_tokens, max_output_tokens
-    plus decoder.* params. 'model' is a top-level required field in ExperimentConfig,
-    not in the shared section of introspection.
+    dtype lives per-engine, not in the shared bucket. Shared now means
+    decoder.* params and dataset.* params.
     """
     params = get_shared_params()
     assert isinstance(params, dict)
-    # Precision is a confirmed shared param
-    assert "dtype" in params
+    # Dataset params are shared
+    assert "dataset.n_prompts" in params
 
 
-def test_get_shared_params_contains_dtype():
-    """get_shared_params() contains 'dtype'."""
+def test_get_shared_params_does_not_contain_dtype():
+    """get_shared_params() does not expose 'dtype' — it's per-engine."""
     params = get_shared_params()
-    assert "dtype" in params
-    assert params["dtype"]["options"] == ["float32", "float16", "bfloat16"]
+    assert "dtype" not in params
 
 
 def test_get_shared_params_contains_n():
@@ -162,8 +160,8 @@ def test_get_param_test_values_pytorch_batch_size_returns_list():
 
 
 def test_get_param_test_values_dtype_returns_all_options():
-    """get_param_test_values('dtype') returns all 3 dtype options."""
-    values = get_param_test_values("dtype")
+    """get_param_test_values('transformers.dtype') returns all 3 dtype options."""
+    values = get_param_test_values("transformers.dtype")
     assert set(values) == {"float32", "float16", "bfloat16"}
 
 
@@ -215,7 +213,7 @@ def test_list_all_param_paths_contains_expected_paths():
     paths = list_all_param_paths()
     assert isinstance(paths, list)
     assert "transformers.batch_size" in paths
-    assert "dtype" in paths
+    assert "transformers.dtype" in paths
 
 
 def test_list_all_param_paths_contains_known_paths():
@@ -226,7 +224,10 @@ def test_list_all_param_paths_contains_known_paths():
     assert "transformers.sampling.temperature" in paths
     assert "vllm.sampling.temperature" in paths
     assert "tensorrt.sampling.temperature" in paths
-    assert "dtype" in paths
+    # dtype also lives per-engine
+    assert "transformers.dtype" in paths
+    assert "vllm.dtype" in paths
+    assert "tensorrt.dtype" in paths
 
 
 def test_list_all_param_paths_filtered_by_engine():
@@ -250,13 +251,13 @@ def test_list_all_param_paths_unknown_engine_raises():
 def test_all_pytorch_dtype_values_produce_valid_config(dt):
     """Schema-driven: each SSOT DTYPE_SUPPORT['transformers'] value creates a valid config."""
     config = make_config(dtype=dt)
-    assert config.dtype == dt
+    assert config.transformers.dtype == dt
 
 
 def test_ssot_dtype_values_match_param_test_values():
-    """DTYPE_SUPPORT['transformers'] values match get_param_test_values('dtype')."""
+    """DTYPE_SUPPORT['transformers'] values match get_param_test_values('transformers.dtype')."""
     from_ssot = set(DTYPE_SUPPORT["transformers"])
-    from_introspection = set(get_param_test_values("dtype"))
+    from_introspection = set(get_param_test_values("transformers.dtype"))
     # The test values from introspection should cover all SSOT dtype values
     assert from_ssot == from_introspection
 
@@ -342,11 +343,15 @@ def test_get_swept_field_paths_single_experiment():
 
 
 def test_get_swept_field_paths_dtype_swept():
-    """Two experiments with different dtypes yield {'dtype'} in swept paths."""
-    exp1 = ExperimentConfig(task={"model": "gpt2"}, dtype="float16")
-    exp2 = ExperimentConfig(task={"model": "gpt2"}, dtype="bfloat16")
+    """Two experiments with different engine dtypes sweep the engine subconfig path."""
+    exp1 = ExperimentConfig(
+        task={"model": "gpt2"}, engine="transformers", transformers={"dtype": "float16"}
+    )
+    exp2 = ExperimentConfig(
+        task={"model": "gpt2"}, engine="transformers", transformers={"dtype": "bfloat16"}
+    )
     result = get_swept_field_paths([exp1, exp2])
-    assert "dtype" in result
+    assert "transformers.dtype" in result
 
 
 def test_get_swept_field_paths_nested_field():
@@ -371,14 +376,12 @@ def test_get_swept_field_paths_multi_engine_none_subconfigs():
     exp_pt = ExperimentConfig(
         task={"model": "gpt2"},
         engine="transformers",
-        dtype="float16",
-        transformers=TransformersConfig(batch_size=4),
+        transformers=TransformersConfig(dtype="float16", batch_size=4),
     )
     exp_vllm = ExperimentConfig(
         task={"model": "gpt2"},
         engine="vllm",
-        dtype="float16",
-        vllm=VLLMConfig(),
+        vllm=VLLMConfig(dtype="float16"),
     )
     # Must not raise AttributeError
     result = get_swept_field_paths([exp_pt, exp_vllm])

--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -43,10 +43,14 @@ def test_load_valid_yaml(tmp_path):
 
 
 def test_load_yaml_with_dtype(tmp_path):
-    """YAML with optional fields loads correctly."""
-    path = _write_yaml(tmp_path, "task:\n  model: gpt2\nengine: transformers\ndtype: float16\n")
+    """YAML with per-engine dtype loads correctly (dtype is nested under the engine section)."""
+    path = _write_yaml(
+        tmp_path,
+        "task:\n  model: gpt2\nengine: transformers\ntransformers:\n  dtype: float16\n",
+    )
     config = load_experiment_config(path)
-    assert config.dtype == "float16"
+    assert config.transformers is not None
+    assert config.transformers.dtype == "float16"
 
 
 def test_load_yaml_with_pytorch_section(tmp_path):
@@ -130,7 +134,9 @@ def test_cli_overrides_merged(tmp_path):
 def test_cli_overrides_none_values_ignored(tmp_path):
     """None values in cli_overrides are ignored (unset CLI flags)."""
     path = _write_yaml(tmp_path, "task:\n  model: gpt2\nengine: transformers\n")
-    config = load_experiment_config(path, cli_overrides={"task.model": None, "dtype": None})
+    config = load_experiment_config(
+        path, cli_overrides={"task.model": None, "transformers.dtype": None}
+    )
     assert config.task.model == "gpt2"  # file value retained
 
 
@@ -225,7 +231,7 @@ def test_load_study_config_grid_sweep(tmp_path):
                 "task": {"model": "gpt2"},
                 "engine": "transformers",
                 "sweep": {
-                    "dtype": ["float16", "bfloat16"],
+                    "transformers.dtype": ["float16", "bfloat16"],
                     "task.dataset.n_prompts": [50, 100],
                 },
             }
@@ -252,8 +258,16 @@ def test_load_study_config_explicit_experiments(tmp_path):
             {
                 "experiments": [
                     {"task": {"model": "gpt2"}, "engine": "transformers"},
-                    {"task": {"model": "gpt2"}, "engine": "transformers", "dtype": "float16"},
-                    {"task": {"model": "gpt2"}, "engine": "transformers", "dtype": "bfloat16"},
+                    {
+                        "task": {"model": "gpt2"},
+                        "engine": "transformers",
+                        "transformers": {"dtype": "float16"},
+                    },
+                    {
+                        "task": {"model": "gpt2"},
+                        "engine": "transformers",
+                        "transformers": {"dtype": "bfloat16"},
+                    },
                 ],
             }
         )
@@ -271,7 +285,7 @@ def test_load_study_config_combined_mode(tmp_path):
                 "task": {"model": "gpt2"},
                 "engine": "transformers",
                 "sweep": {
-                    "dtype": ["float16", "bfloat16"],
+                    "transformers.dtype": ["float16", "bfloat16"],
                 },
                 "experiments": [
                     {"task": {"model": "gpt2-xl"}, "engine": "transformers"},
@@ -293,7 +307,7 @@ def test_load_study_config_with_execution_block(tmp_path):
                 "task": {"model": "gpt2"},
                 "engine": "transformers",
                 "sweep": {
-                    "dtype": ["float16", "bfloat16"],
+                    "transformers.dtype": ["float16", "bfloat16"],
                 },
                 "study_execution": {
                     "n_cycles": 3,
@@ -317,7 +331,7 @@ def test_load_study_config_cli_overrides(tmp_path):
             {
                 "task": {"model": "gpt2"},
                 "engine": "transformers",
-                "sweep": {"dtype": ["float16", "bfloat16"]},
+                "sweep": {"transformers.dtype": ["float16", "bfloat16"]},
                 "study_execution": {"n_cycles": 1},
             }
         )
@@ -345,7 +359,7 @@ def test_load_study_config_with_base(tmp_path):
             {
                 "base": "experiment.yaml",
                 "sweep": {
-                    "dtype": ["float16", "bfloat16"],
+                    "transformers.dtype": ["float16", "bfloat16"],
                 },
             }
         )
@@ -414,7 +428,7 @@ def test_load_study_config_hash_excludes_execution(tmp_path):
     sweep_content = {
         "task": {"model": "gpt2"},
         "engine": "transformers",
-        "sweep": {"dtype": ["float16", "bfloat16"]},
+        "sweep": {"transformers.dtype": ["float16", "bfloat16"]},
     }
     study_yaml_a.write_text(yaml.dump({**sweep_content, "study_execution": {"n_cycles": 1}}))
     study_yaml_b.write_text(yaml.dump({**sweep_content, "study_execution": {"n_cycles": 5}}))

--- a/tests/unit/config/test_config_schema.py
+++ b/tests/unit/config/test_config_schema.py
@@ -60,9 +60,12 @@ def test_field_name_model():
 
 
 def test_field_name_dtype():
-    """v2.0 'dtype' field is accepted."""
-    config = ExperimentConfig(task={"model": "gpt2"}, dtype="float16")
-    assert config.dtype == "float16"
+    """dtype is per-engine (lives on the active engine's config section)."""
+    config = ExperimentConfig(
+        task={"model": "gpt2"}, engine="transformers", transformers={"dtype": "float16"}
+    )
+    assert config.transformers is not None
+    assert config.transformers.dtype == "float16"
 
 
 def test_field_name_n():
@@ -83,6 +86,12 @@ def test_v1x_field_fp_precision_rejected():
     """v1.x 'fp_precision' field is NOT accepted (extra='forbid')."""
     with pytest.raises(ValidationError):
         ExperimentConfig(task={"model": "gpt2"}, fp_dtype="float16")  # type: ignore[call-arg]
+
+
+def test_top_level_dtype_rejected():
+    """Top-level dtype is rejected — dtype lives per-engine (extra='forbid')."""
+    with pytest.raises(ValidationError):
+        ExperimentConfig(task={"model": "gpt2"}, dtype="float16")  # type: ignore[call-arg]
 
 
 # ---------------------------------------------------------------------------
@@ -197,32 +206,40 @@ def test_tensorrt_section_with_wrong_engine_rejected():
 def test_invalid_dtype_raises_validation_error():
     """Invalid dtype value raises ValidationError."""
     with pytest.raises(ValidationError):
-        ExperimentConfig(task={"model": "gpt2"}, dtype="fp16")  # old shorthand
+        ExperimentConfig(
+            task={"model": "gpt2"}, engine="transformers", transformers={"dtype": "fp16"}
+        )  # old shorthand
 
 
 def test_valid_dtype_float32():
-    """dtype='float32' is valid."""
-    config = ExperimentConfig(task={"model": "gpt2"}, dtype="float32")
-    assert config.dtype == "float32"
+    """dtype='float32' is valid on TransformersConfig."""
+    config = ExperimentConfig(
+        task={"model": "gpt2"}, engine="transformers", transformers={"dtype": "float32"}
+    )
+    assert config.transformers.dtype == "float32"
 
 
 def test_valid_dtype_float16():
-    """dtype='float16' is valid."""
-    config = ExperimentConfig(task={"model": "gpt2"}, dtype="float16")
-    assert config.dtype == "float16"
+    """dtype='float16' is valid on TransformersConfig."""
+    config = ExperimentConfig(
+        task={"model": "gpt2"}, engine="transformers", transformers={"dtype": "float16"}
+    )
+    assert config.transformers.dtype == "float16"
 
 
 def test_valid_dtype_bfloat16():
-    """dtype='bfloat16' is valid."""
-    config = ExperimentConfig(task={"model": "gpt2"}, dtype="bfloat16")
-    assert config.dtype == "bfloat16"
+    """dtype='bfloat16' is valid on TransformersConfig."""
+    config = ExperimentConfig(
+        task={"model": "gpt2"}, engine="transformers", transformers={"dtype": "bfloat16"}
+    )
+    assert config.transformers.dtype == "bfloat16"
 
 
 @pytest.mark.parametrize("dt", DTYPE_SUPPORT["transformers"])
 def test_all_pytorch_dtypes_valid(dt):
     """Schema-driven: all SSOT DTYPE_SUPPORT['transformers'] values are valid."""
     config = make_config(dtype=dt)
-    assert config.dtype == dt
+    assert config.transformers.dtype == dt
 
 
 # ---------------------------------------------------------------------------
@@ -263,10 +280,10 @@ def test_make_config_helper_returns_valid_config():
 
 
 def test_make_config_override():
-    """make_config(**overrides) applies overrides over defaults."""
+    """make_config(**overrides) applies overrides over defaults (dtype -> engine section)."""
     config = make_config(model="bert-base", dtype="float32")
     assert config.task.model == "bert-base"
-    assert config.dtype == "float32"
+    assert config.transformers.dtype == "float32"
 
 
 # ---------------------------------------------------------------------------
@@ -391,17 +408,12 @@ def test_pytorch_config_device_map_without_tp_plan_ok():
 # ---------------------------------------------------------------------------
 
 
-def test_vllm_fp8_float32_rejected():
-    """fp8 quantization with dtype=float32 raises ValidationError at parse time."""
-    from llenergymeasure.config.engine_configs import VLLMConfig, VLLMEngineConfig
+def test_vllm_dtype_float32_rejected():
+    """VLLMConfig.dtype Literal rejects float32 (vLLM does not support fp32)."""
+    from llenergymeasure.config.engine_configs import VLLMConfig
 
-    with pytest.raises(ValidationError, match=r"fp8.*incompatible.*float32"):
-        ExperimentConfig(
-            task={"model": "gpt2"},
-            engine="vllm",
-            dtype="float32",
-            vllm=VLLMConfig(engine=VLLMEngineConfig(quantization="fp8")),
-        )
+    with pytest.raises(ValidationError):
+        VLLMConfig(dtype="float32")  # type: ignore[arg-type]
 
 
 def test_vllm_fp8_float16_accepted():
@@ -411,10 +423,9 @@ def test_vllm_fp8_float16_accepted():
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="vllm",
-        dtype="float16",
-        vllm=VLLMConfig(engine=VLLMEngineConfig(quantization="fp8")),
+        vllm=VLLMConfig(dtype="float16", engine=VLLMEngineConfig(quantization="fp8")),
     )
-    assert cfg.dtype == "float16"
+    assert cfg.vllm.dtype == "float16"
 
 
 def test_vllm_fp8_bfloat16_accepted():
@@ -424,36 +435,33 @@ def test_vllm_fp8_bfloat16_accepted():
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="vllm",
-        dtype="bfloat16",
-        vllm=VLLMConfig(engine=VLLMEngineConfig(quantization="fp8")),
+        vllm=VLLMConfig(dtype="bfloat16", engine=VLLMEngineConfig(quantization="fp8")),
     )
-    assert cfg.dtype == "bfloat16"
+    assert cfg.vllm.dtype == "bfloat16"
 
 
-def test_vllm_non_fp8_float32_accepted():
-    """Non-fp8 quantization (awq) with dtype=float32 is accepted."""
+def test_vllm_non_fp8_float16_accepted():
+    """Non-fp8 quantization (awq) with dtype=float16 is accepted."""
     from llenergymeasure.config.engine_configs import VLLMConfig, VLLMEngineConfig
 
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="vllm",
-        dtype="float32",
-        vllm=VLLMConfig(engine=VLLMEngineConfig(quantization="awq")),
+        vllm=VLLMConfig(dtype="float16", engine=VLLMEngineConfig(quantization="awq")),
     )
-    assert cfg.dtype == "float32"
+    assert cfg.vllm.dtype == "float16"
 
 
-def test_vllm_no_quantization_float32_accepted():
-    """No quantization set with dtype=float32 is accepted."""
+def test_vllm_no_quantization_default_dtype_accepted():
+    """No quantization set, no explicit dtype, is accepted (engine default applies)."""
     from llenergymeasure.config.engine_configs import VLLMConfig, VLLMEngineConfig
 
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="vllm",
-        dtype="float32",
         vllm=VLLMConfig(engine=VLLMEngineConfig()),
     )
-    assert cfg.dtype == "float32"
+    assert cfg.vllm.dtype is None
 
 
 # ---------------------------------------------------------------------------
@@ -508,8 +516,9 @@ def test_pytorch_flash_attn2_float32_rejected():
         ExperimentConfig(
             task={"model": "gpt2"},
             engine="transformers",
-            dtype="float32",
-            transformers=TransformersConfig(attn_implementation="flash_attention_2"),
+            transformers=TransformersConfig(
+                dtype="float32", attn_implementation="flash_attention_2"
+            ),
         )
 
 
@@ -521,8 +530,9 @@ def test_pytorch_flash_attn3_float32_rejected():
         ExperimentConfig(
             task={"model": "gpt2"},
             engine="transformers",
-            dtype="float32",
-            transformers=TransformersConfig(attn_implementation="flash_attention_3"),
+            transformers=TransformersConfig(
+                dtype="float32", attn_implementation="flash_attention_3"
+            ),
         )
 
 
@@ -533,10 +543,9 @@ def test_pytorch_flash_attn2_bfloat16_accepted():
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="transformers",
-        dtype="bfloat16",
-        transformers=TransformersConfig(attn_implementation="flash_attention_2"),
+        transformers=TransformersConfig(dtype="bfloat16", attn_implementation="flash_attention_2"),
     )
-    assert cfg.dtype == "bfloat16"
+    assert cfg.transformers.dtype == "bfloat16"
 
 
 def test_pytorch_eager_float32_accepted():
@@ -546,10 +555,9 @@ def test_pytorch_eager_float32_accepted():
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="transformers",
-        dtype="float32",
-        transformers=TransformersConfig(attn_implementation="eager"),
+        transformers=TransformersConfig(dtype="float32", attn_implementation="eager"),
     )
-    assert cfg.dtype == "float32"
+    assert cfg.transformers.dtype == "float32"
 
 
 def test_pytorch_no_attn_impl_float32_accepted():
@@ -559,10 +567,9 @@ def test_pytorch_no_attn_impl_float32_accepted():
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="transformers",
-        dtype="float32",
-        transformers=TransformersConfig(),
+        transformers=TransformersConfig(dtype="float32"),
     )
-    assert cfg.dtype == "float32"
+    assert cfg.transformers.dtype == "float32"
 
 
 # ---------------------------------------------------------------------------
@@ -570,17 +577,12 @@ def test_pytorch_no_attn_impl_float32_accepted():
 # ---------------------------------------------------------------------------
 
 
-def test_trt_fp8_rejects_float32() -> None:
-    """FP8 quantization with dtype=float32 raises ValidationError at parse time."""
-    from llenergymeasure.config.engine_configs import TensorRTConfig, TensorRTQuantConfig
+def test_trt_dtype_float32_rejected() -> None:
+    """TensorRTConfig.dtype Literal rejects float32 (TRT-LLM does not support fp32)."""
+    from llenergymeasure.config.engine_configs import TensorRTConfig
 
-    with pytest.raises(ValidationError, match=r"FP8.*incompatible.*float32"):
-        ExperimentConfig(
-            task={"model": "gpt2"},
-            engine="tensorrt",
-            dtype="float32",
-            tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8")),
-        )
+    with pytest.raises(ValidationError):
+        TensorRTConfig(dtype="float32")  # type: ignore[arg-type]
 
 
 def test_trt_fp8_accepts_float16() -> None:
@@ -590,10 +592,9 @@ def test_trt_fp8_accepts_float16() -> None:
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="tensorrt",
-        dtype="float16",
-        tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8")),
+        tensorrt=TensorRTConfig(dtype="float16", quant=TensorRTQuantConfig(quant_algo="FP8")),
     )
-    assert cfg.dtype == "float16"
+    assert cfg.tensorrt.dtype == "float16"
 
 
 def test_trt_fp8_accepts_bfloat16() -> None:
@@ -603,23 +604,21 @@ def test_trt_fp8_accepts_bfloat16() -> None:
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="tensorrt",
-        dtype="bfloat16",
-        tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8")),
+        tensorrt=TensorRTConfig(dtype="bfloat16", quant=TensorRTQuantConfig(quant_algo="FP8")),
     )
-    assert cfg.dtype == "bfloat16"
+    assert cfg.tensorrt.dtype == "bfloat16"
 
 
-def test_trt_non_fp8_accepts_float32() -> None:
-    """Non-FP8 quantization (INT8) with dtype=float32 is accepted (only FP8 is incompatible)."""
+def test_trt_non_fp8_accepts_float16() -> None:
+    """Non-FP8 quantization (INT8) with dtype=float16 is accepted."""
     from llenergymeasure.config.engine_configs import TensorRTConfig, TensorRTQuantConfig
 
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="tensorrt",
-        dtype="float32",
-        tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="INT8")),
+        tensorrt=TensorRTConfig(dtype="float16", quant=TensorRTQuantConfig(quant_algo="INT8")),
     )
-    assert cfg.dtype == "float32"
+    assert cfg.tensorrt.dtype == "float16"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -123,7 +123,10 @@ class TestProtocolCompliance:
 
 class TestBuildLlmKwargs:
     def test_minimal_config_has_required_keys(self):
-        """With no VLLMConfig, kwargs contains model, dtype, trust_remote_code, seed."""
+        """With no VLLMConfig, kwargs contains model, trust_remote_code, seed.
+
+        dtype is omitted when the user hasn't set it — vLLM uses its own default.
+        """
         config = make_config(**_VLLM_DEFAULTS)
         engine = VLLMEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -132,7 +135,8 @@ class TestBuildLlmKwargs:
         # HF default — env var LLEM_TRUST_REMOTE_CODE not set
         assert kwargs["trust_remote_code"] is False
         assert kwargs["seed"] == 42
-        assert "dtype" in kwargs
+        # dtype is only forwarded when explicitly set in VLLMConfig
+        assert "dtype" not in kwargs
 
     def test_trust_remote_code_env_var_opt_in(self, monkeypatch):
         """LLEM_TRUST_REMOTE_CODE=1 enables trust_remote_code=True."""
@@ -143,9 +147,9 @@ class TestBuildLlmKwargs:
 
         assert kwargs["trust_remote_code"] is True
 
-    def test_minimal_config_dtype_passthrough(self):
-        """Default dtype (bfloat16) passes through in kwargs."""
-        config = make_config(**_VLLM_DEFAULTS)
+    def test_explicit_dtype_passthrough(self):
+        """Explicit VLLMConfig.dtype passes through in kwargs."""
+        config = make_config(**_VLLM_DEFAULTS, vllm=VLLMConfig(dtype="bfloat16"))
         engine = VLLMEngine()
         kwargs = engine._build_llm_kwargs(config)
         assert kwargs["dtype"] == "bfloat16"
@@ -185,18 +189,12 @@ class TestBuildLlmKwargs:
         assert "quantization" not in kwargs
 
     def test_no_vllm_section_produces_no_extra_keys(self):
-        """When config.vllm is None, only the 4 base keys are present."""
+        """When config.vllm is None, only the 3 base keys are present (dtype omitted)."""
         config = make_config(**_VLLM_DEFAULTS)  # vllm=None by default
         engine = VLLMEngine()
         kwargs = engine._build_llm_kwargs(config)
 
-        assert set(kwargs.keys()) == {"model", "dtype", "trust_remote_code", "seed"}
-
-    def test_dtype_float32_in_kwargs(self):
-        """dtype='float32' passes through to vLLM."""
-        config = make_config(**_VLLM_DEFAULTS, dtype="float32")
-        kwargs = VLLMEngine()._build_llm_kwargs(config)
-        assert kwargs["dtype"] == "float32"
+        assert set(kwargs.keys()) == {"model", "trust_remote_code", "seed"}
 
     def test_dtype_float16_in_kwargs(self):
         """dtype='float16' passes through to vLLM."""
@@ -209,6 +207,12 @@ class TestBuildLlmKwargs:
         config = make_config(**_VLLM_DEFAULTS, dtype="bfloat16")
         kwargs = VLLMEngine()._build_llm_kwargs(config)
         assert kwargs["dtype"] == "bfloat16"
+
+    def test_dtype_auto_in_kwargs(self):
+        """dtype='auto' passes through to vLLM (vLLM-specific value)."""
+        config = make_config(**_VLLM_DEFAULTS, vllm=VLLMConfig(dtype="auto"))
+        kwargs = VLLMEngine()._build_llm_kwargs(config)
+        assert kwargs["dtype"] == "auto"
 
     def test_seed_from_config_random_seed(self):
         """kwargs['seed'] matches config.random_seed."""

--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -142,19 +142,19 @@ class TestStudyConfig:
 
 class TestExpandGridSweep:
     def test_universal_sweep_cartesian_product(self):
-        """2 dtypes x 2 n values = 4 configs."""
+        """2 dtypes x 2 n values = 4 configs (dtype now engine-scoped)."""
         raw = {
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
                 "task.dataset.n_prompts": [50, 100],
             },
         }
         valid, skipped = expand_grid(raw)
         assert len(valid) == 4
         assert len(skipped) == 0
-        dtypes_set = {c.dtype for c in valid}
+        dtypes_set = {c.transformers.dtype for c in valid}
         ns = {c.task.dataset.n_prompts for c in valid}
         assert dtypes_set == {"float16", "bfloat16"}
         assert ns == {50, 100}
@@ -175,12 +175,13 @@ class TestExpandGridSweep:
         assert batch_sizes == {1, 8}
 
     def test_multi_engine_scoped_sweep(self):
-        """Multi-engine with scoped keys: independent grids per engine."""
+        """Multi-engine with per-engine dtype axes: independent grids per engine."""
         raw = {
             "task": {"model": "gpt2"},
             "engine": ["transformers", "vllm"],
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
+                "vllm.dtype": ["float16", "bfloat16"],
                 "transformers.batch_size": [1, 8],
                 "vllm.engine.max_num_seqs": [64, 256],
             },
@@ -234,7 +235,7 @@ class TestExpandGridCombined:
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
             },
             "experiments": [
                 {"task": {"model": "gpt2-xl"}, "engine": "transformers"},
@@ -246,7 +247,7 @@ class TestExpandGridCombined:
         # Sweep configs first
         sweep_configs = valid[:2]
         explicit_config = valid[2]
-        assert {c.dtype for c in sweep_configs} == {"float16", "bfloat16"}
+        assert {c.transformers.dtype for c in sweep_configs} == {"float16", "bfloat16"}
         assert explicit_config.task.model == "gpt2-xl"
 
 
@@ -267,7 +268,7 @@ class TestExpandGridBase:
         raw = {
             "base": "base_experiment.yaml",
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
             },
         }
         study_yaml = tmp_path / "study.yaml"
@@ -283,7 +284,7 @@ class TestExpandGridBase:
             "task": {"model": "gpt2"},
             "engine": "transformers",
             # These should be stripped
-            "sweep": {"dtype": ["float32"]},
+            "sweep": {"transformers.dtype": ["float32"]},
             "experiments": [{"model": "other"}],
             "study_execution": {"n_cycles": 5},
             "base": "another.yaml",
@@ -295,17 +296,20 @@ class TestExpandGridBase:
         raw = {
             "base": "base_experiment.yaml",
             "sweep": {
-                "dtype": ["float16"],
+                "transformers.dtype": ["float16"],
             },
         }
         study_yaml = tmp_path / "study.yaml"
         valid, _skipped = expand_grid(raw, study_yaml_path=study_yaml)
         assert len(valid) == 1
-        assert valid[0].dtype == "float16"
+        assert valid[0].transformers.dtype == "float16"
         assert valid[0].task.model == "gpt2"
 
     def test_missing_base_file_raises(self, tmp_path: Path):
-        raw = {"base": "nonexistent.yaml", "sweep": {"dtype": ["float16"]}}
+        raw = {
+            "base": "nonexistent.yaml",
+            "sweep": {"transformers.dtype": ["float16"]},
+        }
         study_yaml = tmp_path / "study.yaml"
         with pytest.raises(ConfigError, match="base"):
             expand_grid(raw, study_yaml_path=study_yaml)
@@ -321,11 +325,9 @@ class TestExpandGridInvalidHandling:
         """Invalid configs become SkippedConfig, valid ones are returned."""
         raw = {
             "task": {"model": "gpt2"},
+            "engine": "transformers",
             "sweep": {
-                # fp32 with tensorrt engine is valid, but dtype float32 is accepted
-                # Use a truly invalid combo: engine=vllm but transformers section provided via explicit
-                "engine": ["transformers", "vllm"],
-                "dtype": ["float16"],
+                "transformers.dtype": ["float16", "bfloat16"],
             },
             "experiments": [
                 # This will fail: vllm section + engine=transformers
@@ -353,19 +355,19 @@ class TestExpandGridInvalidHandling:
 
     def test_skipped_config_short_label(self):
         sc = SkippedConfig(
-            raw_config={"engine": "transformers", "dtype": "float32"},
+            raw_config={"engine": "transformers", "transformers": {"dtype": "float32"}},
             reason="some validation error",
         )
         assert sc.short_label == "transformers, float32"
 
     def test_skipped_config_to_dict(self):
         sc = SkippedConfig(
-            raw_config={"engine": "vllm", "dtype": "float16"},
+            raw_config={"engine": "vllm", "vllm": {"dtype": "float16"}},
             reason="cross-validation error",
             errors=[{"loc": ["engine"], "msg": "test"}],
         )
         d = sc.to_dict()
-        assert d["raw_config"] == {"engine": "vllm", "dtype": "float16"}
+        assert d["raw_config"] == {"engine": "vllm", "vllm": {"dtype": "float16"}}
         assert d["reason"] == "cross-validation error"
         assert d["short_label"] == "vllm, float16"
         assert len(d["errors"]) == 1
@@ -386,7 +388,8 @@ class TestMultiBackendSectionStripping:
             "task": {"model": "gpt2"},
             "tensorrt": {"max_input_len": 1024},
             "sweep": {
-                "dtype": ["bfloat16"],
+                "transformers.dtype": ["bfloat16"],
+                "tensorrt.dtype": ["bfloat16"],
                 "transformers.batch_size": [1],
                 "tensorrt.max_batch_size": [4],
             },
@@ -484,11 +487,11 @@ class TestComputeStudyDesignHash:
         """Same experiments in same order produce same hash (order matters for reproducibility)."""
         exps_a = [
             ExperimentConfig(task={"model": "gpt2"}),
-            ExperimentConfig(task={"model": "gpt2"}, dtype="float16"),
+            ExperimentConfig(task={"model": "gpt2"}, transformers={"dtype": "float16"}),
         ]
         exps_b = [
             ExperimentConfig(task={"model": "gpt2"}),
-            ExperimentConfig(task={"model": "gpt2"}, dtype="float16"),
+            ExperimentConfig(task={"model": "gpt2"}, transformers={"dtype": "float16"}),
         ]
         assert compute_study_design_hash(exps_a) == compute_study_design_hash(exps_b)
 
@@ -703,7 +706,7 @@ class TestFormatPreflightSummary:
         """When skipped_configs populated, Skipping line with reasons appears."""
         skipped = [
             {
-                "raw_config": {"engine": "transformers", "dtype": "float32"},
+                "raw_config": {"engine": "transformers", "transformers": {"dtype": "float32"}},
                 "reason": "cross-validation failed",
                 "short_label": "pytorch, float32",
                 "errors": [],
@@ -720,13 +723,13 @@ class TestFormatPreflightSummary:
         # 1 valid config, 2 skipped → 67% skip rate
         skipped = [
             {
-                "raw_config": {"engine": "vllm", "dtype": "float16"},
+                "raw_config": {"engine": "vllm", "vllm": {"dtype": "float16"}},
                 "reason": "error A",
                 "short_label": "vllm, float16",
                 "errors": [],
             },
             {
-                "raw_config": {"engine": "vllm", "dtype": "bfloat16"},
+                "raw_config": {"engine": "vllm", "vllm": {"dtype": "bfloat16"}},
                 "reason": "error B",
                 "short_label": "vllm, bfloat16",
                 "errors": [],
@@ -742,7 +745,7 @@ class TestFormatPreflightSummary:
         # 4 valid, 1 skipped → 20% skip rate
         skipped = [
             {
-                "raw_config": {"engine": "transformers", "dtype": "float32"},
+                "raw_config": {"engine": "transformers", "transformers": {"dtype": "float32"}},
                 "reason": "validation error",
                 "short_label": "pytorch, float32",
                 "errors": [],
@@ -756,7 +759,7 @@ class TestFormatPreflightSummary:
     def test_skipped_list_argument_takes_precedence(self):
         """If skipped list of SkippedConfig passed, uses it instead of skipped_configs."""
         skipped_obj = SkippedConfig(
-            raw_config={"engine": "transformers", "dtype": "float16"},
+            raw_config={"engine": "transformers", "transformers": {"dtype": "float16"}},
             reason="via argument",
         )
         # StudyConfig has empty skipped_configs
@@ -806,7 +809,11 @@ def _make_panel_study_config(
     for model in models:
         for engine in engines:
             for dt in dtypes:
-                experiments.append(ExperimentConfig(task={"model": model}, engine=engine, dtype=dt))
+                experiments.append(
+                    ExperimentConfig(
+                        task={"model": model}, engine=engine, **{engine: {"dtype": dt}}
+                    )
+                )
 
     # Replicate for cycles
     all_exps = experiments * n_cycles
@@ -1013,17 +1020,25 @@ class TestCountSweepStructure:
         assert count_sweep_structure({}) == (0, 0)
 
     def test_axes_only(self):
-        sweep = {"engine": ["transformers", "vllm"], "dtype": ["float16", "bfloat16"]}
+        sweep = {
+            "engine": ["transformers", "vllm"],
+            "transformers.dtype": ["float16", "bfloat16"],
+        }
         assert count_sweep_structure(sweep) == (2, 0)
 
     def test_groups_only(self):
-        sweep = {"quant_group": [{"dtype": "float16"}, {"dtype": "bfloat16"}]}
+        sweep = {
+            "quant_group": [
+                {"transformers.dtype": "float16"},
+                {"transformers.dtype": "bfloat16"},
+            ]
+        }
         assert count_sweep_structure(sweep) == (0, 1)
 
     def test_mixed_axes_and_groups(self):
         sweep = {
             "engine": ["transformers", "vllm"],
-            "dtype": ["float16", "bfloat16"],
+            "transformers.dtype": ["float16", "bfloat16"],
             "transformers.compilation": [
                 {"transformers.torch_compile": True},
                 {"transformers.torch_compile": False},

--- a/tests/unit/study/test_study_manifest.py
+++ b/tests/unit/study/test_study_manifest.py
@@ -38,7 +38,11 @@ from tests.conftest import TEST_CONFIG_HASH
 def _make_experiment(
     model: str = "meta-llama/Llama-3.1-8B", engine: str = "transformers"
 ) -> ExperimentConfig:
-    return ExperimentConfig(task={"model": model}, engine=engine, dtype="bfloat16")
+    # dtype now lives per-engine; attach it to the matching engine section.
+    kwargs = (
+        {engine: {"dtype": "bfloat16"}} if engine in ("transformers", "vllm", "tensorrt") else {}
+    )
+    return ExperimentConfig(task={"model": model}, engine=engine, **kwargs)
 
 
 def _make_study(n_experiments: int = 2, n_cycles: int = 2) -> StudyConfig:
@@ -362,7 +366,7 @@ def test_config_summary_from_experiment() -> None:
     config = ExperimentConfig(
         task={"model": "meta-llama/Llama-3.1-8B"},
         engine="transformers",
-        dtype="bfloat16",
+        transformers={"dtype": "bfloat16"},
     )
     summary = build_config_summary(config)
     # Uses format_experiment_header: "Llama-3.1-8B / pytorch"

--- a/tests/unit/study/test_sweep_groups.py
+++ b/tests/unit/study/test_sweep_groups.py
@@ -175,8 +175,8 @@ class TestRouteKeyValue:
 
     def test_simple_top_level_key(self):
         config = {"engine": "transformers"}
-        result = _route_key_value(dict(config), "dtype", "float16")
-        assert result["dtype"] == "float16"
+        result = _route_key_value(dict(config), "random_seed", 123)
+        assert result["random_seed"] == 123
 
     def test_deep_nested_key(self):
         """Multi-level dotted engine keys like vllm.engine.block_size."""
@@ -203,8 +203,8 @@ class TestApplyGroupOverlay:
 
     def test_simple_top_level_key(self):
         config = {"engine": "transformers"}
-        result = _apply_group_overlay(dict(config), {"dtype": "float16"})
-        assert result["dtype"] == "float16"
+        result = _apply_group_overlay(dict(config), {"random_seed": 123})
+        assert result["random_seed"] == 123
 
     def test_empty_overlay_no_change(self):
         config = {"engine": "transformers", "transformers": {"batch_size": 4}}
@@ -251,7 +251,7 @@ class TestExpandGridSweepGroups:
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
                 "transformers.compilation": [
                     {"transformers.torch_compile": False},
                     {
@@ -321,7 +321,7 @@ class TestExpandGridSweepGroups:
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
                 "transformers.compilation": [
                     {"transformers.torch_compile": False},
                     {
@@ -365,7 +365,7 @@ class TestExpandGridSweepGroups:
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
                 "transformers.compilation": [
                     {"transformers.torch_compile": False},
                     {
@@ -375,7 +375,11 @@ class TestExpandGridSweepGroups:
                 ],
             },
             "experiments": [
-                {"task": {"model": "gpt2"}, "engine": "transformers", "dtype": "float32"},
+                {
+                    "task": {"model": "gpt2"},
+                    "engine": "transformers",
+                    "transformers": {"dtype": "float32"},
+                },
             ],
         }
         valid, _skipped = expand_grid(raw)
@@ -388,7 +392,8 @@ class TestExpandGridSweepGroups:
             "task": {"model": "gpt2"},
             "engine": ["transformers", "vllm"],
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
+                "vllm.dtype": ["float16", "bfloat16"],
                 "transformers.compilation": [
                     {"transformers.torch_compile": False},
                     {
@@ -457,7 +462,8 @@ class TestExpandGridSweepGroupsMultiBackend:
             "task": {"model": "gpt2"},
             "engine": ["transformers", "vllm"],
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
+                "vllm.dtype": ["float16", "bfloat16"],
                 "transformers.compilation": [
                     {"transformers.torch_compile": False},
                     {
@@ -494,7 +500,7 @@ class TestCombinatorialWarnings:
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
-                "dtype": ["float32", "float16", "bfloat16"],
+                "transformers.dtype": ["float32", "float16", "bfloat16"],
                 "transformers.batch_size": [1, 4, 8, 16, 32],
                 "transformers.attn_implementation": ["sdpa", "flash_attention_2", "eager"],
                 "transformers.compilation": [
@@ -530,7 +536,7 @@ class TestHashStabilityWithGroups:
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
-                "dtype": ["float16", "bfloat16"],
+                "transformers.dtype": ["float16", "bfloat16"],
                 "transformers.compilation": [
                     {"transformers.torch_compile": False},
                     {


### PR DESCRIPTION
## Summary

- Add per-engine `dtype` fields to `TransformersConfig`, `VLLMConfig` (already present on `TensorRTConfig`)
- Remove top-level `dtype` field from `ExperimentConfig`
- Add `ExperimentConfig.resolved_dtype` property to centralise engine-aware lookups for display/CLI sites
- Migrate engine builders, cross-validators, CLI/display sites, sweep YAML examples, test fixtures, and tests

## Why

Each engine has different dtype semantics:
- Transformers accepts `float32`/`float16`/`bfloat16`
- vLLM accepts `float16`/`bfloat16`/`auto` (no `float32`)
- TRT-LLM accepts `float16`/`bfloat16`

Previously a shared top-level `dtype: Literal["float32", "float16", "bfloat16"]` forced Transformers-style values onto engines that don't support them. Moving dtype into each engine's config section lets each engine express its own valid value set through the type system.

## Breaking YAML change (pre-1.0)

Top-level `dtype: <value>` is no longer accepted. Use engine-scoped keys:

```yaml
# before
dtype: bfloat16

# after
transformers:
  dtype: bfloat16

# or
vllm:
  dtype: auto
```

Same applies to sweep axes:

```yaml
sweep:
  # before
  dtype: [float16, bfloat16]

  # after
  transformers.dtype: [float32, float16, bfloat16]
  vllm.dtype: [float16, bfloat16]
  tensorrt.dtype: [float16, bfloat16]
```

## Test plan

- [x] `tests/unit/config/` — 257 pass
- [x] `tests/unit/engines/` — 199 pass
- [x] `tests/unit/cli/` — 167 pass
- [x] `tests/unit/study/` — 434 pass
- [x] `tests/integration/` — all pass
- [x] Full suite: **1968 passed, 0 failed**
- [x] `grep -rn 'config\.dtype\b' src/llenergymeasure/ | grep -v resolved_dtype` — 0 hits
- [x] `grep -n '^\s*dtype.*Field' src/llenergymeasure/config/models.py` — 0 hits
- [x] Schema drift check passes (`transformers.dtype` registered in `LLEM_NATIVE_FIELDS`)

## Companion

Part of Phase 49 engine-scoped configuration work. Decoder/sampling migration lands in a follow-up PR 49.5.