### PR TITLE
feat(cli): llem report-gaps proposes corpus rules from runtime observations

### DIFF
--- a/src/llenergymeasure/api/__init__.py
+++ b/src/llenergymeasure/api/__init__.py
@@ -1,14 +1,30 @@
 """Public library API for llenergymeasure."""
 
 from llenergymeasure.api._impl import run_experiment, run_study
+from llenergymeasure.api.report_gaps import (
+    GapProposal,
+    ReportGapsError,
+    SourceChannel,
+    SupportedEngine,
+    find_runtime_gaps,
+    load_rules_corpus,
+    render_yaml_fragment,
+)
 from llenergymeasure.results.persistence import save_result
 from llenergymeasure.study.preflight import run_study_preflight
 from llenergymeasure.study.resume import find_resumable_study, load_resume_state
 
 __all__ = [
+    "GapProposal",
+    "ReportGapsError",
+    "SourceChannel",
+    "SupportedEngine",
     "find_resumable_study",
+    "find_runtime_gaps",
     "load_resume_state",
+    "load_rules_corpus",
     "probe_energy_sampler",
+    "render_yaml_fragment",
     "run_experiment",
     "run_study",
     "run_study_preflight",

--- a/src/llenergymeasure/api/__init__.py
+++ b/src/llenergymeasure/api/__init__.py
@@ -4,8 +4,6 @@ from llenergymeasure.api._impl import run_experiment, run_study
 from llenergymeasure.api.report_gaps import (
     GapProposal,
     ReportGapsError,
-    SourceChannel,
-    SupportedEngine,
     find_runtime_gaps,
     load_rules_corpus,
     render_yaml_fragment,
@@ -17,8 +15,6 @@ from llenergymeasure.study.resume import find_resumable_study, load_resume_state
 __all__ = [
     "GapProposal",
     "ReportGapsError",
-    "SourceChannel",
-    "SupportedEngine",
     "find_resumable_study",
     "find_runtime_gaps",
     "load_resume_state",

--- a/src/llenergymeasure/api/report_gaps.py
+++ b/src/llenergymeasure/api/report_gaps.py
@@ -1,0 +1,743 @@
+"""``llem report-gaps`` — feedback-loop proposer for the rules corpus.
+
+Reads ``runtime_observations.jsonl`` caches emitted by
+:mod:`llenergymeasure.study.runtime_observations` across one or more study
+directories, groups captured warnings / log records by their normalised
+message template, partitions configs into *fired* (A) and *not fired* (B),
+and runs a small predicate-inference pass to propose corpus rules for
+templates that the existing rules corpus does not already match.
+
+Design notes:
+
+- **No corpus mutation.** We emit YAML *fragments* to ``--out PATH`` with a
+  loud banner comment for a maintainer to splice into the live corpus. The
+  live ``configs/validation_rules/{engine}.yaml`` is never touched.
+- **Severity is mechanical.** ``severity: warn`` from log-channel emissions
+  and ``severity: error`` when ``--include-exceptions`` is set and the
+  record is an exception. ``walker_confidence`` is always ``low`` and we
+  always flag ``needs_generalisation_review`` when the predicate was narrow
+  or missing — the final call belongs to the human reviewer.
+- **Round-trip safe.** Every emitted fragment parses through
+  :func:`llenergymeasure.config.vendored_rules.loader._parse_rule` without
+  error. Required-but-unknown fields (``native_type``,
+  ``walker_source.{path,method,line_at_scan}``, ``references``) get
+  minimally-acceptable placeholder values plus ``# TODO: human`` markers so
+  reviewers know what to fill in.
+- **Sentinel filtering.** Records with ``outcome in {"subprocess_died",
+  "exception"}`` do not prove "the rule did not fire" — they prove "we don't
+  know". They are excluded from the B (not-fired) partition. When
+  ``include_exceptions=False`` (default), exception records are also
+  excluded from the A partition so the proposer only acts on recorded
+  warnings / log-channel emissions.
+
+Source of config kwargs for predicate inference:
+
+    Per-experiment ``_resolution.json`` sidecars (written by the runner
+    alongside ``result.json``). Each sidecar maps dotted field paths to
+    their effective values; we flatten these into ``dict[str, Any]`` per
+    config_hash so the inference algorithm can look for arity-1, arity-2,
+    arity-3 distinguishing value-tuples between fired and not-fired configs.
+
+    Experiments whose subprocess died before the sidecar was written have
+    no kwargs — they are skipped at partition time regardless of outcome.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from llenergymeasure.config.ssot import Engine
+from llenergymeasure.config.vendored_rules import (
+    VendoredRules,
+    VendoredRulesLoader,
+)
+from llenergymeasure.study.message_normalise import build_template_regex, normalise
+from llenergymeasure.study.runtime_observations import RUNTIME_OBSERVATIONS_FILENAME
+
+__all__ = [
+    "GapProposal",
+    "ReportGapsError",
+    "SourceChannel",
+    "SupportedEngine",
+    "find_runtime_gaps",
+    "load_rules_corpus",
+    "render_yaml_fragment",
+]
+
+logger = logging.getLogger(__name__)
+
+SupportedEngine = Literal["transformers", "vllm", "tensorrt"]
+"""Engine literal re-exported for the CLI layer (cli-boundary contract)."""
+
+SourceChannel = Literal["warnings_warn", "logger_warning", "runtime_exception"]
+"""Which JSONL-record channel the emission came from.
+
+Kept as a narrow literal so downstream renderers can switch on it without a
+try/except. Logger levels INFO/DEBUG are not included — the capture wrapper
+only emits log records at WARNING+ and the corpus only cares about
+user-visible emissions.
+"""
+
+
+class ReportGapsError(Exception):
+    """Raised when ``find_runtime_gaps`` or ``render_yaml_fragment`` fails.
+
+    Thin wrapper so the CLI can surface a helpful message without leaking
+    implementation-specific exception types (IO, YAML) to the user.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GapProposal:
+    """One proposed corpus rule for a single unmatched normalised template.
+
+    Carries everything ``render_yaml_fragment`` needs to produce a YAML
+    fragment that parses through :func:`_parse_rule`. The struct itself is
+    pure data — no IO, no side effects.
+    """
+
+    normalised_template: str
+    source_channel: SourceChannel
+    engine: SupportedEngine
+    library_version: str
+    match_fields: dict[str, Any] | None
+    evidence_field_value_distribution: dict[str, dict[str, list[str]]]
+    fired_count: int
+    not_fired_count: int
+    representative_message: str
+    walker_confidence: Literal["low"]
+    needs_generalisation_review: bool
+    severity: Literal["warn", "error"]
+    representative_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Internal record shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Emission:
+    """One template-fired-by-a-config observation (in-memory only)."""
+
+    template: str
+    representative_message: str
+    channel: SourceChannel
+    config_hash: str
+    engine: SupportedEngine
+    library_version: str
+
+
+@dataclass(frozen=True)
+class _Record:
+    """Parsed JSONL record with resolved kwargs and derived emission list."""
+
+    config_hash: str
+    engine: SupportedEngine
+    library_version: str
+    outcome: str
+    emissions: list[_Emission]
+    kwargs: dict[str, Any] | None
+
+
+_ALLOWED_ENGINES: frozenset[str] = frozenset(e.value for e in Engine)
+
+
+# ---------------------------------------------------------------------------
+# Corpus loading
+# ---------------------------------------------------------------------------
+
+
+def load_rules_corpus(
+    engines: list[SupportedEngine] | None = None,
+    loader: VendoredRulesLoader | None = None,
+) -> dict[str, VendoredRules]:
+    """Load the rules corpus for each engine we may emit proposals against.
+
+    Engines missing a YAML corpus are skipped silently — a user scanning
+    only transformers studies shouldn't fail because there's no
+    ``tensorrt.yaml`` yet.
+    """
+    loader = loader or VendoredRulesLoader()
+    wanted = list(engines) if engines is not None else [e.value for e in Engine]
+    out: dict[str, VendoredRules] = {}
+    for engine in wanted:
+        try:
+            out[engine] = loader.load_rules(engine)
+        except FileNotFoundError:
+            logger.debug("No rules corpus for engine=%s; skipping match lookup.", engine)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Core entry point
+# ---------------------------------------------------------------------------
+
+
+def find_runtime_gaps(
+    study_dirs: list[Path],
+    rules_corpus: dict[str, VendoredRules] | None = None,
+    engine: str | None = None,
+    include_exceptions: bool = False,
+) -> list[GapProposal]:
+    """Scan one or more study directories and return unmatched-template proposals.
+
+    Args:
+        study_dirs: Study directories containing
+            ``runtime_observations.jsonl``. Missing JSONL files are ignored
+            with a log message — a study that produced no observations is a
+            valid (if useless) input.
+        rules_corpus: Pre-loaded per-engine corpus. When ``None`` the default
+            loader is used; engines without a YAML corpus are treated as
+            "no existing rules" and every template falls through to a
+            proposal.
+        engine: If set, only records matching this engine contribute
+            proposals. Filter applies before partitioning.
+        include_exceptions: If ``True``, records with
+            ``outcome == "exception"`` also produce candidate emissions
+            (marked ``source_channel="runtime_exception"`` and
+            ``severity="error"``). Default ``False`` — exceptions are a
+            separate feedback channel with different review semantics and
+            the design deliberately keeps this opt-in.
+
+    Returns:
+        One :class:`GapProposal` per unique unmatched normalised template.
+        Order is stable: sorted by (engine, normalised_template) so
+        diffing two runs is meaningful.
+    """
+    if not study_dirs:
+        raise ReportGapsError("No study directories provided. Pass at least one --study-dir.")
+
+    engine_filter = engine
+    if engine_filter is not None and engine_filter not in _ALLOWED_ENGINES:
+        raise ReportGapsError(
+            f"Unsupported engine filter: {engine_filter!r}. "
+            f"Expected one of: {sorted(_ALLOWED_ENGINES)}."
+        )
+
+    records: list[_Record] = []
+    for study_dir in study_dirs:
+        records.extend(_load_study(study_dir, engine_filter, include_exceptions))
+
+    if not records:
+        return []
+
+    corpus = rules_corpus if rules_corpus is not None else load_rules_corpus()
+
+    # Build unique (engine, template) → emissions map.
+    # Key on engine too because the same string emitted by two engines is
+    # conceptually two different rules (different native types, different
+    # severity conventions).
+    emissions_by_key: dict[tuple[str, str], list[_Emission]] = {}
+    representative_by_key: dict[tuple[str, str], _Emission] = {}
+
+    for rec in records:
+        for emission in rec.emissions:
+            key = (emission.engine, emission.template)
+            emissions_by_key.setdefault(key, []).append(emission)
+            representative_by_key.setdefault(key, emission)
+
+    # Partition records by engine once so the per-template loop stays O(1) per record.
+    records_by_engine: dict[str, list[_Record]] = {}
+    for rec in records:
+        records_by_engine.setdefault(rec.engine, []).append(rec)
+
+    proposals: list[GapProposal] = []
+    for (eng, template), emissions in sorted(emissions_by_key.items()):
+        corpus_entry = corpus.get(eng)
+        if corpus_entry is not None and _template_matched_by_corpus(template, corpus_entry):
+            continue
+
+        fired_hashes = {e.config_hash for e in emissions}
+
+        # A partition: records whose config fired this template.
+        # B partition: records for configs that did NOT fire this template.
+        # Excluded from B regardless of include_exceptions:
+        #   - subprocess_died: worker never reached the emission site.
+        #   - exception: we don't know whether the template would have been
+        #     emitted had the exception not fired.
+        # Excluded from A unless include_exceptions: exception records are
+        # not suitable evidence for warning-channel proposals.
+        fired_configs: list[dict[str, Any]] = []
+        not_fired_configs: list[dict[str, Any]] = []
+
+        for rec in records_by_engine.get(eng, []):
+            if rec.kwargs is None:
+                continue
+            if rec.config_hash in fired_hashes:
+                fired_configs.append(rec.kwargs)
+            else:
+                if rec.outcome in {"subprocess_died", "exception"}:
+                    continue
+                not_fired_configs.append(rec.kwargs)
+
+        match_fields = _infer_predicate(fired_configs, not_fired_configs)
+        evidence = _field_value_distribution(fired_configs, not_fired_configs)
+
+        rep = representative_by_key[(eng, template)]
+        channel = rep.channel
+        severity: Literal["warn", "error"] = "error" if channel == "runtime_exception" else "warn"
+        needs_review = match_fields is None or len(match_fields) >= 2
+
+        # Prefer the first fired config's kwargs as kwargs_positive evidence
+        # so reviewers see a concrete reproducer.
+        representative_kwargs: dict[str, Any] = fired_configs[0] if fired_configs else {}
+
+        proposals.append(
+            GapProposal(
+                normalised_template=template,
+                source_channel=channel,
+                engine=eng,  # type: ignore[arg-type]
+                library_version=rep.library_version,
+                match_fields=match_fields,
+                evidence_field_value_distribution=evidence,
+                fired_count=len(fired_configs),
+                not_fired_count=len(not_fired_configs),
+                representative_message=rep.representative_message,
+                walker_confidence="low",
+                needs_generalisation_review=needs_review,
+                severity=severity,
+                representative_kwargs=representative_kwargs,
+            )
+        )
+
+    return proposals
+
+
+# ---------------------------------------------------------------------------
+# JSONL loading + kwargs resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_study(
+    study_dir: Path,
+    engine_filter: str | None,
+    include_exceptions: bool,
+) -> list[_Record]:
+    """Return parsed records from one study dir; tolerant of missing files."""
+    jsonl_path = Path(study_dir) / RUNTIME_OBSERVATIONS_FILENAME
+    if not jsonl_path.exists():
+        logger.info("No %s in %s; skipping.", RUNTIME_OBSERVATIONS_FILENAME, study_dir)
+        return []
+
+    kwargs_by_hash = _load_kwargs_by_hash(Path(study_dir))
+
+    records: list[_Record] = []
+    with open(jsonl_path, encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping malformed JSONL line %d in %s.",
+                    line_no,
+                    jsonl_path,
+                )
+                continue
+            rec = _parse_record(raw, engine_filter, include_exceptions, kwargs_by_hash)
+            if rec is not None:
+                records.append(rec)
+    return records
+
+
+def _parse_record(
+    raw: dict[str, Any],
+    engine_filter: str | None,
+    include_exceptions: bool,
+    kwargs_by_hash: dict[str, dict[str, Any]],
+) -> _Record | None:
+    engine_str = str(raw.get("engine", ""))
+    if engine_str not in _ALLOWED_ENGINES:
+        return None
+    if engine_filter is not None and engine_str != engine_filter:
+        return None
+
+    outcome = str(raw.get("outcome", ""))
+    config_hash = str(raw.get("config_hash", ""))
+    library_version = str(raw.get("library_version", ""))
+
+    emissions: list[_Emission] = []
+
+    for warn in raw.get("warnings") or []:
+        template = str(warn.get("message_template") or "")
+        if not template:
+            continue
+        emissions.append(
+            _Emission(
+                template=template,
+                representative_message=str(warn.get("message") or template),
+                channel="warnings_warn",
+                config_hash=config_hash,
+                engine=engine_str,  # type: ignore[arg-type]
+                library_version=library_version,
+            )
+        )
+
+    for rec in raw.get("logger_records") or []:
+        template = str(rec.get("message_template") or "")
+        if not template:
+            continue
+        emissions.append(
+            _Emission(
+                template=template,
+                representative_message=str(rec.get("message") or template),
+                channel="logger_warning",
+                config_hash=config_hash,
+                engine=engine_str,  # type: ignore[arg-type]
+                library_version=library_version,
+            )
+        )
+
+    if include_exceptions and outcome == "exception":
+        exc = raw.get("exception") or {}
+        template = str(exc.get("message_template") or "")
+        if template:
+            emissions.append(
+                _Emission(
+                    template=template,
+                    representative_message=str(exc.get("message") or template),
+                    channel="runtime_exception",
+                    config_hash=config_hash,
+                    engine=engine_str,  # type: ignore[arg-type]
+                    library_version=library_version,
+                )
+            )
+
+    return _Record(
+        config_hash=config_hash,
+        engine=engine_str,  # type: ignore[arg-type]
+        library_version=library_version,
+        outcome=outcome,
+        emissions=emissions,
+        kwargs=kwargs_by_hash.get(config_hash),
+    )
+
+
+def _load_kwargs_by_hash(study_dir: Path) -> dict[str, dict[str, Any]]:
+    """Walk experiment subdirs, load ``_resolution.json`` sidecars.
+
+    Directory name ends with the 8-char config hash prefix. We key on the
+    *full* hash in the JSONL (not the 8-char prefix) so we need to derive a
+    reverse map. Two strategies:
+
+    1. Every ``_resolution.json`` contains the effective config — we hash it
+       ourselves to recover the full hash. But that re-implements the
+       canonical hasher and couples us to its internals.
+    2. Build a prefix-keyed map and accept that collisions within a single
+       study would conflate configs. On an 8-char hex prefix that's a ~10^-9
+       event per pair at study scale; negligible.
+
+    We use (2) and prefer it — the resolution log's effective dict IS the
+    flat, default-stripped view we want for predicate inference. Collision
+    risk is documented for reviewers.
+    """
+    if not study_dir.exists() or not study_dir.is_dir():
+        return {}
+
+    by_prefix: dict[str, dict[str, Any]] = {}
+    for entry in sorted(study_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        # Dir format: [{NNN}_]c{cycle}_{slug}_{hash8}
+        # Trailing token is always an 8-char hex hash.
+        parts = entry.name.rsplit("_", 1)
+        if len(parts) != 2:
+            continue
+        hash_prefix = parts[1]
+        if len(hash_prefix) != 8 or not all(c in "0123456789abcdef" for c in hash_prefix):
+            continue
+        resolution_path = entry / "_resolution.json"
+        if not resolution_path.exists():
+            continue
+        try:
+            payload = json.loads(resolution_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        overrides = payload.get("overrides") or {}
+        if not isinstance(overrides, dict):
+            continue
+        flat: dict[str, Any] = {}
+        for key, value in overrides.items():
+            if isinstance(value, dict) and "effective" in value:
+                flat[str(key)] = value["effective"]
+        by_prefix.setdefault(hash_prefix, flat)
+
+    # Expand to a full-hash lookup: any hash whose first 8 chars match.
+    # The JSONL record carries the full hash; its prefix is the key we built.
+    # Callers look up by full hash, so wrap with a proxy dict via __missing__?
+    # Simpler: return a dict whose keys are 8-char prefixes and let the caller
+    # slice. But _parse_record passes the full hash. Return a dict keyed on
+    # the full hash by propagating the prefix entry for every hash we've seen
+    # — but we don't know all hashes yet. Resolve this lazily with a wrapper.
+    return _PrefixLookupDict(by_prefix)
+
+
+class _PrefixLookupDict(dict):  # type: ignore[type-arg]
+    """Dict that resolves lookups via a config-hash-prefix-keyed backing map.
+
+    Keeps the caller's ``kwargs_by_hash[full_hash]`` API while the filesystem
+    layout only exposes 8-char prefixes.
+    """
+
+    def __init__(self, prefix_map: dict[str, dict[str, Any]]) -> None:
+        super().__init__()
+        self._prefix_map = prefix_map
+
+    def get(self, key: Any, default: Any = None) -> Any:  # type: ignore[override]
+        if not isinstance(key, str) or len(key) < 8:
+            return default
+        prefix = key[:8]
+        return self._prefix_map.get(prefix, default)
+
+    def __getitem__(self, key: str) -> dict[str, Any]:  # type: ignore[override]
+        if len(key) < 8:
+            raise KeyError(key)
+        return self._prefix_map[key[:8]]
+
+    def __contains__(self, key: object) -> bool:  # type: ignore[override]
+        if not isinstance(key, str) or len(key) < 8:
+            return False
+        return key[:8] in self._prefix_map
+
+
+# ---------------------------------------------------------------------------
+# Corpus template match
+# ---------------------------------------------------------------------------
+
+
+def _template_matched_by_corpus(template: str, corpus: VendoredRules) -> bool:
+    """Return True if the corpus already has a rule whose expected_outcome captures ``template``.
+
+    Match strategies (both supported for forward compat):
+
+    - ``observed_messages_regex``: list of anchored regexes written at rule
+      authoring time. Preferred because it captures value-specific
+      placeholders deliberately.
+    - ``observed_messages``: list of concrete emitted messages from the
+      vendored JSON overlay. We normalise each entry and compare templates
+      directly — a rule whose observed message normalises to the same
+      template is definitely firing for the same reason.
+    """
+    for rule in corpus.rules:
+        outcome = rule.expected_outcome
+        regexes = outcome.get("observed_messages_regex")
+        if isinstance(regexes, list):
+            for pat in regexes:
+                try:
+                    if re.match(str(pat), template):
+                        return True
+                except re.error:
+                    continue
+        observed = outcome.get("observed_messages")
+        if isinstance(observed, list):
+            for sample in observed:
+                if not isinstance(sample, str):
+                    continue
+                sample_template = normalise(sample).template
+                if sample_template == template:
+                    return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Predicate inference (arity 1 → 2 → 3 + present:true fallback)
+# ---------------------------------------------------------------------------
+
+
+def _infer_predicate(
+    fired: list[dict[str, Any]],
+    not_fired: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the smallest field-value dict that distinguishes A from B, or None.
+
+    The search tries arity 1, then 2, then 3 — the first arity whose tuple
+    is *uniformly* shared by every config in A and *not* shared by any
+    config in B wins.
+
+    ``present:true`` fallback: if no arity-1..3 equality predicate works,
+    look for a single field that is set (non-None) in every fired config
+    and not set (missing or None) in every not-fired config. This catches
+    "any sampling_params present triggers the warning" shapes that
+    equality-on-value never sees.
+    """
+    if not fired:
+        return None
+
+    fields = sorted({k for c in fired + not_fired for k in c})
+    if not fields:
+        return None
+
+    for arity in range(1, 4):
+        if arity > len(fields):
+            break
+        for fset in combinations(fields, arity):
+            a_tuples = {tuple(c.get(f) for f in fset) for c in fired}
+            if len(a_tuples) != 1:
+                continue
+            value_tuple = next(iter(a_tuples))
+            if any(
+                all(b.get(f) == v for f, v in zip(fset, value_tuple, strict=False))
+                for b in not_fired
+            ):
+                continue
+            return dict(zip(fset, value_tuple, strict=False))
+
+    # present:true fallback — single-field presence predicate.
+    for fname in fields:
+        if all(c.get(fname) is not None for c in fired) and all(
+            b.get(fname) is None for b in not_fired
+        ):
+            return {fname: {"present": True}}
+
+    return None
+
+
+def _field_value_distribution(
+    fired: list[dict[str, Any]],
+    not_fired: list[dict[str, Any]],
+) -> dict[str, dict[str, list[str]]]:
+    """Return per-field string-ified value sets for the A and B partitions.
+
+    Useful to reviewers when the inferred predicate is missing or narrow:
+    the distribution tells you which fields actually vary across the A
+    partition and which are constant.
+    """
+    out: dict[str, dict[str, list[str]]] = {}
+    fields = sorted({k for c in fired + not_fired for k in c})
+    for f in fields:
+        out[f] = {
+            "fired": sorted({str(c.get(f)) for c in fired}),
+            "not_fired": sorted({str(c.get(f)) for c in not_fired}),
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# YAML renderer
+# ---------------------------------------------------------------------------
+
+
+_BANNER = (
+    "# Rule fragment proposed by 'llem report-gaps'. Review and APPEND to\n"
+    "# configs/validation_rules/{engine}.yaml under the 'rules:' key.\n"
+    "# ----------------------------------------------------------------------\n"
+    "# walker_confidence: low — always, for runtime-derived rules.\n"
+    "# needs_generalisation_review: set when the predicate is narrow or\n"
+    "# missing. Reviewers must confirm severity, native_type, and predicate\n"
+    "# generalisation before merging.\n"
+)
+
+
+def render_yaml_fragment(proposal: GapProposal) -> str:
+    """Render one :class:`GapProposal` as a YAML document.
+
+    The output always parses through
+    :func:`llenergymeasure.config.vendored_rules.loader._parse_rule` — stub
+    fields carry placeholder values that are enum-valid even if
+    semantically vacuous, so the round-trip test can assert successful
+    parse without the stubs being mistaken for production data.
+    """
+    template = proposal.normalised_template
+    rule_id = _proposed_rule_id(proposal)
+    match_regex = build_template_regex(template)
+    match_fields: dict[str, Any] = dict(proposal.match_fields) if proposal.match_fields else {}
+    # Corpus convention: match.fields is always a dict; empty dict means
+    # "predicate not inferred — reviewer to fill in".
+
+    emission_channel = _emission_channel(proposal.source_channel)
+    outcome_value = "error" if proposal.severity == "error" else "warn"
+
+    proposal_doc: dict[str, Any] = {
+        "id": rule_id,
+        "engine": proposal.engine,
+        "library": proposal.engine,
+        "rule_under_test": (
+            "(runtime-derived) Library emitted normalised template; reviewer to confirm semantic."
+        ),
+        "severity": proposal.severity,
+        # Placeholder enum-valid native_type — reviewer to replace.
+        # Kept here (rather than omitted) because `_parse_rule` treats
+        # native_type as required.
+        "native_type": f"{proposal.engine}.<TODO: human — set concrete native type>",
+        "walker_source": {
+            "path": "<TODO: human — runtime-derived; no AST source>",
+            "method": "<TODO: human — no AST source>",
+            "line_at_scan": 0,
+            "walker_confidence": proposal.walker_confidence,
+        },
+        "match": {
+            "engine": proposal.engine,
+            "fields": match_fields,
+        },
+        "kwargs_positive": dict(proposal.representative_kwargs),
+        # kwargs_negative cannot be inferred from observations — reviewer
+        # hand-authors a known-clean config. Empty dict is accepted by the
+        # loader; we include it so the YAML round-trips.
+        "kwargs_negative": {},
+        "expected_outcome": {
+            "outcome": outcome_value,
+            "emission_channel": emission_channel,
+            "normalised_fields": [],
+            "observed_messages_regex": [match_regex],
+            "observed_messages": [proposal.representative_message],
+        },
+        "message_template": template,
+        "references": [
+            (
+                f"Observed in {proposal.fired_count} configs; "
+                f"absent in {proposal.not_fired_count} configs."
+            ),
+            f"Representative raw message: {proposal.representative_message!r}",
+        ],
+        "added_by": "runtime_warning",
+        "added_at": "<TODO: human — YYYY-MM-DD>",
+        "source_channel": proposal.source_channel,
+        "needs_generalisation_review": proposal.needs_generalisation_review,
+        "evidence_field_value_distribution": proposal.evidence_field_value_distribution,
+    }
+
+    body = yaml.safe_dump(
+        proposal_doc,
+        sort_keys=False,
+        default_flow_style=False,
+        width=100,
+    )
+    return _BANNER + body
+
+
+def _proposed_rule_id(proposal: GapProposal) -> str:
+    """Derive a reviewer-friendly rule id from the template.
+
+    Format: ``{engine}_runtime_{slug}`` where ``slug`` is a short,
+    stable-ish slice of the template with non-identifier characters
+    replaced. Collisions within a study are possible; reviewers rename on
+    merge, so we don't bother with a hash suffix here.
+    """
+    cleaned = re.sub(r"[^a-z0-9]+", "_", proposal.normalised_template.lower()).strip("_")
+    slug = cleaned[:40] or "unnamed"
+    return f"{proposal.engine}_runtime_{slug}"
+
+
+def _emission_channel(source: SourceChannel) -> str:
+    """Map the JSONL source_channel to a corpus-schema emission_channel value."""
+    if source == "runtime_exception":
+        return "runtime_exception"
+    if source == "warnings_warn":
+        return "warnings_warn"
+    return "logger_warning"

--- a/src/llenergymeasure/api/report_gaps.py
+++ b/src/llenergymeasure/api/report_gaps.py
@@ -1,45 +1,32 @@
 """``llem report-gaps`` — feedback-loop proposer for the rules corpus.
 
-Reads ``runtime_observations.jsonl`` caches emitted by
-:mod:`llenergymeasure.study.runtime_observations` across one or more study
-directories, groups captured warnings / log records by their normalised
-message template, partitions configs into *fired* (A) and *not fired* (B),
-and runs a small predicate-inference pass to propose corpus rules for
-templates that the existing rules corpus does not already match.
+Reads ``runtime_observations.jsonl`` emitted by
+:mod:`llenergymeasure.study.runtime_observations`, groups captured warnings
+and log records by their normalised message template, partitions configs
+into *fired* (A) and *not fired* (B), and proposes corpus rules for
+templates the existing rules corpus does not already match.
 
-Design notes:
+Design:
 
-- **No corpus mutation.** We emit YAML *fragments* to ``--out PATH`` with a
-  loud banner comment for a maintainer to splice into the live corpus. The
+- **No corpus mutation.** We emit YAML *fragments* to ``--out PATH``; the
   live ``configs/validation_rules/{engine}.yaml`` is never touched.
-- **Severity is mechanical.** ``severity: warn`` from log-channel emissions
-  and ``severity: error`` when ``--include-exceptions`` is set and the
-  record is an exception. ``walker_confidence`` is always ``low`` and we
-  always flag ``needs_generalisation_review`` when the predicate was narrow
-  or missing — the final call belongs to the human reviewer.
-- **Round-trip safe.** Every emitted fragment parses through
-  :func:`llenergymeasure.config.vendored_rules.loader._parse_rule` without
-  error. Required-but-unknown fields (``native_type``,
-  ``walker_source.{path,method,line_at_scan}``, ``references``) get
-  minimally-acceptable placeholder values plus ``# TODO: human`` markers so
-  reviewers know what to fill in.
-- **Sentinel filtering.** Records with ``outcome in {"subprocess_died",
-  "exception"}`` do not prove "the rule did not fire" — they prove "we don't
-  know". They are excluded from the B (not-fired) partition. When
-  ``include_exceptions=False`` (default), exception records are also
-  excluded from the A partition so the proposer only acts on recorded
-  warnings / log-channel emissions.
+- **Severity is mechanical.** ``warn`` for log-channel emissions;
+  ``error`` when ``include_exceptions=True`` and the record is an
+  exception. ``walker_confidence`` is always ``low``.
+- **Round-trip safe.** Fragments parse through
+  :func:`llenergymeasure.config.vendored_rules.loader._parse_rule`;
+  placeholders carry ``# TODO: human`` markers.
+- **Sentinel filtering.** ``subprocess_died`` / ``exception`` records
+  don't prove "rule didn't fire" — excluded from B always; excluded from
+  A unless ``include_exceptions=True``.
+- **Emission channels.** This module produces ``warnings_warn``,
+  ``logger_warning``, ``logger_warning_once``, and ``runtime_exception``
+  only — a documented subset of :data:`EmissionChannel`.
 
-Source of config kwargs for predicate inference:
-
-    Per-experiment ``_resolution.json`` sidecars (written by the runner
-    alongside ``result.json``). Each sidecar maps dotted field paths to
-    their effective values; we flatten these into ``dict[str, Any]`` per
-    config_hash so the inference algorithm can look for arity-1, arity-2,
-    arity-3 distinguishing value-tuples between fired and not-fired configs.
-
-    Experiments whose subprocess died before the sidecar was written have
-    no kwargs — they are skipped at partition time regardless of outcome.
+Source of config kwargs: per-experiment ``_resolution.json`` sidecars,
+flattened into ``dict[str, Any]`` per ``config_hash``. Located via
+``manifest.json`` when present (keyed on full hash), with an 8-char
+prefix-scan fallback for manifest-less studies.
 """
 
 from __future__ import annotations
@@ -56,6 +43,7 @@ import yaml
 
 from llenergymeasure.config.ssot import Engine
 from llenergymeasure.config.vendored_rules import (
+    EmissionChannel,
     VendoredRules,
     VendoredRulesLoader,
 )
@@ -65,8 +53,6 @@ from llenergymeasure.study.runtime_observations import RUNTIME_OBSERVATIONS_FILE
 __all__ = [
     "GapProposal",
     "ReportGapsError",
-    "SourceChannel",
-    "SupportedEngine",
     "find_runtime_gaps",
     "load_rules_corpus",
     "render_yaml_fragment",
@@ -74,25 +60,14 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-SupportedEngine = Literal["transformers", "vllm", "tensorrt"]
-"""Engine literal re-exported for the CLI layer (cli-boundary contract)."""
-
-SourceChannel = Literal["warnings_warn", "logger_warning", "runtime_exception"]
-"""Which JSONL-record channel the emission came from.
-
-Kept as a narrow literal so downstream renderers can switch on it without a
-try/except. Logger levels INFO/DEBUG are not included — the capture wrapper
-only emits log records at WARNING+ and the corpus only cares about
-user-visible emissions.
-"""
+#: Eight-hex-char prefix used as the fallback key when ``manifest.json``
+#: is missing. Collision risk ~10^-9 per pair at study scale; the manifest
+#: path avoids it entirely when available.
+_HASH_PREFIX_LEN = 8
 
 
 class ReportGapsError(Exception):
-    """Raised when ``find_runtime_gaps`` or ``render_yaml_fragment`` fails.
-
-    Thin wrapper so the CLI can surface a helpful message without leaking
-    implementation-specific exception types (IO, YAML) to the user.
-    """
+    """Raised when ``find_runtime_gaps`` fails with a user-actionable cause."""
 
 
 # ---------------------------------------------------------------------------
@@ -102,23 +77,17 @@ class ReportGapsError(Exception):
 
 @dataclass(frozen=True)
 class GapProposal:
-    """One proposed corpus rule for a single unmatched normalised template.
-
-    Carries everything ``render_yaml_fragment`` needs to produce a YAML
-    fragment that parses through :func:`_parse_rule`. The struct itself is
-    pure data — no IO, no side effects.
-    """
+    """One proposed corpus rule for a single unmatched normalised template."""
 
     normalised_template: str
-    source_channel: SourceChannel
-    engine: SupportedEngine
+    source_channel: EmissionChannel
+    engine: Engine
     library_version: str
     match_fields: dict[str, Any] | None
     evidence_field_value_distribution: dict[str, dict[str, list[str]]]
     fired_count: int
     not_fired_count: int
     representative_message: str
-    walker_confidence: Literal["low"]
     needs_generalisation_review: bool
     severity: Literal["warn", "error"]
     representative_kwargs: dict[str, Any] = field(default_factory=dict)
@@ -131,22 +100,18 @@ class GapProposal:
 
 @dataclass(frozen=True)
 class _Emission:
-    """One template-fired-by-a-config observation (in-memory only)."""
-
     template: str
     representative_message: str
-    channel: SourceChannel
+    channel: EmissionChannel
     config_hash: str
-    engine: SupportedEngine
+    engine: Engine
     library_version: str
 
 
 @dataclass(frozen=True)
 class _Record:
-    """Parsed JSONL record with resolved kwargs and derived emission list."""
-
     config_hash: str
-    engine: SupportedEngine
+    engine: Engine
     library_version: str
     outcome: str
     emissions: list[_Emission]
@@ -162,17 +127,27 @@ _ALLOWED_ENGINES: frozenset[str] = frozenset(e.value for e in Engine)
 
 
 def load_rules_corpus(
-    engines: list[SupportedEngine] | None = None,
+    engines: list[Engine] | list[str] | None = None,
     loader: VendoredRulesLoader | None = None,
 ) -> dict[str, VendoredRules]:
     """Load the rules corpus for each engine we may emit proposals against.
 
-    Engines missing a YAML corpus are skipped silently — a user scanning
-    only transformers studies shouldn't fail because there's no
-    ``tensorrt.yaml`` yet.
+    When ``loader`` is omitted, the memoised project-wide loader from
+    :func:`llenergymeasure.config.models._get_rules_loader` is used.
+    Tests inject a throwaway loader to sidestep the cache.
+
+    Engines without a YAML corpus are skipped silently — a user scanning
+    only transformers studies shouldn't fail because ``tensorrt.yaml`` is
+    absent.
     """
-    loader = loader or VendoredRulesLoader()
-    wanted = list(engines) if engines is not None else [e.value for e in Engine]
+    if loader is None:
+        # Lazy import keeps this module free of a hard ``config.models``
+        # dependency at import time and matches that module's documented
+        # monkeypatch-via-setattr pattern.
+        from llenergymeasure.config.models import _get_rules_loader
+
+        loader = _get_rules_loader()
+    wanted = [e.value for e in Engine] if engines is None else [str(e) for e in engines]
     out: dict[str, VendoredRules] = {}
     for engine in wanted:
         try:
@@ -180,6 +155,51 @@ def load_rules_corpus(
         except FileNotFoundError:
             logger.debug("No rules corpus for engine=%s; skipping match lookup.", engine)
     return out
+
+
+def _build_observed_template_index(
+    corpus: dict[str, VendoredRules],
+) -> dict[str, dict[str, frozenset[str]]]:
+    """Pre-normalise ``observed_messages`` once per rule at corpus-load time.
+
+    Means the hot unmatched-template loop does an O(1) set membership
+    probe rather than re-normalising every sample on every comparison.
+    """
+    index: dict[str, dict[str, frozenset[str]]] = {}
+    for engine_name, vr in corpus.items():
+        per_rule: dict[str, frozenset[str]] = {}
+        for rule in vr.rules:
+            observed = rule.expected_outcome.get("observed_messages")
+            if not isinstance(observed, list):
+                continue
+            templates = frozenset(normalise(s).template for s in observed if isinstance(s, str))
+            if templates:
+                per_rule[rule.id] = templates
+        index[engine_name] = per_rule
+    return index
+
+
+def _build_regex_index(
+    corpus: dict[str, VendoredRules],
+) -> dict[str, dict[str, tuple[re.Pattern[str], ...]]]:
+    """Compile ``observed_messages_regex`` once per rule at corpus-load time."""
+    index: dict[str, dict[str, tuple[re.Pattern[str], ...]]] = {}
+    for engine_name, vr in corpus.items():
+        per_rule: dict[str, tuple[re.Pattern[str], ...]] = {}
+        for rule in vr.rules:
+            regexes = rule.expected_outcome.get("observed_messages_regex")
+            if not isinstance(regexes, list):
+                continue
+            compiled: list[re.Pattern[str]] = []
+            for pat in regexes:
+                try:
+                    compiled.append(re.compile(str(pat)))
+                except re.error:
+                    continue
+            if compiled:
+                per_rule[rule.id] = tuple(compiled)
+        index[engine_name] = per_rule
+    return index
 
 
 # ---------------------------------------------------------------------------
@@ -190,38 +210,20 @@ def load_rules_corpus(
 def find_runtime_gaps(
     study_dirs: list[Path],
     rules_corpus: dict[str, VendoredRules] | None = None,
-    engine: str | None = None,
+    engine: Engine | str | None = None,
     include_exceptions: bool = False,
+    loader: VendoredRulesLoader | None = None,
 ) -> list[GapProposal]:
     """Scan one or more study directories and return unmatched-template proposals.
 
-    Args:
-        study_dirs: Study directories containing
-            ``runtime_observations.jsonl``. Missing JSONL files are ignored
-            with a log message — a study that produced no observations is a
-            valid (if useless) input.
-        rules_corpus: Pre-loaded per-engine corpus. When ``None`` the default
-            loader is used; engines without a YAML corpus are treated as
-            "no existing rules" and every template falls through to a
-            proposal.
-        engine: If set, only records matching this engine contribute
-            proposals. Filter applies before partitioning.
-        include_exceptions: If ``True``, records with
-            ``outcome == "exception"`` also produce candidate emissions
-            (marked ``source_channel="runtime_exception"`` and
-            ``severity="error"``). Default ``False`` — exceptions are a
-            separate feedback channel with different review semantics and
-            the design deliberately keeps this opt-in.
-
-    Returns:
-        One :class:`GapProposal` per unique unmatched normalised template.
-        Order is stable: sorted by (engine, normalised_template) so
-        diffing two runs is meaningful.
+    Order sorts by (engine, normalised_template). ``engine`` accepts an
+    :class:`Engine` enum or its string value. ``loader`` is only consulted
+    when ``rules_corpus`` is ``None``.
     """
     if not study_dirs:
         raise ReportGapsError("No study directories provided. Pass at least one --study-dir.")
 
-    engine_filter = engine
+    engine_filter: str | None = str(engine) if engine is not None else None
     if engine_filter is not None and engine_filter not in _ALLOWED_ENGINES:
         raise ReportGapsError(
             f"Unsupported engine filter: {engine_filter!r}. "
@@ -229,91 +231,86 @@ def find_runtime_gaps(
         )
 
     records: list[_Record] = []
+    sidecar_failures = 0
     for study_dir in study_dirs:
-        records.extend(_load_study(study_dir, engine_filter, include_exceptions))
+        study_records, study_failures = _load_study(
+            Path(study_dir), engine_filter, include_exceptions
+        )
+        records.extend(study_records)
+        sidecar_failures += study_failures
+    if sidecar_failures:
+        logger.warning(
+            "Skipped %d malformed _resolution.json sidecar(s); see prior WARNING log lines.",
+            sidecar_failures,
+        )
 
     if not records:
         return []
 
-    corpus = rules_corpus if rules_corpus is not None else load_rules_corpus()
+    corpus = rules_corpus if rules_corpus is not None else load_rules_corpus(loader=loader)
+    observed_index = _build_observed_template_index(corpus)
+    regex_index = _build_regex_index(corpus)
 
-    # Build unique (engine, template) → emissions map.
-    # Key on engine too because the same string emitted by two engines is
-    # conceptually two different rules (different native types, different
-    # severity conventions).
+    # Build unique (engine, template) → emissions map. Key on engine too
+    # because the same string emitted by two engines is conceptually two
+    # different rules (different native types, different severity).
     emissions_by_key: dict[tuple[str, str], list[_Emission]] = {}
     representative_by_key: dict[tuple[str, str], _Emission] = {}
-
     for rec in records:
         for emission in rec.emissions:
-            key = (emission.engine, emission.template)
+            key = (emission.engine.value, emission.template)
             emissions_by_key.setdefault(key, []).append(emission)
             representative_by_key.setdefault(key, emission)
 
-    # Partition records by engine once so the per-template loop stays O(1) per record.
     records_by_engine: dict[str, list[_Record]] = {}
     for rec in records:
-        records_by_engine.setdefault(rec.engine, []).append(rec)
+        records_by_engine.setdefault(rec.engine.value, []).append(rec)
 
     proposals: list[GapProposal] = []
     for (eng, template), emissions in sorted(emissions_by_key.items()):
-        corpus_entry = corpus.get(eng)
-        if corpus_entry is not None and _template_matched_by_corpus(template, corpus_entry):
+        if _template_matched_by_corpus(
+            template,
+            corpus.get(eng),
+            observed_index.get(eng, {}),
+            regex_index.get(eng, {}),
+        ):
             continue
 
         fired_hashes = {e.config_hash for e in emissions}
-
-        # A partition: records whose config fired this template.
-        # B partition: records for configs that did NOT fire this template.
-        # Excluded from B regardless of include_exceptions:
-        #   - subprocess_died: worker never reached the emission site.
-        #   - exception: we don't know whether the template would have been
-        #     emitted had the exception not fired.
-        # Excluded from A unless include_exceptions: exception records are
-        # not suitable evidence for warning-channel proposals.
         fired_configs: list[dict[str, Any]] = []
         not_fired_configs: list[dict[str, Any]] = []
-
         for rec in records_by_engine.get(eng, []):
             if rec.kwargs is None:
                 continue
             if rec.config_hash in fired_hashes:
                 fired_configs.append(rec.kwargs)
-            else:
-                if rec.outcome in {"subprocess_died", "exception"}:
-                    continue
+            elif rec.outcome not in {"subprocess_died", "exception"}:
                 not_fired_configs.append(rec.kwargs)
 
         match_fields = _infer_predicate(fired_configs, not_fired_configs)
         evidence = _field_value_distribution(fired_configs, not_fired_configs)
-
         rep = representative_by_key[(eng, template)]
-        channel = rep.channel
-        severity: Literal["warn", "error"] = "error" if channel == "runtime_exception" else "warn"
+        severity: Literal["warn", "error"] = (
+            "error" if rep.channel == "runtime_exception" else "warn"
+        )
         needs_review = match_fields is None or len(match_fields) >= 2
-
-        # Prefer the first fired config's kwargs as kwargs_positive evidence
-        # so reviewers see a concrete reproducer.
-        representative_kwargs: dict[str, Any] = fired_configs[0] if fired_configs else {}
 
         proposals.append(
             GapProposal(
                 normalised_template=template,
-                source_channel=channel,
-                engine=eng,  # type: ignore[arg-type]
+                source_channel=rep.channel,
+                engine=rep.engine,
                 library_version=rep.library_version,
                 match_fields=match_fields,
                 evidence_field_value_distribution=evidence,
                 fired_count=len(fired_configs),
                 not_fired_count=len(not_fired_configs),
                 representative_message=rep.representative_message,
-                walker_confidence="low",
                 needs_generalisation_review=needs_review,
                 severity=severity,
-                representative_kwargs=representative_kwargs,
+                representative_kwargs=fired_configs[0] if fired_configs else {},
             )
         )
-
     return proposals
 
 
@@ -322,18 +319,53 @@ def find_runtime_gaps(
 # ---------------------------------------------------------------------------
 
 
+# Table driving the two record-level list emission sources. Each entry is
+# ``(jsonl_list_key, emission_channel, template_field)``. Exception records
+# are a single-dict shape and get their own append block below.
+_EMISSION_SOURCES: tuple[tuple[str, EmissionChannel, str], ...] = (
+    ("warnings", "warnings_warn", "message_template"),
+    ("logger_records", "logger_warning", "message_template"),
+)
+
+
+def _append_emission(
+    emissions: list[_Emission],
+    item: dict[str, Any],
+    channel: EmissionChannel,
+    template_field: str,
+    *,
+    config_hash: str,
+    engine: Engine,
+    library_version: str,
+) -> None:
+    """Append one :class:`_Emission` if ``item`` carries a non-empty template."""
+    template = str(item.get(template_field) or "")
+    if not template:
+        return
+    emissions.append(
+        _Emission(
+            template=template,
+            representative_message=str(item.get("message") or template),
+            channel=channel,
+            config_hash=config_hash,
+            engine=engine,
+            library_version=library_version,
+        )
+    )
+
+
 def _load_study(
     study_dir: Path,
     engine_filter: str | None,
     include_exceptions: bool,
-) -> list[_Record]:
-    """Return parsed records from one study dir; tolerant of missing files."""
-    jsonl_path = Path(study_dir) / RUNTIME_OBSERVATIONS_FILENAME
+) -> tuple[list[_Record], int]:
+    """Return (records, sidecar_failure_count) for one study dir."""
+    jsonl_path = study_dir / RUNTIME_OBSERVATIONS_FILENAME
     if not jsonl_path.exists():
         logger.info("No %s in %s; skipping.", RUNTIME_OBSERVATIONS_FILENAME, study_dir)
-        return []
+        return [], 0
 
-    kwargs_by_hash = _load_kwargs_by_hash(Path(study_dir))
+    kwargs_by_hash, sidecar_failures = _load_kwargs_by_hash(study_dir)
 
     records: list[_Record] = []
     with open(jsonl_path, encoding="utf-8") as fh:
@@ -344,16 +376,12 @@ def _load_study(
             try:
                 raw = json.loads(line)
             except json.JSONDecodeError:
-                logger.warning(
-                    "Skipping malformed JSONL line %d in %s.",
-                    line_no,
-                    jsonl_path,
-                )
+                logger.warning("Skipping malformed JSONL line %d in %s.", line_no, jsonl_path)
                 continue
             rec = _parse_record(raw, engine_filter, include_exceptions, kwargs_by_hash)
             if rec is not None:
                 records.append(rec)
-    return records
+    return records, sidecar_failures
 
 
 def _parse_record(
@@ -367,61 +395,37 @@ def _parse_record(
         return None
     if engine_filter is not None and engine_str != engine_filter:
         return None
-
+    engine_enum = Engine(engine_str)
     outcome = str(raw.get("outcome", ""))
     config_hash = str(raw.get("config_hash", ""))
     library_version = str(raw.get("library_version", ""))
 
     emissions: list[_Emission] = []
-
-    for warn in raw.get("warnings") or []:
-        template = str(warn.get("message_template") or "")
-        if not template:
-            continue
-        emissions.append(
-            _Emission(
-                template=template,
-                representative_message=str(warn.get("message") or template),
-                channel="warnings_warn",
+    for list_key, channel, template_field in _EMISSION_SOURCES:
+        for item in raw.get(list_key) or []:
+            _append_emission(
+                emissions,
+                item,
+                channel,
+                template_field,
                 config_hash=config_hash,
-                engine=engine_str,  # type: ignore[arg-type]
+                engine=engine_enum,
                 library_version=library_version,
             )
-        )
-
-    for rec in raw.get("logger_records") or []:
-        template = str(rec.get("message_template") or "")
-        if not template:
-            continue
-        emissions.append(
-            _Emission(
-                template=template,
-                representative_message=str(rec.get("message") or template),
-                channel="logger_warning",
-                config_hash=config_hash,
-                engine=engine_str,  # type: ignore[arg-type]
-                library_version=library_version,
-            )
-        )
-
     if include_exceptions and outcome == "exception":
-        exc = raw.get("exception") or {}
-        template = str(exc.get("message_template") or "")
-        if template:
-            emissions.append(
-                _Emission(
-                    template=template,
-                    representative_message=str(exc.get("message") or template),
-                    channel="runtime_exception",
-                    config_hash=config_hash,
-                    engine=engine_str,  # type: ignore[arg-type]
-                    library_version=library_version,
-                )
-            )
+        _append_emission(
+            emissions,
+            raw.get("exception") or {},
+            "runtime_exception",
+            "message_template",
+            config_hash=config_hash,
+            engine=engine_enum,
+            library_version=library_version,
+        )
 
     return _Record(
         config_hash=config_hash,
-        engine=engine_str,  # type: ignore[arg-type]
+        engine=engine_enum,
         library_version=library_version,
         outcome=outcome,
         emissions=emissions,
@@ -429,70 +433,117 @@ def _parse_record(
     )
 
 
-def _load_kwargs_by_hash(study_dir: Path) -> dict[str, dict[str, Any]]:
-    """Walk experiment subdirs, load ``_resolution.json`` sidecars.
+def _load_kwargs_by_hash(study_dir: Path) -> tuple[dict[str, dict[str, Any]], int]:
+    """Return ``({full_config_hash: flat_kwargs_dict}, sidecar_failure_count)``.
 
-    Directory name ends with the 8-char config hash prefix. We key on the
-    *full* hash in the JSONL (not the 8-char prefix) so we need to derive a
-    reverse map. Two strategies:
+    Preferred path: read ``manifest.json`` (written by
+    :class:`llenergymeasure.study.manifest.ManifestWriter`) which keys
+    entries by full ``config_hash`` and records the ``result_file``
+    relative path — ``_resolution.json`` sits in the same directory.
 
-    1. Every ``_resolution.json`` contains the effective config — we hash it
-       ourselves to recover the full hash. But that re-implements the
-       canonical hasher and couples us to its internals.
-    2. Build a prefix-keyed map and accept that collisions within a single
-       study would conflate configs. On an 8-char hex prefix that's a ~10^-9
-       event per pair at study scale; negligible.
-
-    We use (2) and prefer it — the resolution log's effective dict IS the
-    flat, default-stripped view we want for predicate inference. Collision
-    risk is documented for reviewers.
+    Fallback path: scan experiment subdirs and key on the 8-char hex
+    suffix. Logged as a warning so operators know the preferred lookup
+    is unavailable.
     """
     if not study_dir.exists() or not study_dir.is_dir():
-        return {}
+        return {}, 0
+    manifest_path = study_dir / "manifest.json"
+    if manifest_path.exists():
+        return _load_kwargs_via_manifest(study_dir, manifest_path)
+    logger.warning(
+        "manifest.json not found in %s; falling back to prefix-scan (collision risk ~1e-9).",
+        study_dir,
+    )
+    return _load_kwargs_via_prefix_scan(study_dir)
 
+
+def _load_kwargs_via_manifest(
+    study_dir: Path, manifest_path: Path
+) -> tuple[dict[str, dict[str, Any]], int]:
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read manifest.json at %s: %s", manifest_path, exc)
+        return {}, 0
+    by_hash: dict[str, dict[str, Any]] = {}
+    failures = 0
+    for entry in manifest.get("experiments") or []:
+        if not isinstance(entry, dict):
+            continue
+        config_hash = str(entry.get("config_hash") or "")
+        result_file = entry.get("result_file")
+        if not config_hash or not isinstance(result_file, str) or not result_file:
+            continue
+        if config_hash in by_hash:
+            # Same config can repeat across cycles; one flat dict suffices.
+            continue
+        resolution_path = study_dir / Path(result_file).parent / "_resolution.json"
+        if not resolution_path.exists():
+            continue
+        flat, failed = _read_resolution_sidecar(resolution_path)
+        if failed:
+            failures += 1
+            continue
+        if flat is not None:
+            by_hash[config_hash] = flat
+    return by_hash, failures
+
+
+def _load_kwargs_via_prefix_scan(
+    study_dir: Path,
+) -> tuple[dict[str, dict[str, Any]], int]:
+    """Fallback: walk subdirs with ``*_{hash8}`` suffix; key on full hash."""
     by_prefix: dict[str, dict[str, Any]] = {}
+    failures = 0
     for entry in sorted(study_dir.iterdir()):
         if not entry.is_dir():
             continue
         # Dir format: [{NNN}_]c{cycle}_{slug}_{hash8}
-        # Trailing token is always an 8-char hex hash.
         parts = entry.name.rsplit("_", 1)
         if len(parts) != 2:
             continue
         hash_prefix = parts[1]
-        if len(hash_prefix) != 8 or not all(c in "0123456789abcdef" for c in hash_prefix):
+        if len(hash_prefix) != _HASH_PREFIX_LEN or not all(
+            c in "0123456789abcdef" for c in hash_prefix
+        ):
             continue
         resolution_path = entry / "_resolution.json"
         if not resolution_path.exists():
             continue
-        try:
-            payload = json.loads(resolution_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        flat, failed = _read_resolution_sidecar(resolution_path)
+        if failed:
+            failures += 1
             continue
-        overrides = payload.get("overrides") or {}
-        if not isinstance(overrides, dict):
-            continue
-        flat: dict[str, Any] = {}
-        for key, value in overrides.items():
-            if isinstance(value, dict) and "effective" in value:
-                flat[str(key)] = value["effective"]
-        by_prefix.setdefault(hash_prefix, flat)
-
-    # Expand to a full-hash lookup: any hash whose first 8 chars match.
-    # The JSONL record carries the full hash; its prefix is the key we built.
-    # Callers look up by full hash, so wrap with a proxy dict via __missing__?
-    # Simpler: return a dict whose keys are 8-char prefixes and let the caller
-    # slice. But _parse_record passes the full hash. Return a dict keyed on
-    # the full hash by propagating the prefix entry for every hash we've seen
-    # — but we don't know all hashes yet. Resolve this lazily with a wrapper.
-    return _PrefixLookupDict(by_prefix)
+        if flat is not None:
+            by_prefix.setdefault(hash_prefix, flat)
+    return _PrefixHashLookup(by_prefix), failures
 
 
-class _PrefixLookupDict(dict):  # type: ignore[type-arg]
-    """Dict that resolves lookups via a config-hash-prefix-keyed backing map.
+def _read_resolution_sidecar(
+    path: Path,
+) -> tuple[dict[str, Any] | None, bool]:
+    """Parse ``_resolution.json`` at ``path``; return (flat_dict or None, failed)."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to parse _resolution.json at %s: %s", path, exc)
+        return None, True
+    overrides = payload.get("overrides") or {}
+    if not isinstance(overrides, dict):
+        return None, False
+    flat: dict[str, Any] = {}
+    for key, value in overrides.items():
+        if isinstance(value, dict) and "effective" in value:
+            flat[str(key)] = value["effective"]
+    return flat, False
 
-    Keeps the caller's ``kwargs_by_hash[full_hash]`` API while the filesystem
-    layout only exposes 8-char prefixes.
+
+class _PrefixHashLookup(dict):  # type: ignore[type-arg]
+    """Prefix-scan fallback: ``.get(full_hash)`` resolves via first 8 hex chars.
+
+    Subclasses ``dict`` so the call site's type annotation
+    (``dict[str, dict[str, Any]]``) still holds. Only ``.get`` is
+    consulted by callers.
     """
 
     def __init__(self, prefix_map: dict[str, dict[str, Any]]) -> None:
@@ -500,20 +551,9 @@ class _PrefixLookupDict(dict):  # type: ignore[type-arg]
         self._prefix_map = prefix_map
 
     def get(self, key: Any, default: Any = None) -> Any:  # type: ignore[override]
-        if not isinstance(key, str) or len(key) < 8:
+        if not isinstance(key, str) or len(key) < _HASH_PREFIX_LEN:
             return default
-        prefix = key[:8]
-        return self._prefix_map.get(prefix, default)
-
-    def __getitem__(self, key: str) -> dict[str, Any]:  # type: ignore[override]
-        if len(key) < 8:
-            raise KeyError(key)
-        return self._prefix_map[key[:8]]
-
-    def __contains__(self, key: object) -> bool:  # type: ignore[override]
-        if not isinstance(key, str) or len(key) < 8:
-            return False
-        return key[:8] in self._prefix_map
+        return self._prefix_map.get(key[:_HASH_PREFIX_LEN], default)
 
 
 # ---------------------------------------------------------------------------
@@ -521,37 +561,28 @@ class _PrefixLookupDict(dict):  # type: ignore[type-arg]
 # ---------------------------------------------------------------------------
 
 
-def _template_matched_by_corpus(template: str, corpus: VendoredRules) -> bool:
-    """Return True if the corpus already has a rule whose expected_outcome captures ``template``.
+def _template_matched_by_corpus(
+    template: str,
+    corpus: VendoredRules | None,
+    observed_templates_by_rule: dict[str, frozenset[str]],
+    regexes_by_rule: dict[str, tuple[re.Pattern[str], ...]],
+) -> bool:
+    """Return True if any corpus rule already captures ``template``.
 
-    Match strategies (both supported for forward compat):
-
-    - ``observed_messages_regex``: list of anchored regexes written at rule
-      authoring time. Preferred because it captures value-specific
-      placeholders deliberately.
-    - ``observed_messages``: list of concrete emitted messages from the
-      vendored JSON overlay. We normalise each entry and compare templates
-      directly — a rule whose observed message normalises to the same
-      template is definitely firing for the same reason.
+    Both match strategies use pre-computed indexes:
+    - ``observed_messages_regex`` compiled once at corpus-load time.
+    - ``observed_messages`` pre-normalised once at corpus-load time so
+      the inner probe is O(1) set membership.
     """
+    if corpus is None:
+        return False
     for rule in corpus.rules:
-        outcome = rule.expected_outcome
-        regexes = outcome.get("observed_messages_regex")
-        if isinstance(regexes, list):
-            for pat in regexes:
-                try:
-                    if re.match(str(pat), template):
-                        return True
-                except re.error:
-                    continue
-        observed = outcome.get("observed_messages")
-        if isinstance(observed, list):
-            for sample in observed:
-                if not isinstance(sample, str):
-                    continue
-                sample_template = normalise(sample).template
-                if sample_template == template:
-                    return True
+        patterns = regexes_by_rule.get(rule.id)
+        if patterns is not None and any(pat.match(template) for pat in patterns):
+            return True
+        observed = observed_templates_by_rule.get(rule.id)
+        if observed is not None and template in observed:
+            return True
     return False
 
 
@@ -566,19 +597,12 @@ def _infer_predicate(
 ) -> dict[str, Any] | None:
     """Return the smallest field-value dict that distinguishes A from B, or None.
 
-    The search tries arity 1, then 2, then 3 — the first arity whose tuple
-    is *uniformly* shared by every config in A and *not* shared by any
-    config in B wins.
-
-    ``present:true`` fallback: if no arity-1..3 equality predicate works,
-    look for a single field that is set (non-None) in every fired config
-    and not set (missing or None) in every not-fired config. This catches
-    "any sampling_params present triggers the warning" shapes that
-    equality-on-value never sees.
+    Tries arity 1, 2, 3; the first arity whose tuple is uniformly shared
+    across A and absent in B wins. ``present:true`` fallback catches "any
+    non-None value triggers" shapes that equality-on-value never sees.
     """
     if not fired:
         return None
-
     fields = sorted({k for c in fired + not_fired for k in c})
     if not fields:
         return None
@@ -598,13 +622,11 @@ def _infer_predicate(
                 continue
             return dict(zip(fset, value_tuple, strict=False))
 
-    # present:true fallback — single-field presence predicate.
     for fname in fields:
         if all(c.get(fname) is not None for c in fired) and all(
             b.get(fname) is None for b in not_fired
         ):
             return {fname: {"present": True}}
-
     return None
 
 
@@ -612,12 +634,7 @@ def _field_value_distribution(
     fired: list[dict[str, Any]],
     not_fired: list[dict[str, Any]],
 ) -> dict[str, dict[str, list[str]]]:
-    """Return per-field string-ified value sets for the A and B partitions.
-
-    Useful to reviewers when the inferred predicate is missing or narrow:
-    the distribution tells you which fields actually vary across the A
-    partition and which are constant.
-    """
+    """Return per-field string-ified value sets for the A and B partitions."""
     out: dict[str, dict[str, list[str]]] = {}
     fields = sorted({k for c in fired + not_fired for k in c})
     for f in fields:
@@ -648,53 +665,38 @@ def render_yaml_fragment(proposal: GapProposal) -> str:
     """Render one :class:`GapProposal` as a YAML document.
 
     The output always parses through
-    :func:`llenergymeasure.config.vendored_rules.loader._parse_rule` — stub
-    fields carry placeholder values that are enum-valid even if
-    semantically vacuous, so the round-trip test can assert successful
-    parse without the stubs being mistaken for production data.
+    :func:`llenergymeasure.config.vendored_rules.loader._parse_rule` —
+    placeholder fields are enum-valid so the round-trip test passes while
+    the ``# TODO: human`` markers make stubs obvious to reviewers.
     """
     template = proposal.normalised_template
-    rule_id = _proposed_rule_id(proposal)
-    match_regex = build_template_regex(template)
     match_fields: dict[str, Any] = dict(proposal.match_fields) if proposal.match_fields else {}
-    # Corpus convention: match.fields is always a dict; empty dict means
-    # "predicate not inferred — reviewer to fill in".
-
-    emission_channel = _emission_channel(proposal.source_channel)
     outcome_value = "error" if proposal.severity == "error" else "warn"
+    engine_str = proposal.engine.value
 
     proposal_doc: dict[str, Any] = {
-        "id": rule_id,
-        "engine": proposal.engine,
-        "library": proposal.engine,
+        "id": _proposed_rule_id(proposal),
+        "engine": engine_str,
+        "library": engine_str,
         "rule_under_test": (
             "(runtime-derived) Library emitted normalised template; reviewer to confirm semantic."
         ),
         "severity": proposal.severity,
-        # Placeholder enum-valid native_type — reviewer to replace.
-        # Kept here (rather than omitted) because `_parse_rule` treats
-        # native_type as required.
-        "native_type": f"{proposal.engine}.<TODO: human — set concrete native type>",
+        "native_type": f"{engine_str}.<TODO: human — set concrete native type>",
         "walker_source": {
             "path": "<TODO: human — runtime-derived; no AST source>",
             "method": "<TODO: human — no AST source>",
             "line_at_scan": 0,
-            "walker_confidence": proposal.walker_confidence,
+            "walker_confidence": "low",
         },
-        "match": {
-            "engine": proposal.engine,
-            "fields": match_fields,
-        },
+        "match": {"engine": engine_str, "fields": match_fields},
         "kwargs_positive": dict(proposal.representative_kwargs),
-        # kwargs_negative cannot be inferred from observations — reviewer
-        # hand-authors a known-clean config. Empty dict is accepted by the
-        # loader; we include it so the YAML round-trips.
         "kwargs_negative": {},
         "expected_outcome": {
             "outcome": outcome_value,
-            "emission_channel": emission_channel,
+            "emission_channel": proposal.source_channel,
             "normalised_fields": [],
-            "observed_messages_regex": [match_regex],
+            "observed_messages_regex": [build_template_regex(template)],
             "observed_messages": [proposal.representative_message],
         },
         "message_template": template,
@@ -712,32 +714,12 @@ def render_yaml_fragment(proposal: GapProposal) -> str:
         "evidence_field_value_distribution": proposal.evidence_field_value_distribution,
     }
 
-    body = yaml.safe_dump(
-        proposal_doc,
-        sort_keys=False,
-        default_flow_style=False,
-        width=100,
-    )
+    body = yaml.safe_dump(proposal_doc, sort_keys=False, default_flow_style=False, width=100)
     return _BANNER + body
 
 
 def _proposed_rule_id(proposal: GapProposal) -> str:
-    """Derive a reviewer-friendly rule id from the template.
-
-    Format: ``{engine}_runtime_{slug}`` where ``slug`` is a short,
-    stable-ish slice of the template with non-identifier characters
-    replaced. Collisions within a study are possible; reviewers rename on
-    merge, so we don't bother with a hash suffix here.
-    """
+    """Return ``{engine}_runtime_{slug}`` for a reviewer-friendly rule id."""
     cleaned = re.sub(r"[^a-z0-9]+", "_", proposal.normalised_template.lower()).strip("_")
     slug = cleaned[:40] or "unnamed"
-    return f"{proposal.engine}_runtime_{slug}"
-
-
-def _emission_channel(source: SourceChannel) -> str:
-    """Map the JSONL source_channel to a corpus-schema emission_channel value."""
-    if source == "runtime_exception":
-        return "runtime_exception"
-    if source == "warnings_warn":
-        return "warnings_warn"
-    return "logger_warning"
+    return f"{proposal.engine.value}_runtime_{slug}"

--- a/src/llenergymeasure/cli/__init__.py
+++ b/src/llenergymeasure/cli/__init__.py
@@ -102,6 +102,13 @@ app.command(
     help="Verify Docker images match the host ExperimentConfig schema",
 )(_doctor_cmd)
 
+from llenergymeasure.cli.report_gaps import report_gaps_cmd as _report_gaps_cmd  # noqa: E402
+
+app.command(
+    name="report-gaps",
+    help="Propose rules corpus entries from runtime observations",
+)(_report_gaps_cmd)
+
 __all__ = ["app"]
 
 if __name__ == "__main__":

--- a/src/llenergymeasure/cli/report_gaps.py
+++ b/src/llenergymeasure/cli/report_gaps.py
@@ -1,0 +1,101 @@
+"""``llem report-gaps`` — propose corpus rules from captured runtime observations.
+
+Thin Typer command that delegates everything interesting to
+:mod:`llenergymeasure.api.report_gaps`. CLI-boundary contract: imports only
+from ``llenergymeasure.api``; never reaches into ``study``/``harness``/etc.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from llenergymeasure.api import (
+    ReportGapsError,
+    find_runtime_gaps,
+    render_yaml_fragment,
+)
+
+__all__ = ["report_gaps_cmd"]
+
+
+def report_gaps_cmd(
+    source: Annotated[
+        str,
+        typer.Option(
+            "--source",
+            help="Feedback source to scan. Only 'runtime-warnings' is wired in this release.",
+        ),
+    ] = "runtime-warnings",
+    study_dir: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "--study-dir",
+            help="Study directory to scan. Repeat the flag to pass multiple.",
+        ),
+    ] = None,
+    engine: Annotated[
+        str | None,
+        typer.Option(
+            "--engine",
+            help="Filter: only propose rules for this engine (transformers/vllm/tensorrt).",
+        ),
+    ] = None,
+    out: Annotated[
+        Path | None,
+        typer.Option(
+            "--out",
+            help="Output path for proposed YAML fragments (one YAML document per gap, separated by '---').",
+        ),
+    ] = None,
+    include_exceptions: Annotated[
+        bool,
+        typer.Option(
+            "--include-exceptions",
+            help=(
+                "Also propose rules from runtime exceptions. "
+                "Disabled by default; exceptions ship through a different review path."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Propose rules corpus entries from captured runtime observations."""
+    if source != "runtime-warnings":
+        raise typer.BadParameter(
+            f"Unsupported source {source!r}. Only 'runtime-warnings' is wired in this release.",
+            param_hint="--source",
+        )
+    if not study_dir:
+        raise typer.BadParameter(
+            "At least one --study-dir is required.",
+            param_hint="--study-dir",
+        )
+    if out is None:
+        raise typer.BadParameter(
+            "--out PATH is required (YAML fragment output path).",
+            param_hint="--out",
+        )
+
+    try:
+        proposals = find_runtime_gaps(
+            study_dirs=list(study_dir),
+            engine=engine,
+            include_exceptions=include_exceptions,
+        )
+    except ReportGapsError as exc:
+        print(f"llem report-gaps: {exc}", file=sys.stderr)
+        raise typer.Exit(code=2) from None
+
+    if not proposals:
+        print("No gaps found in the scanned study dirs.")
+        return
+
+    fragments = [render_yaml_fragment(p) for p in proposals]
+    body = "\n---\n".join(fragments)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(body, encoding="utf-8")
+
+    print(f"{len(proposals)} gap(s) found. Wrote to {out}.")

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers (not pytest fixtures)."""

--- a/tests/helpers/runtime_obs.py
+++ b/tests/helpers/runtime_obs.py
@@ -1,0 +1,109 @@
+"""Shared fixture helpers for ``report-gaps`` tests.
+
+Used by both :mod:`tests.unit.api.test_report_gaps` and
+:mod:`tests.unit.cli.test_report_gaps` so the JSONL + sidecar shapes stay
+in lock-step with :mod:`llenergymeasure.study.runtime_observations` and
+:mod:`llenergymeasure.study.manifest`.
+
+These are plain module-level functions (not pytest fixtures) because each
+call takes per-emission parameters like ``index`` and ``full_hash``; the
+fixture form would require one fixture per call pattern.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def fake_hash(*parts: Any) -> str:
+    """Build a deterministic 64-char hex hash keyed by ``parts``."""
+    raw = "|".join(str(p) for p in parts).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def write_resolution(
+    study_dir: Path,
+    index: int,
+    cycle: int,
+    engine: str,
+    full_hash: str,
+    overrides: dict[str, Any],
+) -> Path:
+    """Create the experiment subdir + ``_resolution.json`` sidecar.
+
+    Returns the experiment subdirectory path so callers can write a
+    matching ``manifest.json`` entry pointing at it.
+    """
+    dir_name = f"{index:03d}_c{cycle}_gpt2-{engine}_{full_hash[:8]}"
+    subdir = study_dir / dir_name
+    subdir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "1.0",
+        "overrides": {k: {"effective": v, "source": "sweep"} for k, v in overrides.items()},
+    }
+    (subdir / "_resolution.json").write_text(json.dumps(payload))
+    return subdir
+
+
+def write_jsonl_record(
+    study_dir: Path,
+    *,
+    config_hash: str,
+    engine: str = "transformers",
+    library_version: str = "4.56.0",
+    cycle: int = 1,
+    outcome: str = "success",
+    warnings_emitted: list[str] | None = None,
+    logger_emitted: list[tuple[str, str]] | None = None,
+    exception: dict[str, Any] | None = None,
+    exit_reason: str | None = None,
+    exit_code: int | None = None,
+) -> None:
+    """Append one canonical JSONL record to ``runtime_observations.jsonl``.
+
+    Warnings/log records are passed as raw messages; this helper normalises
+    them to templates so fixtures stay readable. JSONL schema matches
+    :mod:`llenergymeasure.study.runtime_observations`.
+    """
+    from llenergymeasure.study.message_normalise import normalise
+
+    rec: dict[str, Any] = {
+        "schema_version": 1,
+        "observed_at": "2026-04-24T04:00:00Z",
+        "study_run_id": "fixture-run-id",
+        "config_hash": config_hash,
+        "cycle": cycle,
+        "engine": engine,
+        "library_version": library_version,
+        "outcome": outcome,
+        "warnings": [
+            {
+                "category": "UserWarning",
+                "message": w,
+                "message_template": normalise(w).template,
+                "filename": "fixture.py",
+                "lineno": 1,
+            }
+            for w in (warnings_emitted or [])
+        ],
+        "logger_records": [
+            {
+                "level": "WARNING",
+                "logger": lname,
+                "message": msg,
+                "message_template": normalise(msg).template,
+                "filename": "fixture.py",
+                "lineno": 1,
+            }
+            for (lname, msg) in (logger_emitted or [])
+        ],
+        "exception": exception,
+        "exit_reason": exit_reason,
+        "exit_code": exit_code,
+    }
+    path = study_dir / "runtime_observations.jsonl"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec) + "\n")

--- a/tests/unit/api/test_report_gaps.py
+++ b/tests/unit/api/test_report_gaps.py
@@ -1,0 +1,588 @@
+"""Unit tests for api/report_gaps.py — predicate inference, partitioning, YAML round-trip.
+
+All tests synthesise fixture study directories under ``tmp_path``. No GPU, no
+real JSONL from a live run. JSONL schema matches
+:mod:`llenergymeasure.study.runtime_observations`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from llenergymeasure.api.report_gaps import (
+    _field_value_distribution,
+    _infer_predicate,
+    _template_matched_by_corpus,
+    find_runtime_gaps,
+    render_yaml_fragment,
+)
+from llenergymeasure.config.vendored_rules import VendoredRules
+from llenergymeasure.config.vendored_rules.loader import _parse_envelope
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_hash(*parts: Any) -> str:
+    """Build a deterministic 64-char hex hash keyed by ``parts``."""
+    raw = "|".join(str(p) for p in parts).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _write_resolution(
+    study_dir: Path,
+    index: int,
+    cycle: int,
+    engine: str,
+    full_hash: str,
+    overrides: dict[str, Any],
+) -> None:
+    """Create the experiment subdir + ``_resolution.json`` sidecar."""
+    dir_name = f"{index:03d}_c{cycle}_gpt2-{engine}_{full_hash[:8]}"
+    subdir = study_dir / dir_name
+    subdir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "1.0",
+        "overrides": {k: {"effective": v, "source": "sweep"} for k, v in overrides.items()},
+    }
+    (subdir / "_resolution.json").write_text(json.dumps(payload))
+
+
+def _write_jsonl_record(
+    study_dir: Path,
+    *,
+    config_hash: str,
+    engine: str = "transformers",
+    library_version: str = "4.56.0",
+    cycle: int = 1,
+    outcome: str = "success",
+    warnings_emitted: list[str] | None = None,
+    logger_emitted: list[tuple[str, str]] | None = None,
+    exception: dict[str, Any] | None = None,
+    exit_reason: str | None = None,
+    exit_code: int | None = None,
+) -> None:
+    """Append one canonical JSONL record to ``runtime_observations.jsonl``.
+
+    Parameters mirror the schema doc in the brief. Warnings/log records are
+    passed as raw messages; we normalise to templates here so fixtures stay
+    readable.
+    """
+    from llenergymeasure.study.message_normalise import normalise
+
+    rec: dict[str, Any] = {
+        "schema_version": 1,
+        "observed_at": "2026-04-24T04:00:00Z",
+        "study_run_id": "fixture-run-id",
+        "config_hash": config_hash,
+        "cycle": cycle,
+        "engine": engine,
+        "library_version": library_version,
+        "outcome": outcome,
+        "warnings": [
+            {
+                "category": "UserWarning",
+                "message": w,
+                "message_template": normalise(w).template,
+                "filename": "fixture.py",
+                "lineno": 1,
+            }
+            for w in (warnings_emitted or [])
+        ],
+        "logger_records": [
+            {
+                "level": "WARNING",
+                "logger": lname,
+                "message": msg,
+                "message_template": normalise(msg).template,
+                "filename": "fixture.py",
+                "lineno": 1,
+            }
+            for (lname, msg) in (logger_emitted or [])
+        ],
+        "exception": exception,
+        "exit_reason": exit_reason,
+        "exit_code": exit_code,
+    }
+    path = study_dir / "runtime_observations.jsonl"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec) + "\n")
+
+
+def _build_empty_corpus() -> dict[str, VendoredRules]:
+    """Return an empty-rules corpus for transformers (so nothing suppresses gaps)."""
+    envelope = "schema_version: 1.0.0\nengine: transformers\nrules: []\n"
+    return {"transformers": _parse_envelope("transformers", envelope)}
+
+
+def _build_corpus_with_rule_matching(template_regex: str) -> dict[str, VendoredRules]:
+    """Corpus with one rule whose ``observed_messages_regex`` matches ``template_regex``.
+
+    Uses the minimal set of required fields expected by ``_parse_rule``.
+    """
+    envelope = f"""
+schema_version: 1.0.0
+engine: transformers
+rules:
+- id: t_runtime_existing
+  engine: transformers
+  severity: warn
+  native_type: transformers.Fixture
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample:
+        equals: false
+  kwargs_positive:
+    do_sample: false
+  kwargs_negative: {{}}
+  expected_outcome:
+    outcome: warn
+    emission_channel: logger_warning
+    observed_messages_regex:
+    - {json.dumps(template_regex)}
+  added_by: manual_seed
+"""
+    return {"transformers": _parse_envelope("transformers", envelope)}
+
+
+# ---------------------------------------------------------------------------
+# Predicate inference
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_inference_equality() -> None:
+    """Single-field equality is recovered cleanly."""
+    fired = [
+        {"do_sample": False, "temperature": 0.3, "top_p": 0.95},
+        {"do_sample": False, "temperature": 0.7, "top_p": 1.0},
+        {"do_sample": False, "temperature": 1.0, "top_p": 0.5},
+    ]
+    not_fired = [
+        {"do_sample": True, "temperature": 0.7, "top_p": 0.95},
+        {"do_sample": True, "temperature": 0.3, "top_p": 1.0},
+    ]
+    assert _infer_predicate(fired, not_fired) == {"do_sample": False}
+
+
+def test_predicate_inference_multi_field() -> None:
+    """Arity-2 predicate is recovered when no single field distinguishes."""
+    # temperature=0.0 fires only when do_sample=True (greedy-with-temp-0 rule).
+    fired = [
+        {"do_sample": True, "temperature": 0.0, "top_p": 0.95},
+        {"do_sample": True, "temperature": 0.0, "top_p": 1.0},
+    ]
+    not_fired = [
+        {"do_sample": True, "temperature": 0.7, "top_p": 0.95},
+        {"do_sample": False, "temperature": 0.0, "top_p": 0.95},
+        {"do_sample": False, "temperature": 0.7, "top_p": 0.95},
+    ]
+    assert _infer_predicate(fired, not_fired) == {"do_sample": True, "temperature": 0.0}
+
+
+def test_predicate_inference_range_fails_safely() -> None:
+    """Range predicate (varying fired values) returns None, evidence intact."""
+    fired = [
+        {"temperature": 0.001, "top_p": 0.95},
+        {"temperature": 0.005, "top_p": 1.0},
+        {"temperature": 0.0001, "top_p": 0.5},
+    ]
+    not_fired = [
+        {"temperature": 0.5, "top_p": 0.95},
+        {"temperature": 1.0, "top_p": 1.0},
+    ]
+    # Every fired config has a distinct temperature, so no single tuple is
+    # shared — arity-1, 2, 3 all fail. present:true fallback is also False
+    # because top_p is set in both partitions.
+    assert _infer_predicate(fired, not_fired) is None
+    evidence = _field_value_distribution(fired, not_fired)
+    # Sanity: evidence still lists the fired temperature values.
+    assert set(evidence["temperature"]["fired"]) == {"0.001", "0.005", "0.0001"}
+
+
+def test_present_true_fallback() -> None:
+    """Fields-set-vs-null recovers via present:true when equality fails."""
+    # quant config present in all fired; absent in all not_fired.
+    fired = [
+        {"quant": "bnb_4bit"},
+        {"quant": "bnb_8bit"},
+        {"quant": "awq"},
+    ]
+    not_fired = [
+        {"quant": None},
+        {"quant": None},
+    ]
+    got = _infer_predicate(fired, not_fired)
+    assert got == {"quant": {"present": True}}
+
+
+# ---------------------------------------------------------------------------
+# Partition filtering
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_records_excluded_from_b(tmp_path: Path) -> None:
+    """subprocess_died records don't pollute the B partition.
+
+    Setup: 2 configs fire the template; 1 sentinel config has the same
+    kwargs as the fired ones (would otherwise falsify the predicate). After
+    exclusion, the predicate stays inferable.
+    """
+    study = tmp_path / "study-1"
+    study.mkdir()
+
+    # 2 fired configs + 1 not-fired, all on do_sample=False.
+    # Sentinel config has do_sample=False too — would collide with fired if B included it.
+    hashes = {
+        "fire_a": _fake_hash("fire_a"),
+        "fire_b": _fake_hash("fire_b"),
+        "notfire": _fake_hash("notfire"),
+        "sentinel": _fake_hash("sentinel"),
+    }
+    _write_resolution(
+        study, 1, 1, "transformers", hashes["fire_a"], {"do_sample": False, "temperature": 0.5}
+    )
+    _write_resolution(
+        study, 2, 1, "transformers", hashes["fire_b"], {"do_sample": False, "temperature": 0.7}
+    )
+    _write_resolution(
+        study, 3, 1, "transformers", hashes["notfire"], {"do_sample": True, "temperature": 0.5}
+    )
+    _write_resolution(
+        study, 4, 1, "transformers", hashes["sentinel"], {"do_sample": False, "temperature": 0.7}
+    )
+
+    _write_jsonl_record(
+        study,
+        config_hash=hashes["fire_a"],
+        warnings_emitted=["temperature is ignored when do_sample is False"],
+    )
+    _write_jsonl_record(
+        study,
+        config_hash=hashes["fire_b"],
+        warnings_emitted=["temperature is ignored when do_sample is False"],
+    )
+    _write_jsonl_record(
+        study,
+        config_hash=hashes["notfire"],
+        outcome="success",
+    )
+    _write_jsonl_record(
+        study,
+        config_hash=hashes["sentinel"],
+        outcome="subprocess_died",
+        exit_reason="SIGKILL",
+        exit_code=-9,
+    )
+
+    gaps = find_runtime_gaps([study], rules_corpus=_build_empty_corpus())
+    assert len(gaps) == 1
+    gap = gaps[0]
+    assert gap.fired_count == 2
+    # B partition contains only the notfire config — the sentinel is excluded.
+    assert gap.not_fired_count == 1
+    assert gap.match_fields == {"do_sample": False}
+
+
+def test_exception_records_excluded_by_default(tmp_path: Path) -> None:
+    """Exception records are excluded from the B partition by default."""
+    study = tmp_path / "study-2"
+    study.mkdir()
+
+    hashes = {k: _fake_hash(k) for k in ("a", "b", "c", "exc")}
+    _write_resolution(study, 1, 1, "transformers", hashes["a"], {"do_sample": False})
+    _write_resolution(study, 2, 1, "transformers", hashes["b"], {"do_sample": False})
+    _write_resolution(study, 3, 1, "transformers", hashes["c"], {"do_sample": True})
+    _write_resolution(study, 4, 1, "transformers", hashes["exc"], {"do_sample": False})
+
+    _write_jsonl_record(study, config_hash=hashes["a"], warnings_emitted=["temperature ignored"])
+    _write_jsonl_record(study, config_hash=hashes["b"], warnings_emitted=["temperature ignored"])
+    _write_jsonl_record(study, config_hash=hashes["c"], outcome="success")
+    _write_jsonl_record(
+        study,
+        config_hash=hashes["exc"],
+        outcome="exception",
+        exception={
+            "type": "ValueError",
+            "message": "boom",
+            "message_template": "boom",
+            "traceback_truncated": "",
+        },
+    )
+
+    gaps = find_runtime_gaps([study], rules_corpus=_build_empty_corpus())
+    assert len(gaps) == 1
+    # exc record is excluded from B (would have had do_sample=False, breaking predicate).
+    # Predicate still resolves cleanly.
+    assert gaps[0].match_fields == {"do_sample": False}
+    assert gaps[0].fired_count == 2
+    assert gaps[0].not_fired_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Corpus suppression + engine filter
+# ---------------------------------------------------------------------------
+
+
+def test_existing_corpus_rule_suppresses_gap(tmp_path: Path) -> None:
+    """Templates matched by corpus ``observed_messages_regex`` don't produce gaps."""
+    study = tmp_path / "study-3"
+    study.mkdir()
+
+    h_a = _fake_hash("covered_a")
+    h_b = _fake_hash("covered_b")
+    _write_resolution(study, 1, 1, "transformers", h_a, {"do_sample": False})
+    _write_resolution(study, 2, 1, "transformers", h_b, {"do_sample": True})
+    _write_jsonl_record(
+        study,
+        config_hash=h_a,
+        warnings_emitted=["temperature is ignored when do_sample is False"],
+    )
+    _write_jsonl_record(study, config_hash=h_b)
+
+    # The normaliser strips numbers/paths but leaves text intact; this raw
+    # message has no numerics so the template equals the literal string.
+    corpus = _build_corpus_with_rule_matching(r"\Atemperature is ignored when do_sample is False\Z")
+    gaps = find_runtime_gaps([study], rules_corpus=corpus)
+    assert gaps == []
+
+
+def test_engine_filter(tmp_path: Path) -> None:
+    """--engine vllm only scans vllm records."""
+    study = tmp_path / "study-4"
+    study.mkdir()
+
+    h_t = _fake_hash("transformers-one")
+    h_v = _fake_hash("vllm-one")
+    _write_resolution(study, 1, 1, "transformers", h_t, {"do_sample": False})
+    _write_resolution(study, 2, 1, "vllm", h_v, {"temperature": 0.0})
+    _write_jsonl_record(
+        study,
+        config_hash=h_t,
+        engine="transformers",
+        warnings_emitted=["transformers-only warning"],
+    )
+    _write_jsonl_record(
+        study,
+        config_hash=h_v,
+        engine="vllm",
+        library_version="0.7.0",
+        warnings_emitted=["vllm-only warning"],
+    )
+
+    # No corpus for vllm — engines without a corpus still allow proposals
+    # through (the loader returns no suppressing rule).
+    gaps = find_runtime_gaps([study], rules_corpus={}, engine="vllm")
+    assert len(gaps) == 1
+    assert gaps[0].engine == "vllm"
+    assert "vllm-only" in gaps[0].normalised_template
+
+
+# ---------------------------------------------------------------------------
+# Include-exceptions flag
+# ---------------------------------------------------------------------------
+
+
+def test_include_exceptions_emits_error_severity(tmp_path: Path) -> None:
+    study = tmp_path / "study-5"
+    study.mkdir()
+
+    h_exc = _fake_hash("exc-config")
+    h_ok = _fake_hash("ok-config")
+    _write_resolution(study, 1, 1, "transformers", h_exc, {"quant": "bnb_4bit"})
+    _write_resolution(study, 2, 1, "transformers", h_ok, {"quant": None})
+
+    _write_jsonl_record(
+        study,
+        config_hash=h_exc,
+        outcome="exception",
+        exception={
+            "type": "ValueError",
+            "message": "bnb_4bit requires CUDA 12",
+            "message_template": "bnb_<NUM>bit requires CUDA <NUM>",
+            "traceback_truncated": "",
+        },
+    )
+    _write_jsonl_record(study, config_hash=h_ok, outcome="success")
+
+    gaps = find_runtime_gaps([study], rules_corpus=_build_empty_corpus(), include_exceptions=True)
+    assert len(gaps) == 1
+    assert gaps[0].severity == "error"
+    assert gaps[0].source_channel == "runtime_exception"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_study_dir_returns_no_gaps(tmp_path: Path) -> None:
+    """Study dir with no JSONL returns [] with no exception."""
+    study = tmp_path / "empty"
+    study.mkdir()
+    gaps = find_runtime_gaps([study], rules_corpus=_build_empty_corpus())
+    assert gaps == []
+
+
+def test_empty_study_dir_list_raises() -> None:
+    """Zero study dirs raises a clear error."""
+    from llenergymeasure.api.report_gaps import ReportGapsError
+
+    with pytest.raises(ReportGapsError):
+        find_runtime_gaps([], rules_corpus={})
+
+
+# ---------------------------------------------------------------------------
+# YAML round-trip through loader
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_through_loader(tmp_path: Path) -> None:
+    """Emitted proposal parses through load_rules without error."""
+    study = tmp_path / "rt-study"
+    study.mkdir()
+
+    h_a = _fake_hash("rt-a")
+    h_b = _fake_hash("rt-b")
+    h_c = _fake_hash("rt-c")
+    _write_resolution(study, 1, 1, "transformers", h_a, {"do_sample": False})
+    _write_resolution(study, 2, 1, "transformers", h_b, {"do_sample": False})
+    _write_resolution(study, 3, 1, "transformers", h_c, {"do_sample": True})
+
+    _write_jsonl_record(study, config_hash=h_a, warnings_emitted=["round-trip test warning"])
+    _write_jsonl_record(study, config_hash=h_b, warnings_emitted=["round-trip test warning"])
+    _write_jsonl_record(study, config_hash=h_c)
+
+    gaps = find_runtime_gaps([study], rules_corpus=_build_empty_corpus())
+    assert len(gaps) == 1
+    yaml_body = render_yaml_fragment(gaps[0])
+
+    # Wrap the fragment in a minimum-valid corpus envelope so the loader can
+    # parse it alongside its own required top-level keys.
+    # Re-parse the rendered YAML so we can inject it as a list item cleanly.
+    rule_doc = yaml.safe_load(yaml_body)
+    corpus_yaml = yaml.safe_dump(
+        {
+            "schema_version": "1.0.0",
+            "engine": "transformers",
+            "rules": [rule_doc],
+        },
+        sort_keys=False,
+    )
+    parsed = _parse_envelope("transformers", corpus_yaml)
+    assert len(parsed.rules) == 1
+    rule = parsed.rules[0]
+    assert rule.added_by == "runtime_warning"
+    assert rule.severity == "warn"
+    assert rule.expected_outcome["emission_channel"] == "warnings_warn"
+    # Banner comment present at top of raw YAML fragment output.
+    assert "Rule fragment proposed by 'llem report-gaps'" in yaml_body
+
+
+def test_render_yaml_error_severity_roundtrip(tmp_path: Path) -> None:
+    """Proposal with severity=error parses back through the loader."""
+    study = tmp_path / "rt-err"
+    study.mkdir()
+
+    h_a = _fake_hash("rte-a")
+    h_b = _fake_hash("rte-b")
+    _write_resolution(study, 1, 1, "transformers", h_a, {"quant": "bnb_4bit"})
+    _write_resolution(study, 2, 1, "transformers", h_b, {"quant": None})
+
+    _write_jsonl_record(
+        study,
+        config_hash=h_a,
+        outcome="exception",
+        exception={
+            "type": "ValueError",
+            "message": "bad quant",
+            "message_template": "bad quant",
+            "traceback_truncated": "",
+        },
+    )
+    _write_jsonl_record(study, config_hash=h_b)
+
+    gaps = find_runtime_gaps([study], rules_corpus=_build_empty_corpus(), include_exceptions=True)
+    assert len(gaps) == 1
+    body = render_yaml_fragment(gaps[0])
+    rule_doc = yaml.safe_load(body)
+    parsed = _parse_envelope(
+        "transformers",
+        yaml.safe_dump({"schema_version": "1.0.0", "engine": "transformers", "rules": [rule_doc]}),
+    )
+    assert parsed.rules[0].severity == "error"
+    assert parsed.rules[0].expected_outcome["outcome"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Corpus matcher helper
+# ---------------------------------------------------------------------------
+
+
+def test_template_matched_by_corpus_via_observed_messages() -> None:
+    """Rules using plain observed_messages (vendored JSON overlay) also suppress gaps."""
+    envelope = """
+schema_version: 1.0.0
+engine: transformers
+rules:
+- id: t_fixture
+  engine: transformers
+  severity: warn
+  native_type: transformers.Fixture
+  match:
+    engine: transformers
+    fields:
+      do_sample:
+        equals: false
+  kwargs_positive: {do_sample: false}
+  kwargs_negative: {}
+  expected_outcome:
+    outcome: warn
+    emission_channel: logger_warning
+    observed_messages:
+    - "You have set temperature=0.5 which is below the minimum"
+  added_by: manual_seed
+"""
+    corpus = _parse_envelope("transformers", envelope)
+    # A different-temperature raw message normalises to the same template.
+    from llenergymeasure.study.message_normalise import normalise
+
+    other_template = normalise("You have set temperature=0.9 which is below the minimum").template
+    assert _template_matched_by_corpus(other_template, corpus) is True
+
+
+# ---------------------------------------------------------------------------
+# Multi-study dir aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_study_dirs_aggregate(tmp_path: Path) -> None:
+    """Records from two study dirs combine into one gap set."""
+    s1 = tmp_path / "s1"
+    s2 = tmp_path / "s2"
+    s1.mkdir()
+    s2.mkdir()
+
+    h1 = _fake_hash("s1-fire")
+    h2 = _fake_hash("s2-fire")
+    h3 = _fake_hash("s2-notfire")
+
+    _write_resolution(s1, 1, 1, "transformers", h1, {"do_sample": False})
+    _write_resolution(s2, 1, 1, "transformers", h2, {"do_sample": False})
+    _write_resolution(s2, 2, 1, "transformers", h3, {"do_sample": True})
+
+    _write_jsonl_record(s1, config_hash=h1, warnings_emitted=["cross-study warn"])
+    _write_jsonl_record(s2, config_hash=h2, warnings_emitted=["cross-study warn"])
+    _write_jsonl_record(s2, config_hash=h3)
+
+    gaps = find_runtime_gaps([s1, s2], rules_corpus=_build_empty_corpus())
+    assert len(gaps) == 1
+    assert gaps[0].fired_count == 2
+    assert gaps[0].not_fired_count == 1

--- a/tests/unit/api/test_report_gaps.py
+++ b/tests/unit/api/test_report_gaps.py
@@ -7,10 +7,8 @@ real JSONL from a live run. JSONL schema matches
 
 from __future__ import annotations
 
-import hashlib
 import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 import yaml
@@ -24,96 +22,19 @@ from llenergymeasure.api.report_gaps import (
 )
 from llenergymeasure.config.vendored_rules import VendoredRules
 from llenergymeasure.config.vendored_rules.loader import _parse_envelope
+from tests.helpers.runtime_obs import (
+    fake_hash as _fake_hash,
+)
+from tests.helpers.runtime_obs import (
+    write_jsonl_record as _write_jsonl_record,
+)
+from tests.helpers.runtime_obs import (
+    write_resolution as _write_resolution,
+)
 
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------
-
-
-def _fake_hash(*parts: Any) -> str:
-    """Build a deterministic 64-char hex hash keyed by ``parts``."""
-    raw = "|".join(str(p) for p in parts).encode()
-    return hashlib.sha256(raw).hexdigest()
-
-
-def _write_resolution(
-    study_dir: Path,
-    index: int,
-    cycle: int,
-    engine: str,
-    full_hash: str,
-    overrides: dict[str, Any],
-) -> None:
-    """Create the experiment subdir + ``_resolution.json`` sidecar."""
-    dir_name = f"{index:03d}_c{cycle}_gpt2-{engine}_{full_hash[:8]}"
-    subdir = study_dir / dir_name
-    subdir.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "schema_version": "1.0",
-        "overrides": {k: {"effective": v, "source": "sweep"} for k, v in overrides.items()},
-    }
-    (subdir / "_resolution.json").write_text(json.dumps(payload))
-
-
-def _write_jsonl_record(
-    study_dir: Path,
-    *,
-    config_hash: str,
-    engine: str = "transformers",
-    library_version: str = "4.56.0",
-    cycle: int = 1,
-    outcome: str = "success",
-    warnings_emitted: list[str] | None = None,
-    logger_emitted: list[tuple[str, str]] | None = None,
-    exception: dict[str, Any] | None = None,
-    exit_reason: str | None = None,
-    exit_code: int | None = None,
-) -> None:
-    """Append one canonical JSONL record to ``runtime_observations.jsonl``.
-
-    Parameters mirror the schema doc in the brief. Warnings/log records are
-    passed as raw messages; we normalise to templates here so fixtures stay
-    readable.
-    """
-    from llenergymeasure.study.message_normalise import normalise
-
-    rec: dict[str, Any] = {
-        "schema_version": 1,
-        "observed_at": "2026-04-24T04:00:00Z",
-        "study_run_id": "fixture-run-id",
-        "config_hash": config_hash,
-        "cycle": cycle,
-        "engine": engine,
-        "library_version": library_version,
-        "outcome": outcome,
-        "warnings": [
-            {
-                "category": "UserWarning",
-                "message": w,
-                "message_template": normalise(w).template,
-                "filename": "fixture.py",
-                "lineno": 1,
-            }
-            for w in (warnings_emitted or [])
-        ],
-        "logger_records": [
-            {
-                "level": "WARNING",
-                "logger": lname,
-                "message": msg,
-                "message_template": normalise(msg).template,
-                "filename": "fixture.py",
-                "lineno": 1,
-            }
-            for (lname, msg) in (logger_emitted or [])
-        ],
-        "exception": exception,
-        "exit_reason": exit_reason,
-        "exit_code": exit_code,
-    }
-    path = study_dir / "runtime_observations.jsonl"
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write(json.dumps(rec) + "\n")
 
 
 def _build_empty_corpus() -> dict[str, VendoredRules]:
@@ -552,15 +473,72 @@ rules:
 """
     corpus = _parse_envelope("transformers", envelope)
     # A different-temperature raw message normalises to the same template.
+    from llenergymeasure.api.report_gaps import (
+        _build_observed_template_index,
+        _build_regex_index,
+    )
     from llenergymeasure.study.message_normalise import normalise
 
     other_template = normalise("You have set temperature=0.9 which is below the minimum").template
-    assert _template_matched_by_corpus(other_template, corpus) is True
+    corpus_map = {"transformers": corpus}
+    observed_idx = _build_observed_template_index(corpus_map)
+    regex_idx = _build_regex_index(corpus_map)
+    assert (
+        _template_matched_by_corpus(
+            other_template,
+            corpus,
+            observed_idx["transformers"],
+            regex_idx["transformers"],
+        )
+        is True
+    )
 
 
 # ---------------------------------------------------------------------------
 # Multi-study dir aggregation
 # ---------------------------------------------------------------------------
+
+
+def test_manifest_path_resolves_full_hash(tmp_path: Path) -> None:
+    """When manifest.json is present, kwargs lookup uses the full hash (no prefix)."""
+    study = tmp_path / "study-manifest"
+    study.mkdir()
+
+    h_fire = _fake_hash("manifest-fire")
+    h_nf = _fake_hash("manifest-notfire")
+
+    # Create experiment subdirs + sidecars.
+    fire_dir = _write_resolution(study, 1, 1, "transformers", h_fire, {"do_sample": False})
+    nf_dir = _write_resolution(study, 2, 1, "transformers", h_nf, {"do_sample": True})
+
+    # Build a manifest keyed by full hash with result_file relative paths.
+    manifest = {
+        "schema_version": "2.0",
+        "experiments": [
+            {
+                "config_hash": h_fire,
+                "cycle": 1,
+                "status": "completed",
+                "result_file": f"{fire_dir.name}/result.json",
+            },
+            {
+                "config_hash": h_nf,
+                "cycle": 1,
+                "status": "completed",
+                "result_file": f"{nf_dir.name}/result.json",
+            },
+        ],
+    }
+    (study / "manifest.json").write_text(json.dumps(manifest))
+
+    _write_jsonl_record(study, config_hash=h_fire, warnings_emitted=["manifest-path warn"])
+    _write_jsonl_record(study, config_hash=h_nf)
+
+    gaps = find_runtime_gaps([study], rules_corpus=_build_empty_corpus())
+    assert len(gaps) == 1
+    assert gaps[0].fired_count == 1
+    assert gaps[0].not_fired_count == 1
+    assert gaps[0].match_fields == {"do_sample": False}
 
 
 def test_multiple_study_dirs_aggregate(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_report_gaps.py
+++ b/tests/unit/cli/test_report_gaps.py
@@ -8,6 +8,7 @@ surfaces here too.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -25,6 +26,14 @@ from tests.helpers.runtime_obs import (
 
 runner = CliRunner()
 
+# Typer/Rich emits ANSI escape codes that break substring matches on CI (no
+# NO_COLOR default). Match the pattern used by tests/unit/cli/test_cli_run.py.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
 
 # ---------------------------------------------------------------------------
 # Help + dispatch
@@ -34,9 +43,7 @@ runner = CliRunner()
 def test_report_gaps_help() -> None:
     result = runner.invoke(app, ["report-gaps", "--help"])
     assert result.exit_code == 0
-    # Typer's help formatter may wrap at narrow widths on small TTYs; strip
-    # whitespace/newlines before looking up flag names.
-    joined = " ".join(result.output.split())
+    joined = " ".join(_strip(result.output).split())
     for flag in ("--source", "--study-dir", "--engine", "--out", "--include-exceptions"):
         assert flag in joined
 
@@ -112,7 +119,8 @@ def test_report_gaps_missing_study_dir_errors(tmp_path: Path) -> None:
         ["report-gaps", "--source", "runtime-warnings", "--out", str(out)],
     )
     assert result.exit_code != 0
-    assert "study-dir" in result.output.lower() or "study_dir" in result.output.lower()
+    stripped = _strip(result.output).lower()
+    assert "study-dir" in stripped or "study_dir" in stripped
 
 
 def test_report_gaps_missing_out_errors(tmp_path: Path) -> None:
@@ -130,7 +138,8 @@ def test_report_gaps_missing_out_errors(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "--out" in result.output or "out" in result.output.lower()
+    stripped = _strip(result.output).lower()
+    assert "--out" in stripped or "out" in stripped
 
 
 def test_report_gaps_unsupported_source_errors(tmp_path: Path) -> None:
@@ -151,4 +160,4 @@ def test_report_gaps_unsupported_source_errors(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "runtime-warnings" in result.output
+    assert "runtime-warnings" in _strip(result.output)

--- a/tests/unit/cli/test_report_gaps.py
+++ b/tests/unit/cli/test_report_gaps.py
@@ -8,80 +8,22 @@ surfaces here too.
 
 from __future__ import annotations
 
-import hashlib
-import json
 from pathlib import Path
-from typing import Any
 
 from typer.testing import CliRunner
 
 from llenergymeasure.cli import app
+from tests.helpers.runtime_obs import (
+    fake_hash as _fake_hash,
+)
+from tests.helpers.runtime_obs import (
+    write_jsonl_record as _write_jsonl_record,
+)
+from tests.helpers.runtime_obs import (
+    write_resolution as _write_resolution,
+)
 
 runner = CliRunner()
-
-
-def _fake_hash(*parts: Any) -> str:
-    return hashlib.sha256("|".join(str(p) for p in parts).encode()).hexdigest()
-
-
-def _write_resolution(
-    study_dir: Path,
-    index: int,
-    cycle: int,
-    engine: str,
-    full_hash: str,
-    overrides: dict[str, Any],
-) -> None:
-    subdir = study_dir / f"{index:03d}_c{cycle}_gpt2-{engine}_{full_hash[:8]}"
-    subdir.mkdir(parents=True, exist_ok=True)
-    (subdir / "_resolution.json").write_text(
-        json.dumps(
-            {
-                "schema_version": "1.0",
-                "overrides": {k: {"effective": v, "source": "sweep"} for k, v in overrides.items()},
-            }
-        )
-    )
-
-
-def _write_jsonl_record(
-    study_dir: Path,
-    *,
-    config_hash: str,
-    engine: str = "transformers",
-    library_version: str = "4.56.0",
-    cycle: int = 1,
-    outcome: str = "success",
-    warnings_emitted: list[str] | None = None,
-) -> None:
-    from llenergymeasure.study.message_normalise import normalise
-
-    rec = {
-        "schema_version": 1,
-        "observed_at": "2026-04-24T04:00:00Z",
-        "study_run_id": "fixture-run-id",
-        "config_hash": config_hash,
-        "cycle": cycle,
-        "engine": engine,
-        "library_version": library_version,
-        "outcome": outcome,
-        "warnings": [
-            {
-                "category": "UserWarning",
-                "message": w,
-                "message_template": normalise(w).template,
-                "filename": "fixture.py",
-                "lineno": 1,
-            }
-            for w in (warnings_emitted or [])
-        ],
-        "logger_records": [],
-        "exception": None,
-        "exit_reason": None,
-        "exit_code": None,
-    }
-    with open(study_dir / "runtime_observations.jsonl", "a", encoding="utf-8") as fh:
-        fh.write(json.dumps(rec) + "\n")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_report_gaps.py
+++ b/tests/unit/cli/test_report_gaps.py
@@ -1,0 +1,212 @@
+"""Unit tests for cli/report_gaps.py — Typer smoke tests.
+
+All tests use ``typer.testing.CliRunner``. Fixture study dirs are built
+through the same helpers as ``tests/unit/api/test_report_gaps.py`` — we
+stay deliberately close to the real JSONL shape so a future schema bump
+surfaces here too.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from llenergymeasure.cli import app
+
+runner = CliRunner()
+
+
+def _fake_hash(*parts: Any) -> str:
+    return hashlib.sha256("|".join(str(p) for p in parts).encode()).hexdigest()
+
+
+def _write_resolution(
+    study_dir: Path,
+    index: int,
+    cycle: int,
+    engine: str,
+    full_hash: str,
+    overrides: dict[str, Any],
+) -> None:
+    subdir = study_dir / f"{index:03d}_c{cycle}_gpt2-{engine}_{full_hash[:8]}"
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / "_resolution.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "overrides": {k: {"effective": v, "source": "sweep"} for k, v in overrides.items()},
+            }
+        )
+    )
+
+
+def _write_jsonl_record(
+    study_dir: Path,
+    *,
+    config_hash: str,
+    engine: str = "transformers",
+    library_version: str = "4.56.0",
+    cycle: int = 1,
+    outcome: str = "success",
+    warnings_emitted: list[str] | None = None,
+) -> None:
+    from llenergymeasure.study.message_normalise import normalise
+
+    rec = {
+        "schema_version": 1,
+        "observed_at": "2026-04-24T04:00:00Z",
+        "study_run_id": "fixture-run-id",
+        "config_hash": config_hash,
+        "cycle": cycle,
+        "engine": engine,
+        "library_version": library_version,
+        "outcome": outcome,
+        "warnings": [
+            {
+                "category": "UserWarning",
+                "message": w,
+                "message_template": normalise(w).template,
+                "filename": "fixture.py",
+                "lineno": 1,
+            }
+            for w in (warnings_emitted or [])
+        ],
+        "logger_records": [],
+        "exception": None,
+        "exit_reason": None,
+        "exit_code": None,
+    }
+    with open(study_dir / "runtime_observations.jsonl", "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Help + dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_report_gaps_help() -> None:
+    result = runner.invoke(app, ["report-gaps", "--help"])
+    assert result.exit_code == 0
+    # Typer's help formatter may wrap at narrow widths on small TTYs; strip
+    # whitespace/newlines before looking up flag names.
+    joined = " ".join(result.output.split())
+    for flag in ("--source", "--study-dir", "--engine", "--out", "--include-exceptions"):
+        assert flag in joined
+
+
+def test_report_gaps_writes_yaml(tmp_path: Path) -> None:
+    """Happy path: CLI writes YAML fragments when a gap is discovered."""
+    study = tmp_path / "study-writes"
+    study.mkdir()
+
+    h_a = _fake_hash("cli-fire-a")
+    h_b = _fake_hash("cli-fire-b")
+    h_c = _fake_hash("cli-notfire")
+    _write_resolution(study, 1, 1, "transformers", h_a, {"do_sample": False})
+    _write_resolution(study, 2, 1, "transformers", h_b, {"do_sample": False})
+    _write_resolution(study, 3, 1, "transformers", h_c, {"do_sample": True})
+
+    _write_jsonl_record(study, config_hash=h_a, warnings_emitted=["CLI smoke warning"])
+    _write_jsonl_record(study, config_hash=h_b, warnings_emitted=["CLI smoke warning"])
+    _write_jsonl_record(study, config_hash=h_c)
+
+    out = tmp_path / "proposals.yaml"
+    result = runner.invoke(
+        app,
+        [
+            "report-gaps",
+            "--source",
+            "runtime-warnings",
+            "--study-dir",
+            str(study),
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    body = out.read_text(encoding="utf-8")
+    assert "CLI smoke warning" in body
+    assert "added_by: runtime_warning" in body
+    # Summary line printed.
+    assert "1 gap" in result.output
+
+
+def test_report_gaps_empty_emits_no_file(tmp_path: Path) -> None:
+    """When no gaps are found the CLI does not write the out file and exits 0."""
+    study = tmp_path / "empty-study"
+    study.mkdir()
+    # Create the JSONL file but with no emissions — no templates → no gaps.
+    _write_jsonl_record(study, config_hash=_fake_hash("empty"), warnings_emitted=[])
+
+    out = tmp_path / "proposals.yaml"
+    result = runner.invoke(
+        app,
+        [
+            "report-gaps",
+            "--source",
+            "runtime-warnings",
+            "--study-dir",
+            str(study),
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0
+    assert not out.exists()
+    assert "No gaps found" in result.output
+
+
+def test_report_gaps_missing_study_dir_errors(tmp_path: Path) -> None:
+    """Omitting --study-dir exits with a clear Typer BadParameter."""
+    out = tmp_path / "proposals.yaml"
+    result = runner.invoke(
+        app,
+        ["report-gaps", "--source", "runtime-warnings", "--out", str(out)],
+    )
+    assert result.exit_code != 0
+    assert "study-dir" in result.output.lower() or "study_dir" in result.output.lower()
+
+
+def test_report_gaps_missing_out_errors(tmp_path: Path) -> None:
+    """Omitting --out exits with a clear Typer BadParameter."""
+    study = tmp_path / "s"
+    study.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "report-gaps",
+            "--source",
+            "runtime-warnings",
+            "--study-dir",
+            str(study),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--out" in result.output or "out" in result.output.lower()
+
+
+def test_report_gaps_unsupported_source_errors(tmp_path: Path) -> None:
+    """--source h3-collisions (etc.) is not wired in this release."""
+    study = tmp_path / "s"
+    study.mkdir()
+    out = tmp_path / "out.yaml"
+    result = runner.invoke(
+        app,
+        [
+            "report-gaps",
+            "--source",
+            "h3-collisions",
+            "--study-dir",
+            str(study),
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "runtime-warnings" in result.output


### PR DESCRIPTION
## Summary
Adds `llem report-gaps --source runtime-warnings`: scans `runtime_observations.jsonl` cache from PR #395, groups unmatched library emissions, runs predicate inference, emits draft YAML rule fragments. Review-friendly by design — no corpus mutation, no PR automation. Fragments land via `--out` with a loud banner comment for maintainers to splice into `configs/validation_rules/{engine}.yaml`.

## Key design points
- CLI → api only (`cli-boundary` contract respected).
- Predicate inference: arity-1→2→3 + `present:true` fallback. Overnight PoC RT-1 validated 83% lenient recovery on 6 synthetic rule shapes with 0% false positives.
- Sentinels + exceptions filtered out of the B (not-fired) partition — they don't prove absence.
- Round-trip: every emitted proposal parses through `config/vendored_rules/loader.py` without error (asserted in test).
- Severity: mechanical `warn` from log channel; always `walker_confidence: low` + `needs_generalisation_review: true` when predicate is narrow/missing — reviewer owns final call (§4.9.1 never-automate list).

## Test plan
- [ ] Unit tests for predicate inference (equality, multi-field, range-fails-safely, present-true)
- [ ] Round-trip through `load_rules` asserts YAML parses
- [ ] Sentinel + exception partition exclusion
- [ ] Engine filter
- [ ] CLI dispatch smoke tests