### PR TITLE
feat(config): wire vendored rules into generic Pydantic validator

### DIFF
--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -17,11 +17,17 @@ v2.0 removals:
 
 from __future__ import annotations
 
+import logging
+import warnings
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
 from llenergymeasure.config.ssot import SAMPLING_PRESETS, Engine
+from llenergymeasure.config.warnings import ConfigValidationWarning
+
+logger = logging.getLogger(__name__)
 
 #: Valid energy sampler names for ``energy_sampler`` fields.
 EnergySamplerName = Literal["auto", "nvml", "zeus", "codecarbon"]
@@ -35,6 +41,21 @@ if TYPE_CHECKING:
         TransformersConfig,
         VLLMConfig,
     )
+    from llenergymeasure.config.vendored_rules.loader import VendoredRulesLoader
+
+
+@lru_cache(maxsize=1)
+def _get_rules_loader() -> VendoredRulesLoader:
+    # Lazy import so module load doesn't read YAML off disk. Tests substitute
+    # via ``monkeypatch.setattr(models, "_get_rules_loader", ...)``.
+    from llenergymeasure.config.vendored_rules.loader import VendoredRulesLoader
+
+    return VendoredRulesLoader()
+
+
+def _reset_rules_loader_cache() -> None:
+    """Clear the memoised loader; used by tests that mutate the on-disk corpus."""
+    _get_rules_loader.cache_clear()
 
 
 # =============================================================================
@@ -465,7 +486,14 @@ class ExperimentConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_transformers_flash_attn_dtype(self) -> ExperimentConfig:
-        """FlashAttention (FA2/FA3) requires float16 or bfloat16 dtype (not float32)."""
+        """FlashAttention (FA2/FA3) requires float16 or bfloat16 dtype (not float32).
+
+        Retained as a hand-written validator until a ``PreTrainedModel``
+        introspection walker can derive this rule programmatically (the check
+        lives in ``_autoset_attn_implementation``, not in
+        ``GenerationConfig.validate``). See memory note
+        ``project_phase_50_pipeline_replan.md``.
+        """
         if (
             self.engine == "transformers"
             and self.transformers is not None
@@ -477,6 +505,50 @@ class ExperimentConfig(BaseModel):
                 "dtype='float16' or dtype='bfloat16'. FlashAttention does not support "
                 "float32 computation."
             )
+        return self
+
+    @model_validator(mode="after")
+    def _apply_vendored_rules(self) -> ExperimentConfig:
+        # ``object.__setattr__`` bypasses Pydantic's ``extra='forbid'``;
+        # consumers read via ``cfg._dormant_observations``. Missing corpus
+        # is non-fatal — the rules layer is additive.
+        from llenergymeasure.config.probe import DormantField
+
+        dormant_observations: list[DormantField] = []
+        try:
+            rules = _get_rules_loader().load_rules(self.engine.value).rules
+        except FileNotFoundError:
+            logger.debug("No vendored rules corpus for engine %r; skipping.", self.engine.value)
+            rules = ()
+
+        for rule in rules:
+            match = rule.try_match(self)
+            if match is None:
+                continue
+            annotated = f"[{rule.id}] {rule.render_message(match)}"
+            if rule.severity == "error":
+                raise ValueError(annotated)
+            if rule.severity == "warn":
+                warnings.warn(annotated, ConfigValidationWarning, stacklevel=2)
+                continue
+            if rule.severity == "dormant":
+                dormant_observations.append(
+                    DormantField(
+                        declared_value=match.declared_value,
+                        effective_value=match.effective_value,
+                        reason=annotated,
+                    )
+                )
+                continue
+            # Typo in the corpus: loader validation would normally reject this,
+            # but surface it visibly if anything slips past.
+            warnings.warn(
+                f"[{rule.id}] unknown severity {rule.severity!r}",
+                ConfigValidationWarning,
+                stacklevel=2,
+            )
+
+        object.__setattr__(self, "_dormant_observations", dormant_observations)
         return self
 
 

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-23T21:23:37+02:00",
-  "vendor_commit": "8037ead3815fa010a4172b605b061a062639fc66",
+  "vendored_at": "2026-04-23T21:54:02+02:00",
+  "vendor_commit": "30fe188b1c892cf7684c27e2ffa634521e854b15",
   "cases": [
     {
       "id": "transformers_bnb_bnb_4bit_compute_dtype_type",

--- a/src/llenergymeasure/config/warnings.py
+++ b/src/llenergymeasure/config/warnings.py
@@ -1,0 +1,11 @@
+"""Warning categories emitted by the config layer."""
+
+from __future__ import annotations
+
+
+class ConfigValidationWarning(UserWarning):
+    """Emitted when a vendored validation rule matches with ``severity=warn``.
+
+    Distinct subclass so callers can elevate only config-validation warnings
+    to errors via ``warnings.simplefilter("error", ConfigValidationWarning)``.
+    """

--- a/tests/unit/config/test_generic_validator.py
+++ b/tests/unit/config/test_generic_validator.py
@@ -1,0 +1,306 @@
+"""Tests for the generic ``_apply_vendored_rules`` model validator.
+
+Covers the three severity paths (error / warn / dormant) plus the
+no-match / missing-corpus fallbacks. Rule loading is exercised by
+``tests/unit/config/vendored_rules/test_loader.py``; this module focuses on
+the validator's dispatch and the ``_dormant_observations`` contract.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from llenergymeasure.config.engine_configs import (
+    TransformersConfig,
+    TransformersSamplingConfig,
+)
+from llenergymeasure.config.models import (
+    ExperimentConfig,
+    _reset_rules_loader_cache,
+)
+from llenergymeasure.config.probe import DormantField
+from llenergymeasure.config.vendored_rules.loader import Rule, VendoredRules
+from llenergymeasure.config.warnings import ConfigValidationWarning
+
+
+def _make_rule(
+    rule_id: str,
+    severity: str,
+    match_fields: dict[str, Any],
+    message_template: str | None = "test rule fired ({declared_value})",
+    outcome: str = "error",
+) -> Rule:
+    """Build a minimal Rule for validator-path testing."""
+    return Rule(
+        id=rule_id,
+        engine="transformers",
+        library="transformers",
+        rule_under_test="unit test rule",
+        severity=severity,
+        native_type="transformers.GenerationConfig",
+        match_engine="transformers",
+        match_fields=match_fields,
+        kwargs_positive={},
+        kwargs_negative={},
+        expected_outcome={"outcome": outcome, "emission_channel": "none"},
+        message_template=message_template,
+        walker_source={},
+        references=(),
+        added_by="manual_seed",
+        added_at="2026-04-23",
+    )
+
+
+class _StubLoader:
+    def __init__(self, rules: list[Rule]) -> None:
+        self._rules = tuple(rules)
+
+    def load_rules(self, engine: str) -> VendoredRules:
+        return VendoredRules(
+            engine=engine,
+            schema_version="1.0.0",
+            engine_version="test",
+            rules=self._rules,
+        )
+
+
+class _NoCorpusLoader:
+    def load_rules(self, engine: str) -> VendoredRules:
+        raise FileNotFoundError(f"no corpus for {engine}")
+
+
+def _install_test_rules(monkeypatch: pytest.MonkeyPatch, rules: list[Rule]) -> None:
+    """Substitute the module's loader accessor with a stub returning *rules*."""
+    from llenergymeasure.config import models as models_mod
+
+    stub = _StubLoader(rules)
+    monkeypatch.setattr(models_mod, "_get_rules_loader", lambda: stub)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    """Each test starts with a fresh loader cache so real-corpus tests stay hermetic."""
+    _reset_rules_loader_cache()
+
+
+# ---------------------------------------------------------------------------
+# Severity dispatch — error
+# ---------------------------------------------------------------------------
+
+
+def test_error_severity_raises_validation_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    rule = _make_rule(
+        "test_error_rule",
+        "error",
+        {"transformers.attn_implementation": "sdpa"},
+    )
+    _install_test_rules(monkeypatch, [rule])
+
+    with pytest.raises(ValidationError) as exc_info:
+        ExperimentConfig(
+            task={"model": "gpt2"},
+            engine="transformers",
+            transformers=TransformersConfig(attn_implementation="sdpa"),
+        )
+    assert "test_error_rule" in str(exc_info.value)
+
+
+def test_error_severity_no_raise_when_match_misses(monkeypatch: pytest.MonkeyPatch) -> None:
+    rule = _make_rule(
+        "test_error_rule",
+        "error",
+        {"transformers.attn_implementation": "flash_attention_2"},
+    )
+    _install_test_rules(monkeypatch, [rule])
+
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers=TransformersConfig(attn_implementation="sdpa"),
+    )
+    assert cfg._dormant_observations == []
+
+
+# ---------------------------------------------------------------------------
+# Severity dispatch — warn
+# ---------------------------------------------------------------------------
+
+
+def test_warn_severity_emits_config_validation_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    rule = _make_rule(
+        "test_warn_rule",
+        "warn",
+        {"transformers.attn_implementation": "eager"},
+    )
+    _install_test_rules(monkeypatch, [rule])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", ConfigValidationWarning)
+        ExperimentConfig(
+            task={"model": "gpt2"},
+            engine="transformers",
+            transformers=TransformersConfig(attn_implementation="eager"),
+        )
+
+    matched = [w for w in caught if issubclass(w.category, ConfigValidationWarning)]
+    assert matched, "expected a ConfigValidationWarning"
+    assert "test_warn_rule" in str(matched[0].message)
+
+
+def test_warn_severity_not_fatal_under_simplefilter_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``simplefilter('error', ConfigValidationWarning)`` escalates warn to raise."""
+    rule = _make_rule(
+        "test_warn_rule",
+        "warn",
+        {"transformers.attn_implementation": "eager"},
+    )
+    _install_test_rules(monkeypatch, [rule])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConfigValidationWarning)
+        with pytest.raises((ValidationError, ConfigValidationWarning)):
+            ExperimentConfig(
+                task={"model": "gpt2"},
+                engine="transformers",
+                transformers=TransformersConfig(attn_implementation="eager"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Severity dispatch — dormant
+# ---------------------------------------------------------------------------
+
+
+def test_dormant_severity_populates_observations(monkeypatch: pytest.MonkeyPatch) -> None:
+    rule = _make_rule(
+        "test_dormant_rule",
+        "dormant",
+        {"transformers.sampling.temperature": {"present": True, "not_equal": 1.0}},
+        outcome="dormant_announced",
+    )
+    _install_test_rules(monkeypatch, [rule])
+
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers=TransformersConfig(
+            sampling=TransformersSamplingConfig(temperature=0.9),
+        ),
+    )
+
+    observations = cfg._dormant_observations
+    assert len(observations) == 1
+    obs = observations[0]
+    assert isinstance(obs, DormantField)
+    assert obs.declared_value == 0.9
+    assert "test_dormant_rule" in (obs.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# Fallbacks — missing corpus / empty rule set
+# ---------------------------------------------------------------------------
+
+
+def test_missing_corpus_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FileNotFoundError from the loader is swallowed and logged at debug."""
+    from llenergymeasure.config import models as models_mod
+
+    monkeypatch.setattr(models_mod, "_get_rules_loader", lambda: _NoCorpusLoader())
+
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    assert cfg._dormant_observations == []
+
+
+def test_empty_rule_set_populates_empty_observations(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_test_rules(monkeypatch, [])
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    assert cfg._dormant_observations == []
+
+
+# ---------------------------------------------------------------------------
+# Composition
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_dormant_rules_all_recorded(monkeypatch: pytest.MonkeyPatch) -> None:
+    rule_a = _make_rule("a", "dormant", {"transformers.sampling.temperature": {"present": True}})
+    rule_b = _make_rule("b", "dormant", {"transformers.sampling.top_p": {"present": True}})
+    _install_test_rules(monkeypatch, [rule_a, rule_b])
+
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers=TransformersConfig(
+            sampling=TransformersSamplingConfig(temperature=0.9, top_p=0.95),
+        ),
+    )
+    assert len(cfg._dormant_observations) == 2
+
+
+def test_error_rule_shortcircuits_later_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    err = _make_rule("err", "error", {"transformers.attn_implementation": "eager"})
+    dormant = _make_rule(
+        "dormant_after_error",
+        "dormant",
+        {"transformers.sampling.temperature": {"present": True}},
+    )
+    _install_test_rules(monkeypatch, [err, dormant])
+
+    with pytest.raises(ValidationError):
+        ExperimentConfig(
+            task={"model": "gpt2"},
+            engine="transformers",
+            transformers=TransformersConfig(
+                attn_implementation="eager",
+                sampling=TransformersSamplingConfig(temperature=0.9),
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unknown severity — fail-safe
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_severity_emits_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    rule = _make_rule(
+        "weird_severity",
+        "not_a_real_severity",
+        {"transformers.attn_implementation": "sdpa"},
+    )
+    _install_test_rules(monkeypatch, [rule])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", ConfigValidationWarning)
+        ExperimentConfig(
+            task={"model": "gpt2"},
+            engine="transformers",
+            transformers=TransformersConfig(attn_implementation="sdpa"),
+        )
+
+    matched = [w for w in caught if issubclass(w.category, ConfigValidationWarning)]
+    assert matched
+    assert "weird_severity" in str(matched[0].message)
+
+
+# ---------------------------------------------------------------------------
+# Integration — real corpus on disk exercises every engine path without
+# raising (catches predicate-operator / field-path regressions end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_real_corpus_loads_and_default_config_passes() -> None:
+    """Default transformers config doesn't trigger any error-severity rule.
+
+    Sanity check against the actual packaged corpus — catches cases where a
+    rule's match predicate fires on defaults (e.g. the early-stopping
+    false-positive fixed in #375).
+    """
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    assert cfg._dormant_observations == []


### PR DESCRIPTION
## Summary

Add a single \`@model_validator\` on \`ExperimentConfig\` (\`_apply_vendored_rules\`) that consumes the vendored rules corpus and dispatches matches by severity. This is the **consumer side** of the vendored-rules pipeline — until now the 28-rule corpus was loaded nowhere at config-load time.

- **error** → raise \`ValueError\` (Pydantic wraps as \`ValidationError\`) with \`[rule_id]\` annotation
- **warn** → emit \`ConfigValidationWarning\` via \`warnings.warn\` (new category in \`config/warnings.py\` so tests can \`simplefilter('error', ConfigValidationWarning)\`)
- **dormant** / **dormant_silent** → append \`DormantField\` to \`_dormant_observations\` (sidecar/preflight consumes later)

Module-level loader cache (\`_RULES_LOADER\`) with \`_get_rules_loader()\` / \`_reset_rules_loader_cache()\` helpers — tests stub a loader to exercise specific rule shapes without touching disk.

Missing corpus for an engine is non-fatal (debug log + empty observations). Unknown severity values surface as \`ConfigValidationWarning\` rather than silently no-op.

## Intentionally NOT in this PR

- **\`validate_transformers_flash_attn_dtype\` hand-written validator is retained.** The FlashAttention dtype check lives in \`PreTrainedModel._autoset_attn_implementation\` — outside \`GenerationConfig.validate\`'s scope. Auto-generating the corpus rule needs a PreTrainedModel-level walker (follow-up issue). Hand-seeding it compounds #376 by +1 \`manual_seed\` for no durable win. Keep the validator until the walker ships.

## Stack

- Depends on #383 (\`refactor/relocate-vendored-rules-to-config\`) for the Layer 0 placement. No \`import-linter\` ignores needed.
- PR 1 of the M1 consumer pipeline. See \`project_phase_50_pipeline_replan.md\`.

## Test plan

- [x] 12 new validator-dispatch tests (error / warn / dormant / dormant_silent / missing corpus / empty rules / composition / escalated warn / unknown severity / real-corpus sanity).
- [x] \`warnings.simplefilter('error', ConfigValidationWarning)\` path covered.
- [x] Full \`tests/unit/config/\` + \`tests/unit/engines/\` suite passes (599 tests).
- [x] \`lint-imports\` 3 contracts kept (config → engines still forbidden; validator imports \`config.vendored_rules.loader\` + \`config.probe\` — both Layer 0).
- [x] Ruff check + format clean.
- [x] \`mypy --strict\` clean on touched src files.