### PR TITLE
feat(cli): llem report-gaps --source observed-collisions for silent-rule discovery

### DIFF
--- a/src/llenergymeasure/api/__init__.py
+++ b/src/llenergymeasure/api/__init__.py
@@ -4,6 +4,7 @@ from llenergymeasure.api._impl import run_experiment, run_study
 from llenergymeasure.api.report_gaps import (
     GapProposal,
     ReportGapsError,
+    find_observed_collision_gaps,
     find_runtime_gaps,
     load_rules_corpus,
     render_yaml_fragment,
@@ -15,6 +16,7 @@ from llenergymeasure.study.resume import find_resumable_study, load_resume_state
 __all__ = [
     "GapProposal",
     "ReportGapsError",
+    "find_observed_collision_gaps",
     "find_resumable_study",
     "find_runtime_gaps",
     "load_resume_state",

--- a/src/llenergymeasure/api/report_gaps.py
+++ b/src/llenergymeasure/api/report_gaps.py
@@ -1,27 +1,34 @@
 """``llem report-gaps`` — feedback-loop proposer for the rules corpus.
 
-Reads ``runtime_observations.jsonl`` emitted by
-:mod:`llenergymeasure.study.runtime_observations`, groups captured warnings
-and log records by their normalised message template, partitions configs
-into *collision_configs* (A) and *not collision_configs* (B), and proposes corpus rules for
-templates the existing rules corpus does not already match.
+Two source channels:
+
+- ``runtime-warnings`` reads ``runtime_observations.jsonl`` (announced
+  library emissions: ``warnings.warn``, ``logger.warning``, runtime
+  exceptions). Groups by normalised message template.
+- ``observed-collisions`` reads ``equivalence_groups.json`` (silent
+  library normalisations: two configs with distinct
+  ``resolved_config_hash`` collapsing to the same ``observed_config_hash``).
+  Groups by ``(engine, library_version, observed_config_hash)``.
+
+Both channels share predicate inference (:func:`_infer_predicate` —
+arity 1→2→3 + ``present:true`` fallback, requiring a unanimous trigger
+in collision_configs and zero contrast match), evidence emission
+(:func:`_field_value_distribution`), and YAML rendering
+(:func:`render_yaml_fragment`).
 
 Design:
 
-- **No corpus mutation.** We emit YAML *fragments* to ``--out PATH``; the
-  live ``configs/validation_rules/{engine}.yaml`` is never touched.
+- **No corpus mutation.** YAML fragments go to ``--out PATH``; the live
+  ``configs/validation_rules/{engine}.yaml`` is never touched.
 - **Severity is mechanical.** ``warn`` for log-channel emissions;
-  ``error`` when ``include_exceptions=True`` and the record is an
-  exception. ``walker_confidence`` is always ``low``.
+  ``error`` for runtime exceptions; ``dormant`` for silent observed
+  collisions. ``walker_confidence`` is always ``low``.
 - **Round-trip safe.** Fragments parse through
   :func:`llenergymeasure.config.vendored_rules.loader._parse_rule`;
   placeholders carry ``# TODO: human`` markers.
 - **Sentinel filtering.** ``subprocess_died`` / ``exception`` records
-  don't prove "rule didn't fire" — excluded from B always; excluded from
-  A unless ``include_exceptions=True``.
-- **Emission channels.** This module produces ``warnings_warn``,
-  ``logger_warning``, ``logger_warning_once``, and ``runtime_exception``
-  only — a documented subset of :data:`EmissionChannel`.
+  don't prove "rule didn't fire" — excluded from contrast always;
+  excluded from collision unless ``include_exceptions=True``.
 
 Source of config kwargs: per-experiment ``_resolution.json`` sidecars,
 flattened into ``dict[str, Any]`` per ``config_hash``. Located via
@@ -53,6 +60,7 @@ from llenergymeasure.study.runtime_observations import RUNTIME_OBSERVATIONS_FILE
 __all__ = [
     "GapProposal",
     "ReportGapsError",
+    "find_observed_collision_gaps",
     "find_runtime_gaps",
     "load_rules_corpus",
     "render_yaml_fragment",
@@ -77,7 +85,14 @@ class ReportGapsError(Exception):
 
 @dataclass(frozen=True)
 class GapProposal:
-    """One proposed corpus rule for a single unmatched normalised template."""
+    """One proposed corpus rule.
+
+    Two flavours share this dataclass: announced runtime warnings (a
+    normalised message template uniquely identifies the rule) and silent
+    observed-collisions (a ``(library_version, observed_config_hash)``
+    pair uniquely identifies the rule, with no message text). The
+    ``added_by`` field disambiguates at render time.
+    """
 
     normalised_template: str
     source_channel: EmissionChannel
@@ -89,7 +104,8 @@ class GapProposal:
     contrast_count: int
     representative_message: str
     needs_generalisation_review: bool
-    severity: Literal["warn", "error"]
+    severity: Literal["warn", "error", "dormant"]
+    added_by: Literal["runtime_warning", "observed_collision"] = "runtime_warning"
     representative_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -312,6 +328,185 @@ def find_runtime_gaps(
             )
         )
     return proposals
+
+
+# ---------------------------------------------------------------------------
+# Observed-config-hash collision proposals (silent-rule channel)
+# ---------------------------------------------------------------------------
+
+
+def find_observed_collision_gaps(
+    study_dirs: list[Path],
+    engine: Engine | str | None = None,
+) -> list[GapProposal]:
+    """Scan study dirs for observed-config-hash collisions; propose bridging rules.
+
+    Reads each study's ``equivalence_groups.json`` (see
+    :mod:`llenergymeasure.study.equivalence_groups`) and selects entries
+    where ``gap_detected=True`` — the proven library-resolution-mechanism
+    gap signal from sweep-dedup.md §4.1.
+
+    For each gap group, partitions the study's per-experiment configs:
+
+    - ``collision_configs`` — kwargs of the experiments whose
+      ``observed_config_hash`` matches the gap group.
+    - ``contrast_configs`` — kwargs of every other experiment in the
+      same study that has a *different* ``observed_config_hash`` (i.e.
+      not in this collision group).
+
+    Then runs :func:`_infer_predicate` on the partitions. The same
+    arity-1→2→3 + ``present:true`` fallback used by the runtime-warnings
+    flavour applies — it requires a unanimous trigger across collisions
+    AND zero contrast match, so range-trigger rules (where the trigger
+    field varies inside the collision group) correctly route to
+    evidence-only rather than producing a misanchored predicate.
+
+    Order sorts by (engine, library_version, observed_config_hash).
+    """
+    if not study_dirs:
+        raise ReportGapsError("No study directories provided. Pass at least one --study-dir.")
+
+    engine_filter: str | None = str(engine) if engine is not None else None
+    if engine_filter is not None and engine_filter not in _ALLOWED_ENGINES:
+        raise ReportGapsError(
+            f"Unsupported engine filter: {engine_filter!r}. "
+            f"Expected one of: {sorted(_ALLOWED_ENGINES)}."
+        )
+
+    proposals: list[GapProposal] = []
+    for study_dir in study_dirs:
+        proposals.extend(_collision_proposals_for_study(Path(study_dir), engine_filter))
+
+    proposals.sort(key=lambda p: (p.engine.value, p.library_version, p.normalised_template))
+    return proposals
+
+
+def _collision_proposals_for_study(
+    study_dir: Path,
+    engine_filter: str | None,
+) -> list[GapProposal]:
+    """Return proposals for a single study — empty if no gap-detected groups."""
+    groups_path = study_dir / "equivalence_groups.json"
+    if not groups_path.exists():
+        logger.info("No equivalence_groups.json in %s; skipping.", study_dir)
+        return []
+    try:
+        groups_doc = json.loads(groups_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read equivalence_groups.json at %s: %s", groups_path, exc)
+        return []
+
+    raw_groups = groups_doc.get("observed_collision_groups") or []
+    gap_groups: list[dict[str, Any]] = [
+        g for g in raw_groups if isinstance(g, dict) and g.get("gap_detected")
+    ]
+    if not gap_groups:
+        return []
+
+    kwargs_by_hash, _ = _load_kwargs_by_hash(study_dir)
+    if not kwargs_by_hash:
+        logger.info(
+            "No _resolution.json sidecars found under %s; cannot partition gap groups.",
+            study_dir,
+        )
+        return []
+
+    # Build experiment_id → config_hash mapping from the manifest so we
+    # can resolve gap-group member ids back to declared kwargs.
+    exp_id_to_config_hash = _experiment_id_to_config_hash(study_dir)
+
+    proposals: list[GapProposal] = []
+    for group in gap_groups:
+        engine_str = str(group.get("engine") or "")
+        if engine_str not in _ALLOWED_ENGINES:
+            continue
+        if engine_filter is not None and engine_str != engine_filter:
+            continue
+        proposal = _proposal_from_collision_group(
+            group, engine_str, kwargs_by_hash, exp_id_to_config_hash
+        )
+        if proposal is not None:
+            proposals.append(proposal)
+    return proposals
+
+
+def _experiment_id_to_config_hash(study_dir: Path) -> dict[str, str]:
+    """Map each ``experiment_id`` to its full ``config_hash`` via ``manifest.json``.
+
+    Falls back to an empty mapping when the manifest is absent — gap
+    proposals that would have used the prefix-scan path lose their
+    declared-kwargs context but still surface as evidence-only entries.
+    """
+    manifest_path = study_dir / "manifest.json"
+    if not manifest_path.exists():
+        return {}
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    out: dict[str, str] = {}
+    for entry in manifest.get("experiments") or []:
+        if not isinstance(entry, dict):
+            continue
+        exp_id = str(entry.get("experiment_id") or "")
+        config_hash = str(entry.get("config_hash") or "")
+        if exp_id and config_hash:
+            out[exp_id] = config_hash
+    return out
+
+
+def _proposal_from_collision_group(
+    group: dict[str, Any],
+    engine_str: str,
+    kwargs_by_hash: dict[str, dict[str, Any]],
+    exp_id_to_config_hash: dict[str, str],
+) -> GapProposal | None:
+    """Build one :class:`GapProposal` from one observed-collision group."""
+    observed_hash = str(group.get("observed_config_hash") or "")
+    library_version = str(group.get("library_version") or "")
+    member_ids = group.get("member_experiment_ids") or []
+    if not observed_hash or not isinstance(member_ids, list) or not member_ids:
+        return None
+
+    member_hashes: set[str] = set()
+    collision_configs: list[dict[str, Any]] = []
+    for exp_id in member_ids:
+        config_hash = exp_id_to_config_hash.get(str(exp_id))
+        if not config_hash:
+            continue
+        member_hashes.add(config_hash)
+        kwargs = kwargs_by_hash.get(config_hash)
+        if kwargs is not None:
+            collision_configs.append(kwargs)
+
+    contrast_configs: list[dict[str, Any]] = [
+        kwargs for h, kwargs in kwargs_by_hash.items() if h not in member_hashes
+    ]
+
+    match_fields = _infer_predicate(collision_configs, contrast_configs)
+    evidence = _field_value_distribution(collision_configs, contrast_configs)
+    needs_review = match_fields is None or len(match_fields) >= 2
+
+    return GapProposal(
+        # observed-collisions have no message template; use the hash as a
+        # stable id surrogate for sorting and slug generation.
+        normalised_template=f"observed_collision:{observed_hash[:16]}",
+        source_channel="none",
+        engine=Engine(engine_str),
+        library_version=library_version,
+        match_fields=match_fields,
+        evidence_field_value_distribution=evidence,
+        collision_count=len(collision_configs),
+        contrast_count=len(contrast_configs),
+        representative_message=(
+            f"Library silently collapsed {len(collision_configs)} declared configs "
+            f"to observed_config_hash={observed_hash[:16]}."
+        ),
+        needs_generalisation_review=needs_review,
+        severity="dormant",
+        added_by="observed_collision",
+        representative_kwargs=collision_configs[0] if collision_configs else {},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -661,6 +856,13 @@ _BANNER = (
 )
 
 
+_OUTCOME_BY_SEVERITY: dict[str, str] = {
+    "error": "error",
+    "warn": "warn",
+    "dormant": "dormant_silent",
+}
+
+
 def render_yaml_fragment(proposal: GapProposal) -> str:
     """Render one :class:`GapProposal` as a YAML document.
 
@@ -671,16 +873,57 @@ def render_yaml_fragment(proposal: GapProposal) -> str:
     """
     template = proposal.normalised_template
     match_fields: dict[str, Any] = dict(proposal.match_fields) if proposal.match_fields else {}
-    outcome_value = "error" if proposal.severity == "error" else "warn"
+    outcome_value = _OUTCOME_BY_SEVERITY[proposal.severity]
     engine_str = proposal.engine.value
+    is_observed = proposal.added_by == "observed_collision"
+    rule_under_test = (
+        (
+            "(observed-collision) Two configs with distinct resolved_config_hash "
+            "collapsed to the same observed_config_hash; reviewer to confirm semantic."
+        )
+        if is_observed
+        else (
+            "(runtime-derived) Library emitted normalised template; reviewer to confirm semantic."
+        )
+    )
+    expected_outcome: dict[str, Any] = {
+        "outcome": outcome_value,
+        "emission_channel": proposal.source_channel,
+        "normalised_fields": [],
+    }
+    if not is_observed:
+        # Runtime-warnings flavour proves the library text emission.
+        # Observed-collisions are silent — there is no message to match against.
+        expected_outcome["observed_messages_regex"] = [build_template_regex(template)]
+        expected_outcome["observed_messages"] = [proposal.representative_message]
+
+    if is_observed:
+        references = [
+            (
+                f"observed_config_hash collision: {proposal.collision_count} member(s) "
+                f"share the same library-effective state; "
+                f"{proposal.contrast_count} contrast config(s) in the study."
+            ),
+            (
+                "Detected by the post-resolved-config-dedup invariant in "
+                "sweep-dedup.md §4.1: distinct resolved_config_hash + matching "
+                "observed_config_hash = proven library-resolution-mechanism gap."
+            ),
+        ]
+    else:
+        references = [
+            (
+                f"Observed in {proposal.collision_count} configs; "
+                f"absent in {proposal.contrast_count} configs."
+            ),
+            f"Representative raw message: {proposal.representative_message!r}",
+        ]
 
     proposal_doc: dict[str, Any] = {
         "id": _proposed_rule_id(proposal),
         "engine": engine_str,
         "library": engine_str,
-        "rule_under_test": (
-            "(runtime-derived) Library emitted normalised template; reviewer to confirm semantic."
-        ),
+        "rule_under_test": rule_under_test,
         "severity": proposal.severity,
         "native_type": f"{engine_str}.<TODO: human — set concrete native type>",
         "walker_source": {
@@ -692,22 +935,10 @@ def render_yaml_fragment(proposal: GapProposal) -> str:
         "match": {"engine": engine_str, "fields": match_fields},
         "kwargs_positive": dict(proposal.representative_kwargs),
         "kwargs_negative": {},
-        "expected_outcome": {
-            "outcome": outcome_value,
-            "emission_channel": proposal.source_channel,
-            "normalised_fields": [],
-            "observed_messages_regex": [build_template_regex(template)],
-            "observed_messages": [proposal.representative_message],
-        },
+        "expected_outcome": expected_outcome,
         "message_template": template,
-        "references": [
-            (
-                f"Observed in {proposal.collision_count} configs; "
-                f"absent in {proposal.contrast_count} configs."
-            ),
-            f"Representative raw message: {proposal.representative_message!r}",
-        ],
-        "added_by": "runtime_warning",
+        "references": references,
+        "added_by": proposal.added_by,
         "added_at": "<TODO: human — YYYY-MM-DD>",
         "source_channel": proposal.source_channel,
         "needs_generalisation_review": proposal.needs_generalisation_review,
@@ -719,7 +950,8 @@ def render_yaml_fragment(proposal: GapProposal) -> str:
 
 
 def _proposed_rule_id(proposal: GapProposal) -> str:
-    """Return ``{engine}_runtime_{slug}`` for a reviewer-friendly rule id."""
+    """Return ``{engine}_{provenance}_{slug}`` for a reviewer-friendly rule id."""
     cleaned = re.sub(r"[^a-z0-9]+", "_", proposal.normalised_template.lower()).strip("_")
     slug = cleaned[:40] or "unnamed"
-    return f"{proposal.engine.value}_runtime_{slug}"
+    provenance = "observed" if proposal.added_by == "observed_collision" else "runtime"
+    return f"{proposal.engine.value}_{provenance}_{slug}"

--- a/src/llenergymeasure/cli/report_gaps.py
+++ b/src/llenergymeasure/cli/report_gaps.py
@@ -3,6 +3,14 @@
 Thin Typer command that delegates everything interesting to
 :mod:`llenergymeasure.api.report_gaps`. CLI-boundary contract: imports only
 from ``llenergymeasure.api``; never reaches into ``study``/``harness``/etc.
+
+Two source channels:
+
+- ``runtime-warnings`` — announced library emissions captured in
+  ``runtime_observations.jsonl``.
+- ``observed-collisions`` — silent library normalisations surfaced by
+  the post-resolved-config-dedup observed_config_hash collision invariant
+  in ``equivalence_groups.json``.
 """
 
 from __future__ import annotations
@@ -15,11 +23,14 @@ import typer
 
 from llenergymeasure.api import (
     ReportGapsError,
+    find_observed_collision_gaps,
     find_runtime_gaps,
     render_yaml_fragment,
 )
 
 __all__ = ["report_gaps_cmd"]
+
+_SUPPORTED_SOURCES: frozenset[str] = frozenset({"runtime-warnings", "observed-collisions"})
 
 
 def report_gaps_cmd(
@@ -27,7 +38,11 @@ def report_gaps_cmd(
         str,
         typer.Option(
             "--source",
-            help="Feedback source to scan. Only 'runtime-warnings' is wired in this release.",
+            help=(
+                "Feedback source to scan: 'runtime-warnings' "
+                "(announced library emissions) or 'observed-collisions' "
+                "(silent library normalisations)."
+            ),
         ),
     ] = "runtime-warnings",
     study_dir: Annotated[
@@ -56,16 +71,16 @@ def report_gaps_cmd(
         typer.Option(
             "--include-exceptions",
             help=(
-                "Also propose rules from runtime exceptions. "
-                "Disabled by default; exceptions ship through a different review path."
+                "(runtime-warnings only) Also propose rules from runtime exceptions. "
+                "Ignored for observed-collisions."
             ),
         ),
     ] = False,
 ) -> None:
     """Propose rules corpus entries from captured runtime observations."""
-    if source != "runtime-warnings":
+    if source not in _SUPPORTED_SOURCES:
         raise typer.BadParameter(
-            f"Unsupported source {source!r}. Only 'runtime-warnings' is wired in this release.",
+            f"Unsupported source {source!r}. Expected one of: {sorted(_SUPPORTED_SOURCES)}.",
             param_hint="--source",
         )
     if not study_dir:
@@ -80,11 +95,17 @@ def report_gaps_cmd(
         )
 
     try:
-        proposals = find_runtime_gaps(
-            study_dirs=list(study_dir),
-            engine=engine,
-            include_exceptions=include_exceptions,
-        )
+        if source == "runtime-warnings":
+            proposals = find_runtime_gaps(
+                study_dirs=list(study_dir),
+                engine=engine,
+                include_exceptions=include_exceptions,
+            )
+        else:
+            proposals = find_observed_collision_gaps(
+                study_dirs=list(study_dir),
+                engine=engine,
+            )
     except ReportGapsError as exc:
         print(f"llem report-gaps: {exc}", file=sys.stderr)
         raise typer.Exit(code=2) from None

--- a/tests/helpers/runtime_obs.py
+++ b/tests/helpers/runtime_obs.py
@@ -107,3 +107,44 @@ def write_jsonl_record(
     path = study_dir / "runtime_observations.jsonl"
     with open(path, "a", encoding="utf-8") as fh:
         fh.write(json.dumps(rec) + "\n")
+
+
+def write_manifest(
+    study_dir: Path,
+    entries: list[dict[str, Any]],
+) -> None:
+    """Write a minimal ``manifest.json`` mapping experiment_id → config_hash + result_file.
+
+    Each ``entries`` item must carry at least ``experiment_id``,
+    ``config_hash``, and ``result_file`` (relative path to the
+    ``result.json`` so ``_resolution.json`` is locatable as its sibling).
+    """
+    payload = {"schema_version": "1.0", "experiments": entries}
+    (study_dir / "manifest.json").write_text(json.dumps(payload))
+
+
+def write_equivalence_groups(
+    study_dir: Path,
+    *,
+    study_id: str = "fixture-study",
+    dedup_mode: str = "resolved",
+    observed_collision_groups: list[dict[str, Any]] | None = None,
+    pre_run_groups: list[dict[str, Any]] | None = None,
+) -> None:
+    """Write a minimal ``equivalence_groups.json`` for observed-collisions tests.
+
+    Schema matches
+    :class:`llenergymeasure.study.equivalence_groups.EquivalenceGroups`.
+    Each group dict in ``observed_collision_groups`` must carry at least
+    ``observed_config_hash``, ``engine``, ``library_version``,
+    ``member_resolved_config_hashes``, ``member_experiment_ids``, and
+    ``gap_detected``.
+    """
+    payload: dict[str, Any] = {
+        "study_id": study_id,
+        "dedup_mode": dedup_mode,
+        "vendored_rules_version": "",
+        "groups": pre_run_groups or [],
+        "observed_collision_groups": observed_collision_groups or [],
+    }
+    (study_dir / "equivalence_groups.json").write_text(json.dumps(payload, indent=2))

--- a/tests/unit/api/test_report_gaps_observed_collisions.py
+++ b/tests/unit/api/test_report_gaps_observed_collisions.py
@@ -1,0 +1,332 @@
+"""Unit tests for the observed-collisions flavour of ``llem report-gaps``.
+
+Covers :func:`llenergymeasure.api.find_observed_collision_gaps` and the
+shared :func:`render_yaml_fragment` path when ``added_by="observed_collision"``.
+
+The two load-bearing fixtures pin Test 1 from the adversarial review at
+sweep-dedup.md §10 (2026-04-25 entry):
+
+- An *equality-trigger* fixture (``do_sample=False`` is invariant
+  across the collision group and varies in contrast) MUST produce a
+  concrete ``match.fields`` predicate.
+- A *range-predicate* fixture (``temperature`` is the only varying
+  field — ``0.001`` and ``0.005`` collapse to the same observed state)
+  MUST route to evidence-only (``match_fields is None``,
+  ``needs_generalisation_review=True``) because the trigger field
+  varies inside the collision group.
+
+If either of those routes incorrectly, the conservative-field-diff
+contract from the design doc is broken.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llenergymeasure.api import (
+    GapProposal,
+    ReportGapsError,
+    find_observed_collision_gaps,
+    render_yaml_fragment,
+)
+from tests.helpers.runtime_obs import (
+    fake_hash as _fake_hash,
+)
+from tests.helpers.runtime_obs import (
+    write_equivalence_groups as _write_equivalence_groups,
+)
+from tests.helpers.runtime_obs import (
+    write_manifest as _write_manifest,
+)
+from tests.helpers.runtime_obs import (
+    write_resolution as _write_resolution,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _seed_study(
+    study_dir: Path,
+    *,
+    members: list[tuple[str, dict[str, object]]],
+    contrasts: list[tuple[str, dict[str, object]]],
+    engine: str = "transformers",
+    library_version: str = "4.56.0",
+    observed_hash: str = "obs_shared_xxx",
+) -> None:
+    """Write _resolution sidecars + manifest + equivalence_groups for one gap.
+
+    ``members`` and ``contrasts`` are ``(experiment_id, kwargs)`` lists.
+    Each entry creates a per-experiment subdir + ``_resolution.json`` and
+    a manifest entry. The members all share ``observed_hash`` and have
+    distinct ``resolved_config_hash`` values; the contrasts have
+    distinct ``observed_config_hash`` values (so they're outside the
+    collision group).
+    """
+    study_dir.mkdir(parents=True, exist_ok=True)
+    manifest_entries: list[dict[str, object]] = []
+
+    for index, (exp_id, kwargs) in enumerate(members + contrasts, start=1):
+        config_hash = _fake_hash(exp_id)
+        subdir = _write_resolution(study_dir, index, 1, engine, config_hash, kwargs)
+        manifest_entries.append(
+            {
+                "experiment_id": exp_id,
+                "config_hash": config_hash,
+                "result_file": f"{subdir.name}/result.json",
+            }
+        )
+    _write_manifest(study_dir, manifest_entries)
+
+    member_ids = [exp_id for exp_id, _ in members]
+    member_resolved = [_fake_hash(f"resolved_{exp_id}") for exp_id, _ in members]
+    _write_equivalence_groups(
+        study_dir,
+        observed_collision_groups=[
+            {
+                "observed_config_hash": observed_hash,
+                "engine": engine,
+                "library_version": library_version,
+                "member_resolved_config_hashes": member_resolved,
+                "member_experiment_ids": member_ids,
+                "gap_detected": True,
+                "proposed_rule_id": None,
+            }
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Equality-trigger predicate (positive case for conservative field-diff)
+# ---------------------------------------------------------------------------
+
+
+def test_equality_trigger_emits_match_fields(tmp_path: Path) -> None:
+    """Conservative field-diff: do_sample is invariant across collision and
+    varies across contrast → emit ``match.fields: {do_sample: False}``."""
+    study = tmp_path / "study-equality"
+    _seed_study(
+        study,
+        members=[
+            ("exp_a", {"do_sample": False, "temperature": 0.5}),
+            ("exp_b", {"do_sample": False, "temperature": 1.0}),
+        ],
+        contrasts=[
+            ("exp_c", {"do_sample": True, "temperature": 0.5}),
+            ("exp_d", {"do_sample": True, "temperature": 1.0}),
+        ],
+    )
+
+    proposals = find_observed_collision_gaps(study_dirs=[study])
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.match_fields == {"do_sample": False}
+    assert proposal.severity == "dormant"
+    assert proposal.added_by == "observed_collision"
+    assert proposal.source_channel == "none"
+    assert proposal.collision_count == 2
+    assert proposal.contrast_count == 2
+    assert proposal.needs_generalisation_review is False
+
+
+# ---------------------------------------------------------------------------
+# Range-predicate (PoC-H3R failure case — must route to evidence-only)
+# ---------------------------------------------------------------------------
+
+
+def test_range_predicate_routes_to_evidence_only(tmp_path: Path) -> None:
+    """PoC-K range-predicate: temperature varies inside the collision group,
+    so no field is invariant-in-collisions-AND-varying-in-contrasts.
+    Conservative field-diff must refuse to propose ``match.fields``."""
+    study = tmp_path / "study-range"
+    _seed_study(
+        study,
+        members=[
+            # Both clamp to temperature=0.01 in the live library; only
+            # field that distinguishes them from contrast is the
+            # collision-group-internal varying temperature itself, which
+            # the conservative inference correctly cannot resolve to a
+            # trigger predicate.
+            ("exp_a", {"temperature": 0.001, "top_p": 0.95}),
+            ("exp_b", {"temperature": 0.005, "top_p": 0.95}),
+        ],
+        contrasts=[
+            ("exp_c", {"temperature": 0.5, "top_p": 0.95}),
+            ("exp_d", {"temperature": 1.0, "top_p": 0.95}),
+        ],
+    )
+
+    proposals = find_observed_collision_gaps(study_dirs=[study])
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.match_fields is None
+    assert proposal.needs_generalisation_review is True
+    # Evidence is still emitted so reviewers can see the partition.
+    assert "temperature" in proposal.evidence_field_value_distribution
+    distribution = proposal.evidence_field_value_distribution["temperature"]
+    assert distribution["collision_configs"] == ["0.001", "0.005"]
+    assert distribution["contrast_configs"] == ["0.5", "1.0"]
+
+
+# ---------------------------------------------------------------------------
+# Filtering and skip behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_no_groups_file_returns_empty(tmp_path: Path) -> None:
+    study = tmp_path / "study-empty"
+    study.mkdir()
+    assert find_observed_collision_gaps(study_dirs=[study]) == []
+
+
+def test_gap_detected_false_groups_skipped(tmp_path: Path) -> None:
+    study = tmp_path / "study-no-gap"
+    study.mkdir()
+    _write_equivalence_groups(
+        study,
+        observed_collision_groups=[
+            {
+                "observed_config_hash": "obs_x",
+                "engine": "transformers",
+                "library_version": "4.56.0",
+                "member_resolved_config_hashes": ["res_a", "res_a"],
+                "member_experiment_ids": ["exp_a", "exp_b"],
+                "gap_detected": False,
+            }
+        ],
+    )
+    assert find_observed_collision_gaps(study_dirs=[study]) == []
+
+
+def test_engine_filter(tmp_path: Path) -> None:
+    """Multi-engine: --engine vllm filters out a transformers gap."""
+    study = tmp_path / "study-multi-engine"
+    _seed_study(
+        study,
+        members=[
+            ("exp_a", {"do_sample": False}),
+            ("exp_b", {"do_sample": False}),
+        ],
+        contrasts=[("exp_c", {"do_sample": True})],
+    )
+
+    assert find_observed_collision_gaps(study_dirs=[study], engine="vllm") == []
+    # Sanity: filtering by the matching engine still finds the gap.
+    assert len(find_observed_collision_gaps(study_dirs=[study], engine="transformers")) == 1
+
+
+def test_no_study_dirs_raises() -> None:
+    with pytest.raises(ReportGapsError, match="No study directories"):
+        find_observed_collision_gaps(study_dirs=[])
+
+
+def test_unsupported_engine_filter_raises(tmp_path: Path) -> None:
+    with pytest.raises(ReportGapsError, match="Unsupported engine"):
+        find_observed_collision_gaps(study_dirs=[tmp_path], engine="bogus_backend")
+
+
+# ---------------------------------------------------------------------------
+# YAML rendering — the two flavours produce schema-symmetric output
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_fragment_carries_observed_collision_provenance(tmp_path: Path) -> None:
+    study = tmp_path / "study-yaml"
+    _seed_study(
+        study,
+        members=[
+            ("exp_a", {"do_sample": False}),
+            ("exp_b", {"do_sample": False}),
+        ],
+        contrasts=[("exp_c", {"do_sample": True})],
+    )
+    proposals = find_observed_collision_gaps(study_dirs=[study])
+    assert proposals
+    body = render_yaml_fragment(proposals[0])
+
+    # Provenance is the new enum value.
+    assert "added_by: observed_collision" in body
+    # Severity for silent normalisations is dormant; outcome dormant_silent.
+    assert "severity: dormant" in body
+    assert "dormant_silent" in body
+    # Silent channel — no message-text matching surface.
+    assert "emission_channel: none" in body
+    assert "observed_messages_regex" not in body
+    assert "observed_messages:" not in body
+    # Conservative field-diff predicate did fire on this fixture.
+    assert "do_sample: false" in body
+
+
+def test_yaml_fragment_evidence_only_when_predicate_unresolvable(tmp_path: Path) -> None:
+    study = tmp_path / "study-evidence-only"
+    _seed_study(
+        study,
+        members=[
+            ("exp_a", {"temperature": 0.001, "top_p": 0.95}),
+            ("exp_b", {"temperature": 0.005, "top_p": 0.95}),
+        ],
+        contrasts=[("exp_c", {"temperature": 0.5, "top_p": 0.95})],
+    )
+    proposals = find_observed_collision_gaps(study_dirs=[study])
+    assert proposals
+    body = render_yaml_fragment(proposals[0])
+
+    assert "needs_generalisation_review: true" in body
+    # Evidence block is present even when the predicate can't be inferred.
+    assert "evidence_field_value_distribution:" in body
+    # Empty match.fields appears as `{}`.
+    assert "fields: {}" in body
+
+
+# ---------------------------------------------------------------------------
+# Multi-study aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_multi_study_aggregation_sorted(tmp_path: Path) -> None:
+    """Two studies, two gaps — proposals returned sorted by (engine, version, template)."""
+    study_a = tmp_path / "a"
+    study_b = tmp_path / "b"
+    _seed_study(
+        study_a,
+        members=[
+            ("exp_aa", {"do_sample": False}),
+            ("exp_ab", {"do_sample": False}),
+        ],
+        contrasts=[("exp_ac", {"do_sample": True})],
+        observed_hash="obs_aaaa",
+    )
+    _seed_study(
+        study_b,
+        members=[
+            ("exp_ba", {"do_sample": False}),
+            ("exp_bb", {"do_sample": False}),
+        ],
+        contrasts=[("exp_bc", {"do_sample": True})],
+        observed_hash="obs_bbbb",
+    )
+
+    proposals = find_observed_collision_gaps(study_dirs=[study_b, study_a])
+    assert len(proposals) == 2
+    templates = [p.normalised_template for p in proposals]
+    assert templates == sorted(templates)
+
+
+def test_proposal_is_typed_dataclass(tmp_path: Path) -> None:
+    """Sanity check that the public dataclass is what we think it is."""
+    study = tmp_path / "study-types"
+    _seed_study(
+        study,
+        members=[
+            ("exp_a", {"do_sample": False}),
+            ("exp_b", {"do_sample": False}),
+        ],
+        contrasts=[("exp_c", {"do_sample": True})],
+    )
+    proposals = find_observed_collision_gaps(study_dirs=[study])
+    assert proposals
+    assert isinstance(proposals[0], GapProposal)

--- a/tests/unit/cli/test_report_gaps.py
+++ b/tests/unit/cli/test_report_gaps.py
@@ -143,7 +143,7 @@ def test_report_gaps_missing_out_errors(tmp_path: Path) -> None:
 
 
 def test_report_gaps_unsupported_source_errors(tmp_path: Path) -> None:
-    """--source h3-collisions (etc.) is not wired in this release."""
+    """--source h3-collisions (the legacy name) and other unknowns are rejected."""
     study = tmp_path / "s"
     study.mkdir()
     out = tmp_path / "out.yaml"
@@ -160,4 +160,28 @@ def test_report_gaps_unsupported_source_errors(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "runtime-warnings" in _strip(result.output)
+    stripped = _strip(result.output)
+    # Error message lists the supported sources so users can self-correct.
+    assert "observed-collisions" in stripped or "runtime-warnings" in stripped
+
+
+def test_report_gaps_observed_collisions_no_groups_file(tmp_path: Path) -> None:
+    """--source observed-collisions on a study with no equivalence_groups.json exits 0 cleanly."""
+    study = tmp_path / "s-no-groups"
+    study.mkdir()
+    out = tmp_path / "proposals.yaml"
+    result = runner.invoke(
+        app,
+        [
+            "report-gaps",
+            "--source",
+            "observed-collisions",
+            "--study-dir",
+            str(study),
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0
+    assert not out.exists()
+    assert "No gaps found" in result.output


### PR DESCRIPTION
## Summary

Adds the second feedback-loop channel envisioned in `sweep-dedup.md` §4.3: the observed_config_hash collision detector that surfaces silent library normalisations the canonicaliser hasn't yet learned. Closes the only remaining piece from M3+M4 of Phase 50 (per `~/.claude/plans/handover-2026-04-24-end-of-session.md`).

The design considered three options and locked in option (c) after an adversarial review pass:

- (a) original §4.3: emit full proposed YAML with `match.fields` — rejected by PoC-H3R 2026-04-22 (2/3 fixtures wrong-anchor)
- (b) handover-locked evidence-bundle — no `match.fields`, evidence-only — rejected by 2026-04-25 adversarial review for inverted-evidence asymmetry vs the runtime-warnings flavour
- **(c) conservative field-diff** — emit `match.fields` only when ≥1 field is invariant across all collision members AND varies across contrast; otherwise route to evidence-only. **Shipped.**

The decisive insight is that the existing predicate-inference machinery (`_infer_predicate` arity-1→2→3 with both partition checks at `api/report_gaps.py:594`) is **already conservative-field-diff by construction**. Range-trigger rules (where the trigger field varies inside the collision group) correctly route to evidence-only because no field meets the trigger-candidate criterion. The runtime-warnings flavour and the new observed-collisions flavour share `_infer_predicate`, `_field_value_distribution`, and `render_yaml_fragment` — schema symmetry preserved with `added_by` and `severity` → `outcome` mapping disambiguating at render time.

## Two load-bearing tests

`tests/unit/api/test_report_gaps_observed_collisions.py` pins the conservative-field-diff contract:

- `test_equality_trigger_emits_match_fields` — `{do_sample: False}` invariant across collision, varies across contrast → `match.fields: {do_sample: False}` emitted; `needs_generalisation_review=False`. ✅
- `test_range_predicate_routes_to_evidence_only` — PoC-K range-predicate fixture (`temperature=0.001` and `temperature=0.005` collide on observed; only varying field) → `match_fields=None`, evidence-only, `needs_generalisation_review=True`. ✅

If either of those routes incorrectly, the design contract is broken — they're not regression tests, they're the contract.

## Scope

| File | Δ | What |
|---|---|---|
| `src/llenergymeasure/api/report_gaps.py` | +307/-49 | New `find_observed_collision_gaps()` (~150 LoC); `GapProposal` widened with `severity: dormant` and `added_by` provenance; `render_yaml_fragment` honours both flavours |
| `src/llenergymeasure/cli/report_gaps.py` | +41/-… | Source dispatch: `runtime-warnings` ⊕ `observed-collisions` |
| `src/llenergymeasure/api/__init__.py` | +2/-0 | Export `find_observed_collision_gaps` |
| `tests/helpers/runtime_obs.py` | +41/-0 | New `write_equivalence_groups()` + `write_manifest()` fixture builders |
| `tests/unit/cli/test_report_gaps.py` | +28/-… | Negative-test message updated; new `--source observed-collisions` empty-study test |
| `tests/unit/api/test_report_gaps_observed_collisions.py` | +333 (new) | 12 tests covering equality / range / engine-filter / gap-detected-false / multi-study / YAML rendering |

## Test plan

- [x] `pytest tests/unit -q -p no:randomly` — 2345 passed
- [x] `pytest tests/unit/api/test_report_gaps_observed_collisions.py tests/unit/api/test_report_gaps.py tests/unit/cli/test_report_gaps.py -v` — 34/34 pass; both load-bearing tests green
- [x] `lint-imports` — 3 contracts kept, 0 broken
- [x] No new H1/H3 references introduced (PR #403 cleanup preserved)

## Out of scope (tracked separately)

- **Walker-cache match enhancement** — issue #398. The §4.9.2 post-MVP enhancement that would replace conservative field-diff for cases where the AST walker has already extracted a low-confidence range predicate matching the collision pattern. Decision gate: ≥20% manual-widening over the first 3 months of operational use.
- **Runtime-warnings flavour audit** — the adversarial review noted that the runtime-warnings flavour ships full YAML without an analogous PoC. That's preserved as-is here; if a regression surfaces, the tooling and contract symmetry are now in place to apply the same conservative-field-diff fix.