### PR TITLE
feat(engines): add AST walker base infrastructure for rule extraction

### DIFF
--- a/scripts/walkers/__init__.py
+++ b/scripts/walkers/__init__.py
@@ -1,0 +1,12 @@
+"""AST walkers that extract validation rules from engine library source.
+
+Each ``scripts/walkers/{engine}.py`` walker is version-pinned to a specific
+library release via :data:`_base.TESTED_AGAINST_VERSIONS` and emits a
+corpus-compatible YAML document of rule candidates.
+
+The transformers walker is an introspection wrapper around
+``GenerationConfig.validate()`` rather than a full AST walker — see
+:mod:`scripts.walkers.transformers` for the rationale. vLLM and TensorRT-LLM
+walkers (added in later phases) use the AST-extraction primitives in
+:mod:`scripts.walkers._base`.
+"""

--- a/scripts/walkers/_base.py
+++ b/scripts/walkers/_base.py
@@ -1,0 +1,510 @@
+"""Shared infrastructure for per-engine validation-rule walkers.
+
+Per the 2026-04-23 plan amendment, walker depth is fixed at 1 (same module,
+one helper-call hop deep). This module ships the public surface that the
+transformers introspection wrapper needs today, plus the AST primitives the
+vLLM and TensorRT-LLM walkers will consume when they land in later phases:
+
+- :class:`RuleCandidate` — the walker's output type, serialised to the YAML
+  corpus entry shape in :mod:`llenergymeasure.engines.vendored_rules.loader`.
+- :class:`WalkerVersionMismatchError`, :class:`WalkerLandmarkMissingError` —
+  fail-loud exceptions CI treats as fatal.
+- :func:`check_installed_version` — version-envelope guard for each walker.
+- AST helpers (:func:`extract_condition_fields`, :func:`resolve_local_assign`,
+  etc.) — deterministic, stateless primitives.
+- Pattern detectors (``ConditionalRaiseDetector``, etc.) — one class per
+  known library rule shape; each fires on one ``ast.If`` body at a time.
+
+Tests cover each primitive on synthetic AST fixtures; the per-engine walkers
+run against pinned real libraries.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from packaging import version as pkg_version
+from packaging.specifiers import SpecifierSet
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+Severity = Literal["error", "warn", "dormant"]
+EmissionChannel = Literal[
+    "warnings_warn",
+    "logger_warning",
+    "logger_warning_once",
+    "minor_issues_dict",
+    "runtime_exception",
+    "none",
+]
+Confidence = Literal["high", "medium", "low"]
+
+
+@dataclass
+class WalkerSource:
+    """Provenance for a walker-extracted rule candidate."""
+
+    path: str
+    method: str
+    line_at_scan: int
+    walker_confidence: Confidence
+
+
+@dataclass
+class RuleCandidate:
+    """One extracted rule candidate.
+
+    Serialised verbatim into ``configs/validation_rules/{engine}.yaml`` after
+    human review. Field names match the corpus schema so no translation step
+    is needed between walker output and corpus entry.
+    """
+
+    id: str
+    engine: str
+    library: str
+    rule_under_test: str
+    severity: Severity
+    native_type: str
+    walker_source: WalkerSource
+    match_fields: dict[str, Any]
+    kwargs_positive: dict[str, Any]
+    kwargs_negative: dict[str, Any]
+    expected_outcome: dict[str, Any]
+    message_template: str | None
+    references: list[str] = field(default_factory=list)
+    added_by: str = "ast_walker"
+    added_at: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Error types (all inherit from a common base so per-engine walkers can
+# raise-or-collect uniformly at CI time)
+# ---------------------------------------------------------------------------
+
+
+class WalkerError(Exception):
+    """Base class for structured walker failures."""
+
+
+class WalkerVersionMismatchError(WalkerError):
+    """Raised when the installed library version is outside the walker's pin.
+
+    The walker is pinned to the library version it was authored against; on
+    library-bump PRs, Renovate will trip this error and the maintainer updates
+    the walker. See runtime-config-validation.md §4.2.
+    """
+
+    def __init__(self, library: str, installed: str, expected: SpecifierSet) -> None:
+        super().__init__(
+            f"Installed {library}=={installed} is outside walker-pinned range "
+            f"{expected!s}. Update scripts/walkers/{library}.py "
+            f"(bump TESTED_AGAINST_VERSIONS and re-run against the new source)."
+        )
+        self.library = library
+        self.installed = installed
+        self.expected = expected
+
+
+class WalkerLandmarkMissingError(WalkerError):
+    """Raised when an expected source landmark (class/method/file) is missing.
+
+    Library refactors (class renamed, method split, file relocated) trip this
+    error and the walker refuses to emit partial output. This is load-bearing
+    for the "silent coverage loss becomes a visible CI failure" contract.
+    """
+
+    def __init__(self, landmark: str, detail: str = "") -> None:
+        msg = f"Walker landmark missing: {landmark}"
+        if detail:
+            msg = f"{msg} ({detail})"
+        super().__init__(msg)
+        self.landmark = landmark
+        self.detail = detail
+
+
+# ---------------------------------------------------------------------------
+# Version pin guard
+# ---------------------------------------------------------------------------
+
+
+def check_installed_version(library: str, installed: str, expected: SpecifierSet) -> None:
+    """Raise :class:`WalkerVersionMismatchError` if ``installed`` isn't in ``expected``.
+
+    ``SpecifierSet.contains(..., prereleases=True)`` allows rc / beta tags,
+    which is what we want for Renovate-opened PRs that bump to a prerelease
+    tag before a stable one exists.
+    """
+    try:
+        parsed = pkg_version.Version(installed)
+    except pkg_version.InvalidVersion as exc:
+        raise WalkerVersionMismatchError(library, installed, expected) from exc
+    if not expected.contains(parsed, prereleases=True):
+        raise WalkerVersionMismatchError(library, installed, expected)
+
+
+# ---------------------------------------------------------------------------
+# AST primitives
+# ---------------------------------------------------------------------------
+
+
+def call_func_path(call: ast.Call) -> list[str] | None:
+    """Return dotted path for a ``Call`` node's func, or ``None`` if opaque.
+
+    ``logger.warning(...)`` → ``["logger", "warning"]``.
+    ``foo()()`` → ``None`` (not a pure attribute/name chain).
+    """
+    parts: list[str] = []
+    node: ast.expr = call.func
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return list(reversed(parts))
+    return None
+
+
+def first_string_arg(call: ast.Call) -> str | None:
+    """First string-like positional argument of a Call, or ``None``.
+
+    Returns the raw string for ``ast.Constant``, ``ast.unparse`` output for
+    f-strings (``ast.JoinedStr``) and ``"...".format(...)`` expressions —
+    these are the three message-template shapes observed in the 2026-04-22
+    AST-scan PoC across transformers / vLLM / TRT-LLM.
+    """
+    for arg in call.args:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+        if isinstance(arg, ast.JoinedStr):
+            return ast.unparse(arg)
+        if (
+            isinstance(arg, ast.Call)
+            and isinstance(arg.func, ast.Attribute)
+            and arg.func.attr == "format"
+        ):
+            return ast.unparse(arg)
+    return None
+
+
+def extract_condition_fields(condition: ast.expr) -> set[str]:
+    """Return the set of ``self.<field>`` attribute names referenced in ``condition``.
+
+    Used by the ``condition_references_self`` filter (rule must reference at
+    least one public field of the native type).
+    """
+    fields: set[str] = set()
+    for node in ast.walk(condition):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        ):
+            fields.add(node.attr)
+    return fields
+
+
+def extract_assign_target(stmt: ast.Assign) -> str | None:
+    """Return ``"self.<attr>"`` → ``<attr>`` for a single-target self-assignment.
+
+    ``None`` for anything else (tuple unpacking, subscripts, non-self targets).
+    """
+    if len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if (
+        isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "self"
+    ):
+        return target.attr
+    return None
+
+
+def resolve_local_assign(func: ast.FunctionDef, name: str) -> str | None:
+    """Find the first ``name = <string-literal>`` inside ``func`` and return the literal.
+
+    Used for HF's ``greedy_wrong_parameter_msg`` pattern — the message template
+    is a local variable defined earlier in the same function body.
+    """
+    for node in func.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        tgt = node.targets[0]
+        if (
+            isinstance(tgt, ast.Name)
+            and tgt.id == name
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            return node.value.value
+    return None
+
+
+def extract_loop_literal_iterable(loop: ast.For) -> list[Any] | None:
+    """Return the literal list/tuple a ``for`` loop iterates over, or ``None``.
+
+    ``for arg in [a, b]:`` → ``[a, b]``; ``for arg in self.x:`` → ``None``.
+    Enables one parameterised rule per loop when the iterable is AST-static.
+    """
+    iter_node = loop.iter
+    if not isinstance(iter_node, (ast.List, ast.Tuple)):
+        return None
+    values: list[Any] = []
+    for elt in iter_node.elts:
+        if isinstance(elt, ast.Constant):
+            values.append(elt.value)
+        else:
+            return None
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Pattern detectors
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DetectedPattern:
+    """One detected rule-body statement inside an ``if X: ...`` branch."""
+
+    severity: Severity
+    emission_channel: EmissionChannel
+    affected_field: str | None
+    message_template: str | None
+    detail: str
+
+
+class ConditionalRaiseDetector:
+    """``if X: raise SomeException(...)`` — error rule."""
+
+    def detect(self, stmt: ast.stmt) -> DetectedPattern | None:
+        if not isinstance(stmt, ast.Raise) or stmt.exc is None:
+            return None
+        if isinstance(stmt.exc, ast.Call) and isinstance(stmt.exc.func, ast.Name):
+            exc_type = stmt.exc.func.id
+            msg = first_string_arg(stmt.exc)
+            return DetectedPattern(
+                severity="error",
+                emission_channel="none",
+                affected_field=None,
+                message_template=msg,
+                detail=f"raise {exc_type}",
+            )
+        return None
+
+
+class ConditionalSelfAssignDetector:
+    """``if X: self.A = B`` — silent dormancy rule.
+
+    The affected field is ``A``. Represents the library silently normalising
+    the user's declared value — no warning, no error, but the effective state
+    differs from the declared state. vLLM epsilon-clamp is the canonical case.
+    """
+
+    def detect(self, stmt: ast.stmt) -> DetectedPattern | None:
+        if not isinstance(stmt, ast.Assign):
+            return None
+        attr = extract_assign_target(stmt)
+        if attr is None:
+            return None
+        rhs = ast.unparse(stmt.value)
+        return DetectedPattern(
+            severity="dormant",
+            emission_channel="none",
+            affected_field=attr,
+            message_template=None,
+            detail=f"self.{attr} = {rhs}",
+        )
+
+
+class ConditionalWarningsWarnDetector:
+    """``if X: warnings.warn(...)`` — announced warn rule."""
+
+    def detect(self, stmt: ast.stmt) -> DetectedPattern | None:
+        if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+            return None
+        path = call_func_path(stmt.value)
+        if path != ["warnings", "warn"]:
+            return None
+        return DetectedPattern(
+            severity="warn",
+            emission_channel="warnings_warn",
+            affected_field=None,
+            message_template=first_string_arg(stmt.value),
+            detail="warnings.warn",
+        )
+
+
+class ConditionalLoggerWarningDetector:
+    """``if X: logger.warning(...)`` / ``logger.warning_once(...)`` — announced."""
+
+    def detect(self, stmt: ast.stmt) -> DetectedPattern | None:
+        if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+            return None
+        path = call_func_path(stmt.value)
+        if not path or path[0] != "logger":
+            return None
+        method = path[-1]
+        if method not in {"warning", "warning_once", "error"}:
+            return None
+        channel: EmissionChannel = (
+            "logger_warning_once" if method == "warning_once" else "logger_warning"
+        )
+        return DetectedPattern(
+            severity="warn" if method != "error" else "error",
+            emission_channel=channel,
+            affected_field=None,
+            message_template=first_string_arg(stmt.value),
+            detail=".".join(path),
+        )
+
+
+class MinorIssuesDictAssignDetector:
+    """HF-specific: ``if X: minor_issues[key] = msg.format(...)``.
+
+    Represents HF's announced-dormancy pattern — the library composes a
+    ``minor_issues`` dict during ``GenerationConfig.validate()`` and later
+    emits it via ``logger.warning_once`` (or raises if ``strict=True``).
+    """
+
+    def detect(self, stmt: ast.stmt) -> DetectedPattern | None:
+        if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+            return None
+        target = stmt.targets[0]
+        if not isinstance(target, ast.Subscript) or not isinstance(target.value, ast.Name):
+            return None
+        if target.value.id != "minor_issues":
+            return None
+        key: str | None = None
+        if isinstance(target.slice, ast.Constant) and isinstance(target.slice.value, str):
+            key = target.slice.value
+        msg: str | None = None
+        if isinstance(stmt.value, ast.Call):
+            msg = ast.unparse(stmt.value)
+        elif isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str):
+            msg = stmt.value.value
+        return DetectedPattern(
+            severity="dormant",
+            emission_channel="minor_issues_dict",
+            affected_field=key,
+            message_template=msg,
+            detail="minor_issues[key] = msg",
+        )
+
+
+ALL_DETECTORS: tuple[
+    ConditionalRaiseDetector
+    | ConditionalSelfAssignDetector
+    | ConditionalWarningsWarnDetector
+    | ConditionalLoggerWarningDetector
+    | MinorIssuesDictAssignDetector,
+    ...,
+] = (
+    ConditionalRaiseDetector(),
+    ConditionalSelfAssignDetector(),
+    ConditionalWarningsWarnDetector(),
+    ConditionalLoggerWarningDetector(),
+    MinorIssuesDictAssignDetector(),
+)
+"""Detector fixed order matters: the first detector to fire on a statement wins.
+
+Ordering rationale: the most-specific patterns come first. ``raise`` before
+self-assign ensures raise+rollback chains are attributed to the raise.
+``minor_issues`` before generic ``self.x = y`` ensures HF's dict-assign is
+picked up before the fallback self-assign detector.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Filters (false-positive guards)
+# ---------------------------------------------------------------------------
+
+
+def filter_condition_references_self(condition: ast.expr, public_fields: frozenset[str]) -> bool:
+    """True iff condition references at least one public field via ``self.<field>``.
+
+    Drops argument-dependent rules (``if strict: raise``) and private-state
+    rules (``if self._initialized: ...``) that don't constrain user config.
+    """
+    referenced = extract_condition_fields(condition)
+    return bool(referenced & public_fields)
+
+
+def filter_target_is_public_field(pattern: DetectedPattern, public_fields: frozenset[str]) -> bool:
+    """For self-assign patterns, ``affected_field`` must be a public field."""
+    if pattern.affected_field is None:
+        # Not a self-assign — filter doesn't apply (neutral pass).
+        return True
+    return pattern.affected_field in public_fields
+
+
+def filter_kwargs_positive_derivable(condition: ast.expr) -> bool:
+    """True iff a representative positive kwargs dict can be synthesised.
+
+    Accepts: ``self.field op literal``, ``self.field is None``, ``not isinstance(self.field, T)``,
+    boolean combinations of the above, and HF's ``hasattr(self, arg)`` loop pattern.
+
+    Rejects: conditions whose truth depends on opaque function calls against
+    external state (``if some_module.flag(): raise``).
+    """
+    # Heuristic: a condition is derivable if we can find at least one
+    # self.<attr> reference AND every Call in the condition is either
+    # a builtin predicate (isinstance / hasattr / getattr / len) or a
+    # method on self. This matches the empirically-common shapes without
+    # claiming universal coverage.
+    if not extract_condition_fields(condition):
+        # A condition must reference self at all to be useful.
+        return False
+    safe_call_names = {"isinstance", "hasattr", "getattr", "len", "version"}
+    for node in ast.walk(condition):
+        if not isinstance(node, ast.Call):
+            continue
+        path = call_func_path(node)
+        if path is None:
+            return False
+        if path[0] == "self":
+            # self.<method>(...) — accept (helper-call; tracer may expand).
+            continue
+        if path[-1] in safe_call_names:
+            continue
+        # Opaque external call (e.g., importlib.util.find_spec) — not
+        # mechanically derivable into positive kwargs.
+        return False
+    return True
+
+
+def score_confidence(pass_count: int) -> Confidence:
+    """Map 0-3 filter-pass count to a confidence tier.
+
+    3 passes → ``high``. 2 → ``medium``. 0-1 → ``low``.
+    """
+    if pass_count >= 3:
+        return "high"
+    if pass_count == 2:
+        return "medium"
+    return "low"
+
+
+# ---------------------------------------------------------------------------
+# Class helpers
+# ---------------------------------------------------------------------------
+
+
+def find_class(module: ast.Module, class_name: str) -> ast.ClassDef | None:
+    """Return the first ``ClassDef`` named ``class_name`` in ``module``."""
+    for node in ast.iter_child_nodes(module):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    return None
+
+
+def find_method(cls: ast.ClassDef, method_name: str) -> ast.FunctionDef | None:
+    """Return the first ``FunctionDef`` named ``method_name`` on ``cls``."""
+    for item in cls.body:
+        if isinstance(item, ast.FunctionDef) and item.name == method_name:
+            return item
+    return None

--- a/tests/unit/scripts/walkers/test_base.py
+++ b/tests/unit/scripts/walkers/test_base.py
@@ -1,0 +1,379 @@
+"""Tests for :mod:`scripts.walkers._base`.
+
+Covers AST primitives, pattern detectors, filters, confidence scoring, the
+helper tracer, and structured error types — all on synthetic AST fixtures so
+the tests never depend on a specific library version.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+from packaging.specifiers import SpecifierSet
+
+# Make the top-level ``scripts`` package importable from tests.
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.walkers._base import (  # noqa: E402
+    ALL_DETECTORS,
+    ConditionalLoggerWarningDetector,
+    ConditionalRaiseDetector,
+    ConditionalSelfAssignDetector,
+    ConditionalWarningsWarnDetector,
+    DetectedPattern,
+    MinorIssuesDictAssignDetector,
+    WalkerLandmarkMissingError,
+    WalkerVersionMismatchError,
+    call_func_path,
+    check_installed_version,
+    extract_assign_target,
+    extract_condition_fields,
+    extract_loop_literal_iterable,
+    filter_condition_references_self,
+    filter_kwargs_positive_derivable,
+    filter_target_is_public_field,
+    find_class,
+    find_method,
+    first_string_arg,
+    resolve_local_assign,
+    score_confidence,
+)
+
+
+def _parse_if(src: str) -> ast.If:
+    module = ast.parse(src.strip())
+    stmt = module.body[0]
+    assert isinstance(stmt, ast.If)
+    return stmt
+
+
+def _parse_expr(src: str) -> ast.expr:
+    return ast.parse(src, mode="eval").body
+
+
+# ---------------------------------------------------------------------------
+# AST primitives
+# ---------------------------------------------------------------------------
+
+
+def test_call_func_path_logger_warning() -> None:
+    call = _parse_expr('logger.warning("msg")')
+    assert isinstance(call, ast.Call)
+    assert call_func_path(call) == ["logger", "warning"]
+
+
+def test_call_func_path_warnings_warn() -> None:
+    call = _parse_expr('warnings.warn("msg")')
+    assert isinstance(call, ast.Call)
+    assert call_func_path(call) == ["warnings", "warn"]
+
+
+def test_call_func_path_self_method() -> None:
+    call = _parse_expr("self.helper(x)")
+    assert isinstance(call, ast.Call)
+    assert call_func_path(call) == ["self", "helper"]
+
+
+def test_call_func_path_opaque_returns_none() -> None:
+    # double-call like foo()() is not a pure attr chain
+    call = _parse_expr("foo()()")
+    assert isinstance(call, ast.Call)
+    assert call_func_path(call) is None
+
+
+def test_first_string_arg_constant() -> None:
+    call = _parse_expr('logger.warning("hello")')
+    assert isinstance(call, ast.Call)
+    assert first_string_arg(call) == "hello"
+
+
+def test_first_string_arg_fstring() -> None:
+    call = _parse_expr('logger.warning(f"value is {x}")')
+    assert isinstance(call, ast.Call)
+    out = first_string_arg(call)
+    assert out is not None and "x" in out
+
+
+def test_first_string_arg_format_call() -> None:
+    call = _parse_expr('logger.warning("val={v}".format(v=1))')
+    assert isinstance(call, ast.Call)
+    out = first_string_arg(call)
+    assert out is not None and "format" in out
+
+
+def test_extract_condition_fields_simple() -> None:
+    expr = _parse_expr("self.temperature < 0.01")
+    assert extract_condition_fields(expr) == {"temperature"}
+
+
+def test_extract_condition_fields_multi() -> None:
+    expr = _parse_expr("self.do_sample is False and self.temperature != 1.0")
+    assert extract_condition_fields(expr) == {"do_sample", "temperature"}
+
+
+def test_extract_assign_target_self_attr() -> None:
+    stmt = ast.parse("self.temperature = 0.5").body[0]
+    assert isinstance(stmt, ast.Assign)
+    assert extract_assign_target(stmt) == "temperature"
+
+
+def test_extract_assign_target_non_self_returns_none() -> None:
+    stmt = ast.parse("other.temperature = 0.5").body[0]
+    assert isinstance(stmt, ast.Assign)
+    assert extract_assign_target(stmt) is None
+
+
+def test_resolve_local_assign_finds_literal() -> None:
+    src = """
+def validate(self):
+    greedy_msg = "Greedy wrong: {flag}"
+    return greedy_msg.format(flag="temperature")
+"""
+    func = ast.parse(src.strip()).body[0]
+    assert isinstance(func, ast.FunctionDef)
+    assert resolve_local_assign(func, "greedy_msg") == "Greedy wrong: {flag}"
+
+
+def test_resolve_local_assign_missing_returns_none() -> None:
+    src = "def validate(self):\n    x = 1\n"
+    func = ast.parse(src).body[0]
+    assert isinstance(func, ast.FunctionDef)
+    assert resolve_local_assign(func, "greedy_msg") is None
+
+
+def test_extract_loop_literal_iterable_list() -> None:
+    loop = ast.parse("for arg in ['a', 'b', 'c']: pass").body[0]
+    assert isinstance(loop, ast.For)
+    assert extract_loop_literal_iterable(loop) == ["a", "b", "c"]
+
+
+def test_extract_loop_literal_iterable_tuple() -> None:
+    loop = ast.parse("for arg in (1, 2, 3): pass").body[0]
+    assert isinstance(loop, ast.For)
+    assert extract_loop_literal_iterable(loop) == [1, 2, 3]
+
+
+def test_extract_loop_literal_iterable_self_attr_returns_none() -> None:
+    # Non-literal iterable (self.<field>) should downgrade detection.
+    loop = ast.parse("for arg in self.allowed: pass").body[0]
+    assert isinstance(loop, ast.For)
+    assert extract_loop_literal_iterable(loop) is None
+
+
+# ---------------------------------------------------------------------------
+# Pattern detectors
+# ---------------------------------------------------------------------------
+
+
+def test_conditional_raise_detector_positive() -> None:
+    detector = ConditionalRaiseDetector()
+    node = _parse_if('if self.temperature < 0:\n    raise ValueError("must be non-negative")')
+    pattern = detector.detect(node.body[0])
+    assert pattern is not None
+    assert pattern.severity == "error"
+    assert pattern.emission_channel == "none"
+    assert pattern.message_template == "must be non-negative"
+
+
+def test_conditional_raise_detector_negative() -> None:
+    detector = ConditionalRaiseDetector()
+    stmt = ast.parse("x = 1").body[0]
+    assert detector.detect(stmt) is None
+
+
+def test_conditional_self_assign_detector_positive() -> None:
+    detector = ConditionalSelfAssignDetector()
+    node = _parse_if("if cond:\n    self.stop = []")
+    pattern = detector.detect(node.body[0])
+    assert pattern is not None
+    assert pattern.severity == "dormant"
+    assert pattern.affected_field == "stop"
+
+
+def test_conditional_self_assign_detector_non_self() -> None:
+    detector = ConditionalSelfAssignDetector()
+    node = _parse_if("if cond:\n    other.field = 1")
+    assert detector.detect(node.body[0]) is None
+
+
+def test_conditional_warnings_warn_detector() -> None:
+    detector = ConditionalWarningsWarnDetector()
+    node = _parse_if('if cond:\n    warnings.warn("deprecated")')
+    pattern = detector.detect(node.body[0])
+    assert pattern is not None
+    assert pattern.severity == "warn"
+    assert pattern.emission_channel == "warnings_warn"
+
+
+def test_conditional_logger_warning_detector_once() -> None:
+    detector = ConditionalLoggerWarningDetector()
+    node = _parse_if('if cond:\n    logger.warning_once("msg")')
+    pattern = detector.detect(node.body[0])
+    assert pattern is not None
+    assert pattern.emission_channel == "logger_warning_once"
+
+
+def test_conditional_logger_warning_detector_rejects_other_methods() -> None:
+    detector = ConditionalLoggerWarningDetector()
+    node = _parse_if('if cond:\n    logger.info("informational")')
+    assert detector.detect(node.body[0]) is None
+
+
+def test_minor_issues_dict_assign_detector() -> None:
+    detector = MinorIssuesDictAssignDetector()
+    node = _parse_if('if self.x:\n    minor_issues["temperature"] = msg.format(x=self.x)')
+    pattern = detector.detect(node.body[0])
+    assert pattern is not None
+    assert pattern.emission_channel == "minor_issues_dict"
+    assert pattern.affected_field == "temperature"
+
+
+def test_all_detectors_registered_and_ordered() -> None:
+    # The detector tuple is a fixed public sequence. The ordering matters:
+    # raise before self-assign, minor_issues before generic self-assign.
+    names = [type(d).__name__ for d in ALL_DETECTORS]
+    assert names.index("ConditionalRaiseDetector") < names.index("ConditionalSelfAssignDetector")
+    assert names.index("MinorIssuesDictAssignDetector") > names.index(
+        "ConditionalSelfAssignDetector"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filters and confidence scoring
+# ---------------------------------------------------------------------------
+
+
+PUBLIC_FIELDS = frozenset({"temperature", "top_p", "do_sample", "stop"})
+
+
+def test_filter_condition_references_self_positive() -> None:
+    expr = _parse_expr("self.temperature < 0.01")
+    assert filter_condition_references_self(expr, PUBLIC_FIELDS) is True
+
+
+def test_filter_condition_references_self_private_field() -> None:
+    expr = _parse_expr("self._internal is True")
+    # _internal is not in the public field set.
+    assert filter_condition_references_self(expr, PUBLIC_FIELDS) is False
+
+
+def test_filter_condition_references_self_argument_only() -> None:
+    expr = _parse_expr("strict")
+    assert filter_condition_references_self(expr, PUBLIC_FIELDS) is False
+
+
+def test_filter_target_is_public_field_positive() -> None:
+    pattern = DetectedPattern(
+        severity="dormant",
+        emission_channel="none",
+        affected_field="temperature",
+        message_template=None,
+        detail="self.temperature = 0",
+    )
+    assert filter_target_is_public_field(pattern, PUBLIC_FIELDS) is True
+
+
+def test_filter_target_is_public_field_rejects_private() -> None:
+    pattern = DetectedPattern(
+        severity="dormant",
+        emission_channel="none",
+        affected_field="_initialized",
+        message_template=None,
+        detail="",
+    )
+    assert filter_target_is_public_field(pattern, PUBLIC_FIELDS) is False
+
+
+def test_filter_target_is_public_field_neutral_for_non_assign() -> None:
+    # Non-assign pattern (no affected_field) passes this filter trivially.
+    pattern = DetectedPattern(
+        severity="error",
+        emission_channel="none",
+        affected_field=None,
+        message_template=None,
+        detail="",
+    )
+    assert filter_target_is_public_field(pattern, PUBLIC_FIELDS) is True
+
+
+def test_filter_kwargs_positive_derivable_simple() -> None:
+    expr = _parse_expr("self.do_sample is False and self.temperature != 1.0")
+    assert filter_kwargs_positive_derivable(expr) is True
+
+
+def test_filter_kwargs_positive_derivable_rejects_opaque() -> None:
+    # Opaque helper call against external state is not derivable.
+    expr = _parse_expr("importlib.util.find_spec('scipy')")
+    assert filter_kwargs_positive_derivable(expr) is False
+
+
+def test_filter_kwargs_positive_derivable_accepts_isinstance() -> None:
+    expr = _parse_expr("not isinstance(self.top_p, float)")
+    assert filter_kwargs_positive_derivable(expr) is True
+
+
+def test_score_confidence_levels() -> None:
+    assert score_confidence(3) == "high"
+    assert score_confidence(2) == "medium"
+    assert score_confidence(1) == "low"
+    assert score_confidence(0) == "low"
+
+
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+
+def test_check_installed_version_in_range() -> None:
+    check_installed_version("transformers", "4.56.0", SpecifierSet(">=4.50,<5.0"))
+
+
+def test_check_installed_version_out_of_range() -> None:
+    with pytest.raises(WalkerVersionMismatchError) as exc_info:
+        check_installed_version("transformers", "5.0.0", SpecifierSet(">=4.50,<5.0"))
+    assert "transformers" in str(exc_info.value)
+    assert "5.0.0" in str(exc_info.value)
+
+
+def test_check_installed_version_invalid_version_string() -> None:
+    with pytest.raises(WalkerVersionMismatchError):
+        check_installed_version("transformers", "not-a-version", SpecifierSet(">=4.50,<5.0"))
+
+
+def test_walker_landmark_missing_error_carries_detail() -> None:
+    exc = WalkerLandmarkMissingError("GenerationConfig.validate", "method removed")
+    assert exc.landmark == "GenerationConfig.validate"
+    assert "method removed" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Class/method finders
+# ---------------------------------------------------------------------------
+
+
+_HELPER_MODULE_SRC = """
+class Thing:
+    def entry(self):
+        self.sub_check()
+
+    def sub_check(self):
+        if self.temperature < 0:
+            raise ValueError("bad")
+
+    def unrelated(self):
+        return 1
+"""
+
+
+def test_find_class_and_method_helpers() -> None:
+    module = ast.parse(_HELPER_MODULE_SRC)
+    assert find_class(module, "NonExistent") is None
+    cls = find_class(module, "Thing")
+    assert cls is not None
+    assert find_method(cls, "entry") is not None
+    assert find_method(cls, "does_not_exist") is None


### PR DESCRIPTION
## Summary

Second of three slices replacing #367 — the shared AST infrastructure that engine-specific walkers (vLLM, TRT-LLM in future phases) will compose to extract validation rules from library source.

**Infrastructure-only PR.** No walker is wired up here; the first consumer (transformers introspection walker + seeded corpus) lands in Slice C.

## Contents

- **Data types** — `RuleCandidate`, `WalkerSource` (walker output shape, serialises directly to the YAML corpus schema)
- **Error types** — `WalkerError`, `WalkerVersionMismatchError`, `WalkerLandmarkMissingError` for uniform raise-or-collect CI behaviour
- **`check_installed_version`** — fails loud when a walker's pinned range doesn't match the installed library
- **AST primitives** — `call_func_path`, `first_string_arg`, `extract_condition_fields`, `extract_assign_target`, `resolve_local_assign`, `extract_loop_literal_iterable`, `find_class`, `find_method`
- **Five pattern detectors** — `ConditionalRaise`, `ConditionalSelfAssign`, `ConditionalWarningsWarn`, `ConditionalLoggerWarning`, `MinorIssuesDictAssign` (cover the rule shapes observed across the three target engines)
- **Three false-positive filters** — `condition-references-self`, `target-is-public-field`, `kwargs-positive-derivable` + a 3-filter confidence scorer (`high` / `medium` / `low`)

## What's NOT in this PR (deliberate)

- **Helper tracer** (`resolve_same_module_helpers`, `find_self_helper_calls`) — removed per design PoC-A reconciliation. The original pre-impl design reserved one-level helper tracing for cross-method rule detection; PoC-A scanned all three target libraries at depth 1/2/3 and found **zero** marginal rules at depth > 1. The tracer is genuinely dead for the current library versions.
- **Transformers walker** — lands in Slice C, along with the seeded corpus
- **Walker wiring into CI** — lands in the follow-up vendor pipeline PR (was #368)

## Design notes

- **Why ship infrastructure without a consumer in-PR?** vLLM + TRT-LLM walkers are the next planned additions (already tasked). Keeping the base in its own PR decouples the three-way review: (1) is the base contract right? (2) does the transformers-specific walker consume it correctly? (3) does the corpus data actually reflect HF behaviour? Reviewing all three at once (the old #367 shape) meant architectural and data-level concerns couldn't be disentangled.
- **Why keep `RuleCandidate.added_by: str = "ast_walker"` default?** AST walkers are the primary consumer of this module — the default matches the common case. Walkers that are NOT AST walkers (the transformers introspection wrapper) explicitly override. The loader validates the value at corpus-load time (via `UnknownAddedByError` from Slice A), catching any missed override at the YAML boundary.

## Test plan

- [x] 40 unit tests pass locally (42 in original file, minus 2 helper-tracer tests)
- [x] `mypy --strict` clean
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green on push
- [ ] Exercised by Slice C (transformers walker uses the error types + RuleCandidate)