### PR TITLE
refactor(walkers): simplify vLLM extractors per /simplify review

### DIFF
--- a/scripts/vendor_rules.py
+++ b/scripts/vendor_rules.py
@@ -177,30 +177,14 @@ def _construct_generic(native_type: str, kwargs: dict[str, Any]) -> Any:
 def _run_vllm(native_type: str, kwargs: dict[str, Any], *, strict_validate: bool) -> CaptureBuffers:
     """Execute one rule's kwargs through the vLLM library.
 
-    vLLM's SamplingParams performs validation in __post_init__, which
-    raises ValueError on constraint violations. The ``strict_validate``
-    flag is currently ignored (kept for API compatibility) since vLLM
-    always validates at construction time.
+    vLLM validates in ``__post_init__`` at construction time, so
+    ``strict_validate`` has no effect (kept for protocol compatibility).
     """
-    logger_names = ("vllm", "vllm.logger")
-    if native_type == "vllm.SamplingParams":
-        return run_case(
-            lambda: _construct_sampling_params(kwargs),
-            logger_names=logger_names,
-            private_allowlist=frozenset(),
-        )
-    # Fallback: treat native_type as a dotted import path
     return run_case(
         lambda: _construct_generic(native_type, kwargs),
-        logger_names=logger_names,
+        logger_names=("vllm", "vllm.logger"),
         private_allowlist=frozenset(),
     )
-
-
-def _construct_sampling_params(kwargs: dict[str, Any]) -> Any:
-    from vllm import SamplingParams
-
-    return SamplingParams(**kwargs)
 
 
 _ENGINE_RUNNERS = {

--- a/scripts/walkers/vllm_ast.py
+++ b/scripts/walkers/vllm_ast.py
@@ -23,10 +23,19 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+# Guard against script-directory shadowing (e.g. avoid local stub imports).
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+sys.path[:] = [p for p in sys.path if Path(p).resolve() != Path(_SCRIPT_DIR).resolve()]
+sys.path[:] = [p for p in sys.path if p != ""]
+
 from scripts.walkers._base import (  # noqa: E402
     RuleCandidate,
     WalkerSource,
+    call_func_path,
     candidate_to_dict,
+    extract_assign_target,
+    extract_condition_fields,
+    first_string_arg,
 )
 
 # ---------------------------------------------------------------------------
@@ -91,7 +100,6 @@ def _extract_ast_rules_from_source(
     except SyntaxError:
         return candidates
 
-    # Find the function definition (should be __post_init__)
     func_def = None
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == "__post_init__":
@@ -101,25 +109,21 @@ def _extract_ast_rules_from_source(
     if func_def is None:
         return candidates
 
-    # Walk the function body for detected patterns
-    line_offset = func_def.lineno  # Line number of the function definition
+    line_offset = func_def.lineno
 
     for stmt in func_def.body:
         if isinstance(stmt, ast.If):
-            # Extract condition fields
-            condition_fields = _extract_condition_fields(stmt.test)
+            condition_fields = extract_condition_fields(stmt.test)
 
-            # Check for patterns in the if body
             for body_stmt in stmt.body:
-                # Pattern 1: logger.warning(...) inside if condition
+                # Pattern 1: logger.{warning,warning_once,error}(...) — announced dormancy.
                 if isinstance(body_stmt, ast.Expr) and isinstance(body_stmt.value, ast.Call):
                     call = body_stmt.value
-                    func_path = _call_func_path(call)
+                    func_path = call_func_path(call)
                     if func_path and len(func_path) == 2 and func_path[0] == "logger":
                         method = func_path[1]
                         if method in {"warning", "warning_once", "error"}:
-                            msg = _first_string_arg(call)
-                            # Extract the affected field from condition
+                            msg = first_string_arg(call)
                             for field in condition_fields:
                                 candidate = RuleCandidate(
                                     id=f"vllm_ast_warn_{field}",
@@ -149,98 +153,42 @@ def _extract_ast_rules_from_source(
                                 )
                                 candidates.append(candidate)
 
-                # Pattern 2: self.field = value inside if condition (silent normalization)
+                # Pattern 2: self.field = value inside if condition (silent normalization).
+                # Emit one rule per assign so multi-statement greedy blocks like
+                # vLLM's `if temperature < eps: top_p = 1.0; top_k = -1; min_p = 0.0`
+                # produce three rules, not one.
                 elif isinstance(body_stmt, ast.Assign):
-                    attr = _extract_assign_target(body_stmt)
-                    if attr and not attr.startswith("_"):
-                        # Only emit if the condition actually references self fields
-                        if condition_fields:
-                            candidate = RuleCandidate(
-                                id=f"vllm_ast_silent_{attr}",
-                                engine=ENGINE,
-                                library=LIBRARY,
-                                rule_under_test=f"SamplingParams.__post_init__ silently normalises {attr}",
-                                severity="dormant",
-                                native_type=NATIVE_TYPE,
-                                walker_source=WalkerSource(
-                                    path=rel_source_path,
-                                    method="__post_init__",
-                                    line_at_scan=body_stmt.lineno + line_offset,
-                                    walker_confidence="medium",
-                                ),
-                                match_fields={},
-                                kwargs_positive={},
-                                kwargs_negative={},
-                                expected_outcome={
-                                    "outcome": "dormant_silent",
-                                    "emission_channel": "none",
-                                    "normalised_fields": [attr],
-                                },
-                                message_template=None,
-                                references=["vllm.SamplingParams.__post_init__()"],
-                                added_by="ast_walker",
-                                added_at=today,
-                            )
-                            candidates.append(candidate)
-                        break
+                    attr = extract_assign_target(body_stmt)
+                    if attr and not attr.startswith("_") and condition_fields:
+                        candidate = RuleCandidate(
+                            id=f"vllm_ast_silent_{attr}",
+                            engine=ENGINE,
+                            library=LIBRARY,
+                            rule_under_test=f"SamplingParams.__post_init__ silently normalises {attr}",
+                            severity="dormant",
+                            native_type=NATIVE_TYPE,
+                            walker_source=WalkerSource(
+                                path=rel_source_path,
+                                method="__post_init__",
+                                line_at_scan=body_stmt.lineno + line_offset,
+                                walker_confidence="medium",
+                            ),
+                            match_fields={},
+                            kwargs_positive={},
+                            kwargs_negative={},
+                            expected_outcome={
+                                "outcome": "dormant_silent",
+                                "emission_channel": "none",
+                                "normalised_fields": [attr],
+                            },
+                            message_template=None,
+                            references=["vllm.SamplingParams.__post_init__()"],
+                            added_by="ast_walker",
+                            added_at=today,
+                        )
+                        candidates.append(candidate)
 
     return candidates
-
-
-def _extract_condition_fields(condition: ast.expr) -> set[str]:
-    """Return the set of ``self.<field>`` attribute names referenced in condition."""
-    fields: set[str] = set()
-    for node in ast.walk(condition):
-        if (
-            isinstance(node, ast.Attribute)
-            and isinstance(node.value, ast.Name)
-            and node.value.id == "self"
-        ):
-            fields.add(node.attr)
-    return fields
-
-
-def _extract_assign_target(stmt: ast.Assign) -> str | None:
-    """Return ``<attr>`` for ``self.<attr> = ...``, or None."""
-    if len(stmt.targets) != 1:
-        return None
-    target = stmt.targets[0]
-    if (
-        isinstance(target, ast.Attribute)
-        and isinstance(target.value, ast.Name)
-        and target.value.id == "self"
-    ):
-        return target.attr
-    return None
-
-
-def _call_func_path(call: ast.Call) -> list[str] | None:
-    """Return dotted path for a Call node's func, or None if opaque."""
-    parts: list[str] = []
-    node: ast.expr = call.func
-    while isinstance(node, ast.Attribute):
-        parts.append(node.attr)
-        node = node.value
-    if isinstance(node, ast.Name):
-        parts.append(node.id)
-        return list(reversed(parts))
-    return None
-
-
-def _first_string_arg(call: ast.Call) -> str | None:
-    """First string-like positional argument of a Call, or None."""
-    for arg in call.args:
-        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-            return arg.value
-        if isinstance(arg, ast.JoinedStr):
-            return ast.unparse(arg)
-        if (
-            isinstance(arg, ast.Call)
-            and isinstance(arg.func, ast.Attribute)
-            and arg.func.attr == "format"
-        ):
-            return ast.unparse(arg)
-    return None
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/walkers/vllm_introspection.py
+++ b/scripts/walkers/vllm_introspection.py
@@ -25,15 +25,18 @@ import argparse
 import datetime as dt
 import os
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import yaml
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Guard against script-directory shadowing (e.g. avoid local stub imports).
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+sys.path[:] = [p for p in sys.path if Path(p).resolve() != Path(_SCRIPT_DIR).resolve()]
+sys.path[:] = [p for p in sys.path if p != ""]
 
 from scripts.walkers._base import RuleCandidate, WalkerSource, candidate_to_dict  # noqa: E402
 
@@ -47,16 +50,6 @@ NATIVE_TYPE_SAMPLING = "vllm.SamplingParams"
 
 # vLLM's SamplingParams namespace (where fields are exposed in config model)
 SAMPLINGPARAMS_NAMESPACE = "vllm.sampling"
-
-
-@dataclass(frozen=True)
-class _ProbeRow:
-    """One trial row from the probe matrix."""
-
-    kwargs: dict[str, Any]
-    construct_error: str | None
-    construct_message_class: str | None
-    validate_error: str | None
 
 
 def _resolve_source_paths() -> tuple[str, str, str]:
@@ -91,38 +84,6 @@ def _resolve_source_paths() -> tuple[str, str, str]:
     return version, abs_path, rel_path
 
 
-def _get_field_info(cls: Any) -> dict[str, tuple[Any, Any]]:
-    """Extract {field_name: (default, type_hint)} from a dataclass or msgspec struct.
-
-    For msgspec Struct classes, use ``__struct_fields__`` if available.
-    For dataclasses, use ``dataclasses.fields()``.
-    """
-    import dataclasses
-
-    result: dict[str, tuple[Any, Any]] = {}
-
-    # Try msgspec Struct first (vLLM uses msgspec for SamplingParams)
-    if hasattr(cls, "__struct_fields__"):
-        for field_name in cls.__struct_fields__:
-            if not field_name.startswith("_"):
-                try:
-                    # Create a minimal instance to get defaults
-                    default = getattr(cls(), field_name, None)
-                    type_hint = cls.__annotations__.get(field_name, type(None))
-                    result[field_name] = (default, type_hint)
-                except Exception:
-                    # Skip fields we can't introspect
-                    pass
-    # Fallback to dataclasses
-    elif dataclasses.is_dataclass(cls):
-        for f in dataclasses.fields(cls):
-            if not f.name.startswith("_"):
-                default = f.default if f.default is not dataclasses.MISSING else None
-                result[f.name] = (default, f.type)
-
-    return result
-
-
 def _enumerate_field_rules(
     abs_source_path: str,
     rel_source_path: str,
@@ -135,17 +96,9 @@ def _enumerate_field_rules(
     """
     candidates: list[RuleCandidate] = []
 
-    # Try to import SamplingParams for live introspection; if that fails,
-    # we still emit the hand-curated rules based on source code analysis.
-    try:
-        from vllm import SamplingParams
-
-        _field_info = _get_field_info(SamplingParams)
-    except ImportError:
-        # vLLM not importable (likely missing msgspec); proceed with curated rules
-        pass
-
-    # Hand-curated rules for known constraints in vLLM (from reading __post_init__)
+    # Hand-curated rules transcribed from vLLM's __post_init__ source. TODO:
+    # replace with msgspec.inspect-based introspection of SamplingParams once
+    # the bounds-extraction helper lands. Tracked in follow-up issue.
     rules = [
         {
             "id": "vllm_n_must_be_positive",
@@ -336,34 +289,6 @@ def _enumerate_field_rules(
     return candidates
 
 
-def _enumerate_dormancy_rules(
-    abs_source_path: str,
-    rel_source_path: str,
-    today: str,
-) -> list[RuleCandidate]:
-    """Enumerate silence assignments in vLLM's __post_init__.
-
-    vLLM performs several silent assignments:
-    - temperature < _SAMPLING_EPS (1e-5) → top_p=1.0, top_k=-1, min_p=0.0 (greedy)
-    - best_of set → n=best_of, _real_n=original_n
-    - stop converted to list if string
-    - stop_token_ids converted to list
-    - bad_words converted to list
-
-    Note: As of vLLM 0.6.5, many of these are silent normalizations that
-    happen after validation, so they may not trigger dormancy warnings in
-    the expected_outcome sense. The rules below capture what actually happens.
-    """
-    candidates: list[RuleCandidate] = []
-
-    # For now, we skip dormancy rules since vLLM's implementation differs from
-    # transformers. The error rules above capture the validation constraints.
-    # Dormancy rules would need empirical probing with actual SamplingParams
-    # to determine the true behaviour (silent vs warned vs error).
-
-    return candidates
-
-
 def main(argv: list[str] | None = None) -> int:
     """Run the introspection extractor end-to-end and write the staging YAML."""
     parser = argparse.ArgumentParser(description="vLLM introspection walker")
@@ -378,11 +303,7 @@ def main(argv: list[str] | None = None) -> int:
 
     candidates: list[RuleCandidate] = []
 
-    # Enumerate field constraint rules
     candidates.extend(_enumerate_field_rules(abs_source_path, rel_source_path, today))
-
-    # Enumerate silent normalisation rules
-    candidates.extend(_enumerate_dormancy_rules(abs_source_path, rel_source_path, today))
 
     # Stable order: by walker_source.method, then by id
     candidates_sorted = sorted(candidates, key=lambda c: (c.walker_source.method, c.id))

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-26T01:56:05+02:00",
-  "vendor_commit": "5327f3e991e5d2b7bc9958e6263f0b05f731357e",
+  "vendored_at": "2026-04-26T02:36:26+02:00",
+  "vendor_commit": "c781c4fa05dd2d56bc0c19201a44423d4b630e22",
   "cases": [
     {
       "id": "transformers_beam_search_diversity_penalty_eq_0p0",

--- a/tests/unit/scripts/walkers/test_vllm_introspection.py
+++ b/tests/unit/scripts/walkers/test_vllm_introspection.py
@@ -169,33 +169,22 @@ class TestVllmAstRuleSchema:
 class TestBuildCorpusIntegration:
     """Verify that the corpus pipeline can run with vLLM extractors."""
 
-    def test_staging_files_created(self):
-        """staging/{engine}_*.yaml files should exist after extraction."""
-        staging_dir = _PROJECT_ROOT / "configs" / "validation_rules" / "_staging"
-        ast_staging = staging_dir / "vllm_ast.yaml"
-        intro_staging = staging_dir / "vllm_introspection.yaml"
+    def test_introspection_walker_writes_valid_yaml(self, tmp_path):
+        """Running the introspection walker writes a well-formed staging YAML."""
+        from scripts.walkers import vllm_introspection
 
-        # These files may be empty if vLLM isn't properly importable, but they
-        # should exist and be valid YAML after build_corpus runs
-        if ast_staging.exists():
-            doc = yaml.safe_load(ast_staging.read_text())
-            assert isinstance(doc, dict)
-            assert "rules" in doc
-            assert isinstance(doc["rules"], list)
+        out = tmp_path / "vllm_introspection.yaml"
+        vllm_introspection.main(["--out", str(out)])
 
-        if intro_staging.exists():
-            doc = yaml.safe_load(intro_staging.read_text())
-            assert isinstance(doc, dict)
-            assert "rules" in doc
-            assert isinstance(doc["rules"], list)
+        doc = yaml.safe_load(out.read_text())
+        assert isinstance(doc, dict)
+        assert doc["engine"] == "vllm"
+        assert isinstance(doc["rules"], list)
+        assert len(doc["rules"]) >= 15, f"expected >=15 rules, got {len(doc['rules'])}"
 
-    def test_canonical_corpus_exists(self):
-        """Canonical vllm.yaml should exist after build_corpus runs."""
+    def test_canonical_corpus_yaml_is_valid(self):
+        """The committed vllm.yaml stub must parse and declare engine=vllm."""
         corpus_path = _PROJECT_ROOT / "configs" / "validation_rules" / "vllm.yaml"
-        # The corpus may be empty if vLLM environment is incomplete, but structure
-        # should be valid
-        if corpus_path.exists():
-            doc = yaml.safe_load(corpus_path.read_text())
-            assert isinstance(doc, dict)
-            assert doc.get("engine") == "vllm"
-            assert "rules" in doc
+        doc = yaml.safe_load(corpus_path.read_text())
+        assert doc["engine"] == "vllm"
+        assert isinstance(doc["rules"], list)


### PR DESCRIPTION
## Summary

Cleanup pass on the vLLM walkers that just landed in #416. The code-review agents flagged six issues; this PR addresses the cheap wins. Net change: **−158 lines**.

## Changes

- **Dedup four AST helpers** (`call_func_path`, `first_string_arg`, `extract_condition_fields`, `extract_assign_target`) — were byte-for-byte clones of `_base.py`. Now imported.
- **Drop `_construct_sampling_params`** from `vendor_rules.py` — `_construct_generic` already handles `vllm.SamplingParams` via dotted-import fallback. Collapses `_run_vllm` to a single delegation.
- **Remove dead code**:
  - `_ProbeRow` dataclass — never instantiated
  - `_get_field_info` — computed and discarded (variable was `_field_info`)
  - `_enumerate_dormancy_rules` — function body just returns `[]`
- **Fix AST walker break bug** (`vllm_ast.py`): the silent-assign branch was breaking after the first assign, missing 2 of 3 rules in vLLM's greedy block (`if temperature < eps: top_p=1; top_k=-1; min_p=0`). Real coverage bug.
- **Add `_SCRIPT_DIR` shadowing guard** to both vLLM walkers (matches the pattern from `tensorrt_ast.py`).
- **Replace vacuous test guards** with real walker invocation in `tmp_path`.

## Deferred to follow-up

- **Hand-curated SamplingParams rule list** (vllm_introspection.py) — flagged with TODO. Replace with msgspec.inspect-based bounds extraction. Tracked as a separate issue.
- **`_resolve_source_paths` duplicated** across vllm_ast/vllm_introspection — hoist to `_base.py`. Touches all walker families; defer to a focused refactor PR.
- **Inline pattern matching vs `_base` detectors** — both `transformers_ast.py:72-84` and `tensorrt_ast.py` intentionally do their own per-walker patterns (documented decision). Following established convention.

## Test plan

- [x] ruff check passes
- [x] vLLM introspection still emits 15 rules locally
- [x] vLLM AST walker still runs (0 rules in dev env due to graceful import-degradation; CI with full deps will produce rules)
- [ ] CI green