### PR TITLE
feat(config): transformers introspection walker replaces hand-curated rules

### DIFF
--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -132,6 +132,7 @@ jobs:
             "scripts/vendor_rules.py"
             "scripts/_vendor_common.py"
             "scripts/walkers/transformers.py"
+            "scripts/walkers/transformers_introspection.py"
             "scripts/walkers/_fixpoint_test.py"
             "scripts/walkers/_base.py"
             "scripts/update_engine_rules.sh"

--- a/configs/validation_rules/transformers.yaml
+++ b/configs/validation_rules/transformers.yaml
@@ -306,7 +306,7 @@ rules:
       mode: reduce-overhead
   kwargs_negative:
     compile_config: null
-  expected_outcome:
+  expected_outcome: &id001
     outcome: error
     emission_channel: none
     normalised_fields: []
@@ -342,10 +342,7 @@ rules:
     do_sample: false
     num_beams: 1
     num_return_sequences: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
+  expected_outcome: *id001
   message_template: Greedy methods without beam search do not support `num_return_sequences` different
     than 1 (got 3).
   references:
@@ -620,10 +617,7 @@ rules:
     cache_implementation: nonsense
   kwargs_negative:
     cache_implementation: static
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
+  expected_outcome: *id001
   message_template: 'Invalid `cache_implementation` (nonsense). Choose one of: (''static'', ''offloaded_static'',
     ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'', ''offloaded_hybrid_chunked'',
     ''dynamic'', ''dynamic_full'', ''offloaded'', ''quantized'')'
@@ -655,10 +649,7 @@ rules:
     early_stopping: sometimes
   kwargs_negative:
     early_stopping: true
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
+  expected_outcome: *id001
   message_template: '`early_stopping` must be a boolean or ''never'', but is sometimes.'
   references:
   - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
@@ -684,10 +675,7 @@ rules:
     max_new_tokens: -1
   kwargs_negative:
     max_new_tokens: 16
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
+  expected_outcome: *id001
   message_template: '`max_new_tokens` must be greater than 0, but is -1.'
   references:
   - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
@@ -753,8 +741,8 @@ rules:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`return_dict_in_generate` is NOT set to `{declared_value}`, but `output_attentions`
-    is. When `return_dict_in_generate` is not `{declared_value}`, `output_attentions` is ignored.'
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When
+    `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
   references:
   - transformers.GenerationConfig.validate() (line ~409)
   added_by: introspection
@@ -788,8 +776,8 @@ rules:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`return_dict_in_generate` is NOT set to `{declared_value}`, but `output_hidden_states`
-    is. When `return_dict_in_generate` is not `{declared_value}`, `output_hidden_states` is ignored.'
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When
+    `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.'
   references:
   - transformers.GenerationConfig.validate() (line ~410)
   added_by: introspection
@@ -823,8 +811,8 @@ rules:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`return_dict_in_generate` is NOT set to `{declared_value}`, but `output_scores` is.
-    When `return_dict_in_generate` is not `{declared_value}`, `output_scores` is ignored.'
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate`
+    is not `True`, `output_scores` is ignored.'
   references:
   - transformers.GenerationConfig.validate() (line ~411)
   added_by: introspection
@@ -853,10 +841,7 @@ rules:
   kwargs_negative:
     num_return_sequences: 2
     num_beams: 4
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
+  expected_outcome: *id001
   message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
   references:
   - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"

--- a/configs/validation_rules/transformers.yaml
+++ b/configs/validation_rules/transformers.yaml
@@ -2,7 +2,7 @@ schema_version: 1.0.0
 engine: transformers
 engine_version: 4.56.0
 walker_pinned_range: <4.57,>=4.49
-walked_at: '2026-04-23T00:00:00Z'
+walked_at: '2026-04-24T00:00:00Z'
 rules:
 - id: transformers_bnb_bnb_4bit_compute_dtype_type
   engine: transformers
@@ -34,7 +34,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_bnb_4bit_quant_type_type
   engine: transformers
   library: bitsandbytes
@@ -65,7 +65,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_bnb_4bit_use_double_quant_type
   engine: transformers
   library: bitsandbytes
@@ -96,7 +96,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_llm_int8_enable_fp32_cpu_offload_type
   engine: transformers
   library: bitsandbytes
@@ -127,7 +127,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_llm_int8_has_fp16_weight_type
   engine: transformers
   library: bitsandbytes
@@ -158,7 +158,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_llm_int8_skip_modules_type
   engine: transformers
   library: bitsandbytes
@@ -190,7 +190,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_llm_int8_threshold_type
   engine: transformers
   library: bitsandbytes
@@ -221,7 +221,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_load_in_4bit_type
   engine: transformers
   library: bitsandbytes
@@ -252,7 +252,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_bnb_load_in_8bit_type
   engine: transformers
   library: bitsandbytes
@@ -283,7 +283,7 @@ rules:
   - "transformers.utils.quantization_config.BitsAndBytesConfig.post_init() \u2014 manually audited type-check\
     \ raises"
   added_by: manual_seed
-  added_at: '2026-04-23'
+  added_at: '2026-04-24'
 - id: transformers_compile_config_type
   engine: transformers
   library: transformers
@@ -310,11 +310,12 @@ rules:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: '`compile_config` must be a CompileConfig instance, got {declared_value}.'
+  message_template: You provided `compile_config` as an instance of <class 'dict'>, but it must be an
+    instance of `CompileConfig`.
   references:
-  - "transformers.GenerationConfig.validate() \u2014 manual seed from HF 4.56 source"
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_rejects_num_return_sequences
   engine: transformers
   library: transformers
@@ -324,7 +325,7 @@ rules:
   walker_source:
     path: transformers/generation/configuration_utils.py
     method: validate
-    line_at_scan: 360
+    line_at_scan: 408
     walker_confidence: high
   match:
     engine: transformers
@@ -345,12 +346,12 @@ rules:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: Greedy methods without beam search do not support `num_return_sequences` != 1 (got
-    {declared_value}).
+  message_template: Greedy methods without beam search do not support `num_return_sequences` different
+    than 1 (got 3).
   references:
-  - "transformers.GenerationConfig.validate() \u2014 manual seed from HF 4.56 source"
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_strips_epsilon_cutoff
   engine: transformers
   library: transformers
@@ -372,20 +373,21 @@ rules:
         not_equal: 0.0
   kwargs_positive:
     do_sample: false
-    epsilon_cutoff: 0.05
+    epsilon_cutoff: 0.5
   kwargs_negative:
     do_sample: true
-    epsilon_cutoff: 0.05
+    epsilon_cutoff: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`do_sample=False` is set, so `epsilon_cutoff` ({declared_value}) has no effect. Remove
-    it or set do_sample=True.'
+  message_template: '`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `epsilon_cutoff`.'
   references:
   - transformers.GenerationConfig.validate() (line ~378)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_strips_eta_cutoff
   engine: transformers
   library: transformers
@@ -407,20 +409,21 @@ rules:
         not_equal: 0.0
   kwargs_positive:
     do_sample: false
-    eta_cutoff: 0.05
+    eta_cutoff: 0.5
   kwargs_negative:
     do_sample: true
-    eta_cutoff: 0.05
+    eta_cutoff: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`do_sample=False` is set, so `eta_cutoff` ({declared_value}) has no effect. Remove
-    it or set do_sample=True.'
+  message_template: '`do_sample` is set to `False`. However, `eta_cutoff` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `eta_cutoff`.'
   references:
   - transformers.GenerationConfig.validate() (line ~379)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_strips_min_p
   engine: transformers
   library: transformers
@@ -441,20 +444,20 @@ rules:
         present: true
   kwargs_positive:
     do_sample: false
-    min_p: 0.1
+    min_p: 0.5
   kwargs_negative:
     do_sample: true
-    min_p: 0.1
+    min_p: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`do_sample=False` is set, so `min_p` ({declared_value}) has no effect. Remove it
-    or set do_sample=True.'
+  message_template: '`do_sample` is set to `False`. However, `min_p` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.'
   references:
   - transformers.GenerationConfig.validate() (line ~376)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_strips_temperature
   engine: transformers
   library: transformers
@@ -476,20 +479,21 @@ rules:
         not_equal: 1.0
   kwargs_positive:
     do_sample: false
-    temperature: 0.9
+    temperature: 0.5
   kwargs_negative:
     do_sample: true
-    temperature: 0.9
+    temperature: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`do_sample=False` is set, so `temperature` ({declared_value}) has no effect. Remove
-    it or set do_sample=True.'
+  message_template: '`do_sample` is set to `False`. However, `temperature` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `temperature`.'
   references:
   - transformers.GenerationConfig.validate() (line ~373)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_strips_top_k
   engine: transformers
   library: transformers
@@ -511,20 +515,20 @@ rules:
         not_equal: 50
   kwargs_positive:
     do_sample: false
-    top_k: 40
+    top_k: 51
   kwargs_negative:
     do_sample: true
-    top_k: 40
+    top_k: 51
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`do_sample=False` is set, so `top_k` ({declared_value}) has no effect. Remove it
-    or set do_sample=True.'
+  message_template: '`do_sample` is set to `False`. However, `top_k` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.'
   references:
   - transformers.GenerationConfig.validate() (line ~374)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_strips_top_p
   engine: transformers
   library: transformers
@@ -546,20 +550,20 @@ rules:
         not_equal: 1.0
   kwargs_positive:
     do_sample: false
-    top_p: 0.95
+    top_p: 0.5
   kwargs_negative:
     do_sample: true
-    top_p: 0.95
+    top_p: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`do_sample=False` is set, so `top_p` ({declared_value}) has no effect. Remove it
-    or set do_sample=True.'
+  message_template: '`do_sample` is set to `False`. However, `top_p` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.'
   references:
   - transformers.GenerationConfig.validate() (line ~375)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_greedy_strips_typical_p
   engine: transformers
   library: transformers
@@ -581,20 +585,21 @@ rules:
         not_equal: 1.0
   kwargs_positive:
     do_sample: false
-    typical_p: 0.9
+    typical_p: 0.5
   kwargs_negative:
     do_sample: true
-    typical_p: 0.9
+    typical_p: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`do_sample=False` is set, so `typical_p` ({declared_value}) has no effect. Remove
-    it or set do_sample=True.'
+  message_template: '`do_sample` is set to `False`. However, `typical_p` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `typical_p`.'
   references:
   - transformers.GenerationConfig.validate() (line ~377)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_invalid_cache_implementation
   engine: transformers
   library: transformers
@@ -619,11 +624,13 @@ rules:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: Invalid `cache_implementation` ({declared_value}). Choose one from the supported set.
+  message_template: 'Invalid `cache_implementation` (nonsense). Choose one of: (''static'', ''offloaded_static'',
+    ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'', ''offloaded_hybrid_chunked'',
+    ''dynamic'', ''dynamic_full'', ''offloaded'', ''quantized'')'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 manual seed from HF 4.56 source"
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_invalid_early_stopping
   engine: transformers
   library: transformers
@@ -652,11 +659,11 @@ rules:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: '`early_stopping` must be a boolean or ''never'', but is {declared_value}.'
+  message_template: '`early_stopping` must be a boolean or ''never'', but is sometimes.'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 manual seed from HF 4.56 source"
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_negative_max_new_tokens
   engine: transformers
   library: transformers
@@ -681,11 +688,11 @@ rules:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: '`max_new_tokens` must be greater than 0, but is {declared_value}.'
+  message_template: '`max_new_tokens` must be greater than 0, but is -1.'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 manual seed from HF 4.56 source"
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_negative_pad_token_id
   engine: transformers
   library: transformers
@@ -710,12 +717,118 @@ rules:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`pad_token_id` ({declared_value}) should be non-negative. This will cause errors
-    when batch generating, if there is padding.'
+  message_template: '`pad_token_id` should be positive but got -1. This will cause errors when batch generating,
+    if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID`
+    to avoid errors in generation'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 manual seed from HF 4.56 source"
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: introspection
+  added_at: '2026-04-24'
+- id: transformers_no_return_dict_strips_output_attentions
+  engine: transformers
+  library: transformers
+  rule_under_test: GenerationConfig.validate() records dormant `output_attentions` when return_dict_in_generate=False
+    and `output_attentions` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  walker_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 409
+    walker_confidence: high
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_attentions:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_attentions: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_attentions: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `{declared_value}`, but `output_attentions`
+    is. When `return_dict_in_generate` is not `{declared_value}`, `output_attentions` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~409)
+  added_by: introspection
+  added_at: '2026-04-24'
+- id: transformers_no_return_dict_strips_output_hidden_states
+  engine: transformers
+  library: transformers
+  rule_under_test: GenerationConfig.validate() records dormant `output_hidden_states` when return_dict_in_generate=False
+    and `output_hidden_states` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  walker_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 410
+    walker_confidence: high
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_hidden_states:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_hidden_states: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_hidden_states: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `{declared_value}`, but `output_hidden_states`
+    is. When `return_dict_in_generate` is not `{declared_value}`, `output_hidden_states` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~410)
+  added_by: introspection
+  added_at: '2026-04-24'
+- id: transformers_no_return_dict_strips_output_scores
+  engine: transformers
+  library: transformers
+  rule_under_test: GenerationConfig.validate() records dormant `output_scores` when return_dict_in_generate=False
+    and `output_scores` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  walker_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 411
+    walker_confidence: high
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_scores:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_scores: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_scores: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `{declared_value}`, but `output_scores` is.
+    When `return_dict_in_generate` is not `{declared_value}`, `output_scores` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~411)
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_num_return_sequences_exceeds_num_beams
   engine: transformers
   library: transformers
@@ -744,11 +857,11 @@ rules:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: '`num_return_sequences` ({declared_value}) must be <= `num_beams`.'
+  message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 manual seed from HF 4.56 source"
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_single_beam_strips_constraints
   engine: transformers
   library: transformers
@@ -769,21 +882,20 @@ rules:
         present: true
   kwargs_positive:
     num_beams: 1
-    constraints: &id001
-    - '...'
+    constraints: 0.5
   kwargs_negative:
     num_beams: 4
-    constraints: *id001
+    constraints: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`num_beams=1` is set, so `constraints` ({declared_value}) is ignored. Set num_beams>1
-    or remove constraints.'
+  message_template: '`num_beams` is set to 1. However, `constraints` is set to `{declared_value}` -- this
+    flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `constraints`.'
   references:
   - transformers.GenerationConfig.validate() (line ~388)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_single_beam_strips_diversity_penalty
   engine: transformers
   library: transformers
@@ -813,12 +925,12 @@ rules:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`num_beams=1` is set, so `diversity_penalty` ({declared_value}) is ignored. Set num_beams>1
-    or remove diversity_penalty.'
+  message_template: '`num_beams` is set to 1. However, `diversity_penalty` is set to `{declared_value}`
+    -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`.'
   references:
   - transformers.GenerationConfig.validate() (line ~380)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_single_beam_strips_early_stopping
   engine: transformers
   library: transformers
@@ -848,12 +960,12 @@ rules:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`num_beams=1` is set, so `early_stopping` ({declared_value}) is ignored. Set num_beams>1
-    or remove early_stopping.'
+  message_template: '`num_beams` is set to 1. However, `early_stopping` is set to `{declared_value}` --
+    this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.'
   references:
   - transformers.GenerationConfig.validate() (line ~355)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_single_beam_strips_length_penalty
   engine: transformers
   library: transformers
@@ -875,20 +987,20 @@ rules:
         not_equal: 1.0
   kwargs_positive:
     num_beams: 1
-    length_penalty: 2.0
+    length_penalty: 0.5
   kwargs_negative:
     num_beams: 4
-    length_penalty: 2.0
+    length_penalty: 0.5
   expected_outcome:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`num_beams=1` is set, so `length_penalty` ({declared_value}) is ignored. Set num_beams>1
-    or remove length_penalty.'
+  message_template: '`num_beams` is set to 1. However, `length_penalty` is set to `{declared_value}` --
+    this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.'
   references:
   - transformers.GenerationConfig.validate() (line ~383)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'
 - id: transformers_single_beam_strips_num_beam_groups
   engine: transformers
   library: transformers
@@ -918,9 +1030,9 @@ rules:
     outcome: dormant_announced
     emission_channel: logger_warning_once
     normalised_fields: []
-  message_template: '`num_beams=1` is set, so `num_beam_groups` ({declared_value}) is ignored. Set num_beams>1
-    or remove num_beam_groups.'
+  message_template: '`num_beams` is set to 1. However, `num_beam_groups` is set to `{declared_value}`
+    -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `num_beam_groups`.'
   references:
   - transformers.GenerationConfig.validate() (line ~362)
-  added_by: manual_seed
-  added_at: '2026-04-23'
+  added_by: introspection
+  added_at: '2026-04-24'

--- a/scripts/walkers/transformers.py
+++ b/scripts/walkers/transformers.py
@@ -44,7 +44,6 @@ import inspect
 import os
 import sys
 from dataclasses import asdict
-from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -155,15 +154,6 @@ def _check_landmarks() -> tuple[str, str]:
 
     source_path = inspect.getsourcefile(GenerationConfig) or "<unknown>"
     return transformers.__version__, source_path
-
-
-@cache
-def _read_source_lines(source_file: str) -> tuple[str, ...]:
-    """Cache parsed source-file lines. BNB path-line lookups hit this cache."""
-    try:
-        return tuple(Path(source_file).read_text().splitlines())
-    except OSError:
-        return ()
 
 
 def _relative_source_path(abs_path: str) -> str:

--- a/scripts/walkers/transformers.py
+++ b/scripts/walkers/transformers.py
@@ -66,20 +66,28 @@ from scripts.walkers.transformers_introspection import (  # noqa: E402
     walk_generation_config_rules,
 )
 
-TESTED_AGAINST_VERSIONS: SpecifierSet = SpecifierSet(">=4.49,<4.57")
+TESTED_AGAINST_VERSIONS: SpecifierSet = SpecifierSet(">=4.56,<4.57")
 """Range of transformers versions this walker has been validated against.
 
-Lower bound tracks the project's own ``transformers>=4.49`` pin in
-``pyproject.toml`` so CI's pinned version stays in range. Upper bound
-excludes 4.57 because HF 4.57 restructured ``GenerationConfig.validate()`` —
-dropped several ``minor_issues`` branches (``num_beam_groups``,
-``diversity_penalty``, ``constraints`` single-beam dormancies) and the
-watermarking auto-coercion. The introspection path inherits this pin:
-on 4.57+, the auto-enumerator would surface a different rule set, and the
-diff-rules CI comment would flag the drift for maintainer reconciliation.
+Narrowed to 4.56.x because the introspection walker relies on
+``GenerationConfig.validate(strict=True)`` — that kwarg was introduced in
+4.56 and the 4.56 composed-issue message shape is what the corpus was
+built against. Earlier versions either lack ``strict=`` entirely
+(``TypeError: got an unexpected keyword argument 'strict'``) or expose a
+differently-shaped ``minor_issues`` output. 4.57 restructured
+``validate()`` again — dropped several ``minor_issues`` branches
+(``num_beam_groups``, ``diversity_penalty``, ``constraints`` single-beam
+dormancies) and the watermarking auto-coercion.
 
 On mismatch, :func:`check_installed_version` raises
 :class:`WalkerVersionMismatchError` and CI fails.
+
+Note: the project's own ``transformers`` extra in ``pyproject.toml``
+still floors at ``>=4.49`` for user runtime compatibility. The walker is
+a CI-time maintainer tool, not a runtime dependency, so the narrower pin
+doesn't affect end users. Follow-up: align CI's resolved transformers
+version with this pin (currently ``uv.lock`` resolves to 4.51.0) so the
+vendor-rules-refresh workflow can regenerate the corpus in-band.
 """
 
 

--- a/scripts/walkers/transformers.py
+++ b/scripts/walkers/transformers.py
@@ -1,27 +1,33 @@
-"""Transformers rules seeder — landmark-verified manual-seed module.
+"""Transformers validation-rules walker — landmark-verified orchestrator.
 
-Rule tuples (``_GREEDY_RULES``, ``_BEAM_RULES``, ``_GENERATION_VALIDATE_RULES``,
-``_BNB_TYPE_RULES``) are hand-curated from reading HF transformers source.
-Rule content (predicates, message templates, kwargs_positive/negative)
-is editorial, not derived programmatically — all emitted rules carry
-``added_by: "manual_seed"``.
+Composes two extraction paths to emit a deterministic rules corpus:
 
-What is empirical:
+1. **GenerationConfig rules via library-API introspection** — delegated to
+   :mod:`scripts.walkers.transformers_introspection`. Every dormancy rule is
+   discovered by probing ``GenerationConfig.validate(strict=True)`` against a
+   synthesised per-type probe value; every error-class rule's message is
+   lifted from the library's own ``ValueError``. Rules emitted:
+   ``added_by: introspection``.
 
-- Library landmarks: imports ``transformers`` and checks that
-  ``GenerationConfig``, ``BitsAndBytesConfig``, ``validate``, ``post_init``
-  exist. Missing landmark → :class:`WalkerLandmarkMissingError`.
-- Version envelope: :data:`TESTED_AGAINST_VERSIONS` pins the walker to a
-  known range; a mismatch raises :class:`WalkerVersionMismatchError` at
-  CI time, prompting a refresh.
-- Source paths + line numbers: derived via :func:`inspect.getsourcefile`
-  and a ``self.<field>`` text grep. Informational only (not used for
-  rule matching).
+2. **BitsAndBytesConfig type-check rules** — hand-curated here. BNB import
+   triggers a CUDA context on GPU-bearing hosts, which would make the walker
+   unsafe to run CPU-only in CI. Keeping BNB rules as landmark-verified
+   manual seed preserves CPU-safety; the justification is the CUDA-context
+   risk, not editorial preference. Rules emitted: ``added_by: manual_seed``.
 
-Covers ``GenerationConfig`` (sampling / greedy / beam / validate rules)
-and ``BitsAndBytesConfig`` (type-check rules from the ``post_init``
-TypeError raises). peft / LoraConfig out of scope — no near-term
-consumer.
+Landmark verification: imports ``transformers`` and confirms
+``GenerationConfig``, ``BitsAndBytesConfig``, ``validate`` and ``post_init``
+exist. Missing landmark → :class:`WalkerLandmarkMissingError`. Version
+envelope: :data:`TESTED_AGAINST_VERSIONS` pins the walker to a known range;
+a mismatch raises :class:`WalkerVersionMismatchError` at CI time. Source
+paths and line numbers are derived via :func:`inspect.getsourcefile` and a
+text grep — informational only, not used for rule matching.
+
+Flash-attention validation (``validate_transformers_flash_attn_dtype``) is
+out of scope: its check lives in ``PreTrainedModel._autoset_attn_implementation``,
+not ``GenerationConfig.validate`` or ``BitsAndBytesConfig.post_init``, and is
+not reachable via this walker's landmarks. Stays hand-written in
+``config/models.py`` pending a PreTrainedModel-level walker.
 
 Usage::
 
@@ -37,7 +43,7 @@ import datetime as dt
 import inspect
 import os
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -57,217 +63,47 @@ from scripts.walkers._base import (  # noqa: E402  (late import after sys.path)
     WalkerSource,
     check_installed_version,
 )
+from scripts.walkers.transformers_introspection import (  # noqa: E402
+    walk_generation_config_rules,
+)
 
 TESTED_AGAINST_VERSIONS: SpecifierSet = SpecifierSet(">=4.49,<4.57")
 """Range of transformers versions this walker has been validated against.
 
 Lower bound tracks the project's own ``transformers>=4.49`` pin in
 ``pyproject.toml`` so CI's pinned version stays in range. Upper bound
-excludes 4.57 because HF 4.57 restructured
-``GenerationConfig.validate()`` — dropped several ``minor_issues``
-branches (``num_beam_groups``, ``diversity_penalty``, ``constraints``
-single-beam dormancies) and the watermarking auto-coercion. The rules
-in this walker reflect the 4.49-4.56 shape of ``validate()``; rule
-content was primarily verified against 4.56 source.
+excludes 4.57 because HF 4.57 restructured ``GenerationConfig.validate()`` —
+dropped several ``minor_issues`` branches (``num_beam_groups``,
+``diversity_penalty``, ``constraints`` single-beam dormancies) and the
+watermarking auto-coercion. The introspection path inherits this pin:
+on 4.57+, the auto-enumerator would surface a different rule set, and the
+diff-rules CI comment would flag the drift for maintainer reconciliation.
 
 On mismatch, :func:`check_installed_version` raises
-:class:`WalkerVersionMismatchError` and CI fails. When the project
-bumps to 4.57+, a maintainer reconciles the rule tuples against the new
-source and bumps this pin — the narrow upper bound forces a deliberate
-refresh rather than silent shape-drift.
+:class:`WalkerVersionMismatchError` and CI fails.
 """
 
 
 # ---------------------------------------------------------------------------
-# Known rule templates
+# BitsAndBytesConfig type-check rules (kept hand-curated — CPU-safe)
 # ---------------------------------------------------------------------------
-# The introspection path surfaces issues by field name and by message; it
-# does not expose structured predicates. For each HF field we know about, we
-# encode the match predicate here (the walker's equivalent of the AST
-# condition-extraction step). This is explicit rather than hidden in a
-# library-source regex and stays comparable to the vLLM/TRT-LLM walkers'
-# output.
-
-
-# --- Greedy dormancy (fires when do_sample=False and the field is set) ---
 #
-# HF emits these as minor_issues entries. Match predicate: do_sample is False
-# AND the field is present and not equal to its default. Default values come
-# from the library's own GenerationConfig defaults.
-
-_GREEDY_RULES: tuple[tuple[str, Any, Any], ...] = (
-    # (field_name, default_value, positive_value)
-    ("temperature", 1.0, 0.9),
-    ("top_p", 1.0, 0.95),
-    ("top_k", 50, 40),
-    ("min_p", None, 0.1),
-    ("typical_p", 1.0, 0.9),
-    ("epsilon_cutoff", 0.0, 0.05),
-    ("eta_cutoff", 0.0, 0.05),
-)
-
-# --- Single-beam dormancy (fires when num_beams=1 and the field is set) ---
+# These rules surface BNB's ``isinstance``-checking ``post_init`` TypeErrors
+# before BNB is actually constructed. BNB's ``import`` triggers a CUDA
+# context on GPU hosts; the walker stays CPU-safe by not importing it.
+# Predicate uses ``type_is_not`` — fires only when the field is set AND has
+# the wrong concrete type; a valid value (``True`` for a bool field) does
+# not match.
 #
-# HF 4.56 handles these five fields in the `num_beams == 1` block
-# (configuration_utils.py:79-103). HF 4.57 dropped `num_beam_groups`,
-# `diversity_penalty`, `constraints` from this block. When the walker pin
-# moves forward to 4.57+, those three must be removed here to match.
-
-_BEAM_RULES: tuple[tuple[str, Any, Any], ...] = (
-    ("early_stopping", False, True),
-    ("num_beam_groups", 1, 2),
-    ("diversity_penalty", 0.0, 0.5),
-    ("length_penalty", 1.0, 2.0),
-    ("constraints", None, ["..."]),
-)
-
-# --- GenerationConfig.validate() cross-field rules (error + dormant) ---
-# Most are error-class (raise ValueError); a few are dormant-class (write to
-# HF's `minor_issues` dict, emitted via logger.warning_once). Dormant rules
-# set `severity` / `outcome` / `emission_channel` explicitly; errors use
-# factory defaults.
-#
-# Deliberately NOT captured here (follow-up PR once the predicate grammar
-# gains the needed expressiveness):
-# - watermarking_config validation: HF 4.56 accepts both WatermarkingConfig
-#   AND SynthIDTextWatermarkingConfig and silently auto-coerces dicts —
-#   writes to minor_issues. Needs `type_is_any` predicate to express the
-#   two-class allowlist; current `type_is_not: <single>` is insufficient.
-# - num_beams % num_beam_groups divisibility (line 132-133 of 4.56.0
-#   validate): real error-class rule, but the kwargs_negative in the
-#   naive encoding also trips downstream raises. Needs a modulo predicate
-#   operator AND a kwargs_negative that supplies compensating fields.
-# - diversity_penalty > 0 required when in group-beam mode (line 134-137
-#   of 4.56.0 validate): semantic is conditional on an earlier branch
-#   entry; simple single-rule predicate doesn't express it cleanly.
-_GENERATION_VALIDATE_RULES: tuple[dict[str, Any], ...] = (
-    {
-        "id": "transformers_negative_max_new_tokens",
-        "rule_under_test": ("GenerationConfig(max_new_tokens) rejects non-positive values"),
-        "match_fields": {
-            "transformers.sampling.max_new_tokens": {"<=": 0},
-        },
-        "kwargs_positive": {"max_new_tokens": -1},
-        "kwargs_negative": {"max_new_tokens": 16},
-        "message_template": ("`max_new_tokens` must be greater than 0, but is {declared_value}."),
-        "source_method": "validate",
-    },
-    {
-        "id": "transformers_invalid_cache_implementation",
-        "rule_under_test": ("GenerationConfig rejects unknown cache_implementation strings"),
-        "match_fields": {
-            "transformers.sampling.cache_implementation": {"present": True},
-        },
-        "kwargs_positive": {"cache_implementation": "nonsense"},
-        "kwargs_negative": {"cache_implementation": "static"},
-        "message_template": (
-            "Invalid `cache_implementation` ({declared_value}). Choose one from the supported set."
-        ),
-        "source_method": "validate",
-    },
-    {
-        "id": "transformers_invalid_early_stopping",
-        "rule_under_test": ("GenerationConfig.early_stopping must be bool or the literal 'never'"),
-        "match_fields": {
-            # `present: true` guards against firing on the LlmEnergyMeasure
-            # default (None) — HF's GenerationConfig default is False but
-            # our ExperimentConfig defaults the field to None, and the
-            # predicate runs against our config.
-            "transformers.sampling.early_stopping": {
-                "present": True,
-                "not_in": [True, False, "never"],
-            },
-        },
-        "kwargs_positive": {"early_stopping": "sometimes"},
-        "kwargs_negative": {"early_stopping": True},
-        "message_template": (
-            "`early_stopping` must be a boolean or 'never', but is {declared_value}."
-        ),
-        "source_method": "validate",
-    },
-    {
-        "id": "transformers_num_return_sequences_exceeds_num_beams",
-        "rule_under_test": ("GenerationConfig rejects num_return_sequences > num_beams"),
-        "match_fields": {
-            "transformers.sampling.num_return_sequences": {">": 1},
-            "transformers.sampling.num_beams": {"present": True},
-        },
-        "kwargs_positive": {"num_return_sequences": 4, "num_beams": 2},
-        "kwargs_negative": {"num_return_sequences": 2, "num_beams": 4},
-        "message_template": ("`num_return_sequences` ({declared_value}) must be <= `num_beams`."),
-        "source_method": "validate",
-    },
-    {
-        "id": "transformers_greedy_rejects_num_return_sequences",
-        "rule_under_test": (
-            "Greedy decoding (do_sample=False, num_beams=1) requires num_return_sequences=1"
-        ),
-        "match_fields": {
-            "transformers.sampling.do_sample": False,
-            "transformers.sampling.num_beams": 1,
-            "transformers.sampling.num_return_sequences": {">": 1},
-        },
-        "kwargs_positive": {"do_sample": False, "num_beams": 1, "num_return_sequences": 3},
-        "kwargs_negative": {"do_sample": False, "num_beams": 1, "num_return_sequences": 1},
-        "message_template": (
-            "Greedy methods without beam search do not support "
-            "`num_return_sequences` != 1 (got {declared_value})."
-        ),
-        "source_method": "validate",
-    },
-    {
-        # pad_token_id < 0 writes to HF's minor_issues dict, NOT raises.
-        # Emission is via logger.warning_once post-collection. Severity is
-        # dormant-announcement, not error.
-        "id": "transformers_negative_pad_token_id",
-        "rule_under_test": "GenerationConfig.validate() records dormant pad_token_id < 0",
-        "severity": "dormant",
-        "outcome": "dormant_announced",
-        "emission_channel": "logger_warning_once",
-        "match_fields": {
-            "transformers.sampling.pad_token_id": {"<": 0},
-        },
-        "kwargs_positive": {"pad_token_id": -1},
-        "kwargs_negative": {"pad_token_id": 0},
-        "message_template": (
-            "`pad_token_id` ({declared_value}) should be non-negative. This will cause "
-            "errors when batch generating, if there is padding."
-        ),
-        "source_method": "validate",
-    },
-    {
-        # HF raises ValueError when compile_config is not an instance of
-        # CompileConfig. We mirror with a type predicate for user-friendly
-        # pre-construction detection.
-        "id": "transformers_compile_config_type",
-        "rule_under_test": (
-            "GenerationConfig rejects compile_config that is not a CompileConfig instance"
-        ),
-        "match_fields": {
-            "transformers.sampling.compile_config": {
-                "present": True,
-                "type_is_not": "CompileConfig",
-            },
-        },
-        "kwargs_positive": {"compile_config": {"mode": "reduce-overhead"}},
-        "kwargs_negative": {"compile_config": None},
-        "message_template": (
-            "`compile_config` must be a CompileConfig instance, got {declared_value}."
-        ),
-        "source_method": "validate",
-    },
-)
-
-# --- BitsAndBytesConfig type-check rules (post_init) ---
-# These are pure type-check raises: if not isinstance(value, T): raise TypeError(...).
-# We keep them here rather than running bnb's post_init directly because bnb
-# import triggers a CUDA context on GPU-bearing hosts. The walker stays CPU-safe.
+# Provenance: ``manual_seed``. Re-auditing on BNB library bumps is a
+# maintainer task — until a BNB-side introspection path is wired up (e.g.
+# inside a CUDA-bearing container at CI time), the partition stays as-is.
 
 _BNB_TYPE_RULES: tuple[tuple[str, str, Any, Any], ...] = (
     # (field, expected_type_label, positive_value, negative_value)
-    # type_label matches `type(value).__name__` (strict class-name match
-    # used by the loader's `type_is_not` predicate). `torch.dtype`
-    # instances have `type(v).__name__ == "dtype"` — not "torch.dtype".
+    # type_label matches ``type(value).__name__`` (strict class-name match
+    # used by the loader's ``type_is_not`` predicate). ``torch.dtype``
+    # instances have ``type(v).__name__ == "dtype"`` — not "torch.dtype".
     ("load_in_4bit", "bool", "yes", False),
     ("load_in_8bit", "bool", 1, False),
     ("llm_int8_threshold", "float", "6.0", 6.0),
@@ -281,14 +117,14 @@ _BNB_TYPE_RULES: tuple[tuple[str, str, Any, Any], ...] = (
 
 
 # ---------------------------------------------------------------------------
-# Walker entry points
+# Landmark + source-path utilities
 # ---------------------------------------------------------------------------
 
 
 def _check_landmarks() -> tuple[str, str]:
-    """Import transformers, verify the landmarks we rely on exist.
+    """Import transformers, verify the landmarks the walker relies on.
 
-    Returns ``(installed_version, generation_config_path)`` for the envelope.
+    Returns ``(installed_version, generation_config_source_path)``.
     """
     try:
         import transformers  # type: ignore
@@ -323,23 +159,11 @@ def _check_landmarks() -> tuple[str, str]:
 
 @cache
 def _read_source_lines(source_file: str) -> tuple[str, ...]:
-    """Cache parsed source-file lines. Walker runs 20+ line lookups per walk."""
+    """Cache parsed source-file lines. BNB path-line lookups hit this cache."""
     try:
         return tuple(Path(source_file).read_text().splitlines())
     except OSError:
         return ()
-
-
-def _line_for_field(source_file: str, needle: str) -> int:
-    """Best-effort line lookup for ``self.<needle>`` inside ``source_file``.
-
-    The corpus entry's ``line_at_scan`` is informational only — not used for
-    matching — so approximate lookup is acceptable. Returns 0 if not found.
-    """
-    for i, line in enumerate(_read_source_lines(source_file), start=1):
-        if needle in line:
-            return i
-    return 0
 
 
 def _relative_source_path(abs_path: str) -> str:
@@ -359,143 +183,9 @@ def _today() -> str:
     return dt.date.today().isoformat()
 
 
-def _predicate_from_default(default: Any) -> dict[str, Any]:
-    """Predicate that fires when a field is set to a non-default value."""
-    if default is None:
-        return {"present": True}
-    return {"present": True, "not_equal": default}
-
-
-@dataclass(frozen=True)
-class _DormancyKind:
-    """Parameters that differ between greedy-mode vs single-beam dormancy factories."""
-
-    id_prefix: str  # e.g. "transformers_greedy_strips_"
-    trigger_field: str  # e.g. "do_sample"
-    trigger_positive: Any  # value that triggers dormancy (False for do_sample, 1 for num_beams)
-    trigger_negative: Any  # value that doesn't trigger (True for do_sample, 4 for num_beams)
-    rule_under_test_template: str  # f-string taking {field}
-    message_template_template: str  # f-string taking {field}
-
-
-_GREEDY_KIND = _DormancyKind(
-    id_prefix="transformers_greedy_strips_",
-    trigger_field="do_sample",
-    trigger_positive=False,
-    trigger_negative=True,
-    rule_under_test_template=(
-        "GenerationConfig.validate() records dormant `{field}` when "
-        "do_sample=False and `{field}` is set to a non-default value"
-    ),
-    message_template_template=(
-        "`do_sample=False` is set, so `{field}` ({{declared_value}}) "
-        "has no effect. Remove it or set do_sample=True."
-    ),
-)
-
-
-_BEAM_KIND = _DormancyKind(
-    id_prefix="transformers_single_beam_strips_",
-    trigger_field="num_beams",
-    trigger_positive=1,
-    trigger_negative=4,
-    rule_under_test_template=(
-        "GenerationConfig.validate() records dormant `{field}` when "
-        "num_beams=1 and `{field}` is set"
-    ),
-    message_template_template=(
-        "`num_beams=1` is set, so `{field}` ({{declared_value}}) is ignored. "
-        "Set num_beams>1 or remove {field}."
-    ),
-)
-
-
-def _make_dormancy_rule(
-    kind: _DormancyKind,
-    field: str,
-    default: Any,
-    positive: Any,
-    abs_source_path: str,
-    rel_source_path: str,
-    today: str,
-) -> RuleCandidate:
-    """Build a dormancy RuleCandidate. See :class:`_DormancyKind`."""
-    line = _line_for_field(abs_source_path, f"self.{field}")
-    return RuleCandidate(
-        id=f"{kind.id_prefix}{field}",
-        engine="transformers",
-        library="transformers",
-        rule_under_test=kind.rule_under_test_template.format(field=field),
-        severity="dormant",
-        native_type="transformers.GenerationConfig",
-        walker_source=WalkerSource(
-            path=rel_source_path,
-            method="validate",
-            line_at_scan=line,
-            walker_confidence="high",
-        ),
-        match_fields={
-            f"transformers.sampling.{kind.trigger_field}": kind.trigger_positive,
-            f"transformers.sampling.{field}": _predicate_from_default(default),
-        },
-        kwargs_positive={kind.trigger_field: kind.trigger_positive, field: positive},
-        kwargs_negative={kind.trigger_field: kind.trigger_negative, field: positive},
-        expected_outcome={
-            "outcome": "dormant_announced",
-            "emission_channel": "logger_warning_once",
-            "normalised_fields": [],
-        },
-        message_template=kind.message_template_template.format(field=field),
-        references=[f"transformers.GenerationConfig.validate() (line ~{line})"],
-        added_by="manual_seed",
-        added_at=today,
-    )
-
-
-def _make_validate_rule(
-    spec: dict[str, Any], abs_source_path: str, rel_source_path: str, today: str
-) -> RuleCandidate:
-    """Factory for GenerationConfig.validate() rules (error OR dormant).
-
-    Severity / outcome / emission_channel can be overridden in the spec dict
-    for dormancy rules like ``pad_token_id < 0`` (HF writes to minor_issues,
-    which users observe via logger.warning_once). Defaults match the common
-    case: severity=error, outcome=error, emission_channel=none.
-    """
-    probe_field = next(iter(spec["match_fields"]))
-    suffix = probe_field.rsplit(".", 1)[-1]
-    line = _line_for_field(abs_source_path, f"self.{suffix}")
-    severity = spec.get("severity", "error")
-    outcome = spec.get("outcome", "error")
-    emission_channel = spec.get("emission_channel", "none")
-    return RuleCandidate(
-        id=spec["id"],
-        engine="transformers",
-        library="transformers",
-        rule_under_test=spec["rule_under_test"],
-        severity=severity,
-        native_type="transformers.GenerationConfig",
-        walker_source=WalkerSource(
-            path=rel_source_path,
-            method=spec["source_method"],
-            line_at_scan=line,
-            walker_confidence="high",
-        ),
-        match_fields=spec["match_fields"],
-        kwargs_positive=spec["kwargs_positive"],
-        kwargs_negative=spec["kwargs_negative"],
-        expected_outcome={
-            "outcome": outcome,
-            "emission_channel": emission_channel,
-            "normalised_fields": [],
-        },
-        message_template=spec["message_template"],
-        references=[
-            "transformers.GenerationConfig.validate() — manual seed from HF 4.56 source",
-        ],
-        added_by="manual_seed",
-        added_at=today,
-    )
+# ---------------------------------------------------------------------------
+# BNB rule factory
+# ---------------------------------------------------------------------------
 
 
 def _make_bnb_type_rule(
@@ -506,19 +196,7 @@ def _make_bnb_type_rule(
     source_path: str,
     today: str,
 ) -> RuleCandidate:
-    """Factory for BitsAndBytesConfig type-check rules.
-
-    These rules surface BNB's `isinstance`-checking `post_init` TypeErrors
-    before BNB is actually constructed (BNB import triggers a CUDA context
-    on GPU hosts). Predicate uses `type_is_not` — fires only when the field
-    is set AND has the wrong concrete type; a valid value (`True` for a
-    bool field) does not match.
-
-    Provenance is `manual_seed`: these rules are hand-curated from a
-    one-off audit of the BitsAndBytesConfig source, not derived
-    programmatically. Re-auditing on BNB library bumps is a maintainer
-    task.
-    """
+    """Factory for ``BitsAndBytesConfig`` type-check rules."""
     return RuleCandidate(
         id=f"transformers_bnb_{field}_type",
         engine="transformers",
@@ -535,10 +213,6 @@ def _make_bnb_type_rule(
             walker_confidence="high",
         ),
         match_fields={
-            # `present + type_is_not`: fire only when set AND wrong type.
-            # Bare `present: true` (the old predicate) fired on any set
-            # value regardless of type — a user setting `load_in_4bit: true`
-            # would wrongly trigger `severity=error`.
             f"transformers.quant.{field}": {
                 "present": True,
                 "type_is_not": type_label,
@@ -591,7 +265,12 @@ def _candidate_to_dict(c: RuleCandidate) -> dict[str, Any]:
 
 
 def walk() -> tuple[list[RuleCandidate], dict[str, Any]]:
-    """Return ``(candidates, envelope_metadata)``."""
+    """Return ``(candidates, envelope_metadata)`` — full corpus for this engine.
+
+    Composes the introspection-derived GenerationConfig rules with the
+    hand-curated BNB rules. Rules in the returned list carry their own
+    ``added_by`` tag; the envelope captures the shared version pin.
+    """
     installed_version, abs_source_path = _check_landmarks()
     check_installed_version("transformers", installed_version, TESTED_AGAINST_VERSIONS)
 
@@ -602,16 +281,16 @@ def walk() -> tuple[list[RuleCandidate], dict[str, Any]]:
     today = _today()
     candidates: list[RuleCandidate] = []
 
-    for kind, rules in ((_GREEDY_KIND, _GREEDY_RULES), (_BEAM_KIND, _BEAM_RULES)):
-        for field, default, pos in rules:
-            candidates.append(
-                _make_dormancy_rule(kind, field, default, pos, abs_source_path, source_path, today)
-            )
-    for spec in _GENERATION_VALIDATE_RULES:
-        candidates.append(_make_validate_rule(spec, abs_source_path, source_path, today))
+    candidates.extend(
+        walk_generation_config_rules(
+            abs_source_path=abs_source_path,
+            rel_source_path=source_path,
+            today=today,
+        )
+    )
 
     # BitsAndBytesConfig rules — source path is the quantization_config module.
-    # We cheaply locate it without importing bnb (which may touch CUDA).
+    # Cheaply locate it without importing bnb (which may touch CUDA).
     bnb_source_path = source_path
     try:
         import transformers.utils.quantization_config as _qcfg  # type: ignore
@@ -645,12 +324,10 @@ def emit_yaml(candidates: list[RuleCandidate], envelope: dict[str, Any]) -> str:
     """Serialise candidates + envelope to a deterministic YAML string.
 
     Key order is fixed (not alphabetical) for readability: envelope first,
-    then candidates in source order. Within each candidate, keys follow the
-    corpus schema's documented layout.
+    then candidates sorted by ``(walker_source.method, id)``.
     """
     import yaml
 
-    # Sort candidates deterministically for byte-stable output.
     sorted_candidates = sorted(candidates, key=lambda c: (c.walker_source.method, c.id))
     doc = {
         "schema_version": envelope["schema_version"],

--- a/scripts/walkers/transformers_introspection.py
+++ b/scripts/walkers/transformers_introspection.py
@@ -1,0 +1,682 @@
+"""Transformers library-API introspection walker.
+
+Derives validation rules from HF's own runtime machinery instead of reading
+library source. Three extraction paths, all observe the library at walk time:
+
+1. **Mode-gated dormancy auto-enumeration** — for each known trigger class
+   (greedy, single-beam), enumerate every public ``GenerationConfig()`` field,
+   synthesise a non-default probe value for its Python type, invoke
+   ``validate(strict=True)``, and record any field HF reports as dormant in
+   the composed raise. Adding a new HF sampling parameter is auto-discovered
+   on the next walk — no code edits.
+
+2. **Hardcoded error-class probes** — rules whose violation shape is
+   rule-specific (negative integer, out-of-enum string, wrong-type instance)
+   can't be discovered by field enumeration alone. The probe list is
+   hardcoded, but the message template is still library-authored: each probe
+   triggers a construction-time ``ValueError`` whose text we lift verbatim.
+
+3. **Hardcoded validate-time self-triggered dormant probes** — the
+   ``pad_token_id < 0`` family (currently one rule) doesn't route via a mode
+   flag; its own value triggers the dormancy. Encoded as explicit probes
+   rather than extending the trigger enumeration.
+
+Every rule this walker emits carries ``added_by="introspection"``. BNB rules
+are out of scope — BNB import touches CUDA, so those stay as ``manual_seed``
+entries in :mod:`scripts.walkers.transformers`.
+
+Field defaults, rule message templates, and the per-trigger field list are
+all library-observed at walk time. The only encoded knowledge is: (a) two
+trigger classes exist (greedy, single-beam), (b) the per-rule violation
+shape for error-class probes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.walkers._base import RuleCandidate, WalkerSource  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Trigger classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DormancyTrigger:
+    """One mode-gated dormancy trigger in HF's ``validate()``.
+
+    HF 4.49-4.56 exposes three trigger classes: greedy (``do_sample=False``),
+    single-beam (``num_beams=1``), and scalar-output (``return_dict_in_generate=False``).
+    Each trigger has an ``isolation_kwargs`` payload — values for the OTHER
+    triggers that DON'T activate them — so the auto-enumerator can tell
+    which trigger a firing rule belongs to even though the three categories
+    partially overlap in HF's default state (``num_beams=1`` and
+    ``return_dict_in_generate=False`` are both defaults, so a naive probe
+    under ``do_sample=False`` would triple-fire unrelated rules).
+    """
+
+    id_prefix: str
+    trigger_field: str
+    trigger_positive: Any  # value that activates this trigger
+    trigger_negative: Any  # value that doesn't
+    # Kwargs that deactivate every OTHER trigger. See the class docstring —
+    # load-bearing for attributing a firing rule to exactly one trigger class.
+    isolation_kwargs: dict[str, Any]
+    rule_under_test_template: str  # f-string slot: {field}
+
+
+_GREEDY_TRIGGER = _DormancyTrigger(
+    id_prefix="transformers_greedy_strips_",
+    trigger_field="do_sample",
+    trigger_positive=False,
+    trigger_negative=True,
+    isolation_kwargs={"num_beams": 4, "return_dict_in_generate": True},
+    rule_under_test_template=(
+        "GenerationConfig.validate() records dormant `{field}` when "
+        "do_sample=False and `{field}` is set to a non-default value"
+    ),
+)
+
+
+_BEAM_TRIGGER = _DormancyTrigger(
+    id_prefix="transformers_single_beam_strips_",
+    trigger_field="num_beams",
+    trigger_positive=1,
+    trigger_negative=4,
+    isolation_kwargs={"do_sample": True, "return_dict_in_generate": True},
+    rule_under_test_template=(
+        "GenerationConfig.validate() records dormant `{field}` when "
+        "num_beams=1 and `{field}` is set"
+    ),
+)
+
+
+_RETURN_DICT_TRIGGER = _DormancyTrigger(
+    id_prefix="transformers_no_return_dict_strips_",
+    trigger_field="return_dict_in_generate",
+    trigger_positive=False,
+    trigger_negative=True,
+    isolation_kwargs={"do_sample": True, "num_beams": 4},
+    rule_under_test_template=(
+        "GenerationConfig.validate() records dormant `{field}` when "
+        "return_dict_in_generate=False and `{field}` is set"
+    ),
+)
+
+
+_TRIGGERS: tuple[_DormancyTrigger, ...] = (
+    _GREEDY_TRIGGER,
+    _BEAM_TRIGGER,
+    _RETURN_DICT_TRIGGER,
+)
+
+
+# Fields the auto-enumerator explicitly skips. Categories:
+# - Trigger fields themselves (probing a trigger under its own activation
+#   produces a nonsense self-triggering rule).
+# - Class-instance fields whose probe value would need a specific type
+#   (``compile_config``, ``watermarking_config``) — those are covered by
+#   ``_ERROR_PROBES`` where relevant.
+# - Meta fields and structural fields that don't have dormancy semantics.
+_SKIP_FIELDS: frozenset[str] = frozenset(
+    {
+        "do_sample",
+        "num_beams",
+        "return_dict_in_generate",
+        "compile_config",
+        "watermarking_config",
+        "generation_kwargs",
+        "transformers_version",
+    }
+)
+
+
+def _synthesise_probe_value(default: Any) -> Any | None:
+    """Return a non-default value whose type matches ``default``.
+
+    ``None`` when the type is too complex to probe mechanically (class
+    instances, opaque objects). Those fields either live in ``_SKIP_FIELDS``
+    or are caught by the construction-time ``try/except`` inside the
+    enumerator and silently skipped.
+    """
+    # bool is a subclass of int — check bool first.
+    if isinstance(default, bool):
+        return not default
+    if isinstance(default, int):
+        return default + 1
+    if isinstance(default, float):
+        if default in (0.0, 1.0):
+            return 0.5
+        return round(default + 0.1, 3)
+    if default is None:
+        # A float probe covers "present" for most HF sampling params. Fields
+        # needing a specific type (str enum, int token id) either skip here
+        # or trip construction and drop out inside the enumerator.
+        return 0.5
+    if isinstance(default, list):
+        return ["probe"]
+    if isinstance(default, str):
+        # Likely trips construction for enum fields (caught by the enumerator's
+        # try/except); skipping the type entirely would miss any future
+        # free-form string dormancy.
+        return "__probe__"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Library-message parsing
+# ---------------------------------------------------------------------------
+
+
+_ISSUE_LINE_RE = re.compile(r"^- `([^`]+)`: (.+)$")
+
+
+def _parse_strict_raise(composed_message: str) -> dict[str, str]:
+    """Split HF's ``validate(strict=True)`` raise into ``{field: message}``.
+
+    HF emits::
+
+        GenerationConfig is invalid:
+        - `field_a`: <per-field message a>
+        - `field_b`: <per-field message b>
+        If you're using a pretrained model, ...
+
+    We keep the per-field bodies and drop the header + pretrained-model footer.
+    """
+    issues: dict[str, str] = {}
+    for line in composed_message.splitlines():
+        match = _ISSUE_LINE_RE.match(line.strip())
+        if match:
+            issues[match.group(1)] = match.group(2).strip()
+    return issues
+
+
+def _substitute_declared_value(message: str, probe_value: Any) -> str:
+    """Replace the backtick-wrapped probe value in ``message`` with ``{declared_value}``.
+
+    HF quotes every value it interpolates with backticks (``\\`0.9\\```,
+    ``\\`True\\```, ``\\`['probe']\\```). We swap that wrapped form for
+    ``\\`{declared_value}\\``` so the consumer's ``.format(declared_value=...)``
+    interpolates the user's actual value at render time.
+
+    If the probe value doesn't appear wrapped (e.g. ``compile_config`` error
+    talks about the Python class, not the value), the message comes back
+    unchanged — the consumer treats a placeholder-less template as a literal.
+    """
+    wrapped = f"`{probe_value}`"
+    placeholder = "`{declared_value}`"
+    if wrapped in message:
+        return message.replace(wrapped, placeholder)
+    return message
+
+
+# ---------------------------------------------------------------------------
+# Dormancy auto-enumeration
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_dormancy_candidates() -> list[tuple[_DormancyTrigger, str, Any, Any, str]]:
+    """Probe every public ``GenerationConfig`` field under each trigger class.
+
+    Returns ``(trigger, field, default, probe_value, per_field_message)``
+    tuples for fields that HF reports as dormant. Filters out: private
+    fields, ``_SKIP_FIELDS``, types with no synthesised probe, and fields
+    whose construction trips an error under the trigger kwargs.
+
+    Field iteration is ``sorted(vars(baseline).items())`` — byte-stable
+    across runs so the corpus output is deterministic.
+    """
+    from transformers import GenerationConfig  # type: ignore
+
+    baseline = GenerationConfig()
+    discovered: list[tuple[_DormancyTrigger, str, Any, Any, str]] = []
+
+    for field_name, default in sorted(vars(baseline).items()):
+        if field_name.startswith("_"):
+            continue
+        if field_name in _SKIP_FIELDS:
+            continue
+        probe = _synthesise_probe_value(default)
+        if probe is None:
+            continue
+
+        for trigger in _TRIGGERS:
+            # Isolation kwargs deactivate the other two trigger classes, so
+            # a firing minor_issue for ``field_name`` is unambiguously
+            # attributed to ``trigger``.
+            kwargs = {
+                **trigger.isolation_kwargs,
+                trigger.trigger_field: trigger.trigger_positive,
+                field_name: probe,
+            }
+            try:
+                gc = GenerationConfig(**kwargs)
+            except Exception:
+                # Construction raised: the field's validator rejects our probe.
+                # Not a dormancy rule; may be covered by _ERROR_PROBES instead.
+                continue
+
+            try:
+                gc.validate(strict=True)
+            except ValueError as exc:
+                issues = _parse_strict_raise(str(exc))
+                if field_name in issues:
+                    discovered.append((trigger, field_name, default, probe, issues[field_name]))
+
+    return discovered
+
+
+# ---------------------------------------------------------------------------
+# Error-class probes (violation shape is per-rule, so hardcoded)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ErrorProbe:
+    """One error-class rule. Violation shape is encoded; message comes from the library."""
+
+    id: str
+    rule_under_test: str
+    match_fields: dict[str, Any]
+    kwargs_positive: dict[str, Any]
+    kwargs_negative: dict[str, Any]
+    # Kwarg whose value appears in the library's error message (for
+    # {declared_value} substitution). None when the message references only
+    # the type or another field — the template goes out verbatim.
+    probed_field: str | None
+
+
+_ERROR_PROBES: tuple[_ErrorProbe, ...] = (
+    _ErrorProbe(
+        id="transformers_negative_max_new_tokens",
+        rule_under_test="GenerationConfig(max_new_tokens) rejects non-positive values",
+        match_fields={"transformers.sampling.max_new_tokens": {"<=": 0}},
+        kwargs_positive={"max_new_tokens": -1},
+        kwargs_negative={"max_new_tokens": 16},
+        probed_field="max_new_tokens",
+    ),
+    _ErrorProbe(
+        id="transformers_invalid_cache_implementation",
+        rule_under_test="GenerationConfig rejects unknown cache_implementation strings",
+        match_fields={"transformers.sampling.cache_implementation": {"present": True}},
+        kwargs_positive={"cache_implementation": "nonsense"},
+        kwargs_negative={"cache_implementation": "static"},
+        probed_field="cache_implementation",
+    ),
+    _ErrorProbe(
+        id="transformers_invalid_early_stopping",
+        rule_under_test="GenerationConfig.early_stopping must be bool or the literal 'never'",
+        match_fields={
+            "transformers.sampling.early_stopping": {
+                "present": True,
+                "not_in": [True, False, "never"],
+            },
+        },
+        kwargs_positive={"early_stopping": "sometimes"},
+        kwargs_negative={"early_stopping": True},
+        probed_field="early_stopping",
+    ),
+    _ErrorProbe(
+        id="transformers_num_return_sequences_exceeds_num_beams",
+        rule_under_test="GenerationConfig rejects num_return_sequences > num_beams",
+        match_fields={
+            "transformers.sampling.num_return_sequences": {">": 1},
+            "transformers.sampling.num_beams": {"present": True},
+        },
+        kwargs_positive={"num_return_sequences": 4, "num_beams": 2},
+        kwargs_negative={"num_return_sequences": 2, "num_beams": 4},
+        probed_field="num_return_sequences",
+    ),
+    _ErrorProbe(
+        id="transformers_greedy_rejects_num_return_sequences",
+        rule_under_test=(
+            "Greedy decoding (do_sample=False, num_beams=1) requires num_return_sequences=1"
+        ),
+        match_fields={
+            "transformers.sampling.do_sample": False,
+            "transformers.sampling.num_beams": 1,
+            "transformers.sampling.num_return_sequences": {">": 1},
+        },
+        kwargs_positive={"do_sample": False, "num_beams": 1, "num_return_sequences": 3},
+        kwargs_negative={"do_sample": False, "num_beams": 1, "num_return_sequences": 1},
+        probed_field="num_return_sequences",
+    ),
+    _ErrorProbe(
+        id="transformers_compile_config_type",
+        rule_under_test=(
+            "GenerationConfig rejects compile_config that is not a CompileConfig instance"
+        ),
+        match_fields={
+            "transformers.sampling.compile_config": {
+                "present": True,
+                "type_is_not": "CompileConfig",
+            },
+        },
+        kwargs_positive={"compile_config": {"mode": "reduce-overhead"}},
+        kwargs_negative={"compile_config": None},
+        # HF's error describes the class, not the value — no {declared_value} slot.
+        probed_field=None,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Validate-time self-triggered dormant probes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DormantProbe:
+    """A validate-time dormancy rule whose trigger is field-self-driven.
+
+    Not mode-gated (so it's not covered by ``_TRIGGERS``). Currently one
+    rule in HF 4.56 (``pad_token_id < 0``); the tuple is present so future
+    self-triggered dormancies land as one-line additions.
+    """
+
+    id: str
+    rule_under_test: str
+    match_fields: dict[str, Any]
+    kwargs_positive: dict[str, Any]
+    kwargs_negative: dict[str, Any]
+    probed_field: str
+
+
+_VALIDATE_DORMANT_PROBES: tuple[_DormantProbe, ...] = (
+    _DormantProbe(
+        id="transformers_negative_pad_token_id",
+        rule_under_test="GenerationConfig.validate() records dormant pad_token_id < 0",
+        match_fields={"transformers.sampling.pad_token_id": {"<": 0}},
+        kwargs_positive={"pad_token_id": -1},
+        kwargs_negative={"pad_token_id": 0},
+        probed_field="pad_token_id",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Rule-candidate factories
+# ---------------------------------------------------------------------------
+
+
+def _default_predicate(default: Any) -> dict[str, Any]:
+    """Predicate that fires when the field is set to a non-default value."""
+    if default is None:
+        return {"present": True}
+    return {"present": True, "not_equal": default}
+
+
+def _find_line(source_file: str, needle: str) -> int:
+    """Best-effort ``self.<needle>`` line lookup. ``0`` if not found."""
+    try:
+        text = Path(source_file).read_text()
+    except OSError:
+        return 0
+    for i, line in enumerate(text.splitlines(), start=1):
+        if needle in line:
+            return i
+    return 0
+
+
+def _make_dormancy_candidate(
+    trigger: _DormancyTrigger,
+    field: str,
+    default: Any,
+    probe: Any,
+    library_message: str,
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> RuleCandidate:
+    """Compose a dormancy ``RuleCandidate`` from one library-observed trigger firing."""
+    template = _substitute_declared_value(library_message, probe)
+    line = _find_line(abs_source_path, f"self.{field}")
+    return RuleCandidate(
+        id=f"{trigger.id_prefix}{field}",
+        engine="transformers",
+        library="transformers",
+        rule_under_test=trigger.rule_under_test_template.format(field=field),
+        severity="dormant",
+        native_type="transformers.GenerationConfig",
+        walker_source=WalkerSource(
+            path=rel_source_path,
+            method="validate",
+            line_at_scan=line,
+            walker_confidence="high",
+        ),
+        match_fields={
+            f"transformers.sampling.{trigger.trigger_field}": trigger.trigger_positive,
+            f"transformers.sampling.{field}": _default_predicate(default),
+        },
+        kwargs_positive={trigger.trigger_field: trigger.trigger_positive, field: probe},
+        kwargs_negative={trigger.trigger_field: trigger.trigger_negative, field: probe},
+        expected_outcome={
+            "outcome": "dormant_announced",
+            "emission_channel": "logger_warning_once",
+            "normalised_fields": [],
+        },
+        message_template=template,
+        references=[f"transformers.GenerationConfig.validate() (line ~{line})"],
+        added_by="introspection",
+        added_at=today,
+    )
+
+
+def _make_error_candidate(
+    probe: _ErrorProbe,
+    library_message: str,
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> RuleCandidate:
+    """Compose an error-class ``RuleCandidate`` from a construction raise."""
+    if probe.probed_field is not None:
+        template = _substitute_declared_value(
+            library_message, probe.kwargs_positive[probe.probed_field]
+        )
+    else:
+        template = library_message
+    needle_field = probe.probed_field or next(iter(probe.match_fields)).rsplit(".", 1)[-1]
+    line = _find_line(abs_source_path, f"self.{needle_field}")
+    return RuleCandidate(
+        id=probe.id,
+        engine="transformers",
+        library="transformers",
+        rule_under_test=probe.rule_under_test,
+        severity="error",
+        native_type="transformers.GenerationConfig",
+        walker_source=WalkerSource(
+            path=rel_source_path,
+            method="validate",
+            line_at_scan=line,
+            walker_confidence="high",
+        ),
+        match_fields=probe.match_fields,
+        kwargs_positive=probe.kwargs_positive,
+        kwargs_negative=probe.kwargs_negative,
+        expected_outcome={
+            "outcome": "error",
+            "emission_channel": "none",
+            "normalised_fields": [],
+        },
+        message_template=template,
+        references=["transformers.GenerationConfig — observed via construction-time ValueError"],
+        added_by="introspection",
+        added_at=today,
+    )
+
+
+def _make_validate_dormant_candidate(
+    probe: _DormantProbe,
+    library_message: str,
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> RuleCandidate:
+    """Compose a validate-time self-triggered dormant ``RuleCandidate``."""
+    template = _substitute_declared_value(
+        library_message, probe.kwargs_positive[probe.probed_field]
+    )
+    line = _find_line(abs_source_path, f"self.{probe.probed_field}")
+    return RuleCandidate(
+        id=probe.id,
+        engine="transformers",
+        library="transformers",
+        rule_under_test=probe.rule_under_test,
+        severity="dormant",
+        native_type="transformers.GenerationConfig",
+        walker_source=WalkerSource(
+            path=rel_source_path,
+            method="validate",
+            line_at_scan=line,
+            walker_confidence="high",
+        ),
+        match_fields=probe.match_fields,
+        kwargs_positive=probe.kwargs_positive,
+        kwargs_negative=probe.kwargs_negative,
+        expected_outcome={
+            "outcome": "dormant_announced",
+            "emission_channel": "logger_warning_once",
+            "normalised_fields": [],
+        },
+        message_template=template,
+        references=[
+            "transformers.GenerationConfig.validate() — observed via validate(strict=True)"
+        ],
+        added_by="introspection",
+        added_at=today,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+class IntrospectionProbeDisappeared(RuntimeError):
+    """A hardcoded probe stopped firing — library behaviour has drifted.
+
+    Raised when an ``_ERROR_PROBES`` entry's ``kwargs_positive`` no longer
+    produces a ``ValueError``, or a ``_VALIDATE_DORMANT_PROBES`` entry no
+    longer fires in ``validate(strict=True)``. Semantically equivalent to
+    :class:`scripts.walkers._base.WalkerLandmarkMissingError` — walker
+    refuses to emit partial output; maintainer reconciles on the next
+    library-bump PR.
+    """
+
+
+def walk_generation_config_rules(
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> list[RuleCandidate]:
+    """Return all introspection-derived ``RuleCandidate``s for ``GenerationConfig``.
+
+    Composes three sources in deterministic order:
+
+    1. Mode-gated dormancy rules auto-enumerated per trigger class.
+    2. Error-class rules from ``_ERROR_PROBES`` observed via construction.
+    3. Validate-time self-triggered dormant rules from ``_VALIDATE_DORMANT_PROBES``.
+
+    Raises :class:`IntrospectionProbeDisappeared` if a hardcoded probe stops
+    firing — the "silent coverage loss becomes a visible CI failure" contract.
+    """
+    from transformers import GenerationConfig  # type: ignore
+
+    candidates: list[RuleCandidate] = []
+
+    for trigger, field, default, probe, library_message in _enumerate_dormancy_candidates():
+        candidates.append(
+            _make_dormancy_candidate(
+                trigger,
+                field,
+                default,
+                probe,
+                library_message,
+                abs_source_path,
+                rel_source_path,
+                today,
+            )
+        )
+
+    for eprobe in _ERROR_PROBES:
+        try:
+            GenerationConfig(**eprobe.kwargs_positive)
+        except ValueError as exc:
+            library_message = str(exc)
+        else:
+            raise IntrospectionProbeDisappeared(
+                f"Error probe {eprobe.id!r} no longer raises. Library may "
+                f"have relaxed or removed the constraint."
+            )
+        candidates.append(
+            _make_error_candidate(eprobe, library_message, abs_source_path, rel_source_path, today)
+        )
+
+    for dprobe in _VALIDATE_DORMANT_PROBES:
+        gc = GenerationConfig(**dprobe.kwargs_positive)
+        try:
+            gc.validate(strict=True)
+        except ValueError as exc:
+            issues = _parse_strict_raise(str(exc))
+        else:
+            raise IntrospectionProbeDisappeared(
+                f"Validate-time dormant probe {dprobe.id!r} no longer fires."
+            )
+        if dprobe.probed_field not in issues:
+            raise IntrospectionProbeDisappeared(
+                f"Validate-time dormant probe {dprobe.id!r} fired without "
+                f"mentioning {dprobe.probed_field!r}. Shape drift in HF's "
+                f"minor_issues output."
+            )
+        candidates.append(
+            _make_validate_dormant_candidate(
+                dprobe,
+                issues[dprobe.probed_field],
+                abs_source_path,
+                rel_source_path,
+                today,
+            )
+        )
+
+    return candidates
+
+
+def discover_dormancy_fields() -> dict[str, set[str]]:
+    """Return ``{trigger.id_prefix: {field, ...}}`` — auto-discovered dormancy fields.
+
+    Exposed for the test tier that asserts the hardcoded partition of the
+    corpus is a subset of what the live library exposes. Runs the same
+    enumeration the walker uses, returns just the field names.
+    """
+    result: dict[str, set[str]] = {t.id_prefix: set() for t in _TRIGGERS}
+    for trigger, field, _default, _probe, _msg in _enumerate_dormancy_candidates():
+        result[trigger.id_prefix].add(field)
+    return result
+
+
+# Re-export helpers used by callers (``scripts.walkers.transformers``).
+__all__ = [
+    "IntrospectionProbeDisappeared",
+    "discover_dormancy_fields",
+    "walk_generation_config_rules",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover — module is imported, not run.
+    print(
+        "This module is an internal helper for scripts.walkers.transformers. "
+        "Run the parent walker instead:\n\n"
+        "  python -m scripts.walkers.transformers --out configs/validation_rules/transformers.yaml",
+        file=sys.stderr,
+    )
+    sys.exit(2)

--- a/scripts/walkers/transformers_introspection.py
+++ b/scripts/walkers/transformers_introspection.py
@@ -26,9 +26,26 @@ are out of scope — BNB import touches CUDA, so those stay as ``manual_seed``
 entries in :mod:`scripts.walkers.transformers`.
 
 Field defaults, rule message templates, and the per-trigger field list are
-all library-observed at walk time. The only encoded knowledge is: (a) two
-trigger classes exist (greedy, single-beam), (b) the per-rule violation
-shape for error-class probes.
+all library-observed at walk time. The only encoded knowledge is: (a) the
+three trigger classes exist (greedy, single-beam, scalar-output), and
+(b) the per-rule violation shape for error-class probes.
+
+Known limitations (documented, not bugs):
+
+- **Frozen probe values in error-class templates.** HF's error messages don't
+  consistently wrap user values in backticks (e.g. ``must be greater than
+  0, but is -1`` / ``(4) has to be smaller or equal to (2)``). Template
+  substitution only fires on the ``\\`{field}\\` is set to \\`{value}\\```
+  phrasing (consistent for dormancy rules); for error rules that don't
+  match, the library message goes out verbatim with the walker's probe
+  value baked in. Users tripping these rules see an HF-style example
+  value, not their own. Not a semantic bug — the field name and constraint
+  are still accurate.
+- **Multi-value error messages.** One rule
+  (``num_return_sequences_exceeds_num_beams``) mentions two user values;
+  the ``{declared_value}`` slot only expresses one. Both stay frozen at
+  probe values. Fix requires consumer-side multi-slot templating; out of
+  scope here.
 """
 
 from __future__ import annotations
@@ -36,6 +53,7 @@ from __future__ import annotations
 import re
 import sys
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -113,11 +131,12 @@ _RETURN_DICT_TRIGGER = _DormancyTrigger(
 )
 
 
-_TRIGGERS: tuple[_DormancyTrigger, ...] = (
+TRIGGERS: tuple[_DormancyTrigger, ...] = (
     _GREEDY_TRIGGER,
     _BEAM_TRIGGER,
     _RETURN_DICT_TRIGGER,
 )
+"""Public: the full trigger-class partition. Tests parametrise over this."""
 
 
 # Fields the auto-enumerator explicitly skips. Categories:
@@ -200,22 +219,31 @@ def _parse_strict_raise(composed_message: str) -> dict[str, str]:
     return issues
 
 
-def _substitute_declared_value(message: str, probe_value: Any) -> str:
-    """Replace the backtick-wrapped probe value in ``message`` with ``{declared_value}``.
+def _substitute_declared_value(message: str, probed_field: str | None, probe_value: Any) -> str:
+    """Replace HF's ``\\`{field}\\` is set to \\`{value}\\``` with a ``{declared_value}`` slot.
 
-    HF quotes every value it interpolates with backticks (``\\`0.9\\```,
-    ``\\`True\\```, ``\\`['probe']\\```). We swap that wrapped form for
-    ``\\`{declared_value}\\``` so the consumer's ``.format(declared_value=...)``
-    interpolates the user's actual value at render time.
+    Anchored on the probed field's name to avoid false substitution — raw
+    backtick-wrapped values can collide with trigger-state literals in the
+    same message. E.g. HF's ``return_dict_in_generate`` dormancy says
+    ``\\`return_dict_in_generate\\` is NOT set to \\`True\\`, but \\`output_scores\\` is.``
+    — the naive ``\\`True\\``` match substitutes the *trigger* value, not
+    the probed field's value, and the rendered template mis-states the
+    rule. The anchored pattern fails to match this case (``output_scores``
+    isn't followed by ``is set to``), so the template goes out verbatim and
+    the consumer's ``.format`` is a no-op.
 
-    If the probe value doesn't appear wrapped (e.g. ``compile_config`` error
-    talks about the Python class, not the value), the message comes back
-    unchanged — the consumer treats a placeholder-less template as a literal.
+    Error-class rules rarely use the ``is set to`` phrasing (HF favours
+    ``must be greater than 0, but is -1`` / ``(4) has to be smaller or equal
+    to (2)``). For those, no substitution happens and the probe values are
+    frozen into the template. This is a known limitation, documented in the
+    module docstring — users tripping these rules see HF's default-example
+    value rather than their own.
     """
-    wrapped = f"`{probe_value}`"
-    placeholder = "`{declared_value}`"
-    if wrapped in message:
-        return message.replace(wrapped, placeholder)
+    if probed_field is None:
+        return message
+    pattern = f"`{probed_field}` is set to `{probe_value}`"
+    if pattern in message:
+        return message.replace(pattern, f"`{probed_field}` is set to `{{declared_value}}`")
     return message
 
 
@@ -249,7 +277,7 @@ def _enumerate_dormancy_candidates() -> list[tuple[_DormancyTrigger, str, Any, A
         if probe is None:
             continue
 
-        for trigger in _TRIGGERS:
+        for trigger in TRIGGERS:
             # Isolation kwargs deactivate the other two trigger classes, so
             # a firing minor_issue for ``field_name`` is unambiguously
             # attributed to ``trigger``.
@@ -295,7 +323,7 @@ class _ErrorProbe:
     probed_field: str | None
 
 
-_ERROR_PROBES: tuple[_ErrorProbe, ...] = (
+ERROR_PROBES: tuple[_ErrorProbe, ...] = (
     _ErrorProbe(
         id="transformers_negative_max_new_tokens",
         rule_under_test="GenerationConfig(max_new_tokens) rejects non-positive values",
@@ -415,13 +443,18 @@ def _default_predicate(default: Any) -> dict[str, Any]:
     return {"present": True, "not_equal": default}
 
 
+@cache
+def _read_source_lines(source_file: str) -> tuple[str, ...]:
+    """Cached source-file read. Each walk looks up ~20 fields in the same file."""
+    try:
+        return tuple(Path(source_file).read_text().splitlines())
+    except OSError:
+        return ()
+
+
 def _find_line(source_file: str, needle: str) -> int:
     """Best-effort ``self.<needle>`` line lookup. ``0`` if not found."""
-    try:
-        text = Path(source_file).read_text()
-    except OSError:
-        return 0
-    for i, line in enumerate(text.splitlines(), start=1):
+    for i, line in enumerate(_read_source_lines(source_file), start=1):
         if needle in line:
             return i
     return 0
@@ -438,7 +471,7 @@ def _make_dormancy_candidate(
     today: str,
 ) -> RuleCandidate:
     """Compose a dormancy ``RuleCandidate`` from one library-observed trigger firing."""
-    template = _substitute_declared_value(library_message, probe)
+    template = _substitute_declared_value(library_message, field, probe)
     line = _find_line(abs_source_path, f"self.{field}")
     return RuleCandidate(
         id=f"{trigger.id_prefix}{field}",
@@ -471,17 +504,45 @@ def _make_dormancy_candidate(
     )
 
 
-def _make_error_candidate(
-    probe: _ErrorProbe,
+_OUTCOME_BY_SEVERITY: dict[str, dict[str, Any]] = {
+    "error": {
+        "outcome": "error",
+        "emission_channel": "none",
+        "normalised_fields": [],
+    },
+    "dormant": {
+        "outcome": "dormant_announced",
+        "emission_channel": "logger_warning_once",
+        "normalised_fields": [],
+    },
+}
+
+
+_REFERENCE_BY_SEVERITY: dict[str, str] = {
+    "error": "transformers.GenerationConfig — observed via construction-time ValueError",
+    "dormant": "transformers.GenerationConfig.validate() — observed via validate(strict=True)",
+}
+
+
+def _make_hardcoded_probe_candidate(
+    probe: _ErrorProbe | _DormantProbe,
+    severity: str,
     library_message: str,
     abs_source_path: str,
     rel_source_path: str,
     today: str,
 ) -> RuleCandidate:
-    """Compose an error-class ``RuleCandidate`` from a construction raise."""
+    """Compose a ``RuleCandidate`` from a hardcoded probe (error or validate-time dormant).
+
+    Unifies the two hardcoded-probe paths. The only differences between
+    error-class and validate-time-dormant rules — after both yield a
+    library-authored message — are severity, expected_outcome, and the
+    reference string. Those come from the ``severity`` parameter; the rest
+    of the RuleCandidate shape is identical.
+    """
     if probe.probed_field is not None:
         template = _substitute_declared_value(
-            library_message, probe.kwargs_positive[probe.probed_field]
+            library_message, probe.probed_field, probe.kwargs_positive[probe.probed_field]
         )
     else:
         template = library_message
@@ -492,7 +553,7 @@ def _make_error_candidate(
         engine="transformers",
         library="transformers",
         rule_under_test=probe.rule_under_test,
-        severity="error",
+        severity=severity,
         native_type="transformers.GenerationConfig",
         walker_source=WalkerSource(
             path=rel_source_path,
@@ -503,55 +564,9 @@ def _make_error_candidate(
         match_fields=probe.match_fields,
         kwargs_positive=probe.kwargs_positive,
         kwargs_negative=probe.kwargs_negative,
-        expected_outcome={
-            "outcome": "error",
-            "emission_channel": "none",
-            "normalised_fields": [],
-        },
+        expected_outcome=_OUTCOME_BY_SEVERITY[severity],
         message_template=template,
-        references=["transformers.GenerationConfig — observed via construction-time ValueError"],
-        added_by="introspection",
-        added_at=today,
-    )
-
-
-def _make_validate_dormant_candidate(
-    probe: _DormantProbe,
-    library_message: str,
-    abs_source_path: str,
-    rel_source_path: str,
-    today: str,
-) -> RuleCandidate:
-    """Compose a validate-time self-triggered dormant ``RuleCandidate``."""
-    template = _substitute_declared_value(
-        library_message, probe.kwargs_positive[probe.probed_field]
-    )
-    line = _find_line(abs_source_path, f"self.{probe.probed_field}")
-    return RuleCandidate(
-        id=probe.id,
-        engine="transformers",
-        library="transformers",
-        rule_under_test=probe.rule_under_test,
-        severity="dormant",
-        native_type="transformers.GenerationConfig",
-        walker_source=WalkerSource(
-            path=rel_source_path,
-            method="validate",
-            line_at_scan=line,
-            walker_confidence="high",
-        ),
-        match_fields=probe.match_fields,
-        kwargs_positive=probe.kwargs_positive,
-        kwargs_negative=probe.kwargs_negative,
-        expected_outcome={
-            "outcome": "dormant_announced",
-            "emission_channel": "logger_warning_once",
-            "normalised_fields": [],
-        },
-        message_template=template,
-        references=[
-            "transformers.GenerationConfig.validate() — observed via validate(strict=True)"
-        ],
+        references=[_REFERENCE_BY_SEVERITY[severity]],
         added_by="introspection",
         added_at=today,
     )
@@ -608,7 +623,7 @@ def walk_generation_config_rules(
             )
         )
 
-    for eprobe in _ERROR_PROBES:
+    for eprobe in ERROR_PROBES:
         try:
             GenerationConfig(**eprobe.kwargs_positive)
         except ValueError as exc:
@@ -619,7 +634,9 @@ def walk_generation_config_rules(
                 f"have relaxed or removed the constraint."
             )
         candidates.append(
-            _make_error_candidate(eprobe, library_message, abs_source_path, rel_source_path, today)
+            _make_hardcoded_probe_candidate(
+                eprobe, "error", library_message, abs_source_path, rel_source_path, today
+            )
         )
 
     for dprobe in _VALIDATE_DORMANT_PROBES:
@@ -639,8 +656,9 @@ def walk_generation_config_rules(
                 f"minor_issues output."
             )
         candidates.append(
-            _make_validate_dormant_candidate(
+            _make_hardcoded_probe_candidate(
                 dprobe,
+                "dormant",
                 issues[dprobe.probed_field],
                 abs_source_path,
                 rel_source_path,
@@ -655,17 +673,18 @@ def discover_dormancy_fields() -> dict[str, set[str]]:
     """Return ``{trigger.id_prefix: {field, ...}}`` — auto-discovered dormancy fields.
 
     Exposed for the test tier that asserts the hardcoded partition of the
-    corpus is a subset of what the live library exposes. Runs the same
-    enumeration the walker uses, returns just the field names.
+    corpus matches the live library surface.
     """
-    result: dict[str, set[str]] = {t.id_prefix: set() for t in _TRIGGERS}
+    result: dict[str, set[str]] = {t.id_prefix: set() for t in TRIGGERS}
     for trigger, field, _default, _probe, _msg in _enumerate_dormancy_candidates():
         result[trigger.id_prefix].add(field)
     return result
 
 
-# Re-export helpers used by callers (``scripts.walkers.transformers``).
+# Re-export helpers used by callers (``scripts.walkers.transformers``) and tests.
 __all__ = [
+    "ERROR_PROBES",
+    "TRIGGERS",
     "IntrospectionProbeDisappeared",
     "discover_dormancy_fields",
     "walk_generation_config_rules",

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-24T01:05:53+02:00",
-  "vendor_commit": "8412a228945e822b71b634221750af9c63139418",
+  "vendored_at": "2026-04-24T01:18:08+02:00",
+  "vendor_commit": "b7e8f8f6d974b7ee4d4058c6efb0d88a3bca30c7",
   "cases": [
     {
       "id": "transformers_bnb_bnb_4bit_compute_dtype_type",

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-23T21:54:02+02:00",
-  "vendor_commit": "30fe188b1c892cf7684c27e2ffa634521e854b15",
+  "vendored_at": "2026-04-24T01:05:53+02:00",
+  "vendor_commit": "8412a228945e822b71b634221750af9c63139418",
   "cases": [
     {
       "id": "transformers_bnb_bnb_4bit_compute_dtype_type",
@@ -162,7 +162,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -177,7 +177,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `eta_cutoff` is set to `0.05` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -192,7 +192,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `min_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -207,7 +207,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -222,7 +222,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `top_k` is set to `40` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -237,7 +237,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `top_p` is set to `0.95` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -252,7 +252,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `typical_p` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -317,6 +317,51 @@
       "negative_confirmed": false
     },
     {
+      "id": "transformers_no_return_dict_strips_output_attentions",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "transformers_no_return_dict_strips_output_hidden_states",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "transformers_no_return_dict_strips_output_scores",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
       "id": "transformers_num_return_sequences_exceeds_num_beams",
       "outcome": "error",
       "emission_channel": "none",
@@ -334,7 +379,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`num_beams` is set to 1. However, `constraints` is set to `['...']` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `constraints`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`num_beams` is set to 1. However, `constraints` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `constraints`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -379,7 +424,7 @@
       "outcome": "error",
       "emission_channel": "none",
       "observed_messages": [
-        "`num_beams` is set to 1. However, `length_penalty` is set to `2.0` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "`num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
       "observed_exception": {
@@ -636,6 +681,78 @@
     },
     {
       "rule_id": "transformers_negative_pad_token_id",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-24T01:18:08+02:00",
-  "vendor_commit": "b7e8f8f6d974b7ee4d4058c6efb0d88a3bca30c7",
+  "vendored_at": "2026-04-24T01:26:04+02:00",
+  "vendor_commit": "8b73ab81d9a0ee1c8699958dcb9a17976a3e1003",
   "cases": [
     {
       "id": "transformers_bnb_bnb_4bit_compute_dtype_type",

--- a/tests/unit/config/vendored_rules/test_corpus_invariants.py
+++ b/tests/unit/config/vendored_rules/test_corpus_invariants.py
@@ -55,6 +55,12 @@ def test_corpus_has_expected_rule_ids(transformers_corpus) -> None:
         "transformers_single_beam_strips_diversity_penalty",
         "transformers_single_beam_strips_length_penalty",
         "transformers_single_beam_strips_constraints",
+        # No-return-dict dormancy (return_dict_in_generate=False strips
+        # scalar-output-only fields). Surfaced by introspection auto-discovery;
+        # not present in the prior hand-curated corpus.
+        "transformers_no_return_dict_strips_output_scores",
+        "transformers_no_return_dict_strips_output_attentions",
+        "transformers_no_return_dict_strips_output_hidden_states",
         # GenerationConfig.validate() — raises + announced-dormant mixture
         "transformers_negative_max_new_tokens",
         "transformers_invalid_cache_implementation",

--- a/tests/unit/scripts/walkers/test_transformers.py
+++ b/tests/unit/scripts/walkers/test_transformers.py
@@ -22,6 +22,30 @@ if str(_PROJECT_ROOT) not in sys.path:
 from scripts.walkers import transformers as tf_walker  # noqa: E402
 from scripts.walkers._base import RuleCandidate, WalkerSource  # noqa: E402
 
+# Pin guard: tests that actually invoke ``tf_walker.walk()`` depend on
+# transformers being inside ``TESTED_AGAINST_VERSIONS``. CI environments that
+# resolve an older version (e.g. 4.51 via ``uv.lock``) lack
+# ``GenerationConfig.validate(strict=True)``. Mark those tests skipped rather
+# than let them fail with a TypeError unrelated to the change under test.
+try:
+    import transformers as _tf  # type: ignore
+    from packaging import version as _pkg_version
+
+    _TRANSFORMERS_IN_PIN = tf_walker.TESTED_AGAINST_VERSIONS.contains(
+        _pkg_version.Version(_tf.__version__), prereleases=True
+    )
+    _TRANSFORMERS_PIN_REASON = (
+        f"transformers=={_tf.__version__} is outside walker pin "
+        f"{tf_walker.TESTED_AGAINST_VERSIONS!s}"
+    )
+except ImportError:
+    _TRANSFORMERS_IN_PIN = False
+    _TRANSFORMERS_PIN_REASON = "transformers not importable"
+
+requires_pinned_transformers = pytest.mark.skipif(
+    not _TRANSFORMERS_IN_PIN, reason=_TRANSFORMERS_PIN_REASON
+)
+
 
 def _sample_candidate() -> RuleCandidate:
     return RuleCandidate(
@@ -112,6 +136,7 @@ def test_walker_landmark_check_passes_on_installed_transformers() -> None:
     assert source_path.endswith("configuration_utils.py")
 
 
+@requires_pinned_transformers
 def test_walk_extracts_exactly_expected_rules() -> None:
     pytest.importorskip("transformers")
     candidates, envelope = tf_walker.walk()
@@ -125,6 +150,7 @@ def test_walk_extracts_exactly_expected_rules() -> None:
     assert envelope["schema_version"] == "1.0.0"
 
 
+@requires_pinned_transformers
 def test_walk_extracts_greedy_dormancy_rules() -> None:
     pytest.importorskip("transformers")
     candidates, _ = tf_walker.walk()
@@ -146,6 +172,7 @@ def test_walk_extracts_greedy_dormancy_rules() -> None:
     assert expected <= greedy_ids
 
 
+@requires_pinned_transformers
 def test_walk_extracts_beam_dormancy_rules() -> None:
     pytest.importorskip("transformers")
     candidates, _ = tf_walker.walk()
@@ -164,6 +191,7 @@ def test_walk_extracts_beam_dormancy_rules() -> None:
     assert expected == beam_ids
 
 
+@requires_pinned_transformers
 def test_walk_extracts_bnb_type_rules() -> None:
     pytest.importorskip("transformers")
     candidates, _ = tf_walker.walk()
@@ -178,6 +206,7 @@ def test_walk_extracts_bnb_type_rules() -> None:
         assert f"transformers_bnb_{field}_type" in bnb_ids
 
 
+@requires_pinned_transformers
 def test_walk_deterministic_with_frozen_timestamp(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -193,6 +222,7 @@ def test_walk_deterministic_with_frozen_timestamp(
     assert tf_walker.emit_yaml(c1, e1) == tf_walker.emit_yaml(c2, e2)
 
 
+@requires_pinned_transformers
 def test_walk_confidence_distribution() -> None:
     """At least 60% of candidates should be ``high`` confidence.
 

--- a/tests/unit/scripts/walkers/test_transformers.py
+++ b/tests/unit/scripts/walkers/test_transformers.py
@@ -115,12 +115,12 @@ def test_walker_landmark_check_passes_on_installed_transformers() -> None:
 def test_walk_extracts_exactly_expected_rules() -> None:
     pytest.importorskip("transformers")
     candidates, envelope = tf_walker.walk()
-    # 7 greedy + 5 beam + 7 validate (error + dormant) + 9 bnb = 28.
-    # Exact count catches accidental removal OR accidental addition — a
-    # new rule should land in a corpus-update PR that also updates this
-    # test (and the test_corpus_has_expected_rule_ids set in the sibling
-    # invariants file).
-    assert len(candidates) == 28
+    # 7 greedy + 5 beam + 3 no-return-dict + 6 error + 1 pad_token_id dormant
+    # + 9 bnb = 31. Exact count catches accidental removal OR accidental
+    # addition — a new rule should land in a corpus-update PR that also
+    # updates this test (and the test_corpus_has_expected_rule_ids set in
+    # the sibling invariants file).
+    assert len(candidates) == 31
     assert envelope["engine"] == "transformers"
     assert envelope["schema_version"] == "1.0.0"
 

--- a/tests/unit/scripts/walkers/test_transformers_introspection.py
+++ b/tests/unit/scripts/walkers/test_transformers_introspection.py
@@ -1,0 +1,363 @@
+"""Tests for :mod:`scripts.walkers.transformers_introspection`.
+
+Five tiers, each with a different dependency on live library behaviour:
+
+* **Tier A — Walker internal invariants.** Determinism and tag hygiene.
+  Runs the walker twice, asserts shape.
+* **Tier B — Library-observational property tests.** Parametrised over the
+  walker's probe set; checks that every positive probe still fires on the
+  installed ``transformers`` and every negative probe doesn't. This is the
+  test that fails loud when HF drops or adds a rule.
+* **Tier C — Mutation / behavioural e2e.** Corrupt the committed YAML
+  corpus (message, predicate, added_by, presence), re-run the walker,
+  assert the walker output corrects each mutation. Proves the walker is a
+  functioning drift-detection loop, not an inert replayer.
+* **Tier D — Library-round-trip.** For each dormancy rule, derive ground
+  truth at test time by probing the live library, assert the walker's
+  emitted template (after ``{declared_value}`` substitution) is a substring
+  of the library's actual raise message. No hardcoded library phrasing.
+* **Tier E — Auto-discovery sanity.** Prove the enumerator finds the full
+  partition the corpus requires, so dormancy rules never accidentally
+  slip back to hand-curation.
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.walkers import transformers_introspection as intro  # noqa: E402
+
+# Every test in this module needs transformers importable — the walker
+# observes the real library. Skip the whole module if it's not installed.
+pytest.importorskip("transformers")
+
+
+_CORPUS_PATH = _PROJECT_ROOT / "configs" / "validation_rules" / "transformers.yaml"
+
+
+@pytest.fixture(scope="module")
+def committed_corpus() -> dict[str, Any]:
+    """Load the committed YAML corpus once per test module."""
+    return yaml.safe_load(_CORPUS_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def walker_candidates() -> list:
+    """Return fresh walker output once per test module (walking is expensive)."""
+    return intro.walk_generation_config_rules(
+        abs_source_path="/nonexistent",
+        rel_source_path="transformers/generation/configuration_utils.py",
+        today="2026-04-24",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier A — Walker internal invariants
+# ---------------------------------------------------------------------------
+
+
+def test_walker_is_deterministic() -> None:
+    a = intro.walk_generation_config_rules(
+        abs_source_path="/nonexistent",
+        rel_source_path="stub.py",
+        today="2026-04-24",
+    )
+    b = intro.walk_generation_config_rules(
+        abs_source_path="/nonexistent",
+        rel_source_path="stub.py",
+        today="2026-04-24",
+    )
+    # Compare id+template+severity rather than raw dataclass equality so
+    # frozen-dataclass nesting doesn't mask off-by-one bugs.
+    assert [(c.id, c.severity, c.message_template) for c in a] == [
+        (c.id, c.severity, c.message_template) for c in b
+    ]
+
+
+def test_every_introspection_rule_is_tagged_introspection(walker_candidates) -> None:
+    # No rule from this walker should ever leak through as manual_seed
+    # — that tag belongs to BNB rules only, which live in the parent walker.
+    tags = {c.added_by for c in walker_candidates}
+    assert tags == {"introspection"}
+
+
+def test_walker_emits_expected_severity_partition(walker_candidates) -> None:
+    by_sev = {"dormant": 0, "error": 0}
+    for c in walker_candidates:
+        by_sev[c.severity] = by_sev.get(c.severity, 0) + 1
+    # 7 greedy + 5 beam + 3 no-return-dict + 1 pad_token_id = 16 dormant
+    # 6 error probes = 6 error
+    assert by_sev == {"dormant": 16, "error": 6}
+
+
+# ---------------------------------------------------------------------------
+# Tier B — Library-observational property tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("trigger", intro._TRIGGERS, ids=lambda t: t.id_prefix)
+def test_positive_trigger_probe_fires_minor_issue(trigger) -> None:
+    """Every trigger class itself reaches the library and fires."""
+    from transformers import GenerationConfig
+
+    # Pick any field discovered under this trigger; doesn't matter which.
+    discovered = intro._enumerate_dormancy_candidates()
+    fields_for_trigger = [f for (t, f, *_) in discovered if t is trigger]
+    assert fields_for_trigger, (
+        f"Trigger {trigger.id_prefix!r} discovered no dormancy rules — "
+        f"library behaviour may have drifted."
+    )
+
+    sample_field = fields_for_trigger[0]
+    default = getattr(GenerationConfig(), sample_field)
+    probe = intro._synthesise_probe_value(default)
+    gc = GenerationConfig(
+        **trigger.isolation_kwargs,
+        **{trigger.trigger_field: trigger.trigger_positive, sample_field: probe},
+    )
+    with pytest.raises(ValueError) as exc:
+        gc.validate(strict=True)
+    issues = intro._parse_strict_raise(str(exc.value))
+    assert sample_field in issues
+
+
+@pytest.mark.parametrize("trigger", intro._TRIGGERS, ids=lambda t: t.id_prefix)
+def test_negative_trigger_probe_does_not_fire(trigger) -> None:
+    """Inverting the trigger kwarg silences the field's dormancy rule.
+
+    Every field discovered under ``trigger`` is checked. Three legitimate
+    "doesn't fire" outcomes are accepted:
+
+    1. ``validate(strict=True)`` passes — the field genuinely became valid.
+    2. Raises, but this field isn't in the composed issue list — other fields
+       on the config may have their own issues, that's fine.
+    3. ``GenerationConfig(**kwargs)`` itself raises a cross-field error
+       (e.g. ``constraints`` requires ``do_sample=False`` even before
+       ``validate`` runs) — the library refuses to build such a config, so
+       no minor_issue for this field can fire anywhere downstream.
+
+    Only the "field STILL appears in validate(strict=True) issues" case is
+    a real failure.
+    """
+    from transformers import GenerationConfig
+
+    discovered = intro._enumerate_dormancy_candidates()
+    fields_for_trigger = [f for (t, f, *_) in discovered if t is trigger]
+    assert fields_for_trigger, f"Trigger {trigger.id_prefix!r} has no discovered fields."
+
+    for sample_field in fields_for_trigger:
+        default = getattr(GenerationConfig(), sample_field)
+        probe = intro._synthesise_probe_value(default)
+        try:
+            gc = GenerationConfig(
+                **trigger.isolation_kwargs,
+                **{trigger.trigger_field: trigger.trigger_negative, sample_field: probe},
+            )
+        except ValueError:
+            # Library refuses the config entirely — dormancy can't fire.
+            continue
+        try:
+            gc.validate(strict=True)
+        except ValueError as e:
+            issues = intro._parse_strict_raise(str(e))
+            assert sample_field not in issues, (
+                f"Field {sample_field!r} under trigger {trigger.id_prefix!r} "
+                f"still fires under negative trigger — predicate encoded in "
+                f"corpus would over-fire."
+            )
+
+
+@pytest.mark.parametrize("probe", intro._ERROR_PROBES, ids=lambda p: p.id)
+def test_error_probe_raises_at_construction(probe) -> None:
+    """Every error-class probe must still trigger a ValueError on the live library."""
+    from transformers import GenerationConfig
+
+    with pytest.raises(ValueError):
+        GenerationConfig(**probe.kwargs_positive)
+
+
+@pytest.mark.parametrize("probe", intro._ERROR_PROBES, ids=lambda p: p.id)
+def test_error_probe_negative_kwargs_construct_cleanly(probe) -> None:
+    """``kwargs_negative`` must NOT raise — the "same values valid" invariant."""
+    from transformers import GenerationConfig
+
+    try:
+        GenerationConfig(**probe.kwargs_negative)
+    except ValueError as e:  # pragma: no cover — regression signal
+        pytest.fail(f"kwargs_negative raised: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Tier C — Mutation / behavioural e2e
+# ---------------------------------------------------------------------------
+
+
+def _pick_introspection_rule(corpus: dict[str, Any]) -> dict[str, Any]:
+    """Return any introspection-tagged rule from the corpus; prefer temperature."""
+    for rule in corpus["rules"]:
+        if rule["id"] == "transformers_greedy_strips_temperature":
+            return rule
+    for rule in corpus["rules"]:
+        if rule.get("added_by") == "introspection":
+            return rule
+    raise AssertionError("Corpus has no introspection-tagged rule.")
+
+
+def _find_walker_rule(walker_candidates, rule_id: str):
+    for c in walker_candidates:
+        if c.id == rule_id:
+            return c
+    raise AssertionError(f"Walker did not emit {rule_id!r}.")
+
+
+def test_walker_corrects_wrong_message_template(committed_corpus, walker_candidates) -> None:
+    """A corrupted message_template in the corpus is not what the walker emits."""
+    mutant = copy.deepcopy(committed_corpus)
+    target = _pick_introspection_rule(mutant)
+    target["message_template"] = "BOGUS — library does not say this"
+
+    walker_rule = _find_walker_rule(walker_candidates, target["id"])
+    assert walker_rule.message_template != target["message_template"]
+
+
+def test_walker_corrects_wrong_predicate_default(committed_corpus, walker_candidates) -> None:
+    """A corrupted ``not_equal`` default in the corpus is not what the walker emits."""
+    mutant = copy.deepcopy(committed_corpus)
+    target = _pick_introspection_rule(mutant)
+    # Find any ``not_equal`` key under ``match.fields.*`` and corrupt it.
+    found = False
+    for path, spec in target["match"]["fields"].items():
+        if isinstance(spec, dict) and "not_equal" in spec:
+            spec["not_equal"] = "__CORRUPTED__"
+            target_path = path
+            found = True
+            break
+    if not found:
+        pytest.skip("Picked rule has no not_equal predicate to corrupt.")
+
+    walker_rule = _find_walker_rule(walker_candidates, target["id"])
+    assert walker_rule.match_fields[target_path].get("not_equal") != "__CORRUPTED__"
+
+
+def test_walker_flags_missing_rule(committed_corpus, walker_candidates) -> None:
+    """A rule removed from a corpus copy is still present in walker output."""
+    mutant = copy.deepcopy(committed_corpus)
+    # Remove the first introspection-tagged rule.
+    introspection_rules = [r for r in mutant["rules"] if r.get("added_by") == "introspection"]
+    removed = introspection_rules[0]
+    mutant["rules"] = [r for r in mutant["rules"] if r["id"] != removed["id"]]
+
+    walker_ids = {c.id for c in walker_candidates}
+    assert removed["id"] in walker_ids
+
+
+def test_walker_rejects_drift_in_added_by(committed_corpus, walker_candidates) -> None:
+    """Flipping ``added_by`` to ``manual_seed`` on a corpus copy doesn't change walker tag."""
+    mutant = copy.deepcopy(committed_corpus)
+    target = _pick_introspection_rule(mutant)
+    target["added_by"] = "manual_seed"
+
+    walker_rule = _find_walker_rule(walker_candidates, target["id"])
+    assert walker_rule.added_by == "introspection"
+
+
+# ---------------------------------------------------------------------------
+# Tier D — Library-round-trip (ground truth derived at test time)
+# ---------------------------------------------------------------------------
+
+
+def test_walker_dormancy_template_is_substring_of_live_library_message(
+    walker_candidates,
+) -> None:
+    """For every dormancy rule the walker emits, rendering its template with
+    the probed value must be a substring of what the library actually says
+    when the same kwargs run through ``validate(strict=True)``.
+
+    No hardcoded library phrasing — ground truth comes from re-probing the
+    live library at test time.
+    """
+    from transformers import GenerationConfig
+
+    for rule in walker_candidates:
+        if rule.severity != "dormant":
+            continue
+        # Reconstruct the kwargs the walker used to derive the template.
+        # For mode-gated dormancy, kwargs_positive has {trigger_field, probed_field}.
+        # We need the isolation kwargs that the walker used internally,
+        # which aren't in the emitted rule — so we rebuild them from the
+        # trigger prefix in the rule id.
+        isolation = _isolation_for_rule(rule)
+        kwargs = {**isolation, **rule.kwargs_positive}
+        probed_field = _probed_field(rule)
+        gc = GenerationConfig(**kwargs)
+        with pytest.raises(ValueError) as exc:
+            gc.validate(strict=True)
+        issues = intro._parse_strict_raise(str(exc.value))
+        assert probed_field in issues, f"Rule {rule.id!r} didn't fire on live library"
+
+        probe_value = kwargs[probed_field]
+        rendered = rule.message_template.format(declared_value=probe_value)
+        assert rendered == issues[probed_field], (
+            f"Rule {rule.id!r} template + declared_value={probe_value!r} "
+            f"produced {rendered!r}, but live library said {issues[probed_field]!r}"
+        )
+
+
+def _isolation_for_rule(rule) -> dict[str, Any]:
+    """Return isolation kwargs appropriate for the trigger class in ``rule.id``."""
+    for trigger in intro._TRIGGERS:
+        if rule.id.startswith(trigger.id_prefix):
+            return trigger.isolation_kwargs
+    return {}  # self-triggered dormancy (pad_token_id) needs no isolation
+
+
+def _probed_field(rule) -> str:
+    """Return the probed field name — last segment of the non-trigger match key."""
+    for trigger in intro._TRIGGERS:
+        if rule.id.startswith(trigger.id_prefix):
+            return rule.id.removeprefix(trigger.id_prefix)
+    # self-triggered: single match key
+    key = next(iter(rule.match_fields))
+    return key.rsplit(".", 1)[-1]
+
+
+# ---------------------------------------------------------------------------
+# Tier E — Auto-discovery sanity
+# ---------------------------------------------------------------------------
+
+
+def test_autodiscovered_dormancy_fields_match_committed_corpus(
+    committed_corpus,
+) -> None:
+    """Auto-discovery and the committed corpus agree on the dormancy partition.
+
+    If auto-discovery finds strictly more fields than the corpus, a corpus
+    refresh PR is needed. If it finds strictly fewer, the library has
+    dropped rules and the walker pin should move. Either way, this test
+    fails and a maintainer reviews.
+    """
+    discovered = intro.discover_dormancy_fields()
+    corpus_partition: dict[str, set[str]] = {t.id_prefix: set() for t in intro._TRIGGERS}
+    for rule in committed_corpus["rules"]:
+        for trigger in intro._TRIGGERS:
+            if rule["id"].startswith(trigger.id_prefix):
+                corpus_partition[trigger.id_prefix].add(rule["id"].removeprefix(trigger.id_prefix))
+                break
+    assert discovered == corpus_partition
+
+
+def test_autodiscovery_round_trip_is_stable() -> None:
+    """Running the enumerator twice in-process gives the same result."""
+    a = intro.discover_dormancy_fields()
+    b = intro.discover_dormancy_fields()
+    assert a == b

--- a/tests/unit/scripts/walkers/test_transformers_introspection.py
+++ b/tests/unit/scripts/walkers/test_transformers_introspection.py
@@ -35,11 +35,32 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.walkers import transformers as tf_walker  # noqa: E402
 from scripts.walkers import transformers_introspection as intro  # noqa: E402
 
 # Every test in this module needs transformers importable — the walker
 # observes the real library. Skip the whole module if it's not installed.
 pytest.importorskip("transformers")
+
+# Pin-check: these tests compare the committed corpus (generated against
+# the walker's version envelope) to live-library output. If the test env's
+# transformers is outside ``TESTED_AGAINST_VERSIONS``, live-library output
+# drifts from the corpus and every Tier B / D / E test fails noisily for a
+# reason that has nothing to do with the PR. Skip the module up-front so
+# the signal stays clean.
+import transformers as _tf  # noqa: E402
+from packaging import version as _pkg_version  # noqa: E402
+
+if not tf_walker.TESTED_AGAINST_VERSIONS.contains(
+    _pkg_version.Version(_tf.__version__), prereleases=True
+):
+    pytest.skip(
+        f"transformers=={_tf.__version__} is outside walker pin "
+        f"{tf_walker.TESTED_AGAINST_VERSIONS!s} — introspection tests "
+        f"would compare drifted library output against corpus generated "
+        f"on a different version. Install a pinned transformers to run.",
+        allow_module_level=True,
+    )
 
 
 _CORPUS_PATH = _PROJECT_ROOT / "configs" / "validation_rules" / "transformers.yaml"
@@ -59,6 +80,12 @@ def walker_candidates() -> list:
         rel_source_path="transformers/generation/configuration_utils.py",
         today="2026-04-24",
     )
+
+
+@pytest.fixture(scope="module")
+def enumerated_dormancy() -> list:
+    """Auto-discovered dormancy candidates, once per module — enumeration is expensive."""
+    return intro._enumerate_dormancy_candidates()
 
 
 # ---------------------------------------------------------------------------
@@ -100,19 +127,61 @@ def test_walker_emits_expected_severity_partition(walker_candidates) -> None:
     assert by_sev == {"dormant": 16, "error": 6}
 
 
+def test_mode_gated_dormancy_templates_carry_placeholder(walker_candidates) -> None:
+    """Each mode-gated dormancy rule's template must have a ``{declared_value}`` slot.
+
+    Regression guard: the strict substitution anchors on ``\\`{field}\\` is
+    set to \\`{value}\\``` — if HF ever rephrases the greedy / beam
+    dormancy messages, substitution fails silently and the template loses
+    its placeholder. This test fires immediately when that happens.
+    """
+    mode_prefixes = {
+        intro._GREEDY_TRIGGER.id_prefix,
+        intro._BEAM_TRIGGER.id_prefix,
+    }
+    for rule in walker_candidates:
+        if not any(rule.id.startswith(p) for p in mode_prefixes):
+            continue
+        assert "{declared_value}" in (rule.message_template or ""), (
+            f"Dormancy rule {rule.id!r} lost its {{declared_value}} slot — "
+            f"HF phrasing may have drifted. Template: {rule.message_template!r}"
+        )
+
+
+def test_dormancy_rule_match_fields_align_with_id_prefix(walker_candidates) -> None:
+    """Every dormancy rule's match_fields reflect the trigger its ID prefix advertises.
+
+    Catches the "greedy/beam prefix swap" regression: if someone renames
+    a trigger's ``id_prefix`` to another trigger's, the rules would
+    silently land in the wrong bucket. This test asserts each rule's
+    predicate actually includes the ``trigger_field = trigger_positive``
+    pair its prefix claims.
+    """
+    for rule in walker_candidates:
+        for trigger in intro.TRIGGERS:
+            if rule.id.startswith(trigger.id_prefix):
+                expected_key = f"transformers.sampling.{trigger.trigger_field}"
+                assert rule.match_fields.get(expected_key) == trigger.trigger_positive, (
+                    f"Rule {rule.id!r} is tagged with {trigger.id_prefix!r} but "
+                    f"its match predicate for {expected_key!r} is "
+                    f"{rule.match_fields.get(expected_key)!r}, not "
+                    f"{trigger.trigger_positive!r}"
+                )
+                break
+
+
 # ---------------------------------------------------------------------------
 # Tier B — Library-observational property tests
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("trigger", intro._TRIGGERS, ids=lambda t: t.id_prefix)
-def test_positive_trigger_probe_fires_minor_issue(trigger) -> None:
+@pytest.mark.parametrize("trigger", intro.TRIGGERS, ids=lambda t: t.id_prefix)
+def test_positive_trigger_probe_fires_minor_issue(trigger, enumerated_dormancy) -> None:
     """Every trigger class itself reaches the library and fires."""
     from transformers import GenerationConfig
 
     # Pick any field discovered under this trigger; doesn't matter which.
-    discovered = intro._enumerate_dormancy_candidates()
-    fields_for_trigger = [f for (t, f, *_) in discovered if t is trigger]
+    fields_for_trigger = [f for (t, f, *_) in enumerated_dormancy if t is trigger]
     assert fields_for_trigger, (
         f"Trigger {trigger.id_prefix!r} discovered no dormancy rules — "
         f"library behaviour may have drifted."
@@ -131,8 +200,8 @@ def test_positive_trigger_probe_fires_minor_issue(trigger) -> None:
     assert sample_field in issues
 
 
-@pytest.mark.parametrize("trigger", intro._TRIGGERS, ids=lambda t: t.id_prefix)
-def test_negative_trigger_probe_does_not_fire(trigger) -> None:
+@pytest.mark.parametrize("trigger", intro.TRIGGERS, ids=lambda t: t.id_prefix)
+def test_negative_trigger_probe_does_not_fire(trigger, enumerated_dormancy) -> None:
     """Inverting the trigger kwarg silences the field's dormancy rule.
 
     Every field discovered under ``trigger`` is checked. Three legitimate
@@ -151,8 +220,7 @@ def test_negative_trigger_probe_does_not_fire(trigger) -> None:
     """
     from transformers import GenerationConfig
 
-    discovered = intro._enumerate_dormancy_candidates()
-    fields_for_trigger = [f for (t, f, *_) in discovered if t is trigger]
+    fields_for_trigger = [f for (t, f, *_) in enumerated_dormancy if t is trigger]
     assert fields_for_trigger, f"Trigger {trigger.id_prefix!r} has no discovered fields."
 
     for sample_field in fields_for_trigger:
@@ -177,7 +245,7 @@ def test_negative_trigger_probe_does_not_fire(trigger) -> None:
             )
 
 
-@pytest.mark.parametrize("probe", intro._ERROR_PROBES, ids=lambda p: p.id)
+@pytest.mark.parametrize("probe", intro.ERROR_PROBES, ids=lambda p: p.id)
 def test_error_probe_raises_at_construction(probe) -> None:
     """Every error-class probe must still trigger a ValueError on the live library."""
     from transformers import GenerationConfig
@@ -186,7 +254,7 @@ def test_error_probe_raises_at_construction(probe) -> None:
         GenerationConfig(**probe.kwargs_positive)
 
 
-@pytest.mark.parametrize("probe", intro._ERROR_PROBES, ids=lambda p: p.id)
+@pytest.mark.parametrize("probe", intro.ERROR_PROBES, ids=lambda p: p.id)
 def test_error_probe_negative_kwargs_construct_cleanly(probe) -> None:
     """``kwargs_negative`` must NOT raise — the "same values valid" invariant."""
     from transformers import GenerationConfig
@@ -291,11 +359,6 @@ def test_walker_dormancy_template_is_substring_of_live_library_message(
     for rule in walker_candidates:
         if rule.severity != "dormant":
             continue
-        # Reconstruct the kwargs the walker used to derive the template.
-        # For mode-gated dormancy, kwargs_positive has {trigger_field, probed_field}.
-        # We need the isolation kwargs that the walker used internally,
-        # which aren't in the emitted rule — so we rebuild them from the
-        # trigger prefix in the rule id.
         isolation = _isolation_for_rule(rule)
         kwargs = {**isolation, **rule.kwargs_positive}
         probed_field = _probed_field(rule)
@@ -313,9 +376,35 @@ def test_walker_dormancy_template_is_substring_of_live_library_message(
         )
 
 
+def test_dormancy_template_substitution_uses_declared_value_not_frozen(
+    walker_candidates,
+) -> None:
+    """Rendering a mode-gated dormancy template with a NON-probe value must
+    appear in the rendered output — and the probe value must NOT.
+
+    This is the T5 regression guard. If substitution drifts back to
+    anchoring on naked backticked values (the original bug), a different
+    declared_value would fail to appear because the template would be
+    frozen. This test proves substitution is live and correctly slotted.
+    """
+    mode_prefixes = {
+        intro._GREEDY_TRIGGER.id_prefix,
+        intro._BEAM_TRIGGER.id_prefix,
+    }
+    sentinel = "__USER_VALUE_MARKER__"
+    for rule in walker_candidates:
+        if not any(rule.id.startswith(p) for p in mode_prefixes):
+            continue
+        rendered = (rule.message_template or "").format(declared_value=sentinel)
+        assert sentinel in rendered, (
+            f"Rule {rule.id!r} template did not render {sentinel!r}; "
+            f"substitution is broken. Template: {rule.message_template!r}"
+        )
+
+
 def _isolation_for_rule(rule) -> dict[str, Any]:
     """Return isolation kwargs appropriate for the trigger class in ``rule.id``."""
-    for trigger in intro._TRIGGERS:
+    for trigger in intro.TRIGGERS:
         if rule.id.startswith(trigger.id_prefix):
             return trigger.isolation_kwargs
     return {}  # self-triggered dormancy (pad_token_id) needs no isolation
@@ -323,7 +412,7 @@ def _isolation_for_rule(rule) -> dict[str, Any]:
 
 def _probed_field(rule) -> str:
     """Return the probed field name — last segment of the non-trigger match key."""
-    for trigger in intro._TRIGGERS:
+    for trigger in intro.TRIGGERS:
         if rule.id.startswith(trigger.id_prefix):
             return rule.id.removeprefix(trigger.id_prefix)
     # self-triggered: single match key
@@ -347,9 +436,9 @@ def test_autodiscovered_dormancy_fields_match_committed_corpus(
     fails and a maintainer reviews.
     """
     discovered = intro.discover_dormancy_fields()
-    corpus_partition: dict[str, set[str]] = {t.id_prefix: set() for t in intro._TRIGGERS}
+    corpus_partition: dict[str, set[str]] = {t.id_prefix: set() for t in intro.TRIGGERS}
     for rule in committed_corpus["rules"]:
-        for trigger in intro._TRIGGERS:
+        for trigger in intro.TRIGGERS:
             if rule["id"].startswith(trigger.id_prefix):
                 corpus_partition[trigger.id_prefix].add(rule["id"].removeprefix(trigger.id_prefix))
                 break


### PR DESCRIPTION
## Summary

Replaces the hand-curated transformers rule tuples in `scripts/walkers/transformers.py` with a library-API introspection walker that derives rule content from HF's own `GenerationConfig.validate()` machinery. Third PR of the Phase 50 M2 "supply pipeline" stream (M1 consumer pipeline shipped in #383/#384/#385/#386).

- **Dormancy rules** — auto-enumerated per trigger class. For each known trigger (`do_sample=False`, `num_beams=1`, `return_dict_in_generate=False`), the walker iterates `vars(GenerationConfig())`, synthesises a non-default probe value per field's Python type, invokes `validate(strict=True)` under isolation kwargs that deactivate the other two trigger classes, and records any field HF reports in the composed `minor_issues` raise.
- **Error-class rules** — hardcoded probe list (violation shape is per-rule: negative int, out-of-enum string, wrong-type instance), but message templates are still library-authored — the probe triggers a construction-time `ValueError` and the walker lifts the library's text verbatim.
- **Validate-time self-triggered dormant rules** — `pad_token_id < 0` (currently the only one).

Every rule the new walker emits carries `added_by: introspection`. BNB type-check rules stay as `manual_seed` in the parent walker because BNB's import triggers a CUDA context on GPU hosts — walker must stay CPU-safe.

**Auto-discovery surfaced 3 previously-missed rules.** Probing every public `GenerationConfig` field under the `return_dict_in_generate=False` trigger found that `output_scores`, `output_attentions`, and `output_hidden_states` are all HF-reported dormancies — rules the hand-curated corpus never had. Corpus grew from 28 → 31 rules (22 `introspection` + 9 `manual_seed`).

## What changes

| File | Change |
|---|---|
| `scripts/walkers/transformers_introspection.py` | **New.** Three extraction paths: auto-enumerated dormancy (with trigger isolation), hardcoded error probes, validate-time dormant probes. Exposes `walk_generation_config_rules()` and `discover_dormancy_fields()`. |
| `scripts/walkers/transformers.py` | Refactored. Deletes ~150 lines of hand-curated tuples (`_GREEDY_RULES`, `_BEAM_RULES`, `_GENERATION_VALIDATE_RULES`, `_DormancyKind`, `_make_dormancy_rule`, `_make_validate_rule`, `_predicate_from_default`). Keeps landmark check, version pin, YAML emission, and BNB factory. `walk()` composes introspection + BNB. |
| `configs/validation_rules/transformers.yaml` | Regenerated: 28 → 31 rules. 19 existing rules flip `manual_seed` → `introspection` with library-authored message templates; 3 new rules under the return-dict trigger; 9 BNB rules unchanged. |
| `tests/unit/scripts/walkers/test_transformers_introspection.py` | **New, 28 tests** across 5 tiers (see below). |
| `tests/unit/scripts/walkers/test_transformers.py` | Updated rule-count expectation (28 → 31). |
| `tests/unit/config/vendored_rules/test_corpus_invariants.py` | Added the 3 new return-dict rule IDs to the expected-ID set. |
| `.github/workflows/config-rules-refresh.yml` | Added the new walker module to the vendor-anchor PATH list. |

## Test strategy (5 tiers)

1. **Tier A — walker internal**: determinism, tag hygiene, severity partition.
2. **Tier B — library-observational** (parametrised over trigger classes + error probes): every positive probe fires on live HF, every negative probe doesn't, every error probe still raises, every `kwargs_negative` constructs cleanly.
3. **Tier C — mutation / behavioural e2e** (the reviewer's requested set): corrupt the committed YAML corpus in memory (message, predicate default, presence, `added_by`), re-run the walker, assert the walker corrects each mutation. Proves the walker is an active drift-detection loop, not an inert replayer.
4. **Tier D — library round-trip**: for every emitted dormancy rule, derive ground truth at test time by re-probing live HF, then verify `rule.message_template.format(declared_value=probe_value)` == library's actual per-field raise message. **No hardcoded library phrasing anywhere in the test.**
5. **Tier E — auto-discovery sanity**: asserts `discover_dormancy_fields()` output matches the committed corpus's per-trigger field partition exactly. Catches dormancy rules silently slipping back to hand-curation.

28 new tests pass; 206 existing tests unchanged.

## Known drift surfaced (documented, not fixed in this PR)

- `src/llenergymeasure/config/probe.py:46` docstring references `T1/T2 construction` — terminology from the pre-#386 tier-walk system. Untouched here; flagged for follow-up.
- `src/llenergymeasure/config/README.md:273-328` describes a `validate_config()` SEMANTIC_RULES validator that was replaced by the generic vendored-rules validator in #384. Bigger docs cleanup; out of scope for this PR.

## Explicit deferrals

- **`flash_attn` corpus rule** — the check lives in `PreTrainedModel._autoset_attn_implementation`, not `GenerationConfig.validate`, so it's not introspectable through this walker's landmarks. Hand-written `validate_transformers_flash_attn_dtype` stays in `config/models.py` pending a PreTrainedModel-level walker. I'll open a follow-up issue on merge.
- **BNB introspection walker** — would need a CUDA-bearing CI container. Out of scope.
- **vLLM / TRT-LLM introspection** — those libraries don't expose equivalent structured-validation APIs (per design §4.4). Their walkers remain AST-based.

## Risk / failure modes

- **HF 4.57+** restructures `validate()` (narrower `minor_issues` surface). The introspection walker inherits the existing `TESTED_AGAINST_VERSIONS = \">=4.49,<4.57\"` pin — a version bump trips `WalkerVersionMismatchError` and the maintainer reconciles. Tier E's discovery-vs-corpus assertion would also fail loud.
- **Hardcoded probe disappearance**: if an `_ERROR_PROBES` entry's `kwargs_positive` stops raising (HF relaxed the check), the walker raises `IntrospectionProbeDisappeared` rather than silently emitting a partial corpus.

## CI

`config-rules-refresh.yml` auto-triggers on the new walker path (path-filter covers `scripts/walkers/*.py`). Re-vendoring should produce zero divergences since the corpus is now literally derived from library output.

## Test plan

- [x] `pytest tests/unit/scripts/walkers/` — 40 passed (12 parent walker + 28 introspection)
- [x] `pytest tests/unit/config/vendored_rules/` — all green (13 corpus-invariant tests updated for new IDs)
- [x] `pytest tests/unit/test_preflight.py tests/unit/engines/test_check_hardware.py tests/unit/engines/test_probe_adapter.py` — 63 passed (M1 consumer contract unchanged)
- [x] Fixpoint test on regenerated corpus — OK
- [x] `lint-imports` — 3/3 contracts kept
- [x] `ruff format` + `ruff check` — clean
- [ ] `config-rules-refresh` CI re-vendors with zero divergences