### PR TITLE
refactor(config): rename sub-configs to native field names, purge stale allowlist entries

### DIFF
--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -220,11 +220,11 @@ sweep: # TODO: maybe shared_sweep or global_sweep?
   # --- TensorRT parameter space ---
   tensorrt.max_batch_size: [1, 4, 8, 16, 32]
   tensorrt.max_seq_len: [1536, 2048]
-  # tensorrt.quant.quant_algo moved to tensorrt.quant_config group below
+  # tensorrt.quant_config.quant_algo moved to tensorrt.quant_config group below
   # (quant_algo has dependent sub-params: kv_cache_quant_algo, calib.*)
   # TODO: is this not tensorrt.dtype??
   tensorrt.max_input_len: [512, 1024]
-  tensorrt.scheduler.capacity_scheduling_policy: [MAX_UTILIZATION, STATIC_BATCH]
+  tensorrt.scheduler_config.capacity_scheduling_policy: [MAX_UTILIZATION, STATIC_BATCH]
   # tensorrt.tensor_parallel_size: [1, 2, 4]     # Tensor parallel (requires multi-GPU hardware)
 
   # --- TensorRT: dependent groups ─────────────────────────────────
@@ -233,24 +233,24 @@ sweep: # TODO: maybe shared_sweep or global_sweep?
   # FP8 quantisation (commented out - requires SM >= 8.9 / Ada Lovelace / Hopper)
   tensorrt.quant_config:
     - {}                                          # baseline: no quantisation
-    - tensorrt.quant.quant_algo: INT8
-    - tensorrt.quant.quant_algo: INT8
-      tensorrt.quant.kv_cache_quant_algo: INT8
-    - tensorrt.quant.quant_algo: INT8
+    - tensorrt.quant_config.quant_algo: INT8
+    - tensorrt.quant_config.quant_algo: INT8
+      tensorrt.quant_config.kv_cache_quant_algo: INT8
+    - tensorrt.quant_config.quant_algo: INT8
       tensorrt.calib.calib_batches: 512
       tensorrt.calib.calib_dataset: cnn_dailymail
       tensorrt.calib.calib_max_seq_length: 512
-    - tensorrt.quant.quant_algo: [W4A16_AWQ, W8A16]
-    # - tensorrt.quant.quant_algo: FP8  # Requires SM >= 8.9 (Ada Lovelace / Hopper)
+    - tensorrt.quant_config.quant_algo: [W4A16_AWQ, W8A16]
+    # - tensorrt.quant_config.quant_algo: FP8  # Requires SM >= 8.9 (Ada Lovelace / Hopper)
 
   # KV cache compound settings (block_reuse + memory_fraction travel together)
   tensorrt.kv_cache_config:
     - {}                                          # baseline: default KV cache
-    - tensorrt.kv_cache.enable_block_reuse: true
-      tensorrt.kv_cache.free_gpu_memory_fraction: 0.9
-    - tensorrt.kv_cache.host_cache_size: 1073741824
-    - tensorrt.kv_cache.max_tokens: 8192
-      tensorrt.kv_cache.free_gpu_memory_fraction: 0.85
+    - tensorrt.kv_cache_config.enable_block_reuse: true
+      tensorrt.kv_cache_config.free_gpu_memory_fraction: 0.9
+    - tensorrt.kv_cache_config.host_cache_size: 1073741824
+    - tensorrt.kv_cache_config.max_tokens: 8192
+      tensorrt.kv_cache_config.free_gpu_memory_fraction: 0.85
 
     # --- Shared TRT-LLM engine settings ---
 # Applied to all TensorRT sweep experiments. Explicit TRT experiments

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -252,9 +252,9 @@ initialisation time. All fields default to `null` (use vLLM's own default).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `speculative` | VLLMSpeculativeConfig | null | Speculative decoding sub-config (see below) |
+| `speculative_config` | VLLMSpeculativeConfig | null | Speculative decoding sub-config (see below) |
 
-`speculative` sub-config fields:
+`speculative_config` sub-config fields:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -630,11 +630,11 @@ These parameters live in `ExperimentConfig` and are shared across all engines:
 | `tensorrt.dtype` | N/A | N/A | Yes | Model compute dtype (compile-time) |
 | `tensorrt.fast_build` | N/A | N/A | Yes | Fast build mode (compile-time) |
 | `tensorrt.engine_path` | N/A | N/A | Yes | Pre-compiled engine path |
-| `tensorrt.quant.quant_algo` | N/A | N/A | Yes | FP8, INT8, W4A16_AWQ, W4A16_GPTQ, W8A16, etc. |
-| `tensorrt.quant.kv_cache_quant_algo` | N/A | N/A | Yes | KV cache quantization: FP8 or INT8 |
-| `tensorrt.kv_cache.free_gpu_memory_fraction` | N/A | N/A | Yes | KV cache memory fraction |
-| `tensorrt.kv_cache.enable_block_reuse` | N/A | N/A | Yes | KV cache block reuse |
-| `tensorrt.scheduler.capacity_scheduling_policy` | N/A | N/A | Yes | GUARANTEED_NO_EVICT / MAX_UTILIZATION / STATIC_BATCH |
+| `tensorrt.quant_config.quant_algo` | N/A | N/A | Yes | FP8, INT8, W4A16_AWQ, W4A16_GPTQ, W8A16, etc. |
+| `tensorrt.quant_config.kv_cache_quant_algo` | N/A | N/A | Yes | KV cache quantization: FP8 or INT8 |
+| `tensorrt.kv_cache_config.free_gpu_memory_fraction` | N/A | N/A | Yes | KV cache memory fraction |
+| `tensorrt.kv_cache_config.enable_block_reuse` | N/A | N/A | Yes | KV cache block reuse |
+| `tensorrt.scheduler_config.capacity_scheduling_policy` | N/A | N/A | Yes | GUARANTEED_NO_EVICT / MAX_UTILIZATION / STATIC_BATCH |
 | `tensorrt.build_cache.max_cache_storage_gb` | N/A | N/A | Yes | Engine cache size limit |
 | `tensorrt.build_cache.cache_root` | N/A | N/A | Yes | Engine cache directory |
 | `tensorrt.sampling.min_tokens` | N/A | N/A | Yes | Minimum output tokens |

--- a/docs/generated/invalid-combos.md
+++ b/docs/generated/invalid-combos.md
@@ -57,7 +57,7 @@ due to hardware, model, or package requirements.
 | vllm | `vllm.attention.engine=TORCH_SDPA` | TORCH_SDPA not registered in vLLM attention backends | Use attention.engine='auto' or 'FLASH_ATTN' |
 | vllm | `vllm.quantization_method=awq/gptq` | Requires a pre-quantized model checkpoint | Use a quantized model (e.g., TheBloke/*-AWQ) or omit |
 | vllm | `vllm.load_format=pt` | Model checkpoint must have .bin files (not just safetensors) | Use load_format='auto' or 'safetensors' |
-| tensorrt | `tensorrt.quant.quant_algo=FP8` | FP8 requires SM >= 8.9 (Ada Lovelace or Hopper). A100 (SM80) raises ConfigurationError - no silent emulation or fallback | Use INT8, W4A16_AWQ, W4A16_GPTQ, or W8A16 on A100 |
+| tensorrt | `tensorrt.quant_config.quant_algo=FP8` | FP8 requires SM >= 8.9 (Ada Lovelace or Hopper). A100 (SM80) raises ConfigurationError - no silent emulation or fallback | Use INT8, W4A16_AWQ, W4A16_GPTQ, or W8A16 on A100 |
 | tensorrt | `tensorrt.quantization.method=int8_sq` | INT8 SmoothQuant requires calibration dataset | Provide tensorrt.quantization.calibration config or use a supported quantization method |
 
 ## Engine Capability Matrix

--- a/docs/parameter-curation.md
+++ b/docs/parameter-curation.md
@@ -1,0 +1,84 @@
+# Parameter Curation
+
+llem exposes engine parameters to users through hand-authored Pydantic models. This document explains how those models stay in sync with the underlying engines.
+
+---
+
+## Overview
+
+```
+  programmatic discovery                  Pydantic curation
+  (scripts/discover_*.py)                 (config/engine_configs.py)
+  introspect engine APIs                  hand-authored sub-config models
+  → discovered_schemas/*.json             expose typed, documented fields
+            │                                         │
+            └──────────────┬──────────────────────────┘
+                           ▼
+                     drift checker
+              (scripts/check_pydantic_matches_discovered.py)
+                           │
+               flags Pydantic fields with no
+               corresponding discovered entry
+                           │
+                    LLEM_NATIVE_FIELDS
+              the "yes, this divergence is intentional"
+              allowlist — suppresses known-good exceptions
+```
+
+---
+
+## Programmatic discovery
+
+`scripts/discover_*.py` introspects each engine's public Python API (e.g. `inspect.signature(vllm.LLM.__init__)`, `inspect.signature(AutoModelForCausalLM.from_pretrained)`) and writes the result to `src/llenergymeasure/config/discovered_schemas/{engine}.json`.
+
+These JSON files are the ground truth for "what parameters does this engine version accept". They are vendored into the repo and regenerated via the schema-refresh pipeline when an engine version bumps (see `docs/schema-refresh.md`).
+
+---
+
+## Pydantic curation
+
+`src/llenergymeasure/config/engine_configs.py` contains hand-authored Pydantic models that llem exposes to users. Curation decisions:
+
+- **Field names match native engine names.** A field called `quant_config` maps directly to the engine kwarg `quant_config`. No translation layer, no llem aliases.
+- **Sub-configs group related parameters.** e.g. `TensorRTKvCacheConfig` groups all kv-cache knobs under `tensorrt.kv_cache_config.*`. The sub-config name matches the native engine kwarg name.
+- **Types may be narrowed.** A field typed `str` in discovery might become `Literal["bfloat16", "float16", "float32"]` in curation — this is intentional and allowed by the drift checker.
+- **Descriptions are added.** Pydantic `Field(description=...)` docs are user-facing; discovery has none.
+
+---
+
+## Drift checker
+
+`scripts/check_pydantic_matches_discovered.py` compares the set of leaf field names in the Pydantic models against the discovered schemas and reports two kinds of drift:
+
+| Kind | Meaning |
+|------|---------|
+| `pydantic_only` | Pydantic has a field that discovery doesn't — likely a stale field that was removed from the engine, or a kwargs-passed field invisible to signature inspection |
+| `type_mismatch` | Both sides have the field but with different types (beyond intentional narrowing) |
+
+Run it locally:
+
+```bash
+python scripts/check_pydantic_matches_discovered.py
+```
+
+CI runs it automatically on every PR.
+
+---
+
+## LLEM_NATIVE_FIELDS
+
+Some Pydantic fields legitimately have no discovered counterpart. Common reasons:
+
+| Reason | Example |
+|--------|---------|
+| Passed via `**kwargs`, invisible to `inspect.signature` | `transformers.dtype` — `from_pretrained` accepts it as a kwarg alias |
+| llem surfaces a sub-config field that the engine accepts as a flat kwarg at a different nesting level | `tensorrt.quant_algo` inside `TensorRTQuantConfig` |
+| Beam-search or speculative-decoding params from a separate params class | `vllm.beam_width` (from `BeamSearchParams`, not `LLM.__init__`) |
+
+These are listed in `LLEM_NATIVE_FIELDS` in the drift checker. Each entry suppresses one `pydantic_only` warning for a named `(engine, field_name)` pair.
+
+**When to add an entry:** when the drift checker flags a `pydantic_only` field and you have confirmed it is intentionally in the Pydantic model but unreachable by signature-based discovery. Add a comment explaining why.
+
+**When to remove an entry:** when the corresponding Pydantic field is deleted. Stale entries are harmless but misleading — remove them during the same PR that removes the field.
+
+**Never add an entry to paper over a naming divergence.** If a Pydantic field is named differently from the engine kwarg, rename the field instead.

--- a/docs/study-config.md
+++ b/docs/study-config.md
@@ -385,10 +385,10 @@ sweep:
   tensorrt.quant_config:
     - {}                              # baseline: no quantisation
     - &trt_int8
-      tensorrt.quant.quant_algo: INT8
+      tensorrt.quant_config.quant_algo: INT8
     - <<: *trt_int8
-      tensorrt.quant.kv_cache_quant_algo: INT8
-    - tensorrt.quant.quant_algo: W4A16_AWQ
+      tensorrt.quant_config.kv_cache_quant_algo: INT8
+    - tensorrt.quant_config.quant_algo: W4A16_AWQ
 ```
 
 ---
@@ -748,7 +748,7 @@ relates to energy measurement.
 | `num_scheduler_steps` | integer | None | `null` | Multi-step scheduling: decode steps per scheduler iteration (None -> 1). Increases throughput at the cost of more VRAM per step. |
 | `max_seq_len_to_capture` | integer | None | `null` | Max sequence length eligible for CUDA graph capture (None -> 8192). Longer sequences fall back to eager mode. |
 | `distributed_executor_backend` | 'mp' | 'ray' | None | `null` | Multi-GPU executor backend (None -> 'mp'). |
-| `speculative` | VLLMSpeculativeConfig | None | `null` | Speculative decoding sub-config. Fields: model (str), num_speculative_tokens (int), method (str). |
+| `speculative_config` | VLLMSpeculativeConfig | None | `null` | Speculative decoding sub-config. Fields: model (str), num_speculative_tokens (int), method (str). |
 | `offload_group_size` | integer | None | `null` | Groups of layers for CPU offloading (None -> 0). |
 | `offload_num_in_group` | integer | None | `null` | Number of layers offloaded per group (None -> 1). |
 | `offload_prefetch_step` | integer | None | `null` | Prefetch steps ahead for CPU offload (None -> 1). |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -225,7 +225,7 @@ model, or package requirements.
 | vllm | `vllm.engine.attention.backend: FLASHINFER` | FlashInfer requires JIT compilation on first use | Use `attention.backend: auto` or `FLASH_ATTN` |
 | vllm | `vllm.engine.attention.backend: TORCH_SDPA` | TORCH_SDPA not registered in vLLM attention backends | Use `attention.backend: auto` or `FLASH_ATTN` |
 | vllm | `vllm.engine.quantization: awq` or `gptq` | Requires a pre-quantized model checkpoint | Use a quantized model (e.g. `TheBloke/*-AWQ`) or omit |
-| tensorrt | `tensorrt.quant.quant_algo: FP8` | FP8 requires SM >= 8.9 (Ada Lovelace or Hopper). A100 (SM80) raises a `ConfigurationError` — no silent emulation or fallback | Use `INT8`, `W4A16_AWQ`, `W4A16_GPTQ`, or `W8A16` on A100 |
+| tensorrt | `tensorrt.quant_config.quant_algo: FP8` | FP8 requires SM >= 8.9 (Ada Lovelace or Hopper). A100 (SM80) raises a `ConfigurationError` — no silent emulation or fallback | Use `INT8`, `W4A16_AWQ`, `W4A16_GPTQ`, or `W8A16` on A100 |
 | tensorrt | `tensorrt.quantization: int8_sq` | INT8 SmoothQuant requires a calibration dataset | Provide calibration config or use a supported quantization method |
 
 ### Engine Capability Matrix

--- a/scripts/check_pydantic_matches_discovered.py
+++ b/scripts/check_pydantic_matches_discovered.py
@@ -39,7 +39,6 @@ LLEM_NATIVE_FIELDS: set[tuple[str, str]] = {
     # dtype is HF-native (torch_dtype is a deprecated BC alias). Passed via
     # from_pretrained **kwargs, so signature-based discovery misses it.
     ("transformers", "dtype"),
-    ("transformers", "batching_strategy"),
     ("transformers", "load_in_4bit"),
     ("transformers", "load_in_8bit"),
     ("transformers", "bnb_4bit_compute_dtype"),
@@ -61,9 +60,6 @@ LLEM_NATIVE_FIELDS: set[tuple[str, str]] = {
     ("transformers", "tp_plan"),
     ("transformers", "tp_size"),
     # -- vLLM --
-    # Curated fields that map to engine params under different discovery paths
-    ("vllm", "quantization_method"),
-    ("vllm", "load_format"),
     # Speculative decoding sub-config
     ("vllm", "method"),
     ("vllm", "offload_group_size"),
@@ -95,23 +91,14 @@ LLEM_NATIVE_FIELDS: set[tuple[str, str]] = {
     ("tensorrt", "free_gpu_memory_fraction"),
     ("tensorrt", "quant_algo"),
     ("tensorrt", "kv_cache_quant_algo"),
-    ("tensorrt", "calib_dataset"),
-    ("tensorrt", "calib_num_samples"),
-    ("tensorrt", "kv_cache_free_gpu_mem_fraction"),
     ("tensorrt", "enable_block_reuse"),
-    ("tensorrt", "max_tokens_in_paged_kv_cache"),
     ("tensorrt", "host_cache_size"),
+    ("tensorrt", "capacity_scheduling_policy"),
+    # Sampling params (TRT-LLM SamplingConfig; sub-config differs from flat engine API)
     ("tensorrt", "top_k"),
     ("tensorrt", "top_p"),
     ("tensorrt", "temperature"),
     ("tensorrt", "repetition_penalty"),
-    ("tensorrt", "length_penalty"),
-    ("tensorrt", "max_new_tokens"),
-    ("tensorrt", "end_id"),
-    ("tensorrt", "pad_id"),
-    ("tensorrt", "decoding_mode"),
-    ("tensorrt", "capacity_scheduling_policy"),
-    ("tensorrt", "context_chunking_policy"),
 }
 
 

--- a/src/llenergymeasure/config/engine_configs.py
+++ b/src/llenergymeasure/config/engine_configs.py
@@ -23,7 +23,7 @@ Usage in YAML:
     tensorrt:
       tensor_parallel_size: 2
       dtype: bfloat16
-      quant:
+      quant_config:
         quant_algo: W4A16_AWQ
 """
 
@@ -584,11 +584,11 @@ class VLLMEngineConfig(BaseModel):
     # Speculative decoding (typed nested sub-config)
     # -------------------------------------------------------------------------
 
-    speculative: VLLMSpeculativeConfig | None = Field(
+    speculative_config: VLLMSpeculativeConfig | None = Field(
         default=None,
         description=(
-            "Speculative decoding configuration. Replaces flat speculative_model / "
-            "num_speculative_tokens fields. Mirrors vLLM native speculative_config shape."
+            "Speculative decoding configuration. Mirrors vLLM native "
+            "EngineArgs.speculative_config shape."
         ),
     )
 
@@ -805,7 +805,7 @@ class VLLMConfig(BaseModel):
             enforce_eager: false
             gpu_memory_utilization: 0.9
             kv_cache_dtype: fp8
-            speculative:
+            speculative_config:
               model: gpt2
               num_speculative_tokens: 3
           sampling:
@@ -1012,7 +1012,7 @@ class TensorRTConfig(BaseModel):
           tensor_parallel_size: 2
           max_batch_size: 8
           dtype: bfloat16
-          quant:
+          quant_config:
             quant_algo: W4A16_AWQ
     """
 
@@ -1082,17 +1082,17 @@ class TensorRTConfig(BaseModel):
     # Nested sub-configs
     # -------------------------------------------------------------------------
 
-    quant: TensorRTQuantConfig | None = Field(
+    quant_config: TensorRTQuantConfig | None = Field(
         default=None,
-        description="Quantisation configuration (QuantConfig)",
+        description="Quantisation configuration. Mirrors native TrtLlmArgs.quant_config.",
     )
-    kv_cache: TensorRTKvCacheConfig | None = Field(
+    kv_cache_config: TensorRTKvCacheConfig | None = Field(
         default=None,
-        description="KV cache configuration",
+        description="KV cache configuration. Mirrors native TrtLlmArgs.kv_cache_config.",
     )
-    scheduler: TensorRTSchedulerConfig | None = Field(
+    scheduler_config: TensorRTSchedulerConfig | None = Field(
         default=None,
-        description="Scheduler configuration",
+        description="Scheduler configuration. Mirrors native TrtLlmArgs.scheduler_config.",
     )
     sampling: TensorRTSamplingConfig | None = Field(
         default=None,

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -283,7 +283,7 @@ def _get_custom_test_values() -> dict[str, list[Any]]:
         "tensorrt.max_input_len": [0],  # ge=1: 0 violates ge
         "tensorrt.max_seq_len": [0],  # ge=1: 0 violates ge
         # TensorRTKvCacheConfig: cache params
-        "tensorrt.kv_cache.max_tokens": [0],  # ge=1: 0 violates ge
+        "tensorrt.kv_cache_config.max_tokens": [0],  # ge=1: 0 violates ge
         # TensorRTSamplingConfig: sampling params
         "tensorrt.sampling.n": [0],  # ge=1: 0 violates ge
     }
@@ -533,7 +533,7 @@ def get_mutual_exclusions() -> dict[str, list[str]]:
         "vllm.beam_search": ["vllm.sampling"],
         "vllm.sampling": ["vllm.beam_search"],
         # TensorRT: quantisation method is exclusive
-        "tensorrt.quant.quant_algo": [],  # Handled by Literal type constraint
+        "tensorrt.quant_config.quant_algo": [],  # Handled by Literal type constraint
     }
 
 
@@ -569,8 +569,8 @@ def get_special_test_models() -> dict[str, str]:
         "vllm.engine.quantization=awq": "Qwen/Qwen2.5-0.5B-Instruct-AWQ",
         "vllm.engine.quantization=gptq": "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int4",
         # TensorRT quantisation methods requiring pre-quantized models
-        "tensorrt.quant.quant_algo=W4A16_AWQ": "Qwen/Qwen2.5-0.5B-Instruct-AWQ",
-        "tensorrt.quant.quant_algo=W4A16_GPTQ": "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int4",
+        "tensorrt.quant_config.quant_algo=W4A16_AWQ": "Qwen/Qwen2.5-0.5B-Instruct-AWQ",
+        "tensorrt.quant_config.quant_algo=W4A16_GPTQ": "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int4",
     }
 
 
@@ -586,7 +586,7 @@ def get_params_requiring_gpu_capability(min_compute_capability: float = 8.0) -> 
     # These features require Ampere (8.0) or newer GPUs
     ampere_required = [
         "vllm.engine.quantization=fp8",
-        "tensorrt.quant.quant_algo=FP8",
+        "tensorrt.quant_config.quant_algo=FP8",
         "transformers.attn_implementation=flash_attention_2",
         "transformers.attn_implementation=flash_attention_3",
     ]
@@ -617,10 +617,10 @@ def get_param_skip_conditions() -> dict[str, str]:
         "transformers.torch_compile=True": "May fail on some model architectures (non-fatal fallback)",
         # FP8 - Ampere or newer
         "vllm.engine.quantization=fp8": "Requires Ampere+ GPU",
-        "tensorrt.quant.quant_algo=FP8": "Requires Ada Lovelace+ GPU (SM >= 8.9)",
+        "tensorrt.quant_config.quant_algo=FP8": "Requires Ada Lovelace+ GPU (SM >= 8.9)",
         # TensorRT quantisation - requires pre-quantized models
-        "tensorrt.quant.quant_algo=W4A16_AWQ": "Requires AWQ-quantized model",
-        "tensorrt.quant.quant_algo=W4A16_GPTQ": "Requires GPTQ-quantized model",
+        "tensorrt.quant_config.quant_algo=W4A16_AWQ": "Requires AWQ-quantized model",
+        "tensorrt.quant_config.quant_algo=W4A16_GPTQ": "Requires GPTQ-quantized model",
         # Quantization - requires pre-quantized models (see get_special_test_models)
         "vllm.engine.quantization=awq": "Requires AWQ-quantized model",
         "vllm.engine.quantization=gptq": "Requires GPTQ-quantized model",
@@ -979,7 +979,7 @@ def get_runtime_limitations() -> list[dict[str, str]]:
         },
         {
             "engine": "tensorrt",
-            "parameter": "tensorrt.quant.quant_algo=FP8",
+            "parameter": "tensorrt.quant_config.quant_algo=FP8",
             "limitation": "FP8 requires SM >= 8.9 (Ada Lovelace or Hopper). A100 (SM80) raises ConfigurationError - no silent emulation or fallback",
             "resolution": "Use INT8, W4A16_AWQ, W4A16_GPTQ, or W8A16 on A100",
         },

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -392,15 +392,15 @@ class TensorRTEngine:
 
         # Check FP8 quant requirements (SM >= 8.9)
         trt = config.tensorrt
-        if trt is not None and trt.quant is not None:
-            if trt.quant.quant_algo == "FP8" and sm_float < 8.9:
+        if trt is not None and trt.quant_config is not None:
+            if trt.quant_config.quant_algo == "FP8" and sm_float < 8.9:
                 errors.append(
                     f"FP8 quantisation requires SM >= 8.9 (Ada Lovelace or Hopper). "
                     f"This GPU has SM {major}.{minor} "
                     f"(A100=8.0, H100=9.0, RTX4090=8.9). "
                     f"Use W8A16, W4A16_AWQ, or W4A16_GPTQ instead."
                 )
-            if trt.quant.kv_cache_quant_algo == "FP8" and sm_float < 8.9:
+            if trt.quant_config.kv_cache_quant_algo == "FP8" and sm_float < 8.9:
                 errors.append(
                     f"FP8 KV cache quantisation requires SM >= 8.9 (Ada Lovelace or Hopper). "
                     f"This GPU has SM {major}.{minor} "
@@ -476,15 +476,17 @@ class TensorRTEngine:
             kwargs["backend"] = trt.backend
 
         # Quantisation config
-        if trt.quant is not None:
+        if trt.quant_config is not None:
             try:
                 from tensorrt_llm.llmapi import QuantAlgo, QuantConfig
 
                 qc_kwargs: dict[str, Any] = {}
-                if trt.quant.quant_algo is not None:
-                    qc_kwargs["quant_algo"] = QuantAlgo[trt.quant.quant_algo]
-                if trt.quant.kv_cache_quant_algo is not None:
-                    qc_kwargs["kv_cache_quant_algo"] = QuantAlgo[trt.quant.kv_cache_quant_algo]
+                if trt.quant_config.quant_algo is not None:
+                    qc_kwargs["quant_algo"] = QuantAlgo[trt.quant_config.quant_algo]
+                if trt.quant_config.kv_cache_quant_algo is not None:
+                    qc_kwargs["kv_cache_quant_algo"] = QuantAlgo[
+                        trt.quant_config.kv_cache_quant_algo
+                    ]
                 if qc_kwargs:
                     kwargs["quantization"] = QuantConfig(**qc_kwargs)
             except ImportError:
@@ -495,11 +497,11 @@ class TensorRTEngine:
         _apply_default_build_cache(kwargs)
 
         # KV cache config
-        if trt.kv_cache is not None:
+        if trt.kv_cache_config is not None:
             try:
                 from tensorrt_llm.llmapi import KvCacheConfig
 
-                kv = trt.kv_cache
+                kv = trt.kv_cache_config
                 kv_kwargs: dict[str, Any] = {}
                 if kv.enable_block_reuse is not None:
                     kv_kwargs["enable_block_reuse"] = kv.enable_block_reuse
@@ -515,11 +517,11 @@ class TensorRTEngine:
                 logger.debug("tensorrt_llm.llmapi not available; skipping KvCacheConfig")
 
         # Scheduler config
-        if trt.scheduler is not None:
+        if trt.scheduler_config is not None:
             try:
                 from tensorrt_llm.llmapi import CapacitySchedulerPolicy, SchedulerConfig
 
-                sc = trt.scheduler
+                sc = trt.scheduler_config
                 sc_kwargs: dict[str, Any] = {}
                 if sc.capacity_scheduling_policy is not None:
                     sc_kwargs["capacity_scheduling_policy"] = CapacitySchedulerPolicy[

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -324,9 +324,9 @@ class VLLMEngine:
             _set("max_seq_len_to_capture", engine.max_seq_len_to_capture)
             _set("distributed_executor_backend", engine.distributed_executor_backend)
 
-            # Speculative decoding — build vLLM-native speculative_config dict from sub-config
-            if engine.speculative is not None:
-                spec_dict = engine.speculative.model_dump(exclude_none=True)
+            # Speculative decoding — dump the typed sub-config straight into kwargs.
+            if engine.speculative_config is not None:
+                spec_dict = engine.speculative_config.model_dump(exclude_none=True)
                 if spec_dict:
                     kwargs["speculative_config"] = spec_dict
 

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -58,9 +58,9 @@ def test_get_engine_params_tensorrt_returns_params():
     assert isinstance(params, dict)
     assert "tensorrt.max_batch_size" in params
     # Verify expanded nested sub-config params are registered
-    assert "tensorrt.quant.quant_algo" in params
-    assert "tensorrt.kv_cache.free_gpu_memory_fraction" in params
-    assert "tensorrt.scheduler.capacity_scheduling_policy" in params
+    assert "tensorrt.quant_config.quant_algo" in params
+    assert "tensorrt.kv_cache_config.free_gpu_memory_fraction" in params
+    assert "tensorrt.scheduler_config.capacity_scheduling_policy" in params
     # build_cache and calib sub-configs dropped (D1/D3); return_perf_metrics dropped (D1)
     assert "tensorrt.build_cache.max_records" not in params
     assert "tensorrt.sampling.return_perf_metrics" not in params

--- a/tests/unit/config/test_config_schema.py
+++ b/tests/unit/config/test_config_schema.py
@@ -592,7 +592,9 @@ def test_trt_fp8_accepts_float16() -> None:
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="tensorrt",
-        tensorrt=TensorRTConfig(dtype="float16", quant=TensorRTQuantConfig(quant_algo="FP8")),
+        tensorrt=TensorRTConfig(
+            dtype="float16", quant_config=TensorRTQuantConfig(quant_algo="FP8")
+        ),
     )
     assert cfg.tensorrt.dtype == "float16"
 
@@ -604,7 +606,9 @@ def test_trt_fp8_accepts_bfloat16() -> None:
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="tensorrt",
-        tensorrt=TensorRTConfig(dtype="bfloat16", quant=TensorRTQuantConfig(quant_algo="FP8")),
+        tensorrt=TensorRTConfig(
+            dtype="bfloat16", quant_config=TensorRTQuantConfig(quant_algo="FP8")
+        ),
     )
     assert cfg.tensorrt.dtype == "bfloat16"
 
@@ -616,7 +620,9 @@ def test_trt_non_fp8_accepts_float16() -> None:
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="tensorrt",
-        tensorrt=TensorRTConfig(dtype="float16", quant=TensorRTQuantConfig(quant_algo="INT8")),
+        tensorrt=TensorRTConfig(
+            dtype="float16", quant_config=TensorRTQuantConfig(quant_algo="INT8")
+        ),
     )
     assert cfg.tensorrt.dtype == "float16"
 

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -259,12 +259,12 @@ class TestExperimentConfigIntegration:
                 "max_num_tokens": 4096,
                 "dtype": "bfloat16",
                 "fast_build": True,
-                "quant": {"quant_algo": "W4A16_AWQ"},
-                "kv_cache": {
+                "quant_config": {"quant_algo": "W4A16_AWQ"},
+                "kv_cache_config": {
                     "enable_block_reuse": True,
                     "free_gpu_memory_fraction": 0.9,
                 },
-                "scheduler": {
+                "scheduler_config": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
                 "sampling": {
@@ -279,12 +279,12 @@ class TestExperimentConfigIntegration:
         assert config.tensorrt.tensor_parallel_size == 2
         assert config.tensorrt.pipeline_parallel_size == 2
         assert config.tensorrt.max_num_tokens == 4096
-        assert config.tensorrt.quant is not None
-        assert config.tensorrt.quant.quant_algo == "W4A16_AWQ"
-        assert config.tensorrt.kv_cache is not None
-        assert config.tensorrt.kv_cache.enable_block_reuse is True
-        assert config.tensorrt.scheduler is not None
-        assert config.tensorrt.scheduler.capacity_scheduling_policy == "MAX_UTILIZATION"
+        assert config.tensorrt.quant_config is not None
+        assert config.tensorrt.quant_config.quant_algo == "W4A16_AWQ"
+        assert config.tensorrt.kv_cache_config is not None
+        assert config.tensorrt.kv_cache_config.enable_block_reuse is True
+        assert config.tensorrt.scheduler_config is not None
+        assert config.tensorrt.scheduler_config.capacity_scheduling_policy == "MAX_UTILIZATION"
         assert config.tensorrt.sampling is not None
         assert config.tensorrt.sampling.n == 1
 
@@ -314,9 +314,9 @@ class TestExperimentConfigIntegration:
         assert config.max_num_tokens is None
         assert config.dtype is None
         assert config.fast_build is None
-        assert config.quant is None
-        assert config.kv_cache is None
-        assert config.scheduler is None
+        assert config.quant_config is None
+        assert config.kv_cache_config is None
+        assert config.scheduler_config is None
         assert config.sampling is None
         # backend and engine_path are no longer typed fields (D2/D1 drop)
         # calib and build_cache sub-configs dropped (D3/D1)

--- a/tests/unit/config/test_tensorrt_sweep.py
+++ b/tests/unit/config/test_tensorrt_sweep.py
@@ -48,17 +48,17 @@ class TestDottedNestedSweep:
     """Tests for dotted sweep keys expanding into nested TensorRT config."""
 
     def test_dotted_quant_algo_sweep(self):
-        """tensorrt.quant.quant_algo: [INT8, FP8, W4A16_AWQ] produces 3 configs."""
+        """tensorrt.quant_config.quant_algo: [INT8, FP8, W4A16_AWQ] produces 3 configs."""
         raw_study = {
             "task": {"model": "gpt2"},
             "engine": "tensorrt",
             "sweep": {
-                "tensorrt.quant.quant_algo": ["INT8", "FP8", "W4A16_AWQ"],
+                "tensorrt.quant_config.quant_algo": ["INT8", "FP8", "W4A16_AWQ"],
             },
         }
         valid, _skipped = expand_grid(raw_study)
         assert len(valid) == 3
-        algos = [c.tensorrt.quant.quant_algo for c in valid]
+        algos = [c.tensorrt.quant_config.quant_algo for c in valid]
         assert set(algos) == {"INT8", "FP8", "W4A16_AWQ"}
 
     def test_dotted_nested_max_num_tokens_sweep(self):
@@ -86,11 +86,11 @@ class TestDottedNestedSweep:
                 "max_input_len": 1024,
                 "max_seq_len": 2048,
                 "dtype": "bfloat16",
-                "kv_cache": {
+                "kv_cache_config": {
                     "enable_block_reuse": True,
                     "free_gpu_memory_fraction": 0.9,
                 },
-                "scheduler": {
+                "scheduler_config": {
                     "capacity_scheduling_policy": "MAX_UTILIZATION",
                 },
                 "sampling": {
@@ -98,7 +98,7 @@ class TestDottedNestedSweep:
                 },
             },
             "sweep": {
-                "tensorrt.quant.quant_algo": ["INT8", "W4A16_AWQ"],
+                "tensorrt.quant_config.quant_algo": ["INT8", "W4A16_AWQ"],
             },
         }
         valid, _skipped = expand_grid(raw_study)
@@ -109,12 +109,12 @@ class TestDottedNestedSweep:
             assert config.tensorrt.tensor_parallel_size == 2
             assert config.tensorrt.max_batch_size == 8
             assert config.tensorrt.dtype == "bfloat16"
-            assert config.tensorrt.kv_cache is not None
-            assert config.tensorrt.kv_cache.enable_block_reuse is True
-            assert config.tensorrt.scheduler is not None
+            assert config.tensorrt.kv_cache_config is not None
+            assert config.tensorrt.kv_cache_config.enable_block_reuse is True
+            assert config.tensorrt.scheduler_config is not None
             assert config.tensorrt.sampling is not None
             assert config.tensorrt.sampling.n == 1
-        algos = {c.tensorrt.quant.quant_algo for c in valid}
+        algos = {c.tensorrt.quant_config.quant_algo for c in valid}
         assert algos == {"INT8", "W4A16_AWQ"}
 
     def test_invalid_quant_algo_in_sweep_is_skipped(self):
@@ -123,11 +123,11 @@ class TestDottedNestedSweep:
             "task": {"model": "gpt2"},
             "engine": "tensorrt",
             "sweep": {
-                "tensorrt.quant.quant_algo": ["INT8", "INVALID_VALUE"],
+                "tensorrt.quant_config.quant_algo": ["INT8", "INVALID_VALUE"],
             },
         }
         valid, skipped = expand_grid(raw_study)
         assert len(valid) == 1
-        assert valid[0].tensorrt.quant.quant_algo == "INT8"
+        assert valid[0].tensorrt.quant_config.quant_algo == "INT8"
         assert len(skipped) == 1
         assert "INVALID_VALUE" in skipped[0].reason

--- a/tests/unit/engines/test_probe_config.py
+++ b/tests/unit/engines/test_probe_config.py
@@ -432,7 +432,7 @@ def test_tensorrt_t5_fp8_on_a100_captured(monkeypatch):
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="tensorrt",
-        tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8")),
+        tensorrt=TensorRTConfig(quant_config=TensorRTQuantConfig(quant_algo="FP8")),
     )
     engine = TensorRTEngine()
 

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -265,7 +265,8 @@ class TestBuildLlmKwargs:
         monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
 
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="INT8"))
+            **_TRT_DEFAULTS,
+            tensorrt=TensorRTConfig(quant_config=TensorRTQuantConfig(quant_algo="INT8")),
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -355,7 +356,7 @@ class TestBuildLlmKwargs:
         config = make_config(
             **_TRT_DEFAULTS,
             tensorrt=TensorRTConfig(
-                kv_cache=TensorRTKvCacheConfig(
+                kv_cache_config=TensorRTKvCacheConfig(
                     enable_block_reuse=True,
                     free_gpu_memory_fraction=0.8,
                 )
@@ -378,7 +379,7 @@ class TestBuildLlmKwargs:
         config = make_config(
             **_TRT_DEFAULTS,
             tensorrt=TensorRTConfig(
-                scheduler=TensorRTSchedulerConfig(
+                scheduler_config=TensorRTSchedulerConfig(
                     capacity_scheduling_policy="MAX_UTILIZATION",
                 )
             ),
@@ -552,7 +553,8 @@ class TestValidateConfigFP8Checks:
             lambda gpu_index=0: (8, 0),
         )
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8"))
+            **_TRT_DEFAULTS,
+            tensorrt=TensorRTConfig(quant_config=TensorRTQuantConfig(quant_algo="FP8")),
         )
         engine = TensorRTEngine()
         errors = engine.validate_config(config)
@@ -568,7 +570,8 @@ class TestValidateConfigFP8Checks:
             lambda gpu_index=0: (8, 9),
         )
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8"))
+            **_TRT_DEFAULTS,
+            tensorrt=TensorRTConfig(quant_config=TensorRTQuantConfig(quant_algo="FP8")),
         )
         engine = TensorRTEngine()
         errors = engine.validate_config(config)
@@ -581,7 +584,8 @@ class TestValidateConfigFP8Checks:
             lambda gpu_index=0: (9, 0),
         )
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="FP8"))
+            **_TRT_DEFAULTS,
+            tensorrt=TensorRTConfig(quant_config=TensorRTQuantConfig(quant_algo="FP8")),
         )
         engine = TensorRTEngine()
         errors = engine.validate_config(config)
@@ -595,7 +599,7 @@ class TestValidateConfigFP8Checks:
         )
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(kv_cache_quant_algo="FP8")),
+            tensorrt=TensorRTConfig(quant_config=TensorRTQuantConfig(kv_cache_quant_algo="FP8")),
         )
         engine = TensorRTEngine()
         errors = engine.validate_config(config)
@@ -611,7 +615,8 @@ class TestValidateConfigFP8Checks:
             lambda gpu_index=0: (8, 0),
         )
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt=TensorRTConfig(quant=TensorRTQuantConfig(quant_algo="INT8"))
+            **_TRT_DEFAULTS,
+            tensorrt=TensorRTConfig(quant_config=TensorRTQuantConfig(quant_algo="INT8")),
         )
         engine = TensorRTEngine()
         errors = engine.validate_config(config)
@@ -626,7 +631,7 @@ class TestValidateConfigFP8Checks:
         config = make_config(
             **_TRT_DEFAULTS,
             tensorrt=TensorRTConfig(
-                quant=TensorRTQuantConfig(quant_algo="FP8", kv_cache_quant_algo="FP8")
+                quant_config=TensorRTQuantConfig(quant_algo="FP8", kv_cache_quant_algo="FP8")
             ),
         )
         engine = TensorRTEngine()

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -412,7 +412,9 @@ class TestEngineConfigFields:
 
         vllm_cfg = VLLMConfig(
             engine=VLLMEngineConfig(
-                speculative=VLLMSpeculativeConfig(model="draft-model", num_speculative_tokens=5)
+                speculative_config=VLLMSpeculativeConfig(
+                    model="draft-model", num_speculative_tokens=5
+                )
             )
         )
         config = make_config(**_VLLM_DEFAULTS, vllm=vllm_cfg)
@@ -429,7 +431,7 @@ class TestEngineConfigFields:
 
         vllm_cfg = VLLMConfig(
             engine=VLLMEngineConfig(
-                speculative=VLLMSpeculativeConfig(
+                speculative_config=VLLMSpeculativeConfig(
                     model="eagle-model", num_speculative_tokens=3, method="eagle"
                 )
             )

--- a/tests/unit/study/test_sweep_groups.py
+++ b/tests/unit/study/test_sweep_groups.py
@@ -111,7 +111,7 @@ class TestExpandGroupEntry:
 
     def test_multiple_list_fields_cartesian(self):
         entry = {
-            "tensorrt.quant.quant_algo": "INT8",
+            "tensorrt.quant_config.quant_algo": "INT8",
             "tensorrt.calib.calib_batches": [256, 512],
             "tensorrt.calib.calib_max_seq_length": [256, 512],
         }


### PR DESCRIPTION
## Summary

- Renames four Pydantic sub-config fields to match native engine kwarg names: `quant`→`quant_config`, `kv_cache`→`kv_cache_config`, `scheduler`→`scheduler_config` (TensorRT), `speculative`→`speculative_config` (vLLM). All call-sites updated (engines, tests, example YAML, docs).
- Purges 13 stale `LLEM_NATIVE_FIELDS` entries in `scripts/check_pydantic_matches_discovered.py` for fields no longer present in any Pydantic model.
- Adds `docs/parameter-curation.md` explaining the discovery→curation→drift-check pipeline and the role of `LLEM_NATIVE_FIELDS`.

## Test plan

- [ ] Drift checker: `python scripts/check_pydantic_matches_discovered.py` → 0 drifts across all three engines
- [ ] 121 directly-affected unit tests pass (config, sweep, introspection)
- [ ] Ruff lint/format clean