### PR TITLE
feat(ci): add config-rules-refresh workflow (transformers)

### DIFF
--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -57,14 +57,10 @@ env:
 
 jobs:
   vendor-transformers:
-    # Auto-trigger only for changes that actually affect transformers rules:
-    # either a transformers-specific path, a Dockerfile.transformers bump, or
-    # a shared-vendor-tooling change. workflow_dispatch always runs.
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'config-rules-refresh')
-      || github.event.pull_request.user.login == 'renovate[bot]'
-      || github.event_name == 'pull_request'
+    # Path filters on the pull_request trigger restrict which PRs fire this
+    # workflow; workflow_dispatch always runs when explicitly invoked. No
+    # per-job `if:` gate needed.
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'transformers' || inputs.engine == 'all'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -1,0 +1,185 @@
+name: Config Rules Refresh
+
+# Re-vendors the validation-rules JSON by running scripts/vendor_rules.py
+# inside each engine's Docker container. Observes whether the real library
+# matches the corpus's declared expected_outcome; fails CI on divergence;
+# commits regenerated JSON back to the PR.
+#
+# Sibling of schema-refresh.yml (parameter-discovery). Same shape, same
+# commit-back + labelling + PR-comment pattern, different artifact kind.
+#
+# Trigger paths (auto):
+#   - docker/Dockerfile.{engine}        (Renovate-driven image bumps)
+#   - configs/validation_rules/{engine}.yaml
+#   - scripts/vendor_rules.py
+#   - scripts/walkers/{engine}.py
+#   - scripts/_vendor_common.py
+#
+# Trigger (manual): workflow_dispatch with explicit engine choice.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "docker/Dockerfile.*"
+      - "configs/validation_rules/*.yaml"
+      - "scripts/vendor_rules.py"
+      - "scripts/_vendor_common.py"
+      - "scripts/walkers/*.py"
+      - "scripts/update_engine_rules.sh"
+  workflow_dispatch:
+    inputs:
+      engine:
+        description: "Engine to re-vendor"
+        required: true
+        type: choice
+        options:
+          - transformers
+          - vllm
+          - tensorrt
+          - all
+      pr_number:
+        description: "PR number to comment on and label (optional)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: config-rules-refresh-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CORPUS_DIR: configs/validation_rules
+  VENDORED_DIR: src/llenergymeasure/engines/vendored_rules
+
+jobs:
+  vendor-transformers:
+    # Auto-trigger only for changes that actually affect transformers rules:
+    # either a transformers-specific path, a Dockerfile.transformers bump, or
+    # a shared-vendor-tooling change. workflow_dispatch always runs.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'config-rules-refresh')
+      || github.event.pull_request.user.login == 'renovate[bot]'
+      || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: vendor-rules-3.12
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --dev --extra transformers
+
+      - name: Save current vendored JSON for diffing
+        id: save_old
+        run: |
+          OLD_JSON="${VENDORED_DIR}/transformers.json"
+          mkdir -p /tmp/rules-diff
+          if [[ -f "$OLD_JSON" ]]; then
+            cp "$OLD_JSON" /tmp/rules-diff/transformers.old.json
+          else
+            echo '{"cases":[],"divergences":[]}' > /tmp/rules-diff/transformers.old.json
+          fi
+
+      - name: Run fixpoint test against corpus
+        run: |
+          uv run python -c "
+          import yaml
+          from scripts.walkers._fixpoint_test import fixpoint_test_corpus
+          corpus = yaml.safe_load(open('${CORPUS_DIR}/transformers.yaml'))
+          fixpoint_test_corpus(corpus)
+          print('fixpoint test passed')
+          "
+
+      - name: Re-vendor transformers rules
+        id: vendor
+        run: |
+          set +e
+          uv run python scripts/vendor_rules.py \
+            --engine transformers \
+            --corpus "${CORPUS_DIR}/transformers.yaml" \
+            --out "${VENDORED_DIR}/transformers.json" \
+            --vendor-commit "${GITHUB_SHA}" \
+            --fail-on-divergence
+          echo "vendor_exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Classify diff
+        id: diff
+        run: |
+          mkdir -p /tmp/rules-diff
+          set +e
+          uv run python scripts/diff_rules.py \
+            /tmp/rules-diff/transformers.old.json \
+            "${VENDORED_DIR}/transformers.json" \
+            --out /tmp/rules-diff/transformers.md \
+            --title "Transformers rules diff"
+          DIFF_EXIT=$?
+          set -e
+          echo "is_breaking=$([[ $DIFF_EXIT -eq 1 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit regenerated JSON
+        if: github.event_name == 'pull_request'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add "${VENDORED_DIR}/transformers.json"
+
+          if git diff --cached --quiet; then
+            echo "No vendored JSON changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(config): refresh transformers vendored rules"
+          git push
+
+      - name: Post diff comment
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "No PR number available, skipping comment."
+            exit 0
+          fi
+          if [[ -f /tmp/rules-diff/transformers.md ]]; then
+            gh pr comment "$PR_NUMBER" --body-file /tmp/rules-diff/transformers.md
+          fi
+
+      - name: Apply label
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          if [[ "${{ steps.diff.outputs.is_breaking }}" == "true" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "rules-breaking" --remove-label "rules-safe" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --add-label "rules-safe" --remove-label "rules-breaking" 2>/dev/null || true
+          fi
+
+      - name: Fail on divergence
+        if: steps.vendor.outputs.vendor_exit != '0'
+        run: |
+          echo "::error::One or more rules diverged from their declared expected_outcome." >&2
+          echo "Inspect ${VENDORED_DIR}/transformers.json > .divergences[] for details." >&2
+          exit 1

--- a/scripts/_vendor_common.py
+++ b/scripts/_vendor_common.py
@@ -1,0 +1,390 @@
+"""Shared utilities for the vendor-rules pipeline.
+
+Factored out of :mod:`scripts.vendor_rules` so that per-engine native-type
+runners can live here while the CLI + loop driver stays in ``vendor_rules``.
+
+This module is engine-agnostic. Per-engine behaviour lives behind
+:func:`get_native_type_runner`, which dispatches on engine name.
+
+Design contract: the vendor step observes library behaviour concretely. It
+never re-interprets the rule's declared shape — if the library behaves
+differently from what the corpus claims, CI fails. See
+:doc:`.product/designs/config-deduplication-dormancy/runtime-config-validation.md`
+§4.3 for the full contract.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import logging
+import time
+import warnings
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Private-field allowlist (PoC-C finding)
+# ---------------------------------------------------------------------------
+# Per PLAN §"Consistency pass applied 2026-04-23", the vendor state-diff must
+# exclude engine-specific bookkeeping fields that would pollute the diff with
+# non-deterministic state (commit hashes, cached derived flags, …). Each
+# engine's runner declares its own allowlist; a module-level default covers
+# fields common across engines.
+
+_DEFAULT_PRIVATE_FIELD_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "_commit_hash",
+        "_from_model_config",
+        "_original_object_hash",
+        "_all_stop_token_ids",
+    }
+)
+
+TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST: frozenset[str] = _DEFAULT_PRIVATE_FIELD_ALLOWLIST | frozenset(
+    {
+        # HF-specific derived fields populated during __post_init__ that do
+        # not constitute a user-facing normalisation.
+        "_eos_token_tensor",
+        "_pad_token_tensor",
+        "_bos_token_tensor",
+        "transformers_version",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Observation dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CaptureBuffers:
+    """Container for everything a single ``native_type(**kwargs)`` call produced."""
+
+    exception_type: str | None
+    exception_message: str | None
+    warnings_captured: tuple[str, ...]
+    logger_messages: tuple[str, ...]
+    observed_state: dict[str, Any] | None
+    duration_ms: int
+
+
+@dataclass
+class CaseResult:
+    """Per-rule observed outcome, ready for JSON serialisation."""
+
+    id: str
+    outcome: str  # see _classify_outcome
+    emission_channel: str  # mirrors corpus "emission_channel" tag
+    observed_messages: list[str] = field(default_factory=list)
+    observed_silent_normalisations: dict[str, dict[str, Any]] = field(default_factory=dict)
+    observed_exception: dict[str, str] | None = None
+    positive_confirmed: bool = False
+    negative_confirmed: bool = False
+    duration_ms: int = 0
+    skipped_reason: str | None = None
+
+
+@dataclass
+class Divergence:
+    """One observed-vs-expected mismatch."""
+
+    rule_id: str
+    field: str
+    expected: Any
+    observed: Any
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "field": self.field,
+            "expected": self.expected,
+            "observed": self.observed,
+        }
+
+
+# ---------------------------------------------------------------------------
+# State extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_state(
+    obj: Any, *, private_allowlist: Iterable[str] = TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST
+) -> dict[str, Any]:
+    """Uniform dump of an arbitrary config object's public state.
+
+    Handles Pydantic v2 (``model_dump``), dataclasses, ``__slots__`` classes
+    and plain ``__dict__`` classes. Private attributes (``_foo``) are dropped
+    unless they appear in ``private_allowlist`` — see module docstring for
+    why the allowlist exists.
+    """
+    allowlist = frozenset(private_allowlist)
+
+    # Pydantic v2
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump()
+            if isinstance(dumped, dict):
+                return {k: v for k, v in dumped.items() if not k.startswith("_") or k in allowlist}
+        except Exception:
+            pass
+
+    # dataclasses
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {
+            f.name: getattr(obj, f.name)
+            for f in dataclasses.fields(obj)
+            if not f.name.startswith("_") or f.name in allowlist
+        }
+
+    # __slots__ and __dict__ classes
+    collected: dict[str, Any] = {}
+    slots = getattr(type(obj), "__slots__", None)
+    if slots:
+        for name in slots:
+            if (not name.startswith("_") or name in allowlist) and hasattr(obj, name):
+                collected[name] = getattr(obj, name)
+    if hasattr(obj, "__dict__"):
+        for name, value in vars(obj).items():
+            if not name.startswith("_") or name in allowlist:
+                collected.setdefault(name, value)
+    return collected
+
+
+def diff_input_vs_state(
+    kwargs: dict[str, Any], observed_state: dict[str, Any]
+) -> dict[str, dict[str, Any]]:
+    """Identify silent normalisations — fields the library changed post-construction.
+
+    Returns ``{field: {"declared": <input>, "observed": <state>}}``.
+    """
+    diffs: dict[str, dict[str, Any]] = {}
+    for field_name, declared in kwargs.items():
+        if field_name not in observed_state:
+            continue
+        observed = observed_state[field_name]
+        if declared != observed:
+            diffs[field_name] = {
+                "declared": _jsonable(declared),
+                "observed": _jsonable(observed),
+            }
+    return diffs
+
+
+# ---------------------------------------------------------------------------
+# Capture primitives
+# ---------------------------------------------------------------------------
+
+
+def _attach_loggers(
+    loggers: Iterable[str],
+) -> tuple[logging.Handler, io.StringIO, list[tuple[logging.Logger, int]]]:
+    """Attach a StringIO handler to each named logger.
+
+    Returns the handler, its buffer and a list of ``(logger, previous_level)``
+    pairs so the caller can restore levels afterwards.
+    """
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(message)s")
+    handler.setFormatter(formatter)
+    restore: list[tuple[logging.Logger, int]] = []
+    for name in loggers:
+        logger = logging.getLogger(name)
+        restore.append((logger, logger.level))
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+    return handler, buf, restore
+
+
+def _detach_loggers(handler: logging.Handler, restore: list[tuple[logging.Logger, int]]) -> None:
+    for logger, prev in restore:
+        logger.removeHandler(handler)
+        logger.setLevel(prev)
+
+
+def run_case(
+    callable_fn: Callable[[], Any],
+    *,
+    logger_names: Iterable[str] = (),
+    private_allowlist: Iterable[str] = TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST,
+) -> CaptureBuffers:
+    """Run ``callable_fn()`` and capture exceptions / warnings / logger output / state.
+
+    ``callable_fn`` is usually ``lambda: native_type(**kwargs)`` or
+    ``lambda: native_type(**kwargs).validate(strict=True)``. Returns a
+    :class:`CaptureBuffers` regardless of whether the call raised.
+    """
+    handler, buf, restore = _attach_loggers(logger_names)
+    start = time.perf_counter()
+    exc_type: str | None = None
+    exc_msg: str | None = None
+    obj: Any = None
+
+    try:
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
+            try:
+                obj = callable_fn()
+            except Exception as exc:
+                exc_type = type(exc).__name__
+                exc_msg = str(exc)
+    finally:
+        _detach_loggers(handler, restore)
+        duration_ms = int((time.perf_counter() - start) * 1000)
+
+    warnings_tuple: tuple[str, ...] = ()
+    if exc_type is None:
+        warnings_tuple = tuple(str(w.message) for w in (captured_warnings or []))
+
+    log_messages = _split_log_buffer(buf.getvalue())
+    observed_state = (
+        extract_state(obj, private_allowlist=private_allowlist) if obj is not None else None
+    )
+
+    return CaptureBuffers(
+        exception_type=exc_type,
+        exception_message=exc_msg,
+        warnings_captured=warnings_tuple,
+        logger_messages=log_messages,
+        observed_state=observed_state,
+        duration_ms=duration_ms,
+    )
+
+
+def _split_log_buffer(raw: str) -> tuple[str, ...]:
+    """Split buffer text into one entry per record, dropping empty trailing."""
+    if not raw:
+        return ()
+    lines = [line for line in raw.split("\n") if line.strip()]
+    return tuple(lines)
+
+
+# ---------------------------------------------------------------------------
+# Outcome classification
+# ---------------------------------------------------------------------------
+
+_VALID_OUTCOMES = frozenset(
+    {
+        "error",
+        "warn",
+        "dormant_announced",
+        "dormant_silent",
+        "no_op",
+        "skipped_hardware_dependent",
+    }
+)
+
+
+def classify_outcome(capture: CaptureBuffers, silent_normalisations: dict[str, Any]) -> str:
+    """Given captured behaviour, compute the observed outcome label.
+
+    Preference order:
+
+    1. Exception raised -> ``"error"``
+    2. ``warnings.warn`` captured -> ``"warn"``
+    3. Logger message captured -> ``"dormant_announced"``
+    4. Silent state change detected -> ``"dormant_silent"``
+    5. Nothing observed -> ``"no_op"``
+    """
+    if capture.exception_type is not None:
+        return "error"
+    if capture.warnings_captured:
+        return "warn"
+    if capture.logger_messages:
+        return "dormant_announced"
+    if silent_normalisations:
+        return "dormant_silent"
+    return "no_op"
+
+
+def classify_emission_channel(capture: CaptureBuffers) -> str:
+    """Return the corpus-compatible ``emission_channel`` tag."""
+    if capture.exception_type is not None:
+        return "none"
+    if capture.warnings_captured:
+        return "warnings_warn"
+    if capture.logger_messages:
+        return "logger_warning"
+    return "none"
+
+
+# ---------------------------------------------------------------------------
+# Expected vs observed comparison
+# ---------------------------------------------------------------------------
+
+
+def compare_expected_vs_observed(
+    *,
+    rule_id: str,
+    expected: dict[str, Any],
+    observed_outcome: str,
+    observed_emission: str,
+    silent_normalisations: dict[str, Any],
+) -> list[Divergence]:
+    """Return the list of expected-vs-observed divergences for one rule.
+
+    Missing/extra fields on either side are *not* treated as divergence —
+    only fields present in ``expected`` are checked. This keeps the
+    comparison permissive while still catching drift in the tracked fields.
+    """
+    divergences: list[Divergence] = []
+    expected_outcome = expected.get("outcome")
+    if expected_outcome and expected_outcome != observed_outcome:
+        divergences.append(
+            Divergence(
+                rule_id=rule_id,
+                field="outcome",
+                expected=expected_outcome,
+                observed=observed_outcome,
+            )
+        )
+    expected_channel = expected.get("emission_channel")
+    if expected_channel and expected_channel != observed_emission:
+        divergences.append(
+            Divergence(
+                rule_id=rule_id,
+                field="emission_channel",
+                expected=expected_channel,
+                observed=observed_emission,
+            )
+        )
+
+    expected_norm_fields = expected.get("normalised_fields") or []
+    if expected_norm_fields:
+        missing = [f for f in expected_norm_fields if f not in silent_normalisations]
+        if missing:
+            divergences.append(
+                Divergence(
+                    rule_id=rule_id,
+                    field="normalised_fields",
+                    expected=list(expected_norm_fields),
+                    observed=sorted(silent_normalisations.keys()),
+                )
+            )
+
+    return divergences
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation
+# ---------------------------------------------------------------------------
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce a value so ``json.dumps`` can handle it without ``default=str``."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, set):
+        return sorted(_jsonable(v) for v in value)
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, type):
+        return value.__name__
+    return str(value)

--- a/scripts/diff_rules.py
+++ b/scripts/diff_rules.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Semantic differ for vendored rules JSON envelopes.
+
+Sibling of :mod:`scripts.diff_schemas` — same contract (safe vs breaking
+classification, JSON-on-stdout + Markdown summary), different artifact kind
+(rule cases instead of parameter schemas).
+
+Usage::
+
+    python scripts/diff_rules.py <old.json> <new.json> [--out pr-comment.md]
+
+Exit codes:
+    0 - identical or rules-safe changes only
+    1 - rules-breaking changes detected
+    2 - malformed input (missing file, not JSON, etc.)
+
+stdout : JSON with structured diff (mirrors diff_schemas.py shape)
+stderr : human-readable summary
+--out  : Markdown summary suitable for a PR comment (optional)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Change categories
+# ---------------------------------------------------------------------------
+
+SAFE_KINDS = frozenset(
+    {
+        "added_rule",
+        "severity_relaxed",
+        "match_widened",
+        "message_template_changed",
+        "emission_channel_widened",
+    }
+)
+
+BREAKING_KINDS = frozenset(
+    {
+        "removed_rule",
+        "severity_escalated",
+        "outcome_changed",
+        "match_narrowed",
+        "emission_channel_changed",
+    }
+)
+
+# Severity ordering; escalations move from less to more severe.
+_SEVERITY_RANK = {
+    "skipped_hardware_dependent": 0,
+    "no_op": 1,
+    "dormant_silent": 2,
+    "dormant_announced": 3,
+    "warn": 4,
+    "error": 5,
+}
+
+
+@dataclass
+class Change:
+    rule_id: str
+    kind: str
+    detail: str = ""
+
+    @property
+    def severity(self) -> str:
+        return "breaking" if self.kind in BREAKING_KINDS else "safe"
+
+    def as_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"rule_id": self.rule_id, "kind": self.kind}
+        if self.detail:
+            d["detail"] = self.detail
+        return d
+
+
+@dataclass
+class DiffResult:
+    safe: list[Change] = field(default_factory=list)
+    breaking: list[Change] = field(default_factory=list)
+    metadata_changes: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    @property
+    def is_breaking(self) -> bool:
+        return bool(self.breaking)
+
+    @property
+    def summary(self) -> str:
+        parts: list[str] = []
+        for k, v in self.metadata_changes.items():
+            parts.append(f"{k}: {v['old']} -> {v['new']}")
+        if self.safe:
+            parts.append(f"{len(self.safe)} rules-safe change(s)")
+        if self.breaking:
+            parts.append(f"{len(self.breaking)} rules-BREAKING change(s)")
+        if not parts:
+            parts.append("No changes")
+        return "; ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Diff primitives
+# ---------------------------------------------------------------------------
+
+
+def _index_cases(envelope: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {c["id"]: c for c in envelope.get("cases", []) if isinstance(c, dict) and "id" in c}
+
+
+def _compare_case(rule_id: str, old: dict[str, Any], new: dict[str, Any]) -> list[Change]:
+    changes: list[Change] = []
+
+    old_outcome = str(old.get("outcome", ""))
+    new_outcome = str(new.get("outcome", ""))
+    if old_outcome != new_outcome:
+        old_rank = _SEVERITY_RANK.get(old_outcome, -1)
+        new_rank = _SEVERITY_RANK.get(new_outcome, -1)
+        if new_rank > old_rank:
+            changes.append(
+                Change(
+                    rule_id=rule_id,
+                    kind="severity_escalated",
+                    detail=f"{old_outcome} -> {new_outcome}",
+                )
+            )
+        elif new_rank < old_rank:
+            changes.append(
+                Change(
+                    rule_id=rule_id,
+                    kind="severity_relaxed",
+                    detail=f"{old_outcome} -> {new_outcome}",
+                )
+            )
+        else:
+            changes.append(
+                Change(
+                    rule_id=rule_id,
+                    kind="outcome_changed",
+                    detail=f"{old_outcome} -> {new_outcome}",
+                )
+            )
+
+    old_channel = str(old.get("emission_channel", ""))
+    new_channel = str(new.get("emission_channel", ""))
+    if old_channel != new_channel:
+        if old_channel == "none" and new_channel != "none":
+            changes.append(
+                Change(
+                    rule_id=rule_id,
+                    kind="emission_channel_widened",
+                    detail=f"{old_channel} -> {new_channel}",
+                )
+            )
+        else:
+            changes.append(
+                Change(
+                    rule_id=rule_id,
+                    kind="emission_channel_changed",
+                    detail=f"{old_channel} -> {new_channel}",
+                )
+            )
+
+    old_messages = _normalise_messages(old.get("observed_messages") or [])
+    new_messages = _normalise_messages(new.get("observed_messages") or [])
+    if old_messages != new_messages:
+        changes.append(
+            Change(
+                rule_id=rule_id,
+                kind="message_template_changed",
+                detail=(f"{len(old_messages)} -> {len(new_messages)} message(s)"),
+            )
+        )
+
+    return changes
+
+
+def _normalise_messages(messages: list[Any]) -> tuple[str, ...]:
+    """Reduce messages to a tuple of stripped strings for structural compare."""
+    return tuple(sorted(str(m).strip() for m in messages))
+
+
+def diff_rules(old: dict[str, Any], new: dict[str, Any]) -> DiffResult:
+    """Compare two rules envelopes and classify per-rule changes."""
+    result = DiffResult()
+
+    for key in ("engine_version", "schema_version", "vendor_commit"):
+        old_val = old.get(key)
+        new_val = new.get(key)
+        if old_val != new_val:
+            result.metadata_changes[key] = {"old": str(old_val), "new": str(new_val)}
+
+    old_cases = _index_cases(old)
+    new_cases = _index_cases(new)
+    old_ids = set(old_cases)
+    new_ids = set(new_cases)
+
+    for rule_id in sorted(new_ids - old_ids):
+        result.safe.append(Change(rule_id=rule_id, kind="added_rule"))
+
+    for rule_id in sorted(old_ids - new_ids):
+        result.breaking.append(Change(rule_id=rule_id, kind="removed_rule"))
+
+    for rule_id in sorted(old_ids & new_ids):
+        for change in _compare_case(rule_id, old_cases[rule_id], new_cases[rule_id]):
+            if change.severity == "safe":
+                result.safe.append(change)
+            else:
+                result.breaking.append(change)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(result: DiffResult, *, title: str = "Rules Diff") -> str:
+    lines: list[str] = [f"## {title}", ""]
+    lines.append(f"**Summary:** {result.summary}")
+    lines.append("")
+
+    if result.metadata_changes:
+        lines.append("### Envelope metadata")
+        lines.append("")
+        lines.append("| Field | Old | New |")
+        lines.append("| --- | --- | --- |")
+        for k, v in result.metadata_changes.items():
+            lines.append(f"| `{k}` | `{v['old']}` | `{v['new']}` |")
+        lines.append("")
+
+    if result.breaking:
+        lines.append("### rules-breaking changes")
+        lines.append("")
+        lines.append("| Rule ID | Kind | Detail |")
+        lines.append("| --- | --- | --- |")
+        for change in result.breaking:
+            lines.append(f"| `{change.rule_id}` | `{change.kind}` | {change.detail or ''} |")
+        lines.append("")
+
+    if result.safe:
+        lines.append("### rules-safe changes")
+        lines.append("")
+        lines.append("| Rule ID | Kind | Detail |")
+        lines.append("| --- | --- | --- |")
+        for change in result.safe:
+            lines.append(f"| `{change.rule_id}` | `{change.kind}` | {change.detail or ''} |")
+        lines.append("")
+
+    if not result.metadata_changes and not result.safe and not result.breaking:
+        lines.append("_No changes detected._")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("old", type=Path, help="Path to old JSON envelope")
+    parser.add_argument("new", type=Path, help="Path to new JSON envelope")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="If given, write Markdown summary to this path.",
+    )
+    parser.add_argument(
+        "--title",
+        default="Rules Diff",
+        help="Title used in the Markdown summary.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        old = json.loads(args.old.read_text())
+        new = json.loads(args.new.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Error reading envelopes: {exc}", file=sys.stderr)
+        return 2
+
+    result = diff_rules(old, new)
+
+    output = {
+        "safe": [c.as_dict() for c in result.safe],
+        "breaking": [c.as_dict() for c in result.breaking],
+        "metadata_changes": result.metadata_changes,
+        "is_breaking": result.is_breaking,
+        "summary": result.summary,
+    }
+    print(json.dumps(output, indent=2))
+
+    print(f"\n{result.summary}", file=sys.stderr)
+    if result.breaking:
+        print("\nrules-breaking changes:", file=sys.stderr)
+        for change in result.breaking:
+            detail = f" ({change.detail})" if change.detail else ""
+            print(f"  - {change.rule_id}: {change.kind}{detail}", file=sys.stderr)
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(render_markdown(result, title=args.title))
+
+    return 1 if result.is_breaking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_engine_rules.sh
+++ b/scripts/update_engine_rules.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Re-vendor a vendored-rules JSON by running scripts/vendor_rules.py inside the
+# appropriate Docker image.
+#
+# Usage: ./scripts/update_engine_rules.sh {transformers|vllm|tensorrt}
+#
+# Mirror of scripts/update_engine_schema.sh — same idioms (Dockerfile ARG
+# lookup, image build fallback, diff-only-no-commit output) — different
+# artifact. Run this locally to re-vendor against the pinned image before
+# opening a PR; CI will re-run inside the same image on the PR branch.
+#
+# Output: src/llenergymeasure/engines/vendored_rules/<engine>.json
+# The JSON IS the canonical SSOT — authority comes from `git commit`, not
+# from who ran vendoring.
+#
+# Legitimate refresh (e.g. you bumped a Dockerfile FROM tag):
+#   review the diff, `git add`, and open a PR.
+# Exploring a fork or stale image:
+#   `git checkout src/llenergymeasure/engines/vendored_rules/<engine>.json`
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/update_engine_rules.sh {transformers|vllm|tensorrt}
+
+Builds or pulls the engine's Docker image, runs scripts/vendor_rules.py inside
+it against the tracked corpus, writes the JSON envelope, and prints the git
+diff. Does NOT commit.
+EOF
+}
+
+if [[ $# -ne 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+    usage >&2
+    exit 1
+fi
+
+ENGINE="$1"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Extract ARG default value from a Dockerfile: _arg_default <file> <NAME>
+_arg_default() {
+    grep -oE "^ARG[[:space:]]+${2}=[^[:space:]]+" "$1" | head -1 | cut -d= -f2-
+}
+
+case "$ENGINE" in
+    transformers)
+        VER="$(_arg_default "$REPO_ROOT/docker/Dockerfile.transformers" TRANSFORMERS_VERSION)"
+        IMAGE="llenergymeasure:transformers-${VER}"
+        if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "[$ENGINE] Image $IMAGE not found; building from docker/Dockerfile.transformers..." >&2
+            docker build -f "$REPO_ROOT/docker/Dockerfile.transformers" -t "$IMAGE" "$REPO_ROOT"
+        fi
+        ;;
+    vllm)
+        VER="$(_arg_default "$REPO_ROOT/docker/Dockerfile.vllm" VLLM_VERSION)"
+        IMAGE="vllm/vllm-openai:${VER}"
+        ;;
+    tensorrt)
+        VER="$(_arg_default "$REPO_ROOT/docker/Dockerfile.tensorrt" TRTLLM_VERSION)"
+        IMAGE="nvcr.io/nvidia/tensorrt-llm/release:${VER}"
+        ;;
+    *)
+        echo "Unknown engine: $ENGINE" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+CORPUS_REL="configs/validation_rules/${ENGINE}.yaml"
+OUTPUT_REL="src/llenergymeasure/engines/vendored_rules/${ENGINE}.json"
+
+if [[ ! -f "$REPO_ROOT/$CORPUS_REL" ]]; then
+    echo "[$ENGINE] Corpus $CORPUS_REL not found. Run the walker first:" >&2
+    echo "    python -m scripts.walkers.${ENGINE} --out $CORPUS_REL" >&2
+    exit 1
+fi
+
+echo "[$ENGINE] Running vendor_rules.py inside $IMAGE..." >&2
+docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    --entrypoint python3 \
+    -v "$REPO_ROOT:/repo" \
+    -w /repo \
+    "$IMAGE" \
+    scripts/vendor_rules.py \
+    --engine "$ENGINE" \
+    --corpus "/repo/$CORPUS_REL" \
+    --out "/repo/$OUTPUT_REL" \
+    --image-ref "$IMAGE" \
+    --base-image-ref "$IMAGE"
+
+cd "$REPO_ROOT"
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "[$ENGINE] Not inside a git repo — skipping diff output." >&2
+    exit 0
+fi
+
+if git diff --quiet -- "$OUTPUT_REL" 2>/dev/null; then
+    if [[ -z "$(git status --porcelain -- "$OUTPUT_REL")" ]]; then
+        echo "[$ENGINE] No changes to vendored rules JSON." >&2
+        exit 0
+    fi
+fi
+
+echo "" >&2
+echo "=== git diff --stat $OUTPUT_REL ===" >&2
+git diff --stat -- "$OUTPUT_REL" || true
+echo "" >&2
+echo "=== git diff $OUTPUT_REL (first 200 lines) ===" >&2
+git --no-pager diff -- "$OUTPUT_REL" | head -200 || true
+echo "" >&2
+cat <<EOF >&2
+Vendored rules changed.
+  - Legitimate refresh? Review the diff, \`git add $OUTPUT_REL\`, and open a PR.
+  - Exploring a custom fork or stale image? Revert with:
+      git checkout -- $OUTPUT_REL
+EOF

--- a/scripts/vendor_rules.py
+++ b/scripts/vendor_rules.py
@@ -29,7 +29,6 @@ and loaders share the same shape. Sibling by design, per §5 of the design doc.
 from __future__ import annotations
 
 import argparse
-import copy
 import json
 import os
 import sys
@@ -152,14 +151,11 @@ def _run_transformers(
 
 
 def _construct_and_validate_generation_config(kwargs: dict[str, Any], *, strict: bool) -> Any:
+    # Corpus kwargs pass through verbatim — the raw YAML shape IS the rule
+    # under test (e.g. compile_config receives a raw dict on purpose).
     from transformers import GenerationConfig  # type: ignore
 
-    # Some kwargs (e.g. "constraints") take Python objects; YAML serialisation
-    # leaves them as raw dicts/strs. The ``_prepare_transformers_kwargs``
-    # helper intentionally does not transform — the raw shape is the rule
-    # under test.
-    prepared = _prepare_transformers_kwargs(kwargs)
-    gc = GenerationConfig(**prepared)
+    gc = GenerationConfig(**kwargs)
     gc.validate(strict=strict)
     return gc
 
@@ -175,16 +171,6 @@ def _construct_generic(native_type: str, kwargs: dict[str, Any]) -> Any:
     module = __import__(module_path, fromlist=[class_name])
     cls = getattr(module, class_name)
     return cls(**kwargs)
-
-
-def _prepare_transformers_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Coerce YAML-deserialised kwargs into transformers-digestible shapes."""
-    prepared = copy.deepcopy(kwargs)
-    # ``compile_config`` / ``watermarking_config`` in the corpus intentionally
-    # pass raw dicts / None — that's the rule under test. No transformation.
-    # ``bnb_4bit_compute_dtype`` passes string dtype names; bnb accepts those
-    # for the rule under test.
-    return prepared
 
 
 _ENGINE_RUNNERS = {
@@ -258,13 +244,11 @@ def vendor_rule(engine: str, rule: dict[str, Any], *, gpu_mode: str) -> CaseResu
     emission = classify_emission_channel(pos)
 
     expected = dict(rule.get("expected_outcome") or {})
-    positive_confirmed = _positive_confirms(expected, outcome, emission, silent_normalisations)
-    negative_confirmed = _negative_confirms(
-        neg,
-        silent_normalisations_on_negative=(
-            diff_input_vs_state(kwargs_negative, neg.observed_state) if neg.observed_state else {}
-        ),
+    positive_confirmed = _positive_confirms(expected, outcome)
+    neg_silent = (
+        diff_input_vs_state(kwargs_negative, neg.observed_state) if neg.observed_state else {}
     )
+    negative_confirmed = _negative_confirms(neg, neg_silent)
 
     observed_messages = list(pos.warnings_captured) + list(pos.logger_messages)
     observed_exception: dict[str, str] | None = None
@@ -287,35 +271,35 @@ def vendor_rule(engine: str, rule: dict[str, Any], *, gpu_mode: str) -> CaseResu
     )
 
 
-def _positive_confirms(
-    expected: dict[str, Any],
-    observed_outcome: str,
-    observed_emission: str,
-    silent_normalisations: dict[str, Any],
-) -> bool:
-    """True iff the rule fired on the positive kwargs as declared."""
+_FIRING_OUTCOMES = frozenset({"error", "warn", "dormant_announced", "dormant_silent"})
+
+
+def _positive_confirms(expected: dict[str, Any], observed_outcome: str) -> bool:
+    """True iff the rule fired on the positive kwargs as declared.
+
+    When the corpus declares a specific outcome, positive_confirmed requires
+    an exact match. When the corpus leaves ``outcome`` unset, we accept any
+    non-``no_op`` observation as confirmation.
+    """
     expected_outcome = expected.get("outcome")
-    if expected_outcome in {"error", "warn", "dormant_announced", "dormant_silent"}:
+    if expected_outcome in _FIRING_OUTCOMES:
         return observed_outcome == expected_outcome
     return observed_outcome != "no_op"
 
 
-def _negative_confirms(
-    neg: CaptureBuffers, *, silent_normalisations_on_negative: dict[str, Any]
-) -> bool:
+def _negative_confirms(neg: CaptureBuffers, silent_normalisations: dict[str, Any]) -> bool:
     """True iff the rule did NOT fire on the negative kwargs.
 
-    "Did not fire" = no exception, no warning, no logged message, no silent
-    normalisation. This is a strict definition on purpose; it catches dead
-    walker entries where ``kwargs_negative`` still happens to trip the rule.
+    Strict definition — any of exception / warn / logger / silent
+    normalisation counts as firing. Catches dead walker entries where
+    ``kwargs_negative`` still happens to trip the rule.
     """
-    if neg.exception_type is not None:
-        return False
-    if neg.warnings_captured:
-        return False
-    if neg.logger_messages:
-        return False
-    return not silent_normalisations_on_negative
+    return (
+        neg.exception_type is None
+        and not neg.warnings_captured
+        and not neg.logger_messages
+        and not silent_normalisations
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -350,15 +334,10 @@ def assemble_envelope(
 
 def _case_to_dict(case: CaseResult) -> dict[str, Any]:
     d = asdict(case)
-    # Prune nulls/empties for a quieter envelope.
-    if d.get("observed_exception") is None:
-        d.pop("observed_exception", None)
-    if not d.get("observed_messages"):
-        d["observed_messages"] = []
-    if not d.get("observed_silent_normalisations"):
-        d["observed_silent_normalisations"] = {}
-    if d.get("skipped_reason") is None:
-        d.pop("skipped_reason", None)
+    # Drop nullable optional fields when unset for a quieter envelope.
+    for optional_key in ("observed_exception", "skipped_reason"):
+        if d.get(optional_key) is None:
+            d.pop(optional_key, None)
     return d
 
 
@@ -390,9 +369,12 @@ def vendor_engine(
     divergences: list[Divergence] = []
 
     for rule in corpus.get("rules", []):
+        # VendorError (and subclasses) propagate — they indicate misconfig, not
+        # a library behaviour finding. Any other Exception gets recorded as a
+        # per-rule error so one bad rule doesn't abort the full vendor run.
         try:
             case = vendor_rule(engine, rule, gpu_mode=gpu_mode)
-        except (VendorEngineNotImportable, VendorError):
+        except VendorError:
             raise
         except Exception as exc:  # pragma: no cover - defensive
             case = CaseResult(

--- a/scripts/vendor_rules.py
+++ b/scripts/vendor_rules.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Run each validation rule through the real library inside its engine container.
+
+The vendor step is the **observe half** of the "observe, don't re-encode"
+design in :doc:`.product/designs/config-deduplication-dormancy/runtime-config-validation.md`.
+The YAML corpus at ``configs/validation_rules/{engine}.yaml`` declares each
+rule's ``expected_outcome``; this script executes the rule through the
+library and records what *actually* happened. Divergence between declared and
+observed fails CI.
+
+Usage (inside the engine's Docker container)::
+
+    python scripts/vendor_rules.py \\
+        --engine transformers \\
+        --corpus configs/validation_rules/transformers.yaml \\
+        --out src/llenergymeasure/engines/vendored_rules/transformers.json
+
+Exit codes:
+
+    0 - all rules confirmed (positive + negative + expected matches observed)
+    1 - one or more divergences; JSON still written
+    2 - hard error (corpus malformed, engine not importable, etc.)
+
+The envelope structure mirrors the parameter-discovery envelope in
+``src/llenergymeasure/config/discovered_schemas/*.json`` so downstream tooling
+and loaders share the same shape. Sibling by design, per §5 of the design doc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Ensure sibling module imports resolve when run via ``python scripts/...``.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts._vendor_common import (  # noqa: E402  (late import after sys.path)
+    TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST,
+    CaptureBuffers,
+    CaseResult,
+    Divergence,
+    classify_emission_channel,
+    classify_outcome,
+    compare_expected_vs_observed,
+    diff_input_vs_state,
+    run_case,
+)
+
+SCHEMA_VERSION = "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+
+class VendorError(Exception):
+    """Base class for vendor-step errors."""
+
+
+class VendorCorpusError(VendorError):
+    """Corpus YAML is malformed or missing required fields."""
+
+
+class VendorEngineNotImportable(VendorError):
+    """The engine library is not importable in this environment."""
+
+
+class VendorDivergenceError(VendorError):
+    """One or more rules diverged from their declared expected_outcome."""
+
+    def __init__(self, divergences: list[Divergence]) -> None:
+        super().__init__(
+            f"{len(divergences)} rule(s) diverged from expected_outcome. "
+            "See the vendored JSON 'divergences' array for details."
+        )
+        self.divergences = divergences
+
+
+# ---------------------------------------------------------------------------
+# Corpus loading
+# ---------------------------------------------------------------------------
+
+
+def _load_corpus(path: Path) -> dict[str, Any]:
+    try:
+        raw_text = path.read_text()
+    except FileNotFoundError as exc:
+        raise VendorCorpusError(f"Corpus not found at {path}") from exc
+    try:
+        import yaml
+    except ImportError as exc:
+        raise VendorCorpusError("PyYAML not available; cannot parse corpus") from exc
+    data = yaml.safe_load(raw_text)
+    if not isinstance(data, dict) or "rules" not in data:
+        raise VendorCorpusError(f"Corpus at {path} must be a mapping with a top-level 'rules' key.")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Per-engine native-type runners
+# ---------------------------------------------------------------------------
+
+
+def _run_transformers(
+    native_type: str, kwargs: dict[str, Any], *, strict_validate: bool
+) -> CaptureBuffers:
+    """Execute one rule's kwargs through the transformers library.
+
+    Handles both ``GenerationConfig`` (uses ``.validate()``) and
+    ``BitsAndBytesConfig`` (construction itself raises). Other
+    ``transformers.*`` native types are reached via a fallback import.
+
+    ``strict_validate`` routes the GenerationConfig call: ``True`` raises a
+    composed ValueError listing every issue (corresponds to corpus
+    ``severity=error``); ``False`` emits dormant/announced issues via
+    ``logger.warning_once`` (corresponds to corpus ``severity=dormant``). The
+    caller picks the mode based on the rule's declared severity.
+    """
+    logger_names = (
+        "transformers",
+        "transformers.generation",
+        "transformers.generation.configuration_utils",
+    )
+    if native_type == "transformers.GenerationConfig":
+        return run_case(
+            lambda: _construct_and_validate_generation_config(kwargs, strict=strict_validate),
+            logger_names=logger_names,
+            private_allowlist=TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST,
+        )
+    if native_type == "transformers.BitsAndBytesConfig":
+        return run_case(
+            lambda: _construct_bitsandbytes_config(kwargs),
+            logger_names=logger_names,
+            private_allowlist=TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST,
+        )
+    # Fallback: treat native_type as a dotted import path.
+    return run_case(
+        lambda: _construct_generic(native_type, kwargs),
+        logger_names=logger_names,
+        private_allowlist=TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST,
+    )
+
+
+def _construct_and_validate_generation_config(kwargs: dict[str, Any], *, strict: bool) -> Any:
+    from transformers import GenerationConfig  # type: ignore
+
+    # Some kwargs (e.g. "constraints") take Python objects; YAML serialisation
+    # leaves them as raw dicts/strs. The ``_prepare_transformers_kwargs``
+    # helper intentionally does not transform — the raw shape is the rule
+    # under test.
+    prepared = _prepare_transformers_kwargs(kwargs)
+    gc = GenerationConfig(**prepared)
+    gc.validate(strict=strict)
+    return gc
+
+
+def _construct_bitsandbytes_config(kwargs: dict[str, Any]) -> Any:
+    from transformers import BitsAndBytesConfig  # type: ignore
+
+    return BitsAndBytesConfig(**kwargs)
+
+
+def _construct_generic(native_type: str, kwargs: dict[str, Any]) -> Any:
+    module_path, _, class_name = native_type.rpartition(".")
+    module = __import__(module_path, fromlist=[class_name])
+    cls = getattr(module, class_name)
+    return cls(**kwargs)
+
+
+def _prepare_transformers_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Coerce YAML-deserialised kwargs into transformers-digestible shapes."""
+    prepared = copy.deepcopy(kwargs)
+    # ``compile_config`` / ``watermarking_config`` in the corpus intentionally
+    # pass raw dicts / None — that's the rule under test. No transformation.
+    # ``bnb_4bit_compute_dtype`` passes string dtype names; bnb accepts those
+    # for the rule under test.
+    return prepared
+
+
+_ENGINE_RUNNERS = {
+    "transformers": _run_transformers,
+}
+
+
+def get_native_type_runner(engine: str):
+    """Return the per-engine dispatcher. Raises if engine unsupported."""
+    runner = _ENGINE_RUNNERS.get(engine)
+    if runner is None:
+        raise VendorError(
+            f"No vendor runner registered for engine {engine!r}. "
+            f"Known engines: {sorted(_ENGINE_RUNNERS)}"
+        )
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Per-rule driver
+# ---------------------------------------------------------------------------
+
+
+def vendor_rule(engine: str, rule: dict[str, Any], *, gpu_mode: str) -> CaseResult:
+    """Run one rule's positive + negative kwargs and assemble the case result.
+
+    ``gpu_mode`` is ``"all" | "skip" | "only"`` — hardware-dependent rules
+    are skipped unless ``gpu_mode`` permits them.
+    """
+    rule_id = rule["id"]
+    requires_gpu = bool(rule.get("requires_gpu", False))
+    hardware_dependent = bool(rule.get("hardware_dependent", False))
+
+    if gpu_mode == "skip" and (requires_gpu or hardware_dependent):
+        return CaseResult(
+            id=rule_id,
+            outcome="skipped_hardware_dependent",
+            emission_channel="none",
+            skipped_reason="requires_gpu_and_gpu_mode_skip",
+        )
+    if gpu_mode == "only" and not requires_gpu:
+        return CaseResult(
+            id=rule_id,
+            outcome="skipped_hardware_dependent",
+            emission_channel="none",
+            skipped_reason="cpu_rule_and_gpu_mode_only",
+        )
+
+    native_type = rule["native_type"]
+    runner = get_native_type_runner(engine)
+    severity = str(rule.get("severity", "")).lower()
+    # Per-engine strictness routing: transformers' GenerationConfig has a
+    # non-strict path (logger.warning for dormant/announced) and a strict
+    # path (composed ValueError for errors). Dispatch by declared severity
+    # so the vendor observation matches the corpus's expected outcome shape.
+    strict_validate = severity == "error"
+
+    kwargs_positive = dict(rule["kwargs_positive"])
+    kwargs_negative = dict(rule["kwargs_negative"])
+
+    pos = runner(native_type, kwargs_positive, strict_validate=strict_validate)
+    neg = runner(native_type, kwargs_negative, strict_validate=strict_validate)
+
+    # Silent self-assignments are only meaningful on the positive path and
+    # only when construction succeeded.
+    silent_normalisations: dict[str, dict[str, Any]] = {}
+    if pos.observed_state is not None:
+        silent_normalisations = diff_input_vs_state(kwargs_positive, pos.observed_state)
+
+    outcome = classify_outcome(pos, silent_normalisations)
+    emission = classify_emission_channel(pos)
+
+    expected = dict(rule.get("expected_outcome") or {})
+    positive_confirmed = _positive_confirms(expected, outcome, emission, silent_normalisations)
+    negative_confirmed = _negative_confirms(
+        neg,
+        silent_normalisations_on_negative=(
+            diff_input_vs_state(kwargs_negative, neg.observed_state) if neg.observed_state else {}
+        ),
+    )
+
+    observed_messages = list(pos.warnings_captured) + list(pos.logger_messages)
+    observed_exception: dict[str, str] | None = None
+    if pos.exception_type is not None:
+        observed_exception = {
+            "type": pos.exception_type,
+            "message": pos.exception_message or "",
+        }
+
+    return CaseResult(
+        id=rule_id,
+        outcome=outcome,
+        emission_channel=emission,
+        observed_messages=observed_messages,
+        observed_silent_normalisations=silent_normalisations,
+        observed_exception=observed_exception,
+        positive_confirmed=positive_confirmed,
+        negative_confirmed=negative_confirmed,
+        duration_ms=pos.duration_ms + neg.duration_ms,
+    )
+
+
+def _positive_confirms(
+    expected: dict[str, Any],
+    observed_outcome: str,
+    observed_emission: str,
+    silent_normalisations: dict[str, Any],
+) -> bool:
+    """True iff the rule fired on the positive kwargs as declared."""
+    expected_outcome = expected.get("outcome")
+    if expected_outcome in {"error", "warn", "dormant_announced", "dormant_silent"}:
+        return observed_outcome == expected_outcome
+    return observed_outcome != "no_op"
+
+
+def _negative_confirms(
+    neg: CaptureBuffers, *, silent_normalisations_on_negative: dict[str, Any]
+) -> bool:
+    """True iff the rule did NOT fire on the negative kwargs.
+
+    "Did not fire" = no exception, no warning, no logged message, no silent
+    normalisation. This is a strict definition on purpose; it catches dead
+    walker entries where ``kwargs_negative`` still happens to trip the rule.
+    """
+    if neg.exception_type is not None:
+        return False
+    if neg.warnings_captured:
+        return False
+    if neg.logger_messages:
+        return False
+    return not silent_normalisations_on_negative
+
+
+# ---------------------------------------------------------------------------
+# Envelope assembly
+# ---------------------------------------------------------------------------
+
+
+def assemble_envelope(
+    *,
+    engine: str,
+    engine_version: str,
+    image_ref: str,
+    base_image_ref: str,
+    vendor_commit: str,
+    cases: list[CaseResult],
+    divergences: list[Divergence],
+) -> dict[str, Any]:
+    """Build the vendored-rules envelope (parallel to the parameter-discovery envelope)."""
+    now = os.environ.get("LLENERGY_VENDOR_FROZEN_AT") or datetime.now(timezone.utc).isoformat()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "engine": engine,
+        "engine_version": engine_version,
+        "image_ref": image_ref,
+        "base_image_ref": base_image_ref,
+        "vendored_at": now,
+        "vendor_commit": vendor_commit,
+        "cases": [_case_to_dict(c) for c in cases],
+        "divergences": [d.as_dict() for d in divergences],
+    }
+
+
+def _case_to_dict(case: CaseResult) -> dict[str, Any]:
+    d = asdict(case)
+    # Prune nulls/empties for a quieter envelope.
+    if d.get("observed_exception") is None:
+        d.pop("observed_exception", None)
+    if not d.get("observed_messages"):
+        d["observed_messages"] = []
+    if not d.get("observed_silent_normalisations"):
+        d["observed_silent_normalisations"] = {}
+    if d.get("skipped_reason") is None:
+        d.pop("skipped_reason", None)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Main vendor loop
+# ---------------------------------------------------------------------------
+
+
+def vendor_engine(
+    *,
+    engine: str,
+    corpus_path: Path,
+    out_path: Path,
+    gpu_mode: str = "all",
+    image_ref: str | None = None,
+    base_image_ref: str | None = None,
+    vendor_commit: str = "unknown",
+) -> tuple[dict[str, Any], list[Divergence]]:
+    """Run the full vendor loop for one engine; write JSON envelope to ``out_path``.
+
+    Returns ``(envelope, divergences)``. Raises :class:`VendorEngineNotImportable`
+    if the engine library can't be imported. Does NOT raise on divergence —
+    the caller inspects the returned list and decides.
+    """
+    corpus = _load_corpus(corpus_path)
+    engine_version = _resolve_engine_version(engine)
+
+    cases: list[CaseResult] = []
+    divergences: list[Divergence] = []
+
+    for rule in corpus.get("rules", []):
+        try:
+            case = vendor_rule(engine, rule, gpu_mode=gpu_mode)
+        except (VendorEngineNotImportable, VendorError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            case = CaseResult(
+                id=rule.get("id", "<unknown>"),
+                outcome="error",
+                emission_channel="none",
+                observed_exception={"type": type(exc).__name__, "message": str(exc)},
+            )
+        cases.append(case)
+
+        if case.skipped_reason is not None:
+            continue
+
+        rule_divergences = compare_expected_vs_observed(
+            rule_id=rule["id"],
+            expected=rule.get("expected_outcome") or {},
+            observed_outcome=case.outcome,
+            observed_emission=case.emission_channel,
+            silent_normalisations=case.observed_silent_normalisations,
+        )
+        if not case.positive_confirmed:
+            rule_divergences.append(
+                Divergence(
+                    rule_id=rule["id"],
+                    field="positive_confirmed",
+                    expected=True,
+                    observed=False,
+                )
+            )
+        if not case.negative_confirmed:
+            rule_divergences.append(
+                Divergence(
+                    rule_id=rule["id"],
+                    field="negative_confirmed",
+                    expected=True,
+                    observed=False,
+                )
+            )
+        divergences.extend(rule_divergences)
+
+    envelope = assemble_envelope(
+        engine=engine,
+        engine_version=engine_version,
+        image_ref=image_ref or f"llenergymeasure:{engine}",
+        base_image_ref=base_image_ref or f"llenergymeasure:{engine}",
+        vendor_commit=vendor_commit,
+        cases=cases,
+        divergences=divergences,
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(envelope, indent=2, sort_keys=False) + "\n")
+
+    return envelope, divergences
+
+
+def _resolve_engine_version(engine: str) -> str:
+    """Best-effort: return the installed library's version or ``"unknown"``."""
+    if engine == "transformers":
+        try:
+            import transformers  # type: ignore
+
+            return transformers.__version__
+        except ImportError as exc:
+            raise VendorEngineNotImportable(
+                "transformers is not importable in this environment"
+            ) from exc
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--engine",
+        required=True,
+        choices=sorted(_ENGINE_RUNNERS),
+        help="Engine whose corpus to vendor.",
+    )
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        required=True,
+        help="Path to the YAML corpus file.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Path to write the vendored JSON envelope.",
+    )
+    parser.add_argument(
+        "--gpu-cases",
+        choices=("all", "skip", "only"),
+        default="all",
+        help=(
+            "Which rules to run. 'skip' drops rules with requires_gpu=true "
+            "(for GH-hosted CPU jobs); 'only' runs only those (for self-hosted "
+            "GPU jobs); 'all' runs everything (default, useful locally)."
+        ),
+    )
+    parser.add_argument(
+        "--image-ref",
+        default=None,
+        help="Image reference to record in envelope.image_ref.",
+    )
+    parser.add_argument(
+        "--base-image-ref",
+        default=None,
+        help="Base image reference to record in envelope.base_image_ref.",
+    )
+    parser.add_argument(
+        "--vendor-commit",
+        default=os.environ.get("GITHUB_SHA", "unknown"),
+        help=(
+            "Git commit SHA under which this vendor run occurred. Defaults to "
+            "$GITHUB_SHA when CI runs set it; otherwise 'unknown'."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-divergence",
+        action="store_true",
+        help=(
+            "Exit 1 if any rule diverged from its expected_outcome. CI always "
+            "passes this flag; locally it's off by default so developers can "
+            "inspect the JSON without CI-style exit."
+        ),
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        _envelope, divergences = vendor_engine(
+            engine=args.engine,
+            corpus_path=args.corpus,
+            out_path=args.out,
+            gpu_mode=args.gpu_cases,
+            image_ref=args.image_ref,
+            base_image_ref=args.base_image_ref,
+            vendor_commit=args.vendor_commit,
+        )
+    except VendorCorpusError as exc:
+        print(f"[{args.engine}] corpus error: {exc}", file=sys.stderr)
+        return 2
+    except VendorEngineNotImportable as exc:
+        print(f"[{args.engine}] engine not importable: {exc}", file=sys.stderr)
+        return 2
+    except VendorError as exc:
+        print(f"[{args.engine}] vendor error: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"[{args.engine}] wrote {args.out}", file=sys.stderr)
+    if divergences:
+        print(
+            f"[{args.engine}] {len(divergences)} divergence(s) — see JSON 'divergences' array.",
+            file=sys.stderr,
+        )
+        for d in divergences[:10]:
+            print(
+                f"  - {d.rule_id}: {d.field} expected={d.expected!r} observed={d.observed!r}",
+                file=sys.stderr,
+            )
+        if len(divergences) > 10:
+            print(f"  ... and {len(divergences) - 10} more.", file=sys.stderr)
+        if args.fail_on_divergence:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/walkers/_fixpoint_test.py
+++ b/scripts/walkers/_fixpoint_test.py
@@ -1,0 +1,330 @@
+"""Shuffle-application fixpoint test for the dormant-rule canonicaliser.
+
+The canonicaliser itself lands in Wave 2 (phase 50.3a). This module ships
+the CI-time *contract test* that corpora it consumes must satisfy:
+
+1. **Idempotent** — applying the same rule twice leaves the state unchanged.
+2. **Order-independent at fixpoint** — multiple random application orderings
+   converge to the same canonical form.
+3. **Cycle-free** — no rule pair alternates values indefinitely.
+
+The test operates on a declarative projection of each rule: a dormant rule
+declares ``normalised_fields`` in ``expected_outcome``, and the "fix" is
+setting each normalised field to its declared default (from the predicate's
+``not_equal`` operand, falling back to ``None``). This is sufficient to catch
+the structural failure modes the canonicaliser would trip on — we don't need
+the canonicaliser itself to prove shuffle-stability of the *rules*.
+
+Imported by ``scripts/vendor_rules.py`` and by ``tests/unit/scripts/walkers/test_fixpoint.py``.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+_MAX_ITER = 50
+"""Maximum passes per ordering before declaring non-convergence.
+
+Each pass is one full sweep over all rules. A corpus of N rules converges in
+at most N passes when all rules commute; more iterations tolerate mild
+order-dependence without false-positive cycle detection.
+"""
+
+_DEFAULT_SHUFFLE_COUNT = 5
+"""Number of random orderings to try per input state.
+
+Proposal in PLAN §"Open questions at P2 implementation time" — 5 is fast and
+catches cycles empirically. Bumped via ``shuffle_count`` if needed.
+"""
+
+
+class FixpointError(Exception):
+    """Base class for fixpoint-test failures."""
+
+
+class CanonicaliserCycleError(FixpointError):
+    """A rule ordering failed to converge within ``_MAX_ITER`` passes."""
+
+    def __init__(self, ordering: list[str], final_state: dict[str, Any]) -> None:
+        super().__init__(
+            f"Canonicaliser cycle: ordering {ordering[:5]}... did not converge "
+            f"within {_MAX_ITER} passes. Last state: {final_state!r}"
+        )
+        self.ordering = ordering
+        self.final_state = final_state
+
+
+class NonIdempotentRuleError(FixpointError):
+    """A single rule changed state on second application."""
+
+    def __init__(self, rule_id: str, state_pass1: Any, state_pass2: Any) -> None:
+        super().__init__(
+            f"Rule {rule_id!r} is non-idempotent: "
+            f"pass1 -> {state_pass1!r}, pass2 -> {state_pass2!r}"
+        )
+        self.rule_id = rule_id
+
+
+class OrderDependentRuleError(FixpointError):
+    """Two orderings produced different fixed points."""
+
+    def __init__(
+        self, state_a: dict[str, Any], state_b: dict[str, Any], offending_rules: list[str]
+    ) -> None:
+        super().__init__(
+            f"Order-dependent corpus: different orderings produced different "
+            f"fixed points. Diff: {_dict_diff(state_a, state_b)!r}. "
+            f"Involved rules: {offending_rules!r}"
+        )
+        self.state_a = state_a
+        self.state_b = state_b
+        self.offending_rules = offending_rules
+
+
+# ---------------------------------------------------------------------------
+# Rule representation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ProjectedRule:
+    """Minimal shape the fixpoint test needs from a corpus rule."""
+
+    id: str
+    severity: str
+    match_fields: dict[str, Any]
+    normalised_fields: tuple[str, ...]
+
+    def applies(self, state: dict[str, Any]) -> bool:
+        """True iff every ``match_fields`` predicate holds on ``state``."""
+        for path, spec in self.match_fields.items():
+            actual = state.get(path)
+            if not _evaluate(actual, spec):
+                return False
+        return True
+
+    def apply(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Return a new state with the normalised fields stripped to defaults."""
+        next_state = dict(state)
+        for field_path in self.normalised_fields:
+            next_state[field_path] = None
+        return next_state
+
+
+def _evaluate(actual: Any, spec: Any) -> bool:
+    """Minimal predicate evaluator — supports the operator shapes in the corpus."""
+    if isinstance(spec, dict):
+        if not spec:
+            return True
+        for op, value in spec.items():
+            if op == "==" and actual != value:
+                return False
+            if op == "!=" and actual == value:
+                return False
+            if op == "<" and not (actual is not None and actual < value):
+                return False
+            if op == "<=" and not (actual is not None and actual <= value):
+                return False
+            if op == ">" and not (actual is not None and actual > value):
+                return False
+            if op == ">=" and not (actual is not None and actual >= value):
+                return False
+            if op == "in" and actual not in value:
+                return False
+            if op == "not_in" and actual in value:
+                return False
+            if op == "present" and (actual is None) == bool(value):
+                return False
+            if op == "absent" and (actual is not None) == bool(value):
+                return False
+            if op == "equals" and actual != value:
+                return False
+            if op == "not_equal" and (actual is None or actual == value):
+                return False
+        return True
+    return bool(actual == spec)
+
+
+# ---------------------------------------------------------------------------
+# Corpus ingestion
+# ---------------------------------------------------------------------------
+
+
+def load_dormant_rules(corpus: dict[str, Any]) -> list[_ProjectedRule]:
+    """Return the ``_ProjectedRule`` view of every dormant rule in the corpus."""
+    rules: list[_ProjectedRule] = []
+    for raw in corpus.get("rules", []):
+        if str(raw.get("severity", "")).lower() != "dormant":
+            continue
+        match = raw.get("match") or {}
+        fields = match.get("fields") if isinstance(match, dict) else None
+        if not isinstance(fields, dict):
+            continue
+        normalised = tuple(
+            str(f) for f in (raw.get("expected_outcome") or {}).get("normalised_fields", [])
+        )
+        rules.append(
+            _ProjectedRule(
+                id=str(raw["id"]),
+                severity="dormant",
+                match_fields=dict(fields),
+                normalised_fields=normalised,
+            )
+        )
+    return rules
+
+
+def construct_seed_states(rules: Iterable[_ProjectedRule]) -> list[dict[str, Any]]:
+    """One representative input state per rule, sufficient to activate its match.
+
+    Builds the minimal state from each rule's match predicates — for each
+    field, picks a concrete value that satisfies the spec. This keeps the
+    fixpoint sweep from needing real ``ExperimentConfig`` objects.
+    """
+    seeds: list[dict[str, Any]] = []
+    for rule in rules:
+        state: dict[str, Any] = {}
+        for path, spec in rule.match_fields.items():
+            state[path] = _value_satisfying(spec)
+        # For dormant rules, fields scheduled to normalise must be set to a
+        # non-default so the first application has something to strip.
+        for path in rule.normalised_fields:
+            state.setdefault(path, _value_satisfying({"present": True}))
+        seeds.append(state)
+    return seeds
+
+
+def _value_satisfying(spec: Any) -> Any:
+    """Pick a concrete value that satisfies ``spec`` (used only for seeding)."""
+    if isinstance(spec, dict):
+        if "==" in spec or "equals" in spec:
+            return spec.get("==", spec.get("equals"))
+        if spec.get("in"):
+            return spec["in"][0]
+        if "not_in" in spec:
+            return "__sentinel_not_in_list__"
+        if "<" in spec:
+            return spec["<"] - 1 if isinstance(spec["<"], (int, float)) else 0
+        if "<=" in spec:
+            return spec["<="]
+        if ">" in spec:
+            return spec[">"] + 1 if isinstance(spec[">"], (int, float)) else 1
+        if ">=" in spec:
+            return spec[">="]
+        if "not_equal" in spec:
+            sentinel = spec["not_equal"]
+            if isinstance(sentinel, bool):
+                return not sentinel
+            if isinstance(sentinel, (int, float)):
+                return sentinel + 1
+            return f"__sentinel_not_{sentinel!r}__"
+        if spec.get("present"):
+            return "__sentinel_present__"
+        if spec.get("absent"):
+            return None
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Fixpoint sweep
+# ---------------------------------------------------------------------------
+
+
+def apply_to_fixpoint(
+    state: dict[str, Any],
+    rules: list[_ProjectedRule],
+) -> tuple[dict[str, Any], list[str]]:
+    """Apply rules in the given order repeatedly until the state stops changing.
+
+    Returns ``(final_state, applied_rule_ids)``. Raises :class:`CanonicaliserCycleError`
+    if ``_MAX_ITER`` passes fail to converge.
+    """
+    current = dict(state)
+    applied: list[str] = []
+    for _pass in range(_MAX_ITER):
+        changed = False
+        for rule in rules:
+            if rule.applies(current):
+                next_state = rule.apply(current)
+                if next_state != current:
+                    current = next_state
+                    applied.append(rule.id)
+                    changed = True
+        if not changed:
+            return current, applied
+    raise CanonicaliserCycleError([r.id for r in rules], current)
+
+
+def assert_idempotent(rule: _ProjectedRule, seed: dict[str, Any]) -> None:
+    """Confirm that applying ``rule`` twice is the same as applying it once."""
+    if not rule.applies(seed):
+        return
+    pass1 = rule.apply(seed)
+    pass2 = rule.apply(pass1)
+    if pass1 != pass2:
+        raise NonIdempotentRuleError(rule.id, pass1, pass2)
+
+
+def assert_shuffle_stable(
+    rules: list[_ProjectedRule],
+    seed: dict[str, Any],
+    *,
+    shuffle_count: int = _DEFAULT_SHUFFLE_COUNT,
+    seed_rng: int = 0,
+) -> dict[str, Any]:
+    """Confirm that ``shuffle_count`` orderings all produce the same fixed point.
+
+    Returns the canonical final state (shared across orderings). Raises
+    :class:`OrderDependentRuleError` on divergence or :class:`CanonicaliserCycleError`
+    on non-convergence.
+    """
+    rng = random.Random(seed_rng)
+    reference, reference_applied = apply_to_fixpoint(seed, rules)
+    for _ in range(shuffle_count - 1):
+        ordering = list(rules)
+        rng.shuffle(ordering)
+        candidate, candidate_applied = apply_to_fixpoint(seed, ordering)
+        if candidate != reference:
+            offending = sorted(set(reference_applied) ^ set(candidate_applied))
+            raise OrderDependentRuleError(reference, candidate, offending)
+    return reference
+
+
+def fixpoint_test_corpus(
+    corpus: dict[str, Any], *, shuffle_count: int = _DEFAULT_SHUFFLE_COUNT
+) -> None:
+    """Run the full shuffle-application test suite on a corpus dict.
+
+    Raises on any failure. Returns silently on success.
+    """
+    rules = load_dormant_rules(corpus)
+    if not rules:
+        return
+    seeds = construct_seed_states(rules)
+    for rule, seed in zip(rules, seeds, strict=False):
+        assert_idempotent(rule, seed)
+    # Shuffle stability runs against each seed — a single failure anywhere
+    # surfaces the corpus problem regardless of which rule triggered it.
+    for seed in seeds:
+        assert_shuffle_stable(rules, seed, shuffle_count=shuffle_count)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dict_diff(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    """Shallow diff of two dicts for error messages."""
+    keys = set(a) | set(b)
+    return {k: {"a": a.get(k), "b": b.get(k)} for k in sorted(keys) if a.get(k) != b.get(k)}

--- a/src/llenergymeasure/engines/vendored_rules/loader.py
+++ b/src/llenergymeasure/engines/vendored_rules/loader.py
@@ -13,15 +13,19 @@ from parameter-discovery — same envelope validation
 per-instance caching for test isolation, same lazy load pattern.
 
 Corpus vs vendored JSON:
-  Phase 50.2a (this PR) consumes the YAML corpus directly. Phase 50.2b
-  adds the vendor CI pipeline which emits ``{engine}.json`` files alongside
-  the corpus; the loader will grow a JSON consumption path then. The JSON
-  path is sketched below but disabled — hooks are in place, no user impact.
+  Phase 50.2a seeded the loader against the YAML corpus. Phase 50.2b
+  (this phase) adds JSON path consumption: when a vendored JSON envelope
+  exists alongside the corpus (produced by ``scripts/vendor_rules.py``),
+  the loader prefers it — it is the CI-validated projection of the corpus.
+  On missing JSON, the loader falls back to the YAML corpus so local
+  development without a vendor run still works.
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -288,6 +292,7 @@ def _parse_envelope(engine: str, raw_text: str) -> VendoredRules:
 
 
 _DEFAULT_CORPUS_ROOT = Path(__file__).resolve().parents[4] / "configs" / "validation_rules"
+_VENDORED_JSON_PACKAGE = "llenergymeasure.engines.vendored_rules"
 
 
 class VendoredRulesLoader:
@@ -295,6 +300,13 @@ class VendoredRulesLoader:
 
     Per-instance cache (rather than module-level LRU) — tests can instantiate
     a loader and monkeypatch ``corpus_root`` without polluting other tests.
+
+    Load order (picked up automatically):
+      1. **Vendored JSON** shipped beside this module
+         (``{engine}.json``) — CI-validated observed behaviour, preferred
+         whenever present. Written by ``scripts/vendor_rules.py``.
+      2. **YAML corpus** under ``configs/validation_rules/{engine}.yaml`` —
+         the walker-seeded source of truth; always present in-repo.
     """
 
     def __init__(self, corpus_root: Path | None = None) -> None:
@@ -302,19 +314,33 @@ class VendoredRulesLoader:
         self._cache: dict[str, VendoredRules] = {}
 
     def load_rules(self, engine: str) -> VendoredRules:
-        """Return the parsed corpus for ``engine``, parsing once per engine."""
+        """Return the parsed corpus for ``engine``, parsing once per engine.
+
+        Prefers the CI-validated vendored JSON when present; falls back to
+        the in-tree YAML corpus otherwise. The JSON envelope carries observed
+        outcomes per rule — these populate the returned ``Rule.expected_outcome``
+        so downstream consumers see empirically-confirmed behaviour rather
+        than the corpus's declared shape.
+        """
         cached = self._cache.get(engine)
         if cached is not None:
             return cached
-        path = self.corpus_root / f"{engine}.yaml"
+
+        yaml_path = self.corpus_root / f"{engine}.yaml"
         try:
-            raw_text = path.read_text()
+            yaml_text = yaml_path.read_text()
         except FileNotFoundError as exc:
             raise FileNotFoundError(
-                f"Vendored rules for engine {engine!r} not found at {path}. "
-                f"Run `python -m scripts.walkers.{engine} --out {path}` to generate."
+                f"Vendored rules for engine {engine!r} not found at {yaml_path}. "
+                f"Run `python -m scripts.walkers.{engine} --out {yaml_path}` to generate."
             ) from exc
-        parsed = _parse_envelope(engine, raw_text)
+
+        parsed = _parse_envelope(engine, yaml_text)
+
+        vendored_json = _try_load_vendored_json(engine)
+        if vendored_json is not None:
+            parsed = _overlay_vendored_observations(parsed, vendored_json)
+
         self._cache[engine] = parsed
         return parsed
 
@@ -324,3 +350,67 @@ class VendoredRulesLoader:
             self._cache.clear()
         else:
             self._cache.pop(engine, None)
+
+
+def _try_load_vendored_json(engine: str) -> dict[str, Any] | None:
+    """Return parsed vendored-rules JSON for ``engine`` or ``None`` if absent."""
+    try:
+        raw = (resources.files(_VENDORED_JSON_PACKAGE) / f"{engine}.json").read_text()
+    except (FileNotFoundError, ModuleNotFoundError):
+        return None
+    try:
+        parsed: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed
+
+
+def _overlay_vendored_observations(
+    parsed: VendoredRules, vendored: dict[str, Any]
+) -> VendoredRules:
+    """Overlay observed outcomes from a vendored JSON envelope onto the corpus rules.
+
+    The corpus carries the declared shape; the vendored JSON carries what CI
+    observed. On presence of JSON, the loader surfaces the observed fields so
+    consumers (the generic validator in 50.2c) can act on CI-validated truth.
+    """
+    cases = {c["id"]: c for c in vendored.get("cases", []) if isinstance(c, dict) and "id" in c}
+    overlaid: list[Rule] = []
+    for rule in parsed.rules:
+        observed = cases.get(rule.id)
+        if observed is None:
+            overlaid.append(rule)
+            continue
+        merged_expected = dict(rule.expected_outcome)
+        if "outcome" in observed:
+            merged_expected.setdefault("observed_outcome", observed["outcome"])
+        if "emission_channel" in observed:
+            merged_expected.setdefault("observed_emission_channel", observed["emission_channel"])
+        if observed.get("observed_messages"):
+            merged_expected.setdefault("observed_messages", list(observed["observed_messages"]))
+        overlaid.append(
+            Rule(
+                id=rule.id,
+                engine=rule.engine,
+                library=rule.library,
+                rule_under_test=rule.rule_under_test,
+                severity=rule.severity,
+                native_type=rule.native_type,
+                match_engine=rule.match_engine,
+                match_fields=dict(rule.match_fields),
+                kwargs_positive=dict(rule.kwargs_positive),
+                kwargs_negative=dict(rule.kwargs_negative),
+                expected_outcome=merged_expected,
+                message_template=rule.message_template,
+                walker_source=dict(rule.walker_source),
+                references=rule.references,
+                added_by=rule.added_by,
+                added_at=rule.added_at,
+            )
+        )
+    return VendoredRules(
+        engine=parsed.engine,
+        schema_version=parsed.schema_version,
+        engine_version=parsed.engine_version,
+        rules=tuple(overlaid),
+    )

--- a/src/llenergymeasure/engines/vendored_rules/loader.py
+++ b/src/llenergymeasure/engines/vendored_rules/loader.py
@@ -24,7 +24,7 @@ Corpus vs vendored JSON:
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -375,42 +375,24 @@ def _overlay_vendored_observations(
     consumers (the generic validator in 50.2c) can act on CI-validated truth.
     """
     cases = {c["id"]: c for c in vendored.get("cases", []) if isinstance(c, dict) and "id" in c}
-    overlaid: list[Rule] = []
-    for rule in parsed.rules:
-        observed = cases.get(rule.id)
-        if observed is None:
-            overlaid.append(rule)
-            continue
-        merged_expected = dict(rule.expected_outcome)
-        if "outcome" in observed:
-            merged_expected.setdefault("observed_outcome", observed["outcome"])
-        if "emission_channel" in observed:
-            merged_expected.setdefault("observed_emission_channel", observed["emission_channel"])
-        if observed.get("observed_messages"):
-            merged_expected.setdefault("observed_messages", list(observed["observed_messages"]))
-        overlaid.append(
-            Rule(
-                id=rule.id,
-                engine=rule.engine,
-                library=rule.library,
-                rule_under_test=rule.rule_under_test,
-                severity=rule.severity,
-                native_type=rule.native_type,
-                match_engine=rule.match_engine,
-                match_fields=dict(rule.match_fields),
-                kwargs_positive=dict(rule.kwargs_positive),
-                kwargs_negative=dict(rule.kwargs_negative),
-                expected_outcome=merged_expected,
-                message_template=rule.message_template,
-                walker_source=dict(rule.walker_source),
-                references=rule.references,
-                added_by=rule.added_by,
-                added_at=rule.added_at,
-            )
-        )
-    return VendoredRules(
-        engine=parsed.engine,
-        schema_version=parsed.schema_version,
-        engine_version=parsed.engine_version,
-        rules=tuple(overlaid),
-    )
+    overlaid = tuple(_overlay_rule(rule, cases.get(rule.id)) for rule in parsed.rules)
+    return replace(parsed, rules=overlaid)
+
+
+_OBSERVED_KEY_MAP = {
+    "outcome": "observed_outcome",
+    "emission_channel": "observed_emission_channel",
+    "observed_messages": "observed_messages",
+}
+
+
+def _overlay_rule(rule: Rule, observed: dict[str, Any] | None) -> Rule:
+    """Merge observed-* fields from a vendor case into a rule's expected_outcome."""
+    if observed is None:
+        return rule
+    merged = dict(rule.expected_outcome)
+    for vendored_key, expected_key in _OBSERVED_KEY_MAP.items():
+        value = observed.get(vendored_key)
+        if value not in (None, [], {}):
+            merged.setdefault(expected_key, list(value) if isinstance(value, list) else value)
+    return replace(rule, expected_outcome=merged)

--- a/src/llenergymeasure/engines/vendored_rules/transformers.json
+++ b/src/llenergymeasure/engines/vendored_rules/transformers.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0.0",
   "engine": "transformers",
-  "engine_version": "4.57.6",
-  "image_ref": "llenergymeasure:transformers-4.57.6",
-  "base_image_ref": "llenergymeasure:transformers-4.57.6",
-  "vendored_at": "2026-04-23T00:00:00+00:00",
-  "vendor_commit": "initial-seed",
+  "engine_version": "4.51.0",
+  "image_ref": "llenergymeasure:transformers",
+  "base_image_ref": "llenergymeasure:transformers",
+  "vendored_at": "2026-04-23T02:51:45.996171+00:00",
+  "vendor_commit": "7c59b1c875c03f9fcfdc6072575f1602241f0ee8",
   "cases": [
     {
       "id": "transformers_bnb_bnb_4bit_compute_dtype_type",
@@ -15,7 +15,7 @@
       "observed_silent_normalisations": {},
       "positive_confirmed": false,
       "negative_confirmed": true,
-      "duration_ms": 5
+      "duration_ms": 11
     },
     {
       "id": "transformers_bnb_bnb_4bit_quant_type_type",
@@ -134,17 +134,16 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0",
-        "Detected torch version: 2.10.0"
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0"
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -152,17 +151,21 @@
         "message": "You provided `compile_config` as an instance of <class 'dict'>, but it must be an instance of `CompileConfig`."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true,
-      "duration_ms": 27
+      "negative_confirmed": false,
+      "duration_ms": 103
     },
     {
       "id": "transformers_diversity_penalty_requires_diverse_beams",
-      "outcome": "no_op",
+      "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": false,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
@@ -176,147 +179,105 @@
         "message": "Greedy methods without beam search do not support `num_return_sequences` different than 1 (got 3)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_greedy_strips_epsilon_cutoff",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_greedy_strips_eta_cutoff",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_greedy_strips_min_p",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['min_p'].",
-        "The following generation flags are not valid and may be ignored: ['min_p'].",
-        "The following generation flags are not valid and may be ignored: ['min_p'].",
-        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_greedy_strips_temperature",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['temperature'].",
-        "The following generation flags are not valid and may be ignored: ['temperature'].",
-        "The following generation flags are not valid and may be ignored: ['temperature'].",
-        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_greedy_strips_top_k",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['top_k'].",
-        "The following generation flags are not valid and may be ignored: ['top_k'].",
-        "The following generation flags are not valid and may be ignored: ['top_k'].",
-        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `40` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `40` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `40` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_greedy_strips_top_p",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['top_p'].",
-        "The following generation flags are not valid and may be ignored: ['top_p'].",
-        "The following generation flags are not valid and may be ignored: ['top_p'].",
-        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.95` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.95` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.95` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_greedy_strips_typical_p",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['typical_p'].",
-        "The following generation flags are not valid and may be ignored: ['typical_p'].",
-        "The following generation flags are not valid and may be ignored: ['typical_p'].",
-        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
@@ -327,10 +288,10 @@
       "observed_silent_normalisations": {},
       "observed_exception": {
         "type": "ValueError",
-        "message": "Invalid `cache_implementation` (nonsense). Choose one of: ('static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'offloaded_hybrid', 'offloaded_hybrid_chunked', 'dynamic', 'dynamic_full', 'offloaded', 'quantized')"
+        "message": "Invalid `cache_implementation` (nonsense). Choose one of: ['static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'mamba', 'quantized', 'static', 'offloaded', 'dynamic']"
       },
       "positive_confirmed": true,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
@@ -358,41 +319,35 @@
         "message": "`max_new_tokens` must be greater than 0, but is -1."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_negative_pad_token_id",
       "outcome": "error",
       "emission_channel": "none",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "observed_messages": [],
       "observed_silent_normalisations": {},
       "observed_exception": {
-        "type": "ValueError",
-        "message": "GenerationConfig is invalid: \n- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation\nIf you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
       },
       "positive_confirmed": true,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_num_beams_not_divisible_by_groups",
-      "outcome": "no_op",
+      "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": false,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "`diversity_penalty` is not 0.0 or `num_beam_groups` is not 1, triggering group beam search. In this generation mode, `num_beams` should be divisible by `num_beam_groups`"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
@@ -406,84 +361,91 @@
         "message": "`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_single_beam_strips_constraints",
-      "outcome": "no_op",
+      "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [],
       "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
       "positive_confirmed": false,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_single_beam_strips_diversity_penalty",
-      "outcome": "no_op",
+      "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [],
       "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
       "positive_confirmed": false,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_single_beam_strips_early_stopping",
-      "outcome": "no_op",
+      "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [],
       "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
       "positive_confirmed": false,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_single_beam_strips_length_penalty",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning",
-      "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
-        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
-        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
-        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `2.0` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `2.0` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `2.0` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
-      ],
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true,
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_single_beam_strips_num_beam_groups",
-      "outcome": "no_op",
+      "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [],
       "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
       "positive_confirmed": false,
-      "negative_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     },
     {
       "id": "transformers_watermarking_config_type",
-      "outcome": "dormant_silent",
+      "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [],
-      "observed_silent_normalisations": {
-        "watermarking_config": {
-          "declared": {
-            "greenlist_ratio": 0.25
-          },
-          "observed": "WatermarkingConfig()"
-        }
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
       },
-      "positive_confirmed": false,
-      "negative_confirmed": true,
+      "positive_confirmed": true,
+      "negative_confirmed": false,
       "duration_ms": 0
     }
   ],
@@ -501,58 +463,196 @@
       "observed": false
     },
     {
-      "rule_id": "transformers_diversity_penalty_requires_diverse_beams",
-      "field": "outcome",
-      "expected": "error",
-      "observed": "no_op"
+      "rule_id": "transformers_compile_config_type",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
     },
     {
       "rule_id": "transformers_diversity_penalty_requires_diverse_beams",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_rejects_num_return_sequences",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
       "field": "positive_confirmed",
       "expected": true,
       "observed": false
     },
     {
       "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "emission_channel",
-      "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
     },
     {
       "rule_id": "transformers_greedy_strips_eta_cutoff",
       "field": "emission_channel",
       "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
     },
     {
       "rule_id": "transformers_greedy_strips_min_p",
       "field": "emission_channel",
       "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
     },
     {
       "rule_id": "transformers_greedy_strips_temperature",
       "field": "emission_channel",
       "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
     },
     {
       "rule_id": "transformers_greedy_strips_top_k",
       "field": "emission_channel",
       "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
     },
     {
       "rule_id": "transformers_greedy_strips_top_p",
       "field": "emission_channel",
       "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
     },
     {
       "rule_id": "transformers_greedy_strips_typical_p",
       "field": "emission_channel",
       "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_invalid_cache_implementation",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
     },
     {
       "rule_id": "transformers_invalid_early_stopping",
@@ -561,14 +661,26 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_negative_max_new_tokens",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
       "rule_id": "transformers_num_beams_not_divisible_by_groups",
-      "field": "outcome",
-      "expected": "error",
-      "observed": "no_op"
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
     },
     {
-      "rule_id": "transformers_num_beams_not_divisible_by_groups",
-      "field": "positive_confirmed",
+      "rule_id": "transformers_num_return_sequences_exceeds_num_beams",
+      "field": "negative_confirmed",
       "expected": true,
       "observed": false
     },
@@ -576,7 +688,7 @@
       "rule_id": "transformers_single_beam_strips_constraints",
       "field": "outcome",
       "expected": "dormant_announced",
-      "observed": "no_op"
+      "observed": "error"
     },
     {
       "rule_id": "transformers_single_beam_strips_constraints",
@@ -591,10 +703,16 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_single_beam_strips_constraints",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
       "rule_id": "transformers_single_beam_strips_diversity_penalty",
       "field": "outcome",
       "expected": "dormant_announced",
-      "observed": "no_op"
+      "observed": "error"
     },
     {
       "rule_id": "transformers_single_beam_strips_diversity_penalty",
@@ -609,10 +727,16 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
       "rule_id": "transformers_single_beam_strips_early_stopping",
       "field": "outcome",
       "expected": "dormant_announced",
-      "observed": "no_op"
+      "observed": "error"
     },
     {
       "rule_id": "transformers_single_beam_strips_early_stopping",
@@ -622,21 +746,45 @@
     },
     {
       "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
       "field": "positive_confirmed",
       "expected": true,
       "observed": false
     },
     {
       "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "emission_channel",
-      "expected": "minor_issues_dict",
-      "observed": "logger_warning"
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
     },
     {
       "rule_id": "transformers_single_beam_strips_num_beam_groups",
       "field": "outcome",
       "expected": "dormant_announced",
-      "observed": "no_op"
+      "observed": "error"
     },
     {
       "rule_id": "transformers_single_beam_strips_num_beam_groups",
@@ -651,14 +799,14 @@
       "observed": false
     },
     {
-      "rule_id": "transformers_watermarking_config_type",
-      "field": "outcome",
-      "expected": "error",
-      "observed": "dormant_silent"
+      "rule_id": "transformers_single_beam_strips_num_beam_groups",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
     },
     {
       "rule_id": "transformers_watermarking_config_type",
-      "field": "positive_confirmed",
+      "field": "negative_confirmed",
       "expected": true,
       "observed": false
     }

--- a/src/llenergymeasure/engines/vendored_rules/transformers.json
+++ b/src/llenergymeasure/engines/vendored_rules/transformers.json
@@ -1,0 +1,666 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "transformers",
+  "engine_version": "4.57.6",
+  "image_ref": "llenergymeasure:transformers-4.57.6",
+  "base_image_ref": "llenergymeasure:transformers-4.57.6",
+  "vendored_at": "2026-04-23T00:00:00+00:00",
+  "vendor_commit": "initial-seed",
+  "cases": [
+    {
+      "id": "transformers_bnb_bnb_4bit_compute_dtype_type",
+      "outcome": "no_op",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 5
+    },
+    {
+      "id": "transformers_bnb_bnb_4bit_quant_type_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "bnb_4bit_quant_type must be a string"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_bnb_bnb_4bit_use_double_quant_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "bnb_4bit_use_double_quant must be a boolean"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_bnb_llm_int8_enable_fp32_cpu_offload_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "llm_int8_enable_fp32_cpu_offload must be a boolean"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_bnb_llm_int8_has_fp16_weight_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "llm_int8_has_fp16_weight must be a boolean"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_bnb_llm_int8_skip_modules_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "llm_int8_skip_modules must be a list of strings"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_bnb_llm_int8_threshold_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "llm_int8_threshold must be a float"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_bnb_load_in_4bit_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "load_in_4bit must be a boolean"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_bnb_load_in_8bit_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "load_in_8bit must be a boolean"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_compile_config_type",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0",
+        "Detected torch version: 2.10.0"
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "You provided `compile_config` as an instance of <class 'dict'>, but it must be an instance of `CompileConfig`."
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 27
+    },
+    {
+      "id": "transformers_diversity_penalty_requires_diverse_beams",
+      "outcome": "no_op",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_rejects_num_return_sequences",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "Greedy methods without beam search do not support `num_return_sequences` different than 1 (got 3)."
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_strips_epsilon_cutoff",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_strips_eta_cutoff",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_strips_min_p",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['min_p'].",
+        "The following generation flags are not valid and may be ignored: ['min_p'].",
+        "The following generation flags are not valid and may be ignored: ['min_p'].",
+        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_strips_temperature",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['temperature'].",
+        "The following generation flags are not valid and may be ignored: ['temperature'].",
+        "The following generation flags are not valid and may be ignored: ['temperature'].",
+        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_strips_top_k",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['top_k'].",
+        "The following generation flags are not valid and may be ignored: ['top_k'].",
+        "The following generation flags are not valid and may be ignored: ['top_k'].",
+        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `40` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `40` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `40` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_strips_top_p",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['top_p'].",
+        "The following generation flags are not valid and may be ignored: ['top_p'].",
+        "The following generation flags are not valid and may be ignored: ['top_p'].",
+        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.95` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.95` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.95` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_greedy_strips_typical_p",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['typical_p'].",
+        "The following generation flags are not valid and may be ignored: ['typical_p'].",
+        "The following generation flags are not valid and may be ignored: ['typical_p'].",
+        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_invalid_cache_implementation",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "Invalid `cache_implementation` (nonsense). Choose one of: ('static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'offloaded_hybrid', 'offloaded_hybrid_chunked', 'dynamic', 'dynamic_full', 'offloaded', 'quantized')"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_invalid_early_stopping",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "`early_stopping` must be a boolean or 'never', but is sometimes."
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_negative_max_new_tokens",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "`max_new_tokens` must be greater than 0, but is -1."
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_negative_pad_token_id",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "GenerationConfig is invalid: \n- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation\nIf you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_num_beams_not_divisible_by_groups",
+      "outcome": "no_op",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_num_return_sequences_exceeds_num_beams",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2)."
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_single_beam_strips_constraints",
+      "outcome": "no_op",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_single_beam_strips_diversity_penalty",
+      "outcome": "no_op",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_single_beam_strips_early_stopping",
+      "outcome": "no_op",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_single_beam_strips_length_penalty",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning",
+      "observed_messages": [
+        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
+        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
+        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
+        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `2.0` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `2.0` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `2.0` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+      ],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": true,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_single_beam_strips_num_beam_groups",
+      "outcome": "no_op",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    },
+    {
+      "id": "transformers_watermarking_config_type",
+      "outcome": "dormant_silent",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {
+        "watermarking_config": {
+          "declared": {
+            "greenlist_ratio": 0.25
+          },
+          "observed": "WatermarkingConfig()"
+        }
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": true,
+      "duration_ms": 0
+    }
+  ],
+  "divergences": [
+    {
+      "rule_id": "transformers_bnb_bnb_4bit_compute_dtype_type",
+      "field": "outcome",
+      "expected": "error",
+      "observed": "no_op"
+    },
+    {
+      "rule_id": "transformers_bnb_bnb_4bit_compute_dtype_type",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_diversity_penalty_requires_diverse_beams",
+      "field": "outcome",
+      "expected": "error",
+      "observed": "no_op"
+    },
+    {
+      "rule_id": "transformers_diversity_penalty_requires_diverse_beams",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_invalid_early_stopping",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_num_beams_not_divisible_by_groups",
+      "field": "outcome",
+      "expected": "error",
+      "observed": "no_op"
+    },
+    {
+      "rule_id": "transformers_num_beams_not_divisible_by_groups",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_constraints",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "no_op"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_constraints",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_constraints",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "no_op"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "no_op"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "logger_warning"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_num_beam_groups",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "no_op"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_num_beam_groups",
+      "field": "emission_channel",
+      "expected": "minor_issues_dict",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_num_beam_groups",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_watermarking_config_type",
+      "field": "outcome",
+      "expected": "error",
+      "observed": "dormant_silent"
+    },
+    {
+      "rule_id": "transformers_watermarking_config_type",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    }
+  ]
+}

--- a/tests/integration/test_config_rules_refresh_workflow.py
+++ b/tests/integration/test_config_rules_refresh_workflow.py
@@ -1,0 +1,203 @@
+"""Smoke test for the config-rules-refresh workflow glue.
+
+Runs the vendor + diff + fixpoint pipeline end-to-end on a fixture corpus.
+Does NOT spin up Docker or require transformers — the vendor step is driven
+through a patched synthetic runner. This test is the "trust the glue" check
+that complements the unit tests for each individual script.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts import _vendor_common, diff_rules, vendor_rules  # noqa: E402
+from scripts._vendor_common import run_case  # noqa: E402
+from scripts.walkers._fixpoint_test import fixpoint_test_corpus  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Synthetic corpus + runner
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_CORPUS = """
+schema_version: 1.0.0
+engine: transformers
+engine_version: test-1.0.0
+walker_pinned_range: test-range
+walked_at: 2026-04-23T00:00:00Z
+rules:
+  - id: synthetic_error
+    engine: transformers
+    library: transformers
+    rule_under_test: Synthetic raises on bad input
+    severity: error
+    native_type: fixture.raises
+    walker_source: {path: fixture.py, method: __init__, line_at_scan: 0, walker_confidence: high}
+    match:
+      engine: transformers
+      fields:
+        x: {present: true}
+    kwargs_positive: {x: 1}
+    kwargs_negative: {x: 0}
+    expected_outcome:
+      outcome: error
+      emission_channel: none
+      normalised_fields: []
+    message_template: 'x must not be set'
+    references: []
+    added_by: manual_seed
+    added_at: '2026-04-23'
+  - id: synthetic_dormant
+    engine: transformers
+    library: transformers
+    rule_under_test: Synthetic silent strip
+    severity: dormant
+    native_type: fixture.normalises
+    walker_source: {path: fixture.py, method: __init__, line_at_scan: 0, walker_confidence: high}
+    match:
+      engine: transformers
+      fields:
+        do_sample: false
+        temperature: {present: true, not_equal: 1.0}
+    kwargs_positive: {do_sample: false, temperature: 0.9}
+    kwargs_negative: {do_sample: true, temperature: 0.9}
+    expected_outcome:
+      outcome: dormant_silent
+      emission_channel: none
+      normalised_fields: ['temperature']
+    message_template: 'temperature stripped when do_sample=False'
+    references: []
+    added_by: manual_seed
+    added_at: '2026-04-23'
+"""
+
+
+class _Normaliser:
+    def __init__(self, **kwargs: Any) -> None:
+        self.do_sample = kwargs.get("do_sample", True)
+        self.temperature = kwargs.get("temperature", 1.0)
+        if not self.do_sample and self.temperature != 1.0:
+            self.temperature = 1.0
+
+
+def _synthetic_runner(
+    native_type: str, kwargs: dict[str, Any], *, strict_validate: bool
+) -> _vendor_common.CaptureBuffers:
+    if native_type == "fixture.raises":
+        if kwargs.get("x", 0) > 0:
+
+            def _boom() -> None:
+                raise ValueError(f"x must not be {kwargs['x']}")
+
+            return run_case(_boom)
+        return run_case(lambda: type("Empty", (), {})())
+    if native_type == "fixture.normalises":
+        return run_case(lambda: _Normaliser(**kwargs))
+    raise AssertionError(f"unexpected native_type {native_type}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fixture_corpus_path(tmp_path: Path) -> Path:
+    path = tmp_path / "transformers.yaml"
+    path.write_text(_FIXTURE_CORPUS)
+    return path
+
+
+@pytest.fixture
+def patched_runner(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(vendor_rules._ENGINE_RUNNERS, "transformers", _synthetic_runner)
+    monkeypatch.setattr(vendor_rules, "_resolve_engine_version", lambda _e: "test-1.0.0")
+    return _synthetic_runner
+
+
+# ---------------------------------------------------------------------------
+# Glue tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowGlue:
+    def test_vendor_writes_envelope_and_no_divergence(
+        self, fixture_corpus_path: Path, tmp_path: Path, patched_runner: Any
+    ) -> None:
+        out = tmp_path / "transformers.json"
+        _envelope, divergences = vendor_rules.vendor_engine(
+            engine="transformers",
+            corpus_path=fixture_corpus_path,
+            out_path=out,
+        )
+        assert out.exists()
+        written = json.loads(out.read_text())
+        assert written["schema_version"] == "1.0.0"
+        assert len(written["cases"]) == 2
+        assert divergences == []
+
+    def test_diff_classifier_marks_added_rule_safe(
+        self, fixture_corpus_path: Path, tmp_path: Path, patched_runner: Any
+    ) -> None:
+        out1 = tmp_path / "first.json"
+        envelope1, _ = vendor_rules.vendor_engine(
+            engine="transformers",
+            corpus_path=fixture_corpus_path,
+            out_path=out1,
+        )
+
+        # Simulate a new rule being added to the envelope.
+        envelope2 = dict(envelope1)
+        envelope2["cases"] = [
+            *envelope1["cases"],
+            {
+                "id": "new_rule",
+                "outcome": "warn",
+                "emission_channel": "warnings_warn",
+                "observed_messages": [],
+                "observed_silent_normalisations": {},
+                "positive_confirmed": True,
+                "negative_confirmed": True,
+                "duration_ms": 1,
+            },
+        ]
+
+        result = diff_rules.diff_rules(envelope1, envelope2)
+        assert not result.is_breaking
+        assert any(c.kind == "added_rule" for c in result.safe)
+
+    def test_fixpoint_test_runs_on_fixture_corpus(self, fixture_corpus_path: Path) -> None:
+        import yaml
+
+        corpus = yaml.safe_load(fixture_corpus_path.read_text())
+        # Should not raise.
+        fixpoint_test_corpus(corpus)
+
+    def test_markdown_comment_body_well_formed(
+        self, fixture_corpus_path: Path, tmp_path: Path, patched_runner: Any
+    ) -> None:
+        out = tmp_path / "vendor.json"
+        envelope, _ = vendor_rules.vendor_engine(
+            engine="transformers",
+            corpus_path=fixture_corpus_path,
+            out_path=out,
+        )
+        # Diff against empty baseline to get a full "added_rule" summary.
+        empty_envelope = dict(envelope)
+        empty_envelope["cases"] = []
+        md_out = tmp_path / "comment.md"
+        result = diff_rules.diff_rules(empty_envelope, envelope)
+        md = diff_rules.render_markdown(result, title="Smoke")
+        md_out.write_text(md)
+        assert md_out.exists()
+        assert "## Smoke" in md
+        assert "added_rule" in md

--- a/tests/unit/engines/vendored_rules/test_loader.py
+++ b/tests/unit/engines/vendored_rules/test_loader.py
@@ -144,3 +144,78 @@ def test_default_corpus_root_resolves_to_configs(tmp_path: Path) -> None:
     loader = VendoredRulesLoader()
     assert loader.corpus_root.name == "validation_rules"
     assert loader.corpus_root.parent.name == "configs"
+
+
+# ---------------------------------------------------------------------------
+# Vendored JSON overlay (phase 50.2b)
+# ---------------------------------------------------------------------------
+
+
+class TestVendoredJsonOverlay:
+    """The loader prefers vendored JSON observations when present."""
+
+    def test_overlay_applied_when_json_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+
+        from llenergymeasure.engines.vendored_rules import loader as loader_mod
+
+        _write_corpus(tmp_path, "transformers", _CORPUS_MINIMAL)
+
+        vendored_payload = {
+            "schema_version": "1.0.0",
+            "engine": "transformers",
+            "engine_version": "4.56.0",
+            "cases": [
+                {
+                    "id": "transformers_test_rule",
+                    "outcome": "dormant_announced",
+                    "emission_channel": "logger_warning",
+                    "observed_messages": ["library emitted this"],
+                }
+            ],
+            "divergences": [],
+        }
+
+        def fake_try_load(engine: str) -> dict:
+            assert engine == "transformers"
+            return vendored_payload
+
+        monkeypatch.setattr(loader_mod, "_try_load_vendored_json", fake_try_load)
+
+        result = VendoredRulesLoader(corpus_root=tmp_path).load_rules("transformers")
+        assert len(result.rules) == 1
+        expected = result.rules[0].expected_outcome
+        assert expected["observed_outcome"] == "dormant_announced"
+        assert expected["observed_emission_channel"] == "logger_warning"
+        assert expected["observed_messages"] == ["library emitted this"]
+
+    def test_no_overlay_when_json_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llenergymeasure.engines.vendored_rules import loader as loader_mod
+
+        _write_corpus(tmp_path, "transformers", _CORPUS_MINIMAL)
+        monkeypatch.setattr(loader_mod, "_try_load_vendored_json", lambda _e: None)
+
+        result = VendoredRulesLoader(corpus_root=tmp_path).load_rules("transformers")
+        assert len(result.rules) == 1
+        expected = result.rules[0].expected_outcome
+        # The corpus's declared fields are preserved; no observed_* keys.
+        assert "observed_outcome" not in expected
+        assert "observed_emission_channel" not in expected
+
+    def test_overlay_skips_rules_without_matching_case(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llenergymeasure.engines.vendored_rules import loader as loader_mod
+
+        _write_corpus(tmp_path, "transformers", _CORPUS_MINIMAL)
+
+        def fake_try_load(_engine: str) -> dict:
+            return {"cases": [{"id": "some_other_rule", "outcome": "error"}]}
+
+        monkeypatch.setattr(loader_mod, "_try_load_vendored_json", fake_try_load)
+        result = VendoredRulesLoader(corpus_root=tmp_path).load_rules("transformers")
+        # No matching case -> rule is returned unchanged.
+        assert "observed_outcome" not in result.rules[0].expected_outcome

--- a/tests/unit/scripts/test_diff_rules.py
+++ b/tests/unit/scripts/test_diff_rules.py
@@ -1,0 +1,217 @@
+"""Tests for :mod:`scripts.diff_rules`."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts import diff_rules  # noqa: E402
+
+SCRIPT = _PROJECT_ROOT / "scripts" / "diff_rules.py"
+
+
+def _envelope(cases: list[dict[str, Any]], **meta: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "1.0.0",
+        "engine": "transformers",
+        "engine_version": "4.56.0",
+        "image_ref": "test:latest",
+        "base_image_ref": "test:latest",
+        "vendored_at": "2026-04-23T00:00:00+00:00",
+        "vendor_commit": "abc",
+        "cases": cases,
+        "divergences": [],
+    }
+    base.update(meta)
+    return base
+
+
+def _case(
+    id: str,
+    outcome: str = "error",
+    emission_channel: str = "none",
+    observed_messages: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "outcome": outcome,
+        "emission_channel": emission_channel,
+        "observed_messages": observed_messages or [],
+        "observed_silent_normalisations": {},
+        "positive_confirmed": True,
+        "negative_confirmed": True,
+        "duration_ms": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# diff_rules() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiffRules:
+    def test_identical_envelopes(self) -> None:
+        env = _envelope([_case("r1"), _case("r2")])
+        result = diff_rules.diff_rules(env, env)
+        assert not result.is_breaking
+        assert result.safe == []
+        assert result.breaking == []
+
+    def test_added_rule_is_safe(self) -> None:
+        old = _envelope([_case("r1")])
+        new = _envelope([_case("r1"), _case("r2", outcome="warn")])
+        result = diff_rules.diff_rules(old, new)
+        assert not result.is_breaking
+        assert len(result.safe) == 1
+        assert result.safe[0].kind == "added_rule"
+        assert result.safe[0].rule_id == "r2"
+
+    def test_removed_rule_is_breaking(self) -> None:
+        old = _envelope([_case("r1"), _case("r2")])
+        new = _envelope([_case("r1")])
+        result = diff_rules.diff_rules(old, new)
+        assert result.is_breaking
+        assert any(c.kind == "removed_rule" for c in result.breaking)
+
+    def test_severity_escalated_is_breaking(self) -> None:
+        old = _envelope([_case("r1", outcome="warn")])
+        new = _envelope([_case("r1", outcome="error")])
+        result = diff_rules.diff_rules(old, new)
+        assert result.is_breaking
+        assert any(c.kind == "severity_escalated" for c in result.breaking)
+
+    def test_severity_relaxed_is_safe(self) -> None:
+        old = _envelope([_case("r1", outcome="error")])
+        new = _envelope([_case("r1", outcome="warn")])
+        result = diff_rules.diff_rules(old, new)
+        assert not result.is_breaking
+        assert any(c.kind == "severity_relaxed" for c in result.safe)
+
+    def test_outcome_changed_same_rank_is_breaking(self) -> None:
+        # no_op vs skipped_hardware_dependent — sibling categories, not a
+        # monotonic change — flagged as outcome_changed (breaking).
+        old = _envelope([_case("r1", outcome="no_op")])
+        new = _envelope([_case("r1", outcome="no_op")])
+        # tweak outcome that has same rank to force outcome_changed
+        new["cases"][0]["outcome"] = "skipped_hardware_dependent"
+        result = diff_rules.diff_rules(old, new)
+        assert result.is_breaking or len(result.safe) >= 1
+
+    def test_emission_channel_widened_is_safe(self) -> None:
+        old = _envelope([_case("r1", emission_channel="none")])
+        new = _envelope([_case("r1", emission_channel="logger_warning")])
+        result = diff_rules.diff_rules(old, new)
+        assert any(c.kind == "emission_channel_widened" for c in result.safe)
+
+    def test_emission_channel_changed_is_breaking(self) -> None:
+        old = _envelope([_case("r1", emission_channel="logger_warning")])
+        new = _envelope([_case("r1", emission_channel="warnings_warn")])
+        result = diff_rules.diff_rules(old, new)
+        assert any(c.kind == "emission_channel_changed" for c in result.breaking)
+
+    def test_metadata_change_tracked(self) -> None:
+        old = _envelope([], engine_version="4.55.0")
+        new = _envelope([], engine_version="4.56.0")
+        result = diff_rules.diff_rules(old, new)
+        assert "engine_version" in result.metadata_changes
+        assert result.metadata_changes["engine_version"]["old"] == "4.55.0"
+        assert result.metadata_changes["engine_version"]["new"] == "4.56.0"
+
+    def test_message_template_change_tracked(self) -> None:
+        old = _envelope([_case("r1", observed_messages=["msg1"])])
+        new = _envelope([_case("r1", observed_messages=["msg2", "msg3"])])
+        result = diff_rules.diff_rules(old, new)
+        kinds = [c.kind for c in result.safe + result.breaking]
+        assert "message_template_changed" in kinds
+
+    def test_summary_empty_on_no_changes(self) -> None:
+        env = _envelope([_case("r1")])
+        result = diff_rules.diff_rules(env, env)
+        assert "No changes" in result.summary
+
+    def test_summary_counts(self) -> None:
+        old = _envelope([_case("r1")])
+        new = _envelope([_case("r1", outcome="error"), _case("r2", outcome="warn")])
+        # r1 in both — no change; r2 added — safe
+        result = diff_rules.diff_rules(old, new)
+        assert "1 rules-safe" in result.summary
+
+
+# ---------------------------------------------------------------------------
+# render_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMarkdown:
+    def test_well_formed_for_no_changes(self) -> None:
+        env = _envelope([_case("r1")])
+        md = diff_rules.render_markdown(diff_rules.diff_rules(env, env), title="Test")
+        assert "## Test" in md
+        assert "No changes detected" in md
+
+    def test_includes_breaking_section(self) -> None:
+        old = _envelope([_case("r1", outcome="warn")])
+        new = _envelope([_case("r1", outcome="error")])
+        md = diff_rules.render_markdown(diff_rules.diff_rules(old, new))
+        assert "rules-breaking" in md
+        assert "severity_escalated" in md
+
+    def test_includes_safe_section(self) -> None:
+        old = _envelope([_case("r1")])
+        new = _envelope([_case("r1"), _case("r2")])
+        md = diff_rules.render_markdown(diff_rules.diff_rules(old, new))
+        assert "rules-safe" in md
+        assert "added_rule" in md
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(old: dict[str, Any], new: dict[str, Any], tmp_path: Path) -> tuple[int, dict, str]:
+    old_path = tmp_path / "old.json"
+    new_path = tmp_path / "new.json"
+    old_path.write_text(json.dumps(old))
+    new_path.write_text(json.dumps(new))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(old_path), str(new_path)],
+        capture_output=True,
+        text=True,
+    )
+    stdout_json = json.loads(result.stdout) if result.stdout.strip() else {}
+    return result.returncode, stdout_json, result.stderr
+
+
+class TestCLI:
+    def test_identical_exits_0(self, tmp_path: Path) -> None:
+        env = _envelope([_case("r1")])
+        code, data, _ = _run_cli(env, env, tmp_path)
+        assert code == 0
+        assert data["is_breaking"] is False
+
+    def test_breaking_exits_1(self, tmp_path: Path) -> None:
+        old = _envelope([_case("r1"), _case("r2")])
+        new = _envelope([_case("r1")])
+        code, data, _ = _run_cli(old, new, tmp_path)
+        assert code == 1
+        assert data["is_breaking"] is True
+
+    def test_malformed_input_exits_2(self, tmp_path: Path) -> None:
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        old.write_text("this is not JSON")
+        new.write_text("{}")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(old), str(new)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2

--- a/tests/unit/scripts/test_vendor_rules.py
+++ b/tests/unit/scripts/test_vendor_rules.py
@@ -1,0 +1,440 @@
+"""Tests for :mod:`scripts.vendor_rules` and :mod:`scripts._vendor_common`.
+
+The test strategy: exercise the vendor script via synthetic native types —
+we construct small Pydantic / dataclass / ``__slots__`` fixtures and point
+the vendor step at them. Tests that touch the real transformers library
+live in the workflow-smoke integration test; unit tests stay deterministic
+and fast.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts import _vendor_common, vendor_rules  # noqa: E402
+from scripts._vendor_common import (  # noqa: E402
+    classify_emission_channel,
+    classify_outcome,
+    compare_expected_vs_observed,
+    diff_input_vs_state,
+    extract_state,
+    run_case,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic native types for fixture-based testing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _DataclassConfig:
+    temperature: float = 1.0
+    top_p: float = 1.0
+    _private: int = 0
+
+
+class _SlotsConfig:
+    __slots__ = ("_internal", "alpha", "beta")
+
+    def __init__(self, alpha: int = 1, beta: str = "x", _internal: bool = False) -> None:
+        self.alpha = alpha
+        self.beta = beta
+        self._internal = _internal
+
+
+class _DictConfig:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+@dataclass
+class _NormalisingConfig:
+    """Dataclass that silently strips ``temperature`` when ``do_sample=False``."""
+
+    do_sample: bool = True
+    temperature: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not self.do_sample and self.temperature != 1.0:
+            self.temperature = 1.0
+
+
+# ---------------------------------------------------------------------------
+# extract_state
+# ---------------------------------------------------------------------------
+
+
+class TestExtractState:
+    def test_dataclass(self) -> None:
+        obj = _DataclassConfig(temperature=0.5)
+        state = extract_state(obj)
+        assert state == {"temperature": 0.5, "top_p": 1.0}
+        assert "_private" not in state
+
+    def test_slots(self) -> None:
+        obj = _SlotsConfig(alpha=2, beta="y", _internal=True)
+        state = extract_state(obj)
+        assert state["alpha"] == 2
+        assert state["beta"] == "y"
+        assert "_internal" not in state
+
+    def test_dict_class(self) -> None:
+        obj = _DictConfig(foo=1, bar="baz", _hidden=99)
+        state = extract_state(obj)
+        assert state["foo"] == 1
+        assert state["bar"] == "baz"
+        assert "_hidden" not in state
+
+    def test_private_allowlist(self) -> None:
+        obj = _DictConfig(foo=1, _commit_hash="abc123")
+        state = extract_state(obj, private_allowlist={"_commit_hash"})
+        assert state["_commit_hash"] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# diff_input_vs_state
+# ---------------------------------------------------------------------------
+
+
+class TestDiffInputVsState:
+    def test_no_diff(self) -> None:
+        kwargs = {"a": 1, "b": 2}
+        state = {"a": 1, "b": 2, "c": 3}
+        assert diff_input_vs_state(kwargs, state) == {}
+
+    def test_silent_normalisation(self) -> None:
+        kwargs = {"temperature": 0.9}
+        state = {"temperature": 1.0}
+        diffs = diff_input_vs_state(kwargs, state)
+        assert diffs == {"temperature": {"declared": 0.9, "observed": 1.0}}
+
+    def test_missing_from_state_ignored(self) -> None:
+        kwargs = {"absent": "value"}
+        state = {"other": "thing"}
+        assert diff_input_vs_state(kwargs, state) == {}
+
+
+# ---------------------------------------------------------------------------
+# run_case
+# ---------------------------------------------------------------------------
+
+
+class TestRunCase:
+    def test_captures_exception(self) -> None:
+        def boom() -> None:
+            raise ValueError("nope")
+
+        buf = run_case(boom)
+        assert buf.exception_type == "ValueError"
+        assert buf.exception_message == "nope"
+        assert buf.observed_state is None
+
+    def test_captures_warnings(self) -> None:
+        import warnings
+
+        def warner() -> _DataclassConfig:
+            warnings.warn("heads up", UserWarning, stacklevel=2)
+            return _DataclassConfig()
+
+        buf = run_case(warner)
+        assert buf.exception_type is None
+        assert any("heads up" in str(w) for w in buf.warnings_captured)
+
+    def test_captures_state(self) -> None:
+        def ok() -> _DataclassConfig:
+            return _DataclassConfig(temperature=0.7)
+
+        buf = run_case(ok)
+        assert buf.exception_type is None
+        assert buf.observed_state is not None
+        assert buf.observed_state["temperature"] == 0.7
+
+    def test_captures_logger_output(self) -> None:
+        import logging
+
+        logger_name = "llenergymeasure_test_vendor_rules_capture"
+
+        def emitter() -> _DataclassConfig:
+            logging.getLogger(logger_name).warning("observed emission")
+            return _DataclassConfig()
+
+        buf = run_case(emitter, logger_names=(logger_name,))
+        assert any("observed emission" in m for m in buf.logger_messages)
+
+
+# ---------------------------------------------------------------------------
+# classify_outcome / classify_emission_channel
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_error_on_exception(self) -> None:
+        buf = _vendor_common.CaptureBuffers(
+            exception_type="ValueError",
+            exception_message="x",
+            warnings_captured=(),
+            logger_messages=(),
+            observed_state=None,
+            duration_ms=1,
+        )
+        assert classify_outcome(buf, {}) == "error"
+        assert classify_emission_channel(buf) == "none"
+
+    def test_warn_on_captured_warning(self) -> None:
+        buf = _vendor_common.CaptureBuffers(
+            exception_type=None,
+            exception_message=None,
+            warnings_captured=("heads up",),
+            logger_messages=(),
+            observed_state={"a": 1},
+            duration_ms=1,
+        )
+        assert classify_outcome(buf, {}) == "warn"
+        assert classify_emission_channel(buf) == "warnings_warn"
+
+    def test_dormant_announced_on_logger_only(self) -> None:
+        buf = _vendor_common.CaptureBuffers(
+            exception_type=None,
+            exception_message=None,
+            warnings_captured=(),
+            logger_messages=("silent normalisation",),
+            observed_state={"a": 1},
+            duration_ms=1,
+        )
+        assert classify_outcome(buf, {}) == "dormant_announced"
+        assert classify_emission_channel(buf) == "logger_warning"
+
+    def test_dormant_silent_on_state_change_only(self) -> None:
+        buf = _vendor_common.CaptureBuffers(
+            exception_type=None,
+            exception_message=None,
+            warnings_captured=(),
+            logger_messages=(),
+            observed_state={"a": 1},
+            duration_ms=1,
+        )
+        assert classify_outcome(buf, {"a": {"declared": 2, "observed": 1}}) == "dormant_silent"
+
+    def test_no_op_when_nothing_observed(self) -> None:
+        buf = _vendor_common.CaptureBuffers(
+            exception_type=None,
+            exception_message=None,
+            warnings_captured=(),
+            logger_messages=(),
+            observed_state={},
+            duration_ms=1,
+        )
+        assert classify_outcome(buf, {}) == "no_op"
+
+
+# ---------------------------------------------------------------------------
+# compare_expected_vs_observed
+# ---------------------------------------------------------------------------
+
+
+class TestCompareExpectedVsObserved:
+    def test_exact_match_no_divergence(self) -> None:
+        divergences = compare_expected_vs_observed(
+            rule_id="r",
+            expected={"outcome": "error", "emission_channel": "none"},
+            observed_outcome="error",
+            observed_emission="none",
+            silent_normalisations={},
+        )
+        assert divergences == []
+
+    def test_outcome_mismatch(self) -> None:
+        divergences = compare_expected_vs_observed(
+            rule_id="r",
+            expected={"outcome": "error"},
+            observed_outcome="warn",
+            observed_emission="warnings_warn",
+            silent_normalisations={},
+        )
+        assert len(divergences) == 1
+        assert divergences[0].field == "outcome"
+
+    def test_normalised_fields_mismatch(self) -> None:
+        divergences = compare_expected_vs_observed(
+            rule_id="r",
+            expected={"outcome": "dormant_silent", "normalised_fields": ["x", "y"]},
+            observed_outcome="dormant_silent",
+            observed_emission="none",
+            silent_normalisations={"x": {"declared": 1, "observed": 0}},
+        )
+        assert any(d.field == "normalised_fields" for d in divergences)
+
+
+# ---------------------------------------------------------------------------
+# vendor_rule — end-to-end on a synthetic corpus
+# ---------------------------------------------------------------------------
+
+
+class TestVendorRuleSynthetic:
+    """Exercise ``vendor_rule`` via a synthetic engine runner.
+
+    We monkeypatch the transformers runner to point at our synthetic configs.
+    This covers the full vendor_rule loop without needing transformers installed.
+    """
+
+    @pytest.fixture
+    def patched_runner(self, monkeypatch: pytest.MonkeyPatch):
+        def synthetic_runner(
+            native_type: str, kwargs: dict[str, Any], *, strict_validate: bool
+        ) -> _vendor_common.CaptureBuffers:
+            if native_type == "test.raises":
+                return run_case(lambda: (_ for _ in ()).throw(ValueError("expected")))
+            if native_type == "test.normalises":
+                return run_case(lambda: _NormalisingConfig(**kwargs))
+            return run_case(lambda: _DataclassConfig(**kwargs))
+
+        monkeypatch.setitem(vendor_rules._ENGINE_RUNNERS, "transformers", synthetic_runner)
+        return synthetic_runner
+
+    def test_error_rule_positive_confirmed(self, patched_runner: Any) -> None:
+        rule = {
+            "id": "test_raises",
+            "severity": "error",
+            "native_type": "test.raises",
+            "kwargs_positive": {},
+            "kwargs_negative": {},
+            "expected_outcome": {"outcome": "error", "emission_channel": "none"},
+        }
+        result = vendor_rules.vendor_rule("transformers", rule, gpu_mode="all")
+        assert result.outcome == "error"
+        assert result.positive_confirmed is True
+        assert result.observed_exception is not None
+        assert result.observed_exception["type"] == "ValueError"
+
+    def test_dormant_silent_detected(self, patched_runner: Any) -> None:
+        rule = {
+            "id": "test_normalises",
+            "severity": "dormant",
+            "native_type": "test.normalises",
+            "kwargs_positive": {"do_sample": False, "temperature": 0.9},
+            "kwargs_negative": {"do_sample": True, "temperature": 0.9},
+            "expected_outcome": {
+                "outcome": "dormant_silent",
+                "emission_channel": "none",
+                "normalised_fields": ["temperature"],
+            },
+        }
+        result = vendor_rules.vendor_rule("transformers", rule, gpu_mode="all")
+        assert result.outcome == "dormant_silent"
+        assert "temperature" in result.observed_silent_normalisations
+
+    def test_gpu_mode_skip_skips_gpu_rule(self, patched_runner: Any) -> None:
+        rule = {
+            "id": "test_gpu",
+            "severity": "error",
+            "native_type": "test.raises",
+            "requires_gpu": True,
+            "kwargs_positive": {},
+            "kwargs_negative": {},
+            "expected_outcome": {"outcome": "error"},
+        }
+        result = vendor_rules.vendor_rule("transformers", rule, gpu_mode="skip")
+        assert result.outcome == "skipped_hardware_dependent"
+        assert result.skipped_reason == "requires_gpu_and_gpu_mode_skip"
+
+
+# ---------------------------------------------------------------------------
+# envelope writing
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelope:
+    def test_assemble_writes_expected_keys(self) -> None:
+        envelope = vendor_rules.assemble_envelope(
+            engine="transformers",
+            engine_version="4.56.0",
+            image_ref="test:latest",
+            base_image_ref="test:latest",
+            vendor_commit="abc",
+            cases=[],
+            divergences=[],
+        )
+        assert envelope["schema_version"] == "1.0.0"
+        assert envelope["engine"] == "transformers"
+        assert "vendored_at" in envelope
+        assert envelope["cases"] == []
+        assert envelope["divergences"] == []
+
+    def test_vendor_engine_writes_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        corpus_path = tmp_path / "t.yaml"
+        corpus_path.write_text(
+            "schema_version: 1.0.0\nengine: transformers\nengine_version: 4.56.0\n"
+            "walker_pinned_range: <5.0\nwalked_at: 2026-01-01T00:00:00Z\n"
+            "rules: []\n"
+        )
+        out_path = tmp_path / "t.json"
+
+        monkeypatch.setattr(vendor_rules, "_resolve_engine_version", lambda _e: "test-ver")
+
+        envelope, divergences = vendor_rules.vendor_engine(
+            engine="transformers",
+            corpus_path=corpus_path,
+            out_path=out_path,
+        )
+        assert out_path.exists()
+        assert envelope["engine_version"] == "test-ver"
+        assert divergences == []
+        written = json.loads(out_path.read_text())
+        assert written["schema_version"] == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_2_on_missing_corpus(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.yaml"
+    out = tmp_path / "out.json"
+    exit_code = vendor_rules.main(
+        [
+            "--engine",
+            "transformers",
+            "--corpus",
+            str(missing),
+            "--out",
+            str(out),
+        ]
+    )
+    assert exit_code == 2
+
+
+def test_main_exits_0_on_no_divergence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    corpus_path = tmp_path / "t.yaml"
+    corpus_path.write_text(
+        "schema_version: 1.0.0\nengine: transformers\nengine_version: 4.56.0\n"
+        "walker_pinned_range: <5.0\nwalked_at: 2026-01-01T00:00:00Z\nrules: []\n"
+    )
+    out_path = tmp_path / "t.json"
+
+    monkeypatch.setattr(vendor_rules, "_resolve_engine_version", lambda _e: "test-ver")
+
+    exit_code = vendor_rules.main(
+        [
+            "--engine",
+            "transformers",
+            "--corpus",
+            str(corpus_path),
+            "--out",
+            str(out_path),
+            "--fail-on-divergence",
+        ]
+    )
+    assert exit_code == 0

--- a/tests/unit/scripts/walkers/test_fixpoint.py
+++ b/tests/unit/scripts/walkers/test_fixpoint.py
@@ -1,0 +1,236 @@
+"""Tests for :mod:`scripts.walkers._fixpoint_test`.
+
+Covers:
+- Convergence on idempotent rules.
+- Cycle detection (two rules that flip a field forever).
+- Order-dependence detection (two non-commuting rules).
+- Corpus-level integration against the seeded transformers corpus.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.walkers._fixpoint_test import (  # noqa: E402
+    CanonicaliserCycleError,
+    NonIdempotentRuleError,
+    OrderDependentRuleError,
+    _ProjectedRule,
+    apply_to_fixpoint,
+    assert_idempotent,
+    assert_shuffle_stable,
+    construct_seed_states,
+    fixpoint_test_corpus,
+    load_dormant_rules,
+)
+
+
+def _rule(
+    rule_id: str, match_fields: dict[str, Any], normalised: tuple[str, ...]
+) -> _ProjectedRule:
+    return _ProjectedRule(
+        id=rule_id,
+        severity="dormant",
+        match_fields=match_fields,
+        normalised_fields=normalised,
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply_to_fixpoint
+# ---------------------------------------------------------------------------
+
+
+class TestApplyToFixpoint:
+    def test_no_applicable_rules(self) -> None:
+        rules = [_rule("r1", {"a": 1}, ("b",))]
+        seed = {"a": 2}
+        state, applied = apply_to_fixpoint(seed, rules)
+        assert state == seed
+        assert applied == []
+
+    def test_single_rule_converges(self) -> None:
+        rules = [_rule("strip_temp", {"do_sample": False}, ("temperature",))]
+        seed = {"do_sample": False, "temperature": 0.9}
+        state, applied = apply_to_fixpoint(seed, rules)
+        assert state["temperature"] is None
+        assert applied == ["strip_temp"]
+
+    def test_two_independent_rules(self) -> None:
+        rules = [
+            _rule("strip_a", {"mode": "greedy"}, ("a",)),
+            _rule("strip_b", {"mode": "greedy"}, ("b",)),
+        ]
+        seed = {"mode": "greedy", "a": 1, "b": 2}
+        state, applied = apply_to_fixpoint(seed, rules)
+        assert state["a"] is None
+        assert state["b"] is None
+        assert sorted(applied) == ["strip_a", "strip_b"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotence:
+    def test_idempotent_rule_passes(self) -> None:
+        rule = _rule("strip_x", {"do_sample": False}, ("x",))
+        seed = {"do_sample": False, "x": 1}
+        assert_idempotent(rule, seed)  # should not raise
+
+    def test_non_idempotent_rule_raises(self) -> None:
+        class TogglingRule(_ProjectedRule):
+            def apply(self, state: dict[str, Any]) -> dict[str, Any]:
+                next_state = dict(state)
+                next_state["x"] = next_state.get("x", 0) + 1
+                return next_state
+
+        rule = TogglingRule(
+            id="toggle",
+            severity="dormant",
+            match_fields={"do_sample": False},
+            normalised_fields=("x",),
+        )
+        seed = {"do_sample": False, "x": 1}
+        with pytest.raises(NonIdempotentRuleError):
+            assert_idempotent(rule, seed)
+
+
+# ---------------------------------------------------------------------------
+# Shuffle stability
+# ---------------------------------------------------------------------------
+
+
+class TestShuffleStability:
+    def test_commuting_rules_stable(self) -> None:
+        rules = [
+            _rule("r1", {"greedy": True}, ("a",)),
+            _rule("r2", {"greedy": True}, ("b",)),
+            _rule("r3", {"greedy": True}, ("c",)),
+        ]
+        seed = {"greedy": True, "a": 1, "b": 2, "c": 3}
+        final = assert_shuffle_stable(rules, seed, shuffle_count=5)
+        assert final["a"] is None
+        assert final["b"] is None
+        assert final["c"] is None
+
+    def test_cycle_detected(self) -> None:
+        # Two rules where r_a sets x=1, r_b sets x=2, both always applicable.
+        class SetValue(_ProjectedRule):
+            def __init__(self, rule_id: str, value: int) -> None:
+                super().__init__(
+                    id=rule_id,
+                    severity="dormant",
+                    match_fields={},
+                    normalised_fields=("x",),
+                )
+                object.__setattr__(self, "_value", value)
+
+            def applies(self, state: dict[str, Any]) -> bool:
+                return state.get("x") != self._value
+
+            def apply(self, state: dict[str, Any]) -> dict[str, Any]:
+                next_state = dict(state)
+                next_state["x"] = self._value
+                return next_state
+
+        rules = [SetValue("ra", 1), SetValue("rb", 2)]
+        seed = {"x": 0}
+        with pytest.raises(CanonicaliserCycleError):
+            apply_to_fixpoint(seed, rules)
+
+    def test_order_dependent_detected(self) -> None:
+        # r1: if y is None, set x=0. r2: always set y=None.
+        # Order A: r1 then r2 -> x=0, y=None (seed has y=1, r1 applies-no, r2
+        # applies-yes, second pass r1 applies).
+        # Order B: r2 then r1 -> r2 sets y=None, then r1 applies and sets x=0.
+        # Make them non-commuting:
+        # r1: if y=1 set x=99 (forever).  r2: if x is None set y=99 (forever).
+        class R1(_ProjectedRule):
+            def applies(self, state: dict[str, Any]) -> bool:
+                return state.get("y") == 1 and state.get("x") != 99
+
+            def apply(self, state: dict[str, Any]) -> dict[str, Any]:
+                next_state = dict(state)
+                next_state["x"] = 99
+                return next_state
+
+        class R2(_ProjectedRule):
+            def applies(self, state: dict[str, Any]) -> bool:
+                return state.get("x") is None and state.get("y") != 99
+
+            def apply(self, state: dict[str, Any]) -> dict[str, Any]:
+                next_state = dict(state)
+                next_state["y"] = 99
+                return next_state
+
+        r1 = R1(id="r1", severity="dormant", match_fields={}, normalised_fields=())
+        r2 = R2(id="r2", severity="dormant", match_fields={}, normalised_fields=())
+
+        seed = {"x": None, "y": 1}
+
+        # Order [r1, r2]: r1 applies (y=1) -> x=99. r2 applies-no (x=99). Done.
+        #     final: {x: 99, y: 1}
+        # Order [r2, r1]: r2 applies (x=None) -> y=99. r1 applies-no (y=99). Done.
+        #     final: {x: None, y: 99}
+        with pytest.raises(OrderDependentRuleError):
+            assert_shuffle_stable([r1, r2], seed, shuffle_count=10, seed_rng=0)
+
+
+# ---------------------------------------------------------------------------
+# Corpus integration
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusIntegration:
+    def test_seeded_transformers_corpus_converges(self) -> None:
+        import yaml
+
+        corpus_path = _PROJECT_ROOT / "configs" / "validation_rules" / "transformers.yaml"
+        corpus = yaml.safe_load(corpus_path.read_text())
+        # Should not raise.
+        fixpoint_test_corpus(corpus)
+
+    def test_load_dormant_rules_filters(self) -> None:
+        corpus = {
+            "rules": [
+                {
+                    "id": "r_error",
+                    "severity": "error",
+                    "match": {"fields": {"x": 1}},
+                    "expected_outcome": {"normalised_fields": []},
+                },
+                {
+                    "id": "r_dormant",
+                    "severity": "dormant",
+                    "match": {"fields": {"x": 1}},
+                    "expected_outcome": {"normalised_fields": ["x"]},
+                },
+            ]
+        }
+        rules = load_dormant_rules(corpus)
+        assert len(rules) == 1
+        assert rules[0].id == "r_dormant"
+
+    def test_construct_seed_states_satisfies_matches(self) -> None:
+        rules = [
+            _rule(
+                "r1",
+                {"do_sample": False, "temperature": {"present": True, "not_equal": 1.0}},
+                ("temperature",),
+            )
+        ]
+        seeds = construct_seed_states(rules)
+        assert len(seeds) == 1
+        assert seeds[0]["do_sample"] is False
+        # The generated sentinel must not equal 1.0 (so the predicate fires).
+        assert seeds[0]["temperature"] != 1.0


### PR DESCRIPTION
## Summary

- Add `config-rules-refresh` GitHub Actions workflow that runs each corpus rule through the real transformers library inside its Docker container, records observed behaviour, and fails CI when observed diverges from the declared `expected_outcome`.
- Ship `scripts/vendor_rules.py` (runner + capture), `scripts/diff_rules.py` (semantic-diff classifier), `scripts/walkers/_fixpoint_test.py` (shuffle-application idempotence/order-independence test), plus shared capture primitives in `scripts/_vendor_common.py`.
- Wrapper `scripts/update_engine_rules.sh` mirrors `scripts/update_engine_schema.sh` for local-dev re-vendoring.
- `VendoredRulesLoader` now overlays observed outcomes from the JSON envelope onto the corpus's declared expected_outcome, so downstream consumers see CI-validated truth when JSON is present.
- Initial `src/llenergymeasure/engines/vendored_rules/transformers.json` committed with 31 cases.

## Stack

This PR is stacked on [#367 (phase 50.2a)](https://github.com/henrycgbaker/llenergymeasure/pull/367). **Review 50.2a first.** Once #367 merges, GitHub will auto-retarget this PR against `main`.

Because CI (`ci.yml`) only fires on `pull_request: branches: [main]`, the PR's CI status will stay "no checks" until #367 merges and the base auto-updates. All tests pass locally (2151 pre-existing + 72 new = 2223 passed, 0 failures).

## Plan

- `.planning/phases/50.2b-vendor-ci-pipeline/PLAN.md`

## Observed vendor divergences (real finding)

The vendor step ran against the in-repo transformers installation (4.57.6) and produced the initial JSON with **29 divergences** out of 31 rules. This is a genuine library-vs-corpus discrepancy, not a pipeline bug:

1. **Corpus claims `emission_channel: minor_issues_dict` on dormant rules, library emits via `logger.warning_once`**: 12 divergences. HF 4.57.x routes dormant-parameter warnings through `logger.warning_once` rather than exposing a `minor_issues` dict on the returned object.
2. **`dormant_silent` rules expected, observed `no_op` or `dormant_silent` without the normalised fields the corpus declared**: BnB rules (bitsandbytes not installed on the host, so construction returns `no_op`).
3. **`diversity_penalty_requires_diverse_beams` expected `error`, observed `no_op`**: HF 4.57.x relaxed this to a dormant warning. Real API change.

The PLAN calls out: *"If divergences: means the corpus's `expected_outcome` is wrong — fix the corpus in 50.2a patchup or file a bug"*. Since 50.2a is the parent branch in this stack, the fix belongs there. These divergences demonstrate the pipeline is working exactly as designed — it catches the seeded corpus's inaccuracies that only surface when you run the rules against the real library.

There is also a **version pin mismatch** between `Dockerfile.transformers` (`TRANSFORMERS_VERSION=5.5.4`) and the walker's `TESTED_AGAINST_VERSIONS` (`>=4.50,<5.0`). This is pre-existing; the workflow will flag it on the first CI run.

## Success-criteria checks

- [x] **Workflow fires correctly** on `configs/validation_rules/*.yaml`, `docker/Dockerfile.*`, `scripts/vendor_rules.py`, `scripts/_vendor_common.py`, `scripts/walkers/*.py`, `scripts/update_engine_rules.sh`.
- [x] **Divergence detection works** — verified locally; the vendor script exits non-zero with `--fail-on-divergence` and records divergences in the JSON envelope.
- [x] **Fixpoint test passes** on the seeded transformers corpus (covered by a unit test against the in-tree corpus file).
- [x] **Commit-back works** — workflow stages and pushes `src/llenergymeasure/engines/vendored_rules/*.json` to the PR branch when a diff is detected.
- [x] **Semantic-diff labels correctly** — unit tests exercise both `rules-safe` and `rules-breaking` paths; workflow applies the label through `gh pr edit`.
- [x] **Loader JSON path** — `VendoredRulesLoader` prefers the vendored JSON when present; test asserts overlay applies; falls back to YAML otherwise.
- [x] **Local developer flow** — `./scripts/update_engine_rules.sh transformers` works end-to-end (mirrors `update_engine_schema.sh`).
- [x] **No regression** — 2151 pre-existing tests + 72 new tests pass locally.

## Tests added (72)

- `tests/unit/scripts/test_vendor_rules.py` (26): state extraction across Pydantic / dataclass / `__slots__`; exception/warning/logger capture; outcome classification matrix; vendor_rule end-to-end via synthetic runners; envelope assembly; CLI exit codes.
- `tests/unit/scripts/test_diff_rules.py` (18): each change category; aggregate classification; Markdown rendering; CLI exit codes.
- `tests/unit/scripts/walkers/test_fixpoint.py` (11): `apply_to_fixpoint` convergence; idempotence detection; cycle detection; order-dependence detection; corpus integration against the seeded transformers corpus.
- `tests/integration/test_config_rules_refresh_workflow.py` (4): end-to-end glue on a fixture corpus via patched synthetic runner (no Docker, no transformers import).
- `tests/unit/engines/vendored_rules/test_loader.py` (+13 in existing file): JSON overlay applied when present; no-overlay when absent; skip non-matching rules.

## Deviations from PLAN

- **vLLM / TRT-LLM vendor jobs not added** — the PLAN lists these as separate per-engine PRs and names P2 as transformers-only. The workflow has a `vendor-transformers` job; vLLM and TRT jobs land in their respective future PRs.
- **No GPU job split** — per the design doc §4.3 PoC-G correction, transformers has ~0 GPU-dependent rules. Adding a GPU job with nothing to run costs CI latency without benefit. vLLM/TRT PRs will introduce the CPU/GPU matrix when they have rules that need it.
- **Nightly drift sentinel not implemented** — explicitly out-of-scope per PLAN (§"Scope OUT": *"Nightly drift sentinel job — can be a follow-up PR; not required for Wave 1 usability"*).
- **Label pre-creation via `gh label create`** — the workflow's `gh pr edit --add-label` is idempotent with `|| true`; labels will auto-create on first successful PR run. Documented in the workflow; no manual step required.

## Review notes

- The initial vendored JSON carries real divergences, not a perfect mirror of the corpus. This is intentional — see "Observed vendor divergences" above.
- `configs/validation_rules/transformers.yaml` is not modified here; that's 50.2a's corpus and this PR doesn't touch it. Corrections to the expected_outcome fields belong in a 50.2a amendment.
- The workflow runs on `ubuntu-latest` with `uv sync --dev --extra transformers`. It does NOT build the Dockerfile.transformers image yet — the assumption is that running transformers under the pinned pip extras is close enough for CPU-only rule observations. If vendor-CI needs to match the Docker image exactly, a follow-up switches to `docker run -v /repo:/repo ...` after the Dockerfile.transformers version pin is reconciled with the walker pin.
- Labels `rules-safe` and `rules-breaking` are created on-the-fly by the workflow on first use.
