### PR TITLE
refactor(study): drop H1/H3 legacy naming for resolved/observed vocabulary

### DIFF
--- a/configs/validation_rules/README.md
+++ b/configs/validation_rules/README.md
@@ -82,7 +82,7 @@ Every entry under `rules:` must populate the following fields.
     Remove it or set do_sample=True.
   references:
     - "transformers.GenerationConfig.validate() (line ~598)"
-  added_by: ast_walker                   # ast_walker | manual_seed | runtime_warning_pr | h3_collision_pr
+  added_by: ast_walker                   # ast_walker | manual_seed | runtime_warning_pr | observed_collision_pr
   added_at: "2026-04-23"
 ```
 
@@ -157,7 +157,7 @@ YAML entry directly:
 ### Via feedback loop
 
 Phase 50.3 introduces two automated discovery channels: runtime warning
-capture (`runtime_warning_pr`) and H3-collision detection (`h3_collision_pr`).
+capture (`runtime_warning_pr`) and observed-collision detection (`observed_collision_pr`).
 Both open draft PRs with `added_by` set accordingly.
 
 ## PR review checklist

--- a/src/llenergymeasure/config/vendored_rules/loader.py
+++ b/src/llenergymeasure/config/vendored_rules/loader.py
@@ -99,7 +99,7 @@ AddedBy = Literal[
     "introspection",
     "manual_seed",
     "runtime_warning",
-    "h3_collision",
+    "observed_collision",
 ]
 """Provenance of a rule in the corpus.
 
@@ -115,7 +115,7 @@ Five discovery paths with distinct trust/verifiability profiles:
 - ``runtime_warning`` — proposed by the feedback loop from captured
   ``logger.warning_once`` emissions (needs human generalisation before
   landing).
-- ``h3_collision`` — proposed by the feedback loop from observed-config-hash
+- ``observed_collision`` — proposed by the feedback loop from observed-config-hash
   collision detection (needs human generalisation before landing).
 """
 

--- a/src/llenergymeasure/domain/hashing.py
+++ b/src/llenergymeasure/domain/hashing.py
@@ -1,7 +1,7 @@
-"""Canonical serialisation and SHA-256 hashing primitives (H1 and H3).
+"""Canonical serialisation and SHA-256 hashing primitives.
 
-Pure, dependency-free primitives shared by both the H1 (library-resolution
-mechanism output) and H3 (library-observed) hashing pipelines.  Neither
+Pure, dependency-free primitives shared by both the resolved-config (library-resolution
+mechanism output) and observed-config (library-observed) hashing pipelines.  Neither
 hash requires imports from upper layers, so these live at Layer 0 (domain).
 
 ``build_resolved_view`` — the one function that needs ``ExperimentConfig`` —
@@ -31,7 +31,7 @@ values a researcher would write differently.
 
 
 # ---------------------------------------------------------------------------
-# Canonical serialisation (shared by H1 and H3)
+# Canonical serialisation (shared by resolved-config and observed-config hashes)
 # ---------------------------------------------------------------------------
 
 
@@ -104,8 +104,8 @@ class ConfigHashView:
     Per sweep-dedup.md §2.4, the hashed-field set is:
 
     - ``task`` — model, prompt source, batch shape
-    - ``observed_engine_params`` — engine state (library-resolution mechanism output for H1,
-      live library observation for H3)
+    - ``observed_engine_params`` — engine state (library-resolution mechanism output for
+      resolved-config-hash, live library observation for observed-config-hash)
     - ``observed_sampling_params`` — sampling state (same sources as above)
     - ``lora`` / ``passthrough_kwargs`` — user-attached overrides
 
@@ -124,15 +124,15 @@ class ConfigHashView:
 def hash_config(view: ConfigHashView) -> str:
     """Return SHA-256 hex digest of ``view`` via :func:`canonical_serialise`.
 
-    Both H1 and H3 route through this function; they differ only in how
-    the :class:`ConfigHashView` is populated.
+    Both resolved-config-hash and observed-config-hash route through this function;
+    they differ only in how the :class:`ConfigHashView` is populated.
     """
     payload = asdict(view)
     return hashlib.sha256(canonical_serialise(payload)).hexdigest()
 
 
 # ---------------------------------------------------------------------------
-# H3 view construction — from library-observed effective params
+# Observed-config view construction — from library-observed effective params
 # ---------------------------------------------------------------------------
 
 
@@ -145,7 +145,7 @@ def build_observed_view(
     lora: dict[str, Any] | None = None,
     passthrough_kwargs: dict[str, Any] | None = None,
 ) -> ConfigHashView:
-    """Assemble an H3 view from per-engine ``extract_observed_params`` output.
+    """Assemble an observed-config view from per-engine ``extract_observed_params`` output.
 
     Callers live in the harness/sidecar path — they read ``task`` from the
     same config that ran and pair it with the native-object dumps the engine

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Effective-params extraction (H3 source)
+# Effective-params extraction (observed-config source)
 # ---------------------------------------------------------------------------
 
 
@@ -31,13 +31,13 @@ def extract_observed_params(
 ) -> dict[str, Any]:
     """Dump a constructed native type's post-``__post_init__`` state.
 
-    Used by the H3 hashing pipeline (sweep-dedup.md §3.2) — after each
+    Used by the observed-config hashing pipeline (sweep-dedup.md §3.2) — after each
     backend constructs its native type (``GenerationConfig``,
     ``SamplingParams``, ``LlmArgs``), the harness calls this to extract
     the authoritative effective parameters the library settled on.
 
     PoC-C finding (sweep-dedup.md §3.2 and §10 decision log): live
-    libraries leak private state that poisons H3 if passed through
+    libraries leak private state that poisons observed_config_hash if passed through
     unfiltered. Specific leaks observed:
 
     - ``transformers.GenerationConfig``: ``_commit_hash``,
@@ -61,9 +61,9 @@ def extract_observed_params(
 def library_version(module_name: str) -> str:
     """Return ``__version__`` of an imported library or ``"unknown"`` on failure.
 
-    Shared helper for the H3 capture path — all three engines publish the
+    Shared helper for the observed-config capture path — all three engines publish the
     library version alongside their effective-params dump so researchers can
-    disambiguate identical H3 hashes across library versions.
+    disambiguate identical observed_config_hash values across library versions.
     """
     try:
         import importlib

--- a/src/llenergymeasure/engines/protocol.py
+++ b/src/llenergymeasure/engines/protocol.py
@@ -24,7 +24,7 @@ class InferenceOutput:
     model_memory_mb: float
     batch_times: list[float] = field(default_factory=list)
     extras: dict[str, Any] = field(default_factory=dict)
-    inference_time_sec: float = 0.0  # Set by harness after perf_counter brackets (H1)
+    inference_time_sec: float = 0.0  # Set by harness after perf_counter brackets
 
     @property
     def total_tokens(self) -> int:

--- a/src/llenergymeasure/engines/transformers.py
+++ b/src/llenergymeasure/engines/transformers.py
@@ -263,10 +263,10 @@ class TransformersEngine:
         sampling shape) and ``BitsAndBytesConfig`` (the engine-side quantisation
         shape, when active). Both are Pydantic-style dumpable objects;
         :func:`extract_observed_params` strips private fields (``_commit_hash``,
-        ``_from_model_config``) that would poison H3 if included.
+        ``_from_model_config``) that would poison observed_config_hash if included.
 
         Returns a dict with ``engine`` / ``sampling`` / ``library_version``
-        entries ready for the H3 hashing pipeline.
+        entries ready for the observed-config hashing pipeline.
         """
         from llenergymeasure.engines._helpers import (
             assemble_observed_params,

--- a/src/llenergymeasure/harness/__init__.py
+++ b/src/llenergymeasure/harness/__init__.py
@@ -577,7 +577,7 @@ class MeasurementHarness:
 
         Extracts observed params from ``output.extras`` (populated by each engine's
         ``_capture_effective_params`` after inference), computes ``observed_config_hash``
-        from the H3 hashing pipeline, and writes the sidecar atomically. The runner's
+        from the observed-config hashing pipeline, and writes the sidecar atomically. The runner's
         ``_save_and_record`` moves this file to the per-experiment directory alongside
         ``result.json``.
 
@@ -591,16 +591,16 @@ class MeasurementHarness:
             obs_sampling = output.extras.get("observed_sampling_params", {}) or {}
             lib_ver = output.extras.get("library_version", "unknown") or "unknown"
 
-            # Compute observed_config_hash (H3) from extracted native-type state
+            # Compute observed_config_hash from extracted native-type state
             engine_name = result.engine
             task_dict = config.task.model_dump(mode="python")
-            h3_view = build_observed_view(
+            observed_view = build_observed_view(
                 engine=engine_name,
                 task=task_dict,
                 observed_engine_params=obs_engine,
                 observed_sampling_params=obs_sampling,
             )
-            obs_hash = hash_config(h3_view)
+            obs_hash = hash_config(observed_view)
 
             save_config_sidecar(
                 output_dir,

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -106,7 +106,7 @@ def save_config_sidecar(
     observed_config_hash: str | None = None,
     config_validation_observations: list[dict[str, object]] | None = None,
 ) -> Path:
-    """Write the per-experiment ``config.json`` sidecar with H1/H3 payload.
+    """Write the per-experiment ``config.json`` sidecar with resolved/observed config-hash payload.
 
     Schema lives in ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
     §3.3. Fields:

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -1,11 +1,11 @@
-"""Equivalence-groups sidecar — pre-run H1 groups + post-run H3 detection.
+"""Equivalence-groups sidecar — pre-run resolved groups + post-run observed detection.
 
 Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §6.
 
 Written alongside the study's results bundle. ``pre_run_groups`` is populated
 at sweep-expansion time by :func:`resolve_library_effective` and serialised immediately;
-``post_run_h3_groups`` is populated after the study completes by scanning
-sidecars for shared H3 hashes.
+``observed_collision_groups`` is populated after the study completes by scanning
+sidecars for shared observed-config-hash values.
 
 The observed-config-hash collision invariant (§4.1) guarantees that in a post-resolved-config-hash dedup run set,
 any group with ``len(member_resolved_config_hashes) >= 2`` is a **proven library-resolution mechanism gap**.
@@ -43,7 +43,7 @@ class PreRunGroup:
 
 
 @dataclass(frozen=True)
-class PostRunH3Group:
+class ObservedCollisionGroup:
     """Post-run observed-config-hash collision group — a library-resolution mechanism gap if member count >= 2."""
 
     observed_config_hash: str
@@ -63,7 +63,7 @@ class EquivalenceGroups:
     dedup_mode: Literal["resolved", "off"]
     vendored_rules_version: str = ""
     groups: list[PreRunGroup] = field(default_factory=list)
-    post_run_h3_groups: list[PostRunH3Group] = field(default_factory=list)
+    observed_collision_groups: list[ObservedCollisionGroup] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -105,11 +105,11 @@ def build_pre_run_groups(
 
 
 # ---------------------------------------------------------------------------
-# Post-run H3 grouping — scan sidecars after study completes
+# Post-run observed-config-hash grouping — scan sidecars after study completes
 # ---------------------------------------------------------------------------
 
 
-def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
+def find_observed_collisions(sidecars: list[dict[str, Any]]) -> list[ObservedCollisionGroup]:
     """Group sidecars by ``(engine, library_version, observed_config_hash)``.
 
     Any group with size >= 2 AND distinct ``resolved_config_hash`` across its members is
@@ -118,29 +118,29 @@ def find_h3_groups(sidecars: list[dict[str, Any]]) -> list[PostRunH3Group]:
     Each sidecar dict must carry at minimum ``engine``, ``library_version``,
     ``resolved_config_hash``, ``observed_config_hash``, and ``experiment_id`` keys. Sidecars missing any
     of these are silently skipped (pre-50.3a data, or runs with dedup_mode=off
-    for which H3 may be partial).
+    for which observed-config-hash may be partial).
     """
     buckets: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
     for sc in sidecars:
-        h3 = sc.get("observed_config_hash")
-        if not h3:
+        obs_hash = sc.get("observed_config_hash")
+        if not obs_hash:
             continue
         engine = str(sc.get("engine", ""))
         version = str(sc.get("library_version", ""))
-        buckets[(engine, version, h3)].append(sc)
+        buckets[(engine, version, obs_hash)].append(sc)
 
-    groups: list[PostRunH3Group] = []
-    for (engine, version, h3), members in buckets.items():
+    groups: list[ObservedCollisionGroup] = []
+    for (engine, version, obs_hash), members in buckets.items():
         if len(members) < 2:
             continue
         resolved_config_hashes = tuple(str(m.get("resolved_config_hash", "")) for m in members)
         exp_ids = tuple(str(m.get("experiment_id", "")) for m in members)
-        # Gap only if the resolved_config_hashes differ — matching H1 means the
+        # Gap only if the resolved_config_hashes differ — matching resolved-config means the
         # library-resolution mechanism already collapsed them.
         gap_detected = len(set(resolved_config_hashes)) > 1
         groups.append(
-            PostRunH3Group(
-                observed_config_hash=h3,
+            ObservedCollisionGroup(
+                observed_config_hash=obs_hash,
                 engine=engine,
                 library_version=version,
                 member_resolved_config_hashes=resolved_config_hashes,
@@ -167,7 +167,7 @@ def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
         "dedup_mode": groups.dedup_mode,
         "vendored_rules_version": groups.vendored_rules_version,
         "groups": [asdict(g) for g in groups.groups],
-        "post_run_h3_groups": [asdict(g) for g in groups.post_run_h3_groups],
+        "observed_collision_groups": [asdict(g) for g in groups.observed_collision_groups],
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write(json.dumps(payload, indent=2, default=str), path)
@@ -183,7 +183,9 @@ def load_equivalence_groups(path: Path) -> EquivalenceGroups:
         dedup_mode=dedup_mode,
         vendored_rules_version=str(data.get("vendored_rules_version", "")),
         groups=[_pre_from_dict(g) for g in data.get("groups", [])],
-        post_run_h3_groups=[_post_from_dict(g) for g in data.get("post_run_h3_groups", [])],
+        observed_collision_groups=[
+            _post_from_dict(g) for g in data.get("observed_collision_groups", [])
+        ],
     )
 
 
@@ -199,8 +201,8 @@ def _pre_from_dict(data: dict[str, Any]) -> PreRunGroup:
     )
 
 
-def _post_from_dict(data: dict[str, Any]) -> PostRunH3Group:
-    return PostRunH3Group(
+def _post_from_dict(data: dict[str, Any]) -> ObservedCollisionGroup:
+    return ObservedCollisionGroup(
         observed_config_hash=str(data["observed_config_hash"]),
         engine=str(data.get("engine", "")),
         library_version=str(data.get("library_version", "")),

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -1,4 +1,4 @@
-"""H1 view construction from resolved ExperimentConfig (study layer).
+"""Resolved-config view construction from resolved ExperimentConfig (study layer).
 
 The pure hashing primitives live in :mod:`llenergymeasure.domain.hashing`
 (Layer 0).  This module contains only :func:`build_resolved_view`, which
@@ -36,12 +36,12 @@ __all__ = [
 
 
 # ---------------------------------------------------------------------------
-# H1 view construction — from library-resolution mechanism output
+# Resolved-config view construction — from library-resolution mechanism output
 # ---------------------------------------------------------------------------
 
 
 def build_resolved_view(config: ExperimentConfig) -> ConfigHashView:
-    """Project a (post-library-resolution) ``ExperimentConfig`` into an H1 view.
+    """Project a (post-library-resolution) ``ExperimentConfig`` into a resolved-config view.
 
     Reads the active engine section's full post-normalisation state; the
     library-resolution mechanism has already applied dormant rules to fixpoint before this
@@ -49,8 +49,8 @@ def build_resolved_view(config: ExperimentConfig) -> ConfigHashView:
     meaningless on a pre-resolved config.
 
     Engine-specific sub-models carry a ``sampling`` attribute; it is lifted
-    into its own dict so H1/H3 ordering separates "how the engine constructs"
-    from "what it generates with".
+    into its own dict so the resolved-config / observed-config ordering separates
+    "how the engine constructs" from "what it generates with".
     """
     engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
     section: Any = getattr(config, engine_name, None)

--- a/src/llenergymeasure/study/library_resolution.py
+++ b/src/llenergymeasure/study/library_resolution.py
@@ -1,4 +1,4 @@
-"""Sweep library-resolution mechanism — apply vendored dormant rules to fixpoint, dedup by H1.
+"""Sweep library-resolution mechanism — apply vendored dormant rules to fixpoint, dedup by resolved_config_hash.
 
 Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §2.
 
@@ -143,7 +143,7 @@ def _rule_normalisations(rule: Rule) -> dict[str, Any]:
         elif spec.get("present") and "in" not in spec:
             # Subject field marked only as "present" — strip to None (the
             # library either ignores it, or the effective value is captured
-            # later via H3).
+            # later via observed_config_hash).
             out[path] = None
     return out
 
@@ -183,7 +183,7 @@ def _assign_field_path(config: ExperimentConfig, path: str, value: Any) -> None:
 
 @dataclass(frozen=True)
 class EquivalenceGroup:
-    """Pre-run group of declared configs that collapse to the same H1 canonical form."""
+    """Pre-run group of declared configs that collapse to the same resolved canonical form."""
 
     resolved_config_hash: str
     canonical_excerpt: dict[str, Any]

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -178,7 +178,7 @@ def _save_and_record(
             )
 
         # Move config.json sidecar (written by harness to temp dir) to experiment dir.
-        # Also patch in the resolved_config_hash (H1) from StudyConfig, which the harness
+        # Also patch in the resolved_config_hash from StudyConfig, which the harness
         # doesn't have access to at write time.
         if ts_source_dir is not None:
             config_sidecar_src = ts_source_dir / "config.json"
@@ -608,7 +608,7 @@ class StudyRunner:
         self._skip_set: set[tuple[str, int]] = skip_set or set()
         # Pre-built resolution logs keyed by config_hash (written as _resolution.json sidecar)
         self._resolution_logs: dict[str, dict[str, Any]] = resolution_logs or {}
-        # Declared-config-hash → resolved-config-hash (H1) mapping.
+        # Declared-config-hash → resolved-config-hash mapping.
         # Built from study.experiments (post-dedup unique configs) so _save_and_record
         # can patch the resolved_config_hash into each config.json sidecar.
         self._resolved_hashes: dict[str, str] = self._build_resolved_hashes(study)
@@ -853,9 +853,9 @@ class StudyRunner:
 
             from llenergymeasure.study.equivalence_groups import (
                 EquivalenceGroups,
-                PostRunH3Group,
+                ObservedCollisionGroup,
                 PreRunGroup,
-                find_h3_groups,
+                find_observed_collisions,
                 write_equivalence_groups,
             )
 
@@ -887,13 +887,13 @@ class StudyRunner:
             for config_json in self.study_dir.rglob("config.json"):
                 with contextlib.suppress(Exception):
                     sidecars.append(_json.loads(config_json.read_text()))
-            post_run_groups: list[PostRunH3Group] = find_h3_groups(sidecars)
+            post_run_groups: list[ObservedCollisionGroup] = find_observed_collisions(sidecars)
 
             groups = EquivalenceGroups(
                 study_id=study_id,
                 dedup_mode=dedup_mode,
                 groups=pre_run_groups,
-                post_run_h3_groups=post_run_groups,
+                observed_collision_groups=post_run_groups,
             )
             write_equivalence_groups(groups, self.study_dir / "equivalence_groups.json")
             logger.debug("Wrote equivalence_groups.json to %s", self.study_dir)
@@ -902,12 +902,12 @@ class StudyRunner:
 
     @staticmethod
     def _build_resolved_hashes(study: Any) -> dict[str, str]:
-        """Build a declared_config_hash → resolved_config_hash (H1) mapping.
+        """Build a declared_config_hash → resolved_config_hash mapping.
 
         Iterates the unique post-dedup experiments in ``study.experiments``
         (cycles produce duplicates; seen_hashes deduplicates them) and
-        computes each experiment's resolved hash via the same H1 pipeline
-        used at sweep-expansion time.
+        computes each experiment's resolved hash via the same resolved-config
+        pipeline used at sweep-expansion time.
 
         Returns an empty dict on any failure — _save_and_record treats a
         missing resolved_config_hash as best-effort and writes ``None``.

--- a/tests/integration/test_sweep_dedup_end_to_end.py
+++ b/tests/integration/test_sweep_dedup_end_to_end.py
@@ -1,4 +1,4 @@
-"""End-to-end integration test for sweep canonicalisation + H1 dedup.
+"""End-to-end integration test for sweep canonicalisation + resolved-config dedup.
 
 Exercises the full load path: a study YAML with measurement-equivalent
 sweep configs goes through ``load_study_config`` and the resulting
@@ -38,11 +38,11 @@ def test_greedy_temperature_sweep_collapses(tmp_path: Path) -> None:
     path = _write_study(tmp_path, study)
     study_config = load_study_config(path)
 
-    # Dedup mode default is h1.
+    # Dedup mode default is resolved.
     assert study_config.dedup_mode == "resolved"
     # 6 declared x 1 cycle -> 4 unique x 1 cycle = 4 experiments.
     assert len(study_config.experiments) == 4
-    # Declared count preserved via H1 list.
+    # Declared count preserved via resolved-config-hash list.
     assert len(study_config.declared_resolved_config_hashes) == 6
     # At least one group has multiple members (the greedy-family collapse).
     group_sizes = sorted(g["member_count"] for g in study_config.pre_run_equivalence_groups)
@@ -112,7 +112,7 @@ def test_n_cycles_multiplies_unique_set(tmp_path: Path) -> None:
     # plus 2 sampling variants). 3 unique x 3 cycles = 9 runs.
     assert study_config.dedup_mode == "resolved"
     unique = {h for h in study_config.declared_resolved_config_hashes}
-    # Two declared configs share the same H1 (both greedy).
+    # Two declared configs share the same resolved_config_hash (both greedy).
     assert len(unique) == 3
     assert len(study_config.experiments) == 9
 

--- a/tests/unit/config/vendored_rules/test_loader.py
+++ b/tests/unit/config/vendored_rules/test_loader.py
@@ -162,14 +162,16 @@ def test_default_corpus_root_resolves_to_configs(tmp_path: Path) -> None:
 
 def test_valid_added_by_set_has_all_five_provenance_classes() -> None:
     assert (
-        frozenset({"ast_walker", "introspection", "manual_seed", "runtime_warning", "h3_collision"})
+        frozenset(
+            {"ast_walker", "introspection", "manual_seed", "runtime_warning", "observed_collision"}
+        )
         == VALID_ADDED_BY
     )
 
 
 @pytest.mark.parametrize(
     "provenance",
-    ["ast_walker", "introspection", "manual_seed", "runtime_warning", "h3_collision"],
+    ["ast_walker", "introspection", "manual_seed", "runtime_warning", "observed_collision"],
 )
 def test_all_added_by_values_round_trip(tmp_path: Path, provenance: str) -> None:
     corpus = _CORPUS_MINIMAL.replace("added_by: ast_walker", f"added_by: {provenance}")

--- a/tests/unit/engines/test_effective_params_capture.py
+++ b/tests/unit/engines/test_effective_params_capture.py
@@ -2,7 +2,7 @@
 
 PoC-C finding (sweep-dedup.md §3.2): the extractor must strip private
 (``_``-prefixed) fields by default — transformers and vLLM both leak
-state that would poison H3 otherwise. These tests verify the default
+state that would poison observed_config_hash otherwise. These tests verify the default
 behaviour and the allowlist escape hatch.
 """
 

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -739,7 +739,7 @@ class TestBeamSearchParams:
 
 
 # =============================================================================
-# Test Group 15: Multi-output token counting (H3 audit fix)
+# Test Group 15: Multi-output token counting
 # =============================================================================
 
 

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -587,7 +587,7 @@ def test_capture_model_memory_mb_defaults_to_gpu_zero(minimal_config):
 
 
 # ---------------------------------------------------------------------------
-# H1: Harness-owned canonical inference timer (time.perf_counter)
+# Harness-owned canonical inference timer (time.perf_counter)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/harness/test_measurement_integration.py
+++ b/tests/unit/harness/test_measurement_integration.py
@@ -374,7 +374,7 @@ def test_harness_build_result_uses_real_energy_values() -> None:
 
 
 def test_harness_build_result_uses_energy_measurement_duration_for_baseline() -> None:
-    """H1: Baseline energy adjustment uses energy_measurement.duration_sec, not datetime delta."""
+    """Baseline energy adjustment uses energy_measurement.duration_sec, not datetime delta."""
     from datetime import datetime, timedelta
 
     from llenergymeasure.config.models import ExperimentConfig

--- a/tests/unit/study/test_equivalence_groups.py
+++ b/tests/unit/study/test_equivalence_groups.py
@@ -1,4 +1,4 @@
-"""Tests for the equivalence-groups sidecar writer + post-run H3 grouping."""
+"""Tests for the equivalence-groups sidecar writer + post-run observed-collision grouping."""
 
 from __future__ import annotations
 
@@ -7,10 +7,10 @@ from pathlib import Path
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.study.equivalence_groups import (
     EquivalenceGroups,
-    PostRunH3Group,
+    ObservedCollisionGroup,
     PreRunGroup,
     build_pre_run_groups,
-    find_h3_groups,
+    find_observed_collisions,
     load_equivalence_groups,
     write_equivalence_groups,
 )
@@ -40,8 +40,8 @@ class TestRoundTripSerialisation:
                     deduplicated=True,
                 )
             ],
-            post_run_h3_groups=[
-                PostRunH3Group(
+            observed_collision_groups=[
+                ObservedCollisionGroup(
                     observed_config_hash="sha256:def",
                     engine="transformers",
                     library_version="4.56.0",
@@ -62,8 +62,8 @@ class TestRoundTripSerialisation:
         assert len(loaded.groups) == 1
         assert loaded.groups[0].member_count == 2
         assert loaded.groups[0].would_dedup is True
-        assert len(loaded.post_run_h3_groups) == 1
-        assert loaded.post_run_h3_groups[0].gap_detected is True
+        assert len(loaded.observed_collision_groups) == 1
+        assert loaded.observed_collision_groups[0].gap_detected is True
 
 
 class TestBuildPreRunGroups:
@@ -99,69 +99,69 @@ class TestBuildPreRunGroups:
         raise AssertionError("expected ValueError")
 
 
-class TestFindH3Groups:
-    def test_flags_gap_when_same_h3_distinct_h1(self):
+class TestFindObservedCollisions:
+    def test_flags_gap_when_same_observed_distinct_resolved(self):
         sidecars = [
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_a",
-                "observed_config_hash": "h3_shared",
+                "resolved_config_hash": "resolved_a",
+                "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_b",  # Distinct H1 — gap!
-                "observed_config_hash": "h3_shared",
+                "resolved_config_hash": "resolved_b",  # Distinct resolved — gap!
+                "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",
             },
         ]
-        groups = find_h3_groups(sidecars)
+        groups = find_observed_collisions(sidecars)
         assert len(groups) == 1
         assert groups[0].gap_detected is True
 
-    def test_no_flag_when_h1_same(self):
-        # Same H1 collapsing on the library side is not a gap — the
+    def test_no_flag_when_resolved_same(self):
+        # Same resolved-config collapsing on the library side is not a gap — the
         # library-resolution mechanism already saw them as equivalent.
         sidecars = [
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_a",
-                "observed_config_hash": "h3_shared",
+                "resolved_config_hash": "resolved_a",
+                "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_a",
-                "observed_config_hash": "h3_shared",
+                "resolved_config_hash": "resolved_a",
+                "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",
             },
         ]
-        groups = find_h3_groups(sidecars)
+        groups = find_observed_collisions(sidecars)
         assert len(groups) == 1
         assert groups[0].gap_detected is False
 
-    def test_distinct_h3_no_group(self):
+    def test_distinct_observed_no_group(self):
         sidecars = [
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_a",
-                "observed_config_hash": "h3_a",
+                "resolved_config_hash": "resolved_a",
+                "observed_config_hash": "observed_a",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_b",
-                "observed_config_hash": "h3_b",
+                "resolved_config_hash": "resolved_b",
+                "observed_config_hash": "observed_b",
                 "experiment_id": "exp_b",
             },
         ]
-        groups = find_h3_groups(sidecars)
+        groups = find_observed_collisions(sidecars)
         assert groups == []
 
     def test_different_versions_do_not_cross_groups(self):
@@ -169,33 +169,37 @@ class TestFindH3Groups:
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_a",
-                "observed_config_hash": "h3_shared",
+                "resolved_config_hash": "resolved_a",
+                "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
                 "library_version": "4.57.0",  # Different version
-                "resolved_config_hash": "h1_b",
-                "observed_config_hash": "h3_shared",
+                "resolved_config_hash": "resolved_b",
+                "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",
             },
         ]
-        groups = find_h3_groups(sidecars)
+        groups = find_observed_collisions(sidecars)
         # Version mismatch — grouped separately, each with len=1, so no gap.
         assert groups == []
 
-    def test_sidecar_missing_h3_skipped(self):
+    def test_sidecar_missing_observed_skipped(self):
         sidecars = [
-            {"engine": "transformers", "library_version": "4.56.0", "resolved_config_hash": "h1_a"},
             {
                 "engine": "transformers",
                 "library_version": "4.56.0",
-                "resolved_config_hash": "h1_b",
-                "observed_config_hash": "h3_shared",
+                "resolved_config_hash": "resolved_a",
+            },
+            {
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "resolved_config_hash": "resolved_b",
+                "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",
             },
         ]
         # Only one valid sidecar; no group formed.
-        groups = find_h3_groups(sidecars)
+        groups = find_observed_collisions(sidecars)
         assert groups == []

--- a/tests/unit/study/test_hashing.py
+++ b/tests/unit/study/test_hashing.py
@@ -1,4 +1,4 @@
-"""Tests for canonical serialisation + H1/H3 hashing.
+"""Tests for canonical serialisation + resolved/observed config hashing.
 
 Normalisation rules come from ``sweep-dedup.md`` §9.Q3. Each test pins one
 rule from the table so a rule change surfaces as a targeted failure rather
@@ -101,7 +101,7 @@ class TestHashConfig:
         assert hash_config(v1) != hash_config(v2)
 
 
-class TestBuildH1View:
+class TestBuildResolvedView:
     def test_extracts_engine_and_task(self):
         cfg = _mk_config(transformers={"sampling": {"do_sample": False}})
         view = build_resolved_view(cfg)
@@ -121,7 +121,7 @@ class TestBuildH1View:
         assert view.passthrough_kwargs == {"my_key": "my_val"}
 
 
-class TestBuildH3View:
+class TestBuildObservedView:
     def test_carries_inputs_through(self):
         view = build_observed_view(
             engine="vllm",
@@ -133,27 +133,27 @@ class TestBuildH3View:
         assert view.observed_engine_params["dtype"] == "float16"
         assert view.observed_sampling_params["temperature"] == 1.0
 
-    def test_h1_and_h3_match_on_same_inputs(self):
+    def test_resolved_and_observed_match_on_same_inputs(self):
         # Symmetry: both views hashed through the same pipe produce the same hash
-        # when the underlying fields match. This is what makes the H3-collision
+        # when the underlying fields match. This is what makes the observed-collision
         # invariant meaningful.
         task = {"model": "gpt2"}
         engine_params = {"dtype": "float16"}
         sampling_params = {"temperature": 1.0}
 
-        h1_view = ConfigHashView(
+        resolved_view = ConfigHashView(
             engine="vllm",
             task=task,
             observed_engine_params=engine_params,
             observed_sampling_params=sampling_params,
         )
-        h3_view = build_observed_view(
+        observed_view = build_observed_view(
             engine="vllm",
             task=task,
             observed_engine_params=engine_params,
             observed_sampling_params=sampling_params,
         )
-        assert hash_config(h1_view) == hash_config(h3_view)
+        assert hash_config(resolved_view) == hash_config(observed_view)
 
 
 class TestHashStability:


### PR DESCRIPTION
## Summary

Mechanical rename of the legacy `H1` / `H3` vocabulary to the locked declared/resolved/observed scheme established in #401 + #402. Pure cleanup PR — no behaviour change. Lands first so the follow-up reporter PR (`--source observed-collisions`) builds on a clean vocabulary.

**Symbol-level renames** (no callers outside this PR — checked via grep):

| Legacy | New | Site |
|---|---|---|
| `find_h3_groups()` | `find_observed_collisions()` | `study/equivalence_groups.py` |
| `PostRunH3Group` (dataclass) | `ObservedCollisionGroup` | `study/equivalence_groups.py` |
| `post_run_h3_groups` (JSON key) | `observed_collision_groups` | `equivalence_groups.json` schema |
| `AddedBy` literal `"h3_collision"` | `"observed_collision"` | `config/vendored_rules/loader.py` |
| `h3_view` (local var) | `observed_view` | `harness/__init__.py` |

Plus comments, docstrings, test class names (`TestFindH3Groups` → `TestFindObservedCollisions`, `TestBuildH1View` → `TestBuildResolvedView`, `TestBuildH3View` → `TestBuildObservedView`), and test fixture string labels (`"h1_a"` → `"resolved_a"`, `"h3_shared"` → `"observed_shared"`) for consistency throughout the affected suites.

**Schema-level rename:** `observed_collision_groups` is the new top-level key in `equivalence_groups.json`. No on-disk corpus or sidecar entry uses `added_by: h3_collision` today (the reporter that emits this provenance hasn't shipped yet), so the enum rename has zero migration cost.

**False positives left intentionally:**
- `H100=9.0` GPU-compute-capability strings in `engines/tensorrt.py` (Hopper GPU model, not the H1/H3 concept)
- `tests/unit/cli/test_report_gaps.py` deliberately tests `--source h3-collisions` rejection — left as-is since the new `observed-collisions` source value lands in the next PR (this test will update there)
- Frozen PoC scripts under `scripts/probe_h3_*.py` — renaming creates citation drift in the design-doc decision log

## Test plan
- [x] `pytest tests/unit -q` — 2332 passed, 1 pre-existing flake (`test_peak_memory_reset_precedes_measurement` passes in isolation; pytest-randomly order interaction unrelated to this rename)
- [x] `pytest tests/integration/test_sweep_dedup_end_to_end.py tests/unit/engines/test_vllm_engine.py` — 79 passed
- [x] `lint-imports` — 3 contracts kept, 0 broken
- [x] Final grep `'\bH1\b|\bH3\b|\bh1_|\bh3_|H1/H3|H3-collision|H1-collision'` returns zero matches outside the documented false-positive sites