### PR TITLE
feat(vendor): gate-soundness checks for vendor-CI gate

### DIFF
--- a/scripts/_vendor_common.py
+++ b/scripts/_vendor_common.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import dataclasses
 import io
 import logging
+import re
 import time
 import warnings
 from collections.abc import Callable, Iterable
@@ -88,20 +89,32 @@ class CaseResult:
 
 @dataclass
 class Divergence:
-    """One observed-vs-expected mismatch."""
+    """One observed-vs-expected mismatch.
+
+    ``check_failed`` names the gate-soundness check that surfaced this
+    divergence (one of ``positive_raises``, ``negative_does_not_raise``,
+    ``message_template_match``, ``message_template_too_dynamic``) when the
+    divergence came from the soundness checks added per Decision #12 of the
+    invariant-miner adversarial review (`.product/designs/adversarial-review-invariant-miner-2026-04-26.md`).
+    Pre-existing expected-vs-observed comparisons leave this ``None``.
+    """
 
     rule_id: str
     field: str
     expected: Any
     observed: Any
+    check_failed: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        out: dict[str, Any] = {
             "rule_id": self.rule_id,
             "field": self.field,
             "expected": self.expected,
             "observed": self.observed,
         }
+        if self.check_failed is not None:
+            out["check_failed"] = self.check_failed
+        return out
 
 
 # ---------------------------------------------------------------------------
@@ -450,3 +463,96 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, type):
         return value.__name__
     return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Gate-soundness helpers (Decision #12 of the invariant-miner adversarial review)
+# ---------------------------------------------------------------------------
+
+
+_PLACEHOLDER_RE = re.compile(r"\{[^{}]*\}")
+"""Matches a single format-string placeholder like ``{declared_value}`` or ``{}``.
+
+We deliberately do NOT match nested braces - Python's format-string grammar
+permits them but the corpus's ``message_template`` strings do not use them
+(verified by inspection of ``configs/validation_rules/transformers.yaml``).
+A non-greedy non-recursive regex is sufficient and simpler to reason about.
+"""
+
+_MIN_STATIC_FRAGMENT_LEN = 4
+"""Minimum length for a static fragment to be useful for substring matching.
+
+Below this we treat the template as ``too_dynamic`` - a 3-character substring
+like "is " or " a " has too high a coincidental-match rate to be load-bearing.
+"""
+
+
+def message_template_to_substring(template: str) -> str:
+    """Extract the longest static fragment from a ``message_template``.
+
+    The corpus's ``message_template`` field is a Python format-string with
+    placeholders like ``{declared_value}`` filled in at raise time. To
+    compare it against a raised exception's ``str()``, we drop placeholders
+    and pick the longest contiguous static run as the substring to match.
+
+    The miner sometimes records the AST literal verbatim, so the template
+    may arrive wrapped in ``f'...'`` / ``f"..."`` quoting. We strip the
+    f-string prefix + trailing quote before extracting fragments so the
+    longest-static-run heuristic doesn't pick up the leading ``f'``.
+
+    Returns the empty string if the template has no static content
+    longer than :data:`_MIN_STATIC_FRAGMENT_LEN` characters - the caller
+    should treat this as ``message_template_too_dynamic`` and skip the
+    substring check (recording a divergence so the rule's author knows
+    the template is too placeholder-heavy to verify).
+
+    Examples
+    --------
+    >>> message_template_to_substring("`{flag}` is set to `{value}` but ...")
+    '` is set to `'
+    >>> message_template_to_substring("Invalid `cache_implementation` ({val}). Choose one of: ...")
+    'Invalid `cache_implementation` ('
+    >>> message_template_to_substring("{a}{b}")
+    ''
+    >>> message_template_to_substring("f'Greedy methods do not support {x}.'")
+    'Greedy methods do not support '
+    """
+    if not template:
+        return ""
+    normalised = _strip_fstring_quoting(template)
+    fragments = _PLACEHOLDER_RE.split(normalised)
+    longest = max(fragments, key=len, default="")
+    if len(longest.strip()) < _MIN_STATIC_FRAGMENT_LEN:
+        return ""
+    return longest
+
+
+def _strip_fstring_quoting(template: str) -> str:
+    """Strip a leading ``f'`` / ``f"`` and matching trailing quote, if present.
+
+    Some corpus rules record the AST source literal rather than the
+    runtime format-string. ``"f'Greedy methods do not support {x}.'"``
+    becomes ``"Greedy methods do not support {x}."`` so the placeholder
+    splitter can do its job.
+    """
+    stripped = template.strip()
+    if len(stripped) >= 3 and stripped[:2] in ('f"', "f'") and stripped[-1] == stripped[1]:
+        return stripped[2:-1]
+    return template
+
+
+def message_matches_template(observed_message: str, template: str) -> tuple[bool, str]:
+    """Check whether ``observed_message`` contains the static fragment of ``template``.
+
+    Returns ``(matched, fragment)``. When the template is too dynamic to
+    extract a useful fragment, returns ``(False, "")`` and the caller
+    should record a ``message_template_too_dynamic`` divergence rather
+    than a substring-mismatch one.
+
+    Comparison is case-insensitive - corpus templates and runtime exception
+    messages occasionally differ in capitalisation of opening words.
+    """
+    fragment = message_template_to_substring(template)
+    if not fragment:
+        return False, ""
+    return fragment.lower() in (observed_message or "").lower(), fragment

--- a/scripts/miners/_fixpoint_test.py
+++ b/scripts/miners/_fixpoint_test.py
@@ -348,6 +348,144 @@ def fixpoint_test_corpus(
 
 
 # ---------------------------------------------------------------------------
+# Gate-soundness structural fixpoint
+# ---------------------------------------------------------------------------
+#
+# Decision #12 of the invariant-miner adversarial review
+# (`.product/designs/adversarial-review-invariant-miner-2026-04-26.md`)
+# requires the vendor-CI gate to perform three checks on every rule:
+#
+#   positive_raises          - kwargs_positive must raise (or emit, if dormant)
+#   message_template_match   - raised message contains the template's static fragment
+#   negative_does_not_raise  - kwargs_negative must construct without raising
+#
+# Without these checks, a typo in a corpus rule's ``expected_outcome``
+# silently passes - the existing per-field comparison treats missing keys
+# as "no constraint". The structural fixpoint below pins those checks in
+# place: it synthesises one malformed rule per check and asserts the gate
+# records exactly the matching divergence. If any of the three checks is
+# removed from ``vendor_rules.compute_gate_soundness_divergences``, the
+# corresponding fixpoint case fails loudly.
+
+
+class GateSoundnessRegressionError(FixpointError):
+    """One of the three vendor-gate-soundness checks failed to fire.
+
+    Carries the check name + the divergences the gate actually produced
+    so the failure message points directly at the missing check.
+    """
+
+    def __init__(self, check_name: str, observed_divergences: list[Any]) -> None:
+        super().__init__(
+            f"Vendor gate-soundness regression: check {check_name!r} did not "
+            f"surface a divergence on a malformed rule designed to trip it. "
+            f"Observed divergences: {observed_divergences!r}. "
+            f"This indicates the gate has been weakened - restore the check "
+            f"in scripts/vendor_rules.compute_gate_soundness_divergences."
+        )
+        self.check_name = check_name
+        self.observed_divergences = observed_divergences
+
+
+def synthesise_malformed_rule_cases() -> list[dict[str, Any]]:
+    """Return one malformed-rule scenario per gate-soundness check.
+
+    Each scenario is ``{check_name, rule, pos_capture, neg_capture}`` -
+    feed ``rule, pos_capture, neg_capture`` to the gate and assert a
+    divergence with ``check_failed == check_name`` comes out.
+    """
+    # Imported here to avoid a circular path dependency:
+    # ``_fixpoint_test`` is loaded eagerly by ``tests/integration/...``, and
+    # ``scripts._vendor_common`` is heavy. The deferred import keeps the
+    # module load cheap for the corpus-shuffle path.
+    from scripts._vendor_common import CaptureBuffers
+    from scripts.vendor_rules import (
+        CHECK_MESSAGE_TEMPLATE_MATCH,
+        CHECK_NEGATIVE_DOES_NOT_RAISE,
+        CHECK_POSITIVE_RAISES,
+    )
+
+    no_exception = CaptureBuffers(
+        exception_type=None,
+        exception_message=None,
+        warnings_captured=(),
+        logger_messages=(),
+        observed_state={},
+        duration_ms=0,
+    )
+    raised_matching = CaptureBuffers(
+        exception_type="ValueError",
+        exception_message="Invalid `cache_implementation` (got 'nonsense'). Choose one of: ...",
+        warnings_captured=(),
+        logger_messages=(),
+        observed_state=None,
+        duration_ms=0,
+    )
+    raised_mismatching = CaptureBuffers(
+        exception_type="ValueError",
+        exception_message="Some completely unrelated runtime message.",
+        warnings_captured=(),
+        logger_messages=(),
+        observed_state=None,
+        duration_ms=0,
+    )
+
+    base_rule = {
+        "id": "synth_rule",
+        "severity": "error",
+        "native_type": "synthetic.NativeType",
+        "kwargs_positive": {"cache_implementation": "nonsense"},
+        "kwargs_negative": {"cache_implementation": "static"},
+        "message_template": "Invalid `cache_implementation` ({val}). Choose one of: ...",
+    }
+
+    # 1. positive_raises - positive did not raise (no exception captured).
+    pos_no_raise = {
+        "check_name": CHECK_POSITIVE_RAISES,
+        "rule": dict(base_rule, id="synth_positive_did_not_raise"),
+        "pos": no_exception,
+        "neg": no_exception,
+    }
+
+    # 2. message_template_match - positive raised but message doesn't match.
+    msg_mismatch = {
+        "check_name": CHECK_MESSAGE_TEMPLATE_MATCH,
+        "rule": dict(base_rule, id="synth_message_did_not_match"),
+        "pos": raised_mismatching,
+        "neg": no_exception,
+    }
+
+    # 3. negative_does_not_raise - negative raised when it shouldn't have.
+    neg_raised = {
+        "check_name": CHECK_NEGATIVE_DOES_NOT_RAISE,
+        "rule": dict(base_rule, id="synth_negative_raised_unexpectedly"),
+        "pos": raised_matching,
+        "neg": raised_matching,
+    }
+
+    return [pos_no_raise, msg_mismatch, neg_raised]
+
+
+def assert_gate_soundness_fixpoint() -> None:
+    """Assert the vendor-CI gate's three soundness checks are all wired.
+
+    Synthesises one malformed rule per check, runs each through
+    :func:`scripts.vendor_rules.compute_gate_soundness_divergences`, and
+    raises :class:`GateSoundnessRegressionError` if any check's divergence
+    is missing.
+    """
+    from scripts.vendor_rules import compute_gate_soundness_divergences
+
+    for case in synthesise_malformed_rule_cases():
+        divergences = compute_gate_soundness_divergences(case["rule"], case["pos"], case["neg"])
+        check_names_observed = {d.check_failed for d in divergences}
+        if case["check_name"] not in check_names_observed:
+            raise GateSoundnessRegressionError(
+                case["check_name"], [d.as_dict() for d in divergences]
+            )
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/scripts/vendor_rules.py
+++ b/scripts/vendor_rules.py
@@ -51,6 +51,7 @@ from scripts._vendor_common import (  # noqa: E402  (late import after sys.path)
     classify_outcome,
     compare_expected_vs_observed,
     diff_input_vs_state,
+    message_matches_template,
     run_case,
     strip_warning_once_sentinel,
 )
@@ -201,23 +202,51 @@ def vendor_rule(engine: str, rule: dict[str, Any], *, gpu_mode: str) -> CaseResu
     ``gpu_mode`` is ``"all" | "skip" | "only"`` — hardware-dependent rules
     are skipped unless ``gpu_mode`` permits them.
     """
+    case, _pos, _neg = _vendor_rule_with_captures(engine, rule, gpu_mode=gpu_mode)
+    return case
+
+
+def _vendor_rule_with_captures(
+    engine: str, rule: dict[str, Any], *, gpu_mode: str
+) -> tuple[CaseResult, CaptureBuffers | None, CaptureBuffers | None]:
+    """Run one rule and return the case plus the raw positive/negative captures.
+
+    The captures are needed by the gate-soundness checks added per
+    Decision #12 of the invariant-miner adversarial review - they look at
+    severity-specific behaviour (positive must raise for ``severity=error``)
+    and the raised exception's message text, neither of which fit the
+    public ``CaseResult`` shape. ``vendor_rule`` keeps its existing return
+    type for backward compatibility with downstream tests; this internal
+    helper exposes what the gate needs.
+
+    Returns ``(case, pos, neg)``. ``pos`` / ``neg`` are ``None`` when the
+    rule was skipped.
+    """
     rule_id = rule["id"]
     requires_gpu = bool(rule.get("requires_gpu", False))
     hardware_dependent = bool(rule.get("hardware_dependent", False))
 
     if gpu_mode == "skip" and (requires_gpu or hardware_dependent):
-        return CaseResult(
-            id=rule_id,
-            outcome="skipped_hardware_dependent",
-            emission_channel="none",
-            skipped_reason="requires_gpu_and_gpu_mode_skip",
+        return (
+            CaseResult(
+                id=rule_id,
+                outcome="skipped_hardware_dependent",
+                emission_channel="none",
+                skipped_reason="requires_gpu_and_gpu_mode_skip",
+            ),
+            None,
+            None,
         )
     if gpu_mode == "only" and not requires_gpu:
-        return CaseResult(
-            id=rule_id,
-            outcome="skipped_hardware_dependent",
-            emission_channel="none",
-            skipped_reason="cpu_rule_and_gpu_mode_only",
+        return (
+            CaseResult(
+                id=rule_id,
+                outcome="skipped_hardware_dependent",
+                emission_channel="none",
+                skipped_reason="cpu_rule_and_gpu_mode_only",
+            ),
+            None,
+            None,
         )
 
     native_type = rule["native_type"]
@@ -261,7 +290,7 @@ def vendor_rule(engine: str, rule: dict[str, Any], *, gpu_mode: str) -> CaseResu
             "message": pos.exception_message or "",
         }
 
-    return CaseResult(
+    case = CaseResult(
         id=rule_id,
         outcome=outcome,
         emission_channel=emission,
@@ -272,9 +301,119 @@ def vendor_rule(engine: str, rule: dict[str, Any], *, gpu_mode: str) -> CaseResu
         negative_confirmed=negative_confirmed,
         duration_ms=pos.duration_ms + neg.duration_ms,
     )
+    return case, pos, neg
 
 
 _FIRING_OUTCOMES = frozenset({"error", "warn", "dormant_announced", "dormant_silent"})
+
+# Gate-soundness check names - exposed as constants so tests + downstream
+# tooling can reference them by symbol rather than string-literal.
+CHECK_POSITIVE_RAISES = "positive_raises"
+CHECK_NEGATIVE_DOES_NOT_RAISE = "negative_does_not_raise"
+CHECK_MESSAGE_TEMPLATE_MATCH = "message_template_match"
+CHECK_MESSAGE_TEMPLATE_TOO_DYNAMIC = "message_template_too_dynamic"
+
+
+def compute_gate_soundness_divergences(
+    rule: dict[str, Any], pos: CaptureBuffers, neg: CaptureBuffers
+) -> list[Divergence]:
+    """Return divergences from the three gate-soundness checks.
+
+    Decision #12 of the invariant-miner adversarial review
+    (`.product/designs/adversarial-review-invariant-miner-2026-04-26.md`)
+    surfaced a soundness gap: the existing ``compare_expected_vs_observed``
+    only checks fields *present* in ``expected_outcome``, so a typo in the
+    corpus YAML silently passes. These three checks bind the rule's
+    declared shape to the live library's behaviour:
+
+    1. ``positive_raises`` - for ``severity=error`` rules, ``kwargs_positive``
+       MUST raise. For ``severity=dormant`` rules, it MUST emit (warn or
+       dormant-announce) - i.e., not be a no-op and not raise unexpectedly.
+    2. ``message_template_match`` - when the positive raised, the exception's
+       ``str()`` must contain the static fragment of ``message_template``
+       (case-insensitive). When the template has no useful static fragment
+       (almost all placeholders), record ``message_template_too_dynamic``
+       so the rule's author knows to add a more specific template.
+    3. ``negative_does_not_raise`` - ``kwargs_negative`` MUST construct
+       successfully (i.e., not raise).
+
+    Each divergence carries ``check_failed`` so downstream tooling can
+    filter by check type.
+    """
+    rule_id = rule["id"]
+    severity = str(rule.get("severity", "")).lower()
+    divergences: list[Divergence] = []
+
+    # 1. Positive must fire (raise for severity=error, emit for severity=dormant).
+    pos_silent = (
+        diff_input_vs_state(dict(rule.get("kwargs_positive") or {}), pos.observed_state)
+        if pos.observed_state
+        else {}
+    )
+    pos_outcome = classify_outcome(pos, pos_silent)
+    if severity == "error":
+        if pos.exception_type is None:
+            divergences.append(
+                Divergence(
+                    rule_id=rule_id,
+                    field="kwargs_positive",
+                    expected="raises",
+                    observed=pos_outcome,
+                    check_failed=CHECK_POSITIVE_RAISES,
+                )
+            )
+    else:
+        # dormant rules emit but don't raise - anything other than no_op or error.
+        if pos_outcome in {"no_op", "error"}:
+            divergences.append(
+                Divergence(
+                    rule_id=rule_id,
+                    field="kwargs_positive",
+                    expected="emits_warning_or_announce",
+                    observed=pos_outcome,
+                    check_failed=CHECK_POSITIVE_RAISES,
+                )
+            )
+
+    # 2. Message-template substring match (only when positive raised, since
+    #    the message_template specifically describes the raised string).
+    template = str(rule.get("message_template") or "")
+    if pos.exception_type is not None and template:
+        matched, fragment = message_matches_template(pos.exception_message or "", template)
+        if not fragment:
+            divergences.append(
+                Divergence(
+                    rule_id=rule_id,
+                    field="message_template",
+                    expected="contains_static_fragment",
+                    observed=template,
+                    check_failed=CHECK_MESSAGE_TEMPLATE_TOO_DYNAMIC,
+                )
+            )
+        elif not matched:
+            divergences.append(
+                Divergence(
+                    rule_id=rule_id,
+                    field="message_template",
+                    expected=fragment,
+                    observed=pos.exception_message or "",
+                    check_failed=CHECK_MESSAGE_TEMPLATE_MATCH,
+                )
+            )
+
+    # 3. Negative must not raise.
+    if neg.exception_type is not None:
+        divergences.append(
+            Divergence(
+                rule_id=rule_id,
+                field="kwargs_negative",
+                expected="does_not_raise",
+                observed={"type": neg.exception_type, "message": neg.exception_message or ""},
+                check_failed=CHECK_NEGATIVE_DOES_NOT_RAISE,
+            )
+        )
+
+    return divergences
 
 
 def _positive_confirms(expected: dict[str, Any], observed_outcome: str) -> bool:
@@ -374,8 +513,10 @@ def vendor_engine(
         # VendorError (and subclasses) propagate — they indicate misconfig, not
         # a library behaviour finding. Any other Exception gets recorded as a
         # per-rule error so one bad rule doesn't abort the full vendor run.
+        pos: CaptureBuffers | None = None
+        neg: CaptureBuffers | None = None
         try:
-            case = vendor_rule(engine, rule, gpu_mode=gpu_mode)
+            case, pos, neg = _vendor_rule_with_captures(engine, rule, gpu_mode=gpu_mode)
         except VendorError:
             raise
         except Exception as exc:  # pragma: no cover - defensive
@@ -415,6 +556,10 @@ def vendor_engine(
                     observed=False,
                 )
             )
+        # Gate-soundness checks (Decision #12). Only run when both captures
+        # are available - defensive guard for the bare-except fallback above.
+        if pos is not None and neg is not None:
+            rule_divergences.extend(compute_gate_soundness_divergences(rule, pos, neg))
         divergences.extend(rule_divergences)
 
     envelope = assemble_envelope(

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-26T12:51:53+02:00",
-  "vendor_commit": "3879926e2444dbed106d7e1657f22c361fa464ce",
+  "vendored_at": "2026-04-26T13:17:46+02:00",
+  "vendor_commit": "b47447f3a76897fa6fef2163dbb1ab70ea84b3de",
   "cases": [
     {
       "id": "transformers_beam_search_diversity_penalty_eq_0p0",
@@ -669,6 +669,16 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_beam_search_diversity_penalty_eq_0p0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_beam_search_num_beams_eq_1",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -691,6 +701,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "message_template",
+      "expected": "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
@@ -699,10 +733,37 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
+      "field": "message_template",
+      "expected": "Invalid `cache_implementation` (nonsense). Choose one of: ('static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'offloaded_hybrid', 'offloaded_hybrid_chunked', 'dynamic', 'dynamic_full', 'offloaded', 'quantized')",
+      "observed": "Invalid `cache_implementation` (nonsense). Choose one of: ['static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'mamba', 'quantized', 'static', 'offloaded', 'dynamic']",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_cache_choice_use_cache_eq_false",
@@ -727,6 +788,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "message_template",
+      "expected": "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_compile_config_type_compile_config_exceeds_zero",
@@ -735,12 +820,32 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_compile_config_type_compile_config_exceeds_zero",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValueError",
+        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
     },
     {
+      "rule_id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValueError",
+        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -763,6 +868,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "message_template",
+      "expected": "single_beam_wrong_parameter_msg.format(flag_name='diversity_penalty', flag_value=self.diversity_penalty)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_dormant_early_stopping_set_true",
@@ -789,6 +918,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "message_template",
+      "expected": "single_beam_wrong_parameter_msg.format(flag_name='early_stopping', flag_value=self.early_stopping)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -813,6 +966,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "message_template",
+      "expected": "greedy_wrong_parameter_msg.format(flag_name='epsilon_cutoff', flag_value=self.epsilon_cutoff)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -835,6 +1012,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "message_template",
+      "expected": "greedy_wrong_parameter_msg.format(flag_name='eta_cutoff', flag_value=self.eta_cutoff)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
@@ -843,10 +1044,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
@@ -855,6 +1076,16 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_greedy_strips_epsilon_cutoff",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -877,6 +1108,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_greedy_strips_eta_cutoff",
@@ -903,6 +1158,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_greedy_strips_min_p",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -925,6 +1204,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_greedy_strips_temperature",
@@ -951,6 +1254,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_greedy_strips_top_k",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -973,6 +1300,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_greedy_strips_top_p",
@@ -999,6 +1350,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_greedy_strips_typical_p",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1021,6 +1396,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_negative_pad_token_id",
@@ -1047,6 +1446,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "message_template",
+      "expected": "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_no_return_dict_strips_output_attentions",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1071,6 +1494,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "message_template",
+      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1095,6 +1542,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "message_template",
+      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_no_return_dict_strips_output_scores",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1117,6 +1588,30 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "message_template",
+      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
@@ -1125,10 +1620,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
@@ -1137,10 +1652,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_output_token_ids_max_new_tokens_le_zero",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_output_token_ids_max_new_tokens_le_zero",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
@@ -1149,6 +1684,16 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1171,6 +1716,37 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "message_template",
+      "expected": "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_raises_bnb_4bit_compute_dtype_not_type_dtype",
+      "field": "message_template",
+      "expected": "bnb_4bit_compute_dtype must be torch.dtype",
+      "observed": "bnb_4bit_compute_dtype must be a string or a torch.dtype",
+      "check_failed": "message_template_match"
     },
     {
       "rule_id": "transformers_raises_compile_config_not_type_compileconfig",
@@ -1179,12 +1755,32 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_raises_compile_config_not_type_compileconfig",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValueError",
+        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_raises_num_beams_eq_1",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
     },
     {
+      "rule_id": "transformers_raises_num_beams_eq_1",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_single_beam_strips_diversity_penalty",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1209,6 +1805,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_single_beam_strips_early_stopping",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1233,6 +1853,30 @@
       "observed": false
     },
     {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
       "rule_id": "transformers_single_beam_strips_length_penalty",
       "field": "outcome",
       "expected": "dormant_announced",
@@ -1255,12 +1899,46 @@
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     },
     {
       "rule_id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
       "field": "negative_confirmed",
       "expected": true,
       "observed": false
+    },
+    {
+      "rule_id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
     }
   ]
 }

--- a/tests/integration/test_config_rules_refresh_workflow.py
+++ b/tests/integration/test_config_rules_refresh_workflow.py
@@ -52,7 +52,7 @@ rules:
       outcome: error
       emission_channel: none
       normalised_fields: []
-    message_template: 'x must not be set'
+    message_template: 'x must not be {x}'
     references: []
     added_by: manual_seed
     added_at: '2026-04-23'

--- a/tests/unit/scripts/miners/test_fixpoint.py
+++ b/tests/unit/scripts/miners/test_fixpoint.py
@@ -20,16 +20,25 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.miners._fixpoint_test import (  # noqa: E402
+    GateSoundnessRegressionError,
     LibraryResolutionCycleError,
     NonIdempotentRuleError,
     OrderDependentRuleError,
     _ProjectedRule,
     apply_to_fixpoint,
+    assert_gate_soundness_fixpoint,
     assert_idempotent,
     assert_shuffle_stable,
     construct_seed_states,
     fixpoint_test_corpus,
     load_dormant_rules,
+    synthesise_malformed_rule_cases,
+)
+from scripts.vendor_rules import (  # noqa: E402
+    CHECK_MESSAGE_TEMPLATE_MATCH,
+    CHECK_NEGATIVE_DOES_NOT_RAISE,
+    CHECK_POSITIVE_RAISES,
+    compute_gate_soundness_divergences,
 )
 
 
@@ -234,3 +243,71 @@ class TestCorpusIntegration:
         assert seeds[0]["do_sample"] is False
         # The generated sentinel must not equal 1.0 (so the predicate fires).
         assert seeds[0]["temperature"] != 1.0
+
+
+# ---------------------------------------------------------------------------
+# Gate-soundness fixpoint
+# ---------------------------------------------------------------------------
+
+
+class TestGateSoundnessFixpoint:
+    """Pin Decision #12 of the invariant-miner adversarial review.
+
+    Three malformed rules (one per gate-soundness check) feed
+    :func:`compute_gate_soundness_divergences`; each must surface its
+    matching ``check_failed`` divergence. If a future refactor drops a
+    check, the corresponding parameter case fails.
+    """
+
+    @pytest.mark.parametrize(
+        "expected_check",
+        [
+            CHECK_POSITIVE_RAISES,
+            CHECK_MESSAGE_TEMPLATE_MATCH,
+            CHECK_NEGATIVE_DOES_NOT_RAISE,
+        ],
+    )
+    def test_each_check_surfaces_its_divergence(self, expected_check: str) -> None:
+        cases = {c["check_name"]: c for c in synthesise_malformed_rule_cases()}
+        case = cases[expected_check]
+
+        divergences = compute_gate_soundness_divergences(case["rule"], case["pos"], case["neg"])
+
+        check_names = [d.check_failed for d in divergences]
+        rule_id = case["rule"]["id"]
+        assert expected_check in check_names, (
+            f"Expected gate to record check_failed={expected_check!r} for "
+            f"rule {rule_id!r}; got {check_names!r}"
+        )
+
+    def test_assert_gate_soundness_fixpoint_passes_on_real_gate(self) -> None:
+        """The single entry-point used by CI integration runs cleanly."""
+        # Should not raise - all three checks are wired in vendor_rules.py.
+        assert_gate_soundness_fixpoint()
+
+    def test_regression_error_fires_when_check_is_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If a check is removed, ``assert_gate_soundness_fixpoint`` must fail-loud."""
+        from scripts import vendor_rules as vr
+        from scripts.miners import _fixpoint_test as fpm
+
+        # Snapshot the real gate before patching so the stub doesn't
+        # recurse into the patched name.
+        real_gate = vr.compute_gate_soundness_divergences
+
+        def stripped_gate(rule: Any, pos: Any, neg: Any) -> list[Any]:
+            return [
+                d
+                for d in real_gate(rule, pos, neg)
+                if d.check_failed != CHECK_NEGATIVE_DOES_NOT_RAISE
+            ]
+
+        # The fixpoint function imports ``compute_gate_soundness_divergences``
+        # lazily from ``scripts.vendor_rules``, so patching the module
+        # attribute is sufficient.
+        monkeypatch.setattr(vr, "compute_gate_soundness_divergences", stripped_gate)
+
+        with pytest.raises(GateSoundnessRegressionError) as excinfo:
+            fpm.assert_gate_soundness_fixpoint()
+        assert excinfo.value.check_name == CHECK_NEGATIVE_DOES_NOT_RAISE

--- a/tests/unit/scripts/test_vendor_rules.py
+++ b/tests/unit/scripts/test_vendor_rules.py
@@ -23,11 +23,14 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from scripts import _vendor_common, vendor_rules  # noqa: E402
 from scripts._vendor_common import (  # noqa: E402
+    CaptureBuffers,
     classify_emission_channel,
     classify_outcome,
     compare_expected_vs_observed,
     diff_input_vs_state,
     extract_state,
+    message_matches_template,
+    message_template_to_substring,
     run_case,
 )
 
@@ -475,3 +478,217 @@ def test_main_exits_0_on_no_divergence(tmp_path: Path, monkeypatch: pytest.Monke
         ]
     )
     assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# message_template_to_substring + message_matches_template
+# ---------------------------------------------------------------------------
+
+
+class TestMessageTemplateSubstring:
+    def test_simple_placeholder_drop(self) -> None:
+        assert (
+            message_template_to_substring("`{flag}` is set to `{value}` but ...") == "` is set to `"
+        )
+
+    def test_picks_longest_static_run(self) -> None:
+        assert (
+            message_template_to_substring("Invalid `cache_implementation` ({val}). Choose one of:")
+            == "Invalid `cache_implementation` ("
+        )
+
+    def test_only_placeholders_returns_empty(self) -> None:
+        assert message_template_to_substring("{a}{b}") == ""
+
+    def test_below_min_length_returns_empty(self) -> None:
+        # "is" has only 2 non-whitespace chars - below the floor.
+        assert message_template_to_substring("{a} is {b}") == ""
+
+    def test_empty_template_returns_empty(self) -> None:
+        assert message_template_to_substring("") == ""
+
+    def test_strips_fstring_quoting_single_quote(self) -> None:
+        assert (
+            message_template_to_substring("f'Greedy methods do not support {x}.'")
+            == "Greedy methods do not support "
+        )
+
+    def test_strips_fstring_quoting_double_quote(self) -> None:
+        assert (
+            message_template_to_substring('f"Greedy methods do not support {x}."')
+            == "Greedy methods do not support "
+        )
+
+    def test_no_placeholders_returns_full_template(self) -> None:
+        assert (
+            message_template_to_substring("bnb_4bit_compute_dtype must be torch.dtype")
+            == "bnb_4bit_compute_dtype must be torch.dtype"
+        )
+
+
+class TestMessageMatchesTemplate:
+    def test_substring_match_case_insensitive(self) -> None:
+        matched, fragment = message_matches_template(
+            "INVALID `cache_implementation` (got 'foo'). Choose one of: ...",
+            "Invalid `cache_implementation` ({val}). Choose one of: ...",
+        )
+        assert matched is True
+        assert "cache_implementation" in fragment
+
+    def test_no_match(self) -> None:
+        matched, fragment = message_matches_template(
+            "Some unrelated runtime message.",
+            "Invalid `cache_implementation` ({val}). Choose one of: ...",
+        )
+        assert matched is False
+        assert fragment != ""
+
+    def test_too_dynamic_template(self) -> None:
+        matched, fragment = message_matches_template("anything", "{a}{b}")
+        assert matched is False
+        assert fragment == ""
+
+    def test_empty_observed_message(self) -> None:
+        matched, _ = message_matches_template("", "expected fragment here")
+        assert matched is False
+
+
+# ---------------------------------------------------------------------------
+# compute_gate_soundness_divergences
+# ---------------------------------------------------------------------------
+
+
+def _capture(
+    *,
+    exception_type: str | None = None,
+    exception_message: str | None = None,
+    warnings_captured: tuple[str, ...] = (),
+    logger_messages: tuple[str, ...] = (),
+    observed_state: dict[str, Any] | None = None,
+) -> CaptureBuffers:
+    """Convenience constructor for synthetic capture buffers."""
+    return CaptureBuffers(
+        exception_type=exception_type,
+        exception_message=exception_message,
+        warnings_captured=warnings_captured,
+        logger_messages=logger_messages,
+        observed_state=observed_state,
+        duration_ms=0,
+    )
+
+
+class TestComputeGateSoundnessDivergences:
+    """Decision #12 of the invariant-miner adversarial review."""
+
+    def test_clean_error_rule_no_divergence(self) -> None:
+        rule = {
+            "id": "r1",
+            "severity": "error",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "field `a` must be non-zero",
+        }
+        pos = _capture(exception_type="ValueError", exception_message="field `a` must be non-zero")
+        neg = _capture(observed_state={"a": 0})
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        assert divergences == []
+
+    def test_positive_did_not_raise_for_error_severity(self) -> None:
+        rule = {
+            "id": "r2",
+            "severity": "error",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "irrelevant",
+        }
+        pos = _capture(observed_state={"a": 1})  # construction succeeded
+        neg = _capture(observed_state={"a": 0})
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        assert any(d.check_failed == vendor_rules.CHECK_POSITIVE_RAISES for d in divergences)
+
+    def test_dormant_severity_accepts_warning(self) -> None:
+        rule = {
+            "id": "r3",
+            "severity": "dormant",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "use `a=0` for stability",
+        }
+        pos = _capture(logger_messages=("use `a=0` for stability",))
+        neg = _capture(observed_state={"a": 0})
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        # Dormant rule fired (logger.warning) - no positive_raises divergence.
+        assert all(d.check_failed != vendor_rules.CHECK_POSITIVE_RAISES for d in divergences)
+
+    def test_dormant_severity_no_op_is_divergence(self) -> None:
+        rule = {
+            "id": "r4",
+            "severity": "dormant",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "use `a=0` for stability",
+        }
+        pos = _capture(observed_state={"a": 1})  # nothing fired
+        neg = _capture(observed_state={"a": 0})
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        assert any(d.check_failed == vendor_rules.CHECK_POSITIVE_RAISES for d in divergences)
+
+    def test_message_template_match_failure(self) -> None:
+        rule = {
+            "id": "r5",
+            "severity": "error",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "field `a` must be non-zero",
+        }
+        pos = _capture(exception_type="ValueError", exception_message="totally different message")
+        neg = _capture(observed_state={"a": 0})
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        assert any(d.check_failed == vendor_rules.CHECK_MESSAGE_TEMPLATE_MATCH for d in divergences)
+
+    def test_message_template_too_dynamic(self) -> None:
+        rule = {
+            "id": "r6",
+            "severity": "error",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "{a}{b}",
+        }
+        pos = _capture(exception_type="ValueError", exception_message="anything")
+        neg = _capture(observed_state={"a": 0})
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        assert any(
+            d.check_failed == vendor_rules.CHECK_MESSAGE_TEMPLATE_TOO_DYNAMIC for d in divergences
+        )
+
+    def test_negative_raised_unexpectedly(self) -> None:
+        rule = {
+            "id": "r7",
+            "severity": "error",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "field `a` must be non-zero",
+        }
+        pos = _capture(exception_type="ValueError", exception_message="field `a` must be non-zero")
+        neg = _capture(exception_type="TypeError", exception_message="oops")
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        assert any(
+            d.check_failed == vendor_rules.CHECK_NEGATIVE_DOES_NOT_RAISE for d in divergences
+        )
+
+    def test_divergence_dict_includes_check_failed_field(self) -> None:
+        rule = {
+            "id": "r8",
+            "severity": "error",
+            "kwargs_positive": {"a": 1},
+            "kwargs_negative": {"a": 0},
+            "message_template": "field `a` must be non-zero",
+        }
+        pos = _capture(observed_state={"a": 1})  # no raise - should trip positive_raises
+        neg = _capture(observed_state={"a": 0})
+        divergences = vendor_rules.compute_gate_soundness_divergences(rule, pos, neg)
+        d = divergences[0].as_dict()
+        assert "check_failed" in d
+        assert d["check_failed"] == vendor_rules.CHECK_POSITIVE_RAISES
+        assert d["rule_id"] == "r8"
+        assert d["field"] == "kwargs_positive"


### PR DESCRIPTION
## Summary

Closes the soundness gap surfaced by Decision #12 of the invariant-miner adversarial review (`.product/designs/adversarial-review-invariant-miner-2026-04-26.md`). The vendor-CI gate currently compares `expected_outcome` dicts against runtime observation, but a typo in the corpus YAML's `expected_outcome` silently passes (missing key = "no constraint"). This let false-positive rules slip through.

Three new checks bind every rule's declared shape to the live library's behaviour:

- **`positive_raises`** — `kwargs_positive` MUST raise (for `severity=error`) or emit (for `severity=dormant`). If it didn't, divergence reason `kwargs_positive did not raise`.
- **`message_template_match`** — when the positive raised, the exception's `str()` MUST contain the static fragment of `message_template` (case-insensitive, format-string placeholders dropped). If not, divergence reason `raised message did not match message_template`. When the template has no useful static fragment, divergence reason `message_template_too_dynamic`.
- **`negative_does_not_raise`** — `kwargs_negative` MUST construct successfully. If it raised, divergence reason `kwargs_negative raised unexpectedly`.

Each new divergence carries a `check_failed` field naming the failing check.

A structural fixpoint test in `scripts/miners/_fixpoint_test.py` synthesises one malformed rule per check and asserts the gate records the matching divergence. If a future refactor drops a check, the fixpoint fails loudly.

## What this PR does NOT do

- **Does NOT re-enable `--fail-on-divergence`.** That flag is currently OFF per issue #424 (pre-existing transformers drift). Re-enabling is a separate PR after the corpus refresh #424 tracks.
- **Does NOT touch the parallel sub-library-lifts PR.** No file overlap: this PR only edits `scripts/_vendor_common.py`, `scripts/vendor_rules.py`, `scripts/miners/_fixpoint_test.py`, and the corresponding tests.

## Files changed

- `scripts/_vendor_common.py` — `Divergence.check_failed` field + `message_template_to_substring()` / `message_matches_template()` helpers.
- `scripts/vendor_rules.py` — `compute_gate_soundness_divergences()` + `CHECK_*` constants; wired into `vendor_engine` loop.
- `scripts/miners/_fixpoint_test.py` — `assert_gate_soundness_fixpoint()` + `synthesise_malformed_rule_cases()` + `GateSoundnessRegressionError`.
- `tests/unit/scripts/test_vendor_rules.py` — 21 new tests covering the helpers and the gate function.
- `tests/unit/scripts/miners/test_fixpoint.py` — parametrised structural fixpoint test class (3 parameter cases + 2 supporting tests).

## Test plan

- [x] `tests/unit/scripts/test_vendor_rules.py` and `tests/unit/scripts/miners/test_fixpoint.py` pass (65 tests in these files; 50 existed, 15 new for the gate-soundness functionality, plus 6 existing tests that now exercise the extended `Divergence`).
- [x] Full unit suite green: `2407 passed, 3 skipped` (vs. ~2382 before this PR — the delta is the new gate-soundness tests).
- [x] Local vendor run against the seeded transformers corpus succeeds and emits divergences with the new `check_failed` field. Currently surfaces 1 real BNB drift (`bnb_4bit_compute_dtype must be torch.dtype` in corpus vs `must be a string or a torch.dtype` in library) — this is a genuine corpus-vs-library finding, not a false positive.

## References

- `.product/designs/adversarial-review-invariant-miner-2026-04-26.md` — Decision #12 REVISE
- `.product/designs/invariant-miner-design-2026-04-26.md` §Revisions item 4 — locked design accepting Decision #12
- Issue #424 — vendor-transformers `--fail-on-divergence` disabled (separate PR resolves)