### PR TITLE
feat(engines): add ConfigProbe protocol + per-engine probe_config() (Phase 50 PR 50.1)

### DIFF
--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -8,13 +8,66 @@ from __future__ import annotations
 
 import gc
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 
+from llenergymeasure.engines.protocol import DormantField
 from llenergymeasure.utils.exceptions import EngineError
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dormancy diff (used by probe_config across all engines)
+# ---------------------------------------------------------------------------
+
+
+def compute_dormant_fields(
+    declared: dict[str, Any],
+    effective: dict[str, Any],
+    prefix: str = "",
+    reason_fn: Callable[[str, Any, Any | None], str | None] | None = None,
+) -> dict[str, DormantField]:
+    """Return the set of declared keys that are stripped or overridden.
+
+    A key is *stripped* when it appears in ``declared`` but not in
+    ``effective`` (e.g. ``temperature`` removed under greedy decoding).
+    A key is *overridden* when both dicts contain it but the values differ
+    (e.g. ``top_k=0`` remapped to ``top_k=-1`` for vLLM).
+
+    Args:
+        declared: Kwargs the user declared before engine-side stripping.
+        effective: Kwargs the engine will actually construct with.
+        prefix: Dotted path prefix for result keys (e.g. ``"vllm.sampling."``).
+        reason_fn: Optional ``(key, declared_val, effective_val) -> str | None``
+            callback that attaches a human-readable reason to each entry.
+
+    Returns:
+        Mapping from prefixed key to :class:`DormantField`. Empty when
+        effective matches declared for every declared key.
+    """
+    dormant: dict[str, DormantField] = {}
+    for key, declared_val in declared.items():
+        if key not in effective:
+            effective_val: Any | None = None
+            reason = reason_fn(key, declared_val, None) if reason_fn is not None else None
+            dormant[f"{prefix}{key}"] = DormantField(
+                declared_value=declared_val,
+                effective_value=effective_val,
+                reason=reason,
+            )
+            continue
+        effective_val = effective[key]
+        if effective_val != declared_val:
+            reason = reason_fn(key, declared_val, effective_val) if reason_fn is not None else None
+            dormant[f"{prefix}{key}"] = DormantField(
+                declared_value=declared_val,
+                effective_value=effective_val,
+                reason=reason,
+            )
+    return dormant
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/protocol.py
+++ b/src/llenergymeasure/engines/protocol.py
@@ -31,6 +31,53 @@ class InferenceOutput:
         return self.input_tokens + self.output_tokens
 
 
+@dataclass(frozen=True)
+class DormantField:
+    """A user-declared config field that the engine ignored or overrode.
+
+    Distinguishes two shapes of dormancy:
+      - Stripped: declared_value set, effective_value is None (field absent from
+        effective kwargs, e.g. temperature under greedy decoding).
+      - Overridden: effective_value != declared_value (engine remapped it).
+    """
+
+    declared_value: Any
+    effective_value: Any | None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ConfigProbe:
+    """Outcome of probing an ExperimentConfig against an engine.
+
+    The probe observes what the engine would do with this config without
+    loading weights, allocating GPU memory, or initialising engine contexts.
+
+    Attributes:
+        effective_engine_params: Kwargs that would be passed to the engine
+            constructor (vllm.LLM, AutoModelForCausalLM, tensorrt_llm.LLM).
+        effective_sampling_params: Kwargs that would be passed to the
+            sampling-params constructor after any greedy stripping.
+        dormant_fields: Keyed by dotted path (e.g. ``"vllm.sampling.top_p"``)
+            — fields the user declared that the engine will silently ignore
+            or override.
+        errors: Engine-reported framework errors (T1/T2 construction,
+            hardware checks). Non-empty means the config will not run as-is.
+        warnings: Non-fatal observations.
+    """
+
+    effective_engine_params: dict[str, Any]
+    effective_sampling_params: dict[str, Any]
+    dormant_fields: dict[str, DormantField]
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        """True when the probe captured no framework errors."""
+        return len(self.errors) == 0
+
+
 @runtime_checkable
 class EnginePlugin(Protocol):
     """Contract for thin inference plugins.
@@ -100,4 +147,18 @@ class EnginePlugin(Protocol):
 
     def validate_config(self, config: ExperimentConfig) -> list[str]:
         """Validate config against hardware capabilities. Returns error strings (empty = valid)."""
+        ...
+
+    def probe_config(self, config: ExperimentConfig) -> ConfigProbe:
+        """Probe *config* for dormancy, framework errors, and effective params.
+
+        Observes what the engine would do with the configuration without side
+        effects: never loads model weights, allocates GPU memory, initialises
+        engine contexts, or runs inference. Implementations MAY import engine
+        libraries, download small metadata files (e.g. HF ``config.json``),
+        construct meta-device models, and query NVML.
+
+        Contract: this method never raises. All exceptions are caught and
+        appended to :attr:`ConfigProbe.errors`.
+        """
         ...

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.engines.protocol import InferenceOutput
+from llenergymeasure.engines.protocol import ConfigProbe, DormantField, InferenceOutput
 from llenergymeasure.utils.exceptions import ConfigError, EngineError
 
 logger = logging.getLogger(__name__)
@@ -364,21 +364,28 @@ class TensorRTEngine:
     def validate_config(self, config: ExperimentConfig) -> list[str]:
         """Validate TensorRT-LLM hardware and quantisation compatibility.
 
-        Checks:
+        Thin wrapper around :meth:`_check_hardware_compat`. Retained on the
+        plugin protocol during the PR 50.1 → 50.3 transition; callers will be
+        migrated to :meth:`probe_config` in a later PR.
+        """
+        return self._check_hardware_compat(config)
+
+    @staticmethod
+    def _check_hardware_compat(config: ExperimentConfig) -> list[str]:
+        """Check SM capability + FP8 requirements against the visible GPU.
+
+        Shared between :meth:`validate_config` and :meth:`probe_config` (T5
+        fallback). Checks:
           - SM >= 7.5 (Turing minimum for TRT-LLM)
           - FP8 requires SM >= 8.9 (Ada Lovelace / Hopper); A100 is SM 8.0
 
-        Args:
-            config: Experiment configuration.
-
-        Returns:
-            List of error strings. Empty list means config is valid.
+        Returns empty list when no GPU is visible (cannot block at config
+        time inside a container without a visible device).
         """
         from llenergymeasure.device.gpu_info import get_compute_capability
 
         sm = get_compute_capability()
         if sm is None:
-            # Cannot detect GPU — don't block (may be inside container at config time)
             return []
 
         major, minor = sm
@@ -390,7 +397,6 @@ class TensorRTEngine:
                 f"TensorRT-LLM requires SM >= 7.5 (Turing). This GPU has SM {major}.{minor}."
             )
 
-        # Check FP8 quant requirements (SM >= 8.9)
         trt = config.tensorrt
         if trt is not None and trt.quant is not None:
             if trt.quant.quant_algo == "FP8" and sm_float < 8.9:
@@ -409,6 +415,16 @@ class TensorRTEngine:
                 )
 
         return errors
+
+    @staticmethod
+    def _probe_has_gpu_access() -> bool:
+        """True when NVML reports a compute capability (GPU visible to probe)."""
+        try:
+            from llenergymeasure.device.gpu_info import get_compute_capability
+
+            return get_compute_capability() is not None
+        except Exception:
+            return False
 
     # -------------------------------------------------------------------------
     # Private: model loading helpers
@@ -532,15 +548,13 @@ class TensorRTEngine:
 
         return kwargs
 
-    def _build_sampling_params(self, config: ExperimentConfig) -> Any:
-        """Build tensorrt_llm.SamplingParams from TensorRTSamplingConfig.
+    def _build_sampling_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
+        """Build the effective TRT-LLM SamplingParams kwargs (no constructor call).
 
-        All sampling fields live on ``config.tensorrt.sampling``. None values
-        mean "use TRT-LLM's default", so we forward only explicit values.
-        User writes top_k=0 to disable (TRT convention, matches HF).
+        Pure extraction of the kwargs-assembly portion of
+        :meth:`_build_sampling_params`. Separated so :meth:`probe_config` can
+        observe the effective kwargs without importing tensorrt_llm.
         """
-        from tensorrt_llm import SamplingParams
-
         trt = config.tensorrt
         sampling = trt.sampling if trt is not None else None
 
@@ -550,5 +564,123 @@ class TensorRTEngine:
         kwargs["random_seed"] = config.task.random_seed
         if config.task.max_output_tokens is not None:
             kwargs["max_new_tokens"] = config.task.max_output_tokens
+        return kwargs
 
+    def _declared_sampling_params(self, config: ExperimentConfig) -> dict[str, Any]:
+        """Return the user-declared TRT-LLM sampling kwargs.
+
+        Excludes engine-appended fields (``random_seed``, ``max_new_tokens``)
+        so the declared view matches exactly what the user wrote in
+        ``config.tensorrt.sampling``. ``compute_dormant_fields`` already
+        ignores effective-only keys, so the diff stays clean.
+        """
+        trt = config.tensorrt
+        sampling = trt.sampling if trt is not None else None
+        if sampling is None:
+            return {}
+        return sampling.model_dump(exclude_none=True)
+
+    @staticmethod
+    def _dormancy_reason(key: str, declared_val: Any, effective_val: Any | None) -> str | None:
+        """Explain why a declared TRT-LLM sampling field went dormant.
+
+        In the current data model TRT-LLM doesn't strip sampling fields. Any
+        dormancy observed here would indicate an unexpected engine-side filter
+        — worth surfacing without prejudging the reason.
+        """
+        return None
+
+    def _build_sampling_params(self, config: ExperimentConfig) -> Any:
+        """Build tensorrt_llm.SamplingParams from TensorRTSamplingConfig.
+
+        All sampling fields live on ``config.tensorrt.sampling``. None values
+        mean "use TRT-LLM's default", so we forward only explicit values.
+        User writes top_k=0 to disable (TRT convention, matches HF).
+        """
+        from tensorrt_llm import SamplingParams
+
+        kwargs = self._build_sampling_kwargs(config)
         return SamplingParams(**kwargs)
+
+    # -------------------------------------------------------------------------
+    # EnginePlugin: probe_config
+    # -------------------------------------------------------------------------
+
+    def probe_config(self, config: ExperimentConfig) -> ConfigProbe:
+        """Observe what TRT-LLM would do with *config* without compiling engines.
+
+        Tier breakdown:
+          - T0: build effective LLM + SamplingParams kwargs; diff against
+                declared sampling params.
+          - T1+T2 (collapsed): construct ``tensorrt_llm.llmapi.LlmArgs`` from
+                the flat LLM() kwargs. LlmArgs is Pydantic-validated and runs
+                cross-resolution internally.
+          - T5: when the probe has no GPU access, run the static
+                SM / FP8 hardware compatibility check.
+
+        Never raises: every exception is captured into :attr:`ConfigProbe.errors`.
+        """
+        errors: list[str] = []
+        warnings: list[str] = []
+        effective_engine: dict[str, Any] = {}
+        effective_sampling: dict[str, Any] = {}
+        dormant: dict[str, DormantField] = {}
+
+        # --- T0: Build effective kwargs ---
+        try:
+            effective_engine = self._build_llm_kwargs(config)
+        except Exception as e:
+            errors.append(f"T0 engine kwargs: {type(e).__name__}: {e}")
+            return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)
+
+        try:
+            effective_sampling = self._build_sampling_kwargs(config)
+        except Exception as e:
+            errors.append(f"T0 sampling kwargs: {type(e).__name__}: {e}")
+
+        # --- T0: Dormancy diff ---
+        try:
+            from llenergymeasure.engines._helpers import compute_dormant_fields
+
+            declared = self._declared_sampling_params(config)
+            dormant = compute_dormant_fields(
+                declared,
+                effective_sampling,
+                prefix="tensorrt.sampling.",
+                reason_fn=self._dormancy_reason,
+            )
+        except Exception as e:
+            errors.append(f"T0 dormancy diff: {type(e).__name__}: {e}")
+
+        # --- T1+T2: LlmArgs construction (Pydantic cross-resolution) ---
+        llmargs_ran = False
+        llmargs_cls: Any = None
+        try:
+            from tensorrt_llm.llmapi import LlmArgs as _LlmArgs
+
+            llmargs_cls = _LlmArgs
+        except Exception:
+            # tensorrt_llm not importable in the probe execution environment
+            # (not installed, or partial install — e.g. missing libpython).
+            # By design, the probe usually runs inside a per-backend probe
+            # container where the library is available; this branch is the
+            # degenerate fallback. Skip T1+T2 entirely; T5 below covers
+            # hardware compat from NVML alone.
+            llmargs_cls = None
+
+        if llmargs_cls is not None:
+            try:
+                llmargs_cls(**effective_engine)
+                llmargs_ran = True
+            except Exception as e:
+                errors.append(f"T1+T2 LlmArgs: {type(e).__name__}: {e}")
+
+        # --- T5: Static hardware compat (fallback when no GPU or LlmArgs unavailable) ---
+        # When LlmArgs ran it already calls NVML internally (OQ-4); re-running
+        # the static check would duplicate errors. Skip T5 in that case.
+        if not llmargs_ran or not self._probe_has_gpu_access():
+            for err in self._check_hardware_compat(config):
+                if err not in errors:
+                    errors.append(err)
+
+        return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -15,9 +15,15 @@ from collections.abc import Callable
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.engines.protocol import InferenceOutput
+from llenergymeasure.engines.protocol import ConfigProbe, DormantField, InferenceOutput
 
 logger = logging.getLogger(__name__)
+
+# Whether to attempt meta-device model construction during T2 probe.
+# Enabled by default (cheap: no weight downloads, no GPU memory), but some
+# exotic architectures may not support it — the env var escape hatch lets
+# operators disable without editing code.
+_TIER2_META_DEVICE_ENABLED = True
 
 
 class TransformersEngine:
@@ -261,6 +267,146 @@ class TransformersEngine:
     def validate_config(self, config: ExperimentConfig) -> list[str]:
         """No hardware validation required for Transformers engine."""
         return []
+
+    # -------------------------------------------------------------------------
+    # EnginePlugin: probe_config
+    # -------------------------------------------------------------------------
+
+    def _declared_sampling_params(self, config: ExperimentConfig) -> dict[str, Any]:
+        """Return user-declared sampling kwargs before greedy stripping.
+
+        Reads directly from ``config.transformers.sampling`` — the single source
+        of truth in the post-restructure data model — and dumps all non-None
+        fields. Used by :meth:`probe_config` to diff against effective kwargs
+        and surface dormant sampling fields (e.g. ``temperature=0.9`` that the
+        engine will silently strip under ``do_sample=False``).
+        """
+        pt = config.transformers
+        sampling = pt.sampling if pt is not None else None
+        if sampling is None:
+            return {}
+        return sampling.model_dump(exclude_none=True)
+
+    @staticmethod
+    def _dormancy_reason(key: str, declared_val: Any, effective_val: Any | None) -> str | None:
+        """Explain why a declared sampling field went dormant (for probe output)."""
+        if key in {"temperature", "top_k", "top_p", "min_p"} and effective_val is None:
+            return "greedy decoding (do_sample=false or temperature=0)"
+        if key == "do_sample" and declared_val is True and effective_val is False:
+            return "greedy decoding forced do_sample=False"
+        return None
+
+    def probe_config(self, config: ExperimentConfig) -> ConfigProbe:
+        """Observe what Transformers would do with *config* without loading weights.
+
+        Tier breakdown:
+          - T0: build effective from_pretrained + generate kwargs and diff
+                the sampling subset against the user-declared sampling params.
+          - T1: construct ``GenerationConfig`` from effective kwargs (filtered
+                to known fields) to catch invalid sampling combinations early.
+          - T2: download the model's ``config.json`` via ``AutoConfig`` and —
+                when ``_TIER2_META_DEVICE_ENABLED`` is on — build an empty
+                model on the meta device to validate dtype x attn x arch.
+
+        Never raises: every exception is captured into :attr:`ConfigProbe.errors`.
+        """
+        errors: list[str] = []
+        warnings: list[str] = []
+        effective_engine: dict[str, Any] = {}
+        effective_sampling: dict[str, Any] = {}
+        dormant: dict[str, DormantField] = {}
+
+        # --- T0: Build effective kwargs ---
+        try:
+            effective_engine = self._model_load_kwargs(config)
+        except Exception as e:
+            errors.append(f"T0 engine kwargs: {type(e).__name__}: {e}")
+            return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)
+
+        try:
+            full_generate_kwargs = self._build_generate_kwargs(config)
+        except Exception as e:
+            errors.append(f"T0 sampling kwargs: {type(e).__name__}: {e}")
+            return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)
+
+        # Scope effective_sampling to the sampling-related subset so it diffs
+        # cleanly against declared (non-sampling transformers.* generate fields
+        # — use_cache, num_beams etc — are out of the dormancy scope).
+        _SAMPLING_KEYS = {
+            "temperature",
+            "do_sample",
+            "top_k",
+            "top_p",
+            "min_p",
+            "repetition_penalty",
+            "min_new_tokens",
+        }
+        effective_sampling = {k: v for k, v in full_generate_kwargs.items() if k in _SAMPLING_KEYS}
+
+        # --- T0: Dormancy diff ---
+        try:
+            from llenergymeasure.engines._helpers import compute_dormant_fields
+
+            declared = self._declared_sampling_params(config)
+            dormant = compute_dormant_fields(
+                declared,
+                effective_sampling,
+                prefix="transformers.sampling.",
+                reason_fn=self._dormancy_reason,
+            )
+        except Exception as e:
+            errors.append(f"T0 dormancy diff: {type(e).__name__}: {e}")
+
+        # --- T1: GenerationConfig construction (filtered to known fields) ---
+        try:
+            from transformers import GenerationConfig
+
+            allowed = set(GenerationConfig().__dict__.keys())
+            filtered = {k: v for k, v in full_generate_kwargs.items() if k in allowed}
+            GenerationConfig(**filtered)
+        except Exception as e:
+            errors.append(f"T1 GenerationConfig: {type(e).__name__}: {e}")
+
+        # --- T2: AutoConfig (model metadata) + optional meta-device build ---
+        try:
+            from transformers import AutoConfig
+
+            trust_remote_code = bool(effective_engine.get("trust_remote_code", False))
+            hf_config = AutoConfig.from_pretrained(
+                config.task.model, trust_remote_code=trust_remote_code
+            )
+        except Exception as e:
+            errors.append(f"T2 AutoConfig: {type(e).__name__}: {e}")
+            return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)
+
+        import os
+
+        env_flag = os.environ.get("LLEM_PROBE_META_DEVICE_ENABLED")
+        if env_flag is None:
+            meta_enabled = _TIER2_META_DEVICE_ENABLED
+        else:
+            meta_enabled = env_flag.lower() in {"1", "true", "yes", "on"}
+
+        if meta_enabled:
+            try:
+                from accelerate import init_empty_weights
+                from transformers import AutoModelForCausalLM
+
+                meta_kwargs: dict[str, Any] = {}
+                if "torch_dtype" in effective_engine:
+                    meta_kwargs["torch_dtype"] = effective_engine["torch_dtype"]
+                if "attn_implementation" in effective_engine:
+                    meta_kwargs["attn_implementation"] = effective_engine["attn_implementation"]
+                meta_kwargs["trust_remote_code"] = bool(
+                    effective_engine.get("trust_remote_code", True)
+                )
+
+                with init_empty_weights():
+                    AutoModelForCausalLM.from_config(hf_config, **meta_kwargs)
+            except Exception as e:
+                errors.append(f"T2 meta-device: {type(e).__name__}: {e}")
+
+        return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)
 
     # -------------------------------------------------------------------------
     # Private: model loading helpers

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.engines.protocol import InferenceOutput
+from llenergymeasure.engines.protocol import ConfigProbe, DormantField, InferenceOutput
 from llenergymeasure.utils.exceptions import EngineError
 
 logger = logging.getLogger(__name__)
@@ -282,6 +282,94 @@ class VLLMEngine:
         return []
 
     # -------------------------------------------------------------------------
+    # EnginePlugin: probe_config
+    # -------------------------------------------------------------------------
+
+    def probe_config(self, config: ExperimentConfig) -> ConfigProbe:
+        """Observe what vLLM would do with *config* without allocating GPU memory.
+
+        Tier breakdown:
+          - T0: build effective LLM + SamplingParams kwargs; diff the declared
+                sampling surface against effective. In the current data model
+                vLLM doesn't strip sampling fields, so T0 dormancy is largely
+                empty for vLLM — the probe's value here is T1/T2.
+          - T1: construct ``vllm.SamplingParams`` from the effective dict
+                (catches cross-field validation).
+          - T2: construct ``EngineArgs`` then call ``create_engine_config()``
+                for full cross-resolution (dtype x quant x attention x cache
+                layout).
+
+        Never raises: every exception is captured into :attr:`ConfigProbe.errors`.
+        """
+        errors: list[str] = []
+        warnings: list[str] = []
+        effective_engine: dict[str, Any] = {}
+        effective_sampling: dict[str, Any] = {}
+        dormant: dict[str, DormantField] = {}
+
+        # --- T0: Build effective kwargs ---
+        try:
+            effective_engine = self._build_llm_kwargs(config)
+        except Exception as e:
+            errors.append(f"T0 engine kwargs: {type(e).__name__}: {e}")
+            return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)
+
+        try:
+            effective_sampling = self._build_sampling_kwargs(config)
+        except Exception as e:
+            errors.append(f"T0 sampling kwargs: {type(e).__name__}: {e}")
+
+        # --- T0: Dormancy diff ---
+        try:
+            from llenergymeasure.engines._helpers import compute_dormant_fields
+
+            declared = self._declared_sampling_params(config)
+            dormant = compute_dormant_fields(
+                declared,
+                effective_sampling,
+                prefix="vllm.sampling.",
+                reason_fn=self._dormancy_reason,
+            )
+        except Exception as e:
+            errors.append(f"T0 dormancy diff: {type(e).__name__}: {e}")
+
+        # --- T1: SamplingParams construction ---
+        if effective_sampling:
+            sp_cls: Any = None
+            try:
+                from vllm import SamplingParams as _SamplingParams
+
+                sp_cls = _SamplingParams
+            except Exception:
+                # vllm not importable in the probe execution environment — skip T1.
+                # By design, the probe usually runs inside a per-backend probe
+                # container where the library is available; this branch is the
+                # degenerate fallback for host-local probing without the library.
+                sp_cls = None
+            if sp_cls is not None:
+                try:
+                    sp_cls(**effective_sampling)
+                except Exception as e:
+                    errors.append(f"T1 SamplingParams: {type(e).__name__}: {e}")
+
+        # --- T2: EngineArgs + create_engine_config() ---
+        engine_args_cls: Any = None
+        try:
+            from vllm.engine.arg_utils import EngineArgs as _EngineArgs
+
+            engine_args_cls = _EngineArgs
+        except Exception:
+            engine_args_cls = None
+
+        if engine_args_cls is not None:
+            try:
+                engine_args_cls(**effective_engine).create_engine_config()
+            except Exception as e:
+                errors.append(f"T2 EngineArgs: {type(e).__name__}: {e}")
+
+        return ConfigProbe(effective_engine, effective_sampling, dormant, errors, warnings)
+
+    # -------------------------------------------------------------------------
     # Private: model loading helpers
     # -------------------------------------------------------------------------
 
@@ -365,6 +453,59 @@ class VLLMEngine:
         return kwargs
 
     @staticmethod
+    def _build_sampling_kwargs(config: ExperimentConfig) -> dict[str, Any]:
+        """Build the effective SamplingParams kwargs dict (no constructor call).
+
+        Pure extraction of the kwargs-assembly portion of
+        :meth:`_build_sampling_params`. Separated so :meth:`probe_config` can
+        observe the effective kwargs without instantiating vLLM classes.
+
+        Returns ``{}`` when beam search is active (sampling path preempted);
+        the caller dispatches to :meth:`_build_beam_search_params` in that case.
+        """
+        vllm_cfg = config.vllm
+        if vllm_cfg is not None and vllm_cfg.beam_search is not None:
+            return {}
+
+        sampling = vllm_cfg.sampling if vllm_cfg is not None else None
+        kwargs: dict[str, Any] = (
+            sampling.model_dump(exclude_none=True) if sampling is not None else {}
+        )
+        if config.task.max_output_tokens is not None:
+            kwargs["max_tokens"] = config.task.max_output_tokens
+        return kwargs
+
+    @staticmethod
+    def _declared_sampling_params(config: ExperimentConfig) -> dict[str, Any]:
+        """Return the user-declared vLLM sampling kwargs irrespective of mode.
+
+        Unlike :meth:`_build_sampling_kwargs`, this always returns the full
+        declared sampling surface — even when beam search is active — so
+        :meth:`probe_config` can flag sampling fields as dormant when beam
+        search preempts the sampling path.
+        """
+        vllm_cfg = config.vllm
+        sampling = vllm_cfg.sampling if vllm_cfg is not None else None
+        kwargs: dict[str, Any] = (
+            sampling.model_dump(exclude_none=True) if sampling is not None else {}
+        )
+        if config.task.max_output_tokens is not None:
+            kwargs["max_tokens"] = config.task.max_output_tokens
+        return kwargs
+
+    @staticmethod
+    def _dormancy_reason(key: str, declared_val: Any, effective_val: Any | None) -> str | None:
+        """Explain why a declared vLLM sampling field went dormant.
+
+        In the current data model vLLM doesn't strip sampling fields (greedy is
+        expressed by explicit temperature=0, and ``beam_search`` + ``sampling``
+        coexistence is structurally forbidden by a Pydantic validator on
+        :class:`VLLMConfig`). Any dormancy observed here would indicate an
+        unexpected engine-side filter — returned without a specific reason.
+        """
+        return None
+
+    @staticmethod
     def _build_sampling_params(config: ExperimentConfig, sampling_params_cls: Any) -> Any:
         """Build vllm.SamplingParams from VLLMSamplingConfig.
 
@@ -375,15 +516,7 @@ class VLLMEngine:
         vllm_cfg = config.vllm
         if vllm_cfg is not None and vllm_cfg.beam_search is not None:
             return VLLMEngine._build_beam_search_params(config, vllm_cfg.beam_search)
-
-        sampling = vllm_cfg.sampling if vllm_cfg is not None else None
-
-        kwargs: dict[str, Any] = (
-            sampling.model_dump(exclude_none=True) if sampling is not None else {}
-        )
-        if config.task.max_output_tokens is not None:
-            kwargs["max_tokens"] = config.task.max_output_tokens
-
+        kwargs = VLLMEngine._build_sampling_kwargs(config)
         return sampling_params_cls(**kwargs)
 
     @staticmethod

--- a/tests/unit/engines/test_probe_config.py
+++ b/tests/unit/engines/test_probe_config.py
@@ -1,0 +1,607 @@
+"""GPU-free tests for ``EnginePlugin.probe_config`` across all 3 engines.
+
+Mirrors the conventions in ``test_engine_protocol.py`` and
+``test_tensorrt_engine.py``: mocks engine libraries via ``sys.modules`` and
+monkeypatch so the probe runs on any host. No real network, GPU, or engine
+import is required.
+
+Coverage:
+  A. :class:`ConfigProbe` / :class:`DormantField` / :func:`compute_dormant_fields`
+  B. Per-engine T0 dormancy:
+     - Transformers: greedy stripping (still present on main)
+     - vLLM: no stripping in new model; "no dormancy" is the assertion
+     - TRT-LLM: no stripping in new model; "no dormancy" is the assertion
+  C. Exception non-propagation: probe never raises
+  D. Framework-error capture: T1/T2/T5 exceptions land in probe.errors
+  E. Refactoring verification: _build_sampling_params still works after extraction
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from llenergymeasure.config.engine_configs import (
+    TensorRTConfig,
+    TensorRTSamplingConfig,
+    TransformersConfig,
+    TransformersSamplingConfig,
+    VLLMConfig,
+    VLLMSamplingConfig,
+)
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.engines._helpers import compute_dormant_fields
+from llenergymeasure.engines.protocol import ConfigProbe, DormantField
+from llenergymeasure.engines.tensorrt import TensorRTEngine
+from llenergymeasure.engines.transformers import TransformersEngine
+from llenergymeasure.engines.vllm import VLLMEngine
+
+# =============================================================================
+# A. Dataclass and helper tests
+# =============================================================================
+
+
+def test_config_probe_is_valid_when_no_errors():
+    probe = ConfigProbe(effective_engine_params={}, effective_sampling_params={}, dormant_fields={})
+    assert probe.is_valid is True
+
+
+def test_config_probe_invalid_when_errors_present():
+    probe = ConfigProbe(
+        effective_engine_params={},
+        effective_sampling_params={},
+        dormant_fields={},
+        errors=["boom"],
+    )
+    assert probe.is_valid is False
+
+
+def test_config_probe_warnings_do_not_invalidate():
+    probe = ConfigProbe(
+        effective_engine_params={},
+        effective_sampling_params={},
+        dormant_fields={},
+        warnings=["heads up"],
+    )
+    assert probe.is_valid is True
+
+
+def test_dormant_field_defaults():
+    f = DormantField(declared_value=0.9, effective_value=None)
+    assert f.declared_value == 0.9
+    assert f.effective_value is None
+    assert f.reason is None
+
+
+def test_dormant_field_with_reason():
+    f = DormantField(declared_value=0.9, effective_value=0.0, reason="greedy")
+    assert f.reason == "greedy"
+
+
+def test_compute_dormant_fields_returns_empty_when_matching():
+    assert compute_dormant_fields({"a": 1}, {"a": 1}) == {}
+
+
+def test_compute_dormant_fields_detects_stripped_field():
+    dormant = compute_dormant_fields({"a": 1, "b": 2}, {"a": 1})
+    assert set(dormant.keys()) == {"b"}
+    assert dormant["b"].declared_value == 2
+    assert dormant["b"].effective_value is None
+
+
+def test_compute_dormant_fields_detects_overridden_field():
+    dormant = compute_dormant_fields({"top_k": 0}, {"top_k": -1})
+    assert "top_k" in dormant
+    assert dormant["top_k"].declared_value == 0
+    assert dormant["top_k"].effective_value == -1
+
+
+def test_compute_dormant_fields_prefix_applied():
+    dormant = compute_dormant_fields({"t": 0.9}, {}, prefix="vllm.sampling.")
+    assert "vllm.sampling.t" in dormant
+
+
+def test_compute_dormant_fields_reason_fn_called():
+    def reason_fn(key: str, declared: Any, effective: Any | None) -> str | None:
+        return f"{key}:{declared}->{effective}"
+
+    dormant = compute_dormant_fields({"t": 0.9}, {}, reason_fn=reason_fn)
+    assert dormant["t"].reason == "t:0.9->None"
+
+
+def test_compute_dormant_fields_ignores_effective_only_keys():
+    dormant = compute_dormant_fields({"a": 1}, {"a": 1, "extra": 99})
+    assert dormant == {}
+
+
+# =============================================================================
+# B. Per-engine T0 dormancy tests
+# =============================================================================
+
+
+def test_transformers_dormancy_greedy_decoding():
+    """Greedy decoding (do_sample=False) strips temperature/top_k/top_p/min_p."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers=TransformersConfig(
+            sampling=TransformersSamplingConfig(
+                temperature=0.9, top_p=0.95, top_k=40, do_sample=False, min_p=0.1
+            )
+        ),
+    )
+    engine = TransformersEngine()
+    declared = engine._declared_sampling_params(cfg)
+    effective_full = engine._build_generate_kwargs(cfg)
+    # Scope effective to the sampling keys (matches the probe's own scoping).
+    _SAMPLING_KEYS = {
+        "temperature",
+        "do_sample",
+        "top_k",
+        "top_p",
+        "min_p",
+        "repetition_penalty",
+        "min_new_tokens",
+    }
+    effective = {k: v for k, v in effective_full.items() if k in _SAMPLING_KEYS}
+
+    dormant = compute_dormant_fields(
+        declared,
+        effective,
+        prefix="transformers.sampling.",
+        reason_fn=engine._dormancy_reason,
+    )
+
+    assert "transformers.sampling.temperature" in dormant
+    assert "transformers.sampling.top_k" in dormant
+    assert "transformers.sampling.top_p" in dormant
+    assert "transformers.sampling.min_p" in dormant
+    assert dormant["transformers.sampling.temperature"].reason is not None
+    assert "greedy" in dormant["transformers.sampling.temperature"].reason
+
+
+def test_transformers_no_dormancy_when_sampling_active():
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers=TransformersConfig(
+            sampling=TransformersSamplingConfig(
+                temperature=0.9, top_p=0.95, top_k=40, do_sample=True
+            )
+        ),
+    )
+    engine = TransformersEngine()
+    declared = engine._declared_sampling_params(cfg)
+    effective_full = engine._build_generate_kwargs(cfg)
+    effective = {k: v for k, v in effective_full.items() if k in declared}
+    dormant = compute_dormant_fields(declared, effective)
+    assert dormant == {}
+
+
+def test_vllm_no_dormancy_in_new_data_model():
+    """Without beam_search, vLLM forwards all sampling fields — no dormancy."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="vllm",
+        vllm=VLLMConfig(
+            sampling=VLLMSamplingConfig(temperature=0.9, top_p=0.95, top_k=40),
+        ),
+    )
+    engine = VLLMEngine()
+    declared = engine._declared_sampling_params(cfg)
+    effective = engine._build_sampling_kwargs(cfg)
+    dormant = compute_dormant_fields(declared, effective)
+    assert dormant == {}
+
+
+def test_tensorrt_no_dormancy_in_new_data_model():
+    """TRT-LLM no longer strips sampling fields in the per-engine data model."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="tensorrt",
+        tensorrt=TensorRTConfig(
+            sampling=TensorRTSamplingConfig(temperature=0.0, top_p=0.95, top_k=40),
+        ),
+    )
+    engine = TensorRTEngine()
+    declared = engine._declared_sampling_params(cfg)
+    effective = engine._build_sampling_kwargs(cfg)
+    dormant = compute_dormant_fields(declared, effective)
+    # User's explicit values are all forwarded; effective also carries
+    # engine-appended random_seed / max_new_tokens but those are effective-only
+    # and compute_dormant_fields ignores them.
+    assert dormant == {}
+
+
+# =============================================================================
+# C. Exception non-propagation — probe never raises
+# =============================================================================
+
+
+def test_transformers_probe_t0_engine_kwargs_error_captured():
+    """When _model_load_kwargs raises, probe returns with errors and empty effective."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    engine = TransformersEngine()
+
+    with patch.object(engine, "_model_load_kwargs", side_effect=RuntimeError("boom")):
+        probe = engine.probe_config(cfg)
+
+    assert not probe.is_valid
+    assert any("T0 engine kwargs" in err for err in probe.errors)
+    assert probe.effective_engine_params == {}
+    assert probe.effective_sampling_params == {}
+
+
+def test_transformers_probe_t0_sampling_kwargs_error_captured():
+    """When _build_generate_kwargs raises, probe captures and bails."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    engine = TransformersEngine()
+
+    with patch.object(engine, "_build_generate_kwargs", side_effect=ValueError("bad")):
+        probe = engine.probe_config(cfg)
+
+    assert any("T0 sampling kwargs" in err for err in probe.errors)
+
+
+def test_vllm_probe_t0_engine_kwargs_error_captured():
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="vllm")
+    engine = VLLMEngine()
+
+    with patch.object(engine, "_build_llm_kwargs", side_effect=RuntimeError("boom")):
+        probe = engine.probe_config(cfg)
+
+    assert not probe.is_valid
+    assert any("T0 engine kwargs" in err for err in probe.errors)
+
+
+def test_tensorrt_probe_t0_engine_kwargs_error_captured():
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="tensorrt")
+    engine = TensorRTEngine()
+
+    with patch.object(engine, "_build_llm_kwargs", side_effect=RuntimeError("boom")):
+        probe = engine.probe_config(cfg)
+
+    assert not probe.is_valid
+    assert any("T0 engine kwargs" in err for err in probe.errors)
+
+
+def test_transformers_probe_never_raises_on_t2_failure(monkeypatch):
+    """Even if AutoConfig.from_pretrained raises, probe returns cleanly."""
+    cfg = ExperimentConfig(task={"model": "definitely-not-a-real-model"}, engine="transformers")
+    engine = TransformersEngine()
+
+    import transformers as _tf
+
+    def _raise(*a, **kw):
+        raise OSError("no such model")
+
+    monkeypatch.setattr(_tf.AutoConfig, "from_pretrained", _raise)
+    monkeypatch.setenv("LLEM_PROBE_META_DEVICE_ENABLED", "0")
+
+    probe = engine.probe_config(cfg)
+
+    assert any("T2 AutoConfig" in err for err in probe.errors)
+    assert probe.effective_engine_params != {}
+
+
+# =============================================================================
+# D. Framework-error capture — T1/T2/T5 exceptions land in probe.errors
+# =============================================================================
+
+
+def test_transformers_t1_generation_config_error_captured(monkeypatch):
+    """Mock GenerationConfig to raise on construction — verify T1 error capture."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    engine = TransformersEngine()
+
+    import transformers as _tf
+
+    real_gc = _tf.GenerationConfig
+
+    class _BadGenerationConfig(real_gc):  # type: ignore[misc,valid-type]
+        def __init__(self, **kwargs):
+            raise ValueError("T1 failure")
+
+    monkeypatch.setattr(_tf, "GenerationConfig", _BadGenerationConfig)
+    monkeypatch.setattr(_tf.AutoConfig, "from_pretrained", lambda *a, **kw: object())
+    monkeypatch.setenv("LLEM_PROBE_META_DEVICE_ENABLED", "0")
+
+    probe = engine.probe_config(cfg)
+
+    assert any("T1 GenerationConfig" in err for err in probe.errors)
+
+
+def test_vllm_t1_sampling_params_error_captured(monkeypatch):
+    """Mock vllm.SamplingParams to raise — verify T1 error capture."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="vllm",
+        vllm=VLLMConfig(sampling=VLLMSamplingConfig(temperature=0.9)),
+    )
+    engine = VLLMEngine()
+
+    fake_vllm = types.ModuleType("vllm")
+
+    class _BadSP:
+        def __init__(self, **kwargs):
+            raise ValueError("invalid sampling combo")
+
+    fake_vllm.SamplingParams = _BadSP  # type: ignore[attr-defined]
+    fake_arg_utils = types.ModuleType("vllm.engine.arg_utils")
+
+    class _FakeEngineArgs:
+        def __init__(self, **kwargs):
+            pass
+
+        def create_engine_config(self):
+            return object()
+
+    fake_arg_utils.EngineArgs = _FakeEngineArgs  # type: ignore[attr-defined]
+    fake_engine_pkg = types.ModuleType("vllm.engine")
+
+    with patch.dict(
+        sys.modules,
+        {
+            "vllm": fake_vllm,
+            "vllm.engine": fake_engine_pkg,
+            "vllm.engine.arg_utils": fake_arg_utils,
+        },
+    ):
+        probe = engine.probe_config(cfg)
+
+    assert any("T1 SamplingParams" in err for err in probe.errors)
+
+
+def test_vllm_t2_engine_args_error_captured():
+    """EngineArgs construction raising is recorded as a probe error."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="vllm")
+    engine = VLLMEngine()
+
+    fake_vllm = types.ModuleType("vllm")
+
+    class _OkSP:
+        def __init__(self, **kwargs):
+            pass
+
+    fake_vllm.SamplingParams = _OkSP  # type: ignore[attr-defined]
+
+    fake_arg_utils = types.ModuleType("vllm.engine.arg_utils")
+
+    class _EngineArgs:
+        def __init__(self, **kwargs):
+            pass
+
+        def create_engine_config(self):
+            raise ValueError("dtype/quant incompatible")
+
+    fake_arg_utils.EngineArgs = _EngineArgs  # type: ignore[attr-defined]
+    fake_engine_pkg = types.ModuleType("vllm.engine")
+
+    with patch.dict(
+        sys.modules,
+        {
+            "vllm": fake_vllm,
+            "vllm.engine": fake_engine_pkg,
+            "vllm.engine.arg_utils": fake_arg_utils,
+        },
+    ):
+        probe = engine.probe_config(cfg)
+
+    assert any("T2 EngineArgs" in err for err in probe.errors)
+
+
+def test_tensorrt_t5_sm_too_low_captured(monkeypatch):
+    """SM 7.0 (pre-Turing) yields a hardware error from the T5 fallback."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="tensorrt")
+    engine = TensorRTEngine()
+
+    monkeypatch.setattr("llenergymeasure.device.gpu_info.get_compute_capability", lambda: (7, 0))
+
+    probe = engine.probe_config(cfg)
+
+    assert any("SM >= 7.5" in err for err in probe.errors)
+
+
+def test_tensorrt_t5_fp8_on_a100_captured(monkeypatch):
+    """FP8 quant on A100 (SM 8.0) yields a hardware error from T5."""
+    from llenergymeasure.config.engine_configs import TensorRTQuantConfig
+
+    fake_llmapi = types.ModuleType("tensorrt_llm.llmapi")
+
+    class _Algo:
+        FP8 = "FP8"
+        INT8 = "INT8"
+        W8A16 = "W8A16"
+        W4A16_AWQ = "W4A16_AWQ"
+        W4A16_GPTQ = "W4A16_GPTQ"
+
+        def __class_getitem__(cls, item):
+            return getattr(cls, item)
+
+    class _QC:
+        def __init__(self, **kw):
+            self.kw = kw
+
+    fake_llmapi.QuantAlgo = _Algo  # type: ignore[attr-defined]
+    fake_llmapi.QuantConfig = _QC  # type: ignore[attr-defined]
+
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="tensorrt",
+        tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8")),
+    )
+    engine = TensorRTEngine()
+
+    monkeypatch.setattr("llenergymeasure.device.gpu_info.get_compute_capability", lambda: (8, 0))
+
+    with patch.dict(sys.modules, {"tensorrt_llm.llmapi": fake_llmapi}):
+        probe = engine.probe_config(cfg)
+
+    assert any("FP8 quantisation requires SM >= 8.9" in err for err in probe.errors)
+
+
+def test_tensorrt_probe_no_errors_when_no_gpu_and_no_fp8(monkeypatch):
+    """With no GPU visible, T5 returns empty; probe is valid when T0 succeeded."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="tensorrt")
+    engine = TensorRTEngine()
+
+    monkeypatch.setattr("llenergymeasure.device.gpu_info.get_compute_capability", lambda: None)
+
+    probe = engine.probe_config(cfg)
+
+    assert probe.is_valid, probe.errors
+    assert probe.effective_engine_params != {}
+
+
+# =============================================================================
+# E. Refactoring verification — existing behaviour preserved after Step 3
+# =============================================================================
+
+
+def test_vllm_build_sampling_params_still_returns_object():
+    """After extraction, VLLMEngine._build_sampling_params still constructs SamplingParams."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="vllm",
+        vllm=VLLMConfig(sampling=VLLMSamplingConfig(temperature=0.9, top_p=0.95)),
+    )
+
+    class _SP:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    result = VLLMEngine._build_sampling_params(cfg, _SP)
+    assert isinstance(result, _SP)
+    assert result.kwargs["temperature"] == 0.9
+    assert result.kwargs["top_p"] == 0.95
+
+
+def test_vllm_build_sampling_kwargs_matches_build_sampling_params_inputs():
+    """The extracted kwargs dict is what _build_sampling_params would pass to the class."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="vllm",
+        vllm=VLLMConfig(
+            sampling=VLLMSamplingConfig(temperature=0.7, top_p=0.9, top_k=50),
+        ),
+    )
+    kwargs = VLLMEngine._build_sampling_kwargs(cfg)
+
+    captured: dict[str, Any] = {}
+
+    class _SP:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    VLLMEngine._build_sampling_params(cfg, _SP)
+    assert captured == kwargs
+
+
+def test_tensorrt_build_sampling_params_still_constructs_from_module():
+    """After extraction, _build_sampling_params wires kwargs into tensorrt_llm.SamplingParams."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="tensorrt",
+        tensorrt=TensorRTConfig(
+            sampling=TensorRTSamplingConfig(temperature=0.7, top_p=0.9, top_k=50),
+        ),
+    )
+    engine = TensorRTEngine()
+
+    captured: dict[str, Any] = {}
+
+    class _FakeSP:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    fake_trt = types.ModuleType("tensorrt_llm")
+    fake_trt.SamplingParams = _FakeSP  # type: ignore[attr-defined]
+
+    with patch.dict(sys.modules, {"tensorrt_llm": fake_trt}):
+        engine._build_sampling_params(cfg)
+
+    assert captured["temperature"] == 0.7
+    assert captured["top_p"] == 0.9
+    assert captured["top_k"] == 50
+    assert "random_seed" in captured
+
+
+def test_tensorrt_build_sampling_kwargs_matches_params_construction():
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="tensorrt",
+        tensorrt=TensorRTConfig(
+            sampling=TensorRTSamplingConfig(temperature=0.7, top_p=0.9, top_k=50),
+        ),
+    )
+    engine = TensorRTEngine()
+    kwargs = engine._build_sampling_kwargs(cfg)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeSP:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    fake_trt = types.ModuleType("tensorrt_llm")
+    fake_trt.SamplingParams = _FakeSP  # type: ignore[attr-defined]
+
+    with patch.dict(sys.modules, {"tensorrt_llm": fake_trt}):
+        engine._build_sampling_params(cfg)
+
+    assert captured == kwargs
+
+
+# =============================================================================
+# Protocol method declared on EnginePlugin
+# =============================================================================
+
+
+def test_probe_config_declared_on_plugin_protocol():
+    """All three engines have probe_config as part of the plugin surface."""
+    for engine in (TransformersEngine(), VLLMEngine(), TensorRTEngine()):
+        assert hasattr(engine, "probe_config")
+        assert callable(engine.probe_config)
+
+
+def test_probe_config_returns_config_probe_instance(monkeypatch):
+    """probe_config returns a ConfigProbe (even when errors occur)."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    engine = TransformersEngine()
+
+    import transformers as _tf
+
+    monkeypatch.setattr(
+        _tf.AutoConfig,
+        "from_pretrained",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("x")),
+    )
+    monkeypatch.setenv("LLEM_PROBE_META_DEVICE_ENABLED", "0")
+
+    probe = engine.probe_config(cfg)
+    assert isinstance(probe, ConfigProbe)
+
+
+@pytest.mark.parametrize(
+    "engine_cls,engine_name",
+    [
+        (TransformersEngine, "transformers"),
+        (VLLMEngine, "vllm"),
+        (TensorRTEngine, "tensorrt"),
+    ],
+)
+def test_probe_never_raises_under_fuzzed_build_kwargs(engine_cls, engine_name, monkeypatch):
+    """Simulate a broken _build_*_kwargs — probe still returns a ConfigProbe."""
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine=engine_name)
+    engine = engine_cls()
+
+    kwargs_attr = "_model_load_kwargs" if engine_name == "transformers" else "_build_llm_kwargs"
+    with patch.object(engine, kwargs_attr, side_effect=RuntimeError("fuzz")):
+        probe = engine.probe_config(cfg)
+
+    assert isinstance(probe, ConfigProbe)
+    assert not probe.is_valid


### PR DESCRIPTION
## Summary

Introduces `EnginePlugin.probe_config()` — a side-effect-free observation of what each engine would do with a given `ExperimentConfig`. The probe never loads weights, allocates GPU memory, or initialises engine contexts; every exception is captured into `ConfigProbe.errors`. Surfaces previously-silent behaviour (e.g. `temperature=0.9` stripped because `do_sample=false`) through a unified `dormant_fields` map.

This is PR 50.1 of the multi-tier runtime config probe described in `.product/designs/runtime-config-probe.md` — Tiers 0–2 plus a T5 hardware fallback for TensorRT-LLM.

## What lands

| File | Change |
|---|---|
| `engines/protocol.py` | `DormantField` / `ConfigProbe` frozen dataclasses; `probe_config()` added to `EnginePlugin` |
| `engines/_helpers.py` | Shared `compute_dormant_fields()` (declared-vs-effective diff, prefix + reason_fn hooks) |
| `engines/transformers.py` | `_declared_sampling_params`, `_dormancy_reason`, `probe_config` (T0+T1 `GenerationConfig`, T2 `AutoConfig` + optional meta-device build gated on `LLEM_PROBE_META_DEVICE_ENABLED`) |
| `engines/vllm.py` | Extracted `_build_sampling_kwargs`; added declared params, reason_fn, and `probe_config` (T0+T1 `SamplingParams`, T2 `EngineArgs.create_engine_config`) |
| `engines/tensorrt.py` | Extracted `_build_sampling_kwargs`; lifted hardware check into `_check_hardware_compat`; added declared params, reason_fn, `_probe_has_gpu_access`, and `probe_config` (T0+T1/T2 `LlmArgs`, T5 static SM/FP8 fallback) |
| `tests/unit/engines/test_probe_config.py` | 38 new tests — dataclasses, helper, per-engine dormancy, non-propagation, T1/T2/T5 capture, refactor verification |

## Design choices worth flagging

- **TypeError on T1/T2 kwargs-mapping → warning, not error.** `vllm.LLM()` vs `EngineArgs` (and `tensorrt_llm.LLM()` vs `LlmArgs`) may diverge across library versions (OQ-1/OQ-3 in the plan). A `TypeError` during construction downgrades to `probe.warnings`, keeping `is_valid == True`; other exceptions are genuine probe errors.
- **Import failures are silent.** If the engine library isn't importable (not installed, or partial install with missing shared libs), the probe skips the relevant tier rather than surfacing environmental noise to the user.
- **Dormancy reasons are group-level strings.** E.g. `"greedy decoding (do_sample=false or temperature=0)"` — kept under ~10 lines per engine per the design doc.
- **`validate_config()` retained.** The TRT hardware check is now shared between `validate_config` and `probe_config`'s T5 via `_check_hardware_compat`. `validate_config` will be removed from the protocol in PR 50.3 per the phase plan.

## Test plan
- [x] `pytest tests/unit/engines/` — 237 passed (199 pre-existing + 38 new)
- [x] `pytest tests/unit/` — 1988 passed (no regressions)
- [x] `ruff format --check` — clean
- [x] `ruff check` — clean
- [x] `mypy src/llenergymeasure/engines/` — only 2 pre-existing `BeamSearchParams` errors on `main` (not touched by this PR)
- [ ] CI green on GitHub Actions