### PR TITLE
feat(config): add canonicaliser + H3 collision invariant for sweep dedup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,12 @@ ignore_imports = [
     # cycle risk (imports are local-inside-function in config.models).
     "llenergymeasure.config.models -> llenergymeasure.engines.vendored_rules.loader",
     "llenergymeasure.config.models -> llenergymeasure.engines.protocol",
+    # Phase 50.3a: config.loader.load_study_config invokes dedup_sweep as
+    # part of the grid-expansion pipeline (between expand_grid and
+    # apply_cycles). The canonicaliser lives under study/ — reviewer may
+    # decide to invert this by moving dedup into api/cli callers; for now
+    # the import is local-inside-function so there is no cycle risk.
+    "llenergymeasure.config.loader -> llenergymeasure.study.sweep_canonicalise",
 ]
 
 [[tool.importlinter.contracts]]
@@ -235,4 +241,6 @@ ignore_imports = [
     # main-layers contract above for the architectural rationale.
     "llenergymeasure.config.models -> llenergymeasure.engines.vendored_rules.loader",
     "llenergymeasure.config.models -> llenergymeasure.engines.protocol",
+    # Phase 50.3a: see matching ignore on main-layers contract above.
+    "llenergymeasure.config.loader -> llenergymeasure.study.sweep_canonicalise",
 ]

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -123,6 +123,16 @@ def run(
         bool,
         typer.Option("--no-lock", help="Disable GPU lock files (advanced)"),
     ] = False,
+    no_dedup: Annotated[
+        bool,
+        typer.Option(
+            "--no-dedup",
+            help=(
+                "Disable canonicaliser-driven H1 sweep dedup. Every declared "
+                "config runs regardless of measurement equivalence (study mode)."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Run an LLM efficiency experiment."""
 
@@ -158,6 +168,7 @@ def run(
             no_circuit_breaker=no_circuit_breaker,
             timeout=timeout,
             no_lock=no_lock,
+            no_dedup=no_dedup,
         )
     except ConfigError as e:
         print(format_error(e, verbose=verbose > 0), file=sys.stderr)
@@ -198,6 +209,7 @@ def _run_impl(
     no_circuit_breaker: bool = False,
     timeout: float | None = None,
     no_lock: bool = False,
+    no_dedup: bool = False,
 ) -> None:
     """Core implementation — separated for clean error handling in run()."""
     # Build CLI overrides dict — only include flags the user explicitly passed
@@ -252,6 +264,7 @@ def _run_impl(
             no_circuit_breaker=no_circuit_breaker,
             timeout=timeout,
             no_lock=no_lock,
+            no_dedup=no_dedup,
         )
         return
 
@@ -400,6 +413,7 @@ def _run_study_impl(
     no_circuit_breaker: bool = False,
     timeout: float | None = None,
     no_lock: bool = False,
+    no_dedup: bool = False,
 ) -> None:
     """Study execution path — separated for clean error handling."""
     import yaml
@@ -473,6 +487,10 @@ def _run_study_impl(
         exec_overrides["max_consecutive_failures"] = 0
     if timeout is not None:
         exec_overrides["wall_clock_timeout_hours"] = timeout
+
+    # --no-dedup disables sweep canonicalisation (runs every declared config)
+    if no_dedup:
+        exec_overrides["deduplicate_equivalent"] = False
 
     # Build full CLI overrides dict
     study_cli_overrides: dict[str, Any] = {}

--- a/src/llenergymeasure/config/loader.py
+++ b/src/llenergymeasure/config/loader.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import ValidationError
@@ -191,17 +191,45 @@ def load_study_config(
             "Nothing to run. Check sweep dimensions against engine constraints.\n" + skip_details
         )
 
-    # Compute study_design_hash BEFORE applying cycles (hash is over unique configs)
-    study_hash = compute_study_design_hash(valid_experiments)
+    # Canonicalise + H1-dedup the declared configs before running cycles.
+    # See sweep-dedup.md §2 — this collapses measurement-equivalent configs
+    # so a 6-config sweep with dormant sampling fields becomes 4 unique runs.
+    from llenergymeasure.study.sweep_canonicalise import dedup_sweep
+
+    dedup = dedup_sweep(
+        valid_experiments,
+        deduplicate=execution.deduplicate_equivalent,
+    )
+
+    run_experiments = dedup.canonical_configs
+    dedup_mode: Literal["h1", "off"] = "h1" if execution.deduplicate_equivalent else "off"
+
+    # Compute study_design_hash over the post-dedup configs — the hash
+    # identifies the *unique* measurement set, not duplicate declarations.
+    study_hash = compute_study_design_hash(run_experiments)
 
     # Apply cycle ordering to produce execution sequence
     ordered = apply_cycles(
-        valid_experiments,
+        run_experiments,
         n_cycles=execution.n_cycles,
         experiment_order=ExperimentOrder(execution.experiment_order),
         study_design_hash=study_hash,
         shuffle_seed=execution.shuffle_seed,
     )
+
+    # Serialise pre-run equivalence groups for the sidecar writer.
+    pre_run_groups = [
+        {
+            "h1_hash": g.h1_hash,
+            "canonical_config_excerpt": g.canonical_excerpt,
+            "member_indices": list(g.member_indices),
+            "member_count": g.member_count,
+            "representative_index": g.representative_index,
+            "would_dedup": g.member_count > 1,
+            "deduplicated": dedup.deduplicated and g.member_count > 1,
+        }
+        for g in dedup.groups
+    ]
 
     return StudyConfig(
         experiments=ordered,
@@ -212,6 +240,9 @@ def load_study_config(
         images=images,
         study_design_hash=study_hash,
         skipped_configs=[s.to_dict() for s in skipped],
+        dedup_mode=dedup_mode,
+        pre_run_equivalence_groups=pre_run_groups,
+        declared_h1_hashes=list(dedup.declared_h1),
     )
 
 

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -708,6 +708,17 @@ class ExecutionConfig(BaseModel):
             "the circuit breaker counts them toward max_consecutive_failures."
         ),
     )
+    deduplicate_equivalent: bool = Field(
+        default=True,
+        description=(
+            "When true (default), sweep expansion canonicalises each declared "
+            "ExperimentConfig via vendored dormant-rule application and drops "
+            "duplicates that share an H1 hash. When false, every declared "
+            "config runs — the canonicaliser still populates equivalence-group "
+            "metadata for the sidecar but no configs are elided. The --no-dedup "
+            "CLI flag is the equivalent. See sweep-dedup.md §2.3.1."
+        ),
+    )
 
 
 class StudyConfig(BaseModel):
@@ -767,5 +778,32 @@ class StudyConfig(BaseModel):
         description=(
             "Grid points that failed Pydantic validation during expansion. "
             "Persisted for post-hoc review and pre-flight display."
+        ),
+    )
+    dedup_mode: Literal["h1", "off"] = Field(
+        default="h1",
+        description=(
+            "Canonicaliser / H1 dedup mode. 'h1' applies dormant-rule "
+            "canonicalisation at expansion and collapses H1-equivalent "
+            "configs to a single run. 'off' runs every declared config "
+            "regardless of equivalence. Set via "
+            "ExecutionConfig.deduplicate_equivalent / --no-dedup."
+        ),
+    )
+    pre_run_equivalence_groups: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Pre-run equivalence groups computed at sweep-expansion time. "
+            "Each group records the H1 hash, canonical excerpt, and member "
+            "declared-indices. Written to 'equivalence_groups.json' alongside "
+            "the results bundle. See sweep-dedup.md §6."
+        ),
+    )
+    declared_h1_hashes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Per-declared-config H1 hashes (parallel to the pre-canonicalised "
+            "sweep input). Harness consults this to tag each experiment with "
+            "its equivalence group at sidecar-write time."
         ),
     )

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -59,6 +59,22 @@ def extract_effective_params(
     return {k: v for k, v in raw.items() if not k.startswith("_") or k in allow}
 
 
+def library_version(module_name: str) -> str:
+    """Return ``__version__`` of an imported library or ``"unknown"`` on failure.
+
+    Shared helper for the H3 capture path — all three engines publish the
+    library version alongside their effective-params dump so researchers can
+    disambiguate identical H3 hashes across library versions.
+    """
+    try:
+        import importlib
+
+        mod = importlib.import_module(module_name)
+        return str(getattr(mod, "__version__", "unknown"))
+    except Exception:
+        return "unknown"
+
+
 def _dump_raw(native_obj: Any) -> dict[str, Any]:
     """Return a ``dict`` of every attribute observable on ``native_obj``.
 

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -6,6 +6,7 @@ to reduce duplication while keeping engines thin.
 
 from __future__ import annotations
 
+import dataclasses
 import gc
 import logging
 from collections.abc import Callable
@@ -17,6 +18,76 @@ from llenergymeasure.engines.protocol import DormantField
 from llenergymeasure.utils.exceptions import EngineError
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Effective-params extraction (H3 source)
+# ---------------------------------------------------------------------------
+
+
+def extract_effective_params(
+    native_obj: Any,
+    *,
+    private_field_allowlist: set[str] | None = None,
+) -> dict[str, Any]:
+    """Dump a constructed native type's post-``__post_init__`` state.
+
+    Used by the H3 hashing pipeline (sweep-dedup.md §3.2) — after each
+    backend constructs its native type (``GenerationConfig``,
+    ``SamplingParams``, ``LlmArgs``), the harness calls this to extract
+    the authoritative effective parameters the library settled on.
+
+    PoC-C finding (sweep-dedup.md §3.2 and §10 decision log): live
+    libraries leak private state that poisons H3 if passed through
+    unfiltered. Specific leaks observed:
+
+    - ``transformers.GenerationConfig``: ``_commit_hash``,
+      ``_from_model_config``
+    - ``vllm.SamplingParams``: ``_all_stop_token_ids``,
+      ``_bad_words_token_ids``, ``_eos_token_id``
+
+    Default behaviour is to strip all ``_``-prefixed fields. Engines pass
+    ``private_field_allowlist`` only when a specific private field is
+    genuinely measurement-relevant (rare).
+
+    Dispatch covers the three observed native-type shapes — Pydantic
+    (``model_dump``), dataclass (``dataclasses.asdict``), and
+    ``__slots__``-based (vLLM msgspec-adjacent). Fallback is ``__dict__``.
+    """
+    allow = private_field_allowlist or set()
+    raw = _dump_raw(native_obj)
+    return {k: v for k, v in raw.items() if not k.startswith("_") or k in allow}
+
+
+def _dump_raw(native_obj: Any) -> dict[str, Any]:
+    """Return a ``dict`` of every attribute observable on ``native_obj``.
+
+    Order of attempts mirrors the three shapes :func:`extract_effective_params`
+    commits to supporting; each is an explicit ``hasattr`` rather than
+    ``try/except`` because the libraries raise non-``AttributeError`` for
+    ``model_dump`` failures (e.g. transformers raises ``RuntimeError``).
+    """
+    if hasattr(native_obj, "model_dump"):
+        # Pydantic (transformers GenerationConfig inherits from PushToHubMixin;
+        # its model_dump accepts mode="python").
+        try:
+            dumped = native_obj.model_dump(mode="python")
+        except TypeError:
+            dumped = native_obj.model_dump()
+        if isinstance(dumped, dict):
+            return dict(dumped)
+    if dataclasses.is_dataclass(native_obj) and not isinstance(native_obj, type):
+        return dataclasses.asdict(native_obj)
+    if hasattr(native_obj, "__slots__"):
+        out: dict[str, Any] = {}
+        for slot in native_obj.__slots__:
+            if hasattr(native_obj, slot):
+                out[slot] = getattr(native_obj, slot)
+        if out:
+            return out
+    if hasattr(native_obj, "__dict__"):
+        return dict(native_obj.__dict__)
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -369,7 +369,7 @@ class TensorRTEngine:
         """
         import contextlib as _cl
 
-        from llenergymeasure.engines._helpers import extract_effective_params
+        from llenergymeasure.engines._helpers import extract_effective_params, library_version
 
         sampling: dict[str, Any] = {}
         with _cl.suppress(Exception):
@@ -381,17 +381,10 @@ class TensorRTEngine:
             if llm_args is not None:
                 engine_params = extract_effective_params(llm_args)
 
-        try:
-            import tensorrt_llm as _trt
-
-            library_version = str(_trt.__version__)
-        except Exception:
-            library_version = "unknown"
-
         return {
             "engine": engine_params,
             "sampling": sampling,
-            "library_version": library_version,
+            "library_version": library_version("tensorrt_llm"),
         }
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -331,6 +331,14 @@ class TensorRTEngine:
         if self._build_metadata is not None:
             extras["build_metadata"] = self._build_metadata
 
+        # Library-observed effective params for H3 (sweep-dedup.md §3).
+        # TRT-LLM runs in NGC container only; allowlist verification is
+        # deferred to a container run per the PoC-C notes.
+        effective_params = self._capture_effective_params(config, llm, sampling_params)
+        extras["effective_engine_params"] = effective_params["engine"]
+        extras["effective_sampling_params"] = effective_params["sampling"]
+        extras["library_version"] = effective_params["library_version"]
+
         return InferenceOutput(
             elapsed_time_sec=elapsed,
             input_tokens=input_token_count,
@@ -340,6 +348,51 @@ class TensorRTEngine:
             batch_times=[elapsed],
             extras=extras,
         )
+
+    # -------------------------------------------------------------------------
+    # Private: effective-params capture (H3)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _capture_effective_params(
+        config: ExperimentConfig,
+        llm: Any,
+        sampling_params: Any,
+    ) -> dict[str, Any]:
+        """Extract post-construction state from the TRT-LLM native types.
+
+        TRT-LLM's ``LlmArgs`` + nested ``BuildConfig`` are Pydantic; accessible
+        on ``llm.args`` in current releases. Private fields (if any surface in
+        a given TRT-LLM version) are stripped by the default
+        ``_``-prefix allowlist behaviour in
+        :func:`extract_effective_params`.
+        """
+        import contextlib as _cl
+
+        from llenergymeasure.engines._helpers import extract_effective_params
+
+        sampling: dict[str, Any] = {}
+        with _cl.suppress(Exception):
+            sampling = extract_effective_params(sampling_params)
+
+        engine_params: dict[str, Any] = {}
+        with _cl.suppress(Exception):
+            llm_args = getattr(llm, "args", None)
+            if llm_args is not None:
+                engine_params = extract_effective_params(llm_args)
+
+        try:
+            import tensorrt_llm as _trt
+
+            library_version = str(_trt.__version__)
+        except Exception:
+            library_version = "unknown"
+
+        return {
+            "engine": engine_params,
+            "sampling": sampling,
+            "library_version": library_version,
+        }
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -232,6 +232,11 @@ class TransformersEngine:
             total_time_sec,
         )
 
+        # Capture library-observed effective parameters for H3 (sweep-dedup.md §3).
+        # Runs after the measurement loop so we don't perturb timing; the
+        # GenerationConfig's post-__init__ state is stable throughout the run.
+        effective_params = self._capture_effective_params(config, hf_model, generate_kwargs)
+
         return InferenceOutput(
             elapsed_time_sec=total_time_sec,
             input_tokens=total_input_tokens,
@@ -239,8 +244,68 @@ class TransformersEngine:
             peak_memory_mb=peak_memory_mb,
             model_memory_mb=0.0,  # Captured by harness before run_inference
             batch_times=batch_times,
-            extras={"hf_model": hf_model},  # For FLOPs estimation in harness
+            extras={
+                "hf_model": hf_model,  # For FLOPs estimation in harness
+                "effective_engine_params": effective_params["engine"],
+                "effective_sampling_params": effective_params["sampling"],
+                "library_version": effective_params["library_version"],
+            },
         )
+
+    # -------------------------------------------------------------------------
+    # Private: effective-params capture (H3)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _capture_effective_params(
+        config: ExperimentConfig,
+        hf_model: Any,
+        generate_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Extract post-construction state from the native types the engine used.
+
+        Transformers splits its native state across ``GenerationConfig`` (the
+        sampling shape) and ``BitsAndBytesConfig`` (the engine-side quantisation
+        shape, when active). Both are Pydantic-style dumpable objects;
+        :func:`extract_effective_params` strips private fields (``_commit_hash``,
+        ``_from_model_config``) that would poison H3 if included.
+
+        Returns a dict with ``engine`` / ``sampling`` / ``library_version``
+        entries ready for the H3 hashing pipeline.
+        """
+        from llenergymeasure.engines._helpers import extract_effective_params
+
+        sampling: dict[str, Any] = {}
+        try:
+            from transformers import GenerationConfig
+
+            gen_cfg = GenerationConfig(**generate_kwargs)
+            sampling = extract_effective_params(gen_cfg)
+        except Exception as exc:  # pragma: no cover — best-effort capture
+            logger.debug("transformers GenerationConfig capture failed: %s", exc)
+
+        engine_params: dict[str, Any] = {}
+        pt = config.transformers
+        if pt is not None and (pt.load_in_4bit or pt.load_in_8bit):
+            try:
+                bnb = getattr(hf_model, "quantization_config", None)
+                if bnb is not None:
+                    engine_params["quantization_config"] = extract_effective_params(bnb)
+            except Exception as exc:  # pragma: no cover — best-effort capture
+                logger.debug("transformers BitsAndBytesConfig capture failed: %s", exc)
+
+        try:
+            import transformers as _tf
+
+            library_version = str(_tf.__version__)
+        except Exception:
+            library_version = "unknown"
+
+        return {
+            "engine": engine_params,
+            "sampling": sampling,
+            "library_version": library_version,
+        }
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -273,7 +273,7 @@ class TransformersEngine:
         Returns a dict with ``engine`` / ``sampling`` / ``library_version``
         entries ready for the H3 hashing pipeline.
         """
-        from llenergymeasure.engines._helpers import extract_effective_params
+        from llenergymeasure.engines._helpers import extract_effective_params, library_version
 
         sampling: dict[str, Any] = {}
         try:
@@ -294,17 +294,10 @@ class TransformersEngine:
             except Exception as exc:  # pragma: no cover — best-effort capture
                 logger.debug("transformers BitsAndBytesConfig capture failed: %s", exc)
 
-        try:
-            import transformers as _tf
-
-            library_version = str(_tf.__version__)
-        except Exception:
-            library_version = "unknown"
-
         return {
             "engine": engine_params,
             "sampling": sampling,
-            "library_version": library_version,
+            "library_version": library_version("transformers"),
         }
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -291,7 +291,7 @@ class VLLMEngine:
         params derive from ``llm.llm_engine.vllm_config`` when available;
         otherwise we fall back to the declared kwargs dict.
         """
-        from llenergymeasure.engines._helpers import extract_effective_params
+        from llenergymeasure.engines._helpers import extract_effective_params, library_version
 
         sampling: dict[str, Any] = {}
         try:
@@ -305,17 +305,10 @@ class VLLMEngine:
             if vllm_cfg is not None:
                 engine_params = extract_effective_params(vllm_cfg)
 
-        try:
-            import vllm as _vllm
-
-            library_version = str(_vllm.__version__)
-        except Exception:
-            library_version = "unknown"
-
         return {
             "engine": engine_params,
             "sampling": sampling,
-            "library_version": library_version,
+            "library_version": library_version("vllm"),
         }
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -251,6 +251,17 @@ class VLLMEngine:
         with contextlib.suppress(Exception):
             hf_model = llm.llm_engine.model_executor.driver_worker.model_runner.model
 
+        # Library-observed effective params for H3 (sweep-dedup.md §3).
+        effective_params = self._capture_effective_params(config, llm, sampling_params)
+
+        extras: dict[str, Any] = {
+            "effective_engine_params": effective_params["engine"],
+            "effective_sampling_params": effective_params["sampling"],
+            "library_version": effective_params["library_version"],
+        }
+        if hf_model is not None:
+            extras["hf_model"] = hf_model
+
         return InferenceOutput(
             elapsed_time_sec=elapsed,
             input_tokens=input_token_count,
@@ -258,8 +269,54 @@ class VLLMEngine:
             peak_memory_mb=peak_mb,
             model_memory_mb=0.0,  # Captured by harness before run_inference
             batch_times=[elapsed],
-            extras={"hf_model": hf_model} if hf_model is not None else {},
+            extras=extras,
         )
+
+    # -------------------------------------------------------------------------
+    # Private: effective-params capture (H3)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _capture_effective_params(
+        config: ExperimentConfig,
+        llm: Any,
+        sampling_params: Any,
+    ) -> dict[str, Any]:
+        """Extract post-construction state from the vLLM native types.
+
+        Sampling params are captured via :func:`extract_effective_params` —
+        PoC-C allowlist is unset (the private fields ``_all_stop_token_ids``,
+        ``_bad_words_token_ids``, ``_eos_token_id`` default-exclude since they
+        vary per-model without affecting measurement-equivalence). Engine
+        params derive from ``llm.llm_engine.vllm_config`` when available;
+        otherwise we fall back to the declared kwargs dict.
+        """
+        from llenergymeasure.engines._helpers import extract_effective_params
+
+        sampling: dict[str, Any] = {}
+        try:
+            sampling = extract_effective_params(sampling_params)
+        except Exception as exc:  # pragma: no cover — best-effort capture
+            logger.debug("vLLM SamplingParams capture failed: %s", exc)
+
+        engine_params: dict[str, Any] = {}
+        with contextlib.suppress(Exception):
+            vllm_cfg = getattr(llm.llm_engine, "vllm_config", None)
+            if vllm_cfg is not None:
+                engine_params = extract_effective_params(vllm_cfg)
+
+        try:
+            import vllm as _vllm
+
+            library_version = str(_vllm.__version__)
+        except Exception:
+            library_version = "unknown"
+
+        return {
+            "engine": engine_params,
+            "sampling": sampling,
+            "library_version": library_version,
+        }
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -93,6 +93,62 @@ def _atomic_write(content: str, path: Path) -> None:
         raise
 
 
+def save_config_sidecar(
+    experiment_dir: Path,
+    *,
+    experiment_id: str,
+    config_hash: str,
+    engine: str,
+    library_version: str,
+    effective_engine_params: dict[str, object] | None = None,
+    effective_sampling_params: dict[str, object] | None = None,
+    h1_hash: str | None = None,
+    h3_hash: str | None = None,
+    config_validation_observations: list[dict[str, object]] | None = None,
+) -> Path:
+    """Write the per-experiment ``config.json`` sidecar with H1/H3 payload.
+
+    Schema lives in ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
+    §3.3. Fields:
+
+    - ``effective_engine_params`` / ``effective_sampling_params`` — authoritative
+      post-construction library state (populated by
+      :func:`llenergymeasure.engines._helpers.extract_effective_params`).
+    - ``h1_hash`` — canonicaliser-output hash, carried forward from sweep
+      expansion via ``StudyConfig.declared_h1_hashes``.
+    - ``h3_hash`` — library-observation hash computed from the effective
+      params at sidecar-write time.
+    - ``config_validation_observations`` — DormantField entries that
+      ``_apply_vendored_rules`` attached at load time.
+
+    Any missing optional field is omitted from the sidecar (not written as
+    null) so downstream consumers distinguish "not available" from
+    "explicitly null". The file is small (< 4 KB typical) and atomically
+    written.
+    """
+    payload: dict[str, object] = {
+        "experiment_id": experiment_id,
+        "measurement_config_hash": config_hash,
+        "engine": engine,
+        "library_version": library_version,
+    }
+    if effective_engine_params is not None:
+        payload["effective_engine_params"] = effective_engine_params
+    if effective_sampling_params is not None:
+        payload["effective_sampling_params"] = effective_sampling_params
+    if h1_hash is not None:
+        payload["h1_hash"] = h1_hash
+    if h3_hash is not None:
+        payload["h3_hash"] = h3_hash
+    if config_validation_observations is not None:
+        payload["config_validation_observations"] = config_validation_observations
+
+    path = experiment_dir / "config.json"
+    _atomic_write(json.dumps(payload, indent=2, default=str), path)
+    logger.debug("Saved config sidecar to %s", path)
+    return path
+
+
 def save_environment(
     snapshot: EnvironmentSnapshot,
     experiment_id: str,

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -157,13 +157,17 @@ def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
 
 
 def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
-    """Write :class:`EquivalenceGroups` to ``path`` atomically as JSON."""
+    """Write :class:`EquivalenceGroups` to ``path`` atomically as JSON.
+
+    ``json.dumps`` serialises frozen-dataclass tuples as arrays naturally, so
+    no pre-conversion is needed.
+    """
     payload = {
         "study_id": groups.study_id,
         "dedup_mode": groups.dedup_mode,
         "vendored_rules_version": groups.vendored_rules_version,
-        "groups": [_pre_to_dict(g) for g in groups.groups],
-        "post_run_h3_groups": [_post_to_dict(g) for g in groups.post_run_h3_groups],
+        "groups": [asdict(g) for g in groups.groups],
+        "post_run_h3_groups": [asdict(g) for g in groups.post_run_h3_groups],
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write(json.dumps(payload, indent=2, default=str), path)
@@ -172,29 +176,13 @@ def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
 def load_equivalence_groups(path: Path) -> EquivalenceGroups:
     """Load :class:`EquivalenceGroups` from a JSON file on disk."""
     data = json.loads(path.read_text())
-    pre = [_pre_from_dict(g) for g in data.get("groups", [])]
-    post = [_post_from_dict(g) for g in data.get("post_run_h3_groups", [])]
     return EquivalenceGroups(
         study_id=str(data.get("study_id", "")),
         dedup_mode=str(data.get("dedup_mode", "")),
         vendored_rules_version=str(data.get("vendored_rules_version", "")),
-        groups=pre,
-        post_run_h3_groups=post,
+        groups=[_pre_from_dict(g) for g in data.get("groups", [])],
+        post_run_h3_groups=[_post_from_dict(g) for g in data.get("post_run_h3_groups", [])],
     )
-
-
-def _pre_to_dict(g: PreRunGroup) -> dict[str, Any]:
-    d = asdict(g)
-    # asdict() leaves tuples as tuples in the top level too, but JSON wants lists
-    d["member_experiment_ids"] = list(g.member_experiment_ids)
-    return d
-
-
-def _post_to_dict(g: PostRunH3Group) -> dict[str, Any]:
-    d = asdict(g)
-    d["member_h1_hashes"] = list(g.member_h1_hashes)
-    d["member_experiment_ids"] = list(g.member_experiment_ids)
-    return d
 
 
 def _pre_from_dict(data: dict[str, Any]) -> PreRunGroup:

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -1,0 +1,221 @@
+"""Equivalence-groups sidecar — pre-run H1 groups + post-run H3 detection.
+
+Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §6.
+
+Written alongside the study's results bundle. ``pre_run_groups`` is populated
+at sweep-expansion time by :func:`dedup_sweep` and serialised immediately;
+``post_run_h3_groups`` is populated after the study completes by scanning
+sidecars for shared H3 hashes.
+
+The H3-collision invariant (§4.1) guarantees that in a post-H1-dedup run set,
+any group with ``len(member_h1_hashes) >= 2`` is a **proven canonicaliser gap**.
+Phase 50.3b's ``llem report-gaps`` command consumes this file to propose
+corpus additions.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from llenergymeasure.results.persistence import _atomic_write
+from llenergymeasure.study.sweep_canonicalise import DedupResult
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreRunGroup:
+    """Pre-run equivalence group recorded at sweep-expansion time."""
+
+    h1_hash: str
+    canonical_config_excerpt: dict[str, Any]
+    member_experiment_ids: tuple[str, ...]
+    member_count: int
+    representative_experiment_id: str
+    would_dedup: bool
+    deduplicated: bool
+
+
+@dataclass(frozen=True)
+class PostRunH3Group:
+    """Post-run H3-collision group — a canonicaliser gap if member count >= 2."""
+
+    h3_hash: str
+    engine: str
+    library_version: str
+    member_h1_hashes: tuple[str, ...]
+    member_experiment_ids: tuple[str, ...]
+    gap_detected: bool
+    proposed_rule_id: str | None = None
+
+
+@dataclass
+class EquivalenceGroups:
+    """Top-level equivalence-groups record written as ``equivalence_groups.json``."""
+
+    study_id: str
+    dedup_mode: str
+    vendored_rules_version: str = ""
+    groups: list[PreRunGroup] = field(default_factory=list)
+    post_run_h3_groups: list[PostRunH3Group] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Pre-run population — from dedup_sweep output
+# ---------------------------------------------------------------------------
+
+
+def build_pre_run_groups(
+    dedup: DedupResult,
+    *,
+    experiment_ids: list[str],
+) -> list[PreRunGroup]:
+    """Bind :class:`DedupResult` group indices back to caller-supplied IDs.
+
+    ``experiment_ids`` must be parallel to the declared-configs list passed
+    to :func:`dedup_sweep`. The runner is the natural source — it already
+    assigns per-experiment IDs before dispatch.
+    """
+    if len(experiment_ids) != len(dedup.declared_h1):
+        raise ValueError(
+            f"experiment_ids length {len(experiment_ids)} does not match the "
+            f"declared config count {len(dedup.declared_h1)}"
+        )
+    pre: list[PreRunGroup] = []
+    for group in dedup.groups:
+        member_ids = tuple(experiment_ids[i] for i in group.member_indices)
+        pre.append(
+            PreRunGroup(
+                h1_hash=group.h1_hash,
+                canonical_config_excerpt=group.canonical_excerpt,
+                member_experiment_ids=member_ids,
+                member_count=group.member_count,
+                representative_experiment_id=experiment_ids[group.representative_index],
+                would_dedup=group.member_count > 1,
+                deduplicated=dedup.deduplicated and group.member_count > 1,
+            )
+        )
+    return pre
+
+
+# ---------------------------------------------------------------------------
+# Post-run H3 grouping — scan sidecars after study completes
+# ---------------------------------------------------------------------------
+
+
+def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
+    """Group sidecars by ``(engine, library_version, h3_hash)``.
+
+    Any group with size >= 2 AND distinct ``h1_hash`` across its members is
+    flagged as a proven canonicaliser gap — per sweep-dedup.md §4.1.
+
+    Each sidecar dict must carry at minimum ``engine``, ``library_version``,
+    ``h1_hash``, ``h3_hash``, and ``experiment_id`` keys. Sidecars missing any
+    of these are silently skipped (pre-50.3a data, or runs with dedup_mode=off
+    for which H3 may be partial).
+    """
+    buckets: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for sc in sidecars:
+        h3 = sc.get("h3_hash")
+        if not h3:
+            continue
+        engine = str(sc.get("engine", ""))
+        version = str(sc.get("library_version", ""))
+        buckets[(engine, version, h3)].append(sc)
+
+    groups: list[PostRunH3Group] = []
+    for (engine, version, h3), members in buckets.items():
+        if len(members) < 2:
+            continue
+        h1_hashes = tuple(str(m.get("h1_hash", "")) for m in members)
+        exp_ids = tuple(str(m.get("experiment_id", "")) for m in members)
+        # Gap only if the H1 hashes differ — matching H1 means the
+        # canonicaliser already collapsed them.
+        gap_detected = len(set(h1_hashes)) > 1
+        groups.append(
+            PostRunH3Group(
+                h3_hash=h3,
+                engine=engine,
+                library_version=version,
+                member_h1_hashes=h1_hashes,
+                member_experiment_ids=exp_ids,
+                gap_detected=gap_detected,
+            )
+        )
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Writer / reader
+# ---------------------------------------------------------------------------
+
+
+def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
+    """Write :class:`EquivalenceGroups` to ``path`` atomically as JSON."""
+    payload = {
+        "study_id": groups.study_id,
+        "dedup_mode": groups.dedup_mode,
+        "vendored_rules_version": groups.vendored_rules_version,
+        "groups": [_pre_to_dict(g) for g in groups.groups],
+        "post_run_h3_groups": [_post_to_dict(g) for g in groups.post_run_h3_groups],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(json.dumps(payload, indent=2, default=str), path)
+
+
+def load_equivalence_groups(path: Path) -> EquivalenceGroups:
+    """Load :class:`EquivalenceGroups` from a JSON file on disk."""
+    data = json.loads(path.read_text())
+    pre = [_pre_from_dict(g) for g in data.get("groups", [])]
+    post = [_post_from_dict(g) for g in data.get("post_run_h3_groups", [])]
+    return EquivalenceGroups(
+        study_id=str(data.get("study_id", "")),
+        dedup_mode=str(data.get("dedup_mode", "")),
+        vendored_rules_version=str(data.get("vendored_rules_version", "")),
+        groups=pre,
+        post_run_h3_groups=post,
+    )
+
+
+def _pre_to_dict(g: PreRunGroup) -> dict[str, Any]:
+    d = asdict(g)
+    # asdict() leaves tuples as tuples in the top level too, but JSON wants lists
+    d["member_experiment_ids"] = list(g.member_experiment_ids)
+    return d
+
+
+def _post_to_dict(g: PostRunH3Group) -> dict[str, Any]:
+    d = asdict(g)
+    d["member_h1_hashes"] = list(g.member_h1_hashes)
+    d["member_experiment_ids"] = list(g.member_experiment_ids)
+    return d
+
+
+def _pre_from_dict(data: dict[str, Any]) -> PreRunGroup:
+    return PreRunGroup(
+        h1_hash=str(data["h1_hash"]),
+        canonical_config_excerpt=dict(data.get("canonical_config_excerpt", {})),
+        member_experiment_ids=tuple(data.get("member_experiment_ids", [])),
+        member_count=int(data.get("member_count", 0)),
+        representative_experiment_id=str(data.get("representative_experiment_id", "")),
+        would_dedup=bool(data.get("would_dedup", False)),
+        deduplicated=bool(data.get("deduplicated", False)),
+    )
+
+
+def _post_from_dict(data: dict[str, Any]) -> PostRunH3Group:
+    return PostRunH3Group(
+        h3_hash=str(data["h3_hash"]),
+        engine=str(data.get("engine", "")),
+        library_version=str(data.get("library_version", "")),
+        member_h1_hashes=tuple(data.get("member_h1_hashes", [])),
+        member_experiment_ids=tuple(data.get("member_experiment_ids", [])),
+        gap_detected=bool(data.get("gap_detected", False)),
+        proposed_rule_id=data.get("proposed_rule_id"),
+    )

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -147,37 +147,24 @@ def build_h1_view(config: ExperimentConfig) -> ConfigHashView:
     canonicaliser has already applied dormant rules to fixpoint before this
     runs. Callers pass the canonicalised config, not the declared one — H1 is
     meaningless on a pre-canonicalisation config.
-    """
-    engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
-    engine_section: Any = getattr(config, engine_name, None)
-
-    engine_params, sampling_params = _split_engine_section(engine_section)
-
-    task_dump = config.task.model_dump(mode="python")
-    passthrough = dict(config.passthrough_kwargs or {})
-
-    return ConfigHashView(
-        engine=engine_name,
-        task=task_dump,
-        effective_engine_params=engine_params,
-        effective_sampling_params=sampling_params,
-        lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
-        passthrough_kwargs=passthrough,
-    )
-
-
-def _split_engine_section(section: Any) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Return ``(engine_params, sampling_params)`` from a config engine section.
 
     Engine-specific sub-models carry a ``sampling`` attribute; it is lifted
     into its own dict so H1/H3 ordering separates "how the engine constructs"
-    from "what it generates with". Missing section → both dicts empty.
+    from "what it generates with".
     """
-    if section is None:
-        return {}, {}
-    dump = section.model_dump(mode="python") if hasattr(section, "model_dump") else dict(section)
+    engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    section: Any = getattr(config, engine_name, None)
+    dump: dict[str, Any] = section.model_dump(mode="python") if section is not None else {}
     sampling = dump.pop("sampling", None) or {}
-    return dump, sampling
+
+    return ConfigHashView(
+        engine=engine_name,
+        task=config.task.model_dump(mode="python"),
+        effective_engine_params=dump,
+        effective_sampling_params=sampling,
+        lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
+        passthrough_kwargs=dict(config.passthrough_kwargs or {}),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -1,0 +1,210 @@
+"""Canonical serialisation and SHA-256 hashing for H1 and H3.
+
+Two hashes with orthogonal sources but identical shape:
+
+- **H1** (canonicaliser-output): hashed at sweep-expansion time over the
+  canonical form produced by :mod:`llenergymeasure.study.sweep_canonicalise`.
+- **H3** (library-observed): hashed at sidecar-write time over the native
+  types the engine constructed during inference (via
+  :func:`llenergymeasure.engines._helpers.extract_effective_params`).
+
+Sharing the schema and serialisation is what makes the H3-collision invariant
+meaningful (see ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
+§4.1): after H1-dedup, any H3 duplicate is a proven canonicaliser gap.
+
+The normalisation rules below are locked by sweep-dedup.md §9.Q3 — over-
+normalising would hide library-enforced semantics (e.g. ``None`` vs missing in
+vLLM), so the rules are strict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from llenergymeasure.config.models import ExperimentConfig
+
+_FLOAT_SIG_DIGITS = 12
+"""Float rounding precision (significant digits) for hash stability.
+
+Upstream float arithmetic can produce bit-level jitter in the last 1-2
+digits that does not reflect an actual configuration difference. Rounding at
+12 significant digits removes that jitter without compressing any two values
+a researcher would write differently.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialisation (shared by H1 and H3)
+# ---------------------------------------------------------------------------
+
+
+def _normalise(value: Any) -> Any:
+    """Normalise a value for deterministic JSON serialisation.
+
+    Applies the locked rules from sweep-dedup.md §9.Q3:
+
+    - ``NaN`` → string ``"NaN"`` (NaN != NaN breaks dict hashing otherwise)
+    - float → rounded to 12 significant digits (stable across minor
+      arithmetic jitter)
+    - tuple → list (incidental immutability choice, not semantic)
+    - bool is preserved as bool (not folded into int even though
+      ``True == 1`` in Python)
+    - dict → dict with recursively normalised values (key sorting happens
+      at ``json.dumps(sort_keys=True)`` time)
+    - None and missing keys stay distinguishable (by never inserting a
+      sentinel for missing)
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            # Preserve infinity as a string literal for hash stability
+            return "Infinity" if value > 0 else "-Infinity"
+        if value == 0.0:
+            return 0.0
+        # Round to sig-figs rather than decimal places
+        mag = math.floor(math.log10(abs(value)))
+        factor = 10 ** (_FLOAT_SIG_DIGITS - 1 - mag)
+        return round(value * factor) / factor
+    if isinstance(value, (list, tuple)):
+        return [_normalise(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _normalise(v) for k, v in value.items()}
+    return value
+
+
+def canonical_serialise(obj: Any) -> bytes:
+    """Serialise ``obj`` to canonical-JSON bytes, ready for hashing.
+
+    Applies :func:`_normalise` then ``json.dumps(sort_keys=True)``. Uses a
+    separators tuple with no whitespace for compactness and stability
+    across Python versions.
+    """
+    normalised = _normalise(obj)
+    return json.dumps(
+        normalised,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,  # Pydantic enums and dates
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Hashed-field schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConfigHashView:
+    """Fixed-schema view of the fields hashed into H1 or H3.
+
+    Per sweep-dedup.md §2.4, the hashed-field set is:
+
+    - ``task`` — model, prompt source, batch shape
+    - ``effective_engine_params`` — engine state (canonicaliser output for H1,
+      live library observation for H3)
+    - ``effective_sampling_params`` — sampling state (same sources as above)
+    - ``lora`` / ``passthrough_kwargs`` — user-attached overrides
+
+    Excluded: ``MeasurementConfig`` (observation dials), ``ExecutionConfig``
+    (runner/parallelism), ``experiment_id``.
+    """
+
+    engine: str
+    task: dict[str, Any]
+    effective_engine_params: dict[str, Any] = field(default_factory=dict)
+    effective_sampling_params: dict[str, Any] = field(default_factory=dict)
+    lora: dict[str, Any] | None = None
+    passthrough_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+def hash_config(view: ConfigHashView) -> str:
+    """Return SHA-256 hex digest of ``view`` via :func:`canonical_serialise`.
+
+    Both H1 and H3 route through this function; they differ only in how
+    the :class:`ConfigHashView` is populated.
+    """
+    payload = asdict(view)
+    return hashlib.sha256(canonical_serialise(payload)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# H1 view construction — from canonicaliser output
+# ---------------------------------------------------------------------------
+
+
+def build_h1_view(config: ExperimentConfig) -> ConfigHashView:
+    """Project a (post-canonicalisation) ``ExperimentConfig`` into an H1 view.
+
+    Reads the active engine section's full post-normalisation state; the
+    canonicaliser has already applied dormant rules to fixpoint before this
+    runs. Callers pass the canonicalised config, not the declared one — H1 is
+    meaningless on a pre-canonicalisation config.
+    """
+    engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    engine_section: Any = getattr(config, engine_name, None)
+
+    engine_params, sampling_params = _split_engine_section(engine_section)
+
+    task_dump = config.task.model_dump(mode="python")
+    passthrough = dict(config.passthrough_kwargs or {})
+
+    return ConfigHashView(
+        engine=engine_name,
+        task=task_dump,
+        effective_engine_params=engine_params,
+        effective_sampling_params=sampling_params,
+        lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
+        passthrough_kwargs=passthrough,
+    )
+
+
+def _split_engine_section(section: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return ``(engine_params, sampling_params)`` from a config engine section.
+
+    Engine-specific sub-models carry a ``sampling`` attribute; it is lifted
+    into its own dict so H1/H3 ordering separates "how the engine constructs"
+    from "what it generates with". Missing section → both dicts empty.
+    """
+    if section is None:
+        return {}, {}
+    dump = section.model_dump(mode="python") if hasattr(section, "model_dump") else dict(section)
+    sampling = dump.pop("sampling", None) or {}
+    return dump, sampling
+
+
+# ---------------------------------------------------------------------------
+# H3 view construction — from library-observed effective params
+# ---------------------------------------------------------------------------
+
+
+def build_h3_view(
+    *,
+    engine: str,
+    task: dict[str, Any],
+    effective_engine_params: dict[str, Any],
+    effective_sampling_params: dict[str, Any],
+    lora: dict[str, Any] | None = None,
+    passthrough_kwargs: dict[str, Any] | None = None,
+) -> ConfigHashView:
+    """Assemble an H3 view from per-engine ``extract_effective_params`` output.
+
+    Callers live in the harness/sidecar path — they read ``task`` from the
+    same config that ran and pair it with the native-object dumps the engine
+    returned.
+    """
+    return ConfigHashView(
+        engine=engine,
+        task=task,
+        effective_engine_params=dict(effective_engine_params),
+        effective_sampling_params=dict(effective_sampling_params),
+        lora=lora,
+        passthrough_kwargs=dict(passthrough_kwargs or {}),
+    )

--- a/src/llenergymeasure/study/sweep_canonicalise.py
+++ b/src/llenergymeasure/study/sweep_canonicalise.py
@@ -1,0 +1,324 @@
+"""Sweep canonicaliser — apply vendored dormant rules to fixpoint, dedup by H1.
+
+Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §2.
+
+The canonicaliser is the host-side, pre-dispatch layer that normalises every
+field the vendored corpus marks as ``dormant``. Each rule's fired-state
+projection is taken from its match predicate's "not_equal" / "present"
+operand (the sentinel value the predicate is *deviating from*) — that same
+projection is what :mod:`scripts.walkers._fixpoint_test` enforces in CI, so
+runtime canonicalisation and CI correctness tests apply an identical
+normalisation.
+
+Rules chain (vLLM epsilon-clamp → greedy-normalise); iteration is capped at
+:data:`_MAX_ITER` to surface cycles via :class:`CanonicaliserCycleError`.
+
+Out-of-scope per PLAN §Scope OUT: vLLM/TRT-LLM corpora don't exist yet, so
+this PR mostly exercises the transformers rules. The canonicaliser itself is
+engine-generic.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.engines.vendored_rules.loader import (
+    Rule,
+    VendoredRulesLoader,
+    resolve_field_path,
+)
+from llenergymeasure.study.hashing import build_h1_view, hash_config
+
+logger = logging.getLogger(__name__)
+
+_MAX_ITER = 10
+"""Maximum fixpoint passes before declaring non-convergence.
+
+PoC-F (sweep-dedup.md §10) converged every seeded-corpus case within 2
+passes; 10 is generous headroom that still surfaces a rule cycle quickly.
+"""
+
+
+class CanonicaliserCycleError(RuntimeError):
+    """The canonicaliser did not reach a fixpoint within :data:`_MAX_ITER` passes.
+
+    Indicates a cycle in the vendored rules corpus (rule A produces state
+    matching rule B which produces state matching rule A). The corpus vendor
+    step's shuffle-application test is supposed to catch this at CI time,
+    but this guard prevents runtime hangs if a bad corpus ships anyway.
+    """
+
+    def __init__(self, final_config: ExperimentConfig, iterations: int) -> None:
+        super().__init__(
+            f"Canonicaliser did not reach fixpoint within {iterations} iterations. "
+            f"Likely a cycle in the vendored rules corpus. "
+            f"Final engine={final_config.engine}."
+        )
+        self.final_config = final_config
+        self.iterations = iterations
+
+
+# ---------------------------------------------------------------------------
+# Core canonicalise() — one config
+# ---------------------------------------------------------------------------
+
+
+def canonicalise(
+    config: ExperimentConfig, rules: list[Rule] | tuple[Rule, ...]
+) -> ExperimentConfig:
+    """Apply every ``dormant``-severity rule to ``config`` repeatedly until stable.
+
+    Returns a deep-copy of ``config`` with each dormant rule's normalisations
+    projected onto the fired fields. The input is not mutated.
+
+    Args:
+        config: A validated ``ExperimentConfig``.
+        rules: The rule list for the config's engine (typically from
+            ``VendoredRulesLoader.load_rules(engine).rules``).
+
+    Raises:
+        CanonicaliserCycleError: If the fixpoint loop exceeds
+            :data:`_MAX_ITER` passes — the vendored corpus has a rule cycle.
+    """
+    dormant_rules = [r for r in rules if r.severity in ("dormant", "dormant_silent")]
+    if not dormant_rules:
+        return config.model_copy(deep=True)
+
+    current = config.model_copy(deep=True)
+    for _iteration in range(_MAX_ITER):
+        fired = False
+        for rule in dormant_rules:
+            match = rule.try_match(current)
+            if match is None:
+                continue
+            updates = _rule_normalisations(rule)
+            if not updates:
+                continue
+            for field_path, target_value in updates.items():
+                if resolve_field_path(current, field_path) != target_value:
+                    _assign_field_path(current, field_path, target_value)
+                    fired = True
+        if not fired:
+            return current
+    raise CanonicaliserCycleError(current, _MAX_ITER)
+
+
+def _rule_normalisations(rule: Rule) -> dict[str, Any]:
+    """Return ``{field_path: canonical_value}`` the rule normalises to.
+
+    Strategy (per sweep-dedup.md §2.1 and the fixpoint test's projection):
+
+    1. If ``expected_outcome["normalised_fields"]`` lists explicit paths, they
+       collapse to ``None`` (the universal "strip this field" sentinel).
+    2. Otherwise, fall back to the rule's *match* predicate: any field
+       matched with a ``not_equal`` / ``present`` operator is normalised by
+       stripping (setting to ``None`` or the ``not_equal`` sentinel if
+       scalar). This is the fixpoint-test projection — structurally identical
+       to what CI enforces for shuffle-stability.
+
+    Rules that match only on equality (e.g. ``do_sample: false``) do not
+    normalise those fields — equality predicates are *triggers*, not
+    *subjects*. Subject fields are the ones marked ``present``/``not_equal``.
+    """
+    out: dict[str, Any] = {}
+
+    explicit = rule.expected_outcome.get("normalised_fields") or []
+    for raw_path in explicit:
+        path = str(raw_path)
+        out[path] = None
+
+    if out:
+        return out
+
+    for path, spec in rule.match_fields.items():
+        if not isinstance(spec, dict):
+            continue
+        if "not_equal" in spec:
+            # The "canonical" state is the not_equal sentinel — applying the
+            # rule drives the field back to the library-observed default.
+            out[path] = spec["not_equal"]
+        elif spec.get("present") and "not_equal" not in spec and "in" not in spec:
+            # Subject field marked only as "present" — strip to None (the
+            # library either ignores it, or the effective value is captured
+            # later via H3).
+            out[path] = None
+    return out
+
+
+def _assign_field_path(config: ExperimentConfig, path: str, value: Any) -> None:
+    """Set ``value`` at dotted ``path`` on ``config`` in place.
+
+    Walks nested Pydantic models / dicts, tolerant of ``None`` intermediate
+    attributes (silently returns if the path doesn't resolve to an assignable
+    location — mirrors :func:`resolve_field_path`'s permissive traversal).
+    """
+    parts = path.split(".")
+    parent: Any = config
+    for part in parts[:-1]:
+        if parent is None:
+            return
+        parent = parent.get(part) if isinstance(parent, dict) else getattr(parent, part, None)
+    if parent is None:
+        return
+    leaf = parts[-1]
+    try:
+        if isinstance(parent, dict):
+            parent[leaf] = value
+        else:
+            setattr(parent, leaf, value)
+    except (ValueError, TypeError) as exc:
+        # Pydantic model_config={"frozen": True} or field constraints can
+        # reject the assignment. Log at debug — the canonicaliser is best-
+        # effort; a rejected field just stays at its declared value.
+        logger.debug("Canonicaliser could not assign %s=%r: %s", path, value, exc)
+
+
+# ---------------------------------------------------------------------------
+# Sweep dedup
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EquivalenceGroup:
+    """Pre-run group of declared configs that collapse to the same H1 canonical form."""
+
+    h1_hash: str
+    canonical_excerpt: dict[str, Any]
+    member_indices: tuple[int, ...]
+    representative_index: int
+
+    @property
+    def member_count(self) -> int:
+        return len(self.member_indices)
+
+
+@dataclass
+class DedupResult:
+    """Return bundle from :func:`dedup_sweep`.
+
+    Attributes:
+        canonical_configs: The canonicalised configs after dedup (or all
+            canonicalised configs when ``deduplicate=False``, with duplicates
+            kept). This is what the runner iterates over.
+        groups: One :class:`EquivalenceGroup` per unique H1 hash, recording
+            which indices of the input sweep collapsed together.
+        declared_h1: ``declared_index → h1_hash`` — lets the runner tag the
+            manifest entry for each run with its equivalence group.
+        would_dedup: ``True`` iff any group has > 1 member (dedup would save
+            runs even when ``deduplicate=False``).
+        deduplicated: ``True`` iff dedup was actually applied to the
+            ``canonical_configs`` return slot.
+    """
+
+    canonical_configs: list[ExperimentConfig]
+    groups: list[EquivalenceGroup] = field(default_factory=list)
+    declared_h1: list[str] = field(default_factory=list)
+    would_dedup: bool = False
+    deduplicated: bool = False
+
+
+def dedup_sweep(
+    configs: list[ExperimentConfig],
+    *,
+    rules: list[Rule] | tuple[Rule, ...] | None = None,
+    loader: VendoredRulesLoader | None = None,
+    deduplicate: bool = True,
+) -> DedupResult:
+    """Canonicalise then (optionally) H1-dedup ``configs``.
+
+    Rules are resolved lazily: if ``rules`` is None the loader is consulted
+    per-engine for each config (cached by the loader instance). Callers
+    running homogeneous sweeps may pass ``rules`` directly to skip the
+    loader hop.
+
+    Args:
+        configs: Sweep-expanded declared configs.
+        rules: Optional explicit rule list. Overrides the loader when the
+            sweep is single-engine and the caller has a rules handle.
+        loader: Optional ``VendoredRulesLoader``. Defaults to a fresh one
+            (per-process cache is internal to each instance).
+        deduplicate: When ``False``, every declared config still runs —
+            groups are computed for the equivalence-groups sidecar but the
+            returned ``canonical_configs`` list has one entry per input.
+
+    Returns:
+        :class:`DedupResult` — see fields above.
+    """
+    if not configs:
+        return DedupResult(canonical_configs=[])
+
+    resolved_loader = loader or VendoredRulesLoader()
+    rule_cache: dict[str, tuple[Rule, ...]] = {}
+
+    def _rules_for(cfg: ExperimentConfig) -> tuple[Rule, ...]:
+        if rules is not None:
+            return tuple(rules)
+        engine = cfg.engine.value if hasattr(cfg.engine, "value") else str(cfg.engine)
+        cached = rule_cache.get(engine)
+        if cached is not None:
+            return cached
+        try:
+            loaded = resolved_loader.load_rules(engine).rules
+        except FileNotFoundError:
+            loaded = ()
+        rule_cache[engine] = loaded
+        return loaded
+
+    canonicalised: list[ExperimentConfig] = []
+    hashes: list[str] = []
+    for cfg in configs:
+        canon = canonicalise(cfg, _rules_for(cfg))
+        canonicalised.append(canon)
+        hashes.append(hash_config(build_h1_view(canon)))
+
+    groups_by_hash: dict[str, list[int]] = {}
+    for idx, h in enumerate(hashes):
+        groups_by_hash.setdefault(h, []).append(idx)
+
+    groups: list[EquivalenceGroup] = []
+    for h1, indices in groups_by_hash.items():
+        representative = indices[0]
+        rep = canonicalised[representative]
+        excerpt = _canonical_excerpt(rep)
+        groups.append(
+            EquivalenceGroup(
+                h1_hash=h1,
+                canonical_excerpt=excerpt,
+                member_indices=tuple(indices),
+                representative_index=representative,
+            )
+        )
+
+    would_dedup = any(g.member_count > 1 for g in groups)
+
+    if deduplicate:
+        selected = [canonicalised[g.representative_index] for g in groups]
+    else:
+        selected = list(canonicalised)
+
+    return DedupResult(
+        canonical_configs=selected,
+        groups=groups,
+        declared_h1=hashes,
+        would_dedup=would_dedup,
+        deduplicated=deduplicate and would_dedup,
+    )
+
+
+def _canonical_excerpt(config: ExperimentConfig) -> dict[str, Any]:
+    """Small human-readable excerpt of the canonical form for display/logs."""
+    engine = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    excerpt: dict[str, Any] = {
+        "engine": engine,
+        "task.model": config.task.model,
+    }
+    section = getattr(config, engine, None)
+    sampling = getattr(section, "sampling", None) if section is not None else None
+    if sampling is not None:
+        dumped = sampling.model_dump(mode="python", exclude_none=True)
+        for key, value in dumped.items():
+            excerpt[f"{engine}.sampling.{key}"] = value
+    return excerpt

--- a/src/llenergymeasure/study/sweep_canonicalise.py
+++ b/src/llenergymeasure/study/sweep_canonicalise.py
@@ -140,7 +140,7 @@ def _rule_normalisations(rule: Rule) -> dict[str, Any]:
             # The "canonical" state is the not_equal sentinel — applying the
             # rule drives the field back to the library-observed default.
             out[path] = spec["not_equal"]
-        elif spec.get("present") and "not_equal" not in spec and "in" not in spec:
+        elif spec.get("present") and "in" not in spec:
             # Subject field marked only as "present" — strip to None (the
             # library either ignores it, or the effective value is captured
             # later via H3).
@@ -251,21 +251,16 @@ def dedup_sweep(
         return DedupResult(canonical_configs=[])
 
     resolved_loader = loader or VendoredRulesLoader()
-    rule_cache: dict[str, tuple[Rule, ...]] = {}
+    explicit_rules = tuple(rules) if rules is not None else None
 
     def _rules_for(cfg: ExperimentConfig) -> tuple[Rule, ...]:
-        if rules is not None:
-            return tuple(rules)
+        if explicit_rules is not None:
+            return explicit_rules
         engine = cfg.engine.value if hasattr(cfg.engine, "value") else str(cfg.engine)
-        cached = rule_cache.get(engine)
-        if cached is not None:
-            return cached
         try:
-            loaded = resolved_loader.load_rules(engine).rules
+            return resolved_loader.load_rules(engine).rules
         except FileNotFoundError:
-            loaded = ()
-        rule_cache[engine] = loaded
-        return loaded
+            return ()
 
     canonicalised: list[ExperimentConfig] = []
     hashes: list[str] = []

--- a/tests/integration/test_sweep_dedup_end_to_end.py
+++ b/tests/integration/test_sweep_dedup_end_to_end.py
@@ -1,0 +1,136 @@
+"""End-to-end integration test for sweep canonicalisation + H1 dedup.
+
+Exercises the full load path: a study YAML with measurement-equivalent
+sweep configs goes through ``load_study_config`` and the resulting
+``StudyConfig`` records the pre-run equivalence groups + deduplicated
+canonical configs.
+
+Run time: < 1s — no GPU involved, all operations are on Pydantic models
+and the vendored-rules loader.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from llenergymeasure.config.loader import load_study_config
+
+
+def _write_study(tmp_path: Path, raw: dict) -> Path:
+    path = tmp_path / "study.yaml"
+    path.write_text(yaml.safe_dump(raw))
+    return path
+
+
+def test_greedy_temperature_sweep_collapses(tmp_path: Path) -> None:
+    """Six-config sweep with dormant sampling fields collapses to four unique."""
+    study = {
+        "study_name": "dedup_test",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 10}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 1.0, 1.5],
+        },
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    # Dedup mode default is h1.
+    assert study_config.dedup_mode == "h1"
+    # 6 declared x 1 cycle -> 4 unique x 1 cycle = 4 experiments.
+    assert len(study_config.experiments) == 4
+    # Declared count preserved via H1 list.
+    assert len(study_config.declared_h1_hashes) == 6
+    # At least one group has multiple members (the greedy-family collapse).
+    group_sizes = sorted(g["member_count"] for g in study_config.pre_run_equivalence_groups)
+    assert max(group_sizes) >= 2
+    assert sum(group_sizes) == 6
+
+
+def test_no_dedup_preserves_all_configs(tmp_path: Path) -> None:
+    """With ``deduplicate_equivalent: false`` every declared config runs."""
+    study = {
+        "study_name": "no_dedup",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 10}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 1.0, 1.5],
+        },
+        "study_execution": {"deduplicate_equivalent": False},
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    assert study_config.dedup_mode == "off"
+    # All 6 declared configs run — canonicaliser still populated the groups.
+    assert len(study_config.experiments) == 6
+    # Groups still computed for the sidecar trail.
+    assert sum(g["member_count"] for g in study_config.pre_run_equivalence_groups) == 6
+
+
+def test_cli_override_no_dedup(tmp_path: Path) -> None:
+    """CLI-equivalent override (``study_execution.deduplicate_equivalent: false``)."""
+    study = {
+        "study_name": "cli_no_dedup",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 5}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 0.7],
+        },
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(
+        path,
+        cli_overrides={"study_execution": {"deduplicate_equivalent": False}},
+    )
+    assert study_config.dedup_mode == "off"
+    # 2 x 2 = 4 declared configs all run.
+    assert len(study_config.experiments) == 4
+
+
+def test_n_cycles_multiplies_unique_set(tmp_path: Path) -> None:
+    """Dedup happens within a cycle; ``n_cycles`` multiplies the deduped set."""
+    study = {
+        "study_name": "cycles",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 5}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 0.7],
+        },
+        "study_execution": {"n_cycles": 3},
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    # 4 declared -> 3 unique (greedy-0.5 + greedy-0.7 collapse to greedy-1.0,
+    # plus 2 sampling variants). 3 unique x 3 cycles = 9 runs.
+    assert study_config.dedup_mode == "h1"
+    unique = {h for h in study_config.declared_h1_hashes}
+    # Two declared configs share the same H1 (both greedy).
+    assert len(unique) == 3
+    assert len(study_config.experiments) == 9
+
+
+def test_single_config_sweep_no_dedup(tmp_path: Path) -> None:
+    """A sweep with one axis and no equivalence runs normally."""
+    study = {
+        "study_name": "single",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 5}},
+        "sweep": {
+            "transformers.sampling.temperature": [0.5, 0.7, 0.9],
+        },
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    # Sampling is default-true; three temps should stay distinct.
+    assert len(study_config.experiments) == 3
+    group_sizes = sorted(g["member_count"] for g in study_config.pre_run_equivalence_groups)
+    assert group_sizes == [1, 1, 1]

--- a/tests/unit/engines/test_effective_params_capture.py
+++ b/tests/unit/engines/test_effective_params_capture.py
@@ -1,0 +1,143 @@
+"""Tests for :func:`extract_effective_params` and the per-engine capture path.
+
+PoC-C finding (sweep-dedup.md §3.2): the extractor must strip private
+(``_``-prefixed) fields by default — transformers and vLLM both leak
+state that would poison H3 otherwise. These tests verify the default
+behaviour and the allowlist escape hatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+from llenergymeasure.engines._helpers import extract_effective_params
+
+# ---------------------------------------------------------------------------
+# Dispatch behaviour — one per native-type shape
+# ---------------------------------------------------------------------------
+
+
+class _PydanticShape(BaseModel):
+    a: int = 1
+    b: str = "x"
+
+
+@dataclass
+class _DataclassShape:
+    a: int = 1
+    b: str = "x"
+
+
+class _SlotsShape:
+    __slots__ = ("a", "b")
+
+    def __init__(self) -> None:
+        self.a = 1
+        self.b = "x"
+
+
+class _DictShape:
+    def __init__(self) -> None:
+        self.a = 1
+        self.b = "x"
+
+
+class TestDispatch:
+    def test_pydantic(self):
+        out = extract_effective_params(_PydanticShape())
+        assert out == {"a": 1, "b": "x"}
+
+    def test_dataclass(self):
+        out = extract_effective_params(_DataclassShape())
+        assert out == {"a": 1, "b": "x"}
+
+    def test_slots(self):
+        out = extract_effective_params(_SlotsShape())
+        assert out == {"a": 1, "b": "x"}
+
+    def test_dict_fallback(self):
+        out = extract_effective_params(_DictShape())
+        assert out == {"a": 1, "b": "x"}
+
+
+# ---------------------------------------------------------------------------
+# Private-field handling (PoC-C finding)
+# ---------------------------------------------------------------------------
+
+
+class _LeakyPydantic(BaseModel):
+    """Models transformers GenerationConfig leaking private state."""
+
+    model_config = {"extra": "allow"}
+
+    temperature: float = 1.0
+
+
+class _LeakyDataclass:
+    """Models a dataclass-ish leak via __dict__ fallback."""
+
+    def __init__(self) -> None:
+        self.temperature = 1.0
+        self._commit_hash = "deadbeef"
+        self._from_model_config = True
+
+
+class TestPrivateFieldStripping:
+    def test_pydantic_private_fields_stripped_by_default(self):
+        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc", _from_model_config=True)
+        out = extract_effective_params(obj)
+        assert out == {"temperature": 0.7}
+
+    def test_dict_private_fields_stripped_by_default(self):
+        obj = _LeakyDataclass()
+        out = extract_effective_params(obj)
+        assert out == {"temperature": 1.0}
+
+    def test_allowlist_preserves_private_field(self):
+        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc")
+        out = extract_effective_params(obj, private_field_allowlist={"_commit_hash"})
+        assert out == {"temperature": 0.7, "_commit_hash": "abc"}
+
+
+# ---------------------------------------------------------------------------
+# Byte stability — same kwargs → same dump
+# ---------------------------------------------------------------------------
+
+
+class TestByteStability:
+    def test_repeat_constructions_same_output(self):
+        a = extract_effective_params(_PydanticShape(a=5, b="hi"))
+        b = extract_effective_params(_PydanticShape(a=5, b="hi"))
+        assert a == b
+
+    def test_different_kwargs_different_output(self):
+        a = extract_effective_params(_PydanticShape(a=5, b="hi"))
+        b = extract_effective_params(_PydanticShape(a=6, b="hi"))
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_object_returns_empty_dict(self):
+        class _Empty:
+            pass
+
+        out = extract_effective_params(_Empty())
+        assert out == {}
+
+    def test_model_dump_type_error_falls_through(self):
+        # A model_dump that only accepts no args should still work via the
+        # fallback path (TypeError on model_dump(mode=...) → retry with no kwargs).
+        class _ModelDumpNoArgs:
+            def model_dump(self) -> dict[str, Any]:
+                return {"x": 1}
+
+        out = extract_effective_params(_ModelDumpNoArgs())
+        assert out == {"x": 1}

--- a/tests/unit/study/test_canonicaliser.py
+++ b/tests/unit/study/test_canonicaliser.py
@@ -1,0 +1,305 @@
+"""Tests for the sweep canonicaliser — fixpoint iteration + dedup.
+
+Idempotence + shuffle-stability are enforced by
+``scripts/walkers/_fixpoint_test.py`` (CI-time contract — any corpus PR that
+violates them is rejected before this module runs). These tests focus on
+the *runtime* behaviour: does the canonicaliser reach fixpoint, does it
+collapse measurement-equivalent configs, does it detect cycles, does it
+populate equivalence-group metadata.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.engines.vendored_rules.loader import Rule
+from llenergymeasure.study.hashing import build_h1_view, hash_config
+from llenergymeasure.study.sweep_canonicalise import (
+    CanonicaliserCycleError,
+    canonicalise,
+    dedup_sweep,
+)
+
+
+def _mk_rule(
+    *,
+    rule_id: str,
+    match_fields: dict,
+    normalised_fields: list[str] | None = None,
+    severity: str = "dormant",
+) -> Rule:
+    """Construct a minimal ``Rule`` for canonicaliser tests."""
+    return Rule(
+        id=rule_id,
+        engine="transformers",
+        library="transformers",
+        rule_under_test="",
+        severity=severity,
+        native_type="transformers.GenerationConfig",
+        match_engine="transformers",
+        match_fields=match_fields,
+        kwargs_positive={},
+        kwargs_negative={},
+        expected_outcome={"normalised_fields": normalised_fields or []},
+        message_template=None,
+        walker_source={},
+        references=(),
+        added_by="test",
+        added_at="2026-04-23",
+    )
+
+
+def _mk_config(**overrides):
+    base = {"task": {"model": "gpt2"}, "engine": "transformers"}
+    base.update(overrides)
+    return ExperimentConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# canonicalise()
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalise:
+    def test_empty_rules_returns_deep_copy(self):
+        cfg = _mk_config()
+        result = canonicalise(cfg, [])
+        assert result is not cfg
+        assert result.model_dump() == cfg.model_dump()
+
+    def test_no_match_no_change(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="never_fires",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        # do_sample=True disqualifies the rule; temperature should be untouched.
+        assert result.transformers.sampling.temperature == 0.5
+
+    def test_greedy_normalises_temperature_via_not_equal(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        # Canonical form is the not_equal sentinel.
+        assert result.transformers.sampling.temperature == 1.0
+
+    def test_idempotence_on_already_canonical(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 1.0}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        assert result.transformers.sampling.temperature == 1.0
+
+    def test_chained_rules_converge(self):
+        # Rule A: if temperature > 0.8, strip top_p (simulating greedy-when-hot
+        # semantics — imaginary for this test).
+        # Rule B: if top_p is None, strip top_k.
+        # Input with temperature 0.9, top_p=0.95, top_k=50 must converge in 2 passes.
+        cfg = _mk_config(
+            transformers={
+                "sampling": {
+                    "do_sample": True,
+                    "temperature": 0.9,
+                    "top_p": 0.95,
+                    "top_k": 50,
+                }
+            }
+        )
+        rule_a = _mk_rule(
+            rule_id="hot_strips_top_p",
+            match_fields={
+                "transformers.sampling.temperature": {">": 0.8},
+                "transformers.sampling.top_p": {"present": True},
+            },
+        )
+        rule_b = _mk_rule(
+            rule_id="no_top_p_strips_top_k",
+            match_fields={
+                "transformers.sampling.top_p": {"absent": True},
+                "transformers.sampling.top_k": {"present": True, "not_equal": 50},
+            },
+        )
+        result = canonicalise(cfg, [rule_a, rule_b])
+        assert result.transformers.sampling.top_p is None
+        # top_k unchanged: rule_b only fires when top_k != 50, but input is 50.
+        assert result.transformers.sampling.top_k == 50
+
+    def test_cycle_detection(self):
+        # Synthetic cycle: two rules that flip a field back and forth.
+        # rule_a: if top_k=50, strip it
+        # rule_b: if top_k absent, set to 50 (via not_equal on present)
+        # The real rule shape is constrained; simulate a cycle by assigning a
+        # path that gets reset each iteration.
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "top_k": 50}})
+        rule_a = _mk_rule(
+            rule_id="clear_top_k",
+            match_fields={
+                "transformers.sampling.top_k": {"present": True, "not_equal": 999},
+            },
+        )
+        rule_b = _mk_rule(
+            rule_id="restore_top_k",
+            match_fields={
+                "transformers.sampling.top_k": {"present": True, "not_equal": 50},
+            },
+        )
+        with pytest.raises(CanonicaliserCycleError):
+            canonicalise(cfg, [rule_a, rule_b])
+
+    def test_non_dormant_rules_ignored(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="not_dormant",
+            severity="warn",
+            match_fields={
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        # warn severity must not trigger normalisation.
+        assert result.transformers.sampling.temperature == 0.5
+
+
+# ---------------------------------------------------------------------------
+# dedup_sweep()
+# ---------------------------------------------------------------------------
+
+
+class TestDedupSweep:
+    def test_empty_sweep_returns_empty(self):
+        result = dedup_sweep([])
+        assert result.canonical_configs == []
+        assert result.groups == []
+
+    def test_collapse_equivalent_configs(self):
+        # Two configs differ only by a dormant field under greedy decoding; they
+        # must collapse into one after canonicalisation.
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = dedup_sweep([cfg_a, cfg_b], rules=[rule])
+        assert len(result.canonical_configs) == 1
+        assert len(result.groups) == 1
+        assert result.groups[0].member_count == 2
+        assert result.deduplicated is True
+        assert result.would_dedup is True
+
+    def test_distinct_configs_stay_distinct(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = dedup_sweep([cfg_a, cfg_b], rules=[rule])
+        assert len(result.canonical_configs) == 2
+        assert len(result.groups) == 2
+        assert result.would_dedup is False
+        assert result.deduplicated is False
+
+    def test_dedup_disabled_preserves_all_but_groups_still_populated(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = dedup_sweep([cfg_a, cfg_b], rules=[rule], deduplicate=False)
+        # Every declared config still executes.
+        assert len(result.canonical_configs) == 2
+        # But the groups record the collapse that *would* have happened.
+        assert len(result.groups) == 1
+        assert result.groups[0].member_count == 2
+        assert result.would_dedup is True
+        assert result.deduplicated is False
+
+    def test_declared_h1_length_matches_input(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": True}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False}})
+        result = dedup_sweep([cfg_a, cfg_b], rules=[])
+        assert len(result.declared_h1) == 2
+
+    def test_integration_with_real_corpus(self):
+        # End-to-end with the actual vendored rules — the original motivating
+        # example: do_sample x temperature = [T,F] x [0.5, 1.0, 1.5] -> 6 configs,
+        # canonicaliser collapses to 4 (1 greedy canonical + 3 sampling variants).
+        from llenergymeasure.engines.vendored_rules.loader import VendoredRulesLoader
+
+        loader = VendoredRulesLoader()
+        rules = loader.load_rules("transformers").rules
+
+        configs = []
+        for do_sample in (True, False):
+            for temp in (0.5, 1.0, 1.5):
+                configs.append(
+                    _mk_config(
+                        transformers={"sampling": {"do_sample": do_sample, "temperature": temp}}
+                    )
+                )
+        result = dedup_sweep(configs, rules=rules)
+        # do_sample=True x temps=[0.5, 1.0, 1.5] -> 3 distinct sampling configs
+        # do_sample=False x any temp -> 1 canonical greedy
+        assert len(result.canonical_configs) == 4
+
+    def test_hashes_stable_across_repeated_dedup(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="greedy",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        r1 = dedup_sweep([cfg], rules=[rule])
+        r2 = dedup_sweep([cfg], rules=[rule])
+        assert r1.declared_h1 == r2.declared_h1
+        assert r1.groups[0].h1_hash == r2.groups[0].h1_hash
+
+
+# ---------------------------------------------------------------------------
+# H1 hashing symmetry
+# ---------------------------------------------------------------------------
+
+
+class TestH1HashSymmetry:
+    def test_equivalent_canonical_forms_share_h1(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        canon_a = canonicalise(cfg_a, [rule])
+        canon_b = canonicalise(cfg_b, [rule])
+        assert hash_config(build_h1_view(canon_a)) == hash_config(build_h1_view(canon_b))

--- a/tests/unit/study/test_equivalence_groups.py
+++ b/tests/unit/study/test_equivalence_groups.py
@@ -1,0 +1,201 @@
+"""Tests for the equivalence-groups sidecar writer + post-run H3 grouping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.study.equivalence_groups import (
+    EquivalenceGroups,
+    PostRunH3Group,
+    PreRunGroup,
+    build_pre_run_groups,
+    find_h3_groups,
+    load_equivalence_groups,
+    write_equivalence_groups,
+)
+from llenergymeasure.study.sweep_canonicalise import dedup_sweep
+
+
+def _mk_config(**overrides):
+    base = {"task": {"model": "gpt2"}, "engine": "transformers"}
+    base.update(overrides)
+    return ExperimentConfig(**base)
+
+
+class TestRoundTripSerialisation:
+    def test_write_then_load_preserves_fields(self, tmp_path: Path):
+        groups = EquivalenceGroups(
+            study_id="study_abc",
+            dedup_mode="h1",
+            vendored_rules_version="transformers:4.56.0@deadbee",
+            groups=[
+                PreRunGroup(
+                    h1_hash="sha256:abc",
+                    canonical_config_excerpt={"engine": "transformers"},
+                    member_experiment_ids=("exp_0001", "exp_0002"),
+                    member_count=2,
+                    representative_experiment_id="exp_0001",
+                    would_dedup=True,
+                    deduplicated=True,
+                )
+            ],
+            post_run_h3_groups=[
+                PostRunH3Group(
+                    h3_hash="sha256:def",
+                    engine="transformers",
+                    library_version="4.56.0",
+                    member_h1_hashes=("sha256:abc", "sha256:xyz"),
+                    member_experiment_ids=("exp_0001", "exp_0003"),
+                    gap_detected=True,
+                    proposed_rule_id="candidate_rule_1",
+                )
+            ],
+        )
+        path = tmp_path / "equivalence_groups.json"
+        write_equivalence_groups(groups, path)
+        loaded = load_equivalence_groups(path)
+
+        assert loaded.study_id == "study_abc"
+        assert loaded.dedup_mode == "h1"
+        assert loaded.vendored_rules_version.startswith("transformers:")
+        assert len(loaded.groups) == 1
+        assert loaded.groups[0].member_count == 2
+        assert loaded.groups[0].would_dedup is True
+        assert len(loaded.post_run_h3_groups) == 1
+        assert loaded.post_run_h3_groups[0].gap_detected is True
+
+
+class TestBuildPreRunGroups:
+    def test_binds_indices_to_experiment_ids(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        result = dedup_sweep([cfg_a, cfg_b])
+        # Both collapse via the real corpus' greedy rules.
+        pre = build_pre_run_groups(result, experiment_ids=["exp_a", "exp_b"])
+        assert len(pre) == 1
+        assert pre[0].member_experiment_ids == ("exp_a", "exp_b")
+        assert pre[0].representative_experiment_id == "exp_a"
+        assert pre[0].would_dedup is True
+        assert pre[0].deduplicated is True
+
+    def test_without_dedup_groups_record_would_dedup(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        result = dedup_sweep([cfg_a, cfg_b], deduplicate=False)
+        pre = build_pre_run_groups(result, experiment_ids=["exp_a", "exp_b"])
+        assert len(pre) == 1
+        assert pre[0].would_dedup is True
+        assert pre[0].deduplicated is False
+
+    def test_id_length_mismatch_raises(self):
+        cfg = _mk_config()
+        result = dedup_sweep([cfg])
+        try:
+            build_pre_run_groups(result, experiment_ids=[])
+        except ValueError as exc:
+            assert "does not match" in str(exc)
+            return
+        raise AssertionError("expected ValueError")
+
+
+class TestFindH3Groups:
+    def test_flags_gap_when_same_h3_distinct_h1(self):
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_b",  # Distinct H1 — gap!
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        assert len(groups) == 1
+        assert groups[0].gap_detected is True
+
+    def test_no_flag_when_h1_same(self):
+        # Same H1 collapsing on the library side is not a gap — the
+        # canonicaliser already saw them as equivalent.
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        assert len(groups) == 1
+        assert groups[0].gap_detected is False
+
+    def test_distinct_h3_no_group(self):
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_a",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_b",
+                "h3_hash": "h3_b",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        assert groups == []
+
+    def test_different_versions_do_not_cross_groups(self):
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.57.0",  # Different version
+                "h1_hash": "h1_b",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        # Version mismatch — grouped separately, each with len=1, so no gap.
+        assert groups == []
+
+    def test_sidecar_missing_h3_skipped(self):
+        sidecars = [
+            {"engine": "transformers", "library_version": "4.56.0", "h1_hash": "h1_a"},
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_b",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        # Only one valid sidecar; no group formed.
+        groups = find_h3_groups(sidecars)
+        assert groups == []

--- a/tests/unit/study/test_hashing.py
+++ b/tests/unit/study/test_hashing.py
@@ -1,0 +1,167 @@
+"""Tests for canonical serialisation + H1/H3 hashing.
+
+Normalisation rules come from ``sweep-dedup.md`` §9.Q3. Each test pins one
+rule from the table so a rule change surfaces as a targeted failure rather
+than a diffuse hash-mismatch.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.study.hashing import (
+    ConfigHashView,
+    build_h1_view,
+    build_h3_view,
+    canonical_serialise,
+    hash_config,
+)
+
+
+def _mk_config(**overrides):
+    base = {"task": {"model": "gpt2"}, "engine": "transformers"}
+    base.update(overrides)
+    return ExperimentConfig(**base)
+
+
+class TestCanonicalSerialise:
+    def test_none_and_missing_differ(self):
+        a = {"seed": None}
+        b: dict = {}
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_int_and_float_differ(self):
+        a = {"top_k": 0}
+        b = {"top_k": 0.0}
+        # Type difference preserved: int 0 and float 0.0 serialise differently
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_bool_and_int_differ(self):
+        a = {"do_sample": True}
+        b = {"do_sample": 1}
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_tuple_normalises_to_list(self):
+        a = {"stop": ("a", "b")}
+        b = {"stop": ["a", "b"]}
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+    def test_dict_keys_sorted(self):
+        a = {"a": 1, "b": 2}
+        b = {"b": 2, "a": 1}
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+    def test_nan_is_stable_string(self):
+        out = canonical_serialise({"x": math.nan})
+        assert b'"NaN"' in out
+
+    def test_infinity_is_stable(self):
+        pos = canonical_serialise({"x": math.inf})
+        neg = canonical_serialise({"x": -math.inf})
+        assert b"Infinity" in pos and b"-Infinity" in neg
+        assert pos != neg
+
+    def test_float_rounding_stability(self):
+        # Jitter in the 13th+ significant digit should collapse to the same hash.
+        a = {"temp": 0.123456789012345}
+        b = {"temp": 0.1234567890123459}  # 13+ digits differ
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+    def test_float_distinct_values_stay_distinct(self):
+        # Two values that differ at the 11th digit must not collapse.
+        a = {"temp": 0.12345678901}
+        b = {"temp": 0.12345678902}
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_nested_dict_recursive_normalisation(self):
+        a = {"outer": {"inner": (1.0, 2.0)}}
+        b = {"outer": {"inner": [1.0, 2.0]}}
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+
+class TestHashConfig:
+    def test_returns_hex_digest(self):
+        view = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        h = hash_config(view)
+        assert isinstance(h, str)
+        assert len(h) == 64
+        int(h, 16)  # parses as hex
+
+    def test_identical_views_same_hash(self):
+        v1 = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        v2 = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        assert hash_config(v1) == hash_config(v2)
+
+    def test_different_engine_different_hash(self):
+        v1 = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        v2 = ConfigHashView(engine="vllm", task={"model": "gpt2"})
+        assert hash_config(v1) != hash_config(v2)
+
+
+class TestBuildH1View:
+    def test_extracts_engine_and_task(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False}})
+        view = build_h1_view(cfg)
+        assert view.engine == "transformers"
+        assert view.task["model"] == "gpt2"
+
+    def test_sampling_lifted_into_sampling_bucket(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.7}})
+        view = build_h1_view(cfg)
+        assert view.effective_sampling_params["do_sample"] is True
+        assert view.effective_sampling_params["temperature"] == 0.7
+        assert "sampling" not in view.effective_engine_params
+
+    def test_passthrough_kwargs_propagated(self):
+        cfg = _mk_config(passthrough_kwargs={"my_key": "my_val"})
+        view = build_h1_view(cfg)
+        assert view.passthrough_kwargs == {"my_key": "my_val"}
+
+
+class TestBuildH3View:
+    def test_carries_inputs_through(self):
+        view = build_h3_view(
+            engine="vllm",
+            task={"model": "gpt2"},
+            effective_engine_params={"dtype": "float16"},
+            effective_sampling_params={"temperature": 1.0},
+        )
+        assert view.engine == "vllm"
+        assert view.effective_engine_params["dtype"] == "float16"
+        assert view.effective_sampling_params["temperature"] == 1.0
+
+    def test_h1_and_h3_match_on_same_inputs(self):
+        # Symmetry: both views hashed through the same pipe produce the same hash
+        # when the underlying fields match. This is what makes the H3-collision
+        # invariant meaningful.
+        task = {"model": "gpt2"}
+        engine_params = {"dtype": "float16"}
+        sampling_params = {"temperature": 1.0}
+
+        h1_view = ConfigHashView(
+            engine="vllm",
+            task=task,
+            effective_engine_params=engine_params,
+            effective_sampling_params=sampling_params,
+        )
+        h3_view = build_h3_view(
+            engine="vllm",
+            task=task,
+            effective_engine_params=engine_params,
+            effective_sampling_params=sampling_params,
+        )
+        assert hash_config(h1_view) == hash_config(h3_view)
+
+
+class TestHashStability:
+    @pytest.mark.parametrize("_", range(5))
+    def test_hash_stable_across_repeat_calls(self, _):
+        cfg = _mk_config(
+            transformers={"sampling": {"do_sample": False, "temperature": 1.0}},
+        )
+        h1 = hash_config(build_h1_view(cfg))
+        h2 = hash_config(build_h1_view(cfg))
+        assert h1 == h2


### PR DESCRIPTION
## Summary

- Canonicaliser for `ExperimentConfig` (idempotent + shuffle-stable via the
  `_fixpoint_test` contract already enforced at corpus-CI time).
- H1 + H3 collision invariant: both hashes share one `canonical_serialise` /
  `hash_config` pipeline; only the source of the effective-params dict differs.
- Sweep-expansion dedup: `load_study_config` now canonicalises + H1-dedupes
  before cycles are applied. `deduplicate_equivalent` flag on `ExecutionConfig`
  (default `true`); `--no-dedup` CLI flag overrides it.
- Per-engine `extract_effective_params` capture: transformers / vLLM / TRT-LLM
  all return the library-observed effective parameters via
  `InferenceOutput.extras` for sidecar H3 computation.
- `equivalence_groups.json` schema + writer + post-run H3 gap detector.
- `save_config_sidecar()` writes `config.json` carrying effective_engine_params,
  effective_sampling_params, library_version, h1_hash, h3_hash, and
  `config_validation_observations`.

## Stack

This PR is stacked on [#369 (50.2c)](https://github.com/henrycgbaker/llenergymeasure/pull/369).
Review order: 367 -> 368 -> 369 -> this. Wave 2 opener — 50.3b (feedback loop)
consumes the H3-collision invariant from this PR.

## Plan

- `.planning/phases/50.3a-canonicaliser-and-h3/PLAN.md`

## Primary design

- `.product/designs/config-deduplication-dormancy/sweep-dedup.md`
- `.product/designs/config-deduplication-dormancy/runtime-config-validation.md` §4.5
  (canonicaliser as second consumer of the vendored rules corpus)

## Evidence

- Real transformers corpus + a 6-config greedy × temperature sweep collapses
  from 6 declared to 4 unique (3 sampling variants + 1 greedy canonical) via
  `dedup_sweep`, as asserted by
  `tests/integration/test_sweep_dedup_end_to_end.py::test_greedy_temperature_sweep_collapses`.
- Two configs that differ only by a dormant field under `do_sample=false`
  produce identical H1 hashes; a third config with `do_sample=true` stays
  distinct. End-to-end functional check ran green on the 32-rule transformers
  corpus.
- `extract_effective_params` strips `_`-prefixed fields by default
  (`_commit_hash`, `_from_model_config` for transformers; `_all_stop_token_ids`
  etc. for vLLM); allowlist escape hatch covered by unit test.

## Success-criteria checks

- [x] `pytest tests/` — 2256 passed (up from 2167 baseline), 69 warnings, 10 deselected
- [x] `ruff check .` — all checks passed
- [x] `ruff format --check .` — 225 files clean
- [x] `mypy src/llenergymeasure/` — no issues found, 100 files

## Deviations

None material. RuleMatch.effective_value populated path: the PLAN's OQ #1 notes
the generic validator already populates `_dormant_observations` (done in 50.2c);
this PR adds the sidecar-writer surface for those observations but does not
alter the validator itself. Canonicaliser-side population of
`RuleMatch.effective_value` is deferred — the canonicaliser drives the config
to the canonical form directly rather than annotating the match, which is the
simpler path and loses no information (the sidecar still records declared and
effective values via the dormant-observations trail).

## Notes for reviewer

- Sidecar write is plumbed as a standalone `save_config_sidecar()` helper
  in `results/persistence.py`. The runner's current save path does not yet
  call it — that wiring is a small follow-up that 50.3b or the sidecar-
  consolidation refactor can take in its own PR, alongside the `library_version`
  field. Keeping this PR focused on the canonicaliser / H3 surface itself.
- Canonicaliser is engine-generic; the vLLM / TRT-LLM corpora do not exist
  yet, so this PR mostly exercises transformers rules in practice — as
  per PLAN §Scope OUT.
- TRT-LLM extract-effective-params verification deferred to NGC container
  run per PoC-C; helper + wiring are in place and will activate once the
  corpus is seeded.
