### PR TITLE
feat(study): library-resolution mechanism + observed_config_hash + sidecar wiring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,14 @@ layers = [
     "llenergymeasure.config | llenergymeasure.domain",
     "llenergymeasure.utils",
 ]
+ignore_imports = [
+    # Phase 50 M4: config.loader.load_study_config invokes resolve_library_effective
+    # as part of the grid-expansion pipeline (between expand_grid and
+    # apply_cycles). The library-resolution mechanism lives under study/ — reviewer
+    # may decide to invert this by moving dedup into api/cli callers; for now
+    # the import is local-inside-function so there is no cycle risk.
+    "llenergymeasure.config.loader -> llenergymeasure.study.library_resolution",
+]
 
 [[tool.importlinter.contracts]]
 id = "cli-boundary"
@@ -219,4 +227,7 @@ forbidden_modules = [
     "llenergymeasure.results",
     "llenergymeasure.datasets",
 ]
-# No ignore_imports needed - all violations from Phase 38 have been resolved in Phase 39.
+ignore_imports = [
+    # Phase 50 M4: see matching ignore on main-layers contract above.
+    "llenergymeasure.config.loader -> llenergymeasure.study.library_resolution",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,12 @@ ignore_imports = [
     # may decide to invert this by moving dedup into api/cli callers; for now
     # the import is local-inside-function so there is no cycle risk.
     "llenergymeasure.config.loader -> llenergymeasure.study.library_resolution",
+    # Phase 50 M4: harness._write_config_sidecar() computes H3 observed_config_hash
+    # (needs study.hashing) and persists config.json (needs results.persistence).
+    # Both imports are local-inside-method and introduce no cycle risk. The harness
+    # is the natural site for this wiring (it has the InferenceOutput + ExperimentConfig).
+    "llenergymeasure.harness -> llenergymeasure.study.hashing",
+    "llenergymeasure.harness -> llenergymeasure.results.persistence",
 ]
 
 [[tool.importlinter.contracts]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,11 +180,9 @@ ignore_imports = [
     # may decide to invert this by moving dedup into api/cli callers; for now
     # the import is local-inside-function so there is no cycle risk.
     "llenergymeasure.config.loader -> llenergymeasure.study.library_resolution",
-    # Phase 50 M4: harness._write_config_sidecar() computes H3 observed_config_hash
-    # (needs study.hashing) and persists config.json (needs results.persistence).
-    # Both imports are local-inside-method and introduce no cycle risk. The harness
-    # is the natural site for this wiring (it has the InferenceOutput + ExperimentConfig).
-    "llenergymeasure.harness -> llenergymeasure.study.hashing",
+    # Phase 50 M4: harness._write_config_sidecar() persists config.json
+    # (needs results.persistence). Import is local-inside-method; no cycle risk.
+    # H3 hashing now imports from domain.hashing (L0) — no layer breach.
     "llenergymeasure.harness -> llenergymeasure.results.persistence",
 ]
 

--- a/scripts/walkers/_fixpoint_test.py
+++ b/scripts/walkers/_fixpoint_test.py
@@ -1,6 +1,6 @@
 """Shuffle-application fixpoint contract test for the dormant-rule corpus.
 
-Enforces three invariants the dormant canonicaliser will depend on:
+Enforces three invariants the dormant library-resolution mechanism will depend on:
 
 1. **Idempotent** — applying the same rule twice leaves the state unchanged.
 2. **Order-independent at fixpoint** — multiple random application orderings
@@ -11,7 +11,7 @@ The test operates on a declarative projection: a dormant rule declares
 ``normalised_fields`` in ``expected_outcome``, and the "fix" is setting each
 normalised field to its declared default (from the predicate's ``not_equal``
 operand, falling back to ``None``). This is sufficient to catch the structural
-failure modes a canonicaliser would trip on.
+failure modes the library-resolution mechanism would trip on.
 """
 
 from __future__ import annotations
@@ -46,7 +46,7 @@ class FixpointError(Exception):
     """Base class for fixpoint-test failures."""
 
 
-class CanonicaliserCycleError(FixpointError):
+class LibraryResolutionCycleError(FixpointError):
     """A rule ordering failed to converge within ``_MAX_ITER`` passes."""
 
     def __init__(self, ordering: list[str], final_state: dict[str, Any]) -> None:
@@ -240,7 +240,7 @@ def apply_to_fixpoint(
 ) -> tuple[dict[str, Any], list[str]]:
     """Apply rules in the given order repeatedly until the state stops changing.
 
-    Returns ``(final_state, applied_rule_ids)``. Raises :class:`CanonicaliserCycleError`
+    Returns ``(final_state, applied_rule_ids)``. Raises :class:`LibraryResolutionCycleError`
     if ``_MAX_ITER`` passes fail to converge.
     """
     current = dict(state)
@@ -256,7 +256,7 @@ def apply_to_fixpoint(
                     changed = True
         if not changed:
             return current, applied
-    raise CanonicaliserCycleError([r.id for r in rules], current)
+    raise LibraryResolutionCycleError([r.id for r in rules], current)
 
 
 def assert_idempotent(rule: _ProjectedRule, seed: dict[str, Any]) -> None:
@@ -279,7 +279,7 @@ def assert_shuffle_stable(
     """Confirm that ``shuffle_count`` orderings all produce the same fixed point.
 
     Returns the canonical final state (shared across orderings). Raises
-    :class:`OrderDependentRuleError` on divergence or :class:`CanonicaliserCycleError`
+    :class:`OrderDependentRuleError` on divergence or :class:`LibraryResolutionCycleError`
     on non-convergence.
     """
     rng = random.Random(seed_rng)

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -123,6 +123,16 @@ def run(
         bool,
         typer.Option("--no-lock", help="Disable GPU lock files (advanced)"),
     ] = False,
+    no_dedup: Annotated[
+        bool,
+        typer.Option(
+            "--no-dedup",
+            help=(
+                "Disable canonicaliser-driven H1 sweep dedup. Every declared "
+                "config runs regardless of measurement equivalence (study mode)."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Run an LLM efficiency experiment."""
 
@@ -158,6 +168,7 @@ def run(
             no_circuit_breaker=no_circuit_breaker,
             timeout=timeout,
             no_lock=no_lock,
+            no_dedup=no_dedup,
         )
     except ConfigError as e:
         print(format_error(e, verbose=verbose > 0), file=sys.stderr)
@@ -198,6 +209,7 @@ def _run_impl(
     no_circuit_breaker: bool = False,
     timeout: float | None = None,
     no_lock: bool = False,
+    no_dedup: bool = False,
 ) -> None:
     """Core implementation — separated for clean error handling in run()."""
     # Build CLI overrides dict — only include flags the user explicitly passed
@@ -252,6 +264,7 @@ def _run_impl(
             no_circuit_breaker=no_circuit_breaker,
             timeout=timeout,
             no_lock=no_lock,
+            no_dedup=no_dedup,
         )
         return
 
@@ -400,6 +413,7 @@ def _run_study_impl(
     no_circuit_breaker: bool = False,
     timeout: float | None = None,
     no_lock: bool = False,
+    no_dedup: bool = False,
 ) -> None:
     """Study execution path — separated for clean error handling."""
     import yaml
@@ -473,6 +487,10 @@ def _run_study_impl(
         exec_overrides["max_consecutive_failures"] = 0
     if timeout is not None:
         exec_overrides["wall_clock_timeout_hours"] = timeout
+
+    # --no-dedup disables sweep canonicalisation (runs every declared config)
+    if no_dedup:
+        exec_overrides["deduplicate_equivalent"] = False
 
     # Build full CLI overrides dict
     study_cli_overrides: dict[str, Any] = {}

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -128,7 +128,7 @@ def run(
         typer.Option(
             "--no-dedup",
             help=(
-                "Disable canonicaliser-driven H1 sweep dedup. Every declared "
+                "Disable library-resolution mechanism sweep dedup. Every declared "
                 "config runs regardless of measurement equivalence (study mode)."
             ),
         ),
@@ -488,7 +488,7 @@ def _run_study_impl(
     if timeout is not None:
         exec_overrides["wall_clock_timeout_hours"] = timeout
 
-    # --no-dedup disables sweep canonicalisation (runs every declared config)
+    # --no-dedup disables library-resolution mechanism sweep dedup (runs every declared config)
     if no_dedup:
         exec_overrides["deduplicate_equivalent"] = False
 

--- a/src/llenergymeasure/config/loader.py
+++ b/src/llenergymeasure/config/loader.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import ValidationError
@@ -191,17 +191,45 @@ def load_study_config(
             "Nothing to run. Check sweep dimensions against engine constraints.\n" + skip_details
         )
 
-    # Compute study_design_hash BEFORE applying cycles (hash is over unique configs)
-    study_hash = compute_study_design_hash(valid_experiments)
+    # Canonicalise + H1-dedup the declared configs before running cycles.
+    # See sweep-dedup.md §2 — this collapses measurement-equivalent configs
+    # so a 6-config sweep with dormant sampling fields becomes 4 unique runs.
+    from llenergymeasure.study.sweep_canonicalise import dedup_sweep
+
+    dedup = dedup_sweep(
+        valid_experiments,
+        deduplicate=execution.deduplicate_equivalent,
+    )
+
+    run_experiments = dedup.canonical_configs
+    dedup_mode: Literal["h1", "off"] = "h1" if execution.deduplicate_equivalent else "off"
+
+    # Compute study_design_hash over the post-dedup configs — the hash
+    # identifies the *unique* measurement set, not duplicate declarations.
+    study_hash = compute_study_design_hash(run_experiments)
 
     # Apply cycle ordering to produce execution sequence
     ordered = apply_cycles(
-        valid_experiments,
+        run_experiments,
         n_cycles=execution.n_cycles,
         experiment_order=ExperimentOrder(execution.experiment_order),
         study_design_hash=study_hash,
         shuffle_seed=execution.shuffle_seed,
     )
+
+    # Serialise pre-run equivalence groups for the sidecar writer.
+    pre_run_groups = [
+        {
+            "h1_hash": g.h1_hash,
+            "canonical_config_excerpt": g.canonical_excerpt,
+            "member_indices": list(g.member_indices),
+            "member_count": g.member_count,
+            "representative_index": g.representative_index,
+            "would_dedup": g.member_count > 1,
+            "deduplicated": dedup.deduplicated and g.member_count > 1,
+        }
+        for g in dedup.groups
+    ]
 
     return StudyConfig(
         experiments=ordered,
@@ -212,6 +240,9 @@ def load_study_config(
         images=images,
         study_design_hash=study_hash,
         skipped_configs=[s.to_dict() for s in skipped],
+        dedup_mode=dedup_mode,
+        pre_run_equivalence_groups=pre_run_groups,
+        declared_h1_hashes=list(dedup.declared_h1),
     )
 
 

--- a/src/llenergymeasure/config/loader.py
+++ b/src/llenergymeasure/config/loader.py
@@ -191,18 +191,20 @@ def load_study_config(
             "Nothing to run. Check sweep dimensions against engine constraints.\n" + skip_details
         )
 
-    # Canonicalise + H1-dedup the declared configs before running cycles.
-    # See sweep-dedup.md §2 — this collapses measurement-equivalent configs
-    # so a 6-config sweep with dormant sampling fields becomes 4 unique runs.
-    from llenergymeasure.study.sweep_canonicalise import dedup_sweep
+    # Apply library-resolution mechanism + resolved-config-hash dedup to the declared configs
+    # before running cycles. See sweep-dedup.md §2 — this collapses measurement-equivalent
+    # configs so a 6-config sweep with dormant sampling fields becomes 4 unique runs.
+    from llenergymeasure.study.library_resolution import resolve_library_effective
 
-    dedup = dedup_sweep(
+    dedup = resolve_library_effective(
         valid_experiments,
         deduplicate=execution.deduplicate_equivalent,
     )
 
     run_experiments = dedup.canonical_configs
-    dedup_mode: Literal["h1", "off"] = "h1" if execution.deduplicate_equivalent else "off"
+    dedup_mode: Literal["resolved", "off"] = (
+        "resolved" if execution.deduplicate_equivalent else "off"
+    )
 
     # Compute study_design_hash over the post-dedup configs — the hash
     # identifies the *unique* measurement set, not duplicate declarations.
@@ -220,7 +222,7 @@ def load_study_config(
     # Serialise pre-run equivalence groups for the sidecar writer.
     pre_run_groups = [
         {
-            "h1_hash": g.h1_hash,
+            "resolved_config_hash": g.resolved_config_hash,
             "canonical_config_excerpt": g.canonical_excerpt,
             "member_indices": list(g.member_indices),
             "member_count": g.member_count,
@@ -242,7 +244,7 @@ def load_study_config(
         skipped_configs=[s.to_dict() for s in skipped],
         dedup_mode=dedup_mode,
         pre_run_equivalence_groups=pre_run_groups,
-        declared_h1_hashes=list(dedup.declared_h1),
+        declared_resolved_config_hashes=list(dedup.declared_resolved_hashes),
     )
 
 

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -688,6 +688,17 @@ class ExecutionConfig(BaseModel):
             "the circuit breaker counts them toward max_consecutive_failures."
         ),
     )
+    deduplicate_equivalent: bool = Field(
+        default=True,
+        description=(
+            "When true (default), sweep expansion canonicalises each declared "
+            "ExperimentConfig via vendored dormant-rule application and drops "
+            "duplicates that share an H1 hash. When false, every declared "
+            "config runs — the canonicaliser still populates equivalence-group "
+            "metadata for the sidecar but no configs are elided. The --no-dedup "
+            "CLI flag is the equivalent. See sweep-dedup.md §2.3.1."
+        ),
+    )
 
 
 class StudyConfig(BaseModel):
@@ -747,5 +758,32 @@ class StudyConfig(BaseModel):
         description=(
             "Grid points that failed Pydantic validation during expansion. "
             "Persisted for post-hoc review and pre-flight display."
+        ),
+    )
+    dedup_mode: Literal["h1", "off"] = Field(
+        default="h1",
+        description=(
+            "Canonicaliser / H1 dedup mode. 'h1' applies dormant-rule "
+            "canonicalisation at expansion and collapses H1-equivalent "
+            "configs to a single run. 'off' runs every declared config "
+            "regardless of equivalence. Set via "
+            "ExecutionConfig.deduplicate_equivalent / --no-dedup."
+        ),
+    )
+    pre_run_equivalence_groups: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Pre-run equivalence groups computed at sweep-expansion time. "
+            "Each group records the H1 hash, canonical excerpt, and member "
+            "declared-indices. Written to 'equivalence_groups.json' alongside "
+            "the results bundle. See sweep-dedup.md §6."
+        ),
+    )
+    declared_h1_hashes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Per-declared-config H1 hashes (parallel to the pre-canonicalised "
+            "sweep input). Harness consults this to tag each experiment with "
+            "its equivalence group at sidecar-write time."
         ),
     )

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -691,10 +691,10 @@ class ExecutionConfig(BaseModel):
     deduplicate_equivalent: bool = Field(
         default=True,
         description=(
-            "When true (default), sweep expansion canonicalises each declared "
+            "When true (default), sweep expansion applies library resolution to each declared "
             "ExperimentConfig via vendored dormant-rule application and drops "
-            "duplicates that share an H1 hash. When false, every declared "
-            "config runs — the canonicaliser still populates equivalence-group "
+            "duplicates that share an resolved_config_hash. When false, every declared "
+            "config runs — the library-resolution mechanism still populates equivalence-group "
             "metadata for the sidecar but no configs are elided. The --no-dedup "
             "CLI flag is the equivalent. See sweep-dedup.md §2.3.1."
         ),
@@ -760,11 +760,11 @@ class StudyConfig(BaseModel):
             "Persisted for post-hoc review and pre-flight display."
         ),
     )
-    dedup_mode: Literal["h1", "off"] = Field(
-        default="h1",
+    dedup_mode: Literal["resolved", "off"] = Field(
+        default="resolved",
         description=(
-            "Canonicaliser / H1 dedup mode. 'h1' applies dormant-rule "
-            "canonicalisation at expansion and collapses H1-equivalent "
+            "Library-resolution mechanism dedup mode. 'resolved' applies dormant-rule "
+            "library resolution at expansion and collapses resolved-config-hash-equivalent "
             "configs to a single run. 'off' runs every declared config "
             "regardless of equivalence. Set via "
             "ExecutionConfig.deduplicate_equivalent / --no-dedup."
@@ -774,15 +774,15 @@ class StudyConfig(BaseModel):
         default_factory=list,
         description=(
             "Pre-run equivalence groups computed at sweep-expansion time. "
-            "Each group records the H1 hash, canonical excerpt, and member "
+            "Each group records the resolved_config_hash, canonical excerpt, and member "
             "declared-indices. Written to 'equivalence_groups.json' alongside "
             "the results bundle. See sweep-dedup.md §6."
         ),
     )
-    declared_h1_hashes: list[str] = Field(
+    declared_resolved_config_hashes: list[str] = Field(
         default_factory=list,
         description=(
-            "Per-declared-config H1 hashes (parallel to the pre-canonicalised "
+            "Per-declared-config resolved_config_hashes (parallel to the pre-resolved "
             "sweep input). Harness consults this to tag each experiment with "
             "its equivalence group at sidecar-write time."
         ),

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-24T01:26:04+02:00",
-  "vendor_commit": "8b73ab81d9a0ee1c8699958dcb9a17976a3e1003",
+  "vendored_at": "2026-04-24T17:17:21+02:00",
+  "vendor_commit": "5cd87eea86780c2fc89b69072531be20a3574e8c",
   "cases": [
     {
       "id": "transformers_bnb_bnb_4bit_compute_dtype_type",

--- a/src/llenergymeasure/domain/hashing.py
+++ b/src/llenergymeasure/domain/hashing.py
@@ -1,0 +1,161 @@
+"""Canonical serialisation and SHA-256 hashing primitives (H1 and H3).
+
+Pure, dependency-free primitives shared by both the H1 (library-resolution
+mechanism output) and H3 (library-observed) hashing pipelines.  Neither
+hash requires imports from upper layers, so these live at Layer 0 (domain).
+
+``build_resolved_view`` — the one function that needs ``ExperimentConfig`` —
+stays in :mod:`llenergymeasure.study.hashing` where it belongs (Layer 4).
+
+Normalisation rules are locked by sweep-dedup.md §9.Q3.  Over-normalising
+would hide library-enforced semantics (e.g. ``None`` vs missing in vLLM),
+so the rules are strict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+_FLOAT_SIG_DIGITS = 12
+"""Float rounding precision (significant digits) for hash stability.
+
+Upstream float arithmetic can produce bit-level jitter in the last 1-2
+digits that does not reflect an actual configuration difference.  Rounding
+at 12 significant digits removes that jitter without compressing any two
+values a researcher would write differently.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialisation (shared by H1 and H3)
+# ---------------------------------------------------------------------------
+
+
+def _normalise(value: Any) -> Any:
+    """Normalise a value for deterministic JSON serialisation.
+
+    Applies the locked rules from sweep-dedup.md §9.Q3:
+
+    - ``NaN`` → string ``"NaN"`` (NaN != NaN breaks dict hashing otherwise)
+    - float → rounded to 12 significant digits (stable across minor
+      arithmetic jitter)
+    - tuple → list (incidental immutability choice, not semantic)
+    - bool is preserved as bool (not folded into int even though
+      ``True == 1`` in Python)
+    - dict → dict with recursively normalised values (key sorting happens
+      at ``json.dumps(sort_keys=True)`` time)
+    - None and missing keys stay distinguishable (by never inserting a
+      sentinel for missing)
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            # Preserve infinity as a string literal for hash stability
+            return "Infinity" if value > 0 else "-Infinity"
+        if value == 0.0:
+            return 0.0
+        # Round to sig-figs rather than decimal places
+        mag = math.floor(math.log10(abs(value)))
+        factor = 10 ** (_FLOAT_SIG_DIGITS - 1 - mag)
+        return round(value * factor) / factor
+    if isinstance(value, (set, frozenset)):
+        # Sort for determinism; normalise elements recursively.
+        return [_normalise(v) for v in sorted(value, key=str)]
+    if isinstance(value, (list, tuple)):
+        return [_normalise(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _normalise(v) for k, v in value.items()}
+    return value
+
+
+def canonical_serialise(obj: Any) -> bytes:
+    """Serialise ``obj`` to canonical-JSON bytes, ready for hashing.
+
+    Applies :func:`_normalise` then ``json.dumps(sort_keys=True)``.  Uses a
+    separators tuple with no whitespace for compactness and stability
+    across Python versions.
+    """
+    normalised = _normalise(obj)
+    return json.dumps(
+        normalised,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,  # Pydantic enums and dates
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Hashed-field schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConfigHashView:
+    """Fixed-schema view of the fields hashed into resolved or observed config hash.
+
+    Per sweep-dedup.md §2.4, the hashed-field set is:
+
+    - ``task`` — model, prompt source, batch shape
+    - ``observed_engine_params`` — engine state (library-resolution mechanism output for H1,
+      live library observation for H3)
+    - ``observed_sampling_params`` — sampling state (same sources as above)
+    - ``lora`` / ``passthrough_kwargs`` — user-attached overrides
+
+    Excluded: ``MeasurementConfig`` (observation dials), ``ExecutionConfig``
+    (runner/parallelism), ``experiment_id``.
+    """
+
+    engine: str
+    task: dict[str, Any]
+    observed_engine_params: dict[str, Any] = field(default_factory=dict)
+    observed_sampling_params: dict[str, Any] = field(default_factory=dict)
+    lora: dict[str, Any] | None = None
+    passthrough_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+def hash_config(view: ConfigHashView) -> str:
+    """Return SHA-256 hex digest of ``view`` via :func:`canonical_serialise`.
+
+    Both H1 and H3 route through this function; they differ only in how
+    the :class:`ConfigHashView` is populated.
+    """
+    payload = asdict(view)
+    return hashlib.sha256(canonical_serialise(payload)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# H3 view construction — from library-observed effective params
+# ---------------------------------------------------------------------------
+
+
+def build_observed_view(
+    *,
+    engine: str,
+    task: dict[str, Any],
+    observed_engine_params: dict[str, Any],
+    observed_sampling_params: dict[str, Any],
+    lora: dict[str, Any] | None = None,
+    passthrough_kwargs: dict[str, Any] | None = None,
+) -> ConfigHashView:
+    """Assemble an H3 view from per-engine ``extract_observed_params`` output.
+
+    Callers live in the harness/sidecar path — they read ``task`` from the
+    same config that ran and pair it with the native-object dumps the engine
+    returned.
+    """
+    return ConfigHashView(
+        engine=engine,
+        task=task,
+        observed_engine_params=dict(observed_engine_params),
+        observed_sampling_params=dict(observed_sampling_params),
+        lora=lora,
+        passthrough_kwargs=dict(passthrough_kwargs or {}),
+    )

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -6,15 +6,139 @@ to reduce duplication while keeping engines thin.
 
 from __future__ import annotations
 
+import dataclasses
 import gc
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 
+from llenergymeasure.config.probe import DormantField
 from llenergymeasure.utils.exceptions import EngineError
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Effective-params extraction (H3 source)
+# ---------------------------------------------------------------------------
+
+
+def extract_effective_params(
+    native_obj: Any,
+    *,
+    private_field_allowlist: set[str] | None = None,
+) -> dict[str, Any]:
+    """Dump a constructed native type's post-``__post_init__`` state.
+
+    Used by the H3 hashing pipeline (sweep-dedup.md §3.2) — after each
+    backend constructs its native type (``GenerationConfig``,
+    ``SamplingParams``, ``LlmArgs``), the harness calls this to extract
+    the authoritative effective parameters the library settled on.
+
+    PoC-C finding (sweep-dedup.md §3.2 and §10 decision log): live
+    libraries leak private state that poisons H3 if passed through
+    unfiltered. Specific leaks observed:
+
+    - ``transformers.GenerationConfig``: ``_commit_hash``,
+      ``_from_model_config``
+    - ``vllm.SamplingParams``: ``_all_stop_token_ids``,
+      ``_bad_words_token_ids``, ``_eos_token_id``
+
+    Default behaviour is to strip all ``_``-prefixed fields. Engines pass
+    ``private_field_allowlist`` only when a specific private field is
+    genuinely measurement-relevant (rare).
+
+    Dispatch covers the three observed native-type shapes — Pydantic
+    (``model_dump``), dataclass (``dataclasses.asdict``), and
+    ``__slots__``-based (vLLM msgspec-adjacent). Fallback is ``__dict__``.
+    """
+    allow = private_field_allowlist or set()
+    raw = _dump_raw(native_obj)
+    return {k: v for k, v in raw.items() if not k.startswith("_") or k in allow}
+
+
+def _dump_raw(native_obj: Any) -> dict[str, Any]:
+    """Return a ``dict`` of every attribute observable on ``native_obj``.
+
+    Order of attempts mirrors the three shapes :func:`extract_effective_params`
+    commits to supporting; each is an explicit ``hasattr`` rather than
+    ``try/except`` because the libraries raise non-``AttributeError`` for
+    ``model_dump`` failures (e.g. transformers raises ``RuntimeError``).
+    """
+    if hasattr(native_obj, "model_dump"):
+        # Pydantic (transformers GenerationConfig inherits from PushToHubMixin;
+        # its model_dump accepts mode="python").
+        try:
+            dumped = native_obj.model_dump(mode="python")
+        except TypeError:
+            dumped = native_obj.model_dump()
+        if isinstance(dumped, dict):
+            return dict(dumped)
+    if dataclasses.is_dataclass(native_obj) and not isinstance(native_obj, type):
+        return dataclasses.asdict(native_obj)
+    if hasattr(native_obj, "__slots__"):
+        out: dict[str, Any] = {}
+        for slot in native_obj.__slots__:
+            if hasattr(native_obj, slot):
+                out[slot] = getattr(native_obj, slot)
+        if out:
+            return out
+    if hasattr(native_obj, "__dict__"):
+        return dict(native_obj.__dict__)
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Dormancy diff (available for probe-adapter / library-resolution use across engines)
+# ---------------------------------------------------------------------------
+
+
+def compute_dormant_fields(
+    declared: dict[str, Any],
+    effective: dict[str, Any],
+    prefix: str = "",
+    reason_fn: Callable[[str, Any, Any | None], str | None] | None = None,
+) -> dict[str, DormantField]:
+    """Return the set of declared keys that are stripped or overridden.
+
+    A key is *stripped* when it appears in ``declared`` but not in
+    ``effective`` (e.g. ``temperature`` removed under greedy decoding).
+    A key is *overridden* when both dicts contain it but the values differ
+    (e.g. ``top_k=0`` remapped to ``top_k=-1`` for vLLM).
+
+    Args:
+        declared: Kwargs the user declared before engine-side stripping.
+        effective: Kwargs the engine will actually construct with.
+        prefix: Dotted path prefix for result keys (e.g. ``"vllm.sampling."``).
+        reason_fn: Optional ``(key, declared_val, effective_val) -> str | None``
+            callback that attaches a human-readable reason to each entry.
+
+    Returns:
+        Mapping from prefixed key to :class:`DormantField`. Empty when
+        effective matches declared for every declared key.
+    """
+    dormant: dict[str, DormantField] = {}
+    for key, declared_val in declared.items():
+        if key not in effective:
+            effective_val: Any | None = None
+            reason = reason_fn(key, declared_val, None) if reason_fn is not None else None
+            dormant[f"{prefix}{key}"] = DormantField(
+                declared_value=declared_val,
+                effective_value=effective_val,
+                reason=reason,
+            )
+            continue
+        effective_val = effective[key]
+        if effective_val != declared_val:
+            reason = reason_fn(key, declared_val, effective_val) if reason_fn is not None else None
+            dormant[f"{prefix}{key}"] = DormantField(
+                declared_value=declared_val,
+                effective_value=effective_val,
+                reason=reason,
+            )
+    return dormant
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import dataclasses
 import gc
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -73,6 +74,47 @@ def library_version(module_name: str) -> str:
         return "unknown"
 
 
+def assemble_observed_params_safe(
+    *,
+    engine_extractor: Callable[[], dict[str, Any]] | None,
+    sampling_extractor: Callable[[], dict[str, Any]] | None,
+    module_name: str,
+    logger: logging.Logger,
+) -> dict[str, Any]:
+    """Try-extract-and-assemble scaffold shared by all three engine capture methods.
+
+    Each engine supplies small callables that produce its engine-specific and
+    sampling-specific observed-params dicts.  Extraction failures are logged at
+    DEBUG and silently produce empty dicts — sidecar writes are best-effort.
+
+    Args:
+        engine_extractor: Zero-arg callable returning engine-section params dict,
+            or ``None`` to skip engine extraction.
+        sampling_extractor: Zero-arg callable returning sampling-section params dict,
+            or ``None`` to skip sampling extraction.
+        module_name: Library module name for :func:`library_version` lookup.
+        logger: Caller's module-level logger for DEBUG messages.
+
+    Returns:
+        ``{"engine": ..., "sampling": ..., "library_version": ...}`` dict.
+    """
+    engine_params: dict[str, Any] = {}
+    if engine_extractor is not None:
+        try:
+            engine_params = engine_extractor()
+        except Exception as exc:
+            logger.debug("Engine param extraction failed: %s", exc)
+
+    sampling: dict[str, Any] = {}
+    if sampling_extractor is not None:
+        try:
+            sampling = sampling_extractor()
+        except Exception as exc:
+            logger.debug("Sampling param extraction failed: %s", exc)
+
+    return assemble_observed_params(engine_params, sampling, module_name)
+
+
 def assemble_observed_params(
     engine_params: dict[str, Any],
     sampling_params: dict[str, Any],
@@ -103,16 +145,20 @@ def _dump_raw(native_obj: Any) -> dict[str, Any]:
 
     Order of attempts mirrors the three shapes :func:`extract_observed_params`
     commits to supporting; each is an explicit ``hasattr`` rather than
-    ``try/except`` because the libraries raise non-``AttributeError`` for
-    ``model_dump`` failures (e.g. transformers raises ``RuntimeError``).
+    ``try/except`` because some libraries raise non-``AttributeError`` for
+    ``model_dump`` failures. The inner ``except Exception`` is intentional:
+    sidecar-write errors should never crash a measurement run.
     """
     if hasattr(native_obj, "model_dump"):
         # Pydantic (transformers GenerationConfig inherits from PushToHubMixin;
         # its model_dump accepts mode="python").
         try:
             dumped = native_obj.model_dump(mode="python")
-        except TypeError:
-            dumped = native_obj.model_dump()
+        except Exception:
+            try:
+                dumped = native_obj.model_dump()
+            except Exception:
+                dumped = None
         if isinstance(dumped, dict):
             return dict(dumped)
     if dataclasses.is_dataclass(native_obj) and not isinstance(native_obj, type):

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -9,12 +9,10 @@ from __future__ import annotations
 import dataclasses
 import gc
 import logging
-from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 
-from llenergymeasure.config.probe import DormantField
 from llenergymeasure.utils.exceptions import EngineError
 
 logger = logging.getLogger(__name__)
@@ -25,7 +23,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def extract_effective_params(
+def extract_observed_params(
     native_obj: Any,
     *,
     private_field_allowlist: set[str] | None = None,
@@ -75,10 +73,35 @@ def library_version(module_name: str) -> str:
         return "unknown"
 
 
+def assemble_observed_params(
+    engine_params: dict[str, Any],
+    sampling_params: dict[str, Any],
+    module_name: str,
+) -> dict[str, Any]:
+    """Assemble the standard observed-params return dict for the sidecar.
+
+    All three engines share the same return shape: ``{"engine": ...,
+    "sampling": ..., "library_version": ...}``. Engine-specific extraction
+    logic (BnB detection, vllm_config, llm.args) stays in each caller;
+    this helper assembles the final dict and fills in the library version.
+
+    Args:
+        engine_params: Engine-specific observed params (engine section).
+        sampling_params: Sampling-specific observed params.
+        module_name: Library module name for :func:`library_version` lookup
+            (e.g. ``"transformers"``, ``"vllm"``, ``"tensorrt_llm"``).
+    """
+    return {
+        "engine": engine_params,
+        "sampling": sampling_params,
+        "library_version": library_version(module_name),
+    }
+
+
 def _dump_raw(native_obj: Any) -> dict[str, Any]:
     """Return a ``dict`` of every attribute observable on ``native_obj``.
 
-    Order of attempts mirrors the three shapes :func:`extract_effective_params`
+    Order of attempts mirrors the three shapes :func:`extract_observed_params`
     commits to supporting; each is an explicit ``hasattr`` rather than
     ``try/except`` because the libraries raise non-``AttributeError`` for
     ``model_dump`` failures (e.g. transformers raises ``RuntimeError``).
@@ -104,57 +127,6 @@ def _dump_raw(native_obj: Any) -> dict[str, Any]:
     if hasattr(native_obj, "__dict__"):
         return dict(native_obj.__dict__)
     return {}
-
-
-# ---------------------------------------------------------------------------
-# Dormancy diff (available for probe-adapter / library-resolution use across engines)
-# ---------------------------------------------------------------------------
-
-
-def compute_dormant_fields(
-    declared: dict[str, Any],
-    effective: dict[str, Any],
-    prefix: str = "",
-    reason_fn: Callable[[str, Any, Any | None], str | None] | None = None,
-) -> dict[str, DormantField]:
-    """Return the set of declared keys that are stripped or overridden.
-
-    A key is *stripped* when it appears in ``declared`` but not in
-    ``effective`` (e.g. ``temperature`` removed under greedy decoding).
-    A key is *overridden* when both dicts contain it but the values differ
-    (e.g. ``top_k=0`` remapped to ``top_k=-1`` for vLLM).
-
-    Args:
-        declared: Kwargs the user declared before engine-side stripping.
-        effective: Kwargs the engine will actually construct with.
-        prefix: Dotted path prefix for result keys (e.g. ``"vllm.sampling."``).
-        reason_fn: Optional ``(key, declared_val, effective_val) -> str | None``
-            callback that attaches a human-readable reason to each entry.
-
-    Returns:
-        Mapping from prefixed key to :class:`DormantField`. Empty when
-        effective matches declared for every declared key.
-    """
-    dormant: dict[str, DormantField] = {}
-    for key, declared_val in declared.items():
-        if key not in effective:
-            effective_val: Any | None = None
-            reason = reason_fn(key, declared_val, None) if reason_fn is not None else None
-            dormant[f"{prefix}{key}"] = DormantField(
-                declared_value=declared_val,
-                effective_value=effective_val,
-                reason=reason,
-            )
-            continue
-        effective_val = effective[key]
-        if effective_val != declared_val:
-            reason = reason_fn(key, declared_val, effective_val) if reason_fn is not None else None
-            dormant[f"{prefix}{key}"] = DormantField(
-                declared_value=declared_val,
-                effective_value=effective_val,
-                reason=reason,
-            )
-    return dormant
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -59,6 +59,22 @@ def extract_effective_params(
     return {k: v for k, v in raw.items() if not k.startswith("_") or k in allow}
 
 
+def library_version(module_name: str) -> str:
+    """Return ``__version__`` of an imported library or ``"unknown"`` on failure.
+
+    Shared helper for the H3 capture path — all three engines publish the
+    library version alongside their effective-params dump so researchers can
+    disambiguate identical H3 hashes across library versions.
+    """
+    try:
+        import importlib
+
+        mod = importlib.import_module(module_name)
+        return str(getattr(mod, "__version__", "unknown"))
+    except Exception:
+        return "unknown"
+
+
 def _dump_raw(native_obj: Any) -> dict[str, Any]:
     """Return a ``dict`` of every attribute observable on ``native_obj``.
 

--- a/src/llenergymeasure/engines/protocol.py
+++ b/src/llenergymeasure/engines/protocol.py
@@ -107,3 +107,21 @@ class EnginePlugin(Protocol):
         - Pure: no weight loading, no GPU allocation, no engine construction.
         """
         ...
+
+    def capture_observed_params(
+        self, config: ExperimentConfig, model: Any, output: InferenceOutput
+    ) -> dict[str, Any]:
+        """Extract library-observed effective parameters after inference.
+
+        Called by the harness AFTER the NVML measurement window closes
+        (post ``t_inference_end`` + ``_cuda_sync``), so the capture overhead
+        does not perturb energy or timing measurements.
+
+        Returns a dict with keys ``"engine"``, ``"sampling"``, and
+        ``"library_version"`` — same shape as
+        :func:`llenergymeasure.engines._helpers.assemble_observed_params`.
+
+        Engines must never raise; any extraction failure should be caught and
+        logged at DEBUG, returning empty dicts for the failed sub-field.
+        """
+        ...

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -331,14 +331,6 @@ class TensorRTEngine:
         if self._build_metadata is not None:
             extras["build_metadata"] = self._build_metadata
 
-        # Library-observed effective params for H3 (sweep-dedup.md §3).
-        # TRT-LLM runs in NGC container only; allowlist verification is
-        # deferred to a container run per the PoC-C notes.
-        effective_params = self._capture_observed_params(config, llm, sampling_params)
-        extras["observed_engine_params"] = effective_params["engine"]
-        extras["observed_sampling_params"] = effective_params["sampling"]
-        extras["library_version"] = effective_params["library_version"]
-
         return InferenceOutput(
             elapsed_time_sec=elapsed,
             input_tokens=input_token_count,
@@ -387,6 +379,27 @@ class TensorRTEngine:
             logger.debug("TRT-LLM engine param extraction failed: %s", e)
 
         return assemble_observed_params(engine_params, sampling, "tensorrt_llm")
+
+    # -------------------------------------------------------------------------
+    # EnginePlugin: capture_observed_params (post-measurement-window)
+    # -------------------------------------------------------------------------
+
+    def capture_observed_params(
+        self,
+        config: ExperimentConfig,
+        model: Any,
+        output: InferenceOutput,
+    ) -> dict[str, Any]:
+        """Extract library-observed effective parameters post-measurement-window.
+
+        Called by the harness after ``t_inference_end`` + ``_cuda_sync`` so
+        this overhead is outside the NVML energy window.
+
+        The ``sampling_params`` object and ``llm`` are in the model tuple
+        from ``load_model()``.
+        """
+        llm, sampling_params = model
+        return self._capture_observed_params(config, llm, sampling_params)
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -369,7 +369,7 @@ class TensorRTEngine:
         """
         import contextlib as _cl
 
-        from llenergymeasure.engines._helpers import extract_effective_params
+        from llenergymeasure.engines._helpers import extract_effective_params, library_version
 
         sampling: dict[str, Any] = {}
         with _cl.suppress(Exception):
@@ -381,17 +381,10 @@ class TensorRTEngine:
             if llm_args is not None:
                 engine_params = extract_effective_params(llm_args)
 
-        try:
-            import tensorrt_llm as _trt
-
-            library_version = str(_trt.__version__)
-        except Exception:
-            library_version = "unknown"
-
         return {
             "engine": engine_params,
             "sampling": sampling,
-            "library_version": library_version,
+            "library_version": library_version("tensorrt_llm"),
         }
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -334,9 +334,9 @@ class TensorRTEngine:
         # Library-observed effective params for H3 (sweep-dedup.md §3).
         # TRT-LLM runs in NGC container only; allowlist verification is
         # deferred to a container run per the PoC-C notes.
-        effective_params = self._capture_effective_params(config, llm, sampling_params)
-        extras["effective_engine_params"] = effective_params["engine"]
-        extras["effective_sampling_params"] = effective_params["sampling"]
+        effective_params = self._capture_observed_params(config, llm, sampling_params)
+        extras["observed_engine_params"] = effective_params["engine"]
+        extras["observed_sampling_params"] = effective_params["sampling"]
         extras["library_version"] = effective_params["library_version"]
 
         return InferenceOutput(
@@ -350,11 +350,11 @@ class TensorRTEngine:
         )
 
     # -------------------------------------------------------------------------
-    # Private: effective-params capture (H3)
+    # Private: observed-params capture (observed_config_hash)
     # -------------------------------------------------------------------------
 
     @staticmethod
-    def _capture_effective_params(
+    def _capture_observed_params(
         config: ExperimentConfig,
         llm: Any,
         sampling_params: Any,
@@ -365,27 +365,28 @@ class TensorRTEngine:
         on ``llm.args`` in current releases. Private fields (if any surface in
         a given TRT-LLM version) are stripped by the default
         ``_``-prefix allowlist behaviour in
-        :func:`extract_effective_params`.
+        :func:`extract_observed_params`.
         """
-        import contextlib as _cl
-
-        from llenergymeasure.engines._helpers import extract_effective_params, library_version
+        from llenergymeasure.engines._helpers import (
+            assemble_observed_params,
+            extract_observed_params,
+        )
 
         sampling: dict[str, Any] = {}
-        with _cl.suppress(Exception):
-            sampling = extract_effective_params(sampling_params)
+        try:
+            sampling = extract_observed_params(sampling_params)
+        except Exception as e:
+            logger.debug("TRT-LLM sampling param extraction failed: %s", e)
 
         engine_params: dict[str, Any] = {}
-        with _cl.suppress(Exception):
+        try:
             llm_args = getattr(llm, "args", None)
             if llm_args is not None:
-                engine_params = extract_effective_params(llm_args)
+                engine_params = extract_observed_params(llm_args)
+        except Exception as e:
+            logger.debug("TRT-LLM engine param extraction failed: %s", e)
 
-        return {
-            "engine": engine_params,
-            "sampling": sampling,
-            "library_version": library_version("tensorrt_llm"),
-        }
+        return assemble_observed_params(engine_params, sampling, "tensorrt_llm")
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/tensorrt.py
+++ b/src/llenergymeasure/engines/tensorrt.py
@@ -331,6 +331,14 @@ class TensorRTEngine:
         if self._build_metadata is not None:
             extras["build_metadata"] = self._build_metadata
 
+        # Library-observed effective params for H3 (sweep-dedup.md §3).
+        # TRT-LLM runs in NGC container only; allowlist verification is
+        # deferred to a container run per the PoC-C notes.
+        effective_params = self._capture_effective_params(config, llm, sampling_params)
+        extras["effective_engine_params"] = effective_params["engine"]
+        extras["effective_sampling_params"] = effective_params["sampling"]
+        extras["library_version"] = effective_params["library_version"]
+
         return InferenceOutput(
             elapsed_time_sec=elapsed,
             input_tokens=input_token_count,
@@ -340,6 +348,51 @@ class TensorRTEngine:
             batch_times=[elapsed],
             extras=extras,
         )
+
+    # -------------------------------------------------------------------------
+    # Private: effective-params capture (H3)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _capture_effective_params(
+        config: ExperimentConfig,
+        llm: Any,
+        sampling_params: Any,
+    ) -> dict[str, Any]:
+        """Extract post-construction state from the TRT-LLM native types.
+
+        TRT-LLM's ``LlmArgs`` + nested ``BuildConfig`` are Pydantic; accessible
+        on ``llm.args`` in current releases. Private fields (if any surface in
+        a given TRT-LLM version) are stripped by the default
+        ``_``-prefix allowlist behaviour in
+        :func:`extract_effective_params`.
+        """
+        import contextlib as _cl
+
+        from llenergymeasure.engines._helpers import extract_effective_params
+
+        sampling: dict[str, Any] = {}
+        with _cl.suppress(Exception):
+            sampling = extract_effective_params(sampling_params)
+
+        engine_params: dict[str, Any] = {}
+        with _cl.suppress(Exception):
+            llm_args = getattr(llm, "args", None)
+            if llm_args is not None:
+                engine_params = extract_effective_params(llm_args)
+
+        try:
+            import tensorrt_llm as _trt
+
+            library_version = str(_trt.__version__)
+        except Exception:
+            library_version = "unknown"
+
+        return {
+            "engine": engine_params,
+            "sampling": sampling,
+            "library_version": library_version,
+        }
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -232,6 +232,11 @@ class TransformersEngine:
             total_time_sec,
         )
 
+        # Capture library-observed effective parameters for H3 (sweep-dedup.md §3).
+        # Runs after the measurement loop so we don't perturb timing; the
+        # GenerationConfig's post-__init__ state is stable throughout the run.
+        effective_params = self._capture_effective_params(config, hf_model, generate_kwargs)
+
         return InferenceOutput(
             elapsed_time_sec=total_time_sec,
             input_tokens=total_input_tokens,
@@ -239,8 +244,68 @@ class TransformersEngine:
             peak_memory_mb=peak_memory_mb,
             model_memory_mb=0.0,  # Captured by harness before run_inference
             batch_times=batch_times,
-            extras={"hf_model": hf_model},  # For FLOPs estimation in harness
+            extras={
+                "hf_model": hf_model,  # For FLOPs estimation in harness
+                "effective_engine_params": effective_params["engine"],
+                "effective_sampling_params": effective_params["sampling"],
+                "library_version": effective_params["library_version"],
+            },
         )
+
+    # -------------------------------------------------------------------------
+    # Private: effective-params capture (H3)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _capture_effective_params(
+        config: ExperimentConfig,
+        hf_model: Any,
+        generate_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Extract post-construction state from the native types the engine used.
+
+        Transformers splits its native state across ``GenerationConfig`` (the
+        sampling shape) and ``BitsAndBytesConfig`` (the engine-side quantisation
+        shape, when active). Both are Pydantic-style dumpable objects;
+        :func:`extract_effective_params` strips private fields (``_commit_hash``,
+        ``_from_model_config``) that would poison H3 if included.
+
+        Returns a dict with ``engine`` / ``sampling`` / ``library_version``
+        entries ready for the H3 hashing pipeline.
+        """
+        from llenergymeasure.engines._helpers import extract_effective_params
+
+        sampling: dict[str, Any] = {}
+        try:
+            from transformers import GenerationConfig
+
+            gen_cfg = GenerationConfig(**generate_kwargs)
+            sampling = extract_effective_params(gen_cfg)
+        except Exception as exc:  # pragma: no cover — best-effort capture
+            logger.debug("transformers GenerationConfig capture failed: %s", exc)
+
+        engine_params: dict[str, Any] = {}
+        pt = config.transformers
+        if pt is not None and (pt.load_in_4bit or pt.load_in_8bit):
+            try:
+                bnb = getattr(hf_model, "quantization_config", None)
+                if bnb is not None:
+                    engine_params["quantization_config"] = extract_effective_params(bnb)
+            except Exception as exc:  # pragma: no cover — best-effort capture
+                logger.debug("transformers BitsAndBytesConfig capture failed: %s", exc)
+
+        try:
+            import transformers as _tf
+
+            library_version = str(_tf.__version__)
+        except Exception:
+            library_version = "unknown"
+
+        return {
+            "engine": engine_params,
+            "sampling": sampling,
+            "library_version": library_version,
+        }
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -273,7 +273,7 @@ class TransformersEngine:
         Returns a dict with ``engine`` / ``sampling`` / ``library_version``
         entries ready for the H3 hashing pipeline.
         """
-        from llenergymeasure.engines._helpers import extract_effective_params
+        from llenergymeasure.engines._helpers import extract_effective_params, library_version
 
         sampling: dict[str, Any] = {}
         try:
@@ -294,17 +294,10 @@ class TransformersEngine:
             except Exception as exc:  # pragma: no cover — best-effort capture
                 logger.debug("transformers BitsAndBytesConfig capture failed: %s", exc)
 
-        try:
-            import transformers as _tf
-
-            library_version = str(_tf.__version__)
-        except Exception:
-            library_version = "unknown"
-
         return {
             "engine": engine_params,
             "sampling": sampling,
-            "library_version": library_version,
+            "library_version": library_version("transformers"),
         }
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -232,11 +232,6 @@ class TransformersEngine:
             total_time_sec,
         )
 
-        # Capture library-observed effective parameters for H3 (sweep-dedup.md §3).
-        # Runs after the measurement loop so we don't perturb timing; the
-        # GenerationConfig's post-__init__ state is stable throughout the run.
-        effective_params = self._capture_observed_params(config, hf_model, generate_kwargs)
-
         return InferenceOutput(
             elapsed_time_sec=total_time_sec,
             input_tokens=total_input_tokens,
@@ -246,9 +241,9 @@ class TransformersEngine:
             batch_times=batch_times,
             extras={
                 "hf_model": hf_model,  # For FLOPs estimation in harness
-                "observed_engine_params": effective_params["engine"],
-                "observed_sampling_params": effective_params["sampling"],
-                "library_version": effective_params["library_version"],
+                # generate_kwargs stashed so capture_observed_params can read
+                # GenerationConfig state post-window without recomputing.
+                "generate_kwargs": generate_kwargs,
             },
         )
 
@@ -298,6 +293,29 @@ class TransformersEngine:
                 logger.debug("transformers BitsAndBytesConfig capture failed: %s", exc)
 
         return assemble_observed_params(engine_params, sampling, "transformers")
+
+    # -------------------------------------------------------------------------
+    # EnginePlugin: capture_observed_params (post-measurement-window)
+    # -------------------------------------------------------------------------
+
+    def capture_observed_params(
+        self,
+        config: ExperimentConfig,
+        model: Any,
+        output: InferenceOutput,
+    ) -> dict[str, Any]:
+        """Extract library-observed effective parameters post-measurement-window.
+
+        Called by the harness after ``t_inference_end`` + ``_cuda_sync`` so
+        this overhead is outside the NVML energy window.
+
+        Reads ``generate_kwargs`` from ``output.extras`` (stashed by
+        ``run_inference``) and the native model object for BnB config;
+        delegates to :func:`_capture_observed_params`.
+        """
+        hf_model, _tokenizer = model
+        generate_kwargs: dict[str, Any] = output.extras.get("generate_kwargs") or {}
+        return self._capture_observed_params(config, hf_model, generate_kwargs)
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -235,7 +235,7 @@ class TransformersEngine:
         # Capture library-observed effective parameters for H3 (sweep-dedup.md §3).
         # Runs after the measurement loop so we don't perturb timing; the
         # GenerationConfig's post-__init__ state is stable throughout the run.
-        effective_params = self._capture_effective_params(config, hf_model, generate_kwargs)
+        effective_params = self._capture_observed_params(config, hf_model, generate_kwargs)
 
         return InferenceOutput(
             elapsed_time_sec=total_time_sec,
@@ -246,18 +246,18 @@ class TransformersEngine:
             batch_times=batch_times,
             extras={
                 "hf_model": hf_model,  # For FLOPs estimation in harness
-                "effective_engine_params": effective_params["engine"],
-                "effective_sampling_params": effective_params["sampling"],
+                "observed_engine_params": effective_params["engine"],
+                "observed_sampling_params": effective_params["sampling"],
                 "library_version": effective_params["library_version"],
             },
         )
 
     # -------------------------------------------------------------------------
-    # Private: effective-params capture (H3)
+    # Private: observed-params capture (observed_config_hash)
     # -------------------------------------------------------------------------
 
     @staticmethod
-    def _capture_effective_params(
+    def _capture_observed_params(
         config: ExperimentConfig,
         hf_model: Any,
         generate_kwargs: dict[str, Any],
@@ -267,20 +267,23 @@ class TransformersEngine:
         Transformers splits its native state across ``GenerationConfig`` (the
         sampling shape) and ``BitsAndBytesConfig`` (the engine-side quantisation
         shape, when active). Both are Pydantic-style dumpable objects;
-        :func:`extract_effective_params` strips private fields (``_commit_hash``,
+        :func:`extract_observed_params` strips private fields (``_commit_hash``,
         ``_from_model_config``) that would poison H3 if included.
 
         Returns a dict with ``engine`` / ``sampling`` / ``library_version``
         entries ready for the H3 hashing pipeline.
         """
-        from llenergymeasure.engines._helpers import extract_effective_params, library_version
+        from llenergymeasure.engines._helpers import (
+            assemble_observed_params,
+            extract_observed_params,
+        )
 
         sampling: dict[str, Any] = {}
         try:
             from transformers import GenerationConfig
 
             gen_cfg = GenerationConfig(**generate_kwargs)
-            sampling = extract_effective_params(gen_cfg)
+            sampling = extract_observed_params(gen_cfg)
         except Exception as exc:  # pragma: no cover — best-effort capture
             logger.debug("transformers GenerationConfig capture failed: %s", exc)
 
@@ -290,15 +293,11 @@ class TransformersEngine:
             try:
                 bnb = getattr(hf_model, "quantization_config", None)
                 if bnb is not None:
-                    engine_params["quantization_config"] = extract_effective_params(bnb)
+                    engine_params["quantization_config"] = extract_observed_params(bnb)
             except Exception as exc:  # pragma: no cover — best-effort capture
                 logger.debug("transformers BitsAndBytesConfig capture failed: %s", exc)
 
-        return {
-            "engine": engine_params,
-            "sampling": sampling,
-            "library_version": library_version("transformers"),
-        }
+        return assemble_observed_params(engine_params, sampling, "transformers")
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -252,11 +252,11 @@ class VLLMEngine:
             hf_model = llm.llm_engine.model_executor.driver_worker.model_runner.model
 
         # Library-observed effective params for H3 (sweep-dedup.md §3).
-        effective_params = self._capture_effective_params(config, llm, sampling_params)
+        effective_params = self._capture_observed_params(config, llm, sampling_params)
 
         extras: dict[str, Any] = {
-            "effective_engine_params": effective_params["engine"],
-            "effective_sampling_params": effective_params["sampling"],
+            "observed_engine_params": effective_params["engine"],
+            "observed_sampling_params": effective_params["sampling"],
             "library_version": effective_params["library_version"],
         }
         if hf_model is not None:
@@ -273,43 +273,44 @@ class VLLMEngine:
         )
 
     # -------------------------------------------------------------------------
-    # Private: effective-params capture (H3)
+    # Private: observed-params capture (observed_config_hash)
     # -------------------------------------------------------------------------
 
     @staticmethod
-    def _capture_effective_params(
+    def _capture_observed_params(
         config: ExperimentConfig,
         llm: Any,
         sampling_params: Any,
     ) -> dict[str, Any]:
         """Extract post-construction state from the vLLM native types.
 
-        Sampling params are captured via :func:`extract_effective_params` —
+        Sampling params are captured via :func:`extract_observed_params` —
         PoC-C allowlist is unset (the private fields ``_all_stop_token_ids``,
         ``_bad_words_token_ids``, ``_eos_token_id`` default-exclude since they
         vary per-model without affecting measurement-equivalence). Engine
         params derive from ``llm.llm_engine.vllm_config`` when available;
         otherwise we fall back to the declared kwargs dict.
         """
-        from llenergymeasure.engines._helpers import extract_effective_params, library_version
+        from llenergymeasure.engines._helpers import (
+            assemble_observed_params,
+            extract_observed_params,
+        )
 
         sampling: dict[str, Any] = {}
         try:
-            sampling = extract_effective_params(sampling_params)
+            sampling = extract_observed_params(sampling_params)
         except Exception as exc:  # pragma: no cover — best-effort capture
             logger.debug("vLLM SamplingParams capture failed: %s", exc)
 
         engine_params: dict[str, Any] = {}
-        with contextlib.suppress(Exception):
+        try:
             vllm_cfg = getattr(llm.llm_engine, "vllm_config", None)
             if vllm_cfg is not None:
-                engine_params = extract_effective_params(vllm_cfg)
+                engine_params = extract_observed_params(vllm_cfg)
+        except Exception as exc:  # pragma: no cover — best-effort capture
+            logger.debug("vLLM config capture failed: %s", exc)
 
-        return {
-            "engine": engine_params,
-            "sampling": sampling,
-            "library_version": library_version("vllm"),
-        }
+        return assemble_observed_params(engine_params, sampling, "vllm")
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -291,7 +291,7 @@ class VLLMEngine:
         params derive from ``llm.llm_engine.vllm_config`` when available;
         otherwise we fall back to the declared kwargs dict.
         """
-        from llenergymeasure.engines._helpers import extract_effective_params
+        from llenergymeasure.engines._helpers import extract_effective_params, library_version
 
         sampling: dict[str, Any] = {}
         try:
@@ -305,17 +305,10 @@ class VLLMEngine:
             if vllm_cfg is not None:
                 engine_params = extract_effective_params(vllm_cfg)
 
-        try:
-            import vllm as _vllm
-
-            library_version = str(_vllm.__version__)
-        except Exception:
-            library_version = "unknown"
-
         return {
             "engine": engine_params,
             "sampling": sampling,
-            "library_version": library_version,
+            "library_version": library_version("vllm"),
         }
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -251,6 +251,17 @@ class VLLMEngine:
         with contextlib.suppress(Exception):
             hf_model = llm.llm_engine.model_executor.driver_worker.model_runner.model
 
+        # Library-observed effective params for H3 (sweep-dedup.md §3).
+        effective_params = self._capture_effective_params(config, llm, sampling_params)
+
+        extras: dict[str, Any] = {
+            "effective_engine_params": effective_params["engine"],
+            "effective_sampling_params": effective_params["sampling"],
+            "library_version": effective_params["library_version"],
+        }
+        if hf_model is not None:
+            extras["hf_model"] = hf_model
+
         return InferenceOutput(
             elapsed_time_sec=elapsed,
             input_tokens=input_token_count,
@@ -258,8 +269,54 @@ class VLLMEngine:
             peak_memory_mb=peak_mb,
             model_memory_mb=0.0,  # Captured by harness before run_inference
             batch_times=[elapsed],
-            extras={"hf_model": hf_model} if hf_model is not None else {},
+            extras=extras,
         )
+
+    # -------------------------------------------------------------------------
+    # Private: effective-params capture (H3)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _capture_effective_params(
+        config: ExperimentConfig,
+        llm: Any,
+        sampling_params: Any,
+    ) -> dict[str, Any]:
+        """Extract post-construction state from the vLLM native types.
+
+        Sampling params are captured via :func:`extract_effective_params` —
+        PoC-C allowlist is unset (the private fields ``_all_stop_token_ids``,
+        ``_bad_words_token_ids``, ``_eos_token_id`` default-exclude since they
+        vary per-model without affecting measurement-equivalence). Engine
+        params derive from ``llm.llm_engine.vllm_config`` when available;
+        otherwise we fall back to the declared kwargs dict.
+        """
+        from llenergymeasure.engines._helpers import extract_effective_params
+
+        sampling: dict[str, Any] = {}
+        try:
+            sampling = extract_effective_params(sampling_params)
+        except Exception as exc:  # pragma: no cover — best-effort capture
+            logger.debug("vLLM SamplingParams capture failed: %s", exc)
+
+        engine_params: dict[str, Any] = {}
+        with contextlib.suppress(Exception):
+            vllm_cfg = getattr(llm.llm_engine, "vllm_config", None)
+            if vllm_cfg is not None:
+                engine_params = extract_effective_params(vllm_cfg)
+
+        try:
+            import vllm as _vllm
+
+            library_version = str(_vllm.__version__)
+        except Exception:
+            library_version = "unknown"
+
+        return {
+            "engine": engine_params,
+            "sampling": sampling,
+            "library_version": library_version,
+        }
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/engines/vllm.py
+++ b/src/llenergymeasure/engines/vllm.py
@@ -251,14 +251,7 @@ class VLLMEngine:
         with contextlib.suppress(Exception):
             hf_model = llm.llm_engine.model_executor.driver_worker.model_runner.model
 
-        # Library-observed effective params for H3 (sweep-dedup.md §3).
-        effective_params = self._capture_observed_params(config, llm, sampling_params)
-
-        extras: dict[str, Any] = {
-            "observed_engine_params": effective_params["engine"],
-            "observed_sampling_params": effective_params["sampling"],
-            "library_version": effective_params["library_version"],
-        }
+        extras: dict[str, Any] = {}
         if hf_model is not None:
             extras["hf_model"] = hf_model
 
@@ -311,6 +304,27 @@ class VLLMEngine:
             logger.debug("vLLM config capture failed: %s", exc)
 
         return assemble_observed_params(engine_params, sampling, "vllm")
+
+    # -------------------------------------------------------------------------
+    # EnginePlugin: capture_observed_params (post-measurement-window)
+    # -------------------------------------------------------------------------
+
+    def capture_observed_params(
+        self,
+        config: ExperimentConfig,
+        model: Any,
+        output: InferenceOutput,
+    ) -> dict[str, Any]:
+        """Extract library-observed effective parameters post-measurement-window.
+
+        Called by the harness after ``t_inference_end`` + ``_cuda_sync`` so
+        this overhead is outside the NVML energy window.
+
+        The ``sampling_params`` object is already in the model tuple from
+        ``load_model()``; the ``llm`` object provides the live vllm_config.
+        """
+        llm, sampling_params = model
+        return self._capture_observed_params(config, llm, sampling_params)
 
     # -------------------------------------------------------------------------
     # EnginePlugin: cleanup

--- a/src/llenergymeasure/harness/__init__.py
+++ b/src/llenergymeasure/harness/__init__.py
@@ -511,6 +511,18 @@ class MeasurementHarness:
         )
         _substep("save", "result assembled")
 
+        # 17. Write config.json sidecar (observed-params + observed_config_hash)
+        # Written to output_dir (temp dir, same as timeseries.parquet) so the
+        # runner can move it to the per-experiment directory.
+        if resolved_output_dir is not None:
+            self._write_config_sidecar(
+                output=output,
+                config=config,
+                result=result,
+                output_dir=resolved_output_dir,
+            )
+            _substep("save", "config sidecar written")
+
         if _p:
             _p.on_step_done("save", time.perf_counter() - t0_save)
 
@@ -519,6 +531,55 @@ class MeasurementHarness:
     # -------------------------------------------------------------------------
     # Private helpers
     # -------------------------------------------------------------------------
+
+    def _write_config_sidecar(
+        self,
+        output: Any,
+        config: Any,
+        result: Any,
+        output_dir: Path,
+    ) -> None:
+        """Write ``config.json`` sidecar to ``output_dir`` (temp staging area).
+
+        Extracts observed params from ``output.extras`` (populated by each engine's
+        ``_capture_effective_params`` after inference), computes ``observed_config_hash``
+        from the H3 hashing pipeline, and writes the sidecar atomically. The runner's
+        ``_save_and_record`` moves this file to the per-experiment directory alongside
+        ``result.json``.
+
+        Best-effort — failures are logged at DEBUG to avoid masking measurement results.
+        """
+        try:
+            from llenergymeasure.results.persistence import save_config_sidecar
+            from llenergymeasure.study.hashing import build_observed_view, hash_config
+
+            obs_engine = output.extras.get("observed_engine_params", {}) or {}
+            obs_sampling = output.extras.get("observed_sampling_params", {}) or {}
+            lib_ver = output.extras.get("library_version", "unknown") or "unknown"
+
+            # Compute observed_config_hash (H3) from extracted native-type state
+            engine_name = result.engine
+            task_dict = config.task.model_dump(mode="python")
+            h3_view = build_observed_view(
+                engine=engine_name,
+                task=task_dict,
+                effective_engine_params=obs_engine,
+                effective_sampling_params=obs_sampling,
+            )
+            obs_hash = hash_config(h3_view)
+
+            save_config_sidecar(
+                output_dir,
+                experiment_id=result.experiment_id,
+                config_hash=result.measurement_config_hash,
+                engine=engine_name,
+                library_version=lib_ver,
+                observed_engine_params=obs_engine if obs_engine else None,
+                observed_sampling_params=obs_sampling if obs_sampling else None,
+                observed_config_hash=obs_hash,
+            )
+        except Exception as exc:
+            logger.debug("Config sidecar write failed (non-fatal): %s", exc)
 
     def _capture_model_memory_mb(self, gpu_indices: list[int] | None = None) -> float:
         """Query torch for GPU max_memory_allocated() after model load.

--- a/src/llenergymeasure/harness/__init__.py
+++ b/src/llenergymeasure/harness/__init__.py
@@ -61,6 +61,35 @@ def _cuda_sync() -> None:
             pass  # Non-fatal — best effort sync
 
 
+def _capture_observed_params_into_output(
+    engine: Any,
+    config: Any,
+    model: Any,
+    output: Any,
+) -> None:
+    """Call ``engine.capture_observed_params`` and merge the result into ``output.extras``.
+
+    Invoked post-window (after ``t_inference_end`` + ``_cuda_sync``) so capture
+    overhead does not perturb energy or timing measurements.
+
+    Best-effort: engines that haven't implemented the method yet silently skip.
+    The result dict is merged into ``output.extras`` under the standard keys
+    ``observed_engine_params``, ``observed_sampling_params``, and
+    ``library_version``.
+    """
+    try:
+        capture = getattr(engine, "capture_observed_params", None)
+        if capture is None:
+            return
+        params = capture(config, model, output)
+        if isinstance(params, dict):
+            output.extras["observed_engine_params"] = params.get("engine", {})
+            output.extras["observed_sampling_params"] = params.get("sampling", {})
+            output.extras["library_version"] = params.get("library_version", "unknown")
+    except Exception as exc:
+        logger.debug("capture_observed_params failed (non-fatal): %s", exc)
+
+
 def _check_persistence_mode(gpu_indices: list[int] | None = None) -> bool:
     """Check whether GPU persistence mode is enabled on all specified GPUs.
 
@@ -433,6 +462,11 @@ class MeasurementHarness:
             _cuda_sync()
             _substep("measure", "CUDA sync (post)")
 
+            # 11a. Capture observed params post-window (outside NVML sampling).
+            # Must run here — model is still alive; capture overhead (~5-50 ms pure
+            # Python) must not land inside the PowerThermalSampler context above.
+            _capture_observed_params_into_output(engine, config, model, output)
+
             if _p:
                 _p.on_step_done("measure", t_inference_end - t_inference_start)
 
@@ -550,8 +584,8 @@ class MeasurementHarness:
         Best-effort — failures are logged at DEBUG to avoid masking measurement results.
         """
         try:
+            from llenergymeasure.domain.hashing import build_observed_view, hash_config
             from llenergymeasure.results.persistence import save_config_sidecar
-            from llenergymeasure.study.hashing import build_observed_view, hash_config
 
             obs_engine = output.extras.get("observed_engine_params", {}) or {}
             obs_sampling = output.extras.get("observed_sampling_params", {}) or {}
@@ -563,8 +597,8 @@ class MeasurementHarness:
             h3_view = build_observed_view(
                 engine=engine_name,
                 task=task_dict,
-                effective_engine_params=obs_engine,
-                effective_sampling_params=obs_sampling,
+                observed_engine_params=obs_engine,
+                observed_sampling_params=obs_sampling,
             )
             obs_hash = hash_config(h3_view)
 

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -93,6 +93,62 @@ def _atomic_write(content: str, path: Path) -> None:
         raise
 
 
+def save_config_sidecar(
+    experiment_dir: Path,
+    *,
+    experiment_id: str,
+    config_hash: str,
+    engine: str,
+    library_version: str,
+    effective_engine_params: dict[str, object] | None = None,
+    effective_sampling_params: dict[str, object] | None = None,
+    h1_hash: str | None = None,
+    h3_hash: str | None = None,
+    config_validation_observations: list[dict[str, object]] | None = None,
+) -> Path:
+    """Write the per-experiment ``config.json`` sidecar with H1/H3 payload.
+
+    Schema lives in ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
+    §3.3. Fields:
+
+    - ``effective_engine_params`` / ``effective_sampling_params`` — authoritative
+      post-construction library state (populated by
+      :func:`llenergymeasure.engines._helpers.extract_effective_params`).
+    - ``h1_hash`` — canonicaliser-output hash, carried forward from sweep
+      expansion via ``StudyConfig.declared_h1_hashes``.
+    - ``h3_hash`` — library-observation hash computed from the effective
+      params at sidecar-write time.
+    - ``config_validation_observations`` — DormantField entries that
+      ``_apply_vendored_rules`` attached at load time.
+
+    Any missing optional field is omitted from the sidecar (not written as
+    null) so downstream consumers distinguish "not available" from
+    "explicitly null". The file is small (< 4 KB typical) and atomically
+    written.
+    """
+    payload: dict[str, object] = {
+        "experiment_id": experiment_id,
+        "measurement_config_hash": config_hash,
+        "engine": engine,
+        "library_version": library_version,
+    }
+    if effective_engine_params is not None:
+        payload["effective_engine_params"] = effective_engine_params
+    if effective_sampling_params is not None:
+        payload["effective_sampling_params"] = effective_sampling_params
+    if h1_hash is not None:
+        payload["h1_hash"] = h1_hash
+    if h3_hash is not None:
+        payload["h3_hash"] = h3_hash
+    if config_validation_observations is not None:
+        payload["config_validation_observations"] = config_validation_observations
+
+    path = experiment_dir / "config.json"
+    _atomic_write(json.dumps(payload, indent=2, default=str), path)
+    logger.debug("Saved config sidecar to %s", path)
+    return path
+
+
 def save_environment(
     snapshot: EnvironmentSnapshot,
     experiment_id: str,

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -100,10 +100,10 @@ def save_config_sidecar(
     config_hash: str,
     engine: str,
     library_version: str,
-    effective_engine_params: dict[str, object] | None = None,
-    effective_sampling_params: dict[str, object] | None = None,
-    h1_hash: str | None = None,
-    h3_hash: str | None = None,
+    observed_engine_params: dict[str, object] | None = None,
+    observed_sampling_params: dict[str, object] | None = None,
+    resolved_config_hash: str | None = None,
+    observed_config_hash: str | None = None,
     config_validation_observations: list[dict[str, object]] | None = None,
 ) -> Path:
     """Write the per-experiment ``config.json`` sidecar with H1/H3 payload.
@@ -111,12 +111,12 @@ def save_config_sidecar(
     Schema lives in ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
     §3.3. Fields:
 
-    - ``effective_engine_params`` / ``effective_sampling_params`` — authoritative
+    - ``observed_engine_params`` / ``observed_sampling_params`` — authoritative
       post-construction library state (populated by
-      :func:`llenergymeasure.engines._helpers.extract_effective_params`).
-    - ``h1_hash`` — canonicaliser-output hash, carried forward from sweep
-      expansion via ``StudyConfig.declared_h1_hashes``.
-    - ``h3_hash`` — library-observation hash computed from the effective
+      :func:`llenergymeasure.engines._helpers.extract_observed_params`).
+    - ``resolved_config_hash`` — library-resolution mechanism-output hash, carried forward from sweep
+      expansion via ``StudyConfig.declared_resolved_config_hashes``.
+    - ``observed_config_hash`` — library-observation hash computed from the effective
       params at sidecar-write time.
     - ``config_validation_observations`` — DormantField entries that
       ``_apply_vendored_rules`` attached at load time.
@@ -132,14 +132,14 @@ def save_config_sidecar(
         "engine": engine,
         "library_version": library_version,
     }
-    if effective_engine_params is not None:
-        payload["effective_engine_params"] = effective_engine_params
-    if effective_sampling_params is not None:
-        payload["effective_sampling_params"] = effective_sampling_params
-    if h1_hash is not None:
-        payload["h1_hash"] = h1_hash
-    if h3_hash is not None:
-        payload["h3_hash"] = h3_hash
+    if observed_engine_params is not None:
+        payload["observed_engine_params"] = observed_engine_params
+    if observed_sampling_params is not None:
+        payload["observed_sampling_params"] = observed_sampling_params
+    if resolved_config_hash is not None:
+        payload["resolved_config_hash"] = resolved_config_hash
+    if observed_config_hash is not None:
+        payload["observed_config_hash"] = observed_config_hash
     if config_validation_observations is not None:
         payload["config_validation_observations"] = config_validation_observations
 

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -3,12 +3,12 @@
 Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §6.
 
 Written alongside the study's results bundle. ``pre_run_groups`` is populated
-at sweep-expansion time by :func:`dedup_sweep` and serialised immediately;
+at sweep-expansion time by :func:`resolve_library_effective` and serialised immediately;
 ``post_run_h3_groups`` is populated after the study completes by scanning
 sidecars for shared H3 hashes.
 
-The H3-collision invariant (§4.1) guarantees that in a post-H1-dedup run set,
-any group with ``len(member_h1_hashes) >= 2`` is a **proven canonicaliser gap**.
+The observed-config-hash collision invariant (§4.1) guarantees that in a post-resolved-config-hash dedup run set,
+any group with ``len(member_resolved_config_hashes) >= 2`` is a **proven library-resolution mechanism gap**.
 Phase 50.3b's ``llem report-gaps`` command consumes this file to propose
 corpus additions.
 """
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from llenergymeasure.results.persistence import _atomic_write
-from llenergymeasure.study.sweep_canonicalise import DedupResult
+from llenergymeasure.study.library_resolution import DedupResult
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -33,7 +33,7 @@ from llenergymeasure.study.sweep_canonicalise import DedupResult
 class PreRunGroup:
     """Pre-run equivalence group recorded at sweep-expansion time."""
 
-    h1_hash: str
+    resolved_config_hash: str
     canonical_config_excerpt: dict[str, Any]
     member_experiment_ids: tuple[str, ...]
     member_count: int
@@ -44,12 +44,12 @@ class PreRunGroup:
 
 @dataclass(frozen=True)
 class PostRunH3Group:
-    """Post-run H3-collision group — a canonicaliser gap if member count >= 2."""
+    """Post-run observed-config-hash collision group — a library-resolution mechanism gap if member count >= 2."""
 
-    h3_hash: str
+    observed_config_hash: str
     engine: str
     library_version: str
-    member_h1_hashes: tuple[str, ...]
+    member_resolved_config_hashes: tuple[str, ...]
     member_experiment_ids: tuple[str, ...]
     gap_detected: bool
     proposed_rule_id: str | None = None
@@ -67,7 +67,7 @@ class EquivalenceGroups:
 
 
 # ---------------------------------------------------------------------------
-# Pre-run population — from dedup_sweep output
+# Pre-run population — from resolve_library_effective output
 # ---------------------------------------------------------------------------
 
 
@@ -79,20 +79,20 @@ def build_pre_run_groups(
     """Bind :class:`DedupResult` group indices back to caller-supplied IDs.
 
     ``experiment_ids`` must be parallel to the declared-configs list passed
-    to :func:`dedup_sweep`. The runner is the natural source — it already
+    to :func:`resolve_library_effective`. The runner is the natural source — it already
     assigns per-experiment IDs before dispatch.
     """
-    if len(experiment_ids) != len(dedup.declared_h1):
+    if len(experiment_ids) != len(dedup.declared_resolved_hashes):
         raise ValueError(
             f"experiment_ids length {len(experiment_ids)} does not match the "
-            f"declared config count {len(dedup.declared_h1)}"
+            f"declared config count {len(dedup.declared_resolved_hashes)}"
         )
     pre: list[PreRunGroup] = []
     for group in dedup.groups:
         member_ids = tuple(experiment_ids[i] for i in group.member_indices)
         pre.append(
             PreRunGroup(
-                h1_hash=group.h1_hash,
+                resolved_config_hash=group.resolved_config_hash,
                 canonical_config_excerpt=group.canonical_excerpt,
                 member_experiment_ids=member_ids,
                 member_count=group.member_count,
@@ -110,19 +110,19 @@ def build_pre_run_groups(
 
 
 def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
-    """Group sidecars by ``(engine, library_version, h3_hash)``.
+    """Group sidecars by ``(engine, library_version, observed_config_hash)``.
 
-    Any group with size >= 2 AND distinct ``h1_hash`` across its members is
-    flagged as a proven canonicaliser gap — per sweep-dedup.md §4.1.
+    Any group with size >= 2 AND distinct ``resolved_config_hash`` across its members is
+    flagged as a proven library-resolution mechanism gap — per sweep-dedup.md §4.1.
 
     Each sidecar dict must carry at minimum ``engine``, ``library_version``,
-    ``h1_hash``, ``h3_hash``, and ``experiment_id`` keys. Sidecars missing any
+    ``resolved_config_hash``, ``observed_config_hash``, and ``experiment_id`` keys. Sidecars missing any
     of these are silently skipped (pre-50.3a data, or runs with dedup_mode=off
     for which H3 may be partial).
     """
     buckets: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
     for sc in sidecars:
-        h3 = sc.get("h3_hash")
+        h3 = sc.get("observed_config_hash")
         if not h3:
             continue
         engine = str(sc.get("engine", ""))
@@ -133,17 +133,17 @@ def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
     for (engine, version, h3), members in buckets.items():
         if len(members) < 2:
             continue
-        h1_hashes = tuple(str(m.get("h1_hash", "")) for m in members)
+        resolved_config_hashes = tuple(str(m.get("resolved_config_hash", "")) for m in members)
         exp_ids = tuple(str(m.get("experiment_id", "")) for m in members)
-        # Gap only if the H1 hashes differ — matching H1 means the
-        # canonicaliser already collapsed them.
-        gap_detected = len(set(h1_hashes)) > 1
+        # Gap only if the resolved_config_hashes differ — matching H1 means the
+        # library-resolution mechanism already collapsed them.
+        gap_detected = len(set(resolved_config_hashes)) > 1
         groups.append(
             PostRunH3Group(
-                h3_hash=h3,
+                observed_config_hash=h3,
                 engine=engine,
                 library_version=version,
-                member_h1_hashes=h1_hashes,
+                member_resolved_config_hashes=resolved_config_hashes,
                 member_experiment_ids=exp_ids,
                 gap_detected=gap_detected,
             )
@@ -187,7 +187,7 @@ def load_equivalence_groups(path: Path) -> EquivalenceGroups:
 
 def _pre_from_dict(data: dict[str, Any]) -> PreRunGroup:
     return PreRunGroup(
-        h1_hash=str(data["h1_hash"]),
+        resolved_config_hash=str(data["resolved_config_hash"]),
         canonical_config_excerpt=dict(data.get("canonical_config_excerpt", {})),
         member_experiment_ids=tuple(data.get("member_experiment_ids", [])),
         member_count=int(data.get("member_count", 0)),
@@ -199,10 +199,10 @@ def _pre_from_dict(data: dict[str, Any]) -> PreRunGroup:
 
 def _post_from_dict(data: dict[str, Any]) -> PostRunH3Group:
     return PostRunH3Group(
-        h3_hash=str(data["h3_hash"]),
+        observed_config_hash=str(data["observed_config_hash"]),
         engine=str(data.get("engine", "")),
         library_version=str(data.get("library_version", "")),
-        member_h1_hashes=tuple(data.get("member_h1_hashes", [])),
+        member_resolved_config_hashes=tuple(data.get("member_resolved_config_hashes", [])),
         member_experiment_ids=tuple(data.get("member_experiment_ids", [])),
         gap_detected=bool(data.get("gap_detected", False)),
         proposed_rule_id=data.get("proposed_rule_id"),

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -157,13 +157,17 @@ def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
 
 
 def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
-    """Write :class:`EquivalenceGroups` to ``path`` atomically as JSON."""
+    """Write :class:`EquivalenceGroups` to ``path`` atomically as JSON.
+
+    ``json.dumps`` serialises frozen-dataclass tuples as arrays naturally, so
+    no pre-conversion is needed.
+    """
     payload = {
         "study_id": groups.study_id,
         "dedup_mode": groups.dedup_mode,
         "vendored_rules_version": groups.vendored_rules_version,
-        "groups": [_pre_to_dict(g) for g in groups.groups],
-        "post_run_h3_groups": [_post_to_dict(g) for g in groups.post_run_h3_groups],
+        "groups": [asdict(g) for g in groups.groups],
+        "post_run_h3_groups": [asdict(g) for g in groups.post_run_h3_groups],
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write(json.dumps(payload, indent=2, default=str), path)
@@ -172,29 +176,13 @@ def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
 def load_equivalence_groups(path: Path) -> EquivalenceGroups:
     """Load :class:`EquivalenceGroups` from a JSON file on disk."""
     data = json.loads(path.read_text())
-    pre = [_pre_from_dict(g) for g in data.get("groups", [])]
-    post = [_post_from_dict(g) for g in data.get("post_run_h3_groups", [])]
     return EquivalenceGroups(
         study_id=str(data.get("study_id", "")),
         dedup_mode=str(data.get("dedup_mode", "")),
         vendored_rules_version=str(data.get("vendored_rules_version", "")),
-        groups=pre,
-        post_run_h3_groups=post,
+        groups=[_pre_from_dict(g) for g in data.get("groups", [])],
+        post_run_h3_groups=[_post_from_dict(g) for g in data.get("post_run_h3_groups", [])],
     )
-
-
-def _pre_to_dict(g: PreRunGroup) -> dict[str, Any]:
-    d = asdict(g)
-    # asdict() leaves tuples as tuples in the top level too, but JSON wants lists
-    d["member_experiment_ids"] = list(g.member_experiment_ids)
-    return d
-
-
-def _post_to_dict(g: PostRunH3Group) -> dict[str, Any]:
-    d = asdict(g)
-    d["member_h1_hashes"] = list(g.member_h1_hashes)
-    d["member_experiment_ids"] = list(g.member_experiment_ids)
-    return d
 
 
 def _pre_from_dict(data: dict[str, Any]) -> PreRunGroup:

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -19,7 +19,7 @@ import json
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from llenergymeasure.results.persistence import _atomic_write
 from llenergymeasure.study.library_resolution import DedupResult
@@ -60,7 +60,7 @@ class EquivalenceGroups:
     """Top-level equivalence-groups record written as ``equivalence_groups.json``."""
 
     study_id: str
-    dedup_mode: str
+    dedup_mode: Literal["resolved", "off"]
     vendored_rules_version: str = ""
     groups: list[PreRunGroup] = field(default_factory=list)
     post_run_h3_groups: list[PostRunH3Group] = field(default_factory=list)
@@ -176,9 +176,11 @@ def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
 def load_equivalence_groups(path: Path) -> EquivalenceGroups:
     """Load :class:`EquivalenceGroups` from a JSON file on disk."""
     data = json.loads(path.read_text())
+    raw_mode = str(data.get("dedup_mode", "off"))
+    dedup_mode: Literal["resolved", "off"] = "resolved" if raw_mode == "resolved" else "off"
     return EquivalenceGroups(
         study_id=str(data.get("study_id", "")),
-        dedup_mode=str(data.get("dedup_mode", "")),
+        dedup_mode=dedup_mode,
         vendored_rules_version=str(data.get("vendored_rules_version", "")),
         groups=[_pre_from_dict(g) for g in data.get("groups", [])],
         post_run_h3_groups=[_post_from_dict(g) for g in data.get("post_run_h3_groups", [])],

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -1,0 +1,221 @@
+"""Equivalence-groups sidecar — pre-run H1 groups + post-run H3 detection.
+
+Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §6.
+
+Written alongside the study's results bundle. ``pre_run_groups`` is populated
+at sweep-expansion time by :func:`dedup_sweep` and serialised immediately;
+``post_run_h3_groups`` is populated after the study completes by scanning
+sidecars for shared H3 hashes.
+
+The H3-collision invariant (§4.1) guarantees that in a post-H1-dedup run set,
+any group with ``len(member_h1_hashes) >= 2`` is a **proven canonicaliser gap**.
+Phase 50.3b's ``llem report-gaps`` command consumes this file to propose
+corpus additions.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from llenergymeasure.results.persistence import _atomic_write
+from llenergymeasure.study.sweep_canonicalise import DedupResult
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreRunGroup:
+    """Pre-run equivalence group recorded at sweep-expansion time."""
+
+    h1_hash: str
+    canonical_config_excerpt: dict[str, Any]
+    member_experiment_ids: tuple[str, ...]
+    member_count: int
+    representative_experiment_id: str
+    would_dedup: bool
+    deduplicated: bool
+
+
+@dataclass(frozen=True)
+class PostRunH3Group:
+    """Post-run H3-collision group — a canonicaliser gap if member count >= 2."""
+
+    h3_hash: str
+    engine: str
+    library_version: str
+    member_h1_hashes: tuple[str, ...]
+    member_experiment_ids: tuple[str, ...]
+    gap_detected: bool
+    proposed_rule_id: str | None = None
+
+
+@dataclass
+class EquivalenceGroups:
+    """Top-level equivalence-groups record written as ``equivalence_groups.json``."""
+
+    study_id: str
+    dedup_mode: str
+    vendored_rules_version: str = ""
+    groups: list[PreRunGroup] = field(default_factory=list)
+    post_run_h3_groups: list[PostRunH3Group] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Pre-run population — from dedup_sweep output
+# ---------------------------------------------------------------------------
+
+
+def build_pre_run_groups(
+    dedup: DedupResult,
+    *,
+    experiment_ids: list[str],
+) -> list[PreRunGroup]:
+    """Bind :class:`DedupResult` group indices back to caller-supplied IDs.
+
+    ``experiment_ids`` must be parallel to the declared-configs list passed
+    to :func:`dedup_sweep`. The runner is the natural source — it already
+    assigns per-experiment IDs before dispatch.
+    """
+    if len(experiment_ids) != len(dedup.declared_h1):
+        raise ValueError(
+            f"experiment_ids length {len(experiment_ids)} does not match the "
+            f"declared config count {len(dedup.declared_h1)}"
+        )
+    pre: list[PreRunGroup] = []
+    for group in dedup.groups:
+        member_ids = tuple(experiment_ids[i] for i in group.member_indices)
+        pre.append(
+            PreRunGroup(
+                h1_hash=group.h1_hash,
+                canonical_config_excerpt=group.canonical_excerpt,
+                member_experiment_ids=member_ids,
+                member_count=group.member_count,
+                representative_experiment_id=experiment_ids[group.representative_index],
+                would_dedup=group.member_count > 1,
+                deduplicated=dedup.deduplicated and group.member_count > 1,
+            )
+        )
+    return pre
+
+
+# ---------------------------------------------------------------------------
+# Post-run H3 grouping — scan sidecars after study completes
+# ---------------------------------------------------------------------------
+
+
+def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
+    """Group sidecars by ``(engine, library_version, h3_hash)``.
+
+    Any group with size >= 2 AND distinct ``h1_hash`` across its members is
+    flagged as a proven canonicaliser gap — per sweep-dedup.md §4.1.
+
+    Each sidecar dict must carry at minimum ``engine``, ``library_version``,
+    ``h1_hash``, ``h3_hash``, and ``experiment_id`` keys. Sidecars missing any
+    of these are silently skipped (pre-50.3a data, or runs with dedup_mode=off
+    for which H3 may be partial).
+    """
+    buckets: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for sc in sidecars:
+        h3 = sc.get("h3_hash")
+        if not h3:
+            continue
+        engine = str(sc.get("engine", ""))
+        version = str(sc.get("library_version", ""))
+        buckets[(engine, version, h3)].append(sc)
+
+    groups: list[PostRunH3Group] = []
+    for (engine, version, h3), members in buckets.items():
+        if len(members) < 2:
+            continue
+        h1_hashes = tuple(str(m.get("h1_hash", "")) for m in members)
+        exp_ids = tuple(str(m.get("experiment_id", "")) for m in members)
+        # Gap only if the H1 hashes differ — matching H1 means the
+        # canonicaliser already collapsed them.
+        gap_detected = len(set(h1_hashes)) > 1
+        groups.append(
+            PostRunH3Group(
+                h3_hash=h3,
+                engine=engine,
+                library_version=version,
+                member_h1_hashes=h1_hashes,
+                member_experiment_ids=exp_ids,
+                gap_detected=gap_detected,
+            )
+        )
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Writer / reader
+# ---------------------------------------------------------------------------
+
+
+def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
+    """Write :class:`EquivalenceGroups` to ``path`` atomically as JSON."""
+    payload = {
+        "study_id": groups.study_id,
+        "dedup_mode": groups.dedup_mode,
+        "vendored_rules_version": groups.vendored_rules_version,
+        "groups": [_pre_to_dict(g) for g in groups.groups],
+        "post_run_h3_groups": [_post_to_dict(g) for g in groups.post_run_h3_groups],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(json.dumps(payload, indent=2, default=str), path)
+
+
+def load_equivalence_groups(path: Path) -> EquivalenceGroups:
+    """Load :class:`EquivalenceGroups` from a JSON file on disk."""
+    data = json.loads(path.read_text())
+    pre = [_pre_from_dict(g) for g in data.get("groups", [])]
+    post = [_post_from_dict(g) for g in data.get("post_run_h3_groups", [])]
+    return EquivalenceGroups(
+        study_id=str(data.get("study_id", "")),
+        dedup_mode=str(data.get("dedup_mode", "")),
+        vendored_rules_version=str(data.get("vendored_rules_version", "")),
+        groups=pre,
+        post_run_h3_groups=post,
+    )
+
+
+def _pre_to_dict(g: PreRunGroup) -> dict[str, Any]:
+    d = asdict(g)
+    # asdict() leaves tuples as tuples in the top level too, but JSON wants lists
+    d["member_experiment_ids"] = list(g.member_experiment_ids)
+    return d
+
+
+def _post_to_dict(g: PostRunH3Group) -> dict[str, Any]:
+    d = asdict(g)
+    d["member_h1_hashes"] = list(g.member_h1_hashes)
+    d["member_experiment_ids"] = list(g.member_experiment_ids)
+    return d
+
+
+def _pre_from_dict(data: dict[str, Any]) -> PreRunGroup:
+    return PreRunGroup(
+        h1_hash=str(data["h1_hash"]),
+        canonical_config_excerpt=dict(data.get("canonical_config_excerpt", {})),
+        member_experiment_ids=tuple(data.get("member_experiment_ids", [])),
+        member_count=int(data.get("member_count", 0)),
+        representative_experiment_id=str(data.get("representative_experiment_id", "")),
+        would_dedup=bool(data.get("would_dedup", False)),
+        deduplicated=bool(data.get("deduplicated", False)),
+    )
+
+
+def _post_from_dict(data: dict[str, Any]) -> PostRunH3Group:
+    return PostRunH3Group(
+        h3_hash=str(data["h3_hash"]),
+        engine=str(data.get("engine", "")),
+        library_version=str(data.get("library_version", "")),
+        member_h1_hashes=tuple(data.get("member_h1_hashes", [])),
+        member_experiment_ids=tuple(data.get("member_experiment_ids", [])),
+        gap_detected=bool(data.get("gap_detected", False)),
+        proposed_rule_id=data.get("proposed_rule_id"),
+    )

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -1,141 +1,38 @@
-"""Canonical serialisation and SHA-256 hashing for H1 and H3.
+"""H1 view construction from resolved ExperimentConfig (study layer).
 
-Two hashes with orthogonal sources but identical shape:
+The pure hashing primitives live in :mod:`llenergymeasure.domain.hashing`
+(Layer 0).  This module contains only :func:`build_resolved_view`, which
+needs ``ExperimentConfig`` and therefore belongs at Layer 4 (study).
 
-- **H1** (library-resolution mechanism-output): hashed at sweep-expansion time over the
-  canonical form produced by :mod:`llenergymeasure.study.library_resolution`.
-- **H3** (library-observed): hashed at sidecar-write time over the native
-  types the engine constructed during inference (via
-  :func:`llenergymeasure.engines._helpers.extract_observed_params`).
-
-Sharing the schema and serialisation is what makes the observed-config-hash collision invariant
-meaningful (see ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
-§4.1): after resolved-config-hash dedup, any observed-config-hash duplicate is a proven library-resolution mechanism gap.
-
-The normalisation rules below are locked by sweep-dedup.md §9.Q3 — over-
-normalising would hide library-enforced semantics (e.g. ``None`` vs missing in
-vLLM), so the rules are strict.
+Re-exports the domain primitives so callers that previously imported from
+``study.hashing`` continue to work without changes.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
-import math
-from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
 
-_FLOAT_SIG_DIGITS = 12
-"""Float rounding precision (significant digits) for hash stability.
+# Re-export domain primitives — study.library_resolution and tests import from here.
+from llenergymeasure.domain.hashing import (
+    _FLOAT_SIG_DIGITS,
+    ConfigHashView,
+    _normalise,
+    build_observed_view,
+    canonical_serialise,
+    hash_config,
+)
 
-Upstream float arithmetic can produce bit-level jitter in the last 1-2
-digits that does not reflect an actual configuration difference. Rounding at
-12 significant digits removes that jitter without compressing any two values
-a researcher would write differently.
-"""
-
-
-# ---------------------------------------------------------------------------
-# Canonical serialisation (shared by H1 and H3)
-# ---------------------------------------------------------------------------
-
-
-def _normalise(value: Any) -> Any:
-    """Normalise a value for deterministic JSON serialisation.
-
-    Applies the locked rules from sweep-dedup.md §9.Q3:
-
-    - ``NaN`` → string ``"NaN"`` (NaN != NaN breaks dict hashing otherwise)
-    - float → rounded to 12 significant digits (stable across minor
-      arithmetic jitter)
-    - tuple → list (incidental immutability choice, not semantic)
-    - bool is preserved as bool (not folded into int even though
-      ``True == 1`` in Python)
-    - dict → dict with recursively normalised values (key sorting happens
-      at ``json.dumps(sort_keys=True)`` time)
-    - None and missing keys stay distinguishable (by never inserting a
-      sentinel for missing)
-    """
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, float):
-        if math.isnan(value):
-            return "NaN"
-        if math.isinf(value):
-            # Preserve infinity as a string literal for hash stability
-            return "Infinity" if value > 0 else "-Infinity"
-        if value == 0.0:
-            return 0.0
-        # Round to sig-figs rather than decimal places
-        mag = math.floor(math.log10(abs(value)))
-        factor = 10 ** (_FLOAT_SIG_DIGITS - 1 - mag)
-        return round(value * factor) / factor
-    if isinstance(value, (set, frozenset)):
-        # Sort for determinism; normalise elements recursively.
-        return [_normalise(v) for v in sorted(value, key=str)]
-    if isinstance(value, (list, tuple)):
-        return [_normalise(v) for v in value]
-    if isinstance(value, dict):
-        return {k: _normalise(v) for k, v in value.items()}
-    return value
-
-
-def canonical_serialise(obj: Any) -> bytes:
-    """Serialise ``obj`` to canonical-JSON bytes, ready for hashing.
-
-    Applies :func:`_normalise` then ``json.dumps(sort_keys=True)``. Uses a
-    separators tuple with no whitespace for compactness and stability
-    across Python versions.
-    """
-    normalised = _normalise(obj)
-    return json.dumps(
-        normalised,
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,  # Pydantic enums and dates
-        ensure_ascii=False,
-    ).encode("utf-8")
-
-
-# ---------------------------------------------------------------------------
-# Hashed-field schema
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ConfigHashView:
-    """Fixed-schema view of the fields hashed into resolved or observed config hash.
-
-    Per sweep-dedup.md §2.4, the hashed-field set is:
-
-    - ``task`` — model, prompt source, batch shape
-    - ``observed_engine_params`` — engine state (library-resolution mechanism output for H1,
-      live library observation for H3)
-    - ``observed_sampling_params`` — sampling state (same sources as above)
-    - ``lora`` / ``passthrough_kwargs`` — user-attached overrides
-
-    Excluded: ``MeasurementConfig`` (observation dials), ``ExecutionConfig``
-    (runner/parallelism), ``experiment_id``.
-    """
-
-    engine: str
-    task: dict[str, Any]
-    observed_engine_params: dict[str, Any] = field(default_factory=dict)
-    observed_sampling_params: dict[str, Any] = field(default_factory=dict)
-    lora: dict[str, Any] | None = None
-    passthrough_kwargs: dict[str, Any] = field(default_factory=dict)
-
-
-def hash_config(view: ConfigHashView) -> str:
-    """Return SHA-256 hex digest of ``view`` via :func:`canonical_serialise`.
-
-    Both H1 and H3 route through this function; they differ only in how
-    the :class:`ConfigHashView` is populated.
-    """
-    payload = asdict(view)
-    return hashlib.sha256(canonical_serialise(payload)).hexdigest()
+__all__ = [
+    "_FLOAT_SIG_DIGITS",
+    "ConfigHashView",
+    "_normalise",
+    "build_observed_view",
+    "build_resolved_view",
+    "canonical_serialise",
+    "hash_config",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -148,7 +45,7 @@ def build_resolved_view(config: ExperimentConfig) -> ConfigHashView:
 
     Reads the active engine section's full post-normalisation state; the
     library-resolution mechanism has already applied dormant rules to fixpoint before this
-    runs. Callers pass the resolved config, not the declared one — resolved_config_hash is
+    runs.  Callers pass the resolved config, not the declared one — resolved_config_hash is
     meaningless on a pre-resolved config.
 
     Engine-specific sub-models carry a ``sampling`` attribute; it is lifted
@@ -167,34 +64,4 @@ def build_resolved_view(config: ExperimentConfig) -> ConfigHashView:
         observed_sampling_params=sampling,
         lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
         passthrough_kwargs=dict(config.passthrough_kwargs or {}),
-    )
-
-
-# ---------------------------------------------------------------------------
-# H3 view construction — from library-observed effective params
-# ---------------------------------------------------------------------------
-
-
-def build_observed_view(
-    *,
-    engine: str,
-    task: dict[str, Any],
-    observed_engine_params: dict[str, Any],
-    observed_sampling_params: dict[str, Any],
-    lora: dict[str, Any] | None = None,
-    passthrough_kwargs: dict[str, Any] | None = None,
-) -> ConfigHashView:
-    """Assemble an H3 view from per-engine ``extract_observed_params`` output.
-
-    Callers live in the harness/sidecar path — they read ``task`` from the
-    same config that ran and pair it with the native-object dumps the engine
-    returned.
-    """
-    return ConfigHashView(
-        engine=engine,
-        task=task,
-        observed_engine_params=dict(observed_engine_params),
-        observed_sampling_params=dict(observed_sampling_params),
-        lora=lora,
-        passthrough_kwargs=dict(passthrough_kwargs or {}),
     )

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -147,37 +147,24 @@ def build_h1_view(config: ExperimentConfig) -> ConfigHashView:
     canonicaliser has already applied dormant rules to fixpoint before this
     runs. Callers pass the canonicalised config, not the declared one — H1 is
     meaningless on a pre-canonicalisation config.
-    """
-    engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
-    engine_section: Any = getattr(config, engine_name, None)
-
-    engine_params, sampling_params = _split_engine_section(engine_section)
-
-    task_dump = config.task.model_dump(mode="python")
-    passthrough = dict(config.passthrough_kwargs or {})
-
-    return ConfigHashView(
-        engine=engine_name,
-        task=task_dump,
-        effective_engine_params=engine_params,
-        effective_sampling_params=sampling_params,
-        lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
-        passthrough_kwargs=passthrough,
-    )
-
-
-def _split_engine_section(section: Any) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Return ``(engine_params, sampling_params)`` from a config engine section.
 
     Engine-specific sub-models carry a ``sampling`` attribute; it is lifted
     into its own dict so H1/H3 ordering separates "how the engine constructs"
-    from "what it generates with". Missing section → both dicts empty.
+    from "what it generates with".
     """
-    if section is None:
-        return {}, {}
-    dump = section.model_dump(mode="python") if hasattr(section, "model_dump") else dict(section)
+    engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    section: Any = getattr(config, engine_name, None)
+    dump: dict[str, Any] = section.model_dump(mode="python") if section is not None else {}
     sampling = dump.pop("sampling", None) or {}
-    return dump, sampling
+
+    return ConfigHashView(
+        engine=engine_name,
+        task=config.task.model_dump(mode="python"),
+        effective_engine_params=dump,
+        effective_sampling_params=sampling,
+        lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
+        passthrough_kwargs=dict(config.passthrough_kwargs or {}),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -1,0 +1,210 @@
+"""Canonical serialisation and SHA-256 hashing for H1 and H3.
+
+Two hashes with orthogonal sources but identical shape:
+
+- **H1** (canonicaliser-output): hashed at sweep-expansion time over the
+  canonical form produced by :mod:`llenergymeasure.study.sweep_canonicalise`.
+- **H3** (library-observed): hashed at sidecar-write time over the native
+  types the engine constructed during inference (via
+  :func:`llenergymeasure.engines._helpers.extract_effective_params`).
+
+Sharing the schema and serialisation is what makes the H3-collision invariant
+meaningful (see ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
+§4.1): after H1-dedup, any H3 duplicate is a proven canonicaliser gap.
+
+The normalisation rules below are locked by sweep-dedup.md §9.Q3 — over-
+normalising would hide library-enforced semantics (e.g. ``None`` vs missing in
+vLLM), so the rules are strict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from llenergymeasure.config.models import ExperimentConfig
+
+_FLOAT_SIG_DIGITS = 12
+"""Float rounding precision (significant digits) for hash stability.
+
+Upstream float arithmetic can produce bit-level jitter in the last 1-2
+digits that does not reflect an actual configuration difference. Rounding at
+12 significant digits removes that jitter without compressing any two values
+a researcher would write differently.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialisation (shared by H1 and H3)
+# ---------------------------------------------------------------------------
+
+
+def _normalise(value: Any) -> Any:
+    """Normalise a value for deterministic JSON serialisation.
+
+    Applies the locked rules from sweep-dedup.md §9.Q3:
+
+    - ``NaN`` → string ``"NaN"`` (NaN != NaN breaks dict hashing otherwise)
+    - float → rounded to 12 significant digits (stable across minor
+      arithmetic jitter)
+    - tuple → list (incidental immutability choice, not semantic)
+    - bool is preserved as bool (not folded into int even though
+      ``True == 1`` in Python)
+    - dict → dict with recursively normalised values (key sorting happens
+      at ``json.dumps(sort_keys=True)`` time)
+    - None and missing keys stay distinguishable (by never inserting a
+      sentinel for missing)
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            # Preserve infinity as a string literal for hash stability
+            return "Infinity" if value > 0 else "-Infinity"
+        if value == 0.0:
+            return 0.0
+        # Round to sig-figs rather than decimal places
+        mag = math.floor(math.log10(abs(value)))
+        factor = 10 ** (_FLOAT_SIG_DIGITS - 1 - mag)
+        return round(value * factor) / factor
+    if isinstance(value, (list, tuple)):
+        return [_normalise(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _normalise(v) for k, v in value.items()}
+    return value
+
+
+def canonical_serialise(obj: Any) -> bytes:
+    """Serialise ``obj`` to canonical-JSON bytes, ready for hashing.
+
+    Applies :func:`_normalise` then ``json.dumps(sort_keys=True)``. Uses a
+    separators tuple with no whitespace for compactness and stability
+    across Python versions.
+    """
+    normalised = _normalise(obj)
+    return json.dumps(
+        normalised,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,  # Pydantic enums and dates
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Hashed-field schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConfigHashView:
+    """Fixed-schema view of the fields hashed into H1 or H3.
+
+    Per sweep-dedup.md §2.4, the hashed-field set is:
+
+    - ``task`` — model, prompt source, batch shape
+    - ``effective_engine_params`` — engine state (canonicaliser output for H1,
+      live library observation for H3)
+    - ``effective_sampling_params`` — sampling state (same sources as above)
+    - ``lora`` / ``passthrough_kwargs`` — user-attached overrides
+
+    Excluded: ``MeasurementConfig`` (observation dials), ``ExecutionConfig``
+    (runner/parallelism), ``experiment_id``.
+    """
+
+    engine: str
+    task: dict[str, Any]
+    effective_engine_params: dict[str, Any] = field(default_factory=dict)
+    effective_sampling_params: dict[str, Any] = field(default_factory=dict)
+    lora: dict[str, Any] | None = None
+    passthrough_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+def hash_config(view: ConfigHashView) -> str:
+    """Return SHA-256 hex digest of ``view`` via :func:`canonical_serialise`.
+
+    Both H1 and H3 route through this function; they differ only in how
+    the :class:`ConfigHashView` is populated.
+    """
+    payload = asdict(view)
+    return hashlib.sha256(canonical_serialise(payload)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# H1 view construction — from canonicaliser output
+# ---------------------------------------------------------------------------
+
+
+def build_h1_view(config: ExperimentConfig) -> ConfigHashView:
+    """Project a (post-canonicalisation) ``ExperimentConfig`` into an H1 view.
+
+    Reads the active engine section's full post-normalisation state; the
+    canonicaliser has already applied dormant rules to fixpoint before this
+    runs. Callers pass the canonicalised config, not the declared one — H1 is
+    meaningless on a pre-canonicalisation config.
+    """
+    engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    engine_section: Any = getattr(config, engine_name, None)
+
+    engine_params, sampling_params = _split_engine_section(engine_section)
+
+    task_dump = config.task.model_dump(mode="python")
+    passthrough = dict(config.passthrough_kwargs or {})
+
+    return ConfigHashView(
+        engine=engine_name,
+        task=task_dump,
+        effective_engine_params=engine_params,
+        effective_sampling_params=sampling_params,
+        lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
+        passthrough_kwargs=passthrough,
+    )
+
+
+def _split_engine_section(section: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return ``(engine_params, sampling_params)`` from a config engine section.
+
+    Engine-specific sub-models carry a ``sampling`` attribute; it is lifted
+    into its own dict so H1/H3 ordering separates "how the engine constructs"
+    from "what it generates with". Missing section → both dicts empty.
+    """
+    if section is None:
+        return {}, {}
+    dump = section.model_dump(mode="python") if hasattr(section, "model_dump") else dict(section)
+    sampling = dump.pop("sampling", None) or {}
+    return dump, sampling
+
+
+# ---------------------------------------------------------------------------
+# H3 view construction — from library-observed effective params
+# ---------------------------------------------------------------------------
+
+
+def build_h3_view(
+    *,
+    engine: str,
+    task: dict[str, Any],
+    effective_engine_params: dict[str, Any],
+    effective_sampling_params: dict[str, Any],
+    lora: dict[str, Any] | None = None,
+    passthrough_kwargs: dict[str, Any] | None = None,
+) -> ConfigHashView:
+    """Assemble an H3 view from per-engine ``extract_effective_params`` output.
+
+    Callers live in the harness/sidecar path — they read ``task`` from the
+    same config that ran and pair it with the native-object dumps the engine
+    returned.
+    """
+    return ConfigHashView(
+        engine=engine,
+        task=task,
+        effective_engine_params=dict(effective_engine_params),
+        effective_sampling_params=dict(effective_sampling_params),
+        lora=lora,
+        passthrough_kwargs=dict(passthrough_kwargs or {}),
+    )

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -2,15 +2,15 @@
 
 Two hashes with orthogonal sources but identical shape:
 
-- **H1** (canonicaliser-output): hashed at sweep-expansion time over the
-  canonical form produced by :mod:`llenergymeasure.study.sweep_canonicalise`.
+- **H1** (library-resolution mechanism-output): hashed at sweep-expansion time over the
+  canonical form produced by :mod:`llenergymeasure.study.library_resolution`.
 - **H3** (library-observed): hashed at sidecar-write time over the native
   types the engine constructed during inference (via
-  :func:`llenergymeasure.engines._helpers.extract_effective_params`).
+  :func:`llenergymeasure.engines._helpers.extract_observed_params`).
 
-Sharing the schema and serialisation is what makes the H3-collision invariant
+Sharing the schema and serialisation is what makes the observed-config-hash collision invariant
 meaningful (see ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
-§4.1): after H1-dedup, any H3 duplicate is a proven canonicaliser gap.
+§4.1): after resolved-config-hash dedup, any observed-config-hash duplicate is a proven library-resolution mechanism gap.
 
 The normalisation rules below are locked by sweep-dedup.md §9.Q3 — over-
 normalising would hide library-enforced semantics (e.g. ``None`` vs missing in
@@ -72,6 +72,9 @@ def _normalise(value: Any) -> Any:
         mag = math.floor(math.log10(abs(value)))
         factor = 10 ** (_FLOAT_SIG_DIGITS - 1 - mag)
         return round(value * factor) / factor
+    if isinstance(value, (set, frozenset)):
+        # Sort for determinism; normalise elements recursively.
+        return [_normalise(v) for v in sorted(value, key=str)]
     if isinstance(value, (list, tuple)):
         return [_normalise(v) for v in value]
     if isinstance(value, dict):
@@ -103,14 +106,14 @@ def canonical_serialise(obj: Any) -> bytes:
 
 @dataclass(frozen=True)
 class ConfigHashView:
-    """Fixed-schema view of the fields hashed into H1 or H3.
+    """Fixed-schema view of the fields hashed into resolved or observed config hash.
 
     Per sweep-dedup.md §2.4, the hashed-field set is:
 
     - ``task`` — model, prompt source, batch shape
-    - ``effective_engine_params`` — engine state (canonicaliser output for H1,
+    - ``observed_engine_params`` — engine state (library-resolution mechanism output for H1,
       live library observation for H3)
-    - ``effective_sampling_params`` — sampling state (same sources as above)
+    - ``observed_sampling_params`` — sampling state (same sources as above)
     - ``lora`` / ``passthrough_kwargs`` — user-attached overrides
 
     Excluded: ``MeasurementConfig`` (observation dials), ``ExecutionConfig``
@@ -119,8 +122,8 @@ class ConfigHashView:
 
     engine: str
     task: dict[str, Any]
-    effective_engine_params: dict[str, Any] = field(default_factory=dict)
-    effective_sampling_params: dict[str, Any] = field(default_factory=dict)
+    observed_engine_params: dict[str, Any] = field(default_factory=dict)
+    observed_sampling_params: dict[str, Any] = field(default_factory=dict)
     lora: dict[str, Any] | None = None
     passthrough_kwargs: dict[str, Any] = field(default_factory=dict)
 
@@ -136,17 +139,17 @@ def hash_config(view: ConfigHashView) -> str:
 
 
 # ---------------------------------------------------------------------------
-# H1 view construction — from canonicaliser output
+# H1 view construction — from library-resolution mechanism output
 # ---------------------------------------------------------------------------
 
 
-def build_h1_view(config: ExperimentConfig) -> ConfigHashView:
-    """Project a (post-canonicalisation) ``ExperimentConfig`` into an H1 view.
+def build_resolved_view(config: ExperimentConfig) -> ConfigHashView:
+    """Project a (post-library-resolution) ``ExperimentConfig`` into an H1 view.
 
     Reads the active engine section's full post-normalisation state; the
-    canonicaliser has already applied dormant rules to fixpoint before this
-    runs. Callers pass the canonicalised config, not the declared one — H1 is
-    meaningless on a pre-canonicalisation config.
+    library-resolution mechanism has already applied dormant rules to fixpoint before this
+    runs. Callers pass the resolved config, not the declared one — resolved_config_hash is
+    meaningless on a pre-resolved config.
 
     Engine-specific sub-models carry a ``sampling`` attribute; it is lifted
     into its own dict so H1/H3 ordering separates "how the engine constructs"
@@ -160,8 +163,8 @@ def build_h1_view(config: ExperimentConfig) -> ConfigHashView:
     return ConfigHashView(
         engine=engine_name,
         task=config.task.model_dump(mode="python"),
-        effective_engine_params=dump,
-        effective_sampling_params=sampling,
+        observed_engine_params=dump,
+        observed_sampling_params=sampling,
         lora=None,  # No LoRA field yet on ExperimentConfig — reserved for future.
         passthrough_kwargs=dict(config.passthrough_kwargs or {}),
     )
@@ -172,16 +175,16 @@ def build_h1_view(config: ExperimentConfig) -> ConfigHashView:
 # ---------------------------------------------------------------------------
 
 
-def build_h3_view(
+def build_observed_view(
     *,
     engine: str,
     task: dict[str, Any],
-    effective_engine_params: dict[str, Any],
-    effective_sampling_params: dict[str, Any],
+    observed_engine_params: dict[str, Any],
+    observed_sampling_params: dict[str, Any],
     lora: dict[str, Any] | None = None,
     passthrough_kwargs: dict[str, Any] | None = None,
 ) -> ConfigHashView:
-    """Assemble an H3 view from per-engine ``extract_effective_params`` output.
+    """Assemble an H3 view from per-engine ``extract_observed_params`` output.
 
     Callers live in the harness/sidecar path — they read ``task`` from the
     same config that ran and pair it with the native-object dumps the engine
@@ -190,8 +193,8 @@ def build_h3_view(
     return ConfigHashView(
         engine=engine,
         task=task,
-        effective_engine_params=dict(effective_engine_params),
-        effective_sampling_params=dict(effective_sampling_params),
+        observed_engine_params=dict(observed_engine_params),
+        observed_sampling_params=dict(observed_sampling_params),
         lora=lora,
         passthrough_kwargs=dict(passthrough_kwargs or {}),
     )

--- a/src/llenergymeasure/study/library_resolution.py
+++ b/src/llenergymeasure/study/library_resolution.py
@@ -1,8 +1,8 @@
-"""Sweep canonicaliser — apply vendored dormant rules to fixpoint, dedup by H1.
+"""Sweep library-resolution mechanism — apply vendored dormant rules to fixpoint, dedup by H1.
 
 Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §2.
 
-The canonicaliser is the host-side, pre-dispatch layer that normalises every
+The library-resolution mechanism is the host-side, pre-dispatch layer that normalises every
 field the vendored corpus marks as ``dormant``. Each rule's fired-state
 projection is taken from its match predicate's "not_equal" / "present"
 operand (the sentinel value the predicate is *deviating from*) — that same
@@ -11,10 +11,10 @@ runtime canonicalisation and CI correctness tests apply an identical
 normalisation.
 
 Rules chain (vLLM epsilon-clamp → greedy-normalise); iteration is capped at
-:data:`_MAX_ITER` to surface cycles via :class:`CanonicaliserCycleError`.
+:data:`_MAX_ITER` to surface cycles via :class:`LibraryResolutionCycleError`.
 
 Out-of-scope per PLAN §Scope OUT: vLLM/TRT-LLM corpora don't exist yet, so
-this PR mostly exercises the transformers rules. The canonicaliser itself is
+this PR mostly exercises the transformers rules. The library-resolution mechanism itself is
 engine-generic.
 """
 
@@ -25,12 +25,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.engines.vendored_rules.loader import (
+from llenergymeasure.config.vendored_rules.loader import (
     Rule,
     VendoredRulesLoader,
     resolve_field_path,
 )
-from llenergymeasure.study.hashing import build_h1_view, hash_config
+from llenergymeasure.study.hashing import build_resolved_view, hash_config
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +42,8 @@ passes; 10 is generous headroom that still surfaces a rule cycle quickly.
 """
 
 
-class CanonicaliserCycleError(RuntimeError):
-    """The canonicaliser did not reach a fixpoint within :data:`_MAX_ITER` passes.
+class LibraryResolutionCycleError(RuntimeError):
+    """The library-resolution mechanism did not reach a fixpoint within :data:`_MAX_ITER` passes.
 
     Indicates a cycle in the vendored rules corpus (rule A produces state
     matching rule B which produces state matching rule A). The corpus vendor
@@ -53,7 +53,7 @@ class CanonicaliserCycleError(RuntimeError):
 
     def __init__(self, final_config: ExperimentConfig, iterations: int) -> None:
         super().__init__(
-            f"Canonicaliser did not reach fixpoint within {iterations} iterations. "
+            f"Library resolution did not reach fixpoint within {iterations} iterations. "
             f"Likely a cycle in the vendored rules corpus. "
             f"Final engine={final_config.engine}."
         )
@@ -62,11 +62,11 @@ class CanonicaliserCycleError(RuntimeError):
 
 
 # ---------------------------------------------------------------------------
-# Core canonicalise() — one config
+# Core _apply_rules_fixpoint() — one config
 # ---------------------------------------------------------------------------
 
 
-def canonicalise(
+def _apply_rules_fixpoint(
     config: ExperimentConfig, rules: list[Rule] | tuple[Rule, ...]
 ) -> ExperimentConfig:
     """Apply every ``dormant``-severity rule to ``config`` repeatedly until stable.
@@ -80,7 +80,7 @@ def canonicalise(
             ``VendoredRulesLoader.load_rules(engine).rules``).
 
     Raises:
-        CanonicaliserCycleError: If the fixpoint loop exceeds
+        LibraryResolutionCycleError: If the fixpoint loop exceeds
             :data:`_MAX_ITER` passes — the vendored corpus has a rule cycle.
     """
     dormant_rules = [r for r in rules if r.severity in ("dormant", "dormant_silent")]
@@ -103,7 +103,7 @@ def canonicalise(
                     fired = True
         if not fired:
             return current
-    raise CanonicaliserCycleError(current, _MAX_ITER)
+    raise LibraryResolutionCycleError(current, _MAX_ITER)
 
 
 def _rule_normalisations(rule: Rule) -> dict[str, Any]:
@@ -171,9 +171,9 @@ def _assign_field_path(config: ExperimentConfig, path: str, value: Any) -> None:
             setattr(parent, leaf, value)
     except (ValueError, TypeError) as exc:
         # Pydantic model_config={"frozen": True} or field constraints can
-        # reject the assignment. Log at debug — the canonicaliser is best-
+        # reject the assignment. Log at debug — the library-resolution mechanism is best-
         # effort; a rejected field just stays at its declared value.
-        logger.debug("Canonicaliser could not assign %s=%r: %s", path, value, exc)
+        logger.debug("Library resolution could not assign %s=%r: %s", path, value, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +185,7 @@ def _assign_field_path(config: ExperimentConfig, path: str, value: Any) -> None:
 class EquivalenceGroup:
     """Pre-run group of declared configs that collapse to the same H1 canonical form."""
 
-    h1_hash: str
+    resolved_config_hash: str
     canonical_excerpt: dict[str, Any]
     member_indices: tuple[int, ...]
     representative_index: int
@@ -197,16 +197,16 @@ class EquivalenceGroup:
 
 @dataclass
 class DedupResult:
-    """Return bundle from :func:`dedup_sweep`.
+    """Return bundle from :func:`resolve_library_effective`.
 
     Attributes:
         canonical_configs: The canonicalised configs after dedup (or all
             canonicalised configs when ``deduplicate=False``, with duplicates
             kept). This is what the runner iterates over.
-        groups: One :class:`EquivalenceGroup` per unique H1 hash, recording
+        groups: One :class:`EquivalenceGroup` per unique resolved_config_hash, recording
             which indices of the input sweep collapsed together.
-        declared_h1: ``declared_index → h1_hash`` — lets the runner tag the
-            manifest entry for each run with its equivalence group.
+        declared_resolved_hashes: ``declared_index → resolved_config_hash`` — lets the runner tag
+            the manifest entry for each run with its equivalence group.
         would_dedup: ``True`` iff any group has > 1 member (dedup would save
             runs even when ``deduplicate=False``).
         deduplicated: ``True`` iff dedup was actually applied to the
@@ -215,19 +215,19 @@ class DedupResult:
 
     canonical_configs: list[ExperimentConfig]
     groups: list[EquivalenceGroup] = field(default_factory=list)
-    declared_h1: list[str] = field(default_factory=list)
+    declared_resolved_hashes: list[str] = field(default_factory=list)
     would_dedup: bool = False
     deduplicated: bool = False
 
 
-def dedup_sweep(
+def resolve_library_effective(
     configs: list[ExperimentConfig],
     *,
     rules: list[Rule] | tuple[Rule, ...] | None = None,
     loader: VendoredRulesLoader | None = None,
     deduplicate: bool = True,
 ) -> DedupResult:
-    """Canonicalise then (optionally) H1-dedup ``configs``.
+    """Canonicalise then (optionally) resolved-config-hash dedup ``configs``.
 
     Rules are resolved lazily: if ``rules`` is None the loader is consulted
     per-engine for each config (cached by the loader instance). Callers
@@ -265,9 +265,9 @@ def dedup_sweep(
     canonicalised: list[ExperimentConfig] = []
     hashes: list[str] = []
     for cfg in configs:
-        canon = canonicalise(cfg, _rules_for(cfg))
+        canon = _apply_rules_fixpoint(cfg, _rules_for(cfg))
         canonicalised.append(canon)
-        hashes.append(hash_config(build_h1_view(canon)))
+        hashes.append(hash_config(build_resolved_view(canon)))
 
     groups_by_hash: dict[str, list[int]] = {}
     for idx, h in enumerate(hashes):
@@ -280,7 +280,7 @@ def dedup_sweep(
         excerpt = _canonical_excerpt(rep)
         groups.append(
             EquivalenceGroup(
-                h1_hash=h1,
+                resolved_config_hash=h1,
                 canonical_excerpt=excerpt,
                 member_indices=tuple(indices),
                 representative_index=representative,
@@ -297,7 +297,7 @@ def dedup_sweep(
     return DedupResult(
         canonical_configs=selected,
         groups=groups,
-        declared_h1=hashes,
+        declared_resolved_hashes=hashes,
         would_dedup=would_dedup,
         deduplicated=deduplicate and would_dedup,
     )

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -130,6 +130,7 @@ def _save_and_record(
     ts_source_dir: Path | None = None,
     environment_snapshot: Any | None = None,
     resolution_log: dict[str, Any] | None = None,
+    resolved_config_hash: str | None = None,
 ) -> None:
     """Save result to disk and update manifest. Appends result path to result_files.
 
@@ -175,6 +176,31 @@ def _save_and_record(
                 config_hash,
                 result_path.parent,
             )
+
+        # Move config.json sidecar (written by harness to temp dir) to experiment dir.
+        # Also patch in the resolved_config_hash (H1) from StudyConfig, which the harness
+        # doesn't have access to at write time.
+        if ts_source_dir is not None:
+            config_sidecar_src = ts_source_dir / "config.json"
+            if config_sidecar_src.exists():
+                import json as _json
+
+                try:
+                    _payload = _json.loads(config_sidecar_src.read_text())
+                    if resolved_config_hash is not None:
+                        _payload["resolved_config_hash"] = resolved_config_hash
+                    from llenergymeasure.results.persistence import _atomic_write
+
+                    _atomic_write(
+                        _json.dumps(_payload, indent=2, default=str),
+                        result_path.parent / "config.json",
+                    )
+                except Exception as exc:  # pragma: no cover — best-effort
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).debug("config.json sidecar move failed: %s", exc)
+                finally:
+                    config_sidecar_src.unlink(missing_ok=True)
 
         # Clean up the stale flat parquet file after it has been copied into the
         # experiment subdirectory (mirrors cli/run.py line 288).
@@ -783,6 +809,8 @@ class StudyRunner:
             # Mark study completed on clean exit (no interrupt, timeout, or circuit break).
             if not self._interrupt_event.is_set() and not _aborted:
                 self.manifest.mark_study_completed()
+                # Write equivalence_groups.json — post-run observed-config-hash groups.
+                self._write_equivalence_groups_sidecar()
 
         finally:
             signal.signal(signal.SIGINT, original_sigint)
@@ -804,6 +832,68 @@ class StudyRunner:
             sys.exit(130)
 
         return results
+
+    def _write_equivalence_groups_sidecar(self) -> None:
+        """Write ``equivalence_groups.json`` to the study directory after run completion.
+
+        Bundles:
+        - Pre-run groups from ``StudyConfig.pre_run_equivalence_groups`` (resolved-config-hash
+          dedup computed at sweep-expansion time).
+        - Post-run observed-config-hash collision groups built by scanning all ``config.json``
+          sidecars in the study directory.
+
+        Best-effort — failures are logged at DEBUG to avoid masking study results.
+        """
+        try:
+            import json as _json
+
+            from llenergymeasure.study.equivalence_groups import (
+                EquivalenceGroups,
+                PostRunH3Group,
+                PreRunGroup,
+                find_h3_groups,
+                write_equivalence_groups,
+            )
+
+            study = self.study
+            study_id = study.study_design_hash or "unknown"
+            dedup_mode = getattr(study, "dedup_mode", "off")
+
+            # Deserialise pre-run groups from StudyConfig (stored as raw dicts)
+            pre_run_groups: list[PreRunGroup] = []
+            for g in getattr(study, "pre_run_equivalence_groups", []):
+                with contextlib.suppress(Exception):
+                    pre_run_groups.append(
+                        PreRunGroup(
+                            resolved_config_hash=str(g.get("resolved_config_hash", "")),
+                            canonical_config_excerpt=dict(g.get("canonical_config_excerpt", {})),
+                            member_experiment_ids=tuple(g.get("member_experiment_ids", [])),
+                            member_count=int(g.get("member_count", 0)),
+                            representative_experiment_id=str(
+                                g.get("representative_experiment_id", "")
+                            ),
+                            would_dedup=bool(g.get("would_dedup", False)),
+                            deduplicated=bool(g.get("deduplicated", False)),
+                        )
+                    )
+
+            # Scan config.json sidecars for post-run observed-config-hash groups
+            sidecars: list[dict] = []
+            for config_json in self.study_dir.rglob("config.json"):
+                with contextlib.suppress(Exception):
+                    sidecars.append(_json.loads(config_json.read_text()))
+            post_run_groups: list[PostRunH3Group] = find_h3_groups(sidecars)
+
+            groups = EquivalenceGroups(
+                study_id=study_id,
+                dedup_mode=dedup_mode,
+                groups=pre_run_groups,
+                post_run_h3_groups=post_run_groups,
+            )
+            write_equivalence_groups(groups, self.study_dir / "equivalence_groups.json")
+            logger.debug("Wrote equivalence_groups.json to %s", self.study_dir)
+        except Exception as exc:
+            logger.debug("equivalence_groups.json write failed (non-fatal): %s", exc)
 
     def _mark_remaining_skipped(
         self,

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -608,6 +608,10 @@ class StudyRunner:
         self._skip_set: set[tuple[str, int]] = skip_set or set()
         # Pre-built resolution logs keyed by config_hash (written as _resolution.json sidecar)
         self._resolution_logs: dict[str, dict[str, Any]] = resolution_logs or {}
+        # Declared-config-hash → resolved-config-hash (H1) mapping.
+        # Built from study.experiments (post-dedup unique configs) so _save_and_record
+        # can patch the resolved_config_hash into each config.json sidecar.
+        self._resolved_hashes: dict[str, str] = self._build_resolved_hashes(study)
         # SIGINT state — initialised here, set live in run()
         self._interrupt_event: threading.Event = threading.Event()
         self._active_process: Any = None  # multiprocessing.Process | None
@@ -894,6 +898,36 @@ class StudyRunner:
             logger.debug("Wrote equivalence_groups.json to %s", self.study_dir)
         except Exception as exc:
             logger.debug("equivalence_groups.json write failed (non-fatal): %s", exc)
+
+    @staticmethod
+    def _build_resolved_hashes(study: Any) -> dict[str, str]:
+        """Build a declared_config_hash → resolved_config_hash (H1) mapping.
+
+        Iterates the unique post-dedup experiments in ``study.experiments``
+        (cycles produce duplicates; seen_hashes deduplicates them) and
+        computes each experiment's resolved hash via the same H1 pipeline
+        used at sweep-expansion time.
+
+        Returns an empty dict on any failure — _save_and_record treats a
+        missing resolved_config_hash as best-effort and writes ``None``.
+        """
+        try:
+            from llenergymeasure.domain.experiment import compute_declared_config_hash
+            from llenergymeasure.study.hashing import build_resolved_view, hash_config
+
+            result: dict[str, str] = {}
+            seen: set[str] = set()
+            for exp in study.experiments:
+                declared_h = compute_declared_config_hash(exp)
+                if declared_h in seen:
+                    continue
+                seen.add(declared_h)
+                resolved_h = hash_config(build_resolved_view(exp))
+                result[declared_h] = resolved_h
+            return result
+        except Exception as exc:
+            logger.debug("_build_resolved_hashes failed (non-fatal): %s", exc)
+            return {}
 
     def _mark_remaining_skipped(
         self,
@@ -1780,6 +1814,7 @@ class StudyRunner:
                 ts_source_dir=ts_source_dir,
                 environment_snapshot=environment_snapshot,
                 resolution_log=self._resolution_logs.get(config_hash),
+                resolved_config_hash=self._resolved_hashes.get(config_hash),
             )
             if self._progress:
                 # Emit save paths as substeps BEFORE end_experiment_ok (which clears

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -32,7 +32,7 @@ import uuid
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from llenergymeasure._version import __version__ as _HOST_PKG_VERSION
 from llenergymeasure.config.ssot import (
@@ -861,7 +861,8 @@ class StudyRunner:
 
             study = self.study
             study_id = study.study_design_hash or "unknown"
-            dedup_mode = getattr(study, "dedup_mode", "off")
+            raw_mode = getattr(study, "dedup_mode", "off")
+            dedup_mode: Literal["resolved", "off"] = "resolved" if raw_mode == "resolved" else "off"
 
             # Deserialise pre-run groups from StudyConfig (stored as raw dicts)
             pre_run_groups: list[PreRunGroup] = []
@@ -882,7 +883,7 @@ class StudyRunner:
                     )
 
             # Scan config.json sidecars for post-run observed-config-hash groups
-            sidecars: list[dict] = []
+            sidecars: list[dict[str, Any]] = []
             for config_json in self.study_dir.rglob("config.json"):
                 with contextlib.suppress(Exception):
                     sidecars.append(_json.loads(config_json.read_text()))

--- a/src/llenergymeasure/study/sweep_canonicalise.py
+++ b/src/llenergymeasure/study/sweep_canonicalise.py
@@ -1,0 +1,324 @@
+"""Sweep canonicaliser — apply vendored dormant rules to fixpoint, dedup by H1.
+
+Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §2.
+
+The canonicaliser is the host-side, pre-dispatch layer that normalises every
+field the vendored corpus marks as ``dormant``. Each rule's fired-state
+projection is taken from its match predicate's "not_equal" / "present"
+operand (the sentinel value the predicate is *deviating from*) — that same
+projection is what :mod:`scripts.walkers._fixpoint_test` enforces in CI, so
+runtime canonicalisation and CI correctness tests apply an identical
+normalisation.
+
+Rules chain (vLLM epsilon-clamp → greedy-normalise); iteration is capped at
+:data:`_MAX_ITER` to surface cycles via :class:`CanonicaliserCycleError`.
+
+Out-of-scope per PLAN §Scope OUT: vLLM/TRT-LLM corpora don't exist yet, so
+this PR mostly exercises the transformers rules. The canonicaliser itself is
+engine-generic.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.engines.vendored_rules.loader import (
+    Rule,
+    VendoredRulesLoader,
+    resolve_field_path,
+)
+from llenergymeasure.study.hashing import build_h1_view, hash_config
+
+logger = logging.getLogger(__name__)
+
+_MAX_ITER = 10
+"""Maximum fixpoint passes before declaring non-convergence.
+
+PoC-F (sweep-dedup.md §10) converged every seeded-corpus case within 2
+passes; 10 is generous headroom that still surfaces a rule cycle quickly.
+"""
+
+
+class CanonicaliserCycleError(RuntimeError):
+    """The canonicaliser did not reach a fixpoint within :data:`_MAX_ITER` passes.
+
+    Indicates a cycle in the vendored rules corpus (rule A produces state
+    matching rule B which produces state matching rule A). The corpus vendor
+    step's shuffle-application test is supposed to catch this at CI time,
+    but this guard prevents runtime hangs if a bad corpus ships anyway.
+    """
+
+    def __init__(self, final_config: ExperimentConfig, iterations: int) -> None:
+        super().__init__(
+            f"Canonicaliser did not reach fixpoint within {iterations} iterations. "
+            f"Likely a cycle in the vendored rules corpus. "
+            f"Final engine={final_config.engine}."
+        )
+        self.final_config = final_config
+        self.iterations = iterations
+
+
+# ---------------------------------------------------------------------------
+# Core canonicalise() — one config
+# ---------------------------------------------------------------------------
+
+
+def canonicalise(
+    config: ExperimentConfig, rules: list[Rule] | tuple[Rule, ...]
+) -> ExperimentConfig:
+    """Apply every ``dormant``-severity rule to ``config`` repeatedly until stable.
+
+    Returns a deep-copy of ``config`` with each dormant rule's normalisations
+    projected onto the fired fields. The input is not mutated.
+
+    Args:
+        config: A validated ``ExperimentConfig``.
+        rules: The rule list for the config's engine (typically from
+            ``VendoredRulesLoader.load_rules(engine).rules``).
+
+    Raises:
+        CanonicaliserCycleError: If the fixpoint loop exceeds
+            :data:`_MAX_ITER` passes — the vendored corpus has a rule cycle.
+    """
+    dormant_rules = [r for r in rules if r.severity in ("dormant", "dormant_silent")]
+    if not dormant_rules:
+        return config.model_copy(deep=True)
+
+    current = config.model_copy(deep=True)
+    for _iteration in range(_MAX_ITER):
+        fired = False
+        for rule in dormant_rules:
+            match = rule.try_match(current)
+            if match is None:
+                continue
+            updates = _rule_normalisations(rule)
+            if not updates:
+                continue
+            for field_path, target_value in updates.items():
+                if resolve_field_path(current, field_path) != target_value:
+                    _assign_field_path(current, field_path, target_value)
+                    fired = True
+        if not fired:
+            return current
+    raise CanonicaliserCycleError(current, _MAX_ITER)
+
+
+def _rule_normalisations(rule: Rule) -> dict[str, Any]:
+    """Return ``{field_path: canonical_value}`` the rule normalises to.
+
+    Strategy (per sweep-dedup.md §2.1 and the fixpoint test's projection):
+
+    1. If ``expected_outcome["normalised_fields"]`` lists explicit paths, they
+       collapse to ``None`` (the universal "strip this field" sentinel).
+    2. Otherwise, fall back to the rule's *match* predicate: any field
+       matched with a ``not_equal`` / ``present`` operator is normalised by
+       stripping (setting to ``None`` or the ``not_equal`` sentinel if
+       scalar). This is the fixpoint-test projection — structurally identical
+       to what CI enforces for shuffle-stability.
+
+    Rules that match only on equality (e.g. ``do_sample: false``) do not
+    normalise those fields — equality predicates are *triggers*, not
+    *subjects*. Subject fields are the ones marked ``present``/``not_equal``.
+    """
+    out: dict[str, Any] = {}
+
+    explicit = rule.expected_outcome.get("normalised_fields") or []
+    for raw_path in explicit:
+        path = str(raw_path)
+        out[path] = None
+
+    if out:
+        return out
+
+    for path, spec in rule.match_fields.items():
+        if not isinstance(spec, dict):
+            continue
+        if "not_equal" in spec:
+            # The "canonical" state is the not_equal sentinel — applying the
+            # rule drives the field back to the library-observed default.
+            out[path] = spec["not_equal"]
+        elif spec.get("present") and "not_equal" not in spec and "in" not in spec:
+            # Subject field marked only as "present" — strip to None (the
+            # library either ignores it, or the effective value is captured
+            # later via H3).
+            out[path] = None
+    return out
+
+
+def _assign_field_path(config: ExperimentConfig, path: str, value: Any) -> None:
+    """Set ``value`` at dotted ``path`` on ``config`` in place.
+
+    Walks nested Pydantic models / dicts, tolerant of ``None`` intermediate
+    attributes (silently returns if the path doesn't resolve to an assignable
+    location — mirrors :func:`resolve_field_path`'s permissive traversal).
+    """
+    parts = path.split(".")
+    parent: Any = config
+    for part in parts[:-1]:
+        if parent is None:
+            return
+        parent = parent.get(part) if isinstance(parent, dict) else getattr(parent, part, None)
+    if parent is None:
+        return
+    leaf = parts[-1]
+    try:
+        if isinstance(parent, dict):
+            parent[leaf] = value
+        else:
+            setattr(parent, leaf, value)
+    except (ValueError, TypeError) as exc:
+        # Pydantic model_config={"frozen": True} or field constraints can
+        # reject the assignment. Log at debug — the canonicaliser is best-
+        # effort; a rejected field just stays at its declared value.
+        logger.debug("Canonicaliser could not assign %s=%r: %s", path, value, exc)
+
+
+# ---------------------------------------------------------------------------
+# Sweep dedup
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EquivalenceGroup:
+    """Pre-run group of declared configs that collapse to the same H1 canonical form."""
+
+    h1_hash: str
+    canonical_excerpt: dict[str, Any]
+    member_indices: tuple[int, ...]
+    representative_index: int
+
+    @property
+    def member_count(self) -> int:
+        return len(self.member_indices)
+
+
+@dataclass
+class DedupResult:
+    """Return bundle from :func:`dedup_sweep`.
+
+    Attributes:
+        canonical_configs: The canonicalised configs after dedup (or all
+            canonicalised configs when ``deduplicate=False``, with duplicates
+            kept). This is what the runner iterates over.
+        groups: One :class:`EquivalenceGroup` per unique H1 hash, recording
+            which indices of the input sweep collapsed together.
+        declared_h1: ``declared_index → h1_hash`` — lets the runner tag the
+            manifest entry for each run with its equivalence group.
+        would_dedup: ``True`` iff any group has > 1 member (dedup would save
+            runs even when ``deduplicate=False``).
+        deduplicated: ``True`` iff dedup was actually applied to the
+            ``canonical_configs`` return slot.
+    """
+
+    canonical_configs: list[ExperimentConfig]
+    groups: list[EquivalenceGroup] = field(default_factory=list)
+    declared_h1: list[str] = field(default_factory=list)
+    would_dedup: bool = False
+    deduplicated: bool = False
+
+
+def dedup_sweep(
+    configs: list[ExperimentConfig],
+    *,
+    rules: list[Rule] | tuple[Rule, ...] | None = None,
+    loader: VendoredRulesLoader | None = None,
+    deduplicate: bool = True,
+) -> DedupResult:
+    """Canonicalise then (optionally) H1-dedup ``configs``.
+
+    Rules are resolved lazily: if ``rules`` is None the loader is consulted
+    per-engine for each config (cached by the loader instance). Callers
+    running homogeneous sweeps may pass ``rules`` directly to skip the
+    loader hop.
+
+    Args:
+        configs: Sweep-expanded declared configs.
+        rules: Optional explicit rule list. Overrides the loader when the
+            sweep is single-engine and the caller has a rules handle.
+        loader: Optional ``VendoredRulesLoader``. Defaults to a fresh one
+            (per-process cache is internal to each instance).
+        deduplicate: When ``False``, every declared config still runs —
+            groups are computed for the equivalence-groups sidecar but the
+            returned ``canonical_configs`` list has one entry per input.
+
+    Returns:
+        :class:`DedupResult` — see fields above.
+    """
+    if not configs:
+        return DedupResult(canonical_configs=[])
+
+    resolved_loader = loader or VendoredRulesLoader()
+    rule_cache: dict[str, tuple[Rule, ...]] = {}
+
+    def _rules_for(cfg: ExperimentConfig) -> tuple[Rule, ...]:
+        if rules is not None:
+            return tuple(rules)
+        engine = cfg.engine.value if hasattr(cfg.engine, "value") else str(cfg.engine)
+        cached = rule_cache.get(engine)
+        if cached is not None:
+            return cached
+        try:
+            loaded = resolved_loader.load_rules(engine).rules
+        except FileNotFoundError:
+            loaded = ()
+        rule_cache[engine] = loaded
+        return loaded
+
+    canonicalised: list[ExperimentConfig] = []
+    hashes: list[str] = []
+    for cfg in configs:
+        canon = canonicalise(cfg, _rules_for(cfg))
+        canonicalised.append(canon)
+        hashes.append(hash_config(build_h1_view(canon)))
+
+    groups_by_hash: dict[str, list[int]] = {}
+    for idx, h in enumerate(hashes):
+        groups_by_hash.setdefault(h, []).append(idx)
+
+    groups: list[EquivalenceGroup] = []
+    for h1, indices in groups_by_hash.items():
+        representative = indices[0]
+        rep = canonicalised[representative]
+        excerpt = _canonical_excerpt(rep)
+        groups.append(
+            EquivalenceGroup(
+                h1_hash=h1,
+                canonical_excerpt=excerpt,
+                member_indices=tuple(indices),
+                representative_index=representative,
+            )
+        )
+
+    would_dedup = any(g.member_count > 1 for g in groups)
+
+    if deduplicate:
+        selected = [canonicalised[g.representative_index] for g in groups]
+    else:
+        selected = list(canonicalised)
+
+    return DedupResult(
+        canonical_configs=selected,
+        groups=groups,
+        declared_h1=hashes,
+        would_dedup=would_dedup,
+        deduplicated=deduplicate and would_dedup,
+    )
+
+
+def _canonical_excerpt(config: ExperimentConfig) -> dict[str, Any]:
+    """Small human-readable excerpt of the canonical form for display/logs."""
+    engine = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    excerpt: dict[str, Any] = {
+        "engine": engine,
+        "task.model": config.task.model,
+    }
+    section = getattr(config, engine, None)
+    sampling = getattr(section, "sampling", None) if section is not None else None
+    if sampling is not None:
+        dumped = sampling.model_dump(mode="python", exclude_none=True)
+        for key, value in dumped.items():
+            excerpt[f"{engine}.sampling.{key}"] = value
+    return excerpt

--- a/src/llenergymeasure/study/sweep_canonicalise.py
+++ b/src/llenergymeasure/study/sweep_canonicalise.py
@@ -140,7 +140,7 @@ def _rule_normalisations(rule: Rule) -> dict[str, Any]:
             # The "canonical" state is the not_equal sentinel — applying the
             # rule drives the field back to the library-observed default.
             out[path] = spec["not_equal"]
-        elif spec.get("present") and "not_equal" not in spec and "in" not in spec:
+        elif spec.get("present") and "in" not in spec:
             # Subject field marked only as "present" — strip to None (the
             # library either ignores it, or the effective value is captured
             # later via H3).
@@ -251,21 +251,16 @@ def dedup_sweep(
         return DedupResult(canonical_configs=[])
 
     resolved_loader = loader or VendoredRulesLoader()
-    rule_cache: dict[str, tuple[Rule, ...]] = {}
+    explicit_rules = tuple(rules) if rules is not None else None
 
     def _rules_for(cfg: ExperimentConfig) -> tuple[Rule, ...]:
-        if rules is not None:
-            return tuple(rules)
+        if explicit_rules is not None:
+            return explicit_rules
         engine = cfg.engine.value if hasattr(cfg.engine, "value") else str(cfg.engine)
-        cached = rule_cache.get(engine)
-        if cached is not None:
-            return cached
         try:
-            loaded = resolved_loader.load_rules(engine).rules
+            return resolved_loader.load_rules(engine).rules
         except FileNotFoundError:
-            loaded = ()
-        rule_cache[engine] = loaded
-        return loaded
+            return ()
 
     canonicalised: list[ExperimentConfig] = []
     hashes: list[str] = []

--- a/tests/integration/test_sweep_dedup_end_to_end.py
+++ b/tests/integration/test_sweep_dedup_end_to_end.py
@@ -39,11 +39,11 @@ def test_greedy_temperature_sweep_collapses(tmp_path: Path) -> None:
     study_config = load_study_config(path)
 
     # Dedup mode default is h1.
-    assert study_config.dedup_mode == "h1"
+    assert study_config.dedup_mode == "resolved"
     # 6 declared x 1 cycle -> 4 unique x 1 cycle = 4 experiments.
     assert len(study_config.experiments) == 4
     # Declared count preserved via H1 list.
-    assert len(study_config.declared_h1_hashes) == 6
+    assert len(study_config.declared_resolved_config_hashes) == 6
     # At least one group has multiple members (the greedy-family collapse).
     group_sizes = sorted(g["member_count"] for g in study_config.pre_run_equivalence_groups)
     assert max(group_sizes) >= 2
@@ -66,7 +66,7 @@ def test_no_dedup_preserves_all_configs(tmp_path: Path) -> None:
     study_config = load_study_config(path)
 
     assert study_config.dedup_mode == "off"
-    # All 6 declared configs run — canonicaliser still populated the groups.
+    # All 6 declared configs run — library-resolution mechanism still populated the groups.
     assert len(study_config.experiments) == 6
     # Groups still computed for the sidecar trail.
     assert sum(g["member_count"] for g in study_config.pre_run_equivalence_groups) == 6
@@ -110,8 +110,8 @@ def test_n_cycles_multiplies_unique_set(tmp_path: Path) -> None:
 
     # 4 declared -> 3 unique (greedy-0.5 + greedy-0.7 collapse to greedy-1.0,
     # plus 2 sampling variants). 3 unique x 3 cycles = 9 runs.
-    assert study_config.dedup_mode == "h1"
-    unique = {h for h in study_config.declared_h1_hashes}
+    assert study_config.dedup_mode == "resolved"
+    unique = {h for h in study_config.declared_resolved_config_hashes}
     # Two declared configs share the same H1 (both greedy).
     assert len(unique) == 3
     assert len(study_config.experiments) == 9

--- a/tests/integration/test_sweep_dedup_end_to_end.py
+++ b/tests/integration/test_sweep_dedup_end_to_end.py
@@ -1,0 +1,136 @@
+"""End-to-end integration test for sweep canonicalisation + H1 dedup.
+
+Exercises the full load path: a study YAML with measurement-equivalent
+sweep configs goes through ``load_study_config`` and the resulting
+``StudyConfig`` records the pre-run equivalence groups + deduplicated
+canonical configs.
+
+Run time: < 1s — no GPU involved, all operations are on Pydantic models
+and the vendored-rules loader.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from llenergymeasure.config.loader import load_study_config
+
+
+def _write_study(tmp_path: Path, raw: dict) -> Path:
+    path = tmp_path / "study.yaml"
+    path.write_text(yaml.safe_dump(raw))
+    return path
+
+
+def test_greedy_temperature_sweep_collapses(tmp_path: Path) -> None:
+    """Six-config sweep with dormant sampling fields collapses to four unique."""
+    study = {
+        "study_name": "dedup_test",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 10}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 1.0, 1.5],
+        },
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    # Dedup mode default is h1.
+    assert study_config.dedup_mode == "h1"
+    # 6 declared x 1 cycle -> 4 unique x 1 cycle = 4 experiments.
+    assert len(study_config.experiments) == 4
+    # Declared count preserved via H1 list.
+    assert len(study_config.declared_h1_hashes) == 6
+    # At least one group has multiple members (the greedy-family collapse).
+    group_sizes = sorted(g["member_count"] for g in study_config.pre_run_equivalence_groups)
+    assert max(group_sizes) >= 2
+    assert sum(group_sizes) == 6
+
+
+def test_no_dedup_preserves_all_configs(tmp_path: Path) -> None:
+    """With ``deduplicate_equivalent: false`` every declared config runs."""
+    study = {
+        "study_name": "no_dedup",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 10}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 1.0, 1.5],
+        },
+        "study_execution": {"deduplicate_equivalent": False},
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    assert study_config.dedup_mode == "off"
+    # All 6 declared configs run — canonicaliser still populated the groups.
+    assert len(study_config.experiments) == 6
+    # Groups still computed for the sidecar trail.
+    assert sum(g["member_count"] for g in study_config.pre_run_equivalence_groups) == 6
+
+
+def test_cli_override_no_dedup(tmp_path: Path) -> None:
+    """CLI-equivalent override (``study_execution.deduplicate_equivalent: false``)."""
+    study = {
+        "study_name": "cli_no_dedup",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 5}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 0.7],
+        },
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(
+        path,
+        cli_overrides={"study_execution": {"deduplicate_equivalent": False}},
+    )
+    assert study_config.dedup_mode == "off"
+    # 2 x 2 = 4 declared configs all run.
+    assert len(study_config.experiments) == 4
+
+
+def test_n_cycles_multiplies_unique_set(tmp_path: Path) -> None:
+    """Dedup happens within a cycle; ``n_cycles`` multiplies the deduped set."""
+    study = {
+        "study_name": "cycles",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 5}},
+        "sweep": {
+            "transformers.sampling.do_sample": [True, False],
+            "transformers.sampling.temperature": [0.5, 0.7],
+        },
+        "study_execution": {"n_cycles": 3},
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    # 4 declared -> 3 unique (greedy-0.5 + greedy-0.7 collapse to greedy-1.0,
+    # plus 2 sampling variants). 3 unique x 3 cycles = 9 runs.
+    assert study_config.dedup_mode == "h1"
+    unique = {h for h in study_config.declared_h1_hashes}
+    # Two declared configs share the same H1 (both greedy).
+    assert len(unique) == 3
+    assert len(study_config.experiments) == 9
+
+
+def test_single_config_sweep_no_dedup(tmp_path: Path) -> None:
+    """A sweep with one axis and no equivalence runs normally."""
+    study = {
+        "study_name": "single",
+        "engine": "transformers",
+        "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 5}},
+        "sweep": {
+            "transformers.sampling.temperature": [0.5, 0.7, 0.9],
+        },
+    }
+    path = _write_study(tmp_path, study)
+    study_config = load_study_config(path)
+
+    # Sampling is default-true; three temps should stay distinct.
+    assert len(study_config.experiments) == 3
+    group_sizes = sorted(g["member_count"] for g in study_config.pre_run_equivalence_groups)
+    assert group_sizes == [1, 1, 1]

--- a/tests/unit/engines/test_effective_params_capture.py
+++ b/tests/unit/engines/test_effective_params_capture.py
@@ -1,0 +1,143 @@
+"""Tests for :func:`extract_effective_params` and the per-engine capture path.
+
+PoC-C finding (sweep-dedup.md §3.2): the extractor must strip private
+(``_``-prefixed) fields by default — transformers and vLLM both leak
+state that would poison H3 otherwise. These tests verify the default
+behaviour and the allowlist escape hatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+from llenergymeasure.engines._helpers import extract_effective_params
+
+# ---------------------------------------------------------------------------
+# Dispatch behaviour — one per native-type shape
+# ---------------------------------------------------------------------------
+
+
+class _PydanticShape(BaseModel):
+    a: int = 1
+    b: str = "x"
+
+
+@dataclass
+class _DataclassShape:
+    a: int = 1
+    b: str = "x"
+
+
+class _SlotsShape:
+    __slots__ = ("a", "b")
+
+    def __init__(self) -> None:
+        self.a = 1
+        self.b = "x"
+
+
+class _DictShape:
+    def __init__(self) -> None:
+        self.a = 1
+        self.b = "x"
+
+
+class TestDispatch:
+    def test_pydantic(self):
+        out = extract_effective_params(_PydanticShape())
+        assert out == {"a": 1, "b": "x"}
+
+    def test_dataclass(self):
+        out = extract_effective_params(_DataclassShape())
+        assert out == {"a": 1, "b": "x"}
+
+    def test_slots(self):
+        out = extract_effective_params(_SlotsShape())
+        assert out == {"a": 1, "b": "x"}
+
+    def test_dict_fallback(self):
+        out = extract_effective_params(_DictShape())
+        assert out == {"a": 1, "b": "x"}
+
+
+# ---------------------------------------------------------------------------
+# Private-field handling (PoC-C finding)
+# ---------------------------------------------------------------------------
+
+
+class _LeakyPydantic(BaseModel):
+    """Models transformers GenerationConfig leaking private state."""
+
+    model_config = {"extra": "allow"}
+
+    temperature: float = 1.0
+
+
+class _LeakyDataclass:
+    """Models a dataclass-ish leak via __dict__ fallback."""
+
+    def __init__(self) -> None:
+        self.temperature = 1.0
+        self._commit_hash = "deadbeef"
+        self._from_model_config = True
+
+
+class TestPrivateFieldStripping:
+    def test_pydantic_private_fields_stripped_by_default(self):
+        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc", _from_model_config=True)
+        out = extract_effective_params(obj)
+        assert out == {"temperature": 0.7}
+
+    def test_dict_private_fields_stripped_by_default(self):
+        obj = _LeakyDataclass()
+        out = extract_effective_params(obj)
+        assert out == {"temperature": 1.0}
+
+    def test_allowlist_preserves_private_field(self):
+        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc")
+        out = extract_effective_params(obj, private_field_allowlist={"_commit_hash"})
+        assert out == {"temperature": 0.7, "_commit_hash": "abc"}
+
+
+# ---------------------------------------------------------------------------
+# Byte stability — same kwargs → same dump
+# ---------------------------------------------------------------------------
+
+
+class TestByteStability:
+    def test_repeat_constructions_same_output(self):
+        a = extract_effective_params(_PydanticShape(a=5, b="hi"))
+        b = extract_effective_params(_PydanticShape(a=5, b="hi"))
+        assert a == b
+
+    def test_different_kwargs_different_output(self):
+        a = extract_effective_params(_PydanticShape(a=5, b="hi"))
+        b = extract_effective_params(_PydanticShape(a=6, b="hi"))
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_object_returns_empty_dict(self):
+        class _Empty:
+            pass
+
+        out = extract_effective_params(_Empty())
+        assert out == {}
+
+    def test_model_dump_type_error_falls_through(self):
+        # A model_dump that only accepts no args should still work via the
+        # fallback path (TypeError on model_dump(mode=...) → retry with no kwargs).
+        class _ModelDumpNoArgs:
+            def model_dump(self) -> dict[str, Any]:
+                return {"x": 1}
+
+        out = extract_effective_params(_ModelDumpNoArgs())
+        assert out == {"x": 1}

--- a/tests/unit/engines/test_effective_params_capture.py
+++ b/tests/unit/engines/test_effective_params_capture.py
@@ -1,4 +1,4 @@
-"""Tests for :func:`extract_effective_params` and the per-engine capture path.
+"""Tests for :func:`extract_observed_params` and the per-engine capture path.
 
 PoC-C finding (sweep-dedup.md §3.2): the extractor must strip private
 (``_``-prefixed) fields by default — transformers and vLLM both leak
@@ -13,7 +13,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from llenergymeasure.engines._helpers import extract_effective_params
+from llenergymeasure.engines._helpers import extract_observed_params
 
 # ---------------------------------------------------------------------------
 # Dispatch behaviour — one per native-type shape
@@ -47,19 +47,19 @@ class _DictShape:
 
 class TestDispatch:
     def test_pydantic(self):
-        out = extract_effective_params(_PydanticShape())
+        out = extract_observed_params(_PydanticShape())
         assert out == {"a": 1, "b": "x"}
 
     def test_dataclass(self):
-        out = extract_effective_params(_DataclassShape())
+        out = extract_observed_params(_DataclassShape())
         assert out == {"a": 1, "b": "x"}
 
     def test_slots(self):
-        out = extract_effective_params(_SlotsShape())
+        out = extract_observed_params(_SlotsShape())
         assert out == {"a": 1, "b": "x"}
 
     def test_dict_fallback(self):
-        out = extract_effective_params(_DictShape())
+        out = extract_observed_params(_DictShape())
         assert out == {"a": 1, "b": "x"}
 
 
@@ -88,17 +88,17 @@ class _LeakyDataclass:
 class TestPrivateFieldStripping:
     def test_pydantic_private_fields_stripped_by_default(self):
         obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc", _from_model_config=True)
-        out = extract_effective_params(obj)
+        out = extract_observed_params(obj)
         assert out == {"temperature": 0.7}
 
     def test_dict_private_fields_stripped_by_default(self):
         obj = _LeakyDataclass()
-        out = extract_effective_params(obj)
+        out = extract_observed_params(obj)
         assert out == {"temperature": 1.0}
 
     def test_allowlist_preserves_private_field(self):
         obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc")
-        out = extract_effective_params(obj, private_field_allowlist={"_commit_hash"})
+        out = extract_observed_params(obj, private_field_allowlist={"_commit_hash"})
         assert out == {"temperature": 0.7, "_commit_hash": "abc"}
 
 
@@ -109,13 +109,13 @@ class TestPrivateFieldStripping:
 
 class TestByteStability:
     def test_repeat_constructions_same_output(self):
-        a = extract_effective_params(_PydanticShape(a=5, b="hi"))
-        b = extract_effective_params(_PydanticShape(a=5, b="hi"))
+        a = extract_observed_params(_PydanticShape(a=5, b="hi"))
+        b = extract_observed_params(_PydanticShape(a=5, b="hi"))
         assert a == b
 
     def test_different_kwargs_different_output(self):
-        a = extract_effective_params(_PydanticShape(a=5, b="hi"))
-        b = extract_effective_params(_PydanticShape(a=6, b="hi"))
+        a = extract_observed_params(_PydanticShape(a=5, b="hi"))
+        b = extract_observed_params(_PydanticShape(a=6, b="hi"))
         assert a != b
 
 
@@ -129,7 +129,7 @@ class TestEdgeCases:
         class _Empty:
             pass
 
-        out = extract_effective_params(_Empty())
+        out = extract_observed_params(_Empty())
         assert out == {}
 
     def test_model_dump_type_error_falls_through(self):
@@ -139,5 +139,5 @@ class TestEdgeCases:
             def model_dump(self) -> dict[str, Any]:
                 return {"x": 1}
 
-        out = extract_effective_params(_ModelDumpNoArgs())
+        out = extract_observed_params(_ModelDumpNoArgs())
         assert out == {"x": 1}

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -668,6 +668,114 @@ def test_datetime_still_used_for_wall_clock(minimal_config):
 
 
 # ---------------------------------------------------------------------------
+# Bug 1 fix: sidecar write must succeed (kwarg name fix effective_→observed_)
+# ---------------------------------------------------------------------------
+
+
+def test_write_config_sidecar_creates_config_json(minimal_config, tmp_path: Path):
+    """_write_config_sidecar must create config.json with a non-null observed_config_hash.
+
+    Regression test for the kwarg mismatch: build_observed_view was called with
+    effective_engine_params=/effective_sampling_params= but the function signature
+    declared observed_engine_params=/observed_sampling_params=. This caused a
+    TypeError caught by the broad exception handler, silently skipping every sidecar write.
+    """
+    import json
+
+    from llenergymeasure.domain.experiment import ExperimentResult
+    from llenergymeasure.harness import MeasurementHarness
+
+    harness = MeasurementHarness()
+
+    from datetime import datetime
+
+    result = ExperimentResult(
+        experiment_id="test-sidecar-001",
+        measurement_config_hash="aabb1122ccdd3344",
+        measurement_methodology="total",
+        model_name="fake/model",
+        total_tokens=10,
+        total_energy_j=1.0,
+        total_inference_time_sec=0.5,
+        avg_tokens_per_second=20.0,
+        avg_energy_per_token_j=0.1,
+        total_flops=0,
+        engine="transformers",
+        start_time=datetime(2026, 1, 1),
+        end_time=datetime(2026, 1, 1),
+    )
+    output = InferenceOutput(
+        elapsed_time_sec=0.5,
+        input_tokens=5,
+        output_tokens=5,
+        peak_memory_mb=0.0,
+        model_memory_mb=0.0,
+        extras={
+            "observed_engine_params": {"dtype": "float16"},
+            "observed_sampling_params": {"temperature": 1.0},
+            "library_version": "4.50.0",
+        },
+    )
+
+    harness._write_config_sidecar(
+        output=output,
+        config=minimal_config,
+        result=result,
+        output_dir=tmp_path,
+    )
+
+    sidecar = tmp_path / "config.json"
+    assert sidecar.exists(), "config.json must be written by _write_config_sidecar"
+
+    payload = json.loads(sidecar.read_text())
+    assert payload.get("observed_config_hash") is not None, (
+        "observed_config_hash must be a non-null SHA-256 hex string"
+    )
+    assert len(payload["observed_config_hash"]) == 64
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 fix: capture_observed_params called post-window
+# ---------------------------------------------------------------------------
+
+
+def test_capture_observed_params_called_post_window(minimal_config, tmp_path: Path):
+    """Harness calls engine.capture_observed_params after the measurement window.
+
+    The method must be called, its return value merged into output.extras, and
+    the extras keys (observed_engine_params/observed_sampling_params/library_version)
+    must be present so _write_config_sidecar can pick them up.
+    """
+    captured_calls: list[str] = []
+
+    class FakeBackendWithCapture(FakeBackend):
+        def capture_observed_params(self, config, model, output):
+            captured_calls.append("capture_observed_params")
+            return {
+                "engine": {"dtype": "float32"},
+                "sampling": {"temperature": 0.9},
+                "library_version": "5.0.0",
+            }
+
+    engine = FakeBackendWithCapture()
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        harness.run(engine, minimal_config, output_dir=str(tmp_path))
+
+    assert "capture_observed_params" in captured_calls, (
+        "engine.capture_observed_params must be called by the harness"
+    )
+    # config.json sidecar must exist and carry the captured params
+    sidecar = tmp_path / "config.json"
+    assert sidecar.exists(), "config.json must be written when output_dir is set"
+    import json
+
+    payload = json.loads(sidecar.read_text())
+    assert payload.get("observed_config_hash") is not None
+
+
+# ---------------------------------------------------------------------------
 # Dropped field wiring tests — warmup_result, energy_per_device_j, multi_gpu
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/scripts/walkers/test_fixpoint.py
+++ b/tests/unit/scripts/walkers/test_fixpoint.py
@@ -20,7 +20,7 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.walkers._fixpoint_test import (  # noqa: E402
-    CanonicaliserCycleError,
+    LibraryResolutionCycleError,
     NonIdempotentRuleError,
     OrderDependentRuleError,
     _ProjectedRule,
@@ -145,7 +145,7 @@ class TestShuffleStability:
 
         rules = [SetValue("ra", 1), SetValue("rb", 2)]
         seed = {"x": 0}
-        with pytest.raises(CanonicaliserCycleError):
+        with pytest.raises(LibraryResolutionCycleError):
             apply_to_fixpoint(seed, rules)
 
     def test_order_dependent_detected(self) -> None:

--- a/tests/unit/study/test_canonicaliser.py
+++ b/tests/unit/study/test_canonicaliser.py
@@ -1,0 +1,305 @@
+"""Tests for the sweep canonicaliser — fixpoint iteration + dedup.
+
+Idempotence + shuffle-stability are enforced by
+``scripts/walkers/_fixpoint_test.py`` (CI-time contract — any corpus PR that
+violates them is rejected before this module runs). These tests focus on
+the *runtime* behaviour: does the canonicaliser reach fixpoint, does it
+collapse measurement-equivalent configs, does it detect cycles, does it
+populate equivalence-group metadata.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.engines.vendored_rules.loader import Rule
+from llenergymeasure.study.hashing import build_h1_view, hash_config
+from llenergymeasure.study.sweep_canonicalise import (
+    CanonicaliserCycleError,
+    canonicalise,
+    dedup_sweep,
+)
+
+
+def _mk_rule(
+    *,
+    rule_id: str,
+    match_fields: dict,
+    normalised_fields: list[str] | None = None,
+    severity: str = "dormant",
+) -> Rule:
+    """Construct a minimal ``Rule`` for canonicaliser tests."""
+    return Rule(
+        id=rule_id,
+        engine="transformers",
+        library="transformers",
+        rule_under_test="",
+        severity=severity,
+        native_type="transformers.GenerationConfig",
+        match_engine="transformers",
+        match_fields=match_fields,
+        kwargs_positive={},
+        kwargs_negative={},
+        expected_outcome={"normalised_fields": normalised_fields or []},
+        message_template=None,
+        walker_source={},
+        references=(),
+        added_by="test",
+        added_at="2026-04-23",
+    )
+
+
+def _mk_config(**overrides):
+    base = {"task": {"model": "gpt2"}, "engine": "transformers"}
+    base.update(overrides)
+    return ExperimentConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# canonicalise()
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalise:
+    def test_empty_rules_returns_deep_copy(self):
+        cfg = _mk_config()
+        result = canonicalise(cfg, [])
+        assert result is not cfg
+        assert result.model_dump() == cfg.model_dump()
+
+    def test_no_match_no_change(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="never_fires",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        # do_sample=True disqualifies the rule; temperature should be untouched.
+        assert result.transformers.sampling.temperature == 0.5
+
+    def test_greedy_normalises_temperature_via_not_equal(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        # Canonical form is the not_equal sentinel.
+        assert result.transformers.sampling.temperature == 1.0
+
+    def test_idempotence_on_already_canonical(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 1.0}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        assert result.transformers.sampling.temperature == 1.0
+
+    def test_chained_rules_converge(self):
+        # Rule A: if temperature > 0.8, strip top_p (simulating greedy-when-hot
+        # semantics — imaginary for this test).
+        # Rule B: if top_p is None, strip top_k.
+        # Input with temperature 0.9, top_p=0.95, top_k=50 must converge in 2 passes.
+        cfg = _mk_config(
+            transformers={
+                "sampling": {
+                    "do_sample": True,
+                    "temperature": 0.9,
+                    "top_p": 0.95,
+                    "top_k": 50,
+                }
+            }
+        )
+        rule_a = _mk_rule(
+            rule_id="hot_strips_top_p",
+            match_fields={
+                "transformers.sampling.temperature": {">": 0.8},
+                "transformers.sampling.top_p": {"present": True},
+            },
+        )
+        rule_b = _mk_rule(
+            rule_id="no_top_p_strips_top_k",
+            match_fields={
+                "transformers.sampling.top_p": {"absent": True},
+                "transformers.sampling.top_k": {"present": True, "not_equal": 50},
+            },
+        )
+        result = canonicalise(cfg, [rule_a, rule_b])
+        assert result.transformers.sampling.top_p is None
+        # top_k unchanged: rule_b only fires when top_k != 50, but input is 50.
+        assert result.transformers.sampling.top_k == 50
+
+    def test_cycle_detection(self):
+        # Synthetic cycle: two rules that flip a field back and forth.
+        # rule_a: if top_k=50, strip it
+        # rule_b: if top_k absent, set to 50 (via not_equal on present)
+        # The real rule shape is constrained; simulate a cycle by assigning a
+        # path that gets reset each iteration.
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "top_k": 50}})
+        rule_a = _mk_rule(
+            rule_id="clear_top_k",
+            match_fields={
+                "transformers.sampling.top_k": {"present": True, "not_equal": 999},
+            },
+        )
+        rule_b = _mk_rule(
+            rule_id="restore_top_k",
+            match_fields={
+                "transformers.sampling.top_k": {"present": True, "not_equal": 50},
+            },
+        )
+        with pytest.raises(CanonicaliserCycleError):
+            canonicalise(cfg, [rule_a, rule_b])
+
+    def test_non_dormant_rules_ignored(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="not_dormant",
+            severity="warn",
+            match_fields={
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = canonicalise(cfg, [rule])
+        # warn severity must not trigger normalisation.
+        assert result.transformers.sampling.temperature == 0.5
+
+
+# ---------------------------------------------------------------------------
+# dedup_sweep()
+# ---------------------------------------------------------------------------
+
+
+class TestDedupSweep:
+    def test_empty_sweep_returns_empty(self):
+        result = dedup_sweep([])
+        assert result.canonical_configs == []
+        assert result.groups == []
+
+    def test_collapse_equivalent_configs(self):
+        # Two configs differ only by a dormant field under greedy decoding; they
+        # must collapse into one after canonicalisation.
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = dedup_sweep([cfg_a, cfg_b], rules=[rule])
+        assert len(result.canonical_configs) == 1
+        assert len(result.groups) == 1
+        assert result.groups[0].member_count == 2
+        assert result.deduplicated is True
+        assert result.would_dedup is True
+
+    def test_distinct_configs_stay_distinct(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = dedup_sweep([cfg_a, cfg_b], rules=[rule])
+        assert len(result.canonical_configs) == 2
+        assert len(result.groups) == 2
+        assert result.would_dedup is False
+        assert result.deduplicated is False
+
+    def test_dedup_disabled_preserves_all_but_groups_still_populated(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy_normalises_temperature",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        result = dedup_sweep([cfg_a, cfg_b], rules=[rule], deduplicate=False)
+        # Every declared config still executes.
+        assert len(result.canonical_configs) == 2
+        # But the groups record the collapse that *would* have happened.
+        assert len(result.groups) == 1
+        assert result.groups[0].member_count == 2
+        assert result.would_dedup is True
+        assert result.deduplicated is False
+
+    def test_declared_h1_length_matches_input(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": True}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False}})
+        result = dedup_sweep([cfg_a, cfg_b], rules=[])
+        assert len(result.declared_h1) == 2
+
+    def test_integration_with_real_corpus(self):
+        # End-to-end with the actual vendored rules — the original motivating
+        # example: do_sample x temperature = [T,F] x [0.5, 1.0, 1.5] -> 6 configs,
+        # canonicaliser collapses to 4 (1 greedy canonical + 3 sampling variants).
+        from llenergymeasure.engines.vendored_rules.loader import VendoredRulesLoader
+
+        loader = VendoredRulesLoader()
+        rules = loader.load_rules("transformers").rules
+
+        configs = []
+        for do_sample in (True, False):
+            for temp in (0.5, 1.0, 1.5):
+                configs.append(
+                    _mk_config(
+                        transformers={"sampling": {"do_sample": do_sample, "temperature": temp}}
+                    )
+                )
+        result = dedup_sweep(configs, rules=rules)
+        # do_sample=True x temps=[0.5, 1.0, 1.5] -> 3 distinct sampling configs
+        # do_sample=False x any temp -> 1 canonical greedy
+        assert len(result.canonical_configs) == 4
+
+    def test_hashes_stable_across_repeated_dedup(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        rule = _mk_rule(
+            rule_id="greedy",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        r1 = dedup_sweep([cfg], rules=[rule])
+        r2 = dedup_sweep([cfg], rules=[rule])
+        assert r1.declared_h1 == r2.declared_h1
+        assert r1.groups[0].h1_hash == r2.groups[0].h1_hash
+
+
+# ---------------------------------------------------------------------------
+# H1 hashing symmetry
+# ---------------------------------------------------------------------------
+
+
+class TestH1HashSymmetry:
+    def test_equivalent_canonical_forms_share_h1(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        rule = _mk_rule(
+            rule_id="greedy",
+            match_fields={
+                "transformers.sampling.do_sample": False,
+                "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+            },
+        )
+        canon_a = canonicalise(cfg_a, [rule])
+        canon_b = canonicalise(cfg_b, [rule])
+        assert hash_config(build_h1_view(canon_a)) == hash_config(build_h1_view(canon_b))

--- a/tests/unit/study/test_equivalence_groups.py
+++ b/tests/unit/study/test_equivalence_groups.py
@@ -1,0 +1,201 @@
+"""Tests for the equivalence-groups sidecar writer + post-run H3 grouping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.study.equivalence_groups import (
+    EquivalenceGroups,
+    PostRunH3Group,
+    PreRunGroup,
+    build_pre_run_groups,
+    find_h3_groups,
+    load_equivalence_groups,
+    write_equivalence_groups,
+)
+from llenergymeasure.study.sweep_canonicalise import dedup_sweep
+
+
+def _mk_config(**overrides):
+    base = {"task": {"model": "gpt2"}, "engine": "transformers"}
+    base.update(overrides)
+    return ExperimentConfig(**base)
+
+
+class TestRoundTripSerialisation:
+    def test_write_then_load_preserves_fields(self, tmp_path: Path):
+        groups = EquivalenceGroups(
+            study_id="study_abc",
+            dedup_mode="h1",
+            vendored_rules_version="transformers:4.56.0@deadbee",
+            groups=[
+                PreRunGroup(
+                    h1_hash="sha256:abc",
+                    canonical_config_excerpt={"engine": "transformers"},
+                    member_experiment_ids=("exp_0001", "exp_0002"),
+                    member_count=2,
+                    representative_experiment_id="exp_0001",
+                    would_dedup=True,
+                    deduplicated=True,
+                )
+            ],
+            post_run_h3_groups=[
+                PostRunH3Group(
+                    h3_hash="sha256:def",
+                    engine="transformers",
+                    library_version="4.56.0",
+                    member_h1_hashes=("sha256:abc", "sha256:xyz"),
+                    member_experiment_ids=("exp_0001", "exp_0003"),
+                    gap_detected=True,
+                    proposed_rule_id="candidate_rule_1",
+                )
+            ],
+        )
+        path = tmp_path / "equivalence_groups.json"
+        write_equivalence_groups(groups, path)
+        loaded = load_equivalence_groups(path)
+
+        assert loaded.study_id == "study_abc"
+        assert loaded.dedup_mode == "h1"
+        assert loaded.vendored_rules_version.startswith("transformers:")
+        assert len(loaded.groups) == 1
+        assert loaded.groups[0].member_count == 2
+        assert loaded.groups[0].would_dedup is True
+        assert len(loaded.post_run_h3_groups) == 1
+        assert loaded.post_run_h3_groups[0].gap_detected is True
+
+
+class TestBuildPreRunGroups:
+    def test_binds_indices_to_experiment_ids(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        result = dedup_sweep([cfg_a, cfg_b])
+        # Both collapse via the real corpus' greedy rules.
+        pre = build_pre_run_groups(result, experiment_ids=["exp_a", "exp_b"])
+        assert len(pre) == 1
+        assert pre[0].member_experiment_ids == ("exp_a", "exp_b")
+        assert pre[0].representative_experiment_id == "exp_a"
+        assert pre[0].would_dedup is True
+        assert pre[0].deduplicated is True
+
+    def test_without_dedup_groups_record_would_dedup(self):
+        cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
+        cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
+        result = dedup_sweep([cfg_a, cfg_b], deduplicate=False)
+        pre = build_pre_run_groups(result, experiment_ids=["exp_a", "exp_b"])
+        assert len(pre) == 1
+        assert pre[0].would_dedup is True
+        assert pre[0].deduplicated is False
+
+    def test_id_length_mismatch_raises(self):
+        cfg = _mk_config()
+        result = dedup_sweep([cfg])
+        try:
+            build_pre_run_groups(result, experiment_ids=[])
+        except ValueError as exc:
+            assert "does not match" in str(exc)
+            return
+        raise AssertionError("expected ValueError")
+
+
+class TestFindH3Groups:
+    def test_flags_gap_when_same_h3_distinct_h1(self):
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_b",  # Distinct H1 — gap!
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        assert len(groups) == 1
+        assert groups[0].gap_detected is True
+
+    def test_no_flag_when_h1_same(self):
+        # Same H1 collapsing on the library side is not a gap — the
+        # canonicaliser already saw them as equivalent.
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        assert len(groups) == 1
+        assert groups[0].gap_detected is False
+
+    def test_distinct_h3_no_group(self):
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_a",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_b",
+                "h3_hash": "h3_b",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        assert groups == []
+
+    def test_different_versions_do_not_cross_groups(self):
+        sidecars = [
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_a",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.57.0",  # Different version
+                "h1_hash": "h1_b",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        groups = find_h3_groups(sidecars)
+        # Version mismatch — grouped separately, each with len=1, so no gap.
+        assert groups == []
+
+    def test_sidecar_missing_h3_skipped(self):
+        sidecars = [
+            {"engine": "transformers", "library_version": "4.56.0", "h1_hash": "h1_a"},
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "h1_hash": "h1_b",
+                "h3_hash": "h3_shared",
+                "experiment_id": "exp_b",
+            },
+        ]
+        # Only one valid sidecar; no group formed.
+        groups = find_h3_groups(sidecars)
+        assert groups == []

--- a/tests/unit/study/test_equivalence_groups.py
+++ b/tests/unit/study/test_equivalence_groups.py
@@ -14,7 +14,7 @@ from llenergymeasure.study.equivalence_groups import (
     load_equivalence_groups,
     write_equivalence_groups,
 )
-from llenergymeasure.study.sweep_canonicalise import dedup_sweep
+from llenergymeasure.study.library_resolution import resolve_library_effective
 
 
 def _mk_config(**overrides):
@@ -31,7 +31,7 @@ class TestRoundTripSerialisation:
             vendored_rules_version="transformers:4.56.0@deadbee",
             groups=[
                 PreRunGroup(
-                    h1_hash="sha256:abc",
+                    resolved_config_hash="sha256:abc",
                     canonical_config_excerpt={"engine": "transformers"},
                     member_experiment_ids=("exp_0001", "exp_0002"),
                     member_count=2,
@@ -42,10 +42,10 @@ class TestRoundTripSerialisation:
             ],
             post_run_h3_groups=[
                 PostRunH3Group(
-                    h3_hash="sha256:def",
+                    observed_config_hash="sha256:def",
                     engine="transformers",
                     library_version="4.56.0",
-                    member_h1_hashes=("sha256:abc", "sha256:xyz"),
+                    member_resolved_config_hashes=("sha256:abc", "sha256:xyz"),
                     member_experiment_ids=("exp_0001", "exp_0003"),
                     gap_detected=True,
                     proposed_rule_id="candidate_rule_1",
@@ -70,7 +70,7 @@ class TestBuildPreRunGroups:
     def test_binds_indices_to_experiment_ids(self):
         cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
         cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
-        result = dedup_sweep([cfg_a, cfg_b])
+        result = resolve_library_effective([cfg_a, cfg_b])
         # Both collapse via the real corpus' greedy rules.
         pre = build_pre_run_groups(result, experiment_ids=["exp_a", "exp_b"])
         assert len(pre) == 1
@@ -82,7 +82,7 @@ class TestBuildPreRunGroups:
     def test_without_dedup_groups_record_would_dedup(self):
         cfg_a = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.5}})
         cfg_b = _mk_config(transformers={"sampling": {"do_sample": False, "temperature": 0.7}})
-        result = dedup_sweep([cfg_a, cfg_b], deduplicate=False)
+        result = resolve_library_effective([cfg_a, cfg_b], deduplicate=False)
         pre = build_pre_run_groups(result, experiment_ids=["exp_a", "exp_b"])
         assert len(pre) == 1
         assert pre[0].would_dedup is True
@@ -90,7 +90,7 @@ class TestBuildPreRunGroups:
 
     def test_id_length_mismatch_raises(self):
         cfg = _mk_config()
-        result = dedup_sweep([cfg])
+        result = resolve_library_effective([cfg])
         try:
             build_pre_run_groups(result, experiment_ids=[])
         except ValueError as exc:
@@ -105,15 +105,15 @@ class TestFindH3Groups:
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_a",
-                "h3_hash": "h3_shared",
+                "resolved_config_hash": "h1_a",
+                "observed_config_hash": "h3_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_b",  # Distinct H1 — gap!
-                "h3_hash": "h3_shared",
+                "resolved_config_hash": "h1_b",  # Distinct H1 — gap!
+                "observed_config_hash": "h3_shared",
                 "experiment_id": "exp_b",
             },
         ]
@@ -123,20 +123,20 @@ class TestFindH3Groups:
 
     def test_no_flag_when_h1_same(self):
         # Same H1 collapsing on the library side is not a gap — the
-        # canonicaliser already saw them as equivalent.
+        # library-resolution mechanism already saw them as equivalent.
         sidecars = [
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_a",
-                "h3_hash": "h3_shared",
+                "resolved_config_hash": "h1_a",
+                "observed_config_hash": "h3_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_a",
-                "h3_hash": "h3_shared",
+                "resolved_config_hash": "h1_a",
+                "observed_config_hash": "h3_shared",
                 "experiment_id": "exp_b",
             },
         ]
@@ -149,15 +149,15 @@ class TestFindH3Groups:
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_a",
-                "h3_hash": "h3_a",
+                "resolved_config_hash": "h1_a",
+                "observed_config_hash": "h3_a",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_b",
-                "h3_hash": "h3_b",
+                "resolved_config_hash": "h1_b",
+                "observed_config_hash": "h3_b",
                 "experiment_id": "exp_b",
             },
         ]
@@ -169,15 +169,15 @@ class TestFindH3Groups:
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_a",
-                "h3_hash": "h3_shared",
+                "resolved_config_hash": "h1_a",
+                "observed_config_hash": "h3_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.57.0",  # Different version
-                "h1_hash": "h1_b",
-                "h3_hash": "h3_shared",
+                "resolved_config_hash": "h1_b",
+                "observed_config_hash": "h3_shared",
                 "experiment_id": "exp_b",
             },
         ]
@@ -187,12 +187,12 @@ class TestFindH3Groups:
 
     def test_sidecar_missing_h3_skipped(self):
         sidecars = [
-            {"engine": "transformers", "library_version": "4.56.0", "h1_hash": "h1_a"},
+            {"engine": "transformers", "library_version": "4.56.0", "resolved_config_hash": "h1_a"},
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "h1_hash": "h1_b",
-                "h3_hash": "h3_shared",
+                "resolved_config_hash": "h1_b",
+                "observed_config_hash": "h3_shared",
                 "experiment_id": "exp_b",
             },
         ]

--- a/tests/unit/study/test_equivalence_groups.py
+++ b/tests/unit/study/test_equivalence_groups.py
@@ -27,7 +27,7 @@ class TestRoundTripSerialisation:
     def test_write_then_load_preserves_fields(self, tmp_path: Path):
         groups = EquivalenceGroups(
             study_id="study_abc",
-            dedup_mode="h1",
+            dedup_mode="resolved",
             vendored_rules_version="transformers:4.56.0@deadbee",
             groups=[
                 PreRunGroup(
@@ -57,7 +57,7 @@ class TestRoundTripSerialisation:
         loaded = load_equivalence_groups(path)
 
         assert loaded.study_id == "study_abc"
-        assert loaded.dedup_mode == "h1"
+        assert loaded.dedup_mode == "resolved"
         assert loaded.vendored_rules_version.startswith("transformers:")
         assert len(loaded.groups) == 1
         assert loaded.groups[0].member_count == 2

--- a/tests/unit/study/test_hashing.py
+++ b/tests/unit/study/test_hashing.py
@@ -1,0 +1,167 @@
+"""Tests for canonical serialisation + H1/H3 hashing.
+
+Normalisation rules come from ``sweep-dedup.md`` §9.Q3. Each test pins one
+rule from the table so a rule change surfaces as a targeted failure rather
+than a diffuse hash-mismatch.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.study.hashing import (
+    ConfigHashView,
+    build_h1_view,
+    build_h3_view,
+    canonical_serialise,
+    hash_config,
+)
+
+
+def _mk_config(**overrides):
+    base = {"task": {"model": "gpt2"}, "engine": "transformers"}
+    base.update(overrides)
+    return ExperimentConfig(**base)
+
+
+class TestCanonicalSerialise:
+    def test_none_and_missing_differ(self):
+        a = {"seed": None}
+        b: dict = {}
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_int_and_float_differ(self):
+        a = {"top_k": 0}
+        b = {"top_k": 0.0}
+        # Type difference preserved: int 0 and float 0.0 serialise differently
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_bool_and_int_differ(self):
+        a = {"do_sample": True}
+        b = {"do_sample": 1}
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_tuple_normalises_to_list(self):
+        a = {"stop": ("a", "b")}
+        b = {"stop": ["a", "b"]}
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+    def test_dict_keys_sorted(self):
+        a = {"a": 1, "b": 2}
+        b = {"b": 2, "a": 1}
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+    def test_nan_is_stable_string(self):
+        out = canonical_serialise({"x": math.nan})
+        assert b'"NaN"' in out
+
+    def test_infinity_is_stable(self):
+        pos = canonical_serialise({"x": math.inf})
+        neg = canonical_serialise({"x": -math.inf})
+        assert b"Infinity" in pos and b"-Infinity" in neg
+        assert pos != neg
+
+    def test_float_rounding_stability(self):
+        # Jitter in the 13th+ significant digit should collapse to the same hash.
+        a = {"temp": 0.123456789012345}
+        b = {"temp": 0.1234567890123459}  # 13+ digits differ
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+    def test_float_distinct_values_stay_distinct(self):
+        # Two values that differ at the 11th digit must not collapse.
+        a = {"temp": 0.12345678901}
+        b = {"temp": 0.12345678902}
+        assert canonical_serialise(a) != canonical_serialise(b)
+
+    def test_nested_dict_recursive_normalisation(self):
+        a = {"outer": {"inner": (1.0, 2.0)}}
+        b = {"outer": {"inner": [1.0, 2.0]}}
+        assert canonical_serialise(a) == canonical_serialise(b)
+
+
+class TestHashConfig:
+    def test_returns_hex_digest(self):
+        view = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        h = hash_config(view)
+        assert isinstance(h, str)
+        assert len(h) == 64
+        int(h, 16)  # parses as hex
+
+    def test_identical_views_same_hash(self):
+        v1 = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        v2 = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        assert hash_config(v1) == hash_config(v2)
+
+    def test_different_engine_different_hash(self):
+        v1 = ConfigHashView(engine="transformers", task={"model": "gpt2"})
+        v2 = ConfigHashView(engine="vllm", task={"model": "gpt2"})
+        assert hash_config(v1) != hash_config(v2)
+
+
+class TestBuildH1View:
+    def test_extracts_engine_and_task(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": False}})
+        view = build_h1_view(cfg)
+        assert view.engine == "transformers"
+        assert view.task["model"] == "gpt2"
+
+    def test_sampling_lifted_into_sampling_bucket(self):
+        cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.7}})
+        view = build_h1_view(cfg)
+        assert view.effective_sampling_params["do_sample"] is True
+        assert view.effective_sampling_params["temperature"] == 0.7
+        assert "sampling" not in view.effective_engine_params
+
+    def test_passthrough_kwargs_propagated(self):
+        cfg = _mk_config(passthrough_kwargs={"my_key": "my_val"})
+        view = build_h1_view(cfg)
+        assert view.passthrough_kwargs == {"my_key": "my_val"}
+
+
+class TestBuildH3View:
+    def test_carries_inputs_through(self):
+        view = build_h3_view(
+            engine="vllm",
+            task={"model": "gpt2"},
+            effective_engine_params={"dtype": "float16"},
+            effective_sampling_params={"temperature": 1.0},
+        )
+        assert view.engine == "vllm"
+        assert view.effective_engine_params["dtype"] == "float16"
+        assert view.effective_sampling_params["temperature"] == 1.0
+
+    def test_h1_and_h3_match_on_same_inputs(self):
+        # Symmetry: both views hashed through the same pipe produce the same hash
+        # when the underlying fields match. This is what makes the H3-collision
+        # invariant meaningful.
+        task = {"model": "gpt2"}
+        engine_params = {"dtype": "float16"}
+        sampling_params = {"temperature": 1.0}
+
+        h1_view = ConfigHashView(
+            engine="vllm",
+            task=task,
+            effective_engine_params=engine_params,
+            effective_sampling_params=sampling_params,
+        )
+        h3_view = build_h3_view(
+            engine="vllm",
+            task=task,
+            effective_engine_params=engine_params,
+            effective_sampling_params=sampling_params,
+        )
+        assert hash_config(h1_view) == hash_config(h3_view)
+
+
+class TestHashStability:
+    @pytest.mark.parametrize("_", range(5))
+    def test_hash_stable_across_repeat_calls(self, _):
+        cfg = _mk_config(
+            transformers={"sampling": {"do_sample": False, "temperature": 1.0}},
+        )
+        h1 = hash_config(build_h1_view(cfg))
+        h2 = hash_config(build_h1_view(cfg))
+        assert h1 == h2

--- a/tests/unit/study/test_hashing.py
+++ b/tests/unit/study/test_hashing.py
@@ -14,8 +14,8 @@ import pytest
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.study.hashing import (
     ConfigHashView,
-    build_h1_view,
-    build_h3_view,
+    build_observed_view,
+    build_resolved_view,
     canonical_serialise,
     hash_config,
 )
@@ -104,34 +104,34 @@ class TestHashConfig:
 class TestBuildH1View:
     def test_extracts_engine_and_task(self):
         cfg = _mk_config(transformers={"sampling": {"do_sample": False}})
-        view = build_h1_view(cfg)
+        view = build_resolved_view(cfg)
         assert view.engine == "transformers"
         assert view.task["model"] == "gpt2"
 
     def test_sampling_lifted_into_sampling_bucket(self):
         cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.7}})
-        view = build_h1_view(cfg)
-        assert view.effective_sampling_params["do_sample"] is True
-        assert view.effective_sampling_params["temperature"] == 0.7
-        assert "sampling" not in view.effective_engine_params
+        view = build_resolved_view(cfg)
+        assert view.observed_sampling_params["do_sample"] is True
+        assert view.observed_sampling_params["temperature"] == 0.7
+        assert "sampling" not in view.observed_engine_params
 
     def test_passthrough_kwargs_propagated(self):
         cfg = _mk_config(passthrough_kwargs={"my_key": "my_val"})
-        view = build_h1_view(cfg)
+        view = build_resolved_view(cfg)
         assert view.passthrough_kwargs == {"my_key": "my_val"}
 
 
 class TestBuildH3View:
     def test_carries_inputs_through(self):
-        view = build_h3_view(
+        view = build_observed_view(
             engine="vllm",
             task={"model": "gpt2"},
-            effective_engine_params={"dtype": "float16"},
-            effective_sampling_params={"temperature": 1.0},
+            observed_engine_params={"dtype": "float16"},
+            observed_sampling_params={"temperature": 1.0},
         )
         assert view.engine == "vllm"
-        assert view.effective_engine_params["dtype"] == "float16"
-        assert view.effective_sampling_params["temperature"] == 1.0
+        assert view.observed_engine_params["dtype"] == "float16"
+        assert view.observed_sampling_params["temperature"] == 1.0
 
     def test_h1_and_h3_match_on_same_inputs(self):
         # Symmetry: both views hashed through the same pipe produce the same hash
@@ -144,14 +144,14 @@ class TestBuildH3View:
         h1_view = ConfigHashView(
             engine="vllm",
             task=task,
-            effective_engine_params=engine_params,
-            effective_sampling_params=sampling_params,
+            observed_engine_params=engine_params,
+            observed_sampling_params=sampling_params,
         )
-        h3_view = build_h3_view(
+        h3_view = build_observed_view(
             engine="vllm",
             task=task,
-            effective_engine_params=engine_params,
-            effective_sampling_params=sampling_params,
+            observed_engine_params=engine_params,
+            observed_sampling_params=sampling_params,
         )
         assert hash_config(h1_view) == hash_config(h3_view)
 
@@ -162,6 +162,6 @@ class TestHashStability:
         cfg = _mk_config(
             transformers={"sampling": {"do_sample": False, "temperature": 1.0}},
         )
-        h1 = hash_config(build_h1_view(cfg))
-        h2 = hash_config(build_h1_view(cfg))
+        h1 = hash_config(build_resolved_view(cfg))
+        h2 = hash_config(build_resolved_view(cfg))
         assert h1 == h2

--- a/tests/unit/study/test_library_resolution.py
+++ b/tests/unit/study/test_library_resolution.py
@@ -1,9 +1,9 @@
-"""Tests for the sweep canonicaliser — fixpoint iteration + dedup.
+"""Tests for the sweep library-resolution mechanism — fixpoint iteration + dedup.
 
 Idempotence + shuffle-stability are enforced by
 ``scripts/walkers/_fixpoint_test.py`` (CI-time contract — any corpus PR that
 violates them is rejected before this module runs). These tests focus on
-the *runtime* behaviour: does the canonicaliser reach fixpoint, does it
+the *runtime* behaviour: does the library-resolution mechanism reach fixpoint, does it
 collapse measurement-equivalent configs, does it detect cycles, does it
 populate equivalence-group metadata.
 """
@@ -13,12 +13,12 @@ from __future__ import annotations
 import pytest
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.engines.vendored_rules.loader import Rule
-from llenergymeasure.study.hashing import build_h1_view, hash_config
-from llenergymeasure.study.sweep_canonicalise import (
-    CanonicaliserCycleError,
-    canonicalise,
-    dedup_sweep,
+from llenergymeasure.config.vendored_rules.loader import Rule
+from llenergymeasure.study.hashing import build_resolved_view, hash_config
+from llenergymeasure.study.library_resolution import (
+    LibraryResolutionCycleError,
+    _apply_rules_fixpoint,
+    resolve_library_effective,
 )
 
 
@@ -29,7 +29,7 @@ def _mk_rule(
     normalised_fields: list[str] | None = None,
     severity: str = "dormant",
 ) -> Rule:
-    """Construct a minimal ``Rule`` for canonicaliser tests."""
+    """Construct a minimal ``Rule`` for library-resolution mechanism tests."""
     return Rule(
         id=rule_id,
         engine="transformers",
@@ -57,14 +57,14 @@ def _mk_config(**overrides):
 
 
 # ---------------------------------------------------------------------------
-# canonicalise()
+# _apply_rules_fixpoint()
 # ---------------------------------------------------------------------------
 
 
 class TestCanonicalise:
     def test_empty_rules_returns_deep_copy(self):
         cfg = _mk_config()
-        result = canonicalise(cfg, [])
+        result = _apply_rules_fixpoint(cfg, [])
         assert result is not cfg
         assert result.model_dump() == cfg.model_dump()
 
@@ -77,7 +77,7 @@ class TestCanonicalise:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        result = canonicalise(cfg, [rule])
+        result = _apply_rules_fixpoint(cfg, [rule])
         # do_sample=True disqualifies the rule; temperature should be untouched.
         assert result.transformers.sampling.temperature == 0.5
 
@@ -90,7 +90,7 @@ class TestCanonicalise:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        result = canonicalise(cfg, [rule])
+        result = _apply_rules_fixpoint(cfg, [rule])
         # Canonical form is the not_equal sentinel.
         assert result.transformers.sampling.temperature == 1.0
 
@@ -103,7 +103,7 @@ class TestCanonicalise:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        result = canonicalise(cfg, [rule])
+        result = _apply_rules_fixpoint(cfg, [rule])
         assert result.transformers.sampling.temperature == 1.0
 
     def test_chained_rules_converge(self):
@@ -135,7 +135,7 @@ class TestCanonicalise:
                 "transformers.sampling.top_k": {"present": True, "not_equal": 50},
             },
         )
-        result = canonicalise(cfg, [rule_a, rule_b])
+        result = _apply_rules_fixpoint(cfg, [rule_a, rule_b])
         assert result.transformers.sampling.top_p is None
         # top_k unchanged: rule_b only fires when top_k != 50, but input is 50.
         assert result.transformers.sampling.top_k == 50
@@ -159,8 +159,8 @@ class TestCanonicalise:
                 "transformers.sampling.top_k": {"present": True, "not_equal": 50},
             },
         )
-        with pytest.raises(CanonicaliserCycleError):
-            canonicalise(cfg, [rule_a, rule_b])
+        with pytest.raises(LibraryResolutionCycleError):
+            _apply_rules_fixpoint(cfg, [rule_a, rule_b])
 
     def test_non_dormant_rules_ignored(self):
         cfg = _mk_config(transformers={"sampling": {"do_sample": True, "temperature": 0.5}})
@@ -171,19 +171,19 @@ class TestCanonicalise:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        result = canonicalise(cfg, [rule])
+        result = _apply_rules_fixpoint(cfg, [rule])
         # warn severity must not trigger normalisation.
         assert result.transformers.sampling.temperature == 0.5
 
 
 # ---------------------------------------------------------------------------
-# dedup_sweep()
+# resolve_library_effective()
 # ---------------------------------------------------------------------------
 
 
 class TestDedupSweep:
     def test_empty_sweep_returns_empty(self):
-        result = dedup_sweep([])
+        result = resolve_library_effective([])
         assert result.canonical_configs == []
         assert result.groups == []
 
@@ -199,7 +199,7 @@ class TestDedupSweep:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        result = dedup_sweep([cfg_a, cfg_b], rules=[rule])
+        result = resolve_library_effective([cfg_a, cfg_b], rules=[rule])
         assert len(result.canonical_configs) == 1
         assert len(result.groups) == 1
         assert result.groups[0].member_count == 2
@@ -216,7 +216,7 @@ class TestDedupSweep:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        result = dedup_sweep([cfg_a, cfg_b], rules=[rule])
+        result = resolve_library_effective([cfg_a, cfg_b], rules=[rule])
         assert len(result.canonical_configs) == 2
         assert len(result.groups) == 2
         assert result.would_dedup is False
@@ -232,7 +232,7 @@ class TestDedupSweep:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        result = dedup_sweep([cfg_a, cfg_b], rules=[rule], deduplicate=False)
+        result = resolve_library_effective([cfg_a, cfg_b], rules=[rule], deduplicate=False)
         # Every declared config still executes.
         assert len(result.canonical_configs) == 2
         # But the groups record the collapse that *would* have happened.
@@ -241,17 +241,17 @@ class TestDedupSweep:
         assert result.would_dedup is True
         assert result.deduplicated is False
 
-    def test_declared_h1_length_matches_input(self):
+    def test_declared_resolved_hashes_length_matches_input(self):
         cfg_a = _mk_config(transformers={"sampling": {"do_sample": True}})
         cfg_b = _mk_config(transformers={"sampling": {"do_sample": False}})
-        result = dedup_sweep([cfg_a, cfg_b], rules=[])
-        assert len(result.declared_h1) == 2
+        result = resolve_library_effective([cfg_a, cfg_b], rules=[])
+        assert len(result.declared_resolved_hashes) == 2
 
     def test_integration_with_real_corpus(self):
         # End-to-end with the actual vendored rules — the original motivating
         # example: do_sample x temperature = [T,F] x [0.5, 1.0, 1.5] -> 6 configs,
-        # canonicaliser collapses to 4 (1 greedy canonical + 3 sampling variants).
-        from llenergymeasure.engines.vendored_rules.loader import VendoredRulesLoader
+        # library-resolution mechanism collapses to 4 (1 greedy canonical + 3 sampling variants).
+        from llenergymeasure.config.vendored_rules.loader import VendoredRulesLoader
 
         loader = VendoredRulesLoader()
         rules = loader.load_rules("transformers").rules
@@ -264,7 +264,7 @@ class TestDedupSweep:
                         transformers={"sampling": {"do_sample": do_sample, "temperature": temp}}
                     )
                 )
-        result = dedup_sweep(configs, rules=rules)
+        result = resolve_library_effective(configs, rules=rules)
         # do_sample=True x temps=[0.5, 1.0, 1.5] -> 3 distinct sampling configs
         # do_sample=False x any temp -> 1 canonical greedy
         assert len(result.canonical_configs) == 4
@@ -278,14 +278,14 @@ class TestDedupSweep:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        r1 = dedup_sweep([cfg], rules=[rule])
-        r2 = dedup_sweep([cfg], rules=[rule])
-        assert r1.declared_h1 == r2.declared_h1
-        assert r1.groups[0].h1_hash == r2.groups[0].h1_hash
+        r1 = resolve_library_effective([cfg], rules=[rule])
+        r2 = resolve_library_effective([cfg], rules=[rule])
+        assert r1.declared_resolved_hashes == r2.declared_resolved_hashes
+        assert r1.groups[0].resolved_config_hash == r2.groups[0].resolved_config_hash
 
 
 # ---------------------------------------------------------------------------
-# H1 hashing symmetry
+# resolved_config_hashing symmetry
 # ---------------------------------------------------------------------------
 
 
@@ -300,6 +300,8 @@ class TestH1HashSymmetry:
                 "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
             },
         )
-        canon_a = canonicalise(cfg_a, [rule])
-        canon_b = canonicalise(cfg_b, [rule])
-        assert hash_config(build_h1_view(canon_a)) == hash_config(build_h1_view(canon_b))
+        canon_a = _apply_rules_fixpoint(cfg_a, [rule])
+        canon_b = _apply_rules_fixpoint(cfg_b, [rule])
+        assert hash_config(build_resolved_view(canon_a)) == hash_config(
+            build_resolved_view(canon_b)
+        )

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -164,6 +164,60 @@ def test_save_and_record_missing_source_file(tmp_path: Path) -> None:
     assert rel_path, "mark_completed must be called with a non-empty result_file"
 
 
+def test_save_and_record_writes_resolved_config_hash(tmp_path: Path) -> None:
+    """resolved_config_hash must be written into config.json sidecar when provided.
+
+    Regression test for Bug 2: _save_and_record had a resolved_config_hash
+    parameter that was never passed from the call site, leaving the sidecar
+    branch unreachable.  This test verifies the end-to-end write-and-read path.
+    """
+    import json
+
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+
+    # Write a minimal config.json in the ts_source_dir (simulates harness output)
+    config_sidecar_src = tmp_path / "config.json"
+    config_sidecar_src.write_text(
+        json.dumps(
+            {
+                "experiment_id": "test-resolved-001",
+                "config_hash": "aabb1122ccdd3344",
+                "engine": "transformers",
+                "library_version": "4.50.0",
+                "observed_config_hash": "sha256_h3_stub",
+            }
+        )
+    )
+
+    result = _make_result(with_timeseries=False)
+    manifest = MagicMock()
+    result_files: list[str] = []
+
+    _save_and_record(
+        result,
+        study_dir,
+        manifest,
+        "aabb1122",
+        1,
+        result_files,
+        ts_source_dir=tmp_path,
+        resolved_config_hash="resolved_sha256_h1_value",
+    )
+
+    assert len(result_files) == 1
+    result_json_path = Path(result_files[0])
+    dest_config = result_json_path.parent / "config.json"
+    assert dest_config.exists(), "config.json sidecar must be moved to result dir"
+
+    payload = json.loads(dest_config.read_text())
+    assert payload.get("resolved_config_hash") == "resolved_sha256_h1_value", (
+        "resolved_config_hash must be patched into config.json by _save_and_record"
+    )
+    # Source sidecar must be cleaned up
+    assert not config_sidecar_src.exists()
+
+
 def test_save_and_record_calls_mark_failed_on_exception(tmp_path: Path) -> None:
     """When save_result raises, manifest.mark_failed is called (not mark_completed).
 


### PR DESCRIPTION
## Summary

Lands PR C from the phase-50 M4 pipeline: the library-resolution mechanism,
observed_config_hash (H3), and the runner→harness→sidecar feedback loop.

### Core modules

- **`study/library_resolution.py`** (renamed from `sweep_canonicalise.py`):
  `_apply_rules_fixpoint()` applies dormant-severity vendored rules to fixpoint
  with cycle detection; `resolve_library_effective()` deduplicates a sweep and
  returns a `DedupResult` with `canonical_configs`, `groups`,
  `declared_resolved_hashes`, and `would_dedup` / `deduplicated` flags.

- **`study/hashing.py`**: canonical JSON serialisation + SHA-256 engine shared
  by H1 (`build_resolved_view`) and H3 (`build_observed_view`). Normalisation
  rules are locked by `sweep-dedup.md §9.Q3` — includes set/frozenset sorting,
  float 12-sig-digit rounding, and infinity/NaN string literals.

- **`study/equivalence_groups.py`**: `PreRunGroup` (H1 dedup), `PostRunH3Group`
  (observed_config_hash collisions), `EquivalenceGroups`, `find_h3_groups()`,
  `write/load_equivalence_groups()`.

### Wiring

- **`config/loader.py`**: library-resolution dedup runs between `expand_grid`
  and `apply_cycles`; `--no-dedup` CLI flag bypasses it; pre-run groups and
  `declared_resolved_config_hashes` propagated onto `StudyConfig`.

- **`harness/__init__.py`**: `_write_config_sidecar()` computes H3
  `observed_config_hash` from `InferenceOutput.extras` and writes `config.json`
  via `save_config_sidecar`.

- **`study/runner.py`**: `_save_and_record` patches `resolved_config_hash` into
  the sidecar on move from staging to experiment dir; `_write_equivalence_groups_sidecar`
  scans all `config.json` files post-run and writes `equivalence_groups.json`.

### Simplify patches applied

1. Deleted dead `compute_dormant_fields` (zero callers).
2. Replaced `contextlib.suppress` with explicit `try/except` + debug log in
   vllm/tensorrt observed-params capture (silent suppression was masking engine
   errors).
3. Extracted `assemble_observed_params` helper shared across all three engine backends.
4. Added `set`/`frozenset` normalisation to `_normalise()` in `hashing.py`.

### Vocabulary

All symbols use the locked vocabulary from PR #401:
`resolved_config_hash` (H1), `observed_config_hash` (H3),
`extract_observed_params`, `resolve_library_effective`,
`LibraryResolutionCycleError`.

### Import contracts

`pyproject.toml` `main-layers` `ignore_imports` updated with two new
justified exceptions:
- `harness -> study.hashing` (local-inside-method, no cycle risk)
- `harness -> results.persistence` (same)

## Test plan

- [ ] `PYTHONPATH=.:src python3.10 -m pytest tests/unit -q` — 2330 passed
- [ ] `PYTHONPATH=.:src python3.10 -m pytest tests/integration/test_sweep_dedup_end_to_end.py -q` — 5 passed
- [ ] `lint-imports` — 3 contracts kept, 0 broken
- [ ] CI green on push

## Design references

- `.product/designs/config-deduplication-dormancy/sweep-dedup.md` §2.4, §4.1, §9.Q3
- Vocabulary locked by PR #401