### PR TITLE
ci(config): add vendor-vllm job to config-rules-refresh workflow

### DIFF
--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -271,6 +271,26 @@ jobs:
             echo '{"cases":[],"divergences":[]}' > /tmp/rules-diff/vllm.old.json
           fi
 
+      - name: Debug sys.path and scripts/ visibility
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          uv run python -c "
+          import sys, os
+          print('CWD:', os.getcwd())
+          print('PYTHONPATH env:', os.environ.get('PYTHONPATH'))
+          print('sys.path:')
+          for p in sys.path:
+              print('  ', p)
+          import importlib.util
+          spec = importlib.util.find_spec('scripts')
+          print('scripts spec:', spec)
+          spec_w = importlib.util.find_spec('scripts.walkers')
+          print('scripts.walkers spec:', spec_w)
+          print('ls of cwd scripts/:', os.listdir('scripts') if os.path.exists('scripts') else 'no scripts/')
+          print('ls of cwd scripts/walkers/:', os.listdir('scripts/walkers') if os.path.exists('scripts/walkers') else 'no scripts/walkers/')
+          "
+
       - name: Run fixpoint test against corpus
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -229,3 +229,153 @@ jobs:
           echo "::error::One or more rules diverged from their declared expected_outcome." >&2
           echo "Inspect ${VENDORED_DIR}/transformers.json > .divergences[] for details." >&2
           exit 1
+
+  vendor-vllm:
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'vllm' || inputs.engine == 'all'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Mint llem-ci-bot App token
+        id: app-token
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: vendor-rules-3.12-vllm
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --dev --extra vllm
+
+      - name: Save current vendored JSON for diffing
+        id: save_old
+        run: |
+          OLD_JSON="${VENDORED_DIR}/vllm.json"
+          mkdir -p /tmp/rules-diff
+          if [[ -f "$OLD_JSON" ]]; then
+            cp "$OLD_JSON" /tmp/rules-diff/vllm.old.json
+          else
+            echo '{"cases":[],"divergences":[]}' > /tmp/rules-diff/vllm.old.json
+          fi
+
+      - name: Run fixpoint test against corpus
+        run: |
+          uv run python -c "
+          import yaml
+          from scripts.walkers._fixpoint_test import fixpoint_test_corpus
+          corpus = yaml.safe_load(open('${CORPUS_DIR}/vllm.yaml'))
+          fixpoint_test_corpus(corpus)
+          print('fixpoint test passed')
+          "
+
+      - name: Compute stable vendor anchor
+        id: anchor
+        run: |
+          PATHS=(
+            "docker/Dockerfile.vllm"
+            "configs/validation_rules/vllm.yaml"
+            "scripts/vendor_rules.py"
+            "scripts/_vendor_common.py"
+            "scripts/walkers/vllm_ast.py"
+            "scripts/walkers/vllm_introspection.py"
+            "scripts/walkers/_fixpoint_test.py"
+            "scripts/walkers/_base.py"
+          )
+          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
+          DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+
+      - name: Re-vendor vLLM rules
+        id: vendor
+        env:
+          LLENERGY_VENDOR_FROZEN_AT: ${{ steps.anchor.outputs.date }}
+        run: |
+          set +e
+          uv run python scripts/vendor_rules.py \
+            --engine vllm \
+            --corpus "${CORPUS_DIR}/vllm.yaml" \
+            --out "${VENDORED_DIR}/vllm.json" \
+            --vendor-commit "${{ steps.anchor.outputs.sha }}" \
+            --fail-on-divergence
+          echo "vendor_exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Classify diff
+        id: diff
+        run: |
+          mkdir -p /tmp/rules-diff
+          set +e
+          uv run python scripts/diff_rules.py \
+            /tmp/rules-diff/vllm.old.json \
+            "${VENDORED_DIR}/vllm.json" \
+            --out /tmp/rules-diff/vllm.md \
+            --title "vLLM rules diff"
+          DIFF_EXIT=$?
+          set -e
+          echo "is_breaking=$([[ $DIFF_EXIT -eq 1 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit regenerated rule-observations JSON
+        if: steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.name  "llem-ci-bot[bot]"
+          git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
+
+          git add "${VENDORED_DIR}/vllm.json"
+
+          if git diff --cached --quiet; then
+            echo "No vendored JSON changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(config): refresh vllm rule-observations"
+          git push --force-with-lease
+
+      - name: Post diff comment
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "No PR number available, skipping comment."
+            exit 0
+          fi
+          if [[ -f /tmp/rules-diff/vllm.md ]]; then
+            gh pr comment "$PR_NUMBER" --body-file /tmp/rules-diff/vllm.md
+          fi
+
+      - name: Apply label
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          if [[ "${{ steps.diff.outputs.is_breaking }}" == "true" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "rules-breaking" --remove-label "rules-safe" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --add-label "rules-safe" --remove-label "rules-breaking" 2>/dev/null || true
+          fi
+
+      - name: Fail on divergence
+        if: steps.vendor.outputs.vendor_exit != '0'
+        run: |
+          echo "::error::One or more vLLM rules diverged from their declared expected_outcome." >&2
+          echo "Inspect ${VENDORED_DIR}/vllm.json > .divergences[] for details." >&2
+          exit 1

--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -271,29 +271,7 @@ jobs:
             echo '{"cases":[],"divergences":[]}' > /tmp/rules-diff/vllm.old.json
           fi
 
-      - name: Debug sys.path and scripts/ visibility
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-        run: |
-          uv run python -c "
-          import sys, os
-          print('CWD:', os.getcwd())
-          print('PYTHONPATH env:', os.environ.get('PYTHONPATH'))
-          print('sys.path:')
-          for p in sys.path:
-              print('  ', p)
-          import importlib.util
-          spec = importlib.util.find_spec('scripts')
-          print('scripts spec:', spec)
-          spec_w = importlib.util.find_spec('scripts.walkers')
-          print('scripts.walkers spec:', spec_w)
-          print('ls of cwd scripts/:', os.listdir('scripts') if os.path.exists('scripts') else 'no scripts/')
-          print('ls of cwd scripts/walkers/:', os.listdir('scripts/walkers') if os.path.exists('scripts/walkers') else 'no scripts/walkers/')
-          "
-
       - name: Run fixpoint test against corpus
-        env:
-          PYTHONPATH: ${{ github.workspace }}
         run: |
           uv run python -c "
           import yaml

--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -272,6 +272,8 @@ jobs:
           fi
 
       - name: Run fixpoint test against corpus
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           uv run python -c "
           import yaml

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,6 @@
+"""Project tooling scripts.
+
+Marked as a regular package so it wins over any ``scripts`` package that
+some transitive dependency may install into site-packages (vLLM's full
+install graph triggered this — see PR #418 commit log for details).
+"""


### PR DESCRIPTION
## Summary

Adds a `vendor-vllm` job to `.github/workflows/config-rules-refresh.yml` that mirrors `vendor-transformers` for the vLLM corpus.

After #416 merged, vLLM walkers exist on main but the corpus is never validated against the real library in CI. This PR closes that gap.

## What it does

For every PR that touches walker / corpus / vendor paths:

1. Installs vLLM via `uv sync --extra vllm`
2. Runs the fixpoint test against `configs/validation_rules/vllm.yaml`
3. Re-vendors the corpus through the real `SamplingParams` library
4. Commits regenerated `src/llenergymeasure/config/vendored_rules/vllm.json` back to the PR
5. Posts a diff comment
6. Labels the PR `rules-safe` or `rules-breaking`
7. Fails CI on declared-vs-observed divergence

## Side fix: `scripts/__init__.py`

vLLM's transitive deps install a regular `scripts/` package into site-packages (one of ~161 packages). Per PEP 420, when sys.path iteration finds a regular package anywhere — even AFTER a namespace portion earlier in the path — the regular package wins. That broke `from scripts.walkers...` in the fixpoint step.

Fix: marked our `scripts/` as a regular package by adding an `__init__.py`. Now the workspace's `scripts/` wins because `sys.path` lists workspace before site-packages and both are regular packages. Validated by passing fixpoint test in workflow_dispatch run #24944828310.

## Notes

- `timeout-minutes: 45` (up from 30 for transformers) — vLLM sync downloads torch+CUDA stubs.
- `cache-suffix: vendor-rules-3.12-vllm` — separate cache key so transformers and vLLM caches don't collide.
- `vendor-tensorrt` is intentionally NOT added in this PR. tensorrt-llm requires CUDA libs that `ubuntu-latest` lacks; tracked in #421.

## Test plan

- [x] YAML is valid
- [x] Manual `gh workflow run` validates vendor-vllm job succeeds (fixpoint passes, vendor step completes without divergences) — run 24944828310
- [x] Existing vendor-transformers job still works with `scripts/__init__.py` added — run 24944796431