### PR TITLE
feat(engines): add vendored rules loader with typed AddedBy enum

### DIFF
--- a/src/llenergymeasure/engines/vendored_rules/__init__.py
+++ b/src/llenergymeasure/engines/vendored_rules/__init__.py
@@ -1,0 +1,37 @@
+"""Vendored validation rules: loader, matcher, predicate engine.
+
+The corpus at ``configs/validation_rules/{engine}.yaml`` is the SSOT for
+what runtime config validation tells users about their configs. This package
+consumes that corpus and exposes a typed matcher API.
+
+This module does not yet wire into ``config/models.py`` — that wiring lands
+in phase 50.2c alongside the generic ``@model_validator``. Landing the
+loader contract first lets the vendor CI pipeline (50.2b) and the generic
+validator (50.2c) each depend on a stable surface.
+"""
+
+from llenergymeasure.engines.vendored_rules.loader import (
+    VALID_ADDED_BY,
+    AddedBy,
+    Rule,
+    RuleMatch,
+    UnknownAddedByError,
+    UnsupportedSchemaVersionError,
+    VendoredRules,
+    VendoredRulesLoader,
+    evaluate_predicate,
+    resolve_field_path,
+)
+
+__all__ = [
+    "VALID_ADDED_BY",
+    "AddedBy",
+    "Rule",
+    "RuleMatch",
+    "UnknownAddedByError",
+    "UnsupportedSchemaVersionError",
+    "VendoredRules",
+    "VendoredRulesLoader",
+    "evaluate_predicate",
+    "resolve_field_path",
+]

--- a/src/llenergymeasure/engines/vendored_rules/loader.py
+++ b/src/llenergymeasure/engines/vendored_rules/loader.py
@@ -1,0 +1,377 @@
+"""Load, match, and render validation rules from the YAML corpus.
+
+The corpus at ``configs/validation_rules/{engine}.yaml`` is parsed here into
+typed :class:`Rule` entries. Each rule carries a match predicate (operators
+defined in :func:`evaluate_predicate`) and a message template. The generic
+``@model_validator`` in ``config/models.py`` calls :meth:`Rule.try_match` on
+every rule for a given engine and emits error/warn/dormant annotations based
+on the rule's severity.
+
+Design mirror: this module parallels :mod:`llenergymeasure.config.schema_loader`
+from parameter-discovery — same envelope validation
+(:class:`UnsupportedSchemaVersionError` on major-version mismatch), same
+per-instance caching for test isolation, same lazy load pattern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, get_args
+
+import yaml
+
+SUPPORTED_MAJOR_VERSION = 1
+"""Major version the loader knows how to parse.
+
+Raised via :class:`UnsupportedSchemaVersionError` on mismatch; the loader
+refuses partial reads to avoid silently accepting a future schema shape.
+"""
+
+
+AddedBy = Literal[
+    "ast_walker",
+    "introspection",
+    "manual_seed",
+    "runtime_warning",
+    "h3_collision",
+]
+"""Provenance of a rule in the corpus.
+
+Five discovery paths with distinct trust/verifiability profiles:
+
+- ``ast_walker`` — rule extracted by parsing Python source AST
+  (used by vLLM / TRT-LLM walkers; CI can re-derive on library bump).
+- ``introspection`` — rule extracted via library-API introspection
+  (transformers' ``GenerationConfig.validate(strict=True)`` returning
+  structured ``minor_issues`` dict; CI can re-derive on library bump).
+- ``manual_seed`` — hand-written by a maintainer for cases the walkers
+  can't reach (e.g. BNB type rules; not auto-regenerable).
+- ``runtime_warning`` — proposed by the feedback loop from captured
+  ``logger.warning_once`` emissions (needs human generalisation before
+  landing).
+- ``h3_collision`` — proposed by the feedback loop from H3-collision
+  canonicaliser-gap detection (needs human generalisation before landing).
+"""
+
+VALID_ADDED_BY: frozenset[str] = frozenset(get_args(AddedBy))
+
+
+class UnsupportedSchemaVersionError(ValueError):
+    """Vendored rules corpus has a schema_version major the loader can't parse."""
+
+
+class UnknownAddedByError(ValueError):
+    """Rule entry has an ``added_by`` value outside the :data:`AddedBy` enum."""
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RuleMatch:
+    """Result of a rule matching a concrete config.
+
+    ``declared_value`` is the user-set value for the *trigger* field (the first
+    non-trivially-predicated field in the match spec). ``effective_value``
+    populates only when the rule's ``expected_outcome`` lists the rule as
+    ``dormant_silent`` with a ``normalised_fields`` mapping.
+    """
+
+    rule: Rule
+    declared_value: Any
+    effective_value: Any | None = None
+    matched_fields: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One validation rule parsed from the corpus.
+
+    Field names mirror the YAML schema documented in
+    ``configs/validation_rules/README.md``. Construction goes through
+    :func:`_parse_rule`; tests can instantiate directly for unit coverage.
+    """
+
+    id: str
+    engine: str
+    library: str
+    rule_under_test: str
+    severity: str
+    native_type: str
+    match_engine: str
+    match_fields: dict[str, Any]
+    kwargs_positive: dict[str, Any]
+    kwargs_negative: dict[str, Any]
+    expected_outcome: dict[str, Any]
+    message_template: str | None
+    walker_source: dict[str, Any]
+    references: tuple[str, ...]
+    added_by: str
+    added_at: str
+
+    def try_match(self, config: Any) -> RuleMatch | None:
+        """Return a :class:`RuleMatch` if every predicate in ``match_fields`` holds.
+
+        Field paths are dotted (``"transformers.sampling.temperature"``) and
+        resolve against ``config`` attribute-by-attribute, tolerating Pydantic
+        models, dataclasses, and plain dicts.
+
+        ``declared_value`` on the returned match is the last field's value —
+        corpus convention puts the precondition fields first and the
+        *subject* field last (the field the rule is actually about). Users
+        see the subject value substituted into message templates.
+        """
+        matched: dict[str, Any] = {}
+        last_value: Any = None
+        for path, spec in self.match_fields.items():
+            actual = resolve_field_path(config, path)
+            if not evaluate_predicate(actual, spec):
+                return None
+            matched[path] = actual
+            last_value = actual
+        return RuleMatch(rule=self, declared_value=last_value, matched_fields=matched)
+
+    def render_message(self, match: RuleMatch) -> str:
+        """Substitute ``{declared_value}`` / ``{effective_value}`` / ``{rule_id}`` in the template.
+
+        Uses ``str.format`` with permissive defaults — templates that reference
+        missing keys fall back to the rule id + raw template rather than
+        raising at user-facing time.
+        """
+        if self.message_template is None:
+            return f"[{self.id}] <no message template>"
+        try:
+            return self.message_template.format(
+                declared_value=match.declared_value,
+                effective_value=match.effective_value,
+                rule_id=self.id,
+                **match.matched_fields,
+            )
+        except (KeyError, IndexError):
+            return f"[{self.id}] {self.message_template}"
+
+
+@dataclass(frozen=True)
+class VendoredRules:
+    """Parsed corpus for one engine."""
+
+    engine: str
+    schema_version: str
+    engine_version: str
+    rules: tuple[Rule, ...]
+
+
+# ---------------------------------------------------------------------------
+# Predicate engine
+# ---------------------------------------------------------------------------
+
+
+_OPERATOR_HANDLERS: dict[str, Any] = {
+    "==": lambda a, b: a == b,
+    "!=": lambda a, b: a != b,
+    "<": lambda a, b: a is not None and a < b,
+    "<=": lambda a, b: a is not None and a <= b,
+    ">": lambda a, b: a is not None and a > b,
+    ">=": lambda a, b: a is not None and a >= b,
+    "in": lambda a, b: a in b,
+    "not_in": lambda a, b: a not in b,
+    "present": lambda a, _: a is not None,
+    "absent": lambda a, _: a is None,
+    "equals": lambda a, b: a == b,
+    "not_equal": lambda a, b: a is not None and a != b,
+    # Type predicates match by the concrete type's __name__. They are
+    # None-safe: a missing field is treated as not-firing rather than
+    # tripping ``type_is_not``. Spec takes a bare string ("bool", "int",
+    # "dict", "dtype") or a list of strings (any-of); predicate holds if
+    # the field's concrete type name matches (resp. does not match) any.
+    "type_is": lambda a, b: a is not None and _type_name(a) in _as_name_set(b),
+    "type_is_not": lambda a, b: a is not None and _type_name(a) not in _as_name_set(b),
+}
+
+
+def _type_name(value: Any) -> str:
+    """Return the concrete class name of ``value`` (not ``type(value)`` repr)."""
+    return type(value).__name__
+
+
+def _as_name_set(spec: Any) -> frozenset[str]:
+    """Accept a single type name or an iterable of names; return a frozenset."""
+    if isinstance(spec, str):
+        return frozenset({spec})
+    return frozenset(str(x) for x in spec)
+
+
+def evaluate_predicate(actual: Any, spec: Any) -> bool:
+    """Evaluate ``actual`` against the corpus predicate ``spec``.
+
+    ``spec`` shapes:
+
+    - Bare value → equality (``spec == actual``).
+    - One-key dict → operator predicate (``{"<": 1}``, ``{"in": ["a", "b"]}``).
+    - Multi-key dict → every operator must hold (all predicates AND-combined).
+
+    The last form covers corpus entries like
+    ``{present: true, not_equal: 1.0}`` — field must be set AND not default.
+    """
+    if isinstance(spec, dict):
+        if not spec:
+            raise ValueError("Empty match predicate dict")
+        for op, value in spec.items():
+            handler = _OPERATOR_HANDLERS.get(op)
+            if handler is None:
+                raise ValueError(f"Unknown match operator: {op!r}")
+            if not handler(actual, value):
+                return False
+        return True
+    return bool(actual == spec)
+
+
+# ---------------------------------------------------------------------------
+# Field-path resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_field_path(config: Any, path: str) -> Any:
+    """Walk dotted attribute / key path against ``config``.
+
+    Missing attributes return ``None`` rather than raising — the predicate
+    engine treats ``None`` as an absent field. Supports nested Pydantic models,
+    dataclasses, and plain dicts mixed in any combination.
+    """
+    current: Any = config
+    for part in path.split("."):
+        if current is None:
+            return None
+        current = current.get(part) if isinstance(current, dict) else getattr(current, part, None)
+    return current
+
+
+# ---------------------------------------------------------------------------
+# Corpus parsing
+# ---------------------------------------------------------------------------
+
+
+def _major(version: str) -> int:
+    try:
+        return int(version.split(".", 1)[0])
+    except (ValueError, AttributeError) as exc:
+        raise UnsupportedSchemaVersionError(
+            f"Unparseable schema_version {version!r}; expected semver '1.0.0' form."
+        ) from exc
+
+
+def _parse_rule(raw: dict[str, Any]) -> Rule:
+    required = (
+        "id",
+        "engine",
+        "severity",
+        "native_type",
+        "match",
+        "kwargs_positive",
+        "kwargs_negative",
+        "expected_outcome",
+    )
+    for key in required:
+        if key not in raw:
+            raise ValueError(f"Rule {raw.get('id', '<unknown>')} missing field: {key}")
+    match = raw["match"]
+    if not isinstance(match, dict) or "fields" not in match:
+        raise ValueError(f"Rule {raw['id']} has malformed match (missing `fields`): {match!r}")
+    added_by = str(raw.get("added_by", "manual_seed"))
+    if added_by not in VALID_ADDED_BY:
+        raise UnknownAddedByError(
+            f"Rule {raw['id']!r} has added_by={added_by!r}; "
+            f"must be one of: {sorted(VALID_ADDED_BY)}"
+        )
+    return Rule(
+        id=str(raw["id"]),
+        engine=str(raw["engine"]),
+        library=str(raw.get("library", raw["engine"])),
+        rule_under_test=str(raw.get("rule_under_test", "")),
+        severity=str(raw["severity"]),
+        native_type=str(raw["native_type"]),
+        match_engine=str(match.get("engine", raw["engine"])),
+        match_fields=dict(match["fields"]),
+        kwargs_positive=dict(raw["kwargs_positive"]),
+        kwargs_negative=dict(raw["kwargs_negative"]),
+        expected_outcome=dict(raw["expected_outcome"]),
+        message_template=raw.get("message_template"),
+        walker_source=dict(raw.get("walker_source") or {}),
+        references=tuple(raw.get("references") or ()),
+        added_by=added_by,
+        added_at=str(raw.get("added_at", "")),
+    )
+
+
+def _parse_envelope(engine: str, raw_text: str) -> VendoredRules:
+    data = yaml.safe_load(raw_text)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Vendored rules for {engine!r} must be a YAML mapping; got {type(data).__name__}"
+        )
+    schema_version = str(data.get("schema_version", ""))
+    if not schema_version:
+        raise UnsupportedSchemaVersionError(
+            f"Vendored rules for {engine!r} missing schema_version."
+        )
+    if _major(schema_version) != SUPPORTED_MAJOR_VERSION:
+        raise UnsupportedSchemaVersionError(
+            f"Vendored rules for {engine!r} has schema_version={schema_version!r}; "
+            f"this loader only supports major {SUPPORTED_MAJOR_VERSION}. "
+            f"Regenerate the corpus or upgrade the loader."
+        )
+    raw_rules = data.get("rules") or []
+    rules = tuple(_parse_rule(r) for r in raw_rules)
+    return VendoredRules(
+        engine=engine,
+        schema_version=schema_version,
+        engine_version=str(data.get("engine_version", "")),
+        rules=rules,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_CORPUS_ROOT = Path(__file__).resolve().parents[4] / "configs" / "validation_rules"
+
+
+class VendoredRulesLoader:
+    """Load, cache, and serve :class:`VendoredRules` per engine.
+
+    Per-instance cache (rather than module-level LRU) — tests can instantiate
+    a loader and monkeypatch ``corpus_root`` without polluting other tests.
+    """
+
+    def __init__(self, corpus_root: Path | None = None) -> None:
+        self.corpus_root: Path = corpus_root or _DEFAULT_CORPUS_ROOT
+        self._cache: dict[str, VendoredRules] = {}
+
+    def load_rules(self, engine: str) -> VendoredRules:
+        """Return the parsed corpus for ``engine``, parsing once per engine."""
+        cached = self._cache.get(engine)
+        if cached is not None:
+            return cached
+        path = self.corpus_root / f"{engine}.yaml"
+        try:
+            raw_text = path.read_text()
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Vendored rules for engine {engine!r} not found at {path}. "
+                f"Run `python -m scripts.walkers.{engine} --out {path}` to generate."
+            ) from exc
+        parsed = _parse_envelope(engine, raw_text)
+        self._cache[engine] = parsed
+        return parsed
+
+    def invalidate(self, engine: str | None = None) -> None:
+        """Clear cached rules (all or for one engine)."""
+        if engine is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(engine, None)

--- a/tests/unit/engines/vendored_rules/test_loader.py
+++ b/tests/unit/engines/vendored_rules/test_loader.py
@@ -1,0 +1,190 @@
+"""Tests for :class:`VendoredRulesLoader` and corpus envelope parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llenergymeasure.engines.vendored_rules import (
+    VALID_ADDED_BY,
+    UnknownAddedByError,
+    UnsupportedSchemaVersionError,
+    VendoredRules,
+    VendoredRulesLoader,
+)
+
+_CORPUS_MINIMAL = """\
+schema_version: "1.0.0"
+engine: transformers
+engine_version: "4.56.0"
+rules:
+  - id: transformers_test_rule
+    engine: transformers
+    library: transformers
+    rule_under_test: "Test rule"
+    severity: dormant
+    native_type: transformers.GenerationConfig
+    walker_source:
+      path: transformers/generation/configuration_utils.py
+      method: validate
+      line_at_scan: 42
+      walker_confidence: high
+    match:
+      engine: transformers
+      fields:
+        transformers.sampling.temperature: {present: true}
+    kwargs_positive:
+      temperature: 0.5
+    kwargs_negative:
+      temperature: null
+    expected_outcome:
+      outcome: dormant_announced
+      emission_channel: minor_issues_dict
+      normalised_fields: []
+    message_template: "Dormant {declared_value}"
+    references:
+      - "ref"
+    added_by: ast_walker
+    added_at: "2026-04-23"
+"""
+
+
+def _write_corpus(root: Path, engine: str, text: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{engine}.yaml").write_text(text)
+
+
+def test_load_rules_returns_parsed_corpus(tmp_path: Path) -> None:
+    _write_corpus(tmp_path, "transformers", _CORPUS_MINIMAL)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    corpus = loader.load_rules("transformers")
+    assert isinstance(corpus, VendoredRules)
+    assert corpus.engine == "transformers"
+    assert corpus.schema_version == "1.0.0"
+    assert corpus.engine_version == "4.56.0"
+    assert len(corpus.rules) == 1
+    assert corpus.rules[0].id == "transformers_test_rule"
+
+
+def test_load_rules_per_instance_cache(tmp_path: Path) -> None:
+    _write_corpus(tmp_path, "transformers", _CORPUS_MINIMAL)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    corpus1 = loader.load_rules("transformers")
+    corpus2 = loader.load_rules("transformers")
+    # Same identity: pulled from cache on second call.
+    assert corpus1 is corpus2
+
+
+def test_invalidate_clears_cache(tmp_path: Path) -> None:
+    _write_corpus(tmp_path, "transformers", _CORPUS_MINIMAL)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    first = loader.load_rules("transformers")
+    loader.invalidate("transformers")
+    second = loader.load_rules("transformers")
+    # Different instances: cache was cleared.
+    assert first is not second
+
+
+def test_invalidate_all_clears_all(tmp_path: Path) -> None:
+    _write_corpus(tmp_path, "transformers", _CORPUS_MINIMAL)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    loader.load_rules("transformers")
+    assert loader._cache
+    loader.invalidate()
+    assert not loader._cache
+
+
+def test_missing_corpus_raises_file_not_found(tmp_path: Path) -> None:
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    with pytest.raises(FileNotFoundError):
+        loader.load_rules("transformers")
+
+
+def test_unsupported_major_version_raises(tmp_path: Path) -> None:
+    bad_corpus = _CORPUS_MINIMAL.replace('"1.0.0"', '"2.0.0"', 1)
+    _write_corpus(tmp_path, "transformers", bad_corpus)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    with pytest.raises(UnsupportedSchemaVersionError):
+        loader.load_rules("transformers")
+
+
+def test_missing_schema_version_raises(tmp_path: Path) -> None:
+    corpus = """\
+engine: transformers
+engine_version: "4.56.0"
+rules: []
+"""
+    _write_corpus(tmp_path, "transformers", corpus)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    with pytest.raises(UnsupportedSchemaVersionError):
+        loader.load_rules("transformers")
+
+
+def test_non_mapping_root_raises(tmp_path: Path) -> None:
+    _write_corpus(tmp_path, "transformers", "- just a list")
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        loader.load_rules("transformers")
+
+
+def test_empty_rules_list_is_valid(tmp_path: Path) -> None:
+    corpus = """\
+schema_version: "1.0.0"
+engine: transformers
+engine_version: "4.56.0"
+rules: []
+"""
+    _write_corpus(tmp_path, "transformers", corpus)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    result = loader.load_rules("transformers")
+    assert result.rules == ()
+
+
+def test_default_corpus_root_resolves_to_configs(tmp_path: Path) -> None:
+    # Constructing without corpus_root uses the repo's configs/validation_rules/.
+    loader = VendoredRulesLoader()
+    assert loader.corpus_root.name == "validation_rules"
+    assert loader.corpus_root.parent.name == "configs"
+
+
+# ---------------------------------------------------------------------------
+# AddedBy provenance enum
+# ---------------------------------------------------------------------------
+
+
+def test_valid_added_by_set_has_all_five_provenance_classes() -> None:
+    assert (
+        frozenset({"ast_walker", "introspection", "manual_seed", "runtime_warning", "h3_collision"})
+        == VALID_ADDED_BY
+    )
+
+
+@pytest.mark.parametrize(
+    "provenance",
+    ["ast_walker", "introspection", "manual_seed", "runtime_warning", "h3_collision"],
+)
+def test_all_added_by_values_round_trip(tmp_path: Path, provenance: str) -> None:
+    corpus = _CORPUS_MINIMAL.replace("added_by: ast_walker", f"added_by: {provenance}")
+    _write_corpus(tmp_path, "transformers", corpus)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    rules = loader.load_rules("transformers").rules
+    assert rules[0].added_by == provenance
+
+
+def test_unknown_added_by_value_raises(tmp_path: Path) -> None:
+    bad_corpus = _CORPUS_MINIMAL.replace("added_by: ast_walker", "added_by: chatgpt_hallucination")
+    _write_corpus(tmp_path, "transformers", bad_corpus)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    with pytest.raises(UnknownAddedByError, match="chatgpt_hallucination"):
+        loader.load_rules("transformers")
+
+
+def test_missing_added_by_defaults_to_manual_seed(tmp_path: Path) -> None:
+    # Omitting added_by is not a corpus authoring error — unknown provenance
+    # falls back to manual_seed (the conservative default).
+    corpus = _CORPUS_MINIMAL.replace("    added_by: ast_walker\n", "")
+    _write_corpus(tmp_path, "transformers", corpus)
+    loader = VendoredRulesLoader(corpus_root=tmp_path)
+    rules = loader.load_rules("transformers").rules
+    assert rules[0].added_by == "manual_seed"

--- a/tests/unit/engines/vendored_rules/test_rule_matching.py
+++ b/tests/unit/engines/vendored_rules/test_rule_matching.py
@@ -1,0 +1,299 @@
+"""Tests for :class:`Rule.try_match`, the predicate engine, and message rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from llenergymeasure.engines.vendored_rules import (
+    Rule,
+    evaluate_predicate,
+    resolve_field_path,
+)
+
+# ---------------------------------------------------------------------------
+# Config stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Sampling:
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    do_sample: bool | None = None
+    num_beams: int | None = None
+
+
+@dataclass
+class _Transformers:
+    sampling: _Sampling
+
+
+@dataclass
+class _Config:
+    transformers: _Transformers
+
+
+def _make_rule(
+    *,
+    id: str = "rule_x",
+    match_fields: dict[str, Any] | None = None,
+    severity: str = "dormant",
+    message: str | None = "Declared {declared_value}",
+) -> Rule:
+    return Rule(
+        id=id,
+        engine="transformers",
+        library="transformers",
+        rule_under_test="test",
+        severity=severity,
+        native_type="transformers.GenerationConfig",
+        match_engine="transformers",
+        match_fields=match_fields or {},
+        kwargs_positive={},
+        kwargs_negative={},
+        expected_outcome={
+            "outcome": "dormant_announced",
+            "emission_channel": "minor_issues_dict",
+            "normalised_fields": [],
+        },
+        message_template=message,
+        walker_source={},
+        references=(),
+        added_by="ast_walker",
+        added_at="2026-04-23",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Predicate operator coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec, actual, expected",
+    [
+        (0.5, 0.5, True),
+        (0.5, 0.6, False),
+        ({"==": 1}, 1, True),
+        ({"==": 1}, 2, False),
+        ({"!=": 1.0}, 0.9, True),
+        ({"!=": 1.0}, 1.0, False),
+        ({"<": 1}, 0, True),
+        ({"<": 1}, 1, False),
+        ({"<=": 1}, 1, True),
+        ({">": 1}, 2, True),
+        ({">": 1}, 1, False),
+        ({">=": 1}, 1, True),
+        ({"in": ["a", "b"]}, "a", True),
+        ({"in": ["a", "b"]}, "c", False),
+        ({"not_in": ["a", "b"]}, "c", True),
+        ({"not_in": ["a", "b"]}, "a", False),
+        ({"present": True}, 0.5, True),
+        ({"present": True}, None, False),
+        ({"absent": True}, None, True),
+        ({"absent": True}, 0.5, False),
+        ({"equals": 1}, 1, True),
+        ({"not_equal": 1}, 2, True),
+        ({"not_equal": 1}, None, False),  # None is never not-equal (None-safe)
+    ],
+)
+def test_evaluate_predicate_operators(spec: Any, actual: Any, expected: bool) -> None:
+    assert evaluate_predicate(actual, spec) is expected
+
+
+def test_evaluate_predicate_multi_key_all_must_pass() -> None:
+    # AND-combine multi-key predicates.
+    assert evaluate_predicate(0.9, {"present": True, "not_equal": 1.0}) is True
+    assert evaluate_predicate(1.0, {"present": True, "not_equal": 1.0}) is False
+    assert evaluate_predicate(None, {"present": True, "not_equal": 1.0}) is False
+
+
+def test_evaluate_predicate_unknown_operator_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown match operator"):
+        evaluate_predicate(1, {"matches_regex": ".*"})
+
+
+def test_evaluate_predicate_empty_dict_raises() -> None:
+    with pytest.raises(ValueError, match="Empty match"):
+        evaluate_predicate(1, {})
+
+
+def test_comparison_operators_are_none_safe() -> None:
+    # None on either side of a numeric comparator should return False, not
+    # raise a TypeError.
+    assert evaluate_predicate(None, {"<": 1}) is False
+    assert evaluate_predicate(None, {">": 0}) is False
+
+
+# ---------------------------------------------------------------------------
+# Type predicates (type_is / type_is_not)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec, actual, expected",
+    [
+        # single-name spec
+        ({"type_is": "bool"}, True, True),
+        ({"type_is": "bool"}, False, True),
+        ({"type_is": "bool"}, 1, False),
+        ({"type_is": "bool"}, "yes", False),
+        ({"type_is": "int"}, 1, True),
+        ({"type_is": "int"}, True, False),  # strict: bool is not int
+        ({"type_is": "str"}, "foo", True),
+        ({"type_is": "list"}, ["a"], True),
+        ({"type_is": "dict"}, {"a": 1}, True),
+        # any-of (list-of-names) spec
+        ({"type_is": ["int", "float"]}, 1, True),
+        ({"type_is": ["int", "float"]}, 1.0, True),
+        ({"type_is": ["int", "float"]}, "1", False),
+        # complement
+        ({"type_is_not": "bool"}, "yes", True),
+        ({"type_is_not": "bool"}, True, False),
+        ({"type_is_not": "str"}, 1, True),
+        # None is never typed as anything — predicate does not fire on absent fields
+        ({"type_is": "bool"}, None, False),
+        ({"type_is_not": "bool"}, None, False),
+    ],
+)
+def test_type_predicates(spec: Any, actual: Any, expected: bool) -> None:
+    assert evaluate_predicate(actual, spec) is expected
+
+
+def test_type_predicate_with_custom_class_name() -> None:
+    # Works for library-defined types via their __name__.
+    class WatermarkingConfig:
+        pass
+
+    wc = WatermarkingConfig()
+    assert evaluate_predicate(wc, {"type_is": "WatermarkingConfig"}) is True
+    assert evaluate_predicate({"a": 1}, {"type_is_not": "WatermarkingConfig"}) is True
+
+
+def test_type_predicate_multi_key_composes_with_present() -> None:
+    # BNB-style predicate: field must be set AND have the wrong type.
+    spec = {"present": True, "type_is_not": "bool"}
+    assert evaluate_predicate("yes", spec) is True
+    assert evaluate_predicate(True, spec) is False
+    assert evaluate_predicate(None, spec) is False
+
+
+# ---------------------------------------------------------------------------
+# Field-path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_field_path_nested_attrs() -> None:
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.9)))
+    assert resolve_field_path(config, "transformers.sampling.temperature") == 0.9
+
+
+def test_resolve_field_path_missing_returns_none() -> None:
+    config = _Config(transformers=_Transformers(sampling=_Sampling()))
+    assert resolve_field_path(config, "transformers.sampling.missing") is None
+    assert resolve_field_path(config, "vllm.engine.foo") is None
+
+
+def test_resolve_field_path_dict_fallback() -> None:
+    config = {"transformers": {"sampling": {"temperature": 0.9}}}
+    assert resolve_field_path(config, "transformers.sampling.temperature") == 0.9
+
+
+def test_resolve_field_path_mixed_dict_and_attr() -> None:
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.5)))
+    # Works even when the entry point is an attribute chain into a nested dataclass.
+    assert resolve_field_path(config, "transformers.sampling.temperature") == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Rule.try_match
+# ---------------------------------------------------------------------------
+
+
+def test_try_match_returns_none_when_no_predicate() -> None:
+    rule = _make_rule(match_fields={"transformers.sampling.temperature": {"present": True}})
+    config = _Config(transformers=_Transformers(sampling=_Sampling()))
+    assert rule.try_match(config) is None
+
+
+def test_try_match_returns_match_object_when_all_predicates_hold() -> None:
+    rule = _make_rule(
+        match_fields={
+            "transformers.sampling.do_sample": False,
+            "transformers.sampling.temperature": {
+                "present": True,
+                "not_equal": 1.0,
+            },
+        }
+    )
+    config = _Config(
+        transformers=_Transformers(sampling=_Sampling(do_sample=False, temperature=0.9))
+    )
+    match = rule.try_match(config)
+    assert match is not None
+    # declared_value is the last field's value — the subject the user cares about.
+    assert match.declared_value == 0.9
+    assert match.matched_fields == {
+        "transformers.sampling.do_sample": False,
+        "transformers.sampling.temperature": 0.9,
+    }
+
+
+def test_try_match_stops_at_first_failing_predicate() -> None:
+    rule = _make_rule(
+        match_fields={
+            "transformers.sampling.do_sample": True,  # won't match
+            "transformers.sampling.temperature": {"present": True},
+        }
+    )
+    config = _Config(
+        transformers=_Transformers(sampling=_Sampling(do_sample=False, temperature=0.9))
+    )
+    assert rule.try_match(config) is None
+
+
+# ---------------------------------------------------------------------------
+# Message rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_message_substitutes_declared_value() -> None:
+    rule = _make_rule(
+        match_fields={"transformers.sampling.temperature": {"present": True}},
+        message="Dormant: temperature={declared_value} rule={rule_id}",
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
+    match = rule.try_match(config)
+    assert match is not None
+    msg = rule.render_message(match)
+    assert "0.7" in msg
+    assert "rule_x" in msg
+
+
+def test_render_message_missing_template_returns_fallback() -> None:
+    rule = _make_rule(
+        match_fields={"transformers.sampling.temperature": {"present": True}},
+        message=None,
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
+    match = rule.try_match(config)
+    assert match is not None
+    assert "rule_x" in rule.render_message(match)
+
+
+def test_render_message_with_missing_format_key_falls_back_gracefully() -> None:
+    # Template refers to a field not populated in the match.
+    rule = _make_rule(
+        match_fields={"transformers.sampling.temperature": {"present": True}},
+        message="Field {not_in_match_or_declared}",
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
+    match = rule.try_match(config)
+    assert match is not None
+    # Should not raise; should fall back to rule-id + raw template.
+    out = rule.render_message(match)
+    assert "rule_x" in out


### PR DESCRIPTION
## Summary

First of three slices replacing #367 — the consumer-side library for runtime config validation.

- **`VendoredRulesLoader`**: per-instance-cached YAML corpus loader with semver-major schema-version gate
- **`Rule.try_match`**: predicate engine over dotted config field paths, traversing Pydantic / dataclass / dict configs uniformly
- **`AddedBy` Literal enum (5 provenance classes)**: `ast_walker`, `introspection`, `manual_seed`, `runtime_warning`, `h3_collision` — each with distinct trust/verifiability semantics, validated at load time via `UnknownAddedByError`
- **`type_is` / `type_is_not` predicate operators** — enables rule corpora to express type constraints (e.g. BNB `load_in_4bit must be bool`) cleanly, composing with `present: true` for "field set AND wrong type"

## Context

Originally authored as part of #367 (the walker + corpus + loader mega-PR). Extracted here as a standalone slice for tighter review. Two follow-up slices will land:

- **Slice B**: walker base infrastructure (AST machinery for vLLM/TRT-LLM walkers, helper tracer removed per design PoC-A reconciliation)
- **Slice C**: transformers walker + seeded corpus (with all rule-level bug fixes: correct `emission_channel`, `early_stopping` predicate guard, `pad_token_id` dormancy, BNB rules using new `type_is_not`, etc.)

The loader frozen here is consumed by the generic `@model_validator` in `config/models.py` (migration PR lands after the three slices merge).

## Design notes

- **Why 5 provenance classes, not 2?** The original code defaulted every rule to `added_by: ast_walker` — which silently mislabels hand-written rules and introspection-extracted rules. The five values match the real discovery paths in the design (two machine-verified, one maintainer-vouched, two needs-generalisation-after-feedback-loop). CI vendor pipelines can then treat them differently (re-derive the first two on library bump; skip the others).
- **Why validate at load time?** Unknown `added_by` values silently flow through the old `str` typing. Validation catches corpus authoring bugs at the boundary.
- **Why `type_is` via `type(x).__name__`?** Strict class-name match (not `isinstance`). Avoids the `bool-is-subclass-of-int` surprise — `type_is: bool` does not match `1`. Supports both single-name and list-of-names specs. None-safe.

## Test plan

- [x] 74 unit tests pass locally (28 original + 46 new for enum + type predicates)
- [x] `mypy --strict` clean on loader module
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green on push
- [ ] Manual: confirm the loader can consume a pre-existing corpus once Slice C lands (UAT via next slice)