### PR TITLE
refactor(cli): remove --dtype and --batch-size flags

### DIFF
--- a/src/llenergymeasure/cli/README.md
+++ b/src/llenergymeasure/cli/README.md
@@ -39,7 +39,6 @@ Key options:
 | `--engine / -e` | Inference engine (`pytorch`, `vllm`, `tensorrt`) |
 | `--dataset / -d` | Dataset name or JSONL file path |
 | `-n` | Number of prompts |
-| `--batch-size` | Batch size (PyTorch engine) |
 | `--dry-run` | Validate config, print plan, exit |
 | `--skip-preflight` | Skip Docker/CUDA pre-flight checks |
 | `-v / -vv` | Verbosity (INFO / DEBUG) |

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -59,14 +59,6 @@ def run(
         int | None,
         typer.Option("--n-prompts", "-n", help="Number of prompts to run"),
     ] = None,
-    batch_size: Annotated[
-        int | None,
-        typer.Option("--batch-size", help="Batch size (Transformers engine)"),
-    ] = None,
-    dtype: Annotated[
-        str | None,
-        typer.Option("--dtype", "-p", help="Model dtype (float32, float16, bfloat16)"),
-    ] = None,
     output: Annotated[
         str | None,
         typer.Option("--output", "-o", help="Output directory for results"),
@@ -152,8 +144,6 @@ def run(
             engine=engine,
             dataset=dataset,
             n_prompts=n_prompts,
-            batch_size=batch_size,
-            dtype=dtype,
             output=output,
             dry_run=dry_run,
             quiet=quiet,
@@ -194,8 +184,6 @@ def _run_impl(
     engine: str | None,
     dataset: str | None,
     n_prompts: int | None,
-    batch_size: int | None,
-    dtype: str | None,
     output: str | None,
     dry_run: bool,
     quiet: bool,
@@ -222,10 +210,6 @@ def _run_impl(
         cli_overrides["task.dataset.source"] = dataset
     if n_prompts is not None:
         cli_overrides["task.dataset.n_prompts"] = n_prompts
-    if batch_size is not None:
-        cli_overrides["transformers.batch_size"] = batch_size
-    if dtype is not None:
-        cli_overrides["dtype"] = dtype
 
     # Validate we have enough information to resolve a config
     if config is None and model is None:


### PR DESCRIPTION
## Summary

- Remove `--dtype` / `-p` CLI flag (dtype is now per-engine with different valid values per backend)
- Remove `--batch-size` CLI flag (Transformers-specific, belongs in YAML config)
- Update CLI README table

Both params are engine-specific and should be set in YAML config under `<engine>.dtype` / `transformers.batch_size` rather than on the CLI where they falsely imply universality.

## Context

Companion to #290 (per-engine dtype) and #291 (per-engine sampling). Those PRs migrate the config model; this one cleans up the CLI surface.

## Test plan

- [x] `tests/unit/cli/` — 167 passed, 0 failed
- [x] No tests referenced `--dtype` or `--batch-size` flags directly