### PR TITLE
refactor(config,engines): migrate decoder into per-engine sampling

### DIFF
--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -76,18 +76,11 @@ measurement:
     #window_size: 3                # Sliding window for CV calculation. Default: 3
     #min_prompts: 5                # Minimum prompts before checking CV. Default: 5
 
-# --- Decoder / sampling (universal, shared across engines) ---
-decoder:
-  # preset: deterministic          # Presets override individual params below. Available: deterministic | standard | creative | factual
-  temperature: 1.0               # 0.0 (greedy) to 2.0
-  do_sample: true
-  top_k: 50                      # 0 = disabled
-  top_p: 1.0                     # 1.0 = disabled (nucleus sampling)
-  repetition_penalty: 1.0        # 1.0 = no penalty
-  min_p: null                    # Min probability filter (null = disabled)
-  min_new_tokens: null            # Minimum output tokens (null = no minimum)
-  #TODO: validate this works + how incompataible params resolution is handled
-  #TODO: consider moving this to sweep
+# --- Sampling preset (expands into the active engine's sampling section) ---
+# sampling_preset: deterministic   # deterministic | standard | creative | factual
+# Explicit values written under <engine>.sampling override preset values.
+# Sampling params now live per-engine — see `{transformers|vllm|tensorrt}.sampling`
+# in the engine-specific experiments below.
 
 # --- LoRA adapter (optional, applies to all experiments) ---
 # lora:
@@ -173,11 +166,11 @@ sweep: # TODO: maybe shared_sweep or global_sweep?
     - transformers.use_cache: true
       transformers.cache_implementation: [static, offloaded_static, sliding_window]
 
-  # beam search requires decoder.do_sample: false (cross-section dependency)
+  # beam search requires do_sample: false (cross-section dependency)
   transformers.decoding:
-    - {}                                          # baseline: use shared decoder settings
-    - decoder.do_sample: false
-      decoder.temperature: 0.0
+    - {}                                          # baseline: use engine defaults
+    - transformers.sampling.do_sample: false
+      transformers.sampling.temperature: 0.0
       transformers.num_beams: 4
       transformers.early_stopping: true
       transformers.length_penalty: 1.0
@@ -465,11 +458,9 @@ experiments:
     dtype: bfloat16
     dataset:
       n_prompts: 50
-    decoder:
-      temperature: 0.8
-      do_sample: true
     vllm:
       sampling:
+        temperature: 0.8
         max_tokens: 256              # Overrides universal max_output_tokens for this experiment
         min_tokens: 10
         ignore_eos: false

--- a/src/llenergymeasure/config/README.md
+++ b/src/llenergymeasure/config/README.md
@@ -127,10 +127,11 @@ config = ExperimentConfig(
 
 **Sub-configurations:**
 - `DatasetConfig` - source, n_prompts, order (nested sub-object)
-- `DecoderConfig` - temperature, sampling presets, repetition control
-- `TransformersConfig` - PyTorch engine options
-- `VLLMConfig` - vLLM engine options
-- `TensorRTConfig` - TensorRT-LLM backend options
+- `TransformersConfig` - PyTorch engine options (including `sampling: TransformersSamplingConfig`)
+- `VLLMConfig` - vLLM engine options (including `sampling: VLLMSamplingConfig`)
+- `TensorRTConfig` - TensorRT-LLM backend options (including `sampling: TensorRTSamplingConfig`)
+- `sampling_preset: deterministic | standard | creative | factual` - expands
+  preset values into the active engine's `sampling` section at parse time
 
 **Cross-boundary contract:** `ExperimentConfig.model_json_schema()` is the
 canonical host/container contract. Every Docker image is stamped at build time

--- a/src/llenergymeasure/config/__init__.py
+++ b/src/llenergymeasure/config/__init__.py
@@ -15,7 +15,6 @@ from llenergymeasure.config.loader import (
 from llenergymeasure.config.models import (
     BaselineConfig,
     DatasetConfig,
-    DecoderConfig,
     ExperimentConfig,
     LoRAConfig,
     MeasurementConfig,
@@ -37,7 +36,6 @@ from llenergymeasure.config.user_config import (
 __all__ = [
     "BaselineConfig",
     "DatasetConfig",
-    "DecoderConfig",
     "DiscoveredSchema",
     "DiscoveryLimitation",
     "ExperimentConfig",

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -38,6 +38,47 @@ from pydantic import BaseModel, Field, model_validator
 # =============================================================================
 
 
+class TransformersSamplingConfig(BaseModel):
+    """HuggingFace Transformers sampling configuration.
+
+    Maps to model.generate() kwargs. Field names mirror HuggingFace native
+    conventions (do_sample, min_new_tokens, top_k=0 for disabled).
+
+    All fields default to None — None means "use HF's own default at execution".
+    Unknown fields are forwarded to generate() via extra="allow" (the engine
+    builder picks up values from this section and merges them into generate_kwargs).
+    """
+
+    model_config = {"extra": "allow"}
+
+    temperature: float | None = Field(
+        default=None, ge=0.0, le=2.0, description="Sampling temperature (0=greedy)"
+    )
+    do_sample: bool | None = Field(
+        default=None,
+        description=(
+            "Enable sampling (None -> HF default; greedy is inferred from temperature=0)."
+        ),
+    )
+    top_k: int | None = Field(
+        default=None,
+        ge=0,
+        description="Top-k sampling (HF convention: 0 = disabled, None -> 50).",
+    )
+    top_p: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Top-p nucleus sampling (1.0 = disabled)"
+    )
+    repetition_penalty: float | None = Field(
+        default=None, ge=0.1, le=10.0, description="Repetition penalty (1.0 = no penalty)"
+    )
+    min_p: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Minimum probability filter (None -> disabled)"
+    )
+    min_new_tokens: int | None = Field(
+        default=None, ge=1, description="Minimum output tokens (None -> HF default)."
+    )
+
+
 class TransformersConfig(BaseModel):
     """HuggingFace Transformers engine configuration.
 
@@ -219,6 +260,18 @@ class TransformersConfig(BaseModel):
             "Number of tensor parallel ranks (None -> WORLD_SIZE). Only used when tp_plan is set. "
             "Field name preserved to match HuggingFace accelerate convention "
             "(distinct from TensorRTConfig.tensor_parallel_size which aligns with TrtLlmArgs)."
+        ),
+    )
+
+    # -------------------------------------------------------------------------
+    # Sampling (model.generate kwargs)
+    # -------------------------------------------------------------------------
+
+    sampling: TransformersSamplingConfig | None = Field(
+        default=None,
+        description=(
+            "Sampling configuration for model.generate(); fields mirror "
+            "HuggingFace native generate() kwargs."
         ),
     )
 
@@ -628,21 +681,41 @@ class VLLMEngineConfig(BaseModel):
 
 
 class VLLMSamplingConfig(BaseModel):
-    """vLLM sampling-level configuration (vllm.SamplingParams extensions).
+    """vLLM sampling-level configuration (vllm.SamplingParams kwargs).
 
-    Only vLLM-specific sampling parameters are included here.
-    Universal sampling params (temperature, top_p, top_k, repetition_penalty)
-    live in DecoderConfig and are shared across all engines.
+    Includes universal sampling params (temperature, top_k, top_p,
+    repetition_penalty, min_p) and vLLM-specific ones (presence_penalty,
+    frequency_penalty, ignore_eos, n, min_tokens).
 
     All fields default to None — None means "use vLLM's own default".
     Unknown fields are forwarded to vllm.SamplingParams() via extra="allow".
 
     Note: max_tokens is intentionally absent — it is bridged from
     ExperimentConfig.max_output_tokens in _build_sampling_kwargs().
+    top_k uses vLLM's -1-for-disabled convention (not the HF 0-for-disabled one).
     """
 
     model_config = {"extra": "allow"}
 
+    # Universal sampling params (shared across all engines, values mirror vLLM native)
+    temperature: float | None = Field(
+        default=None, ge=0.0, le=2.0, description="Sampling temperature (0=greedy)"
+    )
+    top_k: int | None = Field(
+        default=None,
+        description="Top-k sampling (vLLM convention: -1 = disabled, None -> -1).",
+    )
+    top_p: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Top-p nucleus sampling (1.0 = disabled)"
+    )
+    repetition_penalty: float | None = Field(
+        default=None, ge=0.1, le=10.0, description="Repetition penalty (1.0 = no penalty)"
+    )
+    min_p: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Minimum probability filter (None -> disabled)"
+    )
+
+    # vLLM-specific
     min_tokens: int | None = Field(
         default=None,
         ge=0,
@@ -714,10 +787,7 @@ class VLLMConfig(BaseModel):
 
     Nested structure mirrors vLLM's own two-API separation:
     - engine: vllm.LLM() constructor arguments (engine-level, loaded at model init)
-    - sampling: vllm.SamplingParams arguments (vLLM-specific extensions only)
-
-    Universal sampling params (temperature, top_p, top_k, repetition_penalty)
-    live in DecoderConfig and are shared across all engines.
+    - sampling: vllm.SamplingParams arguments (both universal and vLLM-specific)
 
     Example YAML:
         engine: vllm
@@ -849,15 +919,36 @@ class TensorRTSchedulerConfig(BaseModel):
 class TensorRTSamplingConfig(BaseModel):
     """TRT-LLM sampling configuration.
 
-    Maps to tensorrt_llm.SamplingParams (TRT-LLM-specific extensions only).
-    Universal sampling params (temperature, top_p, top_k, repetition_penalty)
-    live in DecoderConfig and are shared across all engines.
+    Maps to tensorrt_llm.SamplingParams. Includes universal sampling params
+    (temperature, top_k, top_p, repetition_penalty, min_p) and TRT-LLM-specific
+    ones (min_tokens, n, ignore_eos).
 
     Note: return_perf_metrics dropped (D1 observability flag).
+    top_k uses TRT-LLM's 0-for-disabled convention (matches HF, not vLLM's -1).
     """
 
     model_config = {"extra": "allow"}
 
+    # Universal sampling params (shared across all engines)
+    temperature: float | None = Field(
+        default=None, ge=0.0, le=2.0, description="Sampling temperature (0=greedy)"
+    )
+    top_k: int | None = Field(
+        default=None,
+        ge=0,
+        description="Top-k sampling (TRT-LLM convention: 0 = disabled, None -> TRT default).",
+    )
+    top_p: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Top-p nucleus sampling (1.0 = disabled)"
+    )
+    repetition_penalty: float | None = Field(
+        default=None, ge=0.1, le=10.0, description="Repetition penalty (1.0 = no penalty)"
+    )
+    min_p: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Minimum probability filter (None -> disabled)"
+    )
+
+    # TRT-LLM specific
     min_tokens: int | None = Field(
         default=None,
         ge=0,
@@ -885,10 +976,7 @@ class TensorRTConfig(BaseModel):
     - quant: QuantConfig (quantisation algorithm + KV cache quantisation)
     - kv_cache: KvCacheConfig (block reuse, memory fraction)
     - scheduler: SchedulerConfig (capacity policy)
-    - sampling: SamplingParams (TRT-LLM-specific extensions only)
-
-    Universal sampling params (temperature, top_p, top_k, repetition_penalty)
-    live in DecoderConfig and are shared across all engines.
+    - sampling: SamplingParams (both universal and TRT-LLM-specific)
 
     Dropped (falls through extra="allow"):
     - engine_path — D1 deployment path, not a measurement axis

--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -765,7 +765,7 @@ def _route_key_value(
 
     Routing rules:
     - Engine-prefixed dotted key (``transformers.batch_size``) → merge into engine section.
-    - Other dotted key (``decoder.do_sample``) → unflatten at top level.
+    - Other dotted key (``task.dataset.source``) → unflatten at top level.
     - Simple key → direct assignment.
 
     Returns the (possibly replaced) config_dict reference.

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -332,25 +332,17 @@ def get_engine_params(engine: str) -> dict[str, dict[str, Any]]:
 
 
 def get_shared_params() -> dict[str, dict[str, Any]]:
-    """Get shared/universal parameters from ExperimentConfig and DecoderConfig.
+    """Get shared/universal parameters from ExperimentConfig sub-models.
 
     Returns params that are universal across all engines:
     - Top-level: dtype, n, max_input_tokens, max_output_tokens, random_seed
-    - Decoder: temperature, do_sample, top_p, top_k, repetition_penalty, preset
+    - Dataset: source, n_prompts, order
 
-    Each param includes ``engine_support: list[str]`` indicating which engines
-    expose each parameter.
+    Sampling params (temperature, top_k, top_p, etc.) are no longer shared —
+    they live per-engine on TransformersSamplingConfig / VLLMSamplingConfig /
+    TensorRTSamplingConfig (PR 49.5) and are discovered via ``get_engine_params``.
     """
-    from llenergymeasure.config.models import DecoderConfig
-
     shared: dict[str, dict[str, Any]] = {}
-
-    # Decoder params (introspected from model)
-    decoder_params = get_params_from_model(DecoderConfig, prefix="decoder")
-    # Add engine_support to decoder params
-    for param in decoder_params.values():
-        param["engine_support"] = _ALL_ENGINES_LIST
-    shared.update(decoder_params)
 
     # Top-level universal params — defined manually for explicit engine_support
     shared["dtype"] = {

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -338,9 +338,9 @@ def get_shared_params() -> dict[str, dict[str, Any]]:
     - Top-level: dtype, n, max_input_tokens, max_output_tokens, random_seed
     - Dataset: source, n_prompts, order
 
-    Sampling params (temperature, top_k, top_p, etc.) are no longer shared —
-    they live per-engine on TransformersSamplingConfig / VLLMSamplingConfig /
-    TensorRTSamplingConfig (PR 49.5) and are discovered via ``get_engine_params``.
+    Sampling params (temperature, top_k, top_p, etc.) are not shared — they
+    live per-engine on ``TransformersSamplingConfig`` / ``VLLMSamplingConfig`` /
+    ``TensorRTSamplingConfig`` and are discovered via ``get_engine_params``.
     """
     shared: dict[str, dict[str, Any]] = {}
 

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -459,7 +459,7 @@ def get_param_test_values(param_path: str) -> list[Any]:
     """Get test values for a specific parameter.
 
     Args:
-        param_path: Full param path, e.g., "transformers.batch_size" or "decoder.temperature".
+        param_path: Full param path, e.g., "transformers.batch_size" or "transformers.sampling.temperature".
 
     Returns:
         List of test values.

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -393,10 +393,9 @@ class ExperimentConfig(BaseModel):
     def expand_sampling_preset(cls, data: Any) -> Any:
         """Merge ``sampling_preset`` values into the active engine's sampling section.
 
-        Explicit YAML values take precedence over preset values: we ``setdefault``
-        each preset key so a user-provided ``temperature: 0.7`` wins over the
-        preset's default. The preset itself stays on the top-level model so the
-        chosen preset name remains inspectable after parsing.
+        Explicit YAML values take precedence over preset values (each preset key
+        is applied via ``setdefault``). The preset name itself stays on the
+        top-level model so it remains inspectable after parsing.
         """
         if not isinstance(data, dict):
             return data
@@ -405,13 +404,18 @@ class ExperimentConfig(BaseModel):
             return data
         engine = data.get("engine", Engine.TRANSFORMERS)
         engine_key = engine.value if hasattr(engine, "value") else str(engine)
-        engine_section = data.setdefault(engine_key, {}) or {}
-        sampling_section = engine_section.setdefault("sampling", {}) or {}
-        # setdefault per-key preserves any explicit user values
+        # Ensure the engine section and its sampling sub-dict exist as dicts
+        # (an explicit ``engine: null`` in YAML would otherwise leave None here).
+        engine_section = data.get(engine_key)
+        if not isinstance(engine_section, dict):
+            engine_section = {}
+            data[engine_key] = engine_section
+        sampling_section = engine_section.get("sampling")
+        if not isinstance(sampling_section, dict):
+            sampling_section = {}
+            engine_section["sampling"] = sampling_section
         for key, value in SAMPLING_PRESETS[preset_name].items():
             sampling_section.setdefault(key, value)
-        engine_section["sampling"] = sampling_section
-        data[engine_key] = engine_section
         return data
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -21,10 +21,13 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from llenergymeasure.config.ssot import Engine
+from llenergymeasure.config.ssot import SAMPLING_PRESETS, Engine
 
 #: Valid energy sampler names for ``energy_sampler`` fields.
 EnergySamplerName = Literal["auto", "nvml", "zeus", "codecarbon"]
+
+#: Literal type of supported sampling presets (derived from SAMPLING_PRESETS keys).
+SamplingPreset = Literal["deterministic", "standard", "creative", "factual"]
 
 if TYPE_CHECKING:
     from llenergymeasure.config.engine_configs import (
@@ -32,90 +35,6 @@ if TYPE_CHECKING:
         TransformersConfig,
         VLLMConfig,
     )
-
-
-# Sampling presets aligned with industry best practices (vLLM, OpenAI, MLPerf)
-SAMPLING_PRESETS: dict[str, dict[str, Any]] = {
-    "deterministic": {"temperature": 0.0, "do_sample": False},
-    "standard": {"temperature": 1.0, "do_sample": True, "top_p": 0.95},
-    "creative": {"temperature": 0.8, "do_sample": True, "top_p": 0.9, "repetition_penalty": 1.1},
-    "factual": {"temperature": 0.3, "do_sample": True},
-}
-
-
-# =============================================================================
-# Decoder Configuration
-# =============================================================================
-
-
-class DecoderConfig(BaseModel):
-    """Universal decoder/generation configuration.
-
-    Contains parameters with identical semantics across all engines.
-    Engine-specific decoder params live in engine_configs.py.
-
-    Presets:
-        - deterministic: Greedy decoding (temp=0, do_sample=False)
-        - standard: Balanced sampling (temp=1.0, top_p=0.95)
-        - creative: Higher variance (temp=0.8, top_p=0.9, repetition_penalty=1.1)
-        - factual: Lower variance (temp=0.3)
-    """
-
-    model_config = {"extra": "forbid"}
-
-    temperature: float = Field(
-        default=1.0, ge=0.0, le=2.0, description="Sampling temperature (0=greedy)"
-    )
-    do_sample: bool = Field(default=True, description="Enable sampling (ignored if temp=0)")
-    top_k: int = Field(default=50, ge=0, description="Top-k sampling (0=disabled)")
-    top_p: float = Field(
-        default=1.0, ge=0.0, le=1.0, description="Top-p nucleus sampling (1.0=disabled)"
-    )
-    repetition_penalty: float = Field(
-        default=1.0, ge=0.1, le=10.0, description="Repetition penalty (1.0=no penalty)"
-    )
-    min_p: float | None = Field(
-        default=None, ge=0.0, le=1.0, description="Min probability filter (None -> disabled)"
-    )
-    min_new_tokens: int | None = Field(
-        default=None, ge=1, description="Minimum output token count (None -> no minimum)"
-    )
-    preset: Literal["deterministic", "standard", "creative", "factual"] | None = Field(
-        default=None,
-        description="Sampling preset (expands to preset values, overrides apply on top)",
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def apply_preset(cls, data: Any) -> Any:
-        """Expand preset, then apply explicit overrides on top."""
-        if (
-            isinstance(data, dict)
-            and (preset_name := data.get("preset"))
-            and preset_name in SAMPLING_PRESETS
-        ):
-            return {**SAMPLING_PRESETS[preset_name], **data}
-        return data
-
-    @property
-    def is_deterministic(self) -> bool:
-        """True if using greedy decoding (temp=0 or do_sample=False)."""
-        return self.temperature == 0.0 or not self.do_sample
-
-
-def _validate_sampling_presets() -> None:
-    """Validate SAMPLING_PRESETS keys match DecoderConfig fields at import time."""
-    valid_fields = set(DecoderConfig.model_fields.keys())
-    for preset_name, values in SAMPLING_PRESETS.items():
-        invalid_keys = set(values.keys()) - valid_fields
-        if invalid_keys:
-            raise ValueError(
-                f"SAMPLING_PRESETS['{preset_name}'] has invalid keys: {invalid_keys}. "
-                f"Valid keys are: {valid_fields}"
-            )
-
-
-_validate_sampling_presets()
 
 
 # =============================================================================
@@ -431,9 +350,14 @@ class ExperimentConfig(BaseModel):
         json_schema_extra={"display_label": "Dtype"},
     )
 
-    # Sub-configs (to be migrated per-backend in PRs 49.4/49.5)
-    decoder: DecoderConfig = Field(
-        default_factory=DecoderConfig, description="Universal decoder/generation configuration"
+    # Sampling preset — expands into the active engine's sampling section
+    sampling_preset: SamplingPreset | None = Field(
+        default=None,
+        description=(
+            "Sampling preset. When set, preset values are merged into the active "
+            "engine's sampling section at parse time; explicit YAML values take "
+            "precedence over preset values."
+        ),
     )
 
     # Engine sections (None = use engine's own defaults)
@@ -459,6 +383,36 @@ class ExperimentConfig(BaseModel):
         description="Extra kwargs passed through to engine at execution time. "
         "Keys must not collide with ExperimentConfig top-level fields.",
     )
+
+    # -------------------------------------------------------------------------
+    # Pre-validators (run before field parsing)
+    # -------------------------------------------------------------------------
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_sampling_preset(cls, data: Any) -> Any:
+        """Merge ``sampling_preset`` values into the active engine's sampling section.
+
+        Explicit YAML values take precedence over preset values: we ``setdefault``
+        each preset key so a user-provided ``temperature: 0.7`` wins over the
+        preset's default. The preset itself stays on the top-level model so the
+        chosen preset name remains inspectable after parsing.
+        """
+        if not isinstance(data, dict):
+            return data
+        preset_name = data.get("sampling_preset")
+        if not preset_name or preset_name not in SAMPLING_PRESETS:
+            return data
+        engine = data.get("engine", Engine.TRANSFORMERS)
+        engine_key = engine.value if hasattr(engine, "value") else str(engine)
+        engine_section = data.setdefault(engine_key, {}) or {}
+        sampling_section = engine_section.setdefault("sampling", {}) or {}
+        # setdefault per-key preserves any explicit user values
+        for key, value in SAMPLING_PRESETS[preset_name].items():
+            sampling_section.setdefault(key, value)
+        engine_section["sampling"] = sampling_section
+        data[engine_key] = engine_section
+        return data
 
     # -------------------------------------------------------------------------
     # Cross-validators

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -15,7 +15,21 @@ import from here.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Final, Literal
+from typing import Any, Final, Literal
+
+# ---------------------------------------------------------------------------
+# Sampling presets (shared across engines)
+# ---------------------------------------------------------------------------
+# Preset values are aligned with industry conventions (vLLM, OpenAI, MLPerf).
+# do_sample is intentionally absent from presets — it's HF-specific; the
+# transformers engine builder infers do_sample=False from temperature=0.
+
+SAMPLING_PRESETS: dict[str, dict[str, Any]] = {
+    "deterministic": {"temperature": 0.0},
+    "standard": {"temperature": 1.0, "top_p": 0.95},
+    "creative": {"temperature": 0.8, "top_p": 0.9, "repetition_penalty": 1.1},
+    "factual": {"temperature": 0.3},
+}
 
 # ---------------------------------------------------------------------------
 # Engine enum — the ONE source of truth for backend engine identifiers.
@@ -153,27 +167,9 @@ DECODING_SUPPORT: dict[Engine, list[str]] = {
     Engine.TENSORRT: ["greedy", "sampling"],  # TRT-LLM supports both
 }
 
-# Engines that support the full DecoderConfig temperature/top_k/top_p fields.
-# All current engines support these — this dict exists to make future
-# engine additions explicit rather than implicit.
-# min_p and min_new_tokens: transformers and vLLM support them (identical semantics).
-# min_p/min_new_tokens: vLLM supports; TensorRT support varies by version.
-DECODER_PARAM_SUPPORT: dict[Engine, list[str]] = {
-    Engine.TRANSFORMERS: [
-        "temperature",
-        "top_k",
-        "top_p",
-        "repetition_penalty",
-        "min_p",
-        "min_new_tokens",
-    ],
-    Engine.VLLM: ["temperature", "top_k", "top_p", "repetition_penalty"],
-    Engine.TENSORRT: [
-        "temperature",
-        "top_k",
-        "top_p",
-    ],  # TRT-LLM: repetition_penalty support varies
-}
+# Sampling parameter support is now derivable via Pydantic introspection of
+# each engine's <Engine>SamplingConfig model (get_engine_params), so the
+# DECODER_PARAM_SUPPORT constant is no longer needed.
 
 # Map from engine name to the Python package that provides it.
 # Used by preflight checks and CLI to verify engine availability.
@@ -186,7 +182,6 @@ ENGINE_PACKAGES: dict[Engine, str] = {
 __all__ = [
     "ALL_ENGINES",
     "CONTAINER_EXCHANGE_DIR",
-    "DECODER_PARAM_SUPPORT",
     "DECODING_SUPPORT",
     "DOCKER_PULL_TIMEOUT",
     "DTYPE_SUPPORT",
@@ -205,6 +200,7 @@ __all__ = [
     "ENV_TABLE_ROWS",
     "RUNNER_DOCKER",
     "RUNNER_LOCAL",
+    "SAMPLING_PRESETS",
     "SOURCE_MULTI_ENGINE_ELEVATION",
     "TEMP_PREFIX_ENV_FILE",
     "TEMP_PREFIX_EXCHANGE",

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -167,10 +167,6 @@ DECODING_SUPPORT: dict[Engine, list[str]] = {
     Engine.TENSORRT: ["greedy", "sampling"],  # TRT-LLM supports both
 }
 
-# Sampling parameter support is now derivable via Pydantic introspection of
-# each engine's <Engine>SamplingConfig model (get_engine_params), so the
-# DECODER_PARAM_SUPPORT constant is no longer needed.
-
 # Map from engine name to the Python package that provides it.
 # Used by preflight checks and CLI to verify engine availability.
 ENGINE_PACKAGES: dict[Engine, str] = {

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -533,50 +533,41 @@ class TensorRTEngine:
         return kwargs
 
     def _build_sampling_params(self, config: ExperimentConfig) -> Any:
-        """Build tensorrt_llm.SamplingParams from DecoderConfig and TensorRTSamplingConfig.
+        """Build tensorrt_llm.SamplingParams from TensorRTSamplingConfig.
 
-        Args:
-            config: Experiment configuration.
-
-        Returns:
-            tensorrt_llm.SamplingParams instance.
+        All sampling fields (temperature, top_k, top_p, repetition_penalty,
+        min_p, plus TRT-LLM-specific ones) now live on
+        ``config.tensorrt.sampling`` (PR 49.5). None values mean "use TRT-LLM's
+        default", so we forward only explicit values.
         """
         from tensorrt_llm import SamplingParams
 
-        decoder = config.decoder
+        trt = config.tensorrt
+        sampling = trt.sampling if trt is not None else None
+
         kwargs: dict[str, Any] = {
             "random_seed": config.task.random_seed,
         }
         if config.task.max_output_tokens is not None:
             kwargs["max_new_tokens"] = config.task.max_output_tokens
 
-        # Universal decoder params
-        if decoder.temperature != 0.0:
-            kwargs["temperature"] = decoder.temperature
-        if decoder.top_p is not None:
-            kwargs["top_p"] = decoder.top_p
-        if decoder.top_k is not None and decoder.top_k != 0:
-            kwargs["top_k"] = decoder.top_k
-        if decoder.repetition_penalty is not None:
-            kwargs["repetition_penalty"] = decoder.repetition_penalty
-        if decoder.min_p is not None:
-            kwargs["min_p"] = decoder.min_p
-        # Map universal decoder.min_new_tokens to TRT-LLM's min_tokens.
-        # Placed before trt.sampling overrides so tensorrt.sampling.min_tokens
-        # can override the universal mapping if both are set.
-        if decoder.min_new_tokens is not None:
-            kwargs["min_tokens"] = decoder.min_new_tokens
-
-        # TRT-LLM-specific sampling overrides
-        trt = config.tensorrt
-        if trt is not None and trt.sampling is not None:
-            sampling = trt.sampling
-            if sampling.min_tokens is not None:
-                kwargs["min_tokens"] = sampling.min_tokens
-            if sampling.n is not None:
-                kwargs["n"] = sampling.n
-            if sampling.ignore_eos is not None:
-                kwargs["ignore_eos"] = sampling.ignore_eos
-            # return_perf_metrics dropped (D1 observability flag); falls through extra="allow"
+        if sampling is not None:
+            # User writes top_k=0 to disable (TRT convention, matches HF).
+            for field_name in (
+                "temperature",
+                "top_k",
+                "top_p",
+                "repetition_penalty",
+                "min_p",
+                "min_tokens",
+                "n",
+                "ignore_eos",
+            ):
+                value = getattr(sampling, field_name)
+                if value is not None:
+                    kwargs[field_name] = value
+            # Unknown fields (extra="allow") fall through
+            if sampling.model_extra:
+                kwargs.update(sampling.model_extra)
 
         return SamplingParams(**kwargs)

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -535,39 +535,20 @@ class TensorRTEngine:
     def _build_sampling_params(self, config: ExperimentConfig) -> Any:
         """Build tensorrt_llm.SamplingParams from TensorRTSamplingConfig.
 
-        All sampling fields (temperature, top_k, top_p, repetition_penalty,
-        min_p, plus TRT-LLM-specific ones) now live on
-        ``config.tensorrt.sampling`` (PR 49.5). None values mean "use TRT-LLM's
-        default", so we forward only explicit values.
+        All sampling fields live on ``config.tensorrt.sampling``. None values
+        mean "use TRT-LLM's default", so we forward only explicit values.
+        User writes top_k=0 to disable (TRT convention, matches HF).
         """
         from tensorrt_llm import SamplingParams
 
         trt = config.tensorrt
         sampling = trt.sampling if trt is not None else None
 
-        kwargs: dict[str, Any] = {
-            "random_seed": config.task.random_seed,
-        }
+        kwargs: dict[str, Any] = (
+            sampling.model_dump(exclude_none=True) if sampling is not None else {}
+        )
+        kwargs["random_seed"] = config.task.random_seed
         if config.task.max_output_tokens is not None:
             kwargs["max_new_tokens"] = config.task.max_output_tokens
-
-        if sampling is not None:
-            # User writes top_k=0 to disable (TRT convention, matches HF).
-            for field_name in (
-                "temperature",
-                "top_k",
-                "top_p",
-                "repetition_penalty",
-                "min_p",
-                "min_tokens",
-                "n",
-                "ignore_eos",
-            ):
-                value = getattr(sampling, field_name)
-                if value is not None:
-                    kwargs[field_name] = value
-            # Unknown fields (extra="allow") fall through
-            if sampling.model_extra:
-                kwargs.update(sampling.model_extra)
 
         return SamplingParams(**kwargs)

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -474,31 +474,17 @@ class TransformersEngine:
     def _build_generate_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
         """Build generation kwargs from TransformersSamplingConfig and TransformersConfig.
 
-        Sampling params (temperature, top_k, top_p, etc.) now live on
-        ``config.transformers.sampling`` (PR 49.5). None values mean "use HF's
-        default", so we only forward fields the user explicitly set.
+        None values mean "use HF's default"; only explicit fields are forwarded.
+        Greedy decoding (temperature=0 or do_sample=False) strips sampling params
+        and forces do_sample=False, matching HF's own greedy semantics.
         """
         pt = config.transformers
         sampling = pt.sampling if pt is not None else None
 
-        kwargs: dict[str, Any] = {}
+        kwargs: dict[str, Any] = (
+            sampling.model_dump(exclude_none=True) if sampling is not None else {}
+        )
 
-        # Forward each sampling field only when the user set it (None = HF default)
-        if sampling is not None:
-            for field_name in (
-                "do_sample",
-                "temperature",
-                "top_k",
-                "top_p",
-                "repetition_penalty",
-                "min_p",
-                "min_new_tokens",
-            ):
-                value = getattr(sampling, field_name)
-                if value is not None:
-                    kwargs[field_name] = value
-
-        # TransformersConfig generate() fields
         if pt is not None:
             if pt.use_cache is not None:
                 kwargs["use_cache"] = pt.use_cache
@@ -515,15 +501,9 @@ class TransformersEngine:
             if pt.prompt_lookup_num_tokens is not None:
                 kwargs["prompt_lookup_num_tokens"] = pt.prompt_lookup_num_tokens
 
-        # Greedy decoding: temperature=0 or do_sample=False — strip sampling params.
-        # temperature=0 implies greedy; infer do_sample=False for HF.
-        temperature = kwargs.get("temperature")
-        do_sample = kwargs.get("do_sample")
-        if temperature == 0.0 or do_sample is False:
+        if kwargs.get("temperature") == 0.0 or kwargs.get("do_sample") is False:
             kwargs["do_sample"] = False
-            kwargs.pop("temperature", None)
-            kwargs.pop("top_k", None)
-            kwargs.pop("top_p", None)
-            kwargs.pop("min_p", None)
+            for key in ("temperature", "top_k", "top_p", "min_p"):
+                kwargs.pop(key, None)
 
         return kwargs

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -472,24 +472,33 @@ class TransformersEngine:
         return input_token_count, output_token_count, elapsed
 
     def _build_generate_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
-        """Build generation kwargs from DecoderConfig and TransformersConfig."""
-        decoder = config.decoder
-        kwargs: dict[str, Any] = {
-            "do_sample": decoder.do_sample,
-            "temperature": decoder.temperature,
-            "top_k": decoder.top_k,
-            "top_p": decoder.top_p,
-            "repetition_penalty": decoder.repetition_penalty,
-        }
+        """Build generation kwargs from TransformersSamplingConfig and TransformersConfig.
 
-        # DecoderConfig new fields
-        if decoder.min_p is not None:
-            kwargs["min_p"] = decoder.min_p
-        if decoder.min_new_tokens is not None:
-            kwargs["min_new_tokens"] = decoder.min_new_tokens
+        Sampling params (temperature, top_k, top_p, etc.) now live on
+        ``config.transformers.sampling`` (PR 49.5). None values mean "use HF's
+        default", so we only forward fields the user explicitly set.
+        """
+        pt = config.transformers
+        sampling = pt.sampling if pt is not None else None
+
+        kwargs: dict[str, Any] = {}
+
+        # Forward each sampling field only when the user set it (None = HF default)
+        if sampling is not None:
+            for field_name in (
+                "do_sample",
+                "temperature",
+                "top_k",
+                "top_p",
+                "repetition_penalty",
+                "min_p",
+                "min_new_tokens",
+            ):
+                value = getattr(sampling, field_name)
+                if value is not None:
+                    kwargs[field_name] = value
 
         # TransformersConfig generate() fields
-        pt = config.transformers
         if pt is not None:
             if pt.use_cache is not None:
                 kwargs["use_cache"] = pt.use_cache
@@ -506,8 +515,11 @@ class TransformersEngine:
             if pt.prompt_lookup_num_tokens is not None:
                 kwargs["prompt_lookup_num_tokens"] = pt.prompt_lookup_num_tokens
 
-        # Greedy decoding: temperature=0 or do_sample=False — strip sampling params
-        if decoder.temperature == 0.0 or not decoder.do_sample:
+        # Greedy decoding: temperature=0 or do_sample=False — strip sampling params.
+        # temperature=0 implies greedy; infer do_sample=False for HF.
+        temperature = kwargs.get("temperature")
+        do_sample = kwargs.get("do_sample")
+        if temperature == 0.0 or do_sample is False:
             kwargs["do_sample"] = False
             kwargs.pop("temperature", None)
             kwargs.pop("top_k", None)

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -365,52 +365,41 @@ class VLLMEngine:
 
     @staticmethod
     def _build_sampling_params(config: ExperimentConfig, sampling_params_cls: Any) -> Any:
-        """Build vllm.SamplingParams from DecoderConfig."""
+        """Build vllm.SamplingParams from VLLMSamplingConfig.
+
+        All sampling fields (temperature, top_k, top_p, repetition_penalty, min_p,
+        plus vLLM-specific ones) now live on ``config.vllm.sampling`` (PR 49.5).
+        None values mean "use vLLM's default", so we forward only explicit values.
+        """
         vllm_cfg = config.vllm
         if vllm_cfg is not None and vllm_cfg.beam_search is not None:
             return VLLMEngine._build_beam_search_params(config, vllm_cfg.beam_search)
 
-        decoder = config.decoder
-        is_greedy = decoder.temperature == 0.0 or not decoder.do_sample
+        sampling = vllm_cfg.sampling if vllm_cfg is not None else None
 
-        if is_greedy:
-            kwargs: dict[str, Any] = {
-                "temperature": 0.0,
-            }
-        else:
-            top_k = decoder.top_k if decoder.top_k != 0 else -1
-            kwargs = {
-                "temperature": decoder.temperature,
-                "top_p": decoder.top_p,
-                "top_k": top_k,
-                "repetition_penalty": decoder.repetition_penalty,
-            }
-        if config.task.max_output_tokens is not None:
-            kwargs["max_tokens"] = config.task.max_output_tokens
-        if decoder.min_p is not None:
-            kwargs["min_p"] = decoder.min_p
-
-        # Map universal decoder.min_new_tokens to vLLM's min_tokens.
-        # This is placed before vllm_cfg overrides so that vllm.sampling.min_tokens
-        # can override the universal mapping if both are set.
-        if decoder.min_new_tokens is not None:
-            kwargs["min_tokens"] = decoder.min_new_tokens
-
-        # Apply vLLM-specific sampling overrides
-        if vllm_cfg is not None and vllm_cfg.sampling is not None:
-            sampling = vllm_cfg.sampling
-            if sampling.min_tokens is not None:
-                kwargs["min_tokens"] = sampling.min_tokens
-            if sampling.presence_penalty is not None:
-                kwargs["presence_penalty"] = sampling.presence_penalty
-            if sampling.frequency_penalty is not None:
-                kwargs["frequency_penalty"] = sampling.frequency_penalty
-            if sampling.ignore_eos is not None:
-                kwargs["ignore_eos"] = sampling.ignore_eos
-            if sampling.n is not None:
-                kwargs["n"] = sampling.n
+        kwargs: dict[str, Any] = {}
+        if sampling is not None:
+            # User writes top_k=-1 directly to disable (vLLM convention). No translation.
+            for field_name in (
+                "temperature",
+                "top_k",
+                "top_p",
+                "repetition_penalty",
+                "min_p",
+                "min_tokens",
+                "presence_penalty",
+                "frequency_penalty",
+                "ignore_eos",
+                "n",
+            ):
+                value = getattr(sampling, field_name)
+                if value is not None:
+                    kwargs[field_name] = value
             if sampling.model_extra:
                 kwargs.update(sampling.model_extra)
+
+        if config.task.max_output_tokens is not None:
+            kwargs["max_tokens"] = config.task.max_output_tokens
 
         return sampling_params_cls(**kwargs)
 
@@ -436,8 +425,6 @@ class VLLMEngine:
             kwargs["early_stopping"] = beam_cfg.early_stopping
         if config.task.max_output_tokens is not None:
             kwargs["max_tokens"] = config.task.max_output_tokens
-        if config.decoder.min_p is not None:
-            kwargs["min_p"] = config.decoder.min_p
         if beam_cfg.model_extra:
             kwargs.update(beam_cfg.model_extra)
         return BeamSearchParams(**kwargs)

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -367,9 +367,9 @@ class VLLMEngine:
     def _build_sampling_params(config: ExperimentConfig, sampling_params_cls: Any) -> Any:
         """Build vllm.SamplingParams from VLLMSamplingConfig.
 
-        All sampling fields (temperature, top_k, top_p, repetition_penalty, min_p,
-        plus vLLM-specific ones) now live on ``config.vllm.sampling`` (PR 49.5).
-        None values mean "use vLLM's default", so we forward only explicit values.
+        All sampling fields live on ``config.vllm.sampling``. None values mean
+        "use vLLM's default", so we forward only explicit values.
+        User writes top_k=-1 directly to disable (vLLM convention). No translation.
         """
         vllm_cfg = config.vllm
         if vllm_cfg is not None and vllm_cfg.beam_search is not None:
@@ -377,27 +377,9 @@ class VLLMEngine:
 
         sampling = vllm_cfg.sampling if vllm_cfg is not None else None
 
-        kwargs: dict[str, Any] = {}
-        if sampling is not None:
-            # User writes top_k=-1 directly to disable (vLLM convention). No translation.
-            for field_name in (
-                "temperature",
-                "top_k",
-                "top_p",
-                "repetition_penalty",
-                "min_p",
-                "min_tokens",
-                "presence_penalty",
-                "frequency_penalty",
-                "ignore_eos",
-                "n",
-            ):
-                value = getattr(sampling, field_name)
-                if value is not None:
-                    kwargs[field_name] = value
-            if sampling.model_extra:
-                kwargs.update(sampling.model_extra)
-
+        kwargs: dict[str, Any] = (
+            sampling.model_dump(exclude_none=True) if sampling is not None else {}
+        )
         if config.task.max_output_tokens is not None:
             kwargs["max_tokens"] = config.task.max_output_tokens
 

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -108,7 +108,7 @@ def test_get_shared_params_contains_n():
 
 
 def test_get_shared_params_no_longer_contains_decoder():
-    """Sampling params moved to per-engine sections (PR 49.5) — not in shared."""
+    """Sampling params live per-engine — they're not in get_shared_params()."""
     params = get_shared_params()
     assert "decoder.temperature" not in params
     assert "decoder.top_k" not in params
@@ -222,7 +222,7 @@ def test_list_all_param_paths_contains_known_paths():
     """list_all_param_paths() contains expected well-known param paths."""
     paths = list_all_param_paths()
     assert "transformers.batch_size" in paths
-    # Sampling params now live per-engine (PR 49.5), not on a universal decoder
+    # Sampling params live per-engine, not on a universal decoder
     assert "transformers.sampling.temperature" in paths
     assert "vllm.sampling.temperature" in paths
     assert "tensorrt.sampling.temperature" in paths

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -107,10 +107,11 @@ def test_get_shared_params_contains_n():
     assert "dataset.n_prompts" in params
 
 
-def test_get_shared_params_contains_decoder_temperature():
-    """get_shared_params() contains 'decoder.temperature'."""
+def test_get_shared_params_no_longer_contains_decoder():
+    """Sampling params moved to per-engine sections (PR 49.5) — not in shared."""
     params = get_shared_params()
-    assert "decoder.temperature" in params
+    assert "decoder.temperature" not in params
+    assert "decoder.top_k" not in params
 
 
 def test_get_shared_params_all_have_engine_support():
@@ -221,7 +222,10 @@ def test_list_all_param_paths_contains_known_paths():
     """list_all_param_paths() contains expected well-known param paths."""
     paths = list_all_param_paths()
     assert "transformers.batch_size" in paths
-    assert "decoder.temperature" in paths
+    # Sampling params now live per-engine (PR 49.5), not on a universal decoder
+    assert "transformers.sampling.temperature" in paths
+    assert "vllm.sampling.temperature" in paths
+    assert "tensorrt.sampling.temperature" in paths
     assert "dtype" in paths
 
 

--- a/tests/unit/engines/test_engine_protocol.py
+++ b/tests/unit/engines/test_engine_protocol.py
@@ -529,7 +529,7 @@ def test_resolve_torch_dtype_unknown_raises():
 
 
 def test_build_generate_kwargs_defaults():
-    """Default decoder config produces expected generate kwargs."""
+    """Default config with no sampling section produces empty kwargs (HF defaults apply)."""
     from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
@@ -537,22 +537,56 @@ def test_build_generate_kwargs_defaults():
     config = ExperimentConfig(task={"model": "gpt2"})
     kwargs = engine._build_generate_kwargs(config)
 
-    assert "do_sample" in kwargs
-    assert "temperature" in kwargs
-    assert "top_k" in kwargs
-    assert "top_p" in kwargs
-    assert "repetition_penalty" in kwargs
+    # Sampling params now live per-engine; with no section set, kwargs stays empty
+    # and model.generate() uses its own defaults.
+    assert "do_sample" not in kwargs
+    assert "temperature" not in kwargs
+    assert "top_k" not in kwargs
+    assert "top_p" not in kwargs
 
 
-def test_build_generate_kwargs_greedy_decoding():
-    """Greedy decoding (temperature=0) removes sampling params."""
-    from llenergymeasure.config.models import DecoderConfig, ExperimentConfig
+def test_build_generate_kwargs_explicit_sampling_forwarded():
+    """Explicit transformers.sampling fields flow through to generate kwargs."""
+    from llenergymeasure.config.engine_configs import (
+        TransformersConfig,
+        TransformersSamplingConfig,
+    )
+    from llenergymeasure.config.models import ExperimentConfig
     from llenergymeasure.engines.transformers import TransformersEngine
 
     engine = TransformersEngine()
     config = ExperimentConfig(
         task={"model": "gpt2"},
-        decoder=DecoderConfig(temperature=0.0, do_sample=False),
+        transformers=TransformersConfig(
+            sampling=TransformersSamplingConfig(
+                temperature=0.7, top_k=40, top_p=0.9, repetition_penalty=1.1, do_sample=True
+            ),
+        ),
+    )
+    kwargs = engine._build_generate_kwargs(config)
+
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_k"] == 40
+    assert kwargs["top_p"] == 0.9
+    assert kwargs["repetition_penalty"] == 1.1
+    assert kwargs["do_sample"] is True
+
+
+def test_build_generate_kwargs_greedy_decoding():
+    """Greedy decoding (temperature=0) removes sampling params and forces do_sample=False."""
+    from llenergymeasure.config.engine_configs import (
+        TransformersConfig,
+        TransformersSamplingConfig,
+    )
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    engine = TransformersEngine()
+    config = ExperimentConfig(
+        task={"model": "gpt2"},
+        transformers=TransformersConfig(
+            sampling=TransformersSamplingConfig(temperature=0.0, do_sample=False),
+        ),
     )
     kwargs = engine._build_generate_kwargs(config)
 

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -432,31 +432,30 @@ class TestBuildSamplingParams:
 
         assert params._kwargs["random_seed"] == 123
 
-    def test_build_sampling_params_greedy(self, monkeypatch):
-        """temperature=0 omits temperature key (greedy decoding)."""
+    def test_build_sampling_params_default_no_temperature(self, monkeypatch):
+        """Unset sampling -> no temperature in kwargs (TRT-LLM uses its own default)."""
         mock_trt = _make_fake_tensorrt_llm_module()
         monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
         monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
 
-        from llenergymeasure.config.models import DecoderConfig
-
-        config = make_config(**_TRT_DEFAULTS, decoder=DecoderConfig(temperature=0.0))
+        config = make_config(**_TRT_DEFAULTS)
         engine = TensorRTEngine()
         params = engine._build_sampling_params(config)
 
         assert isinstance(params, _FakeSamplingParams)
-        # temperature=0.0 should NOT be in kwargs (greedy check: not != 0.0)
+        # Sampling unset on engine section -> no temperature forwarded
         assert "temperature" not in params._kwargs
 
     def test_build_sampling_params_with_temperature(self, monkeypatch):
-        """Non-zero temperature is included in SamplingParams kwargs."""
+        """Explicit temperature on TensorRTSamplingConfig is forwarded."""
         mock_trt = _make_fake_tensorrt_llm_module()
         monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
         monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
 
-        from llenergymeasure.config.models import DecoderConfig
-
-        config = make_config(**_TRT_DEFAULTS, decoder=DecoderConfig(temperature=0.7))
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt=TensorRTConfig(sampling=TensorRTSamplingConfig(temperature=0.7)),
+        )
         engine = TensorRTEngine()
         params = engine._build_sampling_params(config)
 

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -28,7 +28,6 @@ from llenergymeasure.config.engine_configs import (
     VLLMEngineConfig,
     VLLMSamplingConfig,
 )
-from llenergymeasure.config.models import DecoderConfig
 from llenergymeasure.engines.vllm import VLLMEngine
 from llenergymeasure.utils.exceptions import EngineError
 from tests.conftest import make_config
@@ -245,86 +244,73 @@ class TestBuildLlmKwargs:
 
 class TestBuildSamplingParams:
     def test_greedy_via_temperature_zero(self):
-        """temperature=0.0 triggers greedy mode: temperature=0.0, only max_tokens set."""
-        decoder = DecoderConfig(temperature=0.0, do_sample=False)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, max_output_tokens=64)
+        """temperature=0.0 on VLLMSamplingConfig forwards as-is."""
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(temperature=0.0))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg, max_output_tokens=64)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert params._kwargs["temperature"] == 0.0
         assert params._kwargs["max_tokens"] == 64
-        # Greedy path: top_p, top_k, repetition_penalty NOT set (minimal kwargs)
-        assert "top_p" not in params._kwargs
-        assert "top_k" not in params._kwargs
-
-    def test_greedy_via_do_sample_false_temperature_nonzero(self):
-        """do_sample=False overrides temperature to produce greedy mode."""
-        decoder = DecoderConfig(temperature=0.8, do_sample=False)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
-        params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-
-        assert params._kwargs["temperature"] == 0.0
 
     def test_sampling_mode_temperature(self):
-        """Non-zero temperature with do_sample=True sets temperature in kwargs."""
-        decoder = DecoderConfig(temperature=0.7, do_sample=True)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
+        """temperature=0.7 on VLLMSamplingConfig forwards as-is."""
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(temperature=0.7))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert params._kwargs["temperature"] == pytest.approx(0.7)
 
     def test_sampling_mode_top_p(self):
-        """top_p from DecoderConfig propagates to SamplingParams kwargs."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, top_p=0.9)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
+        """top_p on VLLMSamplingConfig propagates to SamplingParams kwargs."""
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(top_p=0.9))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert params._kwargs["top_p"] == pytest.approx(0.9)
 
-    def test_top_k_zero_sentinel_maps_to_minus_one(self):
-        """Our top_k=0 (disabled) maps to vLLM's top_k=-1 (disabled sentinel)."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, top_k=0)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
+    def test_top_k_minus_one_disabled_passthrough(self):
+        """top_k=-1 (vLLM disabled sentinel) passes through without translation."""
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(top_k=-1))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert params._kwargs["top_k"] == -1
 
     def test_top_k_nonzero_preserved(self):
-        """Non-zero top_k passes through unchanged."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, top_k=40)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
+        """Positive top_k passes through unchanged."""
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(top_k=40))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert params._kwargs["top_k"] == 40
 
     def test_repetition_penalty_propagated(self):
-        """repetition_penalty from DecoderConfig is forwarded."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, repetition_penalty=1.1)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
+        """repetition_penalty on VLLMSamplingConfig is forwarded."""
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(repetition_penalty=1.1))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert params._kwargs["repetition_penalty"] == pytest.approx(1.1)
 
     def test_max_tokens_from_config(self):
         """max_tokens kwarg matches config.max_output_tokens."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, max_output_tokens=256)
+        config = make_config(**_VLLM_DEFAULTS, max_output_tokens=256)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert params._kwargs["max_tokens"] == 256
 
     def test_min_p_included_when_set(self):
-        """min_p is added to kwargs when provided in DecoderConfig."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=0.05)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
+        """min_p is added to kwargs when provided on VLLMSamplingConfig."""
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(min_p=0.05))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert "min_p" in params._kwargs
         assert params._kwargs["min_p"] == pytest.approx(0.05)
 
     def test_min_p_absent_when_none(self):
-        """min_p is NOT in kwargs when DecoderConfig.min_p is None."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=None)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
+        """min_p is NOT in kwargs when VLLMSamplingConfig.min_p is unset."""
+        config = make_config(**_VLLM_DEFAULTS)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
 
         assert "min_p" not in params._kwargs
@@ -531,11 +517,8 @@ class TestSamplingConfigOverrides:
 
     def test_sampling_overrides_applied_to_greedy_path(self):
         """VLLMSamplingConfig overrides work on the greedy (temperature=0.0) path too."""
-        decoder = DecoderConfig(temperature=0.0, do_sample=False)
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(presence_penalty=0.1))
-        config = make_config(
-            **_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=128
-        )
+        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(temperature=0.0, presence_penalty=0.1))
+        config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg, max_output_tokens=128)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
         assert params._kwargs["temperature"] == 0.0
         assert params._kwargs["max_tokens"] == 128  # from max_output_tokens bridge
@@ -543,8 +526,6 @@ class TestSamplingConfigOverrides:
     def test_none_sampling_config_does_not_add_extra_kwargs(self):
         """When vllm.sampling is None, no extra sampling kwargs are added."""
         config = make_config(**_VLLM_DEFAULTS)  # vllm=None by default
-        decoder = DecoderConfig(temperature=1.0, do_sample=True)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
         params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
         assert "presence_penalty" not in params._kwargs
         assert "frequency_penalty" not in params._kwargs
@@ -752,42 +733,6 @@ class TestBeamSearchParams:
 
 
 # =============================================================================
-# Test Group 14: min_new_tokens -> min_tokens mapping (H4)
-# =============================================================================
-
-
-class TestMinNewTokensMapping:
-    def test_min_new_tokens_maps_to_min_tokens_sampling(self):
-        """decoder.min_new_tokens=5 flows through to kwargs['min_tokens']=5 (sampling path)."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_new_tokens=5)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
-        params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-        assert params._kwargs.get("min_tokens") == 5
-
-    def test_min_new_tokens_maps_to_min_tokens_greedy(self):
-        """decoder.min_new_tokens=3 flows through to kwargs['min_tokens']=3 (greedy path)."""
-        decoder = DecoderConfig(temperature=0.0, do_sample=False, min_new_tokens=3)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
-        params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-        assert params._kwargs.get("min_tokens") == 3
-
-    def test_min_new_tokens_absent_when_none(self):
-        """When decoder.min_new_tokens is None, min_tokens is NOT in kwargs."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_new_tokens=None)
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder)
-        params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-        assert "min_tokens" not in params._kwargs
-
-    def test_vllm_sampling_min_tokens_overrides_decoder_min_new_tokens(self):
-        """vllm.sampling.min_tokens=10 overrides decoder.min_new_tokens=5 (engine-specific wins)."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_new_tokens=5)
-        vllm_cfg = VLLMConfig(sampling=VLLMSamplingConfig(min_tokens=10))
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg)
-        params = VLLMEngine._build_sampling_params(config, _FakeSamplingParams)
-        assert params._kwargs.get("min_tokens") == 10
-
-
-# =============================================================================
 # Test Group 15: Multi-output token counting (H3 audit fix)
 # =============================================================================
 
@@ -956,53 +901,3 @@ class TestFlashAttnFieldsWired:
         kwargs = VLLMEngine()._build_llm_kwargs(config)
         assert kwargs["flash_attn_version"] == 2
         assert kwargs["flash_attn_max_num_splits_for_cuda_graph"] == 16
-
-
-# =============================================================================
-# Test Group 18: M2 — min_p forwarded in _build_beam_search_params
-# =============================================================================
-
-
-class TestBeamSearchMinP:
-    """Verify min_p from DecoderConfig flows through to BeamSearchParams."""
-
-    def _build_beam_params(self, config, monkeypatch):
-        """Call _build_beam_search_params with a fake BeamSearchParams to avoid vLLM import."""
-        import sys
-        import types
-
-        # Inject a fake vllm module with our _FakeBeamSearchParams so the lazy
-        # `from vllm import BeamSearchParams` inside _build_beam_search_params succeeds.
-        fake_vllm = types.ModuleType("vllm")
-        fake_vllm.BeamSearchParams = _FakeBeamSearchParams
-        monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
-
-        beam_cfg = config.vllm.beam_search
-        return VLLMEngine._build_beam_search_params(config, beam_cfg)
-
-    def test_min_p_forwarded_to_beam_search_params(self, monkeypatch):
-        """min_p=0.05 from DecoderConfig appears in BeamSearchParams kwargs."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=0.05)
-        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=4))
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg)
-        params = self._build_beam_params(config, monkeypatch)
-        assert "min_p" in params._kwargs
-        assert params._kwargs["min_p"] == pytest.approx(0.05)
-
-    def test_min_p_absent_when_none(self, monkeypatch):
-        """min_p is NOT in BeamSearchParams kwargs when DecoderConfig.min_p is None."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=None)
-        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=4))
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg)
-        params = self._build_beam_params(config, monkeypatch)
-        assert "min_p" not in params._kwargs
-
-    def test_beam_width_and_min_p_together(self, monkeypatch):
-        """beam_width and min_p both appear in kwargs; max_tokens bridged from max_output_tokens."""
-        decoder = DecoderConfig(temperature=1.0, do_sample=True, min_p=0.1)
-        vllm_cfg = VLLMConfig(beam_search=VLLMBeamSearchConfig(beam_width=8))
-        config = make_config(**_VLLM_DEFAULTS, decoder=decoder, vllm=vllm_cfg, max_output_tokens=64)
-        params = self._build_beam_params(config, monkeypatch)
-        assert params._kwargs["beam_width"] == 8
-        assert params._kwargs["min_p"] == pytest.approx(0.1)
-        assert params._kwargs["max_tokens"] == 64

--- a/tests/unit/study/test_sweep_groups.py
+++ b/tests/unit/study/test_sweep_groups.py
@@ -335,16 +335,16 @@ class TestExpandGridSweepGroups:
         assert len(valid) == 4  # 2 dtype x 2 compilation
 
     def test_cross_section_group_overlay(self):
-        """Group entries can override non-engine fields like decoder settings."""
+        """Group entries can override sampling fields and other engine sections together."""
         raw = {
             "task": {"model": "gpt2"},
             "engine": "transformers",
             "sweep": {
                 "transformers.decoding": [
-                    {},  # baseline: use shared decoder settings
+                    {},  # baseline: use engine default sampling
                     {
-                        "decoder.do_sample": False,
-                        "decoder.temperature": 0.0,
+                        "transformers.sampling.do_sample": False,
+                        "transformers.sampling.temperature": 0.0,
                         "transformers.num_beams": 4,
                     },
                 ],
@@ -355,8 +355,8 @@ class TestExpandGridSweepGroups:
         beam_config = next(
             c for c in valid if c.transformers is not None and c.transformers.num_beams is not None
         )
-        assert beam_config.decoder.do_sample is False
-        assert beam_config.decoder.temperature == 0.0
+        assert beam_config.transformers.sampling.do_sample is False
+        assert beam_config.transformers.sampling.temperature == 0.0
         assert beam_config.transformers.num_beams == 4
 
     def test_group_plus_explicit_experiments(self):


### PR DESCRIPTION
## Summary

- Add `TransformersSamplingConfig`, extend `VLLMSamplingConfig` and `TensorRTSamplingConfig` with universal sampling fields using each engine's native conventions
- Remove `DecoderConfig` entirely (both from `config.models` and `config.__init__`)
- Move `SAMPLING_PRESETS` to `ssot.py`; drop the redundant `DECODER_PARAM_SUPPORT` (now derivable via Pydantic introspection of each engine's `*SamplingConfig`)
- Add `ExperimentConfig.sampling_preset: Literal["deterministic"|"standard"|"creative"|"factual"] | None` with a `model_validator(mode="before")` that merges preset values into the active engine's sampling section using `setdefault` (so explicit YAML values win)
- Rewire `transformers`, `vllm`, `tensorrt` engine sampling builders to read from `config.<engine>.sampling.*` and forward only explicit (non-None) values
- Migrate example configs, docs, and all affected tests

## Why per-engine?

The universal `DecoderConfig` forced all engines to share the same value semantics, which doesn't hold:
- `top_k=0` means "disabled" in HF/TRT-LLM but `-1` in vLLM
- `do_sample` is HF-specific (vLLM/TRT infer greedy from `temperature=0`)
- `min_new_tokens` (HF) vs `min_tokens` (vLLM/TRT) have different names
- Previously the builders patched these with ad-hoc translation layers; now each engine's `*SamplingConfig` expresses its own native shape directly, and users write values in the engine's own convention.

## Presets

`sampling_preset` is a one-liner shortcut that expands into the active engine's sampling section at parse time. Explicit YAML values take precedence:

```yaml
engine: transformers
sampling_preset: standard
transformers:
  sampling:
    temperature: 0.3   # overrides preset's temperature=1.0
# Result: temperature=0.3, top_p=0.95 (from preset)
```

## Breaking YAML changes (pre-1.0)

- Top-level `decoder:` section is no longer accepted; move sampling params into `<engine>.sampling:`.
- Sweep keys `decoder.*` become `{engine}.sampling.*`. Existing engine-prefix routing in `grid.py` handles this.
- `top_k` semantics are now engine-native (HF/TRT: 0=disabled; vLLM: -1=disabled).

## Test plan

- [x] Full suite: **1960 passed, 0 failed** (across config/engines/cli/study/integration)
- [x] `grep -rn 'DecoderConfig' src/llenergymeasure/` — 0 hits
- [x] `grep -rn 'config\.decoder\|experiment\.decoder' src/llenergymeasure/` — 0 hits
- [x] Smoke test: preset expansion works; explicit values beat preset values
- [x] New tests: engine-specific sampling, preset expansion, greedy decoding on transformers

## Companion

Second and final part of Phase 49. Depends on the `ExperimentConfig` shape from #288 and complements #290 (dtype per-engine).