### PR TITLE
refactor(config): remove dead introspection helper get_mutual_exclusions

### DIFF
--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -501,42 +501,6 @@ def list_all_param_paths(engine: str | None = None) -> list[str]:
     return sorted(set(paths))
 
 
-# =============================================================================
-# Constraint Metadata for SSOT Architecture Hardening
-# =============================================================================
-
-
-def get_mutual_exclusions() -> dict[str, list[str]]:
-    """Get parameters that are mutually exclusive.
-
-    Returns:
-        Dict mapping param path to list of params it cannot be used with.
-        These combinations should be skipped during runtime testing.
-    """
-    return {
-        # Transformers: can't use both 4-bit and 8-bit quantization
-        "transformers.load_in_4bit": ["transformers.load_in_8bit"],
-        "transformers.load_in_8bit": ["transformers.load_in_4bit"],
-        # torch_compile sub-options require torch_compile=True
-        "transformers.torch_compile_mode": ["transformers.torch_compile=None|False"],
-        "transformers.torch_compile_backend": ["transformers.torch_compile=None|False"],
-        # BitsAndBytes 4-bit sub-options require load_in_4bit=True
-        "transformers.bnb_4bit_compute_dtype": ["transformers.load_in_4bit=None|False"],
-        "transformers.bnb_4bit_quant_type": ["transformers.load_in_4bit=None|False"],
-        "transformers.bnb_4bit_use_double_quant": ["transformers.load_in_4bit=None|False"],
-        # cache_implementation contradicts use_cache=False
-        "transformers.cache_implementation": ["transformers.use_cache=False"],
-        # vLLM kv_cache_memory_bytes vs gpu_memory_utilization
-        "vllm.engine.kv_cache_memory_bytes": ["vllm.engine.gpu_memory_utilization"],
-        "vllm.engine.gpu_memory_utilization": ["vllm.engine.kv_cache_memory_bytes"],
-        # vLLM beam_search vs sampling sections (cross-section mutual exclusion)
-        "vllm.beam_search": ["vllm.sampling"],
-        "vllm.sampling": ["vllm.beam_search"],
-        # TensorRT: quantisation method is exclusive
-        "tensorrt.quant_config.quant_algo": [],  # Handled by Literal type constraint
-    }
-
-
 def get_engine_specific_params() -> dict[str, list[str]]:
     """Get params that are only valid for specific engines.
 


### PR DESCRIPTION
## Summary

Removes `get_mutual_exclusions` from `src/llenergymeasure/config/introspection.py` — the helper has no callers anywhere in `src/`, `tests/`, or `scripts/`. Also drops the orphaned section header that only wrapped this one function.

## Why this supersedes #289

#289 tried to remove two helpers (`get_mutual_exclusions` + `get_streaming_constraints`). Between #289 opening (2026-04-21) and today, `get_streaming_constraints` gained a caller (`scripts/generate_invalid_combos_doc.py:21,64`) — so merging #289 would have broken docs generation. This PR removes only the still-dead one.

## Test plan

- [x] `pytest tests/unit/config/` — 371 passed
- [x] `grep -rn get_mutual_exclusions src/ tests/ scripts/` — no matches after removal
- [x] `from llenergymeasure.config import introspection` — imports cleanly