### PR TITLE
feat(study): capture runtime warnings and logs to per-study JSONL

### DIFF
--- a/src/llenergymeasure/study/message_normalise.py
+++ b/src/llenergymeasure/study/message_normalise.py
@@ -1,0 +1,127 @@
+"""Library-warning message normalisation for the feedback loop.
+
+Strips configuration-specific values (numbers, paths, line numbers, ISO
+timestamps, ANSI sequences) from a captured log / warning message so two
+emissions produced by different configs with the same underlying rule hash to
+the same canonical template.
+
+The pipeline is deliberately conservative — documented substitution order,
+no fuzzy matching. Easy to add a new regex case when a real emission doesn't
+normalise; hard to remove one once consumers depend on permissive behaviour.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "NormalisedMessage",
+    "build_template_regex",
+    "normalise",
+]
+
+
+@dataclass(frozen=True)
+class NormalisedMessage:
+    """Result of normalising a single library-emitted message.
+
+    Attributes:
+        template: The normalised, placeholder-substituted template. Stable
+            across emissions that only differ by numeric values / paths /
+            timestamps.
+        match_regex: Anchored regex that matches the template back against
+            raw messages. Used by the corpus consumer to re-identify the
+            same rule firing later.
+        original: The pre-normalisation message — kept for evidence in draft
+            PR bodies.
+    """
+
+    template: str
+    match_regex: str
+    original: str
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_ISO_TIMESTAMP_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b"
+)
+# Line numbers at end of path-like tokens ("…sampling_params.py:368"). We
+# strip them before path normalisation so the path itself doesn't swallow them.
+_LINE_NUMBER_RE = re.compile(r"(?<=\.py):\d+")
+# Absolute and relative path-like tokens. Kept intentionally narrow — the
+# walker emits short human messages, not shell output.
+_PATH_RE = re.compile(r"(?:(?<=\s)|^)(?:/[^\s:()\[\]]+|[A-Za-z]:\\[^\s:]+)")
+# Hex digests / fingerprints (sha256: prefixes and loose 16+ hex runs).
+_HEX_RE = re.compile(r"\b(?:sha256:)?[0-9a-fA-F]{16,}\b")
+# Numeric literals: integers, decimals, scientific, signed values.
+# Guarded with alphanumeric-aware lookarounds so embedded digits inside
+# identifiers (sha256, float32, fp16) aren't split apart.
+_NUMBER_RE = re.compile(r"(?<![A-Za-z_0-9])-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?(?![A-Za-z_0-9])")
+# Multiple whitespace collapses to a single space.
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+_SUBSTITUTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_ANSI_RE, ""),
+    (_ISO_TIMESTAMP_RE, "<TIMESTAMP>"),
+    (_LINE_NUMBER_RE, ":<LINENO>"),
+    (_PATH_RE, " <PATH>"),
+    (_HEX_RE, "<HEX>"),
+    (_NUMBER_RE, "<NUM>"),
+)
+
+
+def normalise(message: str) -> NormalisedMessage:
+    """Normalise a single message.
+
+    Substitution order (documented; callers should not assume any other):
+
+    1. Strip ANSI escape sequences.
+    2. Replace ISO-8601 timestamps with ``<TIMESTAMP>``.
+    3. Replace ``.py:NNN`` line numbers with ``.py:<LINENO>``.
+    4. Replace absolute / Windows / relative path tokens with ``<PATH>``.
+    5. Replace hex digests / long hex runs with ``<HEX>``.
+    6. Replace numeric literals with ``<NUM>``.
+    7. Collapse repeated whitespace.
+
+    ``build_template_regex`` produces the corresponding match regex —
+    placeholders become loose character classes so the template matches
+    future raw emissions.
+    """
+    original = message
+    normalised = message
+    for pattern, replacement in _SUBSTITUTIONS:
+        normalised = pattern.sub(replacement, normalised)
+    template = _WHITESPACE_RE.sub(" ", normalised).strip()
+    match_regex = build_template_regex(template)
+    return NormalisedMessage(template=template, match_regex=match_regex, original=original)
+
+
+_PLACEHOLDER_REGEXES: dict[str, str] = {
+    "<TIMESTAMP>": r"\\S+",
+    "<LINENO>": r"\\d+",
+    "<PATH>": r"\\S+",
+    "<HEX>": r"\\S+",
+    "<NUM>": r"-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?",
+}
+
+
+def build_template_regex(template: str) -> str:
+    """Return a regex that matches raw messages yielding ``template`` under :func:`normalise`.
+
+    Placeholders are expanded to permissive character classes; the rest of the
+    template is escaped. The result is anchored with ``\\A`` / ``\\Z`` so the
+    corpus consumer can do an exact match without accidentally aliasing with
+    longer emissions.
+    """
+    # Split on placeholders so we can escape each literal chunk but keep
+    # the class regex unescaped.
+    tokens = re.split(r"(<TIMESTAMP>|<LINENO>|<PATH>|<HEX>|<NUM>)", template)
+    parts: list[str] = []
+    for tok in tokens:
+        if tok in _PLACEHOLDER_REGEXES:
+            parts.append(_PLACEHOLDER_REGEXES[tok].replace("\\\\", "\\"))
+        else:
+            parts.append(re.escape(tok))
+    return r"\A" + "".join(parts) + r"\Z"

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -28,6 +28,7 @@ import tempfile
 import threading
 import time
 import traceback
+import uuid
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from pathlib import Path
@@ -80,6 +81,24 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 # Module-level helpers
 # =============================================================================
+
+
+def _derive_exit_reason(exitcode: int | None) -> str | None:
+    """Map a subprocess exit code to a short classifier string.
+
+    Negative exit codes are signal numbers (POSIX convention). We return
+    ``SIGKILL`` and ``SIGSEGV`` explicitly because they are the most common
+    causes of a worker vanishing before its runtime-observations context
+    could flush. Other negatives collapse to ``None`` — downstream
+    consumers can consult ``exit_code`` for the raw value.
+    """
+    if exitcode is None:
+        return None
+    if exitcode == -signal.SIGKILL:
+        return "SIGKILL"
+    if exitcode == -signal.SIGSEGV:
+        return "SIGSEGV"
+    return None
 
 
 def _sanitize_image_for_filename(image: str) -> str:
@@ -258,6 +277,10 @@ def _run_experiment_worker(
     output_dir: str | None = None,
     save_timeseries: bool = True,
     baseline: Any = None,  # BaselineCache | None (avoids import at module level)
+    study_dir: str | None = None,
+    study_run_id: str | None = None,
+    cycle: int | None = None,
+    config_hash: str | None = None,
 ) -> None:
     """Entry point for the child process. Runs one experiment and returns result via Pipe.
 
@@ -275,6 +298,14 @@ def _run_experiment_worker(
         output_dir: Directory for timeseries parquet output. Passed through to harness.
         save_timeseries: Whether to persist GPU timeseries. Passed through to harness.
         baseline: Pre-measured baseline power from parent process (study-level cache).
+        study_dir: Study output directory. When provided together with
+            ``study_run_id``, ``cycle``, and ``config_hash``, the worker body is
+            wrapped in :func:`capture_runtime_observations` so one JSONL record
+            is appended to ``{study_dir}/runtime_observations.jsonl``.
+        study_run_id: UUID identifying this invocation of ``StudyRunner.run()``.
+        cycle: 1-based cycle counter for this config within the study.
+        config_hash: ``compute_measurement_config_hash(config)`` — passed
+            instead of recomputed so the parent is the single SSOT.
     """
     # Become process group leader so all descendants (vLLM workers, MPI ranks, etc.)
     # share this PGID. The parent can then kill the whole group via os.killpg().
@@ -283,46 +314,69 @@ def _run_experiment_worker(
     # parent owns SIGINT; child ignores it
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-    try:
+    # Recompute config_hash only if the parent didn't plumb one — keeps the
+    # worker usable in isolation (test fixtures).
+    if config_hash is None:
         from llenergymeasure.domain.experiment import compute_measurement_config_hash
 
         config_hash = compute_measurement_config_hash(config)
-        progress_queue.put({"event": "started", "config_hash": config_hash})
 
-        # Create progress callback that serialises step events to queue
-        progress_cb = _QueueProgressCallback(progress_queue)
+    # Build the runtime-observations wrapper if the parent plumbed the
+    # identification triple. Fallback to a no-op context for older callers
+    # / tests that don't need capture. The wrapper must enter BEFORE
+    # run_preflight() / get_engine() so engine-library import-time warnings
+    # under ``spawn`` are captured.
+    if study_dir is not None and study_run_id is not None and cycle is not None:
+        from llenergymeasure.study.runtime_observations import capture_runtime_observations
 
-        # Run the actual experiment in-process (within the spawned subprocess)
-        from llenergymeasure.engines import get_engine
-        from llenergymeasure.harness import MeasurementHarness
-        from llenergymeasure.harness.preflight import run_preflight
-
-        # Pre-flight inside subprocess: CUDA availability must be checked in the
-        # process that will use the GPU.
-        progress_cb.on_step_start("container_preflight", "Checking", "CUDA, model access")
-        t0_pf = time.perf_counter()
-        run_preflight(config)
-        progress_cb.on_step_done("container_preflight", time.perf_counter() - t0_pf)
-
-        engine = get_engine(config.engine)
-        harness = MeasurementHarness()
-        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
-
-        gpu_indices = _resolve_gpu_indices(config)
-        result = harness.run(
-            engine,
+        obs_ctx: contextlib.AbstractContextManager[Any] = capture_runtime_observations(
             config,
-            snapshot=snapshot,
-            gpu_indices=gpu_indices,
-            progress=progress_cb,
-            output_dir=output_dir,
-            save_timeseries=save_timeseries,
-            baseline=baseline,
+            study_dir=study_dir,
+            study_run_id=study_run_id,
+            cycle=cycle,
+            config_hash=config_hash,
         )
+    else:
+        obs_ctx = contextlib.nullcontext()
 
-        # Send result back to parent via Pipe
-        conn.send(result)
-        progress_queue.put({"event": "completed", "config_hash": config_hash})
+    try:
+        with obs_ctx:
+            progress_queue.put({"event": "started", "config_hash": config_hash})
+
+            # Create progress callback that serialises step events to queue
+            progress_cb = _QueueProgressCallback(progress_queue)
+
+            # Run the actual experiment in-process (within the spawned subprocess)
+            from llenergymeasure.engines import get_engine
+            from llenergymeasure.harness import MeasurementHarness
+            from llenergymeasure.harness.preflight import run_preflight
+
+            # Pre-flight inside subprocess: CUDA availability must be checked in the
+            # process that will use the GPU.
+            progress_cb.on_step_start("container_preflight", "Checking", "CUDA, model access")
+            t0_pf = time.perf_counter()
+            run_preflight(config)
+            progress_cb.on_step_done("container_preflight", time.perf_counter() - t0_pf)
+
+            engine = get_engine(config.engine)
+            harness = MeasurementHarness()
+            from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+
+            gpu_indices = _resolve_gpu_indices(config)
+            result = harness.run(
+                engine,
+                config,
+                snapshot=snapshot,
+                gpu_indices=gpu_indices,
+                progress=progress_cb,
+                output_dir=output_dir,
+                save_timeseries=save_timeseries,
+                baseline=baseline,
+            )
+
+            # Send result back to parent via Pipe
+            conn.send(result)
+            progress_queue.put({"event": "completed", "config_hash": config_hash})
 
     except Exception as exc:
         error_payload = {
@@ -554,6 +608,10 @@ class StudyRunner:
         self._experiments_since_validation: dict[str, int] = {}
         # Study-level image preparation: True after _prepare_images() succeeds
         self._images_prepared: bool = False
+        # Per-run UUID tagging every runtime-observation record from this
+        # StudyRunner.run() invocation. Generated once so re-runs against
+        # the same study_dir can be disambiguated by downstream consumers.
+        self.study_run_id: str = str(uuid.uuid4())
 
     def run(self) -> list[Any]:
         """Run all experiments in order; return list of results or failure dicts.
@@ -1516,6 +1574,10 @@ class StudyRunner:
                 "output_dir": str(ts_tmpdir) if ts_tmpdir else None,
                 "save_timeseries": save_ts,
                 "baseline": baseline,
+                "study_dir": str(self.study_dir),
+                "study_run_id": self.study_run_id,
+                "cycle": cycle,
+                "config_hash": config_hash,
             },
             daemon=False,  # daemon=False: clean CUDA teardown if parent exits unexpectedly
         )
@@ -1567,6 +1629,32 @@ class StudyRunner:
 
         result = _collect_result(p, parent_conn, config, timeout, pipe_payload=pipe_payload)
         parent_conn.close()
+
+        # Parent-side sentinel: the worker's runtime-observations context
+        # cannot fire when the process was SIGKILLed or timed out before
+        # ``__exit__`` ran. Record one observation line from the parent so
+        # the feedback-loop consumer still sees the outcome.
+        if isinstance(result, dict) and result.get("type") in {
+            "ProcessCrash",
+            "TimeoutError",
+        }:
+            exit_reason = (
+                "timeout"
+                if result.get("type") == "TimeoutError"
+                else _derive_exit_reason(p.exitcode)
+            )
+            with contextlib.suppress(Exception):
+                from llenergymeasure.study.runtime_observations import write_sentinel
+
+                write_sentinel(
+                    config,
+                    study_dir=self.study_dir,
+                    study_run_id=self.study_run_id,
+                    cycle=cycle,
+                    config_hash=config_hash,
+                    exit_reason=exit_reason,
+                    exit_code=p.exitcode,
+                )
 
         exp_elapsed = time.monotonic() - exp_start
         self._handle_result(

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -83,22 +83,26 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-def _derive_exit_reason(exitcode: int | None) -> str | None:
-    """Map a subprocess exit code to a short classifier string.
+# Failure classifiers produced by ``_collect_result`` and consumed by
+# parent-side sentinel handling. Lifted so the producer and consumer don't
+# drift on bare strings.
+COLLECT_RESULT_PROCESS_CRASH = "ProcessCrash"
+COLLECT_RESULT_TIMEOUT = "TimeoutError"
 
-    Negative exit codes are signal numbers (POSIX convention). We return
-    ``SIGKILL`` and ``SIGSEGV`` explicitly because they are the most common
-    causes of a worker vanishing before its runtime-observations context
-    could flush. Other negatives collapse to ``None`` — downstream
-    consumers can consult ``exit_code`` for the raw value.
+
+def _derive_exit_reason(exitcode: int | None) -> str | None:
+    """Map a negative subprocess exit code to its POSIX signal name.
+
+    Negative exit codes are signals (POSIX convention). Returns the signal
+    name (e.g. ``SIGKILL``, ``SIGSEGV``, ``SIGTERM``) for any recognised
+    signal, ``None`` otherwise. The raw code is preserved elsewhere.
     """
-    if exitcode is None:
+    if exitcode is None or exitcode >= 0:
         return None
-    if exitcode == -signal.SIGKILL:
-        return "SIGKILL"
-    if exitcode == -signal.SIGSEGV:
-        return "SIGSEGV"
-    return None
+    try:
+        return signal.Signals(-exitcode).name
+    except ValueError:
+        return None
 
 
 def _sanitize_image_for_filename(image: str) -> str:
@@ -277,16 +281,16 @@ def _run_experiment_worker(
     output_dir: str | None = None,
     save_timeseries: bool = True,
     baseline: Any = None,  # BaselineCache | None (avoids import at module level)
-    study_dir: str | None = None,
-    study_run_id: str | None = None,
-    cycle: int | None = None,
-    config_hash: str | None = None,
+    *,
+    study_dir: str,
+    study_run_id: str,
+    cycle: int,
+    config_hash: str,
 ) -> None:
     """Entry point for the child process. Runs one experiment and returns result via Pipe.
 
     Signal handling:
         Installs SIGINT → SIG_IGN so the child ignores Ctrl+C.
-        # parent owns SIGINT; child ignores it
         The parent handles SIGINT and decides whether to kill the child.
 
     IPC protocol:
@@ -298,46 +302,30 @@ def _run_experiment_worker(
         output_dir: Directory for timeseries parquet output. Passed through to harness.
         save_timeseries: Whether to persist GPU timeseries. Passed through to harness.
         baseline: Pre-measured baseline power from parent process (study-level cache).
-        study_dir: Study output directory. When provided together with
-            ``study_run_id``, ``cycle``, and ``config_hash``, the worker body is
-            wrapped in :func:`capture_runtime_observations` so one JSONL record
-            is appended to ``{study_dir}/runtime_observations.jsonl``.
+        study_dir: Study output directory. Runtime observations append to
+            ``{study_dir}/runtime_observations.jsonl``.
         study_run_id: UUID identifying this invocation of ``StudyRunner.run()``.
         cycle: 1-based cycle counter for this config within the study.
-        config_hash: ``compute_measurement_config_hash(config)`` — passed
-            instead of recomputed so the parent is the single SSOT.
+        config_hash: ``compute_measurement_config_hash(config)``. The parent is
+            the single SSOT for this value.
     """
     # Become process group leader so all descendants (vLLM workers, MPI ranks, etc.)
     # share this PGID. The parent can then kill the whole group via os.killpg().
     os.setpgrp()
 
-    # parent owns SIGINT; child ignores it
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-    # Recompute config_hash only if the parent didn't plumb one — keeps the
-    # worker usable in isolation (test fixtures).
-    if config_hash is None:
-        from llenergymeasure.domain.experiment import compute_measurement_config_hash
+    # Wrap the worker body BEFORE run_preflight() / get_engine() so engine
+    # import-time warnings under ``spawn`` are captured.
+    from llenergymeasure.study.runtime_observations import capture_runtime_observations
 
-        config_hash = compute_measurement_config_hash(config)
-
-    # Build the runtime-observations wrapper if the parent plumbed the
-    # identification triple. Fallback to a no-op context for older callers
-    # / tests that don't need capture. The wrapper must enter BEFORE
-    # run_preflight() / get_engine() so engine-library import-time warnings
-    # under ``spawn`` are captured.
-    if study_dir is not None and study_run_id is not None and cycle is not None:
-        from llenergymeasure.study.runtime_observations import capture_runtime_observations
-
-        obs_ctx: contextlib.AbstractContextManager[Any] = capture_runtime_observations(
-            config,
-            study_dir=study_dir,
-            study_run_id=study_run_id,
-            cycle=cycle,
-            config_hash=config_hash,
-        )
-    else:
-        obs_ctx = contextlib.nullcontext()
+    obs_ctx = capture_runtime_observations(
+        config,
+        study_dir=study_dir,
+        study_run_id=study_run_id,
+        cycle=cycle,
+        config_hash=config_hash,
+    )
 
     try:
         with obs_ctx:
@@ -489,7 +477,7 @@ def _collect_result(
         _kill_process_group(p.pid, signal.SIGKILL)
         p.join()
         return {
-            "type": "TimeoutError",
+            "type": COLLECT_RESULT_TIMEOUT,
             "message": f"Experiment exceeded timeout of {timeout}s and was killed.",
             "config_hash": config_hash,
         }
@@ -512,7 +500,7 @@ def _collect_result(
                 pass
 
         return {
-            "type": "ProcessCrash",
+            "type": COLLECT_RESULT_PROCESS_CRASH,
             "message": f"Subprocess exited with code {p.exitcode} and no error data in Pipe.",
             "config_hash": config_hash,
         }
@@ -550,7 +538,7 @@ def _collect_result(
             }
 
     return {
-        "type": "ProcessCrash",
+        "type": COLLECT_RESULT_PROCESS_CRASH,
         "message": "Subprocess exited 0 but sent no data through Pipe.",
         "config_hash": config_hash,
     }
@@ -1630,31 +1618,29 @@ class StudyRunner:
         result = _collect_result(p, parent_conn, config, timeout, pipe_payload=pipe_payload)
         parent_conn.close()
 
-        # Parent-side sentinel: the worker's runtime-observations context
-        # cannot fire when the process was SIGKILLed or timed out before
-        # ``__exit__`` ran. Record one observation line from the parent so
-        # the feedback-loop consumer still sees the outcome.
+        # Parent writes the sentinel record for SIGKILL / timeout — the
+        # worker's context manager can't flush when its ``__exit__`` never
+        # ran. ``write_sentinel`` is itself best-effort and swallows OSError.
         if isinstance(result, dict) and result.get("type") in {
-            "ProcessCrash",
-            "TimeoutError",
+            COLLECT_RESULT_PROCESS_CRASH,
+            COLLECT_RESULT_TIMEOUT,
         }:
+            from llenergymeasure.study.runtime_observations import write_sentinel
+
             exit_reason = (
                 "timeout"
-                if result.get("type") == "TimeoutError"
+                if result.get("type") == COLLECT_RESULT_TIMEOUT
                 else _derive_exit_reason(p.exitcode)
             )
-            with contextlib.suppress(Exception):
-                from llenergymeasure.study.runtime_observations import write_sentinel
-
-                write_sentinel(
-                    config,
-                    study_dir=self.study_dir,
-                    study_run_id=self.study_run_id,
-                    cycle=cycle,
-                    config_hash=config_hash,
-                    exit_reason=exit_reason,
-                    exit_code=p.exitcode,
-                )
+            write_sentinel(
+                config,
+                study_dir=self.study_dir,
+                study_run_id=self.study_run_id,
+                cycle=cycle,
+                config_hash=config_hash,
+                exit_reason=exit_reason,
+                exit_code=p.exitcode,
+            )
 
         exp_elapsed = time.monotonic() - exp_start
         self._handle_result(

--- a/src/llenergymeasure/study/runtime_observations.py
+++ b/src/llenergymeasure/study/runtime_observations.py
@@ -35,14 +35,18 @@ import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.config.ssot import ENGINE_PACKAGES, Engine
+from llenergymeasure.study.message_normalise import normalise
 
 __all__ = [
     "RUNTIME_OBSERVATIONS_FILENAME",
     "SCHEMA_VERSION",
+    "TRACEBACK_TRUNC_BYTES",
     "capture_runtime_observations",
     "engine_logger_name",
     "write_sentinel",
@@ -56,20 +60,7 @@ SCHEMA_VERSION = 1
 # Max bytes of traceback retained in the JSONL record. The full traceback
 # stays in the per-experiment result.json; this cap keeps each JSONL line
 # under typical kernel atomic-write limits (PIPE_BUF ~= 4 KiB).
-_TRACEBACK_TRUNC_BYTES = 3 * 1024
-
-# Python-logger name for each engine. Hardcoded here rather than reused from
-# ``config.ssot.ENGINE_PACKAGES`` because the two mappings have different
-# responsibilities: ``ENGINE_PACKAGES`` names the installable pip package,
-# while this dict names the top-level logger we attach a handler to. They
-# coincide today but the concerns are orthogonal (e.g. a package could split
-# its logger root) — keeping the indirection explicit prevents accidental
-# coupling.
-_ENGINE_LOGGER_NAME: dict[str, str] = {
-    "transformers": "transformers",
-    "vllm": "vllm",
-    "tensorrt": "tensorrt_llm",
-}
+TRACEBACK_TRUNC_BYTES = 3 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -77,10 +68,12 @@ _ENGINE_LOGGER_NAME: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
-def engine_logger_name(engine: Any) -> str:
-    """Return the Python logger name for ``engine`` (string or ``Engine`` enum)."""
-    value = engine.value if hasattr(engine, "value") else str(engine)
-    return _ENGINE_LOGGER_NAME.get(value, value)
+def engine_logger_name(engine: str | Engine) -> str:
+    """Return the Python logger name for ``engine`` (string or :class:`Engine`)."""
+    try:
+        return ENGINE_PACKAGES[Engine(engine)]
+    except (ValueError, KeyError):
+        return str(engine.value if isinstance(engine, Engine) else engine)
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +147,7 @@ def capture_runtime_observations(
     try:
         try:
             yield
-        except BaseException as exc:
+        except Exception as exc:
             outcome = "exception"
             exception_info = _serialise_exception(exc)
             raise
@@ -207,7 +200,7 @@ def write_sentinel(
         exit_reason=exit_reason,
         exit_code=exit_code,
     )
-    _append_observation_atomic(target, record)
+    _append_observation(target, record)
 
 
 # ---------------------------------------------------------------------------
@@ -278,8 +271,8 @@ def _serialise_exception(exc: BaseException) -> dict[str, Any]:
     message = str(exc)
     full_tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     encoded = full_tb.encode("utf-8", errors="replace")
-    if len(encoded) > _TRACEBACK_TRUNC_BYTES:
-        truncated = encoded[:_TRACEBACK_TRUNC_BYTES].decode("utf-8", errors="replace")
+    if len(encoded) > TRACEBACK_TRUNC_BYTES:
+        truncated = encoded[:TRACEBACK_TRUNC_BYTES].decode("utf-8", errors="replace")
     else:
         truncated = full_tb
     return {
@@ -291,9 +284,6 @@ def _serialise_exception(exc: BaseException) -> dict[str, Any]:
 
 
 def _normalise_message(message: str) -> str:
-    """Delegate to :mod:`message_normalise` — kept private so callers don't couple."""
-    from llenergymeasure.study.message_normalise import normalise
-
     return normalise(message).template
 
 
@@ -301,9 +291,17 @@ def _engine_value(engine: Any) -> str:
     return engine.value if hasattr(engine, "value") else str(engine)
 
 
+@lru_cache(maxsize=8)
 def _installed_version(engine_value: str) -> str:
-    """Return the installed package version for ``engine``, or ``""`` if missing."""
-    package = _ENGINE_LOGGER_NAME.get(engine_value, engine_value)
+    """Return the installed package version for ``engine``, or ``""`` if missing.
+
+    Cached per-engine: library versions cannot change mid-study, and
+    ``importlib.metadata.version`` walks ``sys.path`` on every call.
+    """
+    try:
+        package = ENGINE_PACKAGES[Engine(engine_value)]
+    except (ValueError, KeyError):
+        package = engine_value
     try:
         from importlib.metadata import PackageNotFoundError, version
     except ImportError:  # pragma: no cover - Python <3.8 not supported
@@ -338,25 +336,3 @@ def _append_observation(path: Path, record: dict[str, Any]) -> None:
                 os.fsync(fh.fileno())
     except OSError as exc:
         logger.warning("Could not append runtime observation to %s: %s", path, exc)
-
-
-def _append_observation_atomic(path: Path, record: dict[str, Any]) -> None:
-    """Append one JSONL record using ``os.open + O_APPEND + os.write``.
-
-    Single ``os.write()`` call — kernel treats it as one atomic append on
-    O_APPEND fds up to PIPE_BUF. Used by the parent-side sentinel where
-    the writer may be racing with nothing (worker is dead) but the
-    guarantee is still load-bearing if the user re-runs ``llem run``.
-    """
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        line = (json.dumps(record, default=str) + "\n").encode("utf-8")
-        fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
-        try:
-            os.write(fd, line)
-            with contextlib.suppress(OSError):
-                os.fsync(fd)
-        finally:
-            os.close(fd)
-    except OSError as exc:
-        logger.warning("Could not append runtime sentinel to %s: %s", path, exc)

--- a/src/llenergymeasure/study/runtime_observations.py
+++ b/src/llenergymeasure/study/runtime_observations.py
@@ -1,0 +1,362 @@
+"""Runtime observation capture — feedback channel #1 for the rules corpus.
+
+Wraps an experiment's worker body in a context manager that captures:
+
+- Library ``warnings.warn`` emissions (via ``warnings.catch_warnings(record=True)``).
+- Library ``logger.warning`` / ``logger.error`` / ``logger.warning_once`` records
+  emitted through the engine-level logger (``transformers``, ``vllm``,
+  ``tensorrt_llm``). Attaching at engine-level captures all submodule
+  emissions by propagation.
+- Structured ``outcome: "exception"`` records with truncated tracebacks when
+  inference raises. Runtime rejection is a distinct feedback class — the
+  library rejecting a config at runtime is announced behaviour, just via a
+  different channel than ``warnings.warn``.
+
+Writes one JSONL record per experiment to ``{study_dir}/runtime_observations.jsonl``.
+The wrapper is a **discovery** mechanism, not a gate — it never blocks,
+retries, or modifies runs. Cache-write failures log a warning and are swallowed.
+
+A parent-side :func:`write_sentinel` records the subprocess-died case
+(SIGKILL / OOM / timeout) that the worker's ``finally`` never reaches.
+
+Records are keyed on ``(study_run_id, config_hash, cycle)``. ``experiment_id``
+is intentionally excluded because it is generated inside the harness and is
+not available on failure.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import traceback
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from llenergymeasure.config.models import ExperimentConfig
+
+__all__ = [
+    "RUNTIME_OBSERVATIONS_FILENAME",
+    "SCHEMA_VERSION",
+    "capture_runtime_observations",
+    "engine_logger_name",
+    "write_sentinel",
+]
+
+
+logger = logging.getLogger(__name__)
+
+RUNTIME_OBSERVATIONS_FILENAME = "runtime_observations.jsonl"
+SCHEMA_VERSION = 1
+# Max bytes of traceback retained in the JSONL record. The full traceback
+# stays in the per-experiment result.json; this cap keeps each JSONL line
+# under typical kernel atomic-write limits (PIPE_BUF ~= 4 KiB).
+_TRACEBACK_TRUNC_BYTES = 3 * 1024
+
+# Python-logger name for each engine. Hardcoded here rather than reused from
+# ``config.ssot.ENGINE_PACKAGES`` because the two mappings have different
+# responsibilities: ``ENGINE_PACKAGES`` names the installable pip package,
+# while this dict names the top-level logger we attach a handler to. They
+# coincide today but the concerns are orthogonal (e.g. a package could split
+# its logger root) — keeping the indirection explicit prevents accidental
+# coupling.
+_ENGINE_LOGGER_NAME: dict[str, str] = {
+    "transformers": "transformers",
+    "vllm": "vllm",
+    "tensorrt": "tensorrt_llm",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def engine_logger_name(engine: Any) -> str:
+    """Return the Python logger name for ``engine`` (string or ``Engine`` enum)."""
+    value = engine.value if hasattr(engine, "value") else str(engine)
+    return _ENGINE_LOGGER_NAME.get(value, value)
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+class _ListHandler(logging.Handler):
+    """Logging handler that appends received records to a list.
+
+    Used as a non-destructive observer attached to the engine logger; existing
+    handlers continue to receive records.
+    """
+
+    def __init__(self, out: list[logging.LogRecord]) -> None:
+        super().__init__(level=logging.DEBUG)
+        self._out = out
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+        self._out.append(record)
+
+
+@contextmanager
+def capture_runtime_observations(
+    config: ExperimentConfig,
+    study_dir: Path | str,
+    study_run_id: str,
+    cycle: int,
+    config_hash: str,
+) -> Iterator[None]:
+    """Wrap a worker body; on exit, append one JSONL observation record.
+
+    The context body is the full worker body (``run_preflight()``,
+    ``get_engine()``, ``harness.run()``) so import-time emissions from
+    engine libraries are captured.
+
+    On success: writes ``outcome: "success"`` record (with empty arrays if
+    nothing was emitted — the empty arrays are load-bearing evidence for
+    predicate inference downstream).
+
+    On exception: writes ``outcome: "exception"`` record with serialised
+    traceback, then re-raises.
+
+    Cache-write errors are logged at WARNING and swallowed — a broken cache
+    must never fail a study.
+    """
+    target = Path(study_dir) / RUNTIME_OBSERVATIONS_FILENAME
+
+    records: list[logging.LogRecord] = []
+    handler = _ListHandler(records)
+    logger_name = engine_logger_name(config.engine)
+    engine_logger = logging.getLogger(logger_name)
+
+    # Handler-level DEBUG only — leaves the library logger's own level
+    # untouched so we don't mutate user-visible logging state. Records
+    # emitted below the logger's effective level won't reach handlers
+    # either way, which is fine — they aren't user-visible warnings.
+    engine_logger.addHandler(handler)
+
+    warn_ctx = warnings.catch_warnings(record=True)
+    captured = warn_ctx.__enter__()
+    # Deliberately no ``warnings.simplefilter("always")`` — RT-0 PoC
+    # confirmed ``catch_warnings(record=True)`` alone captures one record
+    # per unique ``(filename, lineno, category, message)`` on Python 3.10+.
+    # Calling simplefilter perturbs the measurement window.
+
+    outcome = "success"
+    exception_info: dict[str, Any] | None = None
+    warnings_buf: list[warnings.WarningMessage] = []
+
+    try:
+        try:
+            yield
+        except BaseException as exc:
+            outcome = "exception"
+            exception_info = _serialise_exception(exc)
+            raise
+        finally:
+            warnings_buf = list(captured or [])
+            warn_ctx.__exit__(None, None, None)
+    finally:
+        engine_logger.removeHandler(handler)
+        record = _build_record(
+            config=config,
+            study_run_id=study_run_id,
+            config_hash=config_hash,
+            cycle=cycle,
+            outcome=outcome,
+            warnings_buf=warnings_buf,
+            log_records=records,
+            exception_info=exception_info,
+            exit_reason=None,
+            exit_code=None,
+        )
+        _append_observation(target, record)
+
+
+def write_sentinel(
+    config: ExperimentConfig,
+    study_dir: Path | str,
+    study_run_id: str,
+    cycle: int,
+    config_hash: str,
+    exit_reason: str | None,
+    exit_code: int | None,
+) -> None:
+    """Append a ``outcome: "subprocess_died"`` record from the parent process.
+
+    Called by :class:`StudyRunner` when the worker was killed before its
+    context manager's ``__exit__`` could run (SIGKILL, OOM, timeout). Uses
+    ``os.open + O_APPEND + os.write`` so the single record hits the kernel
+    as one atomic write — no torn-line risk with other writers.
+    """
+    target = Path(study_dir) / RUNTIME_OBSERVATIONS_FILENAME
+    record = _build_record(
+        config=config,
+        study_run_id=study_run_id,
+        config_hash=config_hash,
+        cycle=cycle,
+        outcome="subprocess_died",
+        warnings_buf=[],
+        log_records=[],
+        exception_info=None,
+        exit_reason=exit_reason,
+        exit_code=exit_code,
+    )
+    _append_observation_atomic(target, record)
+
+
+# ---------------------------------------------------------------------------
+# Record assembly
+# ---------------------------------------------------------------------------
+
+
+def _build_record(
+    *,
+    config: ExperimentConfig,
+    study_run_id: str,
+    config_hash: str,
+    cycle: int,
+    outcome: str,
+    warnings_buf: list[warnings.WarningMessage],
+    log_records: list[logging.LogRecord],
+    exception_info: dict[str, Any] | None,
+    exit_reason: str | None,
+    exit_code: int | None,
+) -> dict[str, Any]:
+    engine_value = _engine_value(config.engine)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "observed_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "study_run_id": study_run_id,
+        "config_hash": config_hash,
+        "cycle": cycle,
+        "engine": engine_value,
+        "library_version": _installed_version(engine_value),
+        "outcome": outcome,
+        "warnings": [_render_warning(wm) for wm in warnings_buf],
+        "logger_records": [_render_log_record(r) for r in log_records],
+        "exception": exception_info,
+        "exit_reason": exit_reason,
+        "exit_code": exit_code,
+    }
+
+
+def _render_warning(wm: warnings.WarningMessage) -> dict[str, Any]:
+    raw = str(wm.message)
+    return {
+        "category": getattr(wm.category, "__name__", str(wm.category)),
+        "message": raw,
+        "message_template": _normalise_message(raw),
+        "filename": str(wm.filename),
+        "lineno": int(wm.lineno),
+    }
+
+
+def _render_log_record(record: logging.LogRecord) -> dict[str, Any]:
+    try:
+        message = record.getMessage()
+    except Exception:  # pragma: no cover - defensive: broken formatter
+        message = str(record.msg)
+    return {
+        "level": record.levelname,
+        "logger": record.name,
+        "message": message,
+        "message_template": _normalise_message(message),
+        "filename": record.filename,
+        "lineno": int(record.lineno),
+    }
+
+
+def _serialise_exception(exc: BaseException) -> dict[str, Any]:
+    message = str(exc)
+    full_tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    encoded = full_tb.encode("utf-8", errors="replace")
+    if len(encoded) > _TRACEBACK_TRUNC_BYTES:
+        truncated = encoded[:_TRACEBACK_TRUNC_BYTES].decode("utf-8", errors="replace")
+    else:
+        truncated = full_tb
+    return {
+        "type": type(exc).__name__,
+        "message": message,
+        "message_template": _normalise_message(message),
+        "traceback_truncated": truncated,
+    }
+
+
+def _normalise_message(message: str) -> str:
+    """Delegate to :mod:`message_normalise` — kept private so callers don't couple."""
+    from llenergymeasure.study.message_normalise import normalise
+
+    return normalise(message).template
+
+
+def _engine_value(engine: Any) -> str:
+    return engine.value if hasattr(engine, "value") else str(engine)
+
+
+def _installed_version(engine_value: str) -> str:
+    """Return the installed package version for ``engine``, or ``""`` if missing."""
+    package = _ENGINE_LOGGER_NAME.get(engine_value, engine_value)
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:  # pragma: no cover - Python <3.8 not supported
+        return ""
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return ""
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _append_observation(path: Path, record: dict[str, Any]) -> None:
+    """Append one JSONL record to ``path`` using buffered IO + flush + fsync.
+
+    W1 pattern from RT-2 PoC: open in append mode, write, flush, fsync.
+    Torn-line-safe at 10 KiB records on Linux ext4. Best-effort — a
+    write failure is logged at WARNING but never raises.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, default=str) + "\n"
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            with contextlib.suppress(OSError):
+                os.fsync(fh.fileno())
+    except OSError as exc:
+        logger.warning("Could not append runtime observation to %s: %s", path, exc)
+
+
+def _append_observation_atomic(path: Path, record: dict[str, Any]) -> None:
+    """Append one JSONL record using ``os.open + O_APPEND + os.write``.
+
+    Single ``os.write()`` call — kernel treats it as one atomic append on
+    O_APPEND fds up to PIPE_BUF. Used by the parent-side sentinel where
+    the writer may be racing with nothing (worker is dead) but the
+    guarantee is still load-bearing if the user re-runs ``llem run``.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = (json.dumps(record, default=str) + "\n").encode("utf-8")
+        fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, line)
+            with contextlib.suppress(OSError):
+                os.fsync(fd)
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        logger.warning("Could not append runtime sentinel to %s: %s", path, exc)

--- a/tests/unit/study/test_message_normalise.py
+++ b/tests/unit/study/test_message_normalise.py
@@ -1,0 +1,101 @@
+"""Tests for library-warning message normalisation."""
+
+from __future__ import annotations
+
+import re
+
+from llenergymeasure.study.message_normalise import normalise
+
+
+class TestNumericSubstitution:
+    def test_integer(self):
+        assert normalise("count=42").template == "count=<NUM>"
+
+    def test_float(self):
+        assert normalise("temperature=0.001").template == "temperature=<NUM>"
+
+    def test_scientific(self):
+        assert normalise("val 1e-5").template == "val <NUM>"
+
+    def test_negative(self):
+        assert normalise("offset -12").template == "offset <NUM>"
+
+    def test_preserves_surrounding_identifiers(self):
+        # Don't eat "sha256" in "sha256_abc123".
+        assert "sha256_abc" in normalise("sha256_abc NUM 42 here").template
+
+
+class TestPathSubstitution:
+    def test_absolute_unix(self):
+        assert "<PATH>" in normalise("error in /usr/lib/foo.py:12").template
+
+    def test_windows_drive(self):
+        t = normalise("error in C:\\Program Files\\foo.py").template
+        assert "<PATH>" in t
+
+
+class TestTimestampSubstitution:
+    def test_iso_with_z(self):
+        assert normalise("at 2026-04-23T12:34:56Z").template == "at <TIMESTAMP>"
+
+    def test_iso_with_offset(self):
+        assert normalise("at 2026-04-23T12:34:56+00:00").template == "at <TIMESTAMP>"
+
+
+class TestLineNumberSubstitution:
+    def test_py_line_number(self):
+        # Path matched first then line number after .py:
+        t = normalise("foo.py:368 warning").template
+        assert "<LINENO>" in t
+
+
+class TestHexSubstitution:
+    def test_sha256_prefixed(self):
+        t = normalise("hash sha256:deadbeefdeadbeef").template
+        assert "<HEX>" in t
+
+    def test_bare_long_hex(self):
+        t = normalise("token abcdef0123456789deadbeef").template
+        assert "<HEX>" in t
+
+
+class TestAnsiStripping:
+    def test_removes_color_codes(self):
+        t = normalise("\x1b[31merror\x1b[0m here").template
+        assert t == "error here"
+
+
+class TestWhitespaceCollapse:
+    def test_multiple_spaces(self):
+        t = normalise("foo   bar   baz").template
+        assert t == "foo bar baz"
+
+
+class TestTemplateRegex:
+    def test_num_placeholder_matches_number(self):
+        nm = normalise("temperature=0.001")
+        assert re.match(nm.match_regex, "temperature=0.5")
+        assert re.match(nm.match_regex, "temperature=1e-3")
+
+    def test_path_placeholder_matches_path(self):
+        nm = normalise("error in /abs/path.py")
+        assert re.match(nm.match_regex, "error in /different/path.py")
+
+    def test_regex_is_anchored(self):
+        nm2 = normalise("count=42")
+        # Anchored so exact match passes.
+        assert re.match(nm2.match_regex, "count=42")
+        # Sanity: extra trailing content breaks the match.
+        assert not re.match(nm2.match_regex, "count=42 and more")
+
+
+class TestEndToEndNormalisationEquivalence:
+    def test_two_configs_produce_same_template(self):
+        a = normalise("vllm clamping temperature=0.001 to 0.01").template
+        b = normalise("vllm clamping temperature=0.005 to 0.01").template
+        assert a == b
+
+    def test_different_messages_stay_distinct(self):
+        a = normalise("temperature out of range").template
+        b = normalise("unknown attention implementation").template
+        assert a != b

--- a/tests/unit/study/test_runtime_observations.py
+++ b/tests/unit/study/test_runtime_observations.py
@@ -1,0 +1,477 @@
+"""Tests for runtime-observation capture (PR A)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import multiprocessing
+import uuid
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.study.runtime_observations import (
+    _TRACEBACK_TRUNC_BYTES,
+    RUNTIME_OBSERVATIONS_FILENAME,
+    SCHEMA_VERSION,
+    capture_runtime_observations,
+    engine_logger_name,
+    write_sentinel,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mk_config(engine: str = "transformers") -> ExperimentConfig:
+    return ExperimentConfig(task={"model": "gpt2"}, engine=engine)
+
+
+def _run_id() -> str:
+    return str(uuid.uuid4())
+
+
+_REQUIRED_KEYS = {
+    "schema_version",
+    "observed_at",
+    "study_run_id",
+    "config_hash",
+    "cycle",
+    "engine",
+    "library_version",
+    "outcome",
+    "warnings",
+    "logger_records",
+    "exception",
+    "exit_reason",
+    "exit_code",
+}
+
+
+def _assert_record_shape(record: dict[str, Any]) -> None:
+    assert set(record.keys()) == _REQUIRED_KEYS, f"unexpected schema; got {sorted(record.keys())!r}"
+    assert record["schema_version"] == SCHEMA_VERSION
+    assert isinstance(record["observed_at"], str) and record["observed_at"].endswith("Z")
+    assert isinstance(record["study_run_id"], str)
+    assert isinstance(record["config_hash"], str)
+    assert isinstance(record["cycle"], int)
+    assert record["outcome"] in {"success", "exception", "subprocess_died"}
+    assert isinstance(record["warnings"], list)
+    assert isinstance(record["logger_records"], list)
+
+
+def _read_records(study_dir: Path) -> list[dict[str, Any]]:
+    path = study_dir / RUNTIME_OBSERVATIONS_FILENAME
+    assert path.exists(), f"expected {path} to exist"
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# engine_logger_name
+# ---------------------------------------------------------------------------
+
+
+class TestEngineLoggerName:
+    def test_transformers(self) -> None:
+        assert engine_logger_name("transformers") == "transformers"
+
+    def test_vllm(self) -> None:
+        assert engine_logger_name("vllm") == "vllm"
+
+    def test_tensorrt_maps_to_tensorrt_llm(self) -> None:
+        assert engine_logger_name("tensorrt") == "tensorrt_llm"
+
+    def test_unknown_engine_falls_through(self) -> None:
+        assert engine_logger_name("nonexistent") == "nonexistent"
+
+    def test_accepts_engine_enum(self) -> None:
+        from llenergymeasure.config.ssot import Engine
+
+        assert engine_logger_name(Engine.TENSORRT) == "tensorrt_llm"
+
+
+# ---------------------------------------------------------------------------
+# Success path — empty record
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessPath:
+    def test_empty_success_record_is_written(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        run_id = _run_id()
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id=run_id,
+            cycle=1,
+            config_hash="hash-1",
+        ):
+            pass
+
+        records = _read_records(tmp_path)
+        assert len(records) == 1
+        rec = records[0]
+        _assert_record_shape(rec)
+        assert rec["outcome"] == "success"
+        assert rec["engine"] == "transformers"
+        assert rec["study_run_id"] == run_id
+        assert rec["config_hash"] == "hash-1"
+        assert rec["cycle"] == 1
+        assert rec["warnings"] == []
+        assert rec["logger_records"] == []
+        assert rec["exception"] is None
+        assert rec["exit_reason"] is None
+        assert rec["exit_code"] is None
+
+    def test_file_name_and_location(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id=_run_id(),
+            cycle=1,
+            config_hash="h",
+        ):
+            pass
+        assert (tmp_path / "runtime_observations.jsonl").exists()
+
+    def test_multiple_experiments_append(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        for cycle in (1, 2, 3):
+            with capture_runtime_observations(
+                cfg,
+                study_dir=tmp_path,
+                study_run_id="run-x",
+                cycle=cycle,
+                config_hash="h",
+            ):
+                pass
+        records = _read_records(tmp_path)
+        assert [r["cycle"] for r in records] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Warnings capture
+# ---------------------------------------------------------------------------
+
+
+class TestWarningCapture:
+    def test_warning_is_captured_with_category(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+        ):
+            warnings.warn("temperature=0.001 is too low", UserWarning, stacklevel=2)
+
+        rec = _read_records(tmp_path)[0]
+        assert len(rec["warnings"]) == 1
+        wrec = rec["warnings"][0]
+        assert wrec["category"] == "UserWarning"
+        assert "temperature=0.001" in wrec["message"]
+        assert wrec["message_template"] == "temperature=<NUM> is too low"
+        assert wrec["filename"] and isinstance(wrec["filename"], str)
+        assert isinstance(wrec["lineno"], int)
+
+    def test_warning_filters_restored(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        before = list(warnings.filters)
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+        ):
+            warnings.warn("inside", UserWarning, stacklevel=2)
+        assert list(warnings.filters) == before
+
+
+# ---------------------------------------------------------------------------
+# Logger capture
+# ---------------------------------------------------------------------------
+
+
+class TestLoggerCapture:
+    def test_engine_logger_warning_is_captured(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+        ):
+            logging.getLogger("transformers").warning("clamp value=42")
+
+        rec = _read_records(tmp_path)[0]
+        assert len(rec["logger_records"]) == 1
+        lrec = rec["logger_records"][0]
+        assert lrec["level"] == "WARNING"
+        assert lrec["logger"] == "transformers"
+        assert lrec["message"] == "clamp value=42"
+        assert lrec["message_template"] == "clamp value=<NUM>"
+        assert isinstance(lrec["lineno"], int)
+
+    def test_submodule_logger_propagates(self, tmp_path: Path) -> None:
+        # Engine-level handler catches submodule emissions via propagation.
+        cfg = _mk_config()
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+        ):
+            logging.getLogger("transformers.generation.utils").warning("sub-emit")
+        rec = _read_records(tmp_path)[0]
+        assert any(r["message"] == "sub-emit" for r in rec["logger_records"])
+
+    def test_does_not_mutate_logger_level(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        engine_logger = logging.getLogger("transformers")
+        prior_level = engine_logger.level
+        prior_handlers = list(engine_logger.handlers)
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+        ):
+            pass
+        assert engine_logger.level == prior_level
+        assert engine_logger.handlers == prior_handlers
+
+    def test_handler_removed_on_exception(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        engine_logger = logging.getLogger("transformers")
+        prior_handlers = list(engine_logger.handlers)
+        with (
+            pytest.raises(RuntimeError),
+            capture_runtime_observations(
+                cfg,
+                study_dir=tmp_path,
+                study_run_id="r",
+                cycle=1,
+                config_hash="h",
+            ),
+        ):
+            raise RuntimeError("boom")
+        assert engine_logger.handlers == prior_handlers
+
+
+# ---------------------------------------------------------------------------
+# Exception capture
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionCapture:
+    def test_exception_is_recorded_and_reraised(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        with (
+            pytest.raises(ValueError, match="bang"),
+            capture_runtime_observations(
+                cfg,
+                study_dir=tmp_path,
+                study_run_id="r",
+                cycle=1,
+                config_hash="h",
+            ),
+        ):
+            raise ValueError("bang 42")
+
+        rec = _read_records(tmp_path)[0]
+        _assert_record_shape(rec)
+        assert rec["outcome"] == "exception"
+        exc = rec["exception"]
+        assert exc is not None
+        assert exc["type"] == "ValueError"
+        assert exc["message"] == "bang 42"
+        assert exc["message_template"] == "bang <NUM>"
+        assert "Traceback" in exc["traceback_truncated"]
+        assert "ValueError: bang 42" in exc["traceback_truncated"]
+
+    def test_traceback_truncated_to_cap(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+
+        # Build a recursion that blows a huge traceback, trapped by RecursionError.
+        def deep(n: int) -> int:
+            return deep(n + 1)
+
+        with (
+            pytest.raises(RecursionError),
+            capture_runtime_observations(
+                cfg,
+                study_dir=tmp_path,
+                study_run_id="r",
+                cycle=1,
+                config_hash="h",
+            ),
+        ):
+            deep(0)
+
+        rec = _read_records(tmp_path)[0]
+        tb = rec["exception"]["traceback_truncated"]
+        assert len(tb.encode("utf-8")) <= _TRACEBACK_TRUNC_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Sentinel
+# ---------------------------------------------------------------------------
+
+
+class TestSentinel:
+    def test_write_sentinel_appends_subprocess_died(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        write_sentinel(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=2,
+            config_hash="h",
+            exit_reason="SIGKILL",
+            exit_code=-9,
+        )
+        rec = _read_records(tmp_path)[0]
+        _assert_record_shape(rec)
+        assert rec["outcome"] == "subprocess_died"
+        assert rec["exit_reason"] == "SIGKILL"
+        assert rec["exit_code"] == -9
+        assert rec["cycle"] == 2
+
+    def test_sentinel_appends_alongside_success(self, tmp_path: Path) -> None:
+        cfg = _mk_config()
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+        ):
+            pass
+        write_sentinel(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=2,
+            config_hash="h",
+            exit_reason="timeout",
+            exit_code=None,
+        )
+        records = _read_records(tmp_path)
+        assert [r["outcome"] for r in records] == ["success", "subprocess_died"]
+
+    def test_sentinel_swallows_oserror(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cfg = _mk_config()
+
+        def _boom(*_a, **_k):
+            raise OSError("disk-full")
+
+        monkeypatch.setattr("llenergymeasure.study.runtime_observations.os.open", _boom)
+        # Must not raise — feedback loop never fails a study.
+        write_sentinel(
+            cfg,
+            study_dir=tmp_path,
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+            exit_reason="SIGKILL",
+            exit_code=-9,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cache-write resilience
+# ---------------------------------------------------------------------------
+
+
+class TestCacheWriteResilience:
+    def test_mkdir_failure_does_not_raise(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cfg = _mk_config()
+
+        def _fail_mkdir(self, *_a, **_k):
+            raise OSError("no perm")
+
+        monkeypatch.setattr(Path, "mkdir", _fail_mkdir)
+        # Must not raise even though we can't write the record.
+        with capture_runtime_observations(
+            cfg,
+            study_dir=tmp_path / "subdir",
+            study_run_id="r",
+            cycle=1,
+            config_hash="h",
+        ):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Integration: real spawn subprocess
+# ---------------------------------------------------------------------------
+
+
+def _spawn_target(study_dir: str, study_run_id: str, cycle: int, config_hash: str) -> None:
+    """Run inside a spawned child — imports everything from scratch.
+
+    Emits one warning and one log record through each channel, then exits.
+    """
+    import logging as _logging
+    import warnings as _warnings
+
+    from llenergymeasure.config.models import ExperimentConfig as _Cfg
+    from llenergymeasure.study.runtime_observations import (
+        capture_runtime_observations as _cap,
+    )
+
+    cfg = _Cfg(task={"model": "gpt2"}, engine="transformers")
+    with _cap(
+        cfg,
+        study_dir=study_dir,
+        study_run_id=study_run_id,
+        cycle=cycle,
+        config_hash=config_hash,
+    ):
+        _warnings.warn("spawned-warning 1e-5", UserWarning, stacklevel=2)
+        _logging.getLogger("transformers").warning("spawned-log 42")
+
+
+class TestSpawnIntegration:
+    def test_spawn_worker_writes_one_record(self, tmp_path: Path) -> None:
+        ctx = multiprocessing.get_context("spawn")
+        run_id = _run_id()
+        p = ctx.Process(
+            target=_spawn_target,
+            args=(str(tmp_path), run_id, 7, "hash-spawn"),
+        )
+        p.start()
+        p.join(timeout=30)
+        assert p.exitcode == 0, f"spawn worker failed with exit={p.exitcode}"
+
+        records = _read_records(tmp_path)
+        assert len(records) == 1
+        rec = records[0]
+        _assert_record_shape(rec)
+        assert rec["outcome"] == "success"
+        assert rec["study_run_id"] == run_id
+        assert rec["cycle"] == 7
+        assert rec["config_hash"] == "hash-spawn"
+        assert any("spawned-warning" in w["message"] for w in rec["warnings"])
+        assert any(
+            "spawned-log" in r["message"] and r["logger"] == "transformers"
+            for r in rec["logger_records"]
+        )

--- a/tests/unit/study/test_runtime_observations.py
+++ b/tests/unit/study/test_runtime_observations.py
@@ -14,9 +14,9 @@ import pytest
 
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.study.runtime_observations import (
-    _TRACEBACK_TRUNC_BYTES,
     RUNTIME_OBSERVATIONS_FILENAME,
     SCHEMA_VERSION,
+    TRACEBACK_TRUNC_BYTES,
     capture_runtime_observations,
     engine_logger_name,
     write_sentinel,
@@ -126,18 +126,6 @@ class TestSuccessPath:
         assert rec["exception"] is None
         assert rec["exit_reason"] is None
         assert rec["exit_code"] is None
-
-    def test_file_name_and_location(self, tmp_path: Path) -> None:
-        cfg = _mk_config()
-        with capture_runtime_observations(
-            cfg,
-            study_dir=tmp_path,
-            study_run_id=_run_id(),
-            cycle=1,
-            config_hash="h",
-        ):
-            pass
-        assert (tmp_path / "runtime_observations.jsonl").exists()
 
     def test_multiple_experiments_append(self, tmp_path: Path) -> None:
         cfg = _mk_config()
@@ -320,7 +308,7 @@ class TestExceptionCapture:
 
         rec = _read_records(tmp_path)[0]
         tb = rec["exception"]["traceback_truncated"]
-        assert len(tb.encode("utf-8")) <= _TRACEBACK_TRUNC_BYTES
+        assert len(tb.encode("utf-8")) <= TRACEBACK_TRUNC_BYTES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -547,7 +547,7 @@ def test_sigint_second_ctrl_c_kills_immediately() -> None:
 # =============================================================================
 
 
-def test_worker_no_longer_stub(monkeypatch) -> None:
+def test_worker_no_longer_stub(monkeypatch, tmp_path) -> None:
     """_run_experiment_worker no longer raises NotImplementedError."""
     from llenergymeasure.config.models import DatasetConfig
     from tests.conftest import make_result
@@ -572,11 +572,19 @@ def test_worker_no_longer_stub(monkeypatch) -> None:
     progress_q: queue.SimpleQueue = queue.SimpleQueue()
 
     # Must not raise NotImplementedError
-    _run_experiment_worker(config, mock_conn, progress_q)
+    _run_experiment_worker(
+        config,
+        mock_conn,
+        progress_q,
+        study_dir=str(tmp_path),
+        study_run_id="test-run",
+        cycle=1,
+        config_hash="test-hash",
+    )
     mock_conn.send.assert_called_once()
 
 
-def test_worker_calls_get_engine(monkeypatch) -> None:
+def test_worker_calls_get_engine(monkeypatch, tmp_path) -> None:
     """_run_experiment_worker calls get_engine with the config's engine name.
 
     Uses a mock conn (not a real Pipe) so MagicMock results don't need pickling.
@@ -613,7 +621,15 @@ def test_worker_calls_get_engine(monkeypatch) -> None:
 
     progress_q: queue.SimpleQueue = queue.SimpleQueue()
 
-    _run_experiment_worker(config, mock_conn, progress_q)
+    _run_experiment_worker(
+        config,
+        mock_conn,
+        progress_q,
+        study_dir=str(tmp_path),
+        study_run_id="test-run",
+        cycle=1,
+        config_hash="test-hash",
+    )
 
     assert len(engine_calls) == 1, f"Expected 1 get_engine call, got {engine_calls}"
     assert engine_calls[0] == "transformers"
@@ -1179,7 +1195,7 @@ def test_parent_conn_closed_after_collect_result(study_config: StudyConfig) -> N
 # =============================================================================
 
 
-def test_worker_calls_setpgrp(monkeypatch) -> None:
+def test_worker_calls_setpgrp(monkeypatch, tmp_path) -> None:
     """_run_experiment_worker calls os.setpgrp() as the first line before any other work."""
     from llenergymeasure.config.models import DatasetConfig
     from tests.conftest import make_result
@@ -1209,7 +1225,15 @@ def test_worker_calls_setpgrp(monkeypatch) -> None:
     mock_conn = MagicMock()
     progress_q: queue.SimpleQueue = queue.SimpleQueue()
 
-    _run_experiment_worker(config, mock_conn, progress_q)
+    _run_experiment_worker(
+        config,
+        mock_conn,
+        progress_q,
+        study_dir=str(tmp_path),
+        study_run_id="test-run",
+        cycle=1,
+        config_hash="test-hash",
+    )
 
     assert len(setpgrp_calls) == 1, f"Expected os.setpgrp() called once, got {len(setpgrp_calls)}"
 


### PR DESCRIPTION
## Summary
Adds `study/runtime_observations.py`: a context manager that captures Python warnings, engine-logger records, and exceptions around every experiment in a `StudyRunner` run. One JSONL record per experiment is written to `{study_dir}/runtime_observations.jsonl`, with a parent-side sentinel record when the subprocess is SIGKILLed / OOM'd / times out.

Feeds PR B (`llem report-gaps --source runtime-warnings`) and runtime-config-validation.md §4.7 feedback-channel #1.

## Key design points
- `catch_warnings(record=True)` alone — no `simplefilter("always")`, which perturbs the measurement window (RT-0 PoC).
- Handler-level DEBUG, not logger-level — leaves user-visible logging state untouched.
- Wrapper enters BEFORE `run_preflight()` / `get_engine()` so engine-library import-time emissions under `spawn` are captured.
- Per-study JSONL at `{study_dir}/runtime_observations.jsonl` — torn-line-safe on Linux ext4 (RT-2 PoC: 0 torn lines across 1600+ SIGKILL trials).
- Parent-side sentinel via `os.open + O_APPEND + os.write` for SIGKILL / OOM / timeout cases that the worker's `finally` would miss.
- Records keyed on `(study_run_id, config_hash, cycle)`. `experiment_id` is intentionally excluded — it is generated inside the harness and is not available on failure.
- `study_run_id` generated once per `StudyRunner.run()` so re-runs against the same study_dir can be disambiguated by downstream consumers.
- Traceback capped at 3 KiB in the JSONL; full traceback remains in `result.json`.
- Engine → logger-name mapping hardcoded in `_ENGINE_LOGGER_NAME` (not reused from `config.ssot.ENGINE_PACKAGES`) — the two concerns are orthogonal and decoupling them prevents accidental coupling if a library splits its logger root.

## JSONL schema (locked)
Keys: `schema_version`, `observed_at`, `study_run_id`, `config_hash`, `cycle`, `engine`, `library_version`, `outcome`, `warnings`, `logger_records`, `exception`, `exit_reason`, `exit_code`. `outcome ∈ {success, exception, subprocess_died}`. Warning and log records carry both raw `message` and normalised `message_template`. Empty arrays on `success` are load-bearing evidence for predicate inference in PR B.

## Test plan
- [x] Unit tests for warning / log / exception capture paths
- [x] Integration test with real `spawn` subprocess
- [x] Schema round-trip assertion against locked JSONL shape
- [x] Sentinel round-trip
- [x] No-perturbation check on outer warnings.filters + logger handlers/level
- [x] Cache-write failures swallowed (mkdir + os.open monkeypatch)
- [x] Traceback truncation cap enforced on deep recursion
- [x] `message_normalise` unit tests ported from preview

## Out of scope
- `llem report-gaps` CLI surface — PR B.
- Predicate-inference algorithm — PR B.
- Sweep-dedup / equivalence groups — M4.