### PR TITLE
feat(config): cross-field operators in vendored-rules loader

### DIFF
--- a/configs/validation_rules/README.md
+++ b/configs/validation_rules/README.md
@@ -99,6 +99,8 @@ Every entry under `rules:` must populate the following fields.
 | `{"!=": x}`, `{"not_equal": x}` | Inequality, None-safe. |
 | `{"in": [a, b]}`, `{"not_in": [a, b]}` | Membership. |
 | `{"present": true}`, `{"absent": true}` | None-presence check. |
+| `{"type_is": "X"}`, `{"type_is_not": "X"}` | Concrete `type(value).__name__` match. Spec accepts a single name or a list of names (any-of). |
+| `{"divisible_by": n}`, `{"not_divisible_by": n}` | Integer divisibility. Both operands must be non-bool ints; zero divisor never fires. |
 | Multi-key dict | All predicates AND-combined. |
 
 Multi-key example — "field is set AND isn't default":
@@ -107,8 +109,66 @@ Multi-key example — "field is set AND isn't default":
 transformers.sampling.temperature: {present: true, not_equal: 1.0}
 ```
 
+`match.fields` is also AND-combined **across field paths** — every entry
+under `match.fields` must satisfy its predicate for the rule to fire.
+Use this for cross-field preconditions (e.g. "fires when
+`num_beam_groups > 1` AND `diversity_penalty <= 0`").
+
+`type_is_not` accepts a list to express an allowlist negation — the
+predicate fires when the field's concrete type name is **not** in any of
+the listed names. Useful for "must be an instance of one of these
+classes" checks:
+
+```yaml
+transformers.sampling.watermarking_config:
+  present: true
+  type_is_not: [WatermarkingConfig, SynthIDTextWatermarkingConfig]
+```
+
 Every predicate in `match.fields` must hold for `rule.try_match(config)` to
 return a `RuleMatch`.
+
+### Cross-field references (`@field_path`)
+
+Any operator's right-hand side may carry a `@field_path` reference,
+substituted from the same config before evaluation. Two resolution modes:
+
+| Form | Resolves against | Example |
+|---|---|---|
+| Bare `@name` | Sibling of the predicate's field path | `'>': '@num_beams'` resolves `num_beams` next to the predicate's field |
+| Dotted `@a.b.c` | Config root | `'>': '@transformers.sampling.num_beams'` |
+
+Example — fires when `num_return_sequences > num_beams`:
+
+```yaml
+match:
+  fields:
+    transformers.sampling.num_return_sequences:
+      '>': '@num_beams'
+```
+
+Example — fires when `num_beams` is not a multiple of `num_beam_groups`,
+guarded by `num_beam_groups > 1`:
+
+```yaml
+match:
+  fields:
+    transformers.sampling.num_beam_groups:
+      '>': 1
+    transformers.sampling.num_beams:
+      not_divisible_by: '@num_beam_groups'
+```
+
+References resolve to `None` when the target is missing; comparison
+operators treat `None` as "predicate does not fire", so a partially-set
+config never trips a cross-field rule by accident. References are also
+walked recursively through list / tuple specs, so e.g.
+`{in: ['@x', '@y']}` resolves both items before evaluation.
+
+The `divisible_by` / `not_divisible_by` operators reject non-`int`
+operands (including `bool`, which would otherwise pass via Python's
+`bool < int`) and zero divisors, so a malformed config silently fails the
+predicate rather than raising.
 
 ### ID convention
 

--- a/src/llenergymeasure/config/vendored_rules/loader.py
+++ b/src/llenergymeasure/config/vendored_rules/loader.py
@@ -269,6 +269,24 @@ class VendoredRules:
 _FIELD_REF_PREFIX = "@"
 
 
+def _spec_has_field_ref(spec: Any) -> bool:
+    """Return True if ``spec`` contains any ``@field_path`` string anywhere.
+
+    Used to short-circuit :func:`_resolve_field_refs_in_spec` on the hot
+    path: most predicates are literal (no cross-field refs), so paying a
+    cheap pre-scan to skip the substitution-recursion's allocations is
+    a win — every ``Rule.try_match`` runs this on every match_fields
+    spec on every config construction.
+    """
+    if isinstance(spec, str):
+        return spec.startswith(_FIELD_REF_PREFIX)
+    if isinstance(spec, dict):
+        return any(_spec_has_field_ref(v) for v in spec.values())
+    if isinstance(spec, (list, tuple)):
+        return any(_spec_has_field_ref(v) for v in spec)
+    return False
+
+
 def _resolve_field_refs_in_spec(spec: Any, config: Any, predicate_field_path: str) -> Any:
     """Substitute ``@field`` references in a predicate spec with config values.
 
@@ -278,10 +296,17 @@ def _resolve_field_refs_in_spec(spec: Any, config: Any, predicate_field_path: st
     ``predicate_field_path``; dotted references (``@a.b.c``) resolve from
     the config root.
 
+    Short-circuits via :func:`_spec_has_field_ref` when the spec contains
+    no references — returns the original spec unchanged in that case,
+    avoiding the dict/list rebuild overhead on the common literal-spec
+    path.
+
     Returns a new spec with substitutions applied; the input is not
     mutated. Non-ref strings pass through unchanged.
     """
-    if isinstance(spec, str) and spec.startswith(_FIELD_REF_PREFIX):
+    if not _spec_has_field_ref(spec):
+        return spec
+    if isinstance(spec, str):
         return _resolve_one_ref(spec, config, predicate_field_path)
     if isinstance(spec, dict):
         return {

--- a/src/llenergymeasure/config/vendored_rules/loader.py
+++ b/src/llenergymeasure/config/vendored_rules/loader.py
@@ -208,6 +208,13 @@ class Rule:
         resolve against ``config`` attribute-by-attribute, tolerating Pydantic
         models, dataclasses, and plain dicts.
 
+        Predicate specs may carry ``@field_path`` references on the
+        right-hand side of any operator. References are resolved against
+        the same ``config`` before predicate evaluation. Bare references
+        (``@num_beams``) resolve as siblings of the predicate's field;
+        dotted references (``@transformers.sampling.num_beams``) resolve
+        from the config root.
+
         ``declared_value`` on the returned match is the last field's value —
         corpus convention puts the precondition fields first and the
         *subject* field last (the field the rule is actually about). Users
@@ -217,7 +224,8 @@ class Rule:
         last_value: Any = None
         for path, spec in self.match_fields.items():
             actual = resolve_field_path(config, path)
-            if not evaluate_predicate(actual, spec):
+            resolved_spec = _resolve_field_refs_in_spec(spec, config, path)
+            if not evaluate_predicate(actual, resolved_spec):
                 return None
             matched[path] = actual
             last_value = actual
@@ -258,27 +266,69 @@ class VendoredRules:
 # ---------------------------------------------------------------------------
 
 
+_FIELD_REF_PREFIX = "@"
+
+
+def _resolve_field_refs_in_spec(spec: Any, config: Any, predicate_field_path: str) -> Any:
+    """Substitute ``@field`` references in a predicate spec with config values.
+
+    Walks the spec dict (or bare value) and replaces any string starting
+    with ``@`` with the corresponding field's value resolved against
+    ``config``. Bare references (``@num_beams``) resolve as siblings of
+    ``predicate_field_path``; dotted references (``@a.b.c``) resolve from
+    the config root.
+
+    Returns a new spec with substitutions applied; the input is not
+    mutated. Non-ref strings pass through unchanged.
+    """
+    if isinstance(spec, str) and spec.startswith(_FIELD_REF_PREFIX):
+        return _resolve_one_ref(spec, config, predicate_field_path)
+    if isinstance(spec, dict):
+        return {
+            op: _resolve_field_refs_in_spec(v, config, predicate_field_path)
+            for op, v in spec.items()
+        }
+    if isinstance(spec, (list, tuple)):
+        return type(spec)(
+            _resolve_field_refs_in_spec(v, config, predicate_field_path) for v in spec
+        )
+    return spec
+
+
+def _resolve_one_ref(ref: str, config: Any, predicate_field_path: str) -> Any:
+    target = ref[len(_FIELD_REF_PREFIX) :]
+    if "." in target:
+        return resolve_field_path(config, target)
+    parent_parts = predicate_field_path.split(".")[:-1]
+    full_path = ".".join([*parent_parts, target]) if parent_parts else target
+    return resolve_field_path(config, full_path)
+
+
 _OPERATOR_HANDLERS: dict[str, Any] = {
-    # Comparison operators: all None-safe on the *asymmetric* ones (a missing
-    # field doesn't trip ``!=`` / ``not_equal`` / ``<`` / etc). ``==`` and
-    # ``equals`` stay as-is — `None == x` evaluates to `False` for any
-    # non-None `x`, so they naturally don't fire on None.
+    # Comparison operators: bilaterally None-safe on the *asymmetric* ones.
+    # ``a`` may be None when the predicate's field is unset; ``b`` may be
+    # None when a ``@field_ref`` resolves against a missing target. Both
+    # cases must yield False (rule does not fire) rather than raise.
+    # ``==`` and ``equals`` stay as plain equality — `None == x` evaluates
+    # to `False` for any non-None `x`, so they naturally don't fire on None.
     # ``equals`` / ``not_equal`` are word-form aliases of ``==`` / ``!=``
     # and MUST match their symbol forms exactly — corpus authors swap them.
     "==": lambda a, b: a == b,
-    "!=": lambda a, b: a is not None and a != b,
-    "<": lambda a, b: a is not None and a < b,
-    "<=": lambda a, b: a is not None and a <= b,
-    ">": lambda a, b: a is not None and a > b,
-    ">=": lambda a, b: a is not None and a >= b,
+    "!=": lambda a, b: a is not None and b is not None and a != b,
+    "<": lambda a, b: a is not None and b is not None and a < b,
+    "<=": lambda a, b: a is not None and b is not None and a <= b,
+    ">": lambda a, b: a is not None and b is not None and a > b,
+    ">=": lambda a, b: a is not None and b is not None and a >= b,
     "equals": lambda a, b: a == b,
-    "not_equal": lambda a, b: a is not None and a != b,
-    # Membership operators: reject non-iterable specs (a string spec would
-    # otherwise fall through to substring match — "ab" in "abc" is True,
-    # which surprises corpus authors writing {"in": "abc"} thinking "exactly
-    # one of these three chars").
+    "not_equal": lambda a, b: a is not None and b is not None and a != b,
+    # Membership operators: None-safe on the asymmetric one (``not_in``)
+    # so unset fields don't trip the rule. ``in`` against a missing field
+    # naturally yields False without an explicit guard. Reject non-iterable
+    # specs (a string spec would otherwise fall through to substring match —
+    # "ab" in "abc" is True, which surprises corpus authors writing
+    # {"in": "abc"} thinking "exactly one of these three chars").
     "in": lambda a, b: _require_iterable(b, "in") and a in b,
-    "not_in": lambda a, b: _require_iterable(b, "not_in") and a not in b,
+    "not_in": lambda a, b: a is not None and _require_iterable(b, "not_in") and a not in b,
     # Presence operators: no None-guard needed (they're the test for None).
     "present": lambda a, _: a is not None,
     "absent": lambda a, _: a is None,
@@ -289,7 +339,27 @@ _OPERATOR_HANDLERS: dict[str, Any] = {
     # for the type-name format and its known ambiguities.
     "type_is": lambda a, b: a is not None and _type_name(a) in _as_name_set(b),
     "type_is_not": lambda a, b: a is not None and _type_name(a) not in _as_name_set(b),
+    # Cross-field divisibility checks. Naming follows the existing
+    # positive/negative convention (``equals`` / ``not_equal``,
+    # ``in`` / ``not_in``). Both operands must be non-bool integers
+    # (``True``/``False`` would silently pass via ``bool`` < ``int``).
+    # ``not_divisible_by`` fires when ``a % b != 0`` — corpus authors
+    # write ``num_beams: {not_divisible_by: '@num_beam_groups'}`` to
+    # express "rule fires when num_beams isn't a multiple of
+    # num_beam_groups". A zero divisor yields False (no rule fires).
+    "divisible_by": lambda a, b: _is_int_pair(a, b) and b != 0 and a % b == 0,
+    "not_divisible_by": lambda a, b: _is_int_pair(a, b) and b != 0 and a % b != 0,
 }
+
+
+def _is_int_pair(a: Any, b: Any) -> bool:
+    """Return True iff both operands are non-bool integers."""
+    return (
+        isinstance(a, int)
+        and isinstance(b, int)
+        and not isinstance(a, bool)
+        and not isinstance(b, bool)
+    )
 
 
 def _type_name(value: Any) -> str:

--- a/tests/unit/config/vendored_rules/test_loader_field_ref_and_divisibility.py
+++ b/tests/unit/config/vendored_rules/test_loader_field_ref_and_divisibility.py
@@ -1,0 +1,283 @@
+"""Tests for cross-field ``@field_path`` references and divisibility operators.
+
+Covers the loader-grammar extensions that close gaps surfaced by PR #387:
+
+- ``@field_path`` substitution on the right-hand side of any operator,
+  with sibling and dotted-from-root resolution semantics.
+- ``divisible_by`` / ``not_divisible_by`` operators with strict
+  non-bool integer operands and zero-divisor guards.
+- Spec walking through nested lists / dicts so refs anywhere in the
+  predicate tree get resolved before evaluation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from llenergymeasure.config.vendored_rules import (
+    Rule,
+    evaluate_predicate,
+)
+from llenergymeasure.config.vendored_rules.loader import (
+    _is_int_pair,
+    _resolve_field_refs_in_spec,
+)
+
+# ---------------------------------------------------------------------------
+# Config stubs (mirror test_rule_matching.py shape)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Sampling:
+    num_beams: int | None = None
+    num_beam_groups: int | None = None
+    num_return_sequences: int | None = None
+    diversity_penalty: float | None = None
+
+
+@dataclass
+class _Transformers:
+    sampling: _Sampling
+
+
+@dataclass
+class _Config:
+    transformers: _Transformers
+
+
+def _make_rule(*, match_fields: dict[str, Any]) -> Rule:
+    return Rule(
+        id="rule_x",
+        engine="transformers",
+        library="transformers",
+        rule_under_test="test",
+        severity="error",
+        native_type="transformers.GenerationConfig",
+        match_engine="transformers",
+        match_fields=match_fields,
+        kwargs_positive={},
+        kwargs_negative={},
+        expected_outcome={
+            "outcome": "error",
+            "emission_channel": "runtime_exception",
+            "normalised_fields": [],
+        },
+        message_template="msg {declared_value}",
+        walker_source={},
+        references=(),
+        added_by="manual_seed",
+        added_at="2026-04-25",
+    )
+
+
+# ---------------------------------------------------------------------------
+# @field_ref resolution — sibling
+# ---------------------------------------------------------------------------
+
+
+def test_field_ref_sibling_substitutes_value() -> None:
+    config = {"a": {"b": {"x": 5, "y": 3}}}
+    spec = {">": "@y"}
+    resolved = _resolve_field_refs_in_spec(spec, config, "a.b.x")
+    assert resolved == {">": 3}
+
+
+def test_field_ref_sibling_resolves_to_none_when_missing() -> None:
+    config = {"a": {"b": {"x": 5}}}
+    spec = {">": "@y"}
+    resolved = _resolve_field_refs_in_spec(spec, config, "a.b.x")
+    assert resolved == {">": None}
+
+
+@pytest.mark.parametrize(
+    "x_value, y_value, expected_fires",
+    [
+        (5, 3, True),  # x > y → fires
+        (3, 3, False),  # x == y → does not fire
+        (2, 3, False),  # x < y → does not fire
+        (5, None, False),  # y missing → comparison is None-safe, does not fire
+    ],
+)
+def test_field_ref_sibling_via_evaluate_predicate(
+    x_value: int, y_value: int | None, expected_fires: bool
+) -> None:
+    config = {"a": {"b": {"x": x_value, "y": y_value}}}
+    spec = {">": "@y"}
+    resolved = _resolve_field_refs_in_spec(spec, config, "a.b.x")
+    assert evaluate_predicate(x_value, resolved) is expected_fires
+
+
+# ---------------------------------------------------------------------------
+# @field_ref resolution — dotted from root
+# ---------------------------------------------------------------------------
+
+
+def test_field_ref_dotted_resolves_from_root() -> None:
+    config = {"deep": {"nested": {"path": 42}}, "a": {"b": {"x": 1}}}
+    spec = {">": "@deep.nested.path"}
+    resolved = _resolve_field_refs_in_spec(spec, config, "a.b.x")
+    assert resolved == {">": 42}
+
+
+def test_field_ref_dotted_resolves_through_attribute_chains() -> None:
+    config = _Config(
+        transformers=_Transformers(sampling=_Sampling(num_beams=4, num_return_sequences=6))
+    )
+    spec = {">": "@transformers.sampling.num_beams"}
+    resolved = _resolve_field_refs_in_spec(
+        spec, config, "transformers.sampling.num_return_sequences"
+    )
+    assert resolved == {">": 4}
+
+
+# ---------------------------------------------------------------------------
+# Spec walk — recursion through lists and nested dicts
+# ---------------------------------------------------------------------------
+
+
+def test_spec_walk_resolves_refs_inside_list() -> None:
+    config = {"a": {"b": {"x": 1, "y": 7, "z": 9}}}
+    spec = {"in": ["@y", "@z"]}
+    resolved = _resolve_field_refs_in_spec(spec, config, "a.b.x")
+    assert resolved == {"in": [7, 9]}
+
+
+def test_spec_walk_leaves_non_ref_strings_alone() -> None:
+    config = {"a": {"x": 1, "name": "foo"}}
+    spec = {"==": "literal_value"}
+    resolved = _resolve_field_refs_in_spec(spec, config, "a.x")
+    assert resolved == {"==": "literal_value"}
+
+
+def test_spec_walk_passes_through_bare_value() -> None:
+    # Bare-value spec (equality) is returned unchanged when not a ref.
+    assert _resolve_field_refs_in_spec(0.5, {"a": 1}, "a") == 0.5
+
+
+# ---------------------------------------------------------------------------
+# divisible_by / not_divisible_by operator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec, actual, expected",
+    [
+        # not_divisible_by: positive case (rule fires)
+        ({"not_divisible_by": 4}, 6, True),  # 6 % 4 == 2 → fires
+        ({"not_divisible_by": 3}, 6, False),  # 6 % 3 == 0 → does not fire
+        # divisible_by: positive case (rule fires)
+        ({"divisible_by": 3}, 6, True),  # 6 % 3 == 0 → fires
+        ({"divisible_by": 4}, 6, False),  # 6 % 4 == 2 → does not fire
+    ],
+)
+def test_divisibility_basic(spec: dict[str, Any], actual: int, expected: bool) -> None:
+    assert evaluate_predicate(actual, spec) is expected
+
+
+def test_divisibility_zero_divisor_does_not_fire() -> None:
+    # b == 0: never fires (avoids ZeroDivisionError, no rule should match).
+    assert evaluate_predicate(6, {"not_divisible_by": 0}) is False
+    assert evaluate_predicate(6, {"divisible_by": 0}) is False
+
+
+@pytest.mark.parametrize(
+    "actual, divisor",
+    [
+        (None, 3),  # missing field — predicate must not fire
+        (6.0, 3),  # float operand — strict int-only
+        ("6", 3),  # str operand — strict int-only
+        (6, 3.0),  # float divisor — strict int-only
+    ],
+)
+def test_divisibility_rejects_non_int_operands(actual: Any, divisor: Any) -> None:
+    assert evaluate_predicate(actual, {"not_divisible_by": divisor}) is False
+    assert evaluate_predicate(actual, {"divisible_by": divisor}) is False
+
+
+@pytest.mark.parametrize(
+    "actual, divisor",
+    [
+        (True, 1),  # bool actual: would otherwise pass via bool < int
+        (False, 1),
+        (6, True),  # bool divisor
+        (True, True),
+    ],
+)
+def test_divisibility_rejects_bool_operands(actual: Any, divisor: Any) -> None:
+    assert evaluate_predicate(actual, {"not_divisible_by": divisor}) is False
+    assert evaluate_predicate(actual, {"divisible_by": divisor}) is False
+
+
+def test_is_int_pair_helper() -> None:
+    # Direct unit on the helper for a tight regression guard.
+    assert _is_int_pair(6, 3) is True
+    assert _is_int_pair(0, 1) is True
+    assert _is_int_pair(True, 1) is False
+    assert _is_int_pair(1, False) is False
+    assert _is_int_pair(6.0, 3) is False
+    assert _is_int_pair(None, 3) is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via Rule.try_match — corpus-shape predicate
+# ---------------------------------------------------------------------------
+
+
+def test_try_match_with_field_ref_fires_when_left_exceeds_right() -> None:
+    # Mirrors the rewritten transformers_num_return_sequences_exceeds_num_beams
+    # rule: fires when num_return_sequences > num_beams.
+    rule = _make_rule(
+        match_fields={
+            "transformers.sampling.num_return_sequences": {">": "@num_beams"},
+        }
+    )
+    config = _Config(
+        transformers=_Transformers(sampling=_Sampling(num_beams=2, num_return_sequences=4))
+    )
+    match = rule.try_match(config)
+    assert match is not None
+    assert match.declared_value == 4
+
+
+def test_try_match_with_field_ref_does_not_fire_when_left_le_right() -> None:
+    # The valid case (num_return_sequences=2, num_beams=4) — rule must not fire.
+    rule = _make_rule(
+        match_fields={
+            "transformers.sampling.num_return_sequences": {">": "@num_beams"},
+        }
+    )
+    config = _Config(
+        transformers=_Transformers(sampling=_Sampling(num_beams=4, num_return_sequences=2))
+    )
+    assert rule.try_match(config) is None
+
+
+def test_try_match_with_not_divisible_by_field_ref_fires() -> None:
+    # Mirrors the new transformers_num_beams_not_divisible_by_groups rule.
+    rule = _make_rule(
+        match_fields={
+            "transformers.sampling.num_beam_groups": {">": 1},
+            "transformers.sampling.num_beams": {"not_divisible_by": "@num_beam_groups"},
+        }
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(num_beams=6, num_beam_groups=4)))
+    match = rule.try_match(config)
+    assert match is not None
+    # Last predicate's field is the subject (num_beams).
+    assert match.declared_value == 6
+
+
+def test_try_match_with_not_divisible_by_field_ref_does_not_fire_on_valid() -> None:
+    rule = _make_rule(
+        match_fields={
+            "transformers.sampling.num_beam_groups": {">": 1},
+            "transformers.sampling.num_beams": {"not_divisible_by": "@num_beam_groups"},
+        }
+    )
+    # 6 % 3 == 0 → divisible → rule does not fire.
+    config = _Config(transformers=_Transformers(sampling=_Sampling(num_beams=6, num_beam_groups=3)))
+    assert rule.try_match(config) is None


### PR DESCRIPTION
## Summary

Adds cross-field predicate operators to the vendored-rules loader so the corpus grammar can express invariants like "num_beams must be divisible by num_beam_groups" or "num_return_sequences must not exceed num_beams" — things PR #387's introspection extractor can detect *exist* but couldn't *encode* because the operator surface didn't include cross-field comparisons.

**This PR is the operator surface.** Rule extraction against this surface lands in two follow-up PRs (AST walker + introspection refactor); this is the foundation those extractors emit against.

## Three new operators

| Operator | Semantic | Example |
|---|---|---|
| `@field_path` (substitution) | Right-hand side of any op resolves to another field's value at predicate-eval time | `num_return_sequences: {'>': '@num_beams'}` |
| `divisible_by` / `not_divisible_by` | Modulo predicate; rejects bool operands and zero divisors | `num_beams: {not_divisible_by: '@num_beam_groups'}` |

Bare `@x` references resolve as siblings of the predicate's field path. Dotted `@a.b.c` resolves from config root. Both forms documented in `configs/validation_rules/README.md` with worked examples.

## One None-safety fix

`not_in` was bilaterally unsafe — `None not in [allowed_values]` returned True and fired the rule on configs where the field hadn't been set at all. Now matches the bilateral None-safety the comparison ops (`<`, `<=`, `>`, `>=`, `!=`, `not_equal`) already have. Behavioural backstop: corpus rules that intentionally fire on absent fields use `absent: true`, which is unaffected.

## Why this is a separate PR

The branch this came from bundles the operator extensions with a full extraction pipeline rebuild (AST walker + introspection refactor + merger + vendor validation). Splitting into reviewable units:

- **PR 1 (this one)**: pure loader/grammar change. Schema-additive, tested in isolation, lands first.
- **PR 2** (next): AST walker that emits rules using these operators.
- **PR 3**: introspection refactor, also uses these operators.
- **PR 4**: corpus merger.
- **PR 5**: vendor-validation gate.

This PR has no corpus changes, no rule emissions, no extractor work. Just the predicate vocabulary.

## Test plan

- [x] `pytest tests/unit/config/vendored_rules/` — 132 pass (29 new tests in `test_loader_field_ref_and_divisibility.py` + 103 existing)
- [x] `pytest tests/unit` — full suite green
- [x] `lint-imports` — 3 contracts kept, 0 broken
- [x] Existing corpus loads identically (no rule semantics changed for rules that don't opt into the new operators)