### PR TITLE
docs(architecture): user-facing architecture documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See [Installation](docs/installation.md) for system requirements, Docker setup, 
 
 | Guide | Description |
 |-------|-------------|
-| [Architecture Overview](docs/architecture-overview.md) | System diagram, pipeline overview, key concepts |
+| **Start here:** [Architecture Overview](docs/architecture-overview.md) | System diagram, pipeline overview, key concepts (entry point to the suite) |
 | [Invariant Miner Pipeline](docs/miner-pipeline.md) | How validation rules are extracted from engine library source |
 | [Config Validation Pipeline](docs/parameter-discovery.md) | How configs are validated before engine initialisation |
 | [Validation Rule Corpus Format](docs/validation-rule-corpus.md) | YAML schema reference for corpus rules |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ See [Installation](docs/installation.md) for system requirements, Docker setup, 
 | [Getting Started (Policy Maker)](docs/guide-getting-started.md) | Minimal path to running a measurement |
 | [Comparison with Other Benchmarks](docs/guide-comparison-context.md) | MLPerf, AI Energy Score, CodeCarbon, Zeus context |
 
+### Architecture and Internals
+
+| Guide | Description |
+|-------|-------------|
+| [Architecture Overview](docs/architecture-overview.md) | System diagram, pipeline overview, key concepts |
+| [Invariant Miner Pipeline](docs/miner-pipeline.md) | How validation rules are extracted from engine library source |
+| [Config Validation Pipeline](docs/parameter-discovery.md) | How configs are validated before engine initialisation |
+| [Validation Rule Corpus Format](docs/validation-rule-corpus.md) | YAML schema reference for corpus rules |
+| [Extending the Miner](docs/extending-miners.md) | How to add a new engine to the invariant miner |
+| [Research Context](docs/research-context.md) | Academic positioning: Daikon, Houdini, NeuRI, and what is novel |
+| [Schema Refresh Pipeline](docs/schema-refresh.md) | Renovate-driven engine schema refresh |
+
 ---
 
 ## Contributing

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -108,7 +108,7 @@ Deep-dive: [miner-pipeline.md](miner-pipeline.md)
 
 **Key components:**
 - `loader.py` - parses the corpus and exposes `Rule.try_match()`.
-- Loader grammar - the predicate DSL (`type_in`, `@field_ref`, `not_divisible_by`, etc.).
+- Loader grammar - the predicate DSL (`type_is`, `@field_ref`, `not_divisible_by`, etc.).
 - Gap reporting - flags when a config combination the corpus has no rule for is encountered.
 
 Deep-dive: [parameter-discovery.md](parameter-discovery.md)
@@ -128,7 +128,7 @@ Both pipelines sit inside the larger LLenergyMeasure architecture. The config-va
                │
   Layer 3  harness/        MeasurementHarness, energy sampling
                │
-  Layer 2  backends/       PyTorch, vLLM, TensorRT-LLM plugins
+  Layer 2  engines/        PyTorch, vLLM, TensorRT-LLM plugins
                │
   Layer 1  infra/          Docker runner, container entrypoint
                │
@@ -225,7 +225,7 @@ The trade-off is staleness risk: the corpus must be regenerated when the engine 
 | **Vendored JSON** | The CI-observed version of the corpus that ships with the package |
 | **Vendor-CI gate** | The step that replays every rule against the live library; divergences fail CI |
 | **Fixpoint contract** | `_fixpoint_test.py` - asserts dormant rules converge to a stable state under repeated application |
-| **AddedBy** | Provenance field on each rule: `static_miner`, `dynamic_miner`, `pydantic_lift`, `msgspec_lift`, `dataclass_lift`, `manual_seed` |
+| **AddedBy** | Provenance field on each rule: `static_miner`, `dynamic_miner`, `pydantic_lift`, `msgspec_lift`, `dataclass_lift`, `manual_seed`, `runtime_warning`, `observed_collision` (full reference in [validation-rule-corpus.md](validation-rule-corpus.md#added_by)) |
 | **MinerSource** | The `{path, method, line_at_scan}` record pointing back to the library source line that produced a rule |
 | **Loader grammar** | The predicate DSL used in `match.fields`: `in`, `not_in`, `@field_ref`, `not_divisible_by`, `type_is`, etc. |
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,280 @@
+# Architecture Overview
+
+This document is the entry point to the LLenergyMeasure architecture documentation suite. It introduces the two major subsystems - the invariant miner pipeline and the runtime config-validation pipeline - and shows how they connect to the broader measurement framework.
+
+**Start here.** Deep-dive docs for each subsystem are linked throughout.
+
+---
+
+## Who this is for
+
+- **End users** running experiments: read the "Why configs are rejected" section and the [parameter-discovery](parameter-discovery.md) guide.
+- **Engine extenders** adding a new backend: read this overview, then [miner-pipeline](miner-pipeline.md) and [extending-miners](extending-miners.md).
+- **Researchers and paper readers**: read this overview, then [research-context](research-context.md) for academic positioning.
+
+---
+
+## System overview
+
+LLenergyMeasure has two pipelines that work together to give users early, actionable feedback when their configs are invalid before an expensive engine initialisation takes place.
+
+```
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │  COMPILE-TIME (CI / Renovate-driven library bumps)                  │
+  │                                                                     │
+  │   Engine library source                                             │
+  │   (transformers, vLLM, TRT-LLM)                                    │
+  │              │                                                      │
+  │              ▼                                                      │
+  │   ┌─────────────────────────┐                                       │
+  │   │   Invariant Miner       │  scripts/miners/                     │
+  │   │   Pipeline              │                                       │
+  │   │  ┌──────────────┐       │                                       │
+  │   │  │ static miner │       │  AST walking of validator methods    │
+  │   │  └──────────────┘       │                                       │
+  │   │  ┌──────────────┐       │                                       │
+  │   │  │dynamic miner │       │  combinatorial probing               │
+  │   │  └──────────────┘       │                                       │
+  │   │  ┌──────────────┐       │                                       │
+  │   │  │  lift modules│       │  pydantic / msgspec / dataclass      │
+  │   │  └──────────────┘       │                                       │
+  │   │         │               │                                       │
+  │   │    staging files        │                                       │
+  │   │         │               │                                       │
+  │   │    build_corpus.py      │  merge + dedup + fingerprint         │
+  │   │         │               │                                       │
+  │   │    vendor_rules.py      │  replay against live library         │
+  │   │         │               │                                       │
+  │   │  corpus YAML            │  configs/validation_rules/{e}.yaml   │
+  │   │  vendored JSON          │  src/.../vendored_rules/{e}.json     │
+  │   └─────────────────────────┘                                       │
+  └─────────────────────────────────────────────────────────────────────┘
+                      │
+                      │ vendored JSON ships with package
+                      │
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │  RUNTIME (user submits ExperimentConfig)                            │
+  │                                                                     │
+  │   User YAML / Python API                                            │
+  │              │                                                      │
+  │              ▼                                                      │
+  │   ┌─────────────────────────┐                                       │
+  │   │  Config Validation      │  src/.../config/vendored_rules/      │
+  │   │  Pipeline               │  loader.py                           │
+  │   │                         │                                       │
+  │   │  ┌───────────────┐      │                                       │
+  │   │  │ loader.py     │      │  parse corpus + evaluate predicates  │
+  │   │  └───────────────┘      │                                       │
+  │   │  ┌───────────────┐      │                                       │
+  │   │  │ rule match    │      │  try_match() per rule per engine     │
+  │   │  └───────────────┘      │                                       │
+  │   │         │               │                                       │
+  │   │    error / warn /       │                                       │
+  │   │    dormant annotation   │                                       │
+  │   └─────────────────────────┘                                       │
+  │              │                                                      │
+  │              ▼                                                      │
+  │   User sees rejection BEFORE engine initialisation                  │
+  │   (engine initialisation is expensive; this saves GPU time)         │
+  └─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## The two pipelines
+
+### 1. The invariant miner pipeline
+
+**What it does:** Extracts validation invariants from ML engine library source code and packages them into a versioned corpus of structured rules. Runs in CI whenever a library version bumps (Renovate-driven).
+
+**Inputs:** Engine library source code (at a pinned version).
+
+**Outputs:** `configs/validation_rules/{engine}.yaml` (authoritative corpus) and `src/llenergymeasure/config/vendored_rules/{engine}.json` (ship-ready vendored observations).
+
+**Three components:**
+- Static miner - walks Python AST of validator methods; no constructor calls.
+- Dynamic miner - instantiates config classes with combinatorial probe values; observes raise/no-raise patterns.
+- Lift modules (`_pydantic_lift.py`, `_msgspec_lift.py`, `_dataclass_lift.py`) - extract constraints directly from type-system metadata (Pydantic `FieldInfo`, msgspec `Meta`, stdlib `Literal[...]`).
+
+Deep-dive: [miner-pipeline.md](miner-pipeline.md)
+
+### 2. The parameter-discovery / config-validation pipeline
+
+**What it does:** At runtime, when a user submits an `ExperimentConfig`, evaluates each rule in the vendored corpus against the config and rejects invalid combinations before engine initialisation begins.
+
+**Inputs:** User's `ExperimentConfig`; vendored corpus JSON.
+
+**Outputs:** Error / warning / dormant annotations surfaced to the user via the CLI or the Python API.
+
+**Key components:**
+- `loader.py` - parses the corpus and exposes `Rule.try_match()`.
+- Loader grammar - the predicate DSL (`type_in`, `@field_ref`, `not_divisible_by`, etc.).
+- Gap reporting - flags when a config combination the corpus has no rule for is encountered.
+
+Deep-dive: [parameter-discovery.md](parameter-discovery.md)
+
+---
+
+## Broader framework context
+
+Both pipelines sit inside the larger LLenergyMeasure architecture. The config-validation pipeline plugs into Layer 0 (`config/`), which the rest of the stack builds on.
+
+```
+  Layer 6  cli/            llem run, llem config
+               │
+  Layer 5  api/            run_experiment(), run_study()
+               │
+  Layer 4  study/          StudyRunner, sweep expansion
+               │
+  Layer 3  harness/        MeasurementHarness, energy sampling
+               │
+  Layer 2  backends/       PyTorch, vLLM, TensorRT-LLM plugins
+               │
+  Layer 1  infra/          Docker runner, container entrypoint
+               │
+  Layer 0  config/  ◄──── config validation pipeline lives here
+           domain/         vendored_rules/loader.py
+           device/
+           utils/
+```
+
+The invariant miner pipeline lives in `scripts/miners/` - it is a build-time tool, not a library module. Its output is the vendored corpus that ships with the package.
+
+---
+
+## Data flow: end-to-end
+
+```
+  Library version bump (e.g. transformers 4.56.0 → 4.57.0)
+               │
+               ▼
+  Renovate opens PR bumping Dockerfile ARG
+               │
+               ▼
+  CI fires config-rules-refresh.yml
+               │
+               ├──► static miner runs (GH-hosted runner, CPU only)
+               │
+               ├──► dynamic miner runs (GH-hosted runner)
+               │
+               ├──► lift modules run (pydantic / msgspec / dataclass)
+               │
+               ▼
+  build_corpus.py merges staging files
+  (dedup by fingerprint; static miner wins on match.fields,
+   dynamic miner wins on message_template)
+               │
+               ▼
+  vendor_rules.py replays every rule against the live library
+  (checks: kwargs_positive raises, message matches template,
+            kwargs_negative does NOT raise)
+               │
+               ├──► divergent rules quarantined to _failed_validation_*.yaml
+               │
+               └──► confirmed rules written to:
+                    configs/validation_rules/{engine}.yaml   (YAML corpus)
+                    src/.../vendored_rules/{engine}.json     (vendored JSON)
+               │
+               ▼
+  Bot writes vendored JSON back to PR branch
+  CI must be green before merge
+               │
+               ▼
+  Package ships with updated corpus
+               │
+               ▼
+  User submits ExperimentConfig
+               │
+               ▼
+  loader.py evaluates rules against config
+               │
+               ▼
+  Invalid combination caught BEFORE engine initialisation
+  User sees: "config rejected: num_beams must be divisible by num_beam_groups"
+```
+
+---
+
+## Why validate before engine initialisation?
+
+Engine initialisation is expensive: model weights load from disk, CUDA contexts initialise, and for TensorRT-LLM the engine may need compilation. A rejected config discovered after two minutes of initialisation wastes GPU time and researcher patience.
+
+Pre-construction validation from a corpus catches the most common mistakes at config-parse time - a few milliseconds rather than several minutes.
+
+The corpus complements, rather than replaces, engine-side validation: it captures invariants that fire only in specific combinations (cross-field constraints), silent normalisations (`dormant` rules), and invariants from methods that run at build time rather than construction time.
+
+---
+
+## Why a versioned corpus instead of live introspection?
+
+Live introspection at runtime would require importing each engine at startup - which on vLLM and TRT-LLM means initialising CUDA contexts. The corpus is pre-computed and ships as a JSON file that loads in a few milliseconds with no GPU dependency.
+
+The trade-off is staleness risk: the corpus must be regenerated when the engine library changes. The Renovate-driven refresh loop and the vendor-CI gate together enforce this discipline. See [miner-pipeline.md - Renovate refresh loop](miner-pipeline.md#renovate-driven-refresh-loop).
+
+---
+
+## Key concepts
+
+| Term | Meaning |
+|------|---------|
+| **Invariant miner** | The umbrella for the mining pipeline; extracts constraints from library source |
+| **Static miner** | The AST-walking component; reads source, no constructor calls |
+| **Dynamic miner** | The probing component; constructs config objects, observes raises |
+| **Lift module** | Type-system adapter; extracts constraints from Pydantic / msgspec / dataclass metadata |
+| **Corpus** | The YAML file of extracted, vendor-validated rules for one engine |
+| **Vendored JSON** | The CI-observed version of the corpus that ships with the package |
+| **Vendor-CI gate** | The step that replays every rule against the live library; divergences fail CI |
+| **Fixpoint contract** | `_fixpoint_test.py` - asserts dormant rules converge to a stable state under repeated application |
+| **AddedBy** | Provenance field on each rule: `static_miner`, `dynamic_miner`, `pydantic_lift`, `msgspec_lift`, `dataclass_lift`, `manual_seed` |
+| **MinerSource** | The `{path, method, line_at_scan}` record pointing back to the library source line that produced a rule |
+| **Loader grammar** | The predicate DSL used in `match.fields`: `in`, `not_in`, `@field_ref`, `not_divisible_by`, `type_is`, etc. |
+
+---
+
+## File and package map
+
+```
+  scripts/
+  └── miners/                     Invariant miner pipeline (build-time)
+      ├── _base.py                Shared infrastructure: RuleCandidate, MinerError types,
+      │                           AST primitives, pattern detectors
+      ├── _pydantic_lift.py       Pydantic v2 sub-library lift
+      ├── _msgspec_lift.py        msgspec sub-library lift
+      ├── _dataclass_lift.py      stdlib dataclass sub-library lift
+      ├── _fixpoint_test.py       Gate-soundness + corpus fixpoint contract
+      ├── transformers_miner.py   Transformers orchestration entry
+      ├── transformers_static_miner.py
+      ├── transformers_dynamic_miner.py
+      ├── vllm_static_miner.py    (in flight)
+      ├── vllm_dynamic_miner.py   (in flight)
+      ├── tensorrt_static_miner.py  (in flight)
+      └── build_corpus.py         Merge + dedup + vendor-validate orchestration
+
+  scripts/
+  ├── vendor_rules.py             Replay rules against live library; write vendored JSON
+  └── _vendor_common.py           Shared capture + comparison utilities
+
+  configs/
+  └── validation_rules/
+      ├── transformers.yaml       Authoritative corpus (transformers, 46 rules)
+      └── _staging/               Per-miner staging output (not committed)
+
+  src/llenergymeasure/config/
+  └── vendored_rules/
+      ├── loader.py               Runtime corpus consumer + predicate engine
+      ├── transformers.json       Vendored observations (ships with package)
+      └── __init__.py
+```
+
+---
+
+## See also
+
+- [miner-pipeline.md](miner-pipeline.md) - invariant miner deep-dive
+- [parameter-discovery.md](parameter-discovery.md) - runtime validation pipeline
+- [validation-rule-corpus.md](validation-rule-corpus.md) - corpus YAML format reference
+- [extending-miners.md](extending-miners.md) - how to add a new engine miner
+- [research-context.md](research-context.md) - academic positioning
+- [engines.md](engines.md) - engine configuration reference
+- [methodology.md](methodology.md) - energy measurement methodology
+- [schema-refresh.md](schema-refresh.md) - Renovate-driven schema refresh pipeline

--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -77,18 +77,26 @@ if _cls is None:
 
 Based on your Step 0 research, apply one or more lift modules to extract constraints directly from type metadata.
 
+All three lift modules expose a single function named `lift` with the same signature: `lift(target_type, *, namespace, today, source_path) -> list[RuleCandidate]`. The engine/library is derived automatically from `target_type.__module__`. Import each lift under an alias to keep call sites readable.
+
 ### If the engine uses Pydantic v2
 
 ```python
-from scripts.miners._pydantic_lift import lift_pydantic_model
+from datetime import date
+from scripts.miners._pydantic_lift import lift as lift_pydantic
 from enginelib.config import CacheConfig, SchedulerConfig
 
-ENGINE = "myengine"
+TODAY = date.today().isoformat()
 
 def mine_pydantic_rules():
     rules = []
     for cls in [CacheConfig, SchedulerConfig]:
-        rules.extend(lift_pydantic_model(cls, engine=ENGINE, namespace="myengine.config"))
+        rules.extend(lift_pydantic(
+            cls,
+            namespace="myengine.config",
+            today=TODAY,
+            source_path="enginelib/config.py",
+        ))
     return rules
 ```
 
@@ -97,11 +105,16 @@ The lift emits one rule per `Gt`, `Ge`, `Lt`, `Le`, `MultipleOf`, `MinLen`, `Max
 ### If the engine uses msgspec
 
 ```python
-from scripts.miners._msgspec_lift import lift_msgspec_struct
+from scripts.miners._msgspec_lift import lift as lift_msgspec
 from enginelib.config import SamplingParams
 
 def mine_msgspec_rules():
-    return lift_msgspec_struct(SamplingParams, engine=ENGINE, namespace="myengine.sampling")
+    return lift_msgspec(
+        SamplingParams,
+        namespace="myengine.sampling",
+        today=TODAY,
+        source_path="enginelib/sampling.py",
+    )
 ```
 
 Note: if the class ships zero `Meta(ge=...)` annotations (common for msgspec classes), the lift returns `[]` - that is expected and not an error.
@@ -109,11 +122,16 @@ Note: if the class ships zero `Meta(ge=...)` annotations (common for msgspec cla
 ### If the engine uses stdlib dataclasses
 
 ```python
-from scripts.miners._dataclass_lift import lift_dataclass
+from scripts.miners._dataclass_lift import lift as lift_dataclass
 from enginelib.config import EngineArgs
 
 def mine_dataclass_rules():
-    return lift_dataclass(EngineArgs, engine=ENGINE, namespace="myengine.args")
+    return lift_dataclass(
+        EngineArgs,
+        namespace="myengine.args",
+        today=TODAY,
+        source_path="enginelib/args.py",
+    )
 ```
 
 The dataclass lift is limited to `Literal[...]` value-allowlist rules (no numeric bounds; stdlib dataclasses carry no bound metadata by default).
@@ -333,7 +351,7 @@ if __name__ == "__main__":
 Each per-engine miner ships with parametrised tests:
 
 ```python
-# tests/miners/test_myengine_miner.py
+# tests/unit/scripts/miners/test_myengine_miner.py
 
 import pytest
 from scripts.miners.myengine_miner import CLUSTERS, TESTED_AGAINST_VERSIONS

--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -1,0 +1,485 @@
+# Extending the Invariant Miner: Adding a New Engine
+
+This document is the practitioner's guide to adding invariant miner support for a new engine. It uses the transformers miner as the gold-standard reference throughout.
+
+**Audience:** engine extenders. Assumes familiarity with the [miner-pipeline.md](miner-pipeline.md) concepts.
+
+---
+
+## Before you start
+
+1. Read [miner-pipeline.md](miner-pipeline.md) to understand the static miner / dynamic miner / lift module split.
+2. Read the [corpus format reference](validation-rule-corpus.md) to understand what rules look like.
+3. Review `scripts/miners/transformers_static_miner.py` and `scripts/miners/transformers_dynamic_miner.py` as the gold standard. The comments in those files contain important design decisions.
+
+---
+
+## Step 0: Research the engine's validation surface
+
+Before writing any code, answer these questions:
+
+1. Which config classes does the engine validate? Where does validation happen - in `__init__`, in a separate `validate()` method, in validators decorated with `@model_validator`?
+
+2. Which Python type system does each class use? (`pydantic.BaseModel` / `pydantic.dataclasses.dataclass`, `msgspec.Struct`, `@dataclasses.dataclass`, or something else?)
+
+3. Does the engine constructor raise on invalid inputs, or silently normalise them? (Transformers and vLLM raise; TRT-LLM constructors are more permissive, so TRT-LLM has no dynamic miner.)
+
+4. What is the CUDA / import dependency? Can you `import enginelib` on a CPU-only host? (vLLM: yes on CPU-only with a non-GPU-enabled pip install; TRT-LLM: requires CUDA-aware container.)
+
+5. What is a realistic post-vendor-CI rule count? (Transformers: 46; vLLM: 80-110; TRT-LLM: 20-28.) This helps plan the scope.
+
+---
+
+## Step 1: Add the fail-loud import contract
+
+Create `scripts/miners/{engine}_miner.py` (the orchestration entry point). The very first thing it must do:
+
+```python
+import importlib.metadata
+from packaging.specifiers import SpecifierSet
+from scripts.miners._base import check_installed_version, MinerLandmarkMissingError
+
+TESTED_AGAINST_VERSIONS = SpecifierSet(">=X.Y,<X.Z")
+# Set this to the specific version range you have tested against.
+# Keep the upper bound tight (e.g. <4.60 not <99.0) so
+# MinerVersionMismatchError fires on a library bump.
+
+_installed = importlib.metadata.version("your-engine-library")
+check_installed_version("your-engine-library", _installed, TESTED_AGAINST_VERSIONS)
+# Raises MinerVersionMismatchError if installed version is outside the range.
+# This is CI-fatal: the miner will not emit partial output.
+```
+
+Then declare landmark checks for every class or method the miner will walk:
+
+```python
+import ast
+import inspect
+from scripts.miners._base import find_class, find_method
+
+from enginelib.config import SomeConfigClass
+
+_source = inspect.getsource(SomeConfigClass)
+_module = ast.parse(_source)
+_cls = find_class(_module, "SomeConfigClass")
+if _cls is None:
+    raise MinerLandmarkMissingError(
+        "SomeConfigClass",
+        "expected in enginelib.config - check if the class was renamed"
+    )
+```
+
+**Why this matters:** the Haiku-era TRT-LLM extractor imported `LlmConfig` - a class that does not exist in TRT-LLM 0.21.0. It caught the `ImportError` and silently returned `[]`. The fail-loud contract makes silent coverage loss impossible.
+
+---
+
+## Step 2: Apply the relevant lift module(s)
+
+Based on your Step 0 research, apply one or more lift modules to extract constraints directly from type metadata.
+
+### If the engine uses Pydantic v2
+
+```python
+from scripts.miners._pydantic_lift import lift_pydantic_model
+from enginelib.config import CacheConfig, SchedulerConfig
+
+ENGINE = "myengine"
+
+def mine_pydantic_rules():
+    rules = []
+    for cls in [CacheConfig, SchedulerConfig]:
+        rules.extend(lift_pydantic_model(cls, engine=ENGINE, namespace="myengine.config"))
+    return rules
+```
+
+The lift emits one rule per `Gt`, `Ge`, `Lt`, `Le`, `MultipleOf`, `MinLen`, `MaxLen` constraint and per `Literal[...]` allowlist found on any field.
+
+### If the engine uses msgspec
+
+```python
+from scripts.miners._msgspec_lift import lift_msgspec_struct
+from enginelib.config import SamplingParams
+
+def mine_msgspec_rules():
+    return lift_msgspec_struct(SamplingParams, engine=ENGINE, namespace="myengine.sampling")
+```
+
+Note: if the class ships zero `Meta(ge=...)` annotations (common for msgspec classes), the lift returns `[]` - that is expected and not an error.
+
+### If the engine uses stdlib dataclasses
+
+```python
+from scripts.miners._dataclass_lift import lift_dataclass
+from enginelib.config import EngineArgs
+
+def mine_dataclass_rules():
+    return lift_dataclass(EngineArgs, engine=ENGINE, namespace="myengine.args")
+```
+
+The dataclass lift is limited to `Literal[...]` value-allowlist rules (no numeric bounds; stdlib dataclasses carry no bound metadata by default).
+
+---
+
+## Step 3: Write the static miner
+
+Create `scripts/miners/{engine}_static_miner.py`. The static miner walks the AST of validator methods and emits rules for conditional raises, warnings, and silent normalisations.
+
+### Pattern: walking a validator method
+
+```python
+import ast
+import inspect
+from scripts.miners._base import (
+    find_class, find_method, extract_condition_fields,
+    filter_condition_references_self,
+    ConditionalRaiseDetector, ConditionalSelfAssignDetector,
+    ConditionalWarningsWarnDetector, ConditionalLoggerWarningDetector,
+    RuleCandidate, MinerSource,
+)
+
+def walk_validate_method(cls_source: str, cls_name: str) -> list[RuleCandidate]:
+    module = ast.parse(cls_source)
+    cls_node = find_class(module, cls_name)
+    if cls_node is None:
+        raise MinerLandmarkMissingError(cls_name)
+
+    validate = find_method(cls_node, "validate")
+    if validate is None:
+        raise MinerLandmarkMissingError(f"{cls_name}.validate")
+
+    public_fields = frozenset(
+        # derive from the class's dataclasses.fields() or __annotations__
+    )
+
+    detectors = (
+        ConditionalRaiseDetector(),
+        ConditionalSelfAssignDetector(),
+        ConditionalWarningsWarnDetector(),
+        ConditionalLoggerWarningDetector(),
+    )
+
+    candidates = []
+    for node in ast.walk(validate):
+        if not isinstance(node, ast.If):
+            continue
+        if not filter_condition_references_self(node.test, public_fields):
+            continue
+        for stmt in node.body:
+            for detector in detectors:
+                pattern = detector.detect(stmt)
+                if pattern is not None:
+                    # build RuleCandidate from pattern + condition
+                    candidate = _build_candidate(node.test, pattern, ...)
+                    candidates.append(candidate)
+    return candidates
+```
+
+### Per-engine detector customisation
+
+The five default detectors cover the most common patterns. For engine-specific patterns, write a custom detector:
+
+```python
+# Example: engine uses self.errors.append(...) for error collection
+class ErrorsAppendDetector:
+    def detect(self, stmt: ast.stmt) -> DetectedPattern | None:
+        if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+            return None
+        path = call_func_path(stmt.value)
+        if path != ["self", "errors", "append"]:
+            return None
+        return DetectedPattern(
+            severity="error",
+            emission_channel="none",
+            affected_field=None,
+            message_template=first_string_arg(stmt.value),
+            detail="self.errors.append",
+        )
+```
+
+### Important: the "revisit" comment
+
+Per the transformers static miner's header, per-engine miners currently define their own `_detect_*` functions rather than using `_base.py`'s detector classes directly. This is because the `DetectedPattern` shape from `_base.py` doesn't carry the structured `FieldPredicate` data needed for cross-field corpus rules (operators like `not_divisible_by` and `@field_ref`). Once two or more engine miners exist and we can see whether the parallel detector logic is genuinely divergent or accidentally so, harmonise in a `_base.py` refactor.
+
+---
+
+## Step 4: Write the dynamic miner (if applicable)
+
+Create `scripts/miners/{engine}_dynamic_miner.py` if the engine's constructors raise on invalid inputs.
+
+**Skip this step if:** probing the engine's constructors yields zero raises. This is the case for TRT-LLM, where `TrtLlmArgs(**kwargs)` is extremely permissive at construction time; constraints are enforced in validator methods (covered by the static miner) or at build time.
+
+### Cluster definition
+
+Clusters group related fields for Cartesian probing:
+
+```python
+from dataclasses import dataclass, field
+from typing import Any
+
+@dataclass
+class _Cluster:
+    name: str
+    fields: list[str]
+    values: dict[str, list[Any]]
+    constructor: type  # e.g. SamplingParams
+    validate_method: str | None = None  # e.g. "_verify_args"
+
+CLUSTERS = [
+    _Cluster(
+        name="sampling_temperature",
+        fields=["temperature", "top_p", "top_k"],
+        values={
+            "temperature": [0.0, 0.5, 1.0, 2.0, -0.1],
+            "top_p": [0.0, 0.5, 1.0, 1.1],
+            "top_k": [0, 1, 50, -1],
+        },
+        constructor=SamplingParams,
+    ),
+]
+```
+
+Cluster size rule: if `product(len(values[f]) for f in fields) > 200`, use Hypothesis as a supplement instead of Cartesian product:
+
+```python
+import itertools
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+def probe_cluster(cluster: _Cluster) -> list[tuple[dict, str | None]]:
+    size = 1
+    for vs in cluster.values.values():
+        size *= len(vs)
+
+    if size <= 200:
+        # Cartesian probe
+        rows = []
+        for combo in itertools.product(*[cluster.values[f] for f in cluster.fields]):
+            kwargs = dict(zip(cluster.fields, combo))
+            rows.append(_run_probe(kwargs, cluster))
+        return rows
+    else:
+        # Hypothesis supplement (deterministic, fixed seed)
+        return _hypothesis_probe(cluster)
+```
+
+**Important:** Hypothesis is used here as a deterministic value generator with a fixed seed - not as a property-based test runner. The pipeline must be deterministic: the same library version + miner code must produce the same corpus.
+
+### Predicate inference
+
+After probing, group error rows by message class and infer predicates:
+
+```python
+def infer_predicates(rows: list[tuple[dict, str | None]]) -> list[RuleCandidate]:
+    # Group by error message
+    by_message: dict[str, list[dict]] = {}
+    for kwargs, error in rows:
+        if error is not None:
+            by_message.setdefault(error, []).append(kwargs)
+
+    candidates = []
+    for message, trigger_kwargs in by_message.items():
+        # Try templates in order of preference:
+        # 1. cross-field divisibility: a % b != 0
+        # 2. cross-field comparison: a > b
+        # 3. type allowlist
+        # 4. single-field range
+        # 5. single-field equality
+        # 6. value allowlist
+        # Emit ALL plausible candidates (recall-first; vendor CI prunes false positives)
+        ...
+    return candidates
+```
+
+---
+
+## Step 5: Write the corpus orchestration entry
+
+`scripts/miners/{engine}_miner.py` is the main entry point:
+
+```python
+def mine() -> list[RuleCandidate]:
+    candidates = []
+    candidates.extend(mine_pydantic_rules())
+    candidates.extend(mine_dataclass_rules())
+
+    # Static miner
+    from scripts.miners.myengine_static_miner import mine as static_mine
+    candidates.extend(static_mine())
+
+    # Dynamic miner (if applicable)
+    from scripts.miners.myengine_dynamic_miner import mine as dynamic_mine
+    candidates.extend(dynamic_mine())
+
+    return candidates
+
+if __name__ == "__main__":
+    import yaml
+    from scripts.miners._base import candidate_to_dict
+    results = mine()
+    staging = {
+        "schema_version": "1.0.0",
+        "engine": ENGINE,
+        "rules": [candidate_to_dict(c) for c in results],
+    }
+    output_path = Path("configs/validation_rules/_staging/myengine_miner.yaml")
+    output_path.write_text(yaml.dump(staging, allow_unicode=True))
+    print(f"Wrote {len(results)} candidates to {output_path}")
+```
+
+---
+
+## Step 6: Write fixpoint regression tests
+
+Each per-engine miner ships with parametrised tests:
+
+```python
+# tests/miners/test_myengine_miner.py
+
+import pytest
+from scripts.miners.myengine_miner import CLUSTERS, TESTED_AGAINST_VERSIONS
+
+@pytest.mark.parametrize("cluster", CLUSTERS, ids=lambda c: c.name)
+def test_cluster_probes_without_crashing(cluster):
+    """Each cluster must complete probing without an unhandled exception."""
+    rows = probe_cluster(cluster)
+    assert isinstance(rows, list)
+
+def test_version_envelope_set():
+    """TESTED_AGAINST_VERSIONS must be a non-empty SpecifierSet."""
+    from packaging.specifiers import SpecifierSet
+    assert isinstance(TESTED_AGAINST_VERSIONS, SpecifierSet)
+    assert str(TESTED_AGAINST_VERSIONS) != ""
+
+def test_landmark_checks_raise_on_missing():
+    """find_class returning None must raise MinerLandmarkMissingError."""
+    from scripts.miners._base import find_class, MinerLandmarkMissingError
+    import ast
+    module = ast.parse("class Unrelated: pass")
+    cls = find_class(module, "SomeConfigClass")
+    assert cls is None
+    # Confirm caller raises (contract test)
+    with pytest.raises(MinerLandmarkMissingError):
+        if cls is None:
+            raise MinerLandmarkMissingError("SomeConfigClass")
+```
+
+---
+
+## Step 7: Add to CI
+
+1. Add the engine to `config-rules-refresh.yml`:
+
+```yaml
+- name: Run myengine miners
+  run: |
+    python scripts/miners/myengine_miner.py
+```
+
+2. Set the runner tier:
+   - CPU-safe imports (`import myenginelib` works without CUDA): add to the GH-hosted job.
+   - CUDA-aware import required: add to the self-hosted GPU runner job.
+
+3. Add the engine's Dockerfile to the vendor-rules step so `vendor_rules.py` can replay rules inside the engine's container.
+
+4. Add a Renovate `packageRule` so library bumps trigger `config-rules-refresh.yml`.
+
+---
+
+## Step 8: Generate and review the corpus
+
+Run the miner locally (inside the engine's Docker container if CUDA is required):
+
+```bash
+python scripts/miners/myengine_miner.py
+# Writes configs/validation_rules/_staging/myengine_miner.yaml
+
+python scripts/miners/build_corpus.py --engine myengine
+# Merges staging files, runs vendor-CI gate, writes corpus
+
+python scripts/vendor_rules.py \
+  --engine myengine \
+  --corpus configs/validation_rules/myengine.yaml \
+  --out src/llenergymeasure/config/vendored_rules/myengine.json
+# Validates all rules against live library
+```
+
+Review the corpus manually:
+- Do the `kwargs_positive` examples look right?
+- Are there rules that fire too broadly (false positives)?
+- Are there obvious constraints the miner missed (coverage gaps)?
+
+If coverage gaps exist, extend the miner. Only add `manual_seed` rules as a last resort, with a justification comment.
+
+---
+
+## Transformers as the gold standard: key patterns
+
+The transformers miner is the reference implementation. Key patterns to follow:
+
+### The `find_class` / `find_method` / `MinerLandmarkMissingError` contract
+
+Every class and method the miner walks must be guarded:
+
+```python
+cls_node = find_class(module, "GenerationConfig")
+if cls_node is None:
+    raise MinerLandmarkMissingError("GenerationConfig")
+
+method_node = find_method(cls_node, "validate")
+if method_node is None:
+    raise MinerLandmarkMissingError("GenerationConfig.validate")
+```
+
+### The `public_fields` filter
+
+Derive public fields from the class's dataclass fields or `__annotations__`, and use `filter_condition_references_self` to drop predicates that don't reference a public field:
+
+```python
+public_fields = frozenset(
+    f.name for f in dataclasses.fields(GenerationConfig)
+    if not f.name.startswith("_")
+)
+```
+
+### Unparseable sub-clauses: log, don't drop
+
+When the static miner encounters a condition sub-clause it cannot translate (e.g. an opaque function call), it logs the clause and emits the surrounding rule with the parseable parts. The rule is still useful; the vendor-CI gate will confirm whether it fires correctly:
+
+```python
+# transformers_static_miner.py pattern:
+if unparseable_clause:
+    logger.debug(
+        "static_miner: dropped sub-clause in %s.%s:%d: %s",
+        cls_name, method_name, node.lineno, ast.unparse(sub_clause)
+    )
+    # Continue emitting the rule without the sub-clause
+```
+
+### Recall-first: emit all plausible candidates
+
+Both static and dynamic miners err toward recall. The vendor-CI gate is the prune step. Do not add extra filters "just in case" - if a rule candidate is wrong, the vendor-CI gate will quarantine it.
+
+---
+
+## Common mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Not setting `TESTED_AGAINST_VERSIONS` | Miner runs against wrong library version silently | Add `TESTED_AGAINST_VERSIONS = SpecifierSet(">=X,<Y")` and call `check_installed_version` at import |
+| Catching `ImportError` on landmark imports | Silent degradation (returns `[]` on failure) | Let `ImportError` propagate; or raise `MinerLandmarkMissingError` explicitly |
+| Cartesian-only probing with large clusters | Exponential probe count; CI timeouts | Add Hypothesis supplement for clusters > 200 combinations |
+| Adding `manual_seed` rules for automatable constraints | Pipeline-failure debt | Extend the miner instead |
+| Using Hypothesis as property-based test runner (not value generator) | Non-deterministic corpus | Use `hypothesis.strategies.from_type` with a fixed seed; never `@given` |
+| Not calling `find_method` before walking | `AttributeError` on `None` if method renamed | Always guard: `if method is None: raise MinerLandmarkMissingError(...)` |
+
+---
+
+## See also
+
+- [miner-pipeline.md](miner-pipeline.md) - pipeline architecture reference
+- [validation-rule-corpus.md](validation-rule-corpus.md) - corpus format
+- [parameter-discovery.md](parameter-discovery.md) - runtime validation
+- [architecture-overview.md](architecture-overview.md) - system overview
+- `scripts/miners/transformers_static_miner.py` - gold-standard static miner
+- `scripts/miners/transformers_dynamic_miner.py` - gold-standard dynamic miner
+- `scripts/miners/_base.py` - shared infrastructure

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -1,0 +1,508 @@
+# Invariant Miner Pipeline
+
+This document is the deep-dive reference for the invariant miner pipeline: how it extracts validation rules from engine library source code and packages them into a versioned corpus.
+
+**Audience:** engine extenders, CI maintainers, and research readers interested in the technical approach.
+
+For the runtime side of the pipeline (how the corpus is consumed at validation time), see [parameter-discovery.md](parameter-discovery.md).
+
+---
+
+## What the miner pipeline does
+
+The miner pipeline derives structured constraint rules from ML engine config classes by combining:
+
+1. **Static analysis** - walking the AST of validator methods to extract conditional predicates.
+2. **Dynamic analysis** - instantiating config classes with combinatorial probe values and observing raise/no-raise patterns.
+3. **Type-system lifting** - extracting constraints directly from Pydantic `FieldInfo`, msgspec `Meta`, and stdlib `Literal[...]` annotations.
+
+The output is a corpus of rules, each describing one constraint on a config field or combination of fields. Corpus rules are then validated against the live library (the vendor-CI gate) before shipping.
+
+---
+
+## Component overview
+
+```
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │  INVARIANT MINER PIPELINE                                           │
+  │                                                                     │
+  │  ┌─────────────────────────┐   ┌─────────────────────────┐         │
+  │  │    STATIC MINER         │   │    DYNAMIC MINER        │         │
+  │  │                         │   │                         │         │
+  │  │  inspect.getsource()    │   │  class constructors     │         │
+  │  │     + ast.parse()       │   │  + validate() calls     │         │
+  │  │         │               │   │         │               │         │
+  │  │  ConditionalRaiseDetector   │  Cartesian probe grid   │         │
+  │  │  ConditionalSelfAssign  │   │         │               │         │
+  │  │  ConditionalWarnDetector│   │  predicate inference    │         │
+  │  │  (etc.)                 │   │                         │         │
+  │  └──────────┬──────────────┘   └──────────┬──────────────┘         │
+  │             │                              │                        │
+  │             └──────────────┬───────────────┘                        │
+  │                            │                                        │
+  │  ┌─────────────────────────▼─────────────────────────┐             │
+  │  │              LIFT MODULES                          │             │
+  │  │                                                    │             │
+  │  │  _pydantic_lift.py   model_json_schema()           │             │
+  │  │                      FieldInfo.metadata            │             │
+  │  │                                                    │             │
+  │  │  _msgspec_lift.py    msgspec.inspect.type_info()   │             │
+  │  │                      Meta(ge=, le=, ...)           │             │
+  │  │                                                    │             │
+  │  │  _dataclass_lift.py  dataclasses.fields()          │             │
+  │  │                      Literal[...] annotations      │             │
+  │  └─────────────────────────┬─────────────────────────┘             │
+  │                            │                                        │
+  │                            ▼                                        │
+  │                   staging files                                     │
+  │              configs/validation_rules/_staging/                     │
+  │                            │                                        │
+  │                            ▼                                        │
+  │                    build_corpus.py                                  │
+  │                (merge + dedup + fingerprint)                        │
+  │                            │                                        │
+  │                            ▼                                        │
+  │                    vendor_rules.py                                  │
+  │              (replay against live library)                          │
+  │                            │                                        │
+  │           ┌────────────────┴──────────────────┐                    │
+  │           ▼                                   ▼                    │
+  │  confirmed rules                   quarantined rules               │
+  │  configs/validation_rules/         configs/validation_rules/        │
+  │  {engine}.yaml                     _staging/_failed_*.yaml         │
+  │  src/.../vendored_rules/                                            │
+  │  {engine}.json                                                      │
+  └─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Static miner
+
+The static miner reads engine library source via `inspect.getsource()` + `ast.parse()` and walks the AST of known validator methods. It does not call constructors or run the validator methods.
+
+This is "static" in the sense that it reads source without executing the methods under analysis. The library is still imported (to get source file paths), but no config classes are instantiated.
+
+### Why AST walking
+
+Pure introspection (running the constructor and observing errors) cannot recover the shape of cross-field predicates. The dynamic miner sees the message `"num_beams should be divisible by num_beam_groups"` but cannot determine that the underlying check is `num_beams % num_beam_groups != 0`. The static miner reads the predicate structure directly from the AST.
+
+Example: the rule `not_divisible_by` can only be expressed in the corpus because the static miner found `if num_beams % num_beam_groups != 0: raise` in the AST.
+
+### AST primitives (in `_base.py`)
+
+```
+  ast.parse(source)
+       │
+       ▼
+  find_class(module, "GenerationConfig")
+       │
+       ▼
+  find_method(cls, "validate")
+       │
+       ▼
+  for stmt in if_body:
+       │
+       ├── ConditionalRaiseDetector      → severity: "error"
+       │   "if X: raise SomeException(msg)"
+       │
+       ├── ConditionalSelfAssignDetector → severity: "dormant"
+       │   "if X: self.A = B" (silent normalisation)
+       │
+       ├── ConditionalWarningsWarnDetector → severity: "warn"
+       │   "if X: warnings.warn(msg)"
+       │
+       ├── ConditionalLoggerWarningDetector → severity: "warn"
+       │   "if X: logger.warning(msg)"
+       │
+       └── MinorIssuesDictAssignDetector → severity: "dormant"
+           HF-specific: "if X: minor_issues[key] = msg"
+```
+
+### Filters (false-positive guards)
+
+Before emitting a candidate, the static miner applies three filters:
+
+1. `filter_condition_references_self` - the predicate must reference at least one public field via `self.<field>`. Drops argument-gated rules (`if strict: raise`) and private-state rules (`if self._initialized: ...`).
+
+2. `filter_target_is_public_field` - for self-assign patterns, the affected field must be a public field.
+
+3. `filter_kwargs_positive_derivable` - a representative `kwargs_positive` dict must be synthetically derivable from the predicate. Rejects predicates whose truth depends on opaque external calls.
+
+### Miner depth
+
+Static miner depth is fixed at 1: it walks one level of helper calls (`WatermarkingConfig.validate`, `SynthIDTextWatermarkingConfig.validate`) but does not trace through general function calls in the validator body. This avoids an unbounded call-graph traversal while capturing the most common engine validation patterns.
+
+---
+
+## Dynamic miner
+
+The dynamic miner instantiates config classes with combinatorial probe values and observes raise/no-raise patterns. It then runs predicate inference on the resulting table of `(kwargs, error_message)` rows.
+
+### Probe strategy: Cartesian primary, Hypothesis supplement
+
+```
+  cluster definition
+  (e.g. beam-search: num_beams, num_beam_groups, diversity_penalty)
+               │
+               ▼
+  representative values per field
+  (e.g. num_beams=[1, 2, 4], num_beam_groups=[1, 2, 3])
+               │
+               ▼
+  Cartesian product of values
+               │
+               ├── cluster size ≤ threshold
+               │   Cartesian probe runs every combination
+               │
+               └── cluster size > threshold (e.g. 8 fields × 5 values)
+                   Hypothesis from_type generates values deterministically
+                   (fixed seed, no randomness; Hypothesis as value generator only)
+               │
+               ▼
+  for each combination:
+    try:
+      ClassName(**kwargs)
+      .validate(strict=True) if applicable
+      → record (kwargs, None)
+    except Exception as e:
+      → record (kwargs, str(e))
+               │
+               ▼
+  probe-row table: list[(kwargs, error_message | None)]
+```
+
+**Important:** Hypothesis is used here only as a deterministic value generator with a fixed seed, not as a property-based test runner. The miner pipeline must be deterministic: the same library version + miner code must produce the same corpus. Randomness would break Renovate-driven library bump diffs.
+
+### Predicate inference
+
+Given the probe-row table, the dynamic miner infers one rule per error message class using seven predicate templates (in order of preference):
+
+| Template | Example | Fires when |
+|----------|---------|-----------|
+| Cross-field divisibility | `a % b != 0` | error rows align with divisibility failure |
+| Cross-field comparison | `a > b` | error rows align with comparison |
+| Cross-field equality gate | `a == V AND b == W` | error rows correlate with combined field values |
+| Type allowlist | `type(a) not in {T1, T2}` | error rows correlate with field type |
+| Single-field range | `a < 0` | error rows correlate with one field crossing a threshold |
+| Single-field equality | `a == V` | error rows correlate with one field having a specific value |
+| Value allowlist | `a not in {v1, v2, ...}` | error rows correlate with field value not in a set |
+
+The dynamic miner errs toward recall: when multiple templates fit the evidence, it emits all plausible candidates. The vendor-CI gate prunes false positives downstream.
+
+---
+
+## Lift modules
+
+The three lift modules extract constraints from type-system metadata without requiring probe rounds. They are independent stages that run alongside AST walking and probing.
+
+```
+  Type-system axis         Lift module              Engines using it
+  ──────────────────────   ─────────────────────    ────────────────────────────
+  pydantic.BaseModel       _pydantic_lift.py         vLLM (27 pydantic-dataclasses)
+  pydantic.dataclasses                               TRT-LLM (TrtLlmArgs)
+                                                     (Literal-typed enum fields)
+  msgspec.Struct           _msgspec_lift.py          vLLM (SamplingParams)
+  stdlib @dataclass        _dataclass_lift.py        transformers (GenerationConfig,
+                                                     BitsAndBytesConfig)
+                                                     vLLM (EngineArgs, 175 fields)
+                                                     TRT-LLM (BuildConfig, QuantConfig)
+```
+
+### Pydantic lift (`_pydantic_lift.py`)
+
+Walks `model_json_schema()` and `FieldInfo.metadata` (Pydantic v2). Emits one rule per `annotated-types` constraint or `Literal[...]` allowlist found on a field.
+
+Operator vocabulary aligns with the `annotated-types` standard:
+
+```
+  annotated-types predicate   corpus operator key
+  ─────────────────────────   ───────────────────
+  Gt(value)                   ">"
+  Ge(value)                   ">="
+  Lt(value)                   "<"
+  Le(value)                   "<="
+  MultipleOf(value)           "multiple_of"
+  MinLen(value)               "min_len"
+  MaxLen(value)               "max_len"
+  Literal[a, b, c]            "in": [a, b, c]
+```
+
+### msgspec lift (`_msgspec_lift.py`)
+
+Walks `msgspec.inspect.type_info()` and the `Constraints` object per field. Maps `Meta(ge=, le=, ...)` constraints to corpus operator keys using the same vocabulary as the Pydantic lift.
+
+Note: vLLM's `SamplingParams` currently ships zero `Meta` annotations - the msgspec lift returns `[]` for it. The lift exists so that if vLLM (or another msgspec user) adds `Meta(ge=...)` in a future version, the constraints are captured for free.
+
+### Dataclass lift (`_dataclass_lift.py`)
+
+Walks `dataclasses.fields()` and extracts `Literal[a, b, c]` annotations. Plain stdlib dataclasses carry no numeric-bound metadata, so the lift is limited to value-allowlist rules.
+
+---
+
+## Per-engine miner comparison
+
+The three engines have structurally different config surfaces, which determines which components each miner uses.
+
+```
+  ┌──────────────┬─────────────────────┬──────────────┬─────────────────────────┐
+  │ Engine       │ Static miner        │ Dynamic miner│ Lift modules            │
+  ├──────────────┼─────────────────────┼──────────────┼─────────────────────────┤
+  │ transformers │ GenerationConfig     │ Cartesian    │ dataclass_lift          │
+  │              │ .validate(), BNB    │ cluster      │ (GenerationConfig,      │
+  │              │ .post_init()        │ probing      │ BitsAndBytesConfig)     │
+  │              │ ~1700 LoC walked    │              │                         │
+  ├──────────────┼─────────────────────┼──────────────┼─────────────────────────┤
+  │ vLLM         │ SamplingParams      │ Cartesian    │ pydantic_lift (27       │
+  │              │ ._verify_args()     │ + Hypothesis │ vllm.config.* classes)  │
+  │              │ ~20 validator       │ supplement   │ msgspec_lift            │
+  │              │ methods             │              │ (SamplingParams)        │
+  │              │                     │              │ dataclass_lift          │
+  │              │                     │              │ (EngineArgs)            │
+  ├──────────────┼─────────────────────┼──────────────┼─────────────────────────┤
+  │ TRT-LLM      │ BaseLlmArgs         │ SKIPPED      │ pydantic_lift           │
+  │              │ .validate_*()       │ (constructor │ (TrtLlmArgs)            │
+  │              │ ~11 validator       │ yields zero  │ dataclass_lift          │
+  │              │ methods             │ raises)      │ (BuildConfig,           │
+  │              │                     │              │  QuantConfig)           │
+  └──────────────┴─────────────────────┴──────────────┴─────────────────────────┘
+
+  Target rule count after vendor-CI gate:
+    transformers:  46 rules (shipped)
+    vLLM:          80-110 rules (target)
+    TRT-LLM:       20-28 rules (target)
+```
+
+**Why no dynamic miner for TRT-LLM:** empirical probing of `TrtLlmArgs(**kwargs)` constructors produced zero raises. TRT-LLM performs construction-time validation in a much more permissive way than transformers or vLLM; its constraints are primarily enforced in validator methods (covered by the static miner) and at engine build time (hardware-gated, not corpus rules).
+
+---
+
+## Fail-loud import contract
+
+Every miner module must declare its version envelope and validate it at import time. This is a structural contract, not a guideline.
+
+```python
+# Every *_miner.py must declare this:
+TESTED_AGAINST_VERSIONS = SpecifierSet(">=4.50,<4.60")
+
+# And call this at import time:
+check_installed_version(
+    "transformers",
+    importlib.metadata.version("transformers"),
+    TESTED_AGAINST_VERSIONS,
+)
+```
+
+If the installed library version falls outside the envelope, the miner raises `MinerVersionMismatchError` - a hard CI failure.
+
+If an expected class or method is missing from the library source (e.g. a class was renamed in a library refactor), the miner raises `MinerLandmarkMissingError` - also a hard CI failure.
+
+```
+  check_installed_version()
+       │
+       ├── version in TESTED_AGAINST_VERSIONS → continue
+       │
+       └── version out of range → MinerVersionMismatchError (CI fatal)
+
+  find_class(module, "GenerationConfig")
+       │
+       ├── class found → continue
+       │
+       └── None → MinerLandmarkMissingError (CI fatal)
+```
+
+**Why this matters:** the Haiku-era TRT-LLM extractor (PRs #415-#417, reverted in #423) silently degraded when it encountered an import error - it caught `ImportError` and returned `[]` instead of failing. The silent degradation was indistinguishable from "no rules found for this engine", which masked a broken extractor. The fail-loud contract makes that impossible.
+
+### Structural fixpoint: ensuring the contract is enforced
+
+`_fixpoint_test.py` includes a structural test that synthesises one malformed rule per gate-soundness check and asserts the vendor-CI gate records a divergence for each. This pins the three checks in place:
+
+1. `positive_raises` - `kwargs_positive` must cause the library to raise.
+2. `message_template_match` - the raised message must contain the template's static fragment.
+3. `negative_does_not_raise` - `kwargs_negative` must construct without raising.
+
+If any of the three checks is removed from `vendor_rules.compute_gate_soundness_divergences`, the corresponding case in `_fixpoint_test.py` fails loudly.
+
+---
+
+## Build corpus: merge and dedup
+
+`build_corpus.py` is the orchestration entrypoint. It runs all miners, collects staging files, merges them, deduplicates, and calls the vendor-CI gate.
+
+### Fingerprinting
+
+The deduplication key is:
+
+```python
+canonical_serialise({
+    "engine": rule.engine,
+    "severity": rule.severity,
+    "match_fields": rule.match["fields"],
+})
+```
+
+Two rules with the same fingerprint are treated as the same constraint discovered by two independent paths (cross-validation). The merger keeps one rule with the primary `added_by` source and records the secondary source in `cross_validated_by`.
+
+### Per-field merge precedence
+
+When static and dynamic miners both emit a rule with the same fingerprint, the fields are merged by source preference:
+
+| Field | Source that wins |
+|-------|-----------------|
+| `match.fields` predicate | static miner (more specific operators) |
+| `message_template` | dynamic miner (real library text) |
+| `observed_messages` | dynamic miner (real captured emissions) |
+| `kwargs_positive` / `kwargs_negative` | static miner (derived from conditional) |
+| `miner_source.line_at_scan` | static miner (real source line) |
+| `references` | union (all evidence preserved) |
+| `id` | first source's id is canonical |
+
+---
+
+## Vendor-CI gate
+
+The vendor-CI gate runs after merge. It replays every rule's `kwargs_positive` and `kwargs_negative` against the live library inside the engine's Docker container and compares observed behaviour against the declared `expected_outcome`.
+
+```
+  for each rule in merged corpus:
+       │
+       ▼
+  run_case(kwargs_positive, native_type) → CaptureBuffers
+       │
+       ├── CHECK positive_raises
+       │   CaptureBuffers.exception_type must not be None
+       │
+       ├── CHECK message_template_match
+       │   CaptureBuffers.exception_message must contain
+       │   rule.message_template (static fragment)
+       │
+       └── CHECK negative_does_not_raise
+           run_case(kwargs_negative, native_type)
+           CaptureBuffers.exception_type must be None
+       │
+       ├── all checks pass → rule confirmed → write to corpus
+       │
+       └── any check fails → rule quarantined to _failed_validation_*.yaml
+```
+
+The gate runs inside the Docker container for each engine so that the live library version used for validation matches the version the miner was built against.
+
+**Exit codes from `vendor_rules.py`:**
+- `0` - all rules confirmed.
+- `1` - one or more divergences; vendored JSON still written (for diagnostic purposes).
+- `2` - hard error (corpus malformed, engine not importable).
+
+---
+
+## Renovate-driven refresh loop
+
+Library version bumps trigger corpus regeneration automatically.
+
+```
+  ┌───────────────────────────────────────────────────────────────────┐
+  │                    RENOVATE REFRESH LOOP                          │
+  │                                                                   │
+  │  Upstream library releases new version                            │
+  │  (e.g. transformers 4.56.0 → 4.57.0)                             │
+  │               │                                                   │
+  │               ▼                                                   │
+  │  Renovate detects version bump                                    │
+  │  (weekly schedule, 3-day stability window)                        │
+  │               │                                                   │
+  │               ▼                                                   │
+  │  Renovate opens PR bumping Dockerfile ARG                         │
+  │  or PyPI version pin in requirements file                         │
+  │               │                                                   │
+  │               ▼                                                   │
+  │  config-rules-refresh.yml fires                                   │
+  │  (guarded: only Renovate PRs touching engine version files)       │
+  │               │                                                   │
+  │         ┌─────┴─────────────────────────────┐                    │
+  │         ▼                                   ▼                    │
+  │  GH-hosted runner                   Self-hosted GPU runner       │
+  │  - transformers static miner        - TRT-LLM static miner       │
+  │  - transformers dynamic miner       (CUDA-aware import required)  │
+  │  - vLLM static miner                                              │
+  │  - vLLM dynamic miner                                             │
+  │  (CPU-safe imports confirmed)                                     │
+  │         │                                   │                    │
+  │         └─────────────┬─────────────────────┘                    │
+  │                       ▼                                           │
+  │         build_corpus.py + vendor_rules.py run                    │
+  │         (inside Docker container for engine)                      │
+  │                       │                                           │
+  │                       ▼                                           │
+  │         Bot writes updated vendored JSON to PR branch             │
+  │         (llem-ci-bot GitHub App; see reference_llem_ci_bot.md)   │
+  │                       │                                           │
+  │                       ▼                                           │
+  │         CI green required before merge                            │
+  │         Divergences are P0 incidents (block merge)                │
+  │                       │                                           │
+  │                       ▼                                           │
+  │         Maintainer reviews corpus diff in PR                      │
+  │         (gate-breaking = action required before merge)            │
+  └───────────────────────────────────────────────────────────────────┘
+```
+
+### Version mismatch as CI signal
+
+When `TESTED_AGAINST_VERSIONS` in a miner module does not cover the newly bumped library version, `MinerVersionMismatchError` is raised and CI fails. This is intentional: it forces a maintainer to update the miner against the new library version before the corpus is regenerated.
+
+The update workflow:
+
+1. Renovate opens PR bumping library version.
+2. CI fires, `MinerVersionMismatchError` raised for the affected miner.
+3. Maintainer checks the library's release notes for validator changes.
+4. Maintainer updates `TESTED_AGAINST_VERSIONS` and any landmark names that changed.
+5. CI re-runs with updated miner; vendor-CI gate runs.
+6. If any rules now diverge, they are quarantined; maintainer updates the corpus.
+
+---
+
+## Two-tier CI
+
+Miners run on two runner tiers based on their import requirements.
+
+| Tier | Runner | What runs |
+|------|--------|-----------|
+| GH-hosted | `ubuntu-latest` | All static miners (pure file I/O); transformers + vLLM dynamic miners (CPU-safe imports confirmed) |
+| Self-hosted | GPU runner (closes issue #389) | TRT-LLM static miner (requires CUDA-aware `import tensorrt_llm`); the TRT-LLM Docker image `llenergymeasure:tensorrt` at pin v0.21.0 is the runtime |
+
+TRT-LLM is pinned at v0.21.0 (CUDA 12.6.x) because v1.x requires CUDA 13.x, which is not available on the current A100 (SM80) runner fleet.
+
+---
+
+## `_base.py` shared infrastructure
+
+All miners import from `scripts/miners/_base.py`. It provides:
+
+- `RuleCandidate` - the output type; fields mirror the corpus YAML schema exactly (no translation step needed).
+- `MinerSource` - `{path, method, line_at_scan}` provenance record.
+- `MinerError`, `MinerVersionMismatchError`, `MinerLandmarkMissingError` - fail-loud error hierarchy.
+- `check_installed_version` - version envelope guard.
+- `find_class`, `find_method` - AST navigation helpers.
+- `call_func_path`, `first_string_arg`, `extract_condition_fields`, `resolve_local_assign`, `extract_loop_literal_iterable` - AST extraction primitives.
+- `ConditionalRaiseDetector`, `ConditionalSelfAssignDetector`, `ConditionalWarningsWarnDetector`, `ConditionalLoggerWarningDetector`, `MinorIssuesDictAssignDetector` - pattern detectors.
+- `filter_condition_references_self`, `filter_target_is_public_field`, `filter_kwargs_positive_derivable` - false-positive guards.
+- `candidate_to_dict` - serialises `RuleCandidate` to the corpus YAML dict shape.
+
+---
+
+## Predicate-inference template coverage
+
+The seven templates were derived empirically from the transformers corpus. When the static miner encounters an AST predicate it cannot translate, it logs the dropped sub-clause (without failing). A monthly audit of the unparsed-predicate log drives empirical template expansion - templates are only added when a real rule shape appears three or more times.
+
+The templates NOT adopted from Daikon's full library: linear arithmetic ternary (`z = ax + by + c`), sortedness, sequence-equality. These cover scientific-computing trace patterns not seen in engine config classes.
+
+---
+
+## See also
+
+- [architecture-overview.md](architecture-overview.md) - system overview and data-flow
+- [validation-rule-corpus.md](validation-rule-corpus.md) - corpus YAML format reference
+- [extending-miners.md](extending-miners.md) - how to add a new engine miner
+- [parameter-discovery.md](parameter-discovery.md) - runtime validation pipeline
+- [research-context.md](research-context.md) - academic positioning
+- [engines.md](engines.md) - engine configuration reference
+- [schema-refresh.md](schema-refresh.md) - Renovate-driven schema refresh

--- a/docs/parameter-curation.md
+++ b/docs/parameter-curation.md
@@ -1,6 +1,6 @@
 # Parameter Curation
 
-> **Note:** This document covers the programmatic parameter-discovery pipeline for engine API parameters (what fields each engine accepts, type information, drift detection). For the config **validation** pipeline (how invalid parameter combinations are caught before engine initialisation), see [parameter-discovery.md](parameter-discovery.md).
+> **Note:** This document covers engine-API-parameter introspection and Pydantic-model curation (what fields each engine accepts, type information, drift detection). For the runtime validation of parameter *values* (how invalid combinations are caught before engine initialisation), see [parameter-discovery.md](parameter-discovery.md).
 
 ---
 

--- a/docs/parameter-curation.md
+++ b/docs/parameter-curation.md
@@ -1,5 +1,9 @@
 # Parameter Curation
 
+> **Note:** This document covers the programmatic parameter-discovery pipeline for engine API parameters (what fields each engine accepts, type information, drift detection). For the config **validation** pipeline (how invalid parameter combinations are caught before engine initialisation), see [parameter-discovery.md](parameter-discovery.md).
+
+---
+
 llem exposes engine parameters to users through hand-authored Pydantic models. This document explains how those models stay in sync with the underlying engines.
 
 ---
@@ -31,7 +35,7 @@ llem exposes engine parameters to users through hand-authored Pydantic models. T
 
 `scripts/discover_*.py` introspects each engine's public Python API (e.g. `inspect.signature(vllm.LLM.__init__)`, `inspect.signature(AutoModelForCausalLM.from_pretrained)`) and writes the result to `src/llenergymeasure/config/discovered_schemas/{engine}.json`.
 
-These JSON files are the ground truth for "what parameters does this engine version accept". They are vendored into the repo and regenerated via the schema-refresh pipeline when an engine version bumps (see `docs/schema-refresh.md`).
+These JSON files are the ground truth for "what parameters does this engine version accept". They are vendored into the repo and regenerated via the schema-refresh pipeline when an engine version bumps (see [schema-refresh.md](schema-refresh.md)).
 
 ---
 
@@ -82,3 +86,11 @@ These are listed in `LLEM_NATIVE_FIELDS` in the drift checker. Each entry suppre
 **When to remove an entry:** when the corresponding Pydantic field is deleted. Stale entries are harmless but misleading — remove them during the same PR that removes the field.
 
 **Never add an entry to paper over a naming divergence.** If a Pydantic field is named differently from the engine kwarg, rename the field instead.
+
+---
+
+## See also
+
+- [parameter-discovery.md](parameter-discovery.md) - config validation pipeline (how invalid combinations are caught)
+- [schema-refresh.md](schema-refresh.md) - Renovate-driven schema refresh
+- [engines.md](engines.md) - engine configuration reference

--- a/docs/parameter-discovery.md
+++ b/docs/parameter-discovery.md
@@ -1,0 +1,321 @@
+# Parameter Discovery and Config Validation
+
+This document covers the runtime config-validation pipeline: how a user's `ExperimentConfig` is evaluated against the vendored rule corpus, what the loader grammar means, and what happens when a rule fires.
+
+**Audience:** end users debugging a rejected config; extenders writing new corpus rules; anyone wanting to understand the error messages llem produces.
+
+For the compile-time side (how the corpus is built), see [miner-pipeline.md](miner-pipeline.md).
+
+---
+
+## Why configs are rejected before engine initialisation
+
+Engine initialisation is expensive: model weights load from disk, CUDA contexts initialise, and TensorRT-LLM may need to compile an engine (minutes). A rejected config discovered after two minutes of initialisation wastes GPU time.
+
+llem evaluates each submitted `ExperimentConfig` against a pre-computed corpus of validation rules before the engine starts. Invalid combinations are caught at config-parse time - milliseconds, not minutes.
+
+---
+
+## Data flow: user config to validation result
+
+```
+  User submits config
+  (YAML file, CLI flags, or Python API)
+               │
+               ▼
+  ExperimentConfig (Pydantic model)
+  parsed and validated by Pydantic
+               │
+               ▼
+  @model_validator in config/models.py
+  calls load_rules_for_engine(engine)
+               │
+               ▼
+  loader.py: parse vendored JSON
+  ┌─────────────────────────────────────────┐
+  │  VendoredRules                          │
+  │  engine: "transformers"                 │
+  │  schema_version: "1.0.0"               │
+  │  rules: [Rule, Rule, Rule, ...]         │
+  └─────────────────────────────────────────┘
+               │
+               ▼
+  for each Rule in rules:
+    Rule.try_match(config)
+               │
+               ├── None (predicate did not fire) → skip
+               │
+               └── RuleMatch (predicate fired)
+                       │
+                       ├── severity: "error"
+                       │   → raise ConfigurationError with message
+                       │
+                       ├── severity: "warn"
+                       │   → emit warning to user
+                       │
+                       └── severity: "dormant"
+                           → annotate config
+                           → log "field X will be silently
+                              ignored or normalised by the engine"
+```
+
+---
+
+## The loader grammar
+
+The `match.fields` section of each corpus rule contains predicates expressed in a small domain-specific grammar. The loader's `evaluate_predicate()` function implements it.
+
+### Grammar tree
+
+```
+  match.fields value types
+  ─────────────────────────
+  bare value                   field == value  (equality shorthand)
+  dict with operator keys:
+  ├── comparison
+  │   ├── "=="  / "equals"     equality
+  │   ├── "!="  / "not_equal"  inequality
+  │   ├── "<"                  less-than
+  │   ├── "<="                 less-than-or-equal
+  │   ├── ">"                  greater-than
+  │   └── ">="                 greater-than-or-equal
+  │
+  ├── membership
+  │   ├── "in"                 value in [v1, v2, ...]
+  │   └── "not_in"             value not in [v1, v2, ...]
+  │
+  ├── presence
+  │   ├── "present"            field is not None
+  │   └── "absent"             field is None
+  │
+  ├── type check
+  │   ├── "type_is"            type(field).__name__ in name_set
+  │   └── "type_is_not"        type(field).__name__ not in name_set
+  │
+  └── cross-field divisibility
+      ├── "divisible_by"       a % b == 0
+      └── "not_divisible_by"   a % b != 0  (b=0 → False, no rule fires)
+```
+
+### Field path resolution
+
+Field paths are dotted strings resolved against the config model attribute by attribute:
+
+```yaml
+match:
+  fields:
+    transformers.sampling.num_beams:
+      ">": 1
+    transformers.sampling.num_beam_groups:
+      ">": 1
+```
+
+- `transformers.sampling.num_beams` resolves as `config.transformers.sampling.num_beams`.
+- Pydantic models, dataclasses, and plain dicts are all supported.
+- A missing attribute at any path segment yields `None` - the predicate does not fire (rules do not produce false positives on configs that simply lack a field).
+
+### `@field_ref` cross-field references
+
+Operator values may be `@field_path` strings, which are resolved against the same config before evaluation. This is how cross-field constraints are expressed:
+
+```yaml
+match:
+  fields:
+    transformers.sampling.num_beams:
+      not_divisible_by: "@num_beam_groups"
+```
+
+`@num_beam_groups` resolves as a sibling field (relative to `transformers.sampling.num_beams`'s parent namespace). Dotted refs (e.g. `@transformers.sampling.num_beam_groups`) resolve from the config root.
+
+### Loader grammar examples
+
+```yaml
+# Single-field range: temperature must be positive
+match:
+  fields:
+    vllm.sampling.temperature:
+      ">": 0.0
+
+# Value allowlist: cache_implementation must be one of these
+match:
+  fields:
+    transformers.sampling.cache_implementation:
+      in: ["static", "sliding_window", "hybrid"]
+
+# Cross-field divisibility: num_beams must divide evenly by num_beam_groups
+match:
+  fields:
+    transformers.sampling.num_beams:
+      not_divisible_by: "@num_beam_groups"
+
+# Multi-field gate: rule fires only when both conditions hold
+match:
+  fields:
+    transformers.sampling.num_beams:
+      ">": 1
+    transformers.sampling.diversity_penalty:
+      "==": 0.0
+
+# Type check: field must be a float, not an int
+match:
+  fields:
+    transformers.sampling.temperature:
+      type_is_not: "int"
+```
+
+---
+
+## Severity levels
+
+Each rule has a severity that determines how the loader responds when the predicate fires.
+
+```
+  severity: "error"
+  ├── The engine raises if the config is submitted as-is.
+  └── Loader raises ConfigurationError before engine initialisation.
+      Message template is rendered with declared_value substituted.
+      Example: "num_beams (2) is not divisible by num_beam_groups (3)"
+
+  severity: "warn"
+  ├── The engine announces a suboptimal setting but still proceeds.
+  └── Loader emits a warning to the user.
+      Example: "temperature=0 with do_sample=True; engine will warn"
+
+  severity: "dormant"
+  ├── The engine silently normalises or ignores the field.
+  │   The user's declared value is not the effective value.
+  └── Loader annotates the config:
+      "field X will be silently coerced by the engine to Y"
+      Example: "seed=-1 will be normalised to None by the engine"
+```
+
+### Dormant rules: the "silent surprise" class
+
+`dormant` rules are the most subtle. They describe configurations where the engine accepts the value but silently normalises it to something else. Without the corpus, the user would submit `seed=-1`, not see any error, and later discover the seed was ignored.
+
+The `expected_outcome.normalised_fields` list in a dormant rule tells the loader which fields are affected. The fixpoint contract (`_fixpoint_test.py`) asserts that applying dormant rules to a config converges to a stable state - no two dormant rules should conflict by normalising the same field to different values under the same conditions.
+
+---
+
+## Error messages
+
+When a rule fires at `error` severity, the loader renders the rule's `message_template` using field values from the matched config.
+
+Template substitution variables:
+- `{declared_value}` - the value of the triggering field.
+- `{effective_value}` - the normalised value (dormant rules only).
+- `{rule_id}` - the rule's identifier.
+- Any `match.fields` key - the actual field value.
+
+Example error message from the corpus:
+
+```
+ConfigurationError: `diversity_penalty` is not 0.0 or `num_beam_groups` is
+not 1, triggering group beam search. In this generation mode,
+`diversity_penalty` should be greater than `0.0`, otherwise your groups will
+be identical.
+```
+
+If no template is available, the loader falls back to `[{rule_id}] <no message template>` rather than raising silently.
+
+---
+
+## Library version resolution
+
+The vendored JSON carries the engine version the corpus was validated against. When the loader loads the vendored JSON:
+
+1. It checks `schema_version` major against `SUPPORTED_MAJOR_VERSION`. A major-version mismatch raises `UnsupportedSchemaVersionError` (the package is incompatible with the installed corpus version).
+2. It parses all rules with strict enum validation: unknown `added_by` values raise `UnknownAddedByError`; unknown severity values raise `UnknownSeverityError`.
+
+The loader does not check whether the currently installed engine library version matches the corpus version. That alignment is enforced at corpus-build time (the miner's `TESTED_AGAINST_VERSIONS` + `check_installed_version`) and at runtime via the engine's own constructor validation.
+
+---
+
+## Gap reporting
+
+When a user submits a config combination that no rule in the corpus addresses, no validation fires - the combination passes through. This is by design (the corpus is recall-first, not exhaustive), but it means some invalid combinations are caught only by the engine constructor.
+
+Gap reporting surfaces these at the `dormant` level or via a separate gap-detection pipeline. When a `gap_detected: true` group appears in experiment results, it indicates the config combination triggered a library-side normalisation that the corpus did not yet describe.
+
+Extending the corpus to cover new gap classes is done by adding a miner cluster or a `manual_seed` rule. See [extending-miners.md](extending-miners.md).
+
+---
+
+## Corpus vs vendored JSON: the two-file structure
+
+The corpus YAML (`configs/validation_rules/{engine}.yaml`) is the authoritative human-reviewable format. The vendored JSON (`src/llenergymeasure/config/vendored_rules/{engine}.json`) is the CI-validated version that ships with the package.
+
+```
+  YAML corpus                         Vendored JSON
+  ─────────────────────────────────   ─────────────────────────────────
+  Human-reviewable                    Machine-parsed only
+  Source of truth (git-tracked)       Output of vendor_rules.py
+  Carries declared expected_outcome   Carries observed outcomes (CI run)
+  Read by vendor_rules.py             Read by loader.py at runtime
+  Regenerated by miners               Regenerated by vendor_rules.py
+  In configs/validation_rules/        In src/.../vendored_rules/
+```
+
+The loader overlays vendored observations onto the corpus so downstream consumers see CI-validated truth. When the vendored JSON is absent (e.g. in a local development environment without a vendor run), the loader falls back to the YAML corpus.
+
+---
+
+## Loader API
+
+The loader is in `src/llenergymeasure/config/vendored_rules/loader.py`.
+
+```python
+from llenergymeasure.config.vendored_rules.loader import (
+    VendoredRules,
+    Rule,
+    RuleMatch,
+    load_rules_for_engine,   # → VendoredRules
+    evaluate_predicate,       # → bool
+)
+
+# Load corpus for an engine
+rules = load_rules_for_engine("transformers")
+
+# Match against a config
+for rule in rules.rules:
+    match = rule.try_match(config)
+    if match is not None:
+        print(rule.severity, rule.render_message(match))
+```
+
+Per-instance caching in `load_rules_for_engine` ensures the corpus JSON is parsed once per engine per process. Tests can disable caching for isolation.
+
+---
+
+## Troubleshooting: common error messages
+
+### "ConfigurationError: `num_beams` is not divisible by `num_beam_groups`"
+
+Rule: `transformers_beam_search_num_beams_not_divisible_by_num_beam_groups`
+
+The transformers engine requires `num_beams` to be an exact multiple of `num_beam_groups` for group beam search. Set both to compatible values: e.g. `num_beams=4, num_beam_groups=2`.
+
+### "ConfigurationError: `diversity_penalty` is not 0.0 or `num_beam_groups` is not 1..."
+
+Rule: `transformers_beam_search_diversity_penalty_eq_0p0`
+
+When `num_beams > 1` and `num_beam_groups > 1` (group beam search mode), `diversity_penalty` must be greater than 0.0. Set `diversity_penalty` to a positive value, or disable group beam search.
+
+### "Warning: field `seed` will be silently normalised to None by the engine"
+
+Rule: a dormant rule matching `seed=-1`. The engine treats -1 as "no seed" and normalises it to `None`. Set an explicit non-negative seed, or leave the field unset.
+
+### "UnsupportedSchemaVersionError"
+
+The vendored JSON in the installed package was built with a schema major version the current loader does not understand. This indicates a library/package version mismatch. Update llenergymeasure to the version that matches your installed engines.
+
+---
+
+## See also
+
+- [architecture-overview.md](architecture-overview.md) - system overview
+- [validation-rule-corpus.md](validation-rule-corpus.md) - corpus YAML format reference
+- [miner-pipeline.md](miner-pipeline.md) - how the corpus is built
+- [extending-miners.md](extending-miners.md) - adding new rules
+- [engines.md](engines.md) - engine configuration reference
+- [troubleshooting.md](troubleshooting.md) - general troubleshooting guide

--- a/docs/parameter-discovery.md
+++ b/docs/parameter-discovery.md
@@ -27,8 +27,8 @@ llem evaluates each submitted `ExperimentConfig` against a pre-computed corpus o
   parsed and validated by Pydantic
                │
                ▼
-  @model_validator in config/models.py
-  calls load_rules_for_engine(engine)
+  _apply_vendored_rules in config/models.py
+  calls VendoredRulesLoader().load_rules(engine)
                │
                ▼
   loader.py: parse vendored JSON
@@ -48,7 +48,8 @@ llem evaluates each submitted `ExperimentConfig` against a pre-computed corpus o
                └── RuleMatch (predicate fired)
                        │
                        ├── severity: "error"
-                       │   → raise ConfigurationError with message
+                       │   → raise ValueError (Pydantic surfaces it
+                       │     as ValidationError) with message
                        │
                        ├── severity: "warn"
                        │   → emit warning to user
@@ -172,7 +173,8 @@ Each rule has a severity that determines how the loader responds when the predic
 ```
   severity: "error"
   ├── The engine raises if the config is submitted as-is.
-  └── Loader raises ConfigurationError before engine initialisation.
+  └── Loader raises ValueError before engine initialisation.
+      Pydantic surfaces it to the user as a ValidationError.
       Message template is rendered with declared_value substituted.
       Example: "num_beams (2) is not divisible by num_beam_groups (3)"
 
@@ -210,7 +212,7 @@ Template substitution variables:
 Example error message from the corpus:
 
 ```
-ConfigurationError: `diversity_penalty` is not 0.0 or `num_beam_groups` is
+ValidationError: `diversity_penalty` is not 0.0 or `num_beam_groups` is
 not 1, triggering group beam search. In this generation mode,
 `diversity_penalty` should be greater than `0.0`, otherwise your groups will
 be identical.
@@ -267,14 +269,14 @@ The loader is in `src/llenergymeasure/config/vendored_rules/loader.py`.
 ```python
 from llenergymeasure.config.vendored_rules.loader import (
     VendoredRules,
+    VendoredRulesLoader,
     Rule,
     RuleMatch,
-    load_rules_for_engine,   # → VendoredRules
-    evaluate_predicate,       # → bool
 )
 
 # Load corpus for an engine
-rules = load_rules_for_engine("transformers")
+loader = VendoredRulesLoader()
+rules = loader.load_rules("transformers")
 
 # Match against a config
 for rule in rules.rules:
@@ -283,19 +285,19 @@ for rule in rules.rules:
         print(rule.severity, rule.render_message(match))
 ```
 
-Per-instance caching in `load_rules_for_engine` ensures the corpus JSON is parsed once per engine per process. Tests can disable caching for isolation.
+For higher-level use cases, see `llenergymeasure.api.report_gaps.load_rules_corpus`, which loads all configured engines via a shared loader. Per-instance caching in `VendoredRulesLoader` ensures the corpus JSON is parsed once per engine per process; tests can construct a fresh loader for isolation.
 
 ---
 
 ## Troubleshooting: common error messages
 
-### "ConfigurationError: `num_beams` is not divisible by `num_beam_groups`"
+### "ValidationError: `num_beams` is not divisible by `num_beam_groups`"
 
 Rule: `transformers_beam_search_num_beams_not_divisible_by_num_beam_groups`
 
 The transformers engine requires `num_beams` to be an exact multiple of `num_beam_groups` for group beam search. Set both to compatible values: e.g. `num_beams=4, num_beam_groups=2`.
 
-### "ConfigurationError: `diversity_penalty` is not 0.0 or `num_beam_groups` is not 1..."
+### "ValidationError: `diversity_penalty` is not 0.0 or `num_beam_groups` is not 1..."
 
 Rule: `transformers_beam_search_diversity_penalty_eq_0p0`
 

--- a/docs/research-context.md
+++ b/docs/research-context.md
@@ -1,0 +1,187 @@
+# Research Context: Invariant Mining for ML Engine Configs
+
+This document positions the LLenergyMeasure invariant miner pipeline relative to the academic literature. It is written for paper readers, peer reviewers, and researchers interested in the contribution beyond the practical tooling.
+
+**For end users or extenders**, the [architecture-overview.md](architecture-overview.md), [miner-pipeline.md](miner-pipeline.md), and [extending-miners.md](extending-miners.md) are more directly useful.
+
+---
+
+## What we are doing (in one sentence)
+
+We mine configuration constraint invariants from ML inference engine config classes by combining static AST analysis of validator method bodies with dynamic combinatorial constructor probing, and we emit a versioned corpus of structured constraints that is re-validated against the live library on every library version bump.
+
+---
+
+## The nearest prior art
+
+### 1. Daikon (Ernst et al., 2001) - canonical dynamic invariant detection
+
+Daikon is the direct ancestor of our approach at the predicate-inference stage. It runs an instrumented program, observes variable values at function entry/exit and loop heads, and matches observations against a fixed template library (`x > 0`, `x % y == 0`, `x in {a,b,c}`, etc.).
+
+**Where we converge with Daikon:**
+- Same template-based predicate inference loop (we use seven templates; Daikon uses dozens).
+- Same recall-first strategy: emit all matching candidates, prune false positives via an external checker.
+- Same splitter-predicate structure: `condition ⇒ invariant` (HF's dormancy mode gates like "if do_sample=False then temperature is dormant" are structurally identical to Daikon splitter predicates).
+
+**Where we diverge:**
+- Our "execution traces" are constructor-call outcomes (raises/no-raise), not variable value traces at function entry/exit. Daikon instruments a running program; we probe a class constructor.
+- Our checker is the live vendor library (authoritative ground truth). Daikon's checker is a theorem prover (Simplify/ESC/Java). Ours is more accurate because the library is the spec; no SMT approximation.
+- We deliberately do not implement Daikon's statistical confidence scoring. Daikon computes `P(invariant arises by chance)` and applies a threshold. We remove the `confidence` field entirely: the vendor-CI gate is binary (rule passes or is quarantined). A confidence score that informs no downstream decision is dead weight in the corpus.
+
+**Citation:** Ernst, M.D., Cockrell, J., Griswold, W.G., and Notkin, D. (2001). *Dynamically discovering likely program invariants to support program evolution.* IEEE TSE 27(2):1-25.
+
+### 2. Houdini (Flanagan & Leino, FME 2001) - the canonical guess-and-check pattern
+
+Houdini generates a large set of candidate annotations from heuristic templates (e.g. `f != null` for every reference field, `i ≥ 0` for every int field), then asks a checker (ESC/Java + SMT) which survive verification. It iterates to a fixpoint: remove refuted candidates, recheck, repeat.
+
+This is exactly our pipeline:
+- **Houdini guess** ≡ our miner emit (recall-first, all plausible candidates).
+- **ESC/Java check** ≡ our vendor-CI prune (replay against live library).
+- **Fixpoint** ≡ `_fixpoint_test.py` (asserts dormant rules converge to a stable normalisation state).
+
+The Houdini correctness theorem proves the inferred annotation set is the *unique maximal valid subset* of the candidate set, modulo soundness of the checker. Our corpus is the maximal valid subset of miner candidates modulo the vendor-CI gate's soundness.
+
+Our `_fixpoint_test.py` pins the gate-soundness contract in place: it synthesises malformed rules and asserts the gate fails loudly on each, so that a future refactor cannot silently weaken the gate without breaking CI.
+
+**Citation:** Flanagan, C. and Leino, K.R.M. (2001). *Houdini, an annotation assistant for ESC/Java.* FME 2001, LNCS 2021, pp. 500-517.
+
+### 3. NeuRI (FSE 2023) - the closest ML-library framing
+
+NeuRI mines constraints for neural network operator APIs by generating valid and invalid traces, then using inductive synthesis to infer input constraints. It is the most direct analogue to our approach in the ML-library literature.
+
+**Mapping to our pipeline:**
+- NeuRI's "valid + invalid trace pairs" ≡ our `(kwargs_positive, kwargs_negative)` pairs in each corpus rule.
+- NeuRI's inductive synthesis step ≡ our predicate-inference templates (we use a simpler template-matching approach; NeuRI uses full inductive synthesis which generalises better to quantified constraints but costs more).
+- NeuRI operates on operator kernel APIs (shapes, dtypes, device constraints). We operate on config-class constructor APIs (field ranges, cross-field relationships, mode gating).
+
+**Where we are novel relative to NeuRI:** vLLM and TRT-LLM are uncharted at the config layer. The PyTorch-fuzz lineage (NeuRI, NNSmith, DocTer, FreeFuzz, DeepREL, TitanFuzz, DeepConstr, ConFL) targets operator kernels. We target the config classes that sit above those kernels and govern how a deployment is parameterised - a distinct and previously unmapped constraint space.
+
+**Citation:** Luo, Y., Hu, S., Shi, X., et al. (2023). *NeuRI: Diversifying DNN Generation via Inductive Rule Inference.* ESEC/FSE 2023.
+
+### 4. Configuration constraint mining (Hadoop, Linux kernel corpus studies)
+
+The "configuration mining" literature (e.g. Rabkin & Katz, ASE 2011; Jin et al., FSE 2014) mines real-world deployed config files to discover constraints that users satisfy in practice. Our approach is distinct:
+
+- We mine **library-source validation logic**, not deployed config files.
+- We produce a **constraint corpus** (formal predicates with test cases), not a frequency analysis.
+- Our constraints are derived from the library's enforcement mechanism, not from statistical patterns in user configurations.
+
+The closest label for our approach: **configuration constraint mining at the API layer**, or **API configuration constraint inference**.
+
+### 5. DocTer (ISSTA 2022) - doc-guided constraint mining
+
+DocTer extracts input constraints for deep learning APIs by parsing API documentation and natural language descriptions. It uses a dependency parser + constraint pattern matcher on docstrings.
+
+**Comparison:** DocTer mines documentation; we mine source code. Documentation describes intent; source code describes enforcement. For config classes where the enforcement is in validator method bodies (all three of our target engines), source mining is more accurate. DocTer's approach is complementary for cases where constraints are documented but not enforced in parseable code.
+
+**Citation:** Xie, D., Li, Y., Pham, N., et al. (2022). *DocTer: Documentation-Guided Fuzzing for Testing Deep Learning API Functions.* ISSTA 2022.
+
+---
+
+## What we are NOT doing
+
+### Not differential testing
+
+Differential testing compares two implementations to observe behavioural divergence. We probe a single implementation. Our `kwargs_positive` / `kwargs_negative` pairs are evidence for one rule's predicate, not a comparison between two systems.
+
+### Not metamorphic testing
+
+Metamorphic testing requires a stated input/output relation (e.g. `f(x+1) ≥ f(x)` for a monotone function). We do not define metamorphic relations. Our predicate inference is inductive from observed behaviour, not deductive from a stated relation.
+
+### Not static analysis of tensor shapes
+
+PyTea (PLDI 2022) translates Python tensor-shape preconditions into Z3 constraints for static verification. Our static miner also does AST-to-constraint translation, but for scalar config values (ranges, allowlists, cross-field arithmetic) not tensor shapes. The Z3-backed path exhaustion approach PyTea takes is not applicable to our setting: our constraints involve Pydantic v2 internals and Rust-backed validators that Z3 cannot model.
+
+### Not LLM-assisted mining
+
+DeepConstr (ISSTA 2024) uses an LLM as a constraint hypothesiser: it generates candidate constraints in natural language, which are then validated against the library. We explicitly do not use LLMs anywhere in the pipeline. Reasons:
+
+1. The corpus build runs in CI, which may be air-gapped or have no API access.
+2. LLM providers deprecate model versions; a model fingerprint is not permanent. A Renovate-driven library bump that fires in CI three months from now must produce a reproducible corpus diff.
+3. The pipeline must be a pure function of (library SHA, library version, miner code, probe seed). An LLM call introduces a dependency on a third-party API whose output is not reproducible under this definition.
+
+---
+
+## The novel contribution at the type-system level
+
+The lift modules (`_pydantic_lift.py`, `_msgspec_lift.py`, `_dataclass_lift.py`) represent a contribution not present in the prior-art literature: extracting configuration constraints directly from the Python type-system metadata of ML library config classes.
+
+```
+  Type-system metadata → constraint corpus
+
+  Pydantic v2 FieldInfo.metadata:
+    Gt(0), Le(1), MultipleOf(64)
+    → corpus rules at operator granularity
+    → aligns operator vocabulary with annotated-types standard (Gt, Le, etc.)
+
+  msgspec Meta(ge=, le=, ...):
+    → same corpus operator vocabulary
+    → unified with Pydantic lift output
+
+  stdlib Literal[...] annotations:
+    → value-allowlist corpus rules
+    → no probing required; purely type-structure derived
+```
+
+The prior-art tools (NeuRI, DocTer, FreeFuzz, etc.) all operate at the runtime-trace level. None of them exploit the type-system metadata that modern Python ML libraries expose through Pydantic v2, msgspec, and `annotated-types`. This is a Tier-1 adoption opportunity that our pipeline is the first (to our knowledge) to realise in the config-constraint-mining context.
+
+The lift output is deterministic: no probing, no randomness, pure function of the class definition. Rules derived from type-system metadata are the most reliable in the corpus because the type system itself is the spec.
+
+---
+
+## The fail-loud import contract as a design contribution
+
+The Haiku-era TRT-LLM extractor (PRs #415-#417, reverted in #423) demonstrated a failure mode not discussed in the prior-art literature: a miner that silently degraded on import errors. When `LlmConfig` (a class that does not exist in TRT-LLM 0.21.0) failed to import, the extractor caught the `ImportError` and returned `[]`. The empty return was indistinguishable from "no rules found for this engine".
+
+The fail-loud import contract - `TESTED_AGAINST_VERSIONS` + `check_installed_version` + `MinerLandmarkMissingError` - makes silent coverage loss impossible. This is a design contribution specifically for the setting where the miner is a CI artefact that runs against a pinned library version: the version pin and the landmark check together guarantee that a miner either mines at the version it was tested against or fails loudly.
+
+---
+
+## The fixpoint contract
+
+`_fixpoint_test.py` implements what we call a **gate-soundness fixpoint**: a structural test that synthesises malformed rules and asserts the vendor-CI gate records a divergence for each. The three checks it pins:
+
+1. `positive_raises` - `kwargs_positive` must trigger the rule.
+2. `message_template_match` - the raised message must contain the template fragment.
+3. `negative_does_not_raise` - `kwargs_negative` must not trigger.
+
+This is inspired by the Houdini fixpoint concept but applied to the soundness of the checker itself rather than the convergence of the annotation set. Without the gate-soundness fixpoint, a future maintainer could remove one of the three checks "just to get CI green" without understanding the consequences.
+
+The dormant-rule fixpoint (also in `_fixpoint_test.py`) asserts that applying the corpus's dormant rules to a config state converges to a stable fixed point: idempotent, order-independent, cycle-free. This is a necessary condition for the library-resolution mechanism in the runtime pipeline to be well-defined.
+
+---
+
+## Positioning statement
+
+Our approach is best described as: **API configuration constraint mining via static AST analysis and dynamic constructor probing, with type-system lifting and a live-library vendor-CI gate, in the Houdini guess-and-check tradition.**
+
+The nearest citation cluster: Daikon (inference), Houdini (guess-and-check architecture), NeuRI (ML-library framing). The key novelties:
+
+1. Type-system lifting at the `pydantic` / `msgspec` / `dataclass` level (no analogues in prior art).
+2. The fail-loud import contract for pinned-version miners in CI pipelines.
+3. The gate-soundness fixpoint contract as a structural regression test.
+4. Application to **config-class APIs** (vLLM `SamplingParams`, TRT-LLM `TrtLlmArgs`) rather than operator kernel APIs - a previously uncharted constraint space.
+
+---
+
+## Citation shortlist for any write-up
+
+| Reference | Why it matters |
+|-----------|----------------|
+| Ernst et al. (2001), Daikon TSE | Predicate-template inference ancestor |
+| Flanagan & Leino (2001), Houdini FME | Recall-first emit + checker-prune architecture |
+| Luo et al. (2023), NeuRI FSE | ML-library framing; valid+invalid trace pairing |
+| Xie et al. (2022), DocTer ISSTA | Documentation-guided constraint mining (contrast point) |
+| Dwarakanath et al. (2018), PreInfer DSN | Quantified precondition inference (adjacent; we don't need this yet) |
+| DeepConstr (ISSTA 2024) | LLM-assisted constraint hypothesiser (contrast point: we don't use LLMs) |
+| PyTea (PLDI 2022) | Static tensor-shape analysis with Z3 (contrast point: different domain) |
+
+---
+
+## See also
+
+- [architecture-overview.md](architecture-overview.md) - system overview
+- [miner-pipeline.md](miner-pipeline.md) - implementation details
+- [validation-rule-corpus.md](validation-rule-corpus.md) - corpus format
+- `.product/research/miners-redo/research-prior-art-miners-2026-04-26.md` - full prior-art survey (internal)
+- `.product/designs/invariant-miner-design-2026-04-26.md` - locked design (internal)

--- a/docs/research-context.md
+++ b/docs/research-context.md
@@ -172,7 +172,7 @@ The nearest citation cluster: Daikon (inference), Houdini (guess-and-check archi
 | Flanagan & Leino (2001), Houdini FME | Recall-first emit + checker-prune architecture |
 | Luo et al. (2023), NeuRI FSE | ML-library framing; valid+invalid trace pairing |
 | Xie et al. (2022), DocTer ISSTA | Documentation-guided constraint mining (contrast point) |
-| Dwarakanath et al. (2018), PreInfer DSN | Quantified precondition inference (adjacent; we don't need this yet) |
+| Astorga et al. (2018), PreInfer DSN | Quantified precondition inference (adjacent; we don't need this yet) |
 | DeepConstr (ISSTA 2024) | LLM-assisted constraint hypothesiser (contrast point: we don't use LLMs) |
 | PyTea (PLDI 2022) | Static tensor-shape analysis with Z3 (contrast point: different domain) |
 
@@ -183,5 +183,8 @@ The nearest citation cluster: Daikon (inference), Houdini (guess-and-check archi
 - [architecture-overview.md](architecture-overview.md) - system overview
 - [miner-pipeline.md](miner-pipeline.md) - implementation details
 - [validation-rule-corpus.md](validation-rule-corpus.md) - corpus format
-- `.product/research/miners-redo/research-prior-art-miners-2026-04-26.md` - full prior-art survey (internal)
-- `.product/designs/invariant-miner-design-2026-04-26.md` - locked design (internal)
+
+Internal-only design artefacts (not in the public package):
+
+- `.product/research/miners-redo/research-prior-art-miners-2026-04-26.md` - full prior-art survey
+- `.product/designs/invariant-miner-design-2026-04-26.md` - locked design

--- a/docs/schema-refresh.md
+++ b/docs/schema-refresh.md
@@ -176,3 +176,5 @@ via path-based triggers (`docker/Dockerfile.*`).
 
 - [Docker Setup](docker-setup.md) - building engine images locally
 - [Engine Configuration](engines.md) - configuring engine parameters
+- [Miner Pipeline](miner-pipeline.md) - how the validation-rule corpus is regenerated alongside parameter schemas on library bumps
+- [Architecture Overview](architecture-overview.md) - full system context

--- a/docs/validation-rule-corpus.md
+++ b/docs/validation-rule-corpus.md
@@ -1,0 +1,340 @@
+# Validation Rule Corpus Format
+
+This document is the reference for the YAML corpus format: what each field means, valid values, and how to read an existing rule.
+
+**Audience:** maintainers writing or reviewing corpus rules; extenders adding rules for new engines; anyone debugging a rule that behaves unexpectedly.
+
+---
+
+## File locations
+
+```
+  configs/validation_rules/
+  ├── transformers.yaml          Authoritative corpus - human-reviewable, git-tracked
+  └── _staging/
+      ├── transformers_static_miner.yaml   Per-miner staging output (not committed)
+      ├── transformers_dynamic_miner.yaml
+      └── _failed_validation_transformers.yaml  Quarantined rules
+
+  src/llenergymeasure/config/vendored_rules/
+  ├── transformers.json          Vendored observations - ships with package
+  └── loader.py                  Runtime consumer
+```
+
+---
+
+## Top-level corpus envelope
+
+```yaml
+schema_version: 1.0.0          # Major version must match loader's SUPPORTED_MAJOR_VERSION
+engine: transformers            # Engine name; must match a known engine key
+engine_version: 4.56.0         # Library version the corpus was mined and validated against
+mined_at: '2026-04-25T18:01:18Z'  # ISO 8601 timestamp of last full mine run
+rules:
+  - ...                          # List of rule entries
+```
+
+---
+
+## Rule schema: annotated example
+
+Below is a complete rule from the transformers corpus with every field annotated.
+
+```yaml
+- id: transformers_beam_search_num_beams_not_divisible_by_num_beam_groups
+  # Unique identifier for this rule.
+  # Convention: {engine}_{subject_field}_{condition_slug}
+  # Used as the key in divergence reports and error messages.
+
+  engine: transformers
+  # Engine this rule applies to.
+  # Must match the corpus envelope's engine field.
+
+  library: transformers
+  # Python package name (importlib.metadata.version uses this).
+  # Matches engine for single-library engines;
+  # may differ for engines that alias a library.
+
+  rule_under_test: "GenerationConfig.__init__ flags `num_beams` (num beams not divisible by num beam groups)"
+  # Human-readable description of what library behaviour this rule captures.
+  # Format: {NativeType}.{method} flags {field} ({condition})
+
+  severity: error
+  # One of: error | warn | dormant
+  # error    - engine raises; loader rejects before initialisation
+  # warn     - engine announces; loader warns the user
+  # dormant  - engine silently normalises; loader annotates the config
+
+  native_type: transformers.GenerationConfig
+  # The fully-qualified class name the rule's predicate applies to.
+  # Used by the vendor-CI gate to know which class to instantiate.
+
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    # Relative path within the library's source tree.
+    method: __init__
+    # Method name where the AST detector found this rule.
+    line_at_scan: 361
+    # Line number in the source at mined_at time.
+    # Will drift when the library is updated; used for human inspection only.
+
+  match:
+    engine: transformers
+    # Must match rule.engine (redundant, for grep-ability).
+    fields:
+      transformers.sampling.num_beams:
+        not_divisible_by: "@num_beam_groups"
+      # Field paths are dotted, resolved against ExperimentConfig.
+      # Operator: not_divisible_by - fires when a % b != 0.
+      # @num_beam_groups is a @field_ref: resolved as a sibling field.
+
+  kwargs_positive:
+    num_beams: 2
+    num_beam_groups: 3
+    # kwargs that trigger the rule (should cause the engine to raise/warn/normalise).
+    # Passed directly to the native_type constructor in the vendor-CI gate.
+    # 2 is not divisible by 3, so the rule fires.
+
+  kwargs_negative:
+    num_beams: 4
+    num_beam_groups: 2
+    # kwargs that do NOT trigger the rule (should pass cleanly).
+    # 4 is divisible by 2, so the rule does not fire.
+
+  expected_outcome:
+    outcome: error
+    # One of: dormant_silent | dormant_announced | warn | error | pass
+    emission_channel: none
+    # How the engine signals the issue.
+    # One of: warnings_warn | logger_warning | logger_warning_once |
+    #         minor_issues_dict | none | runtime_exception
+    normalised_fields: []
+    # For dormant rules: which fields the engine silently normalises.
+    # Empty for error rules.
+
+  message_template: >
+    `num_beams` has to be divisible by `num_beam_groups`, but got
+    `num_beams`={val} and `num_beam_groups`={val}.
+  # The static fragment of the library's error message.
+  # Used by the vendor-CI gate's message_template_match check:
+  # the gate asserts this fragment appears in the live library's exception message.
+  # Template variables ({declared_value}, {effective_value}, etc.) are
+  # substituted when the rule fires at validation time.
+
+  references:
+    - "transformers.GenerationConfig.__init__() - observed via construction-time ValueError"
+  # Human-readable provenance citations. Free-form strings.
+  # Useful for tracking down the library source line that motivated the rule.
+
+  added_by: static_miner
+  # Provenance: which pipeline component produced this rule.
+  # See AddedBy values below.
+
+  added_at: '2026-04-25'
+  # Date (YYYY-MM-DD) when this rule was added to the corpus.
+
+  cross_validated_by: []
+  # Optional. Other miner sources that independently emitted a rule with the
+  # same fingerprint (engine + severity + match.fields).
+  # Set by build_corpus.py when two miners agree; empty for single-source rules.
+```
+
+---
+
+## Field reference
+
+### `id`
+
+Unique identifier for the rule. Used in error messages, divergence reports, and logs. Convention:
+
+```
+{engine}_{native_type_slug}_{condition_slug}
+```
+
+Examples:
+- `transformers_beam_search_num_beams_not_divisible_by_num_beam_groups`
+- `vllm_sampling_temperature_out_of_range`
+- `tensorrt_quantization_fp8_not_supported_on_sm80`
+
+### `severity`
+
+| Value | When it fires | User sees |
+|-------|--------------|-----------|
+| `error` | Engine would raise at construction / validate time | `ConfigurationError` before initialisation |
+| `warn` | Engine announces a suboptimal setting but proceeds | Warning message |
+| `dormant` | Engine silently normalises or ignores the field | Annotation: "field X will be coerced to Y" |
+
+### `expected_outcome.outcome`
+
+| Value | Meaning |
+|-------|---------|
+| `dormant_silent` | Engine silently normalises; no user-visible emission |
+| `dormant_announced` | Engine writes to `minor_issues` dict / logger, but config runs |
+| `warn` | Engine calls `warnings.warn(...)` or equivalent |
+| `error` | Engine raises at construct / validate time |
+| `pass` | Predicate matched but engine handles it cleanly (positive-reference rules) |
+
+### `expected_outcome.emission_channel`
+
+| Value | Meaning |
+|-------|---------|
+| `warnings_warn` | Python `warnings.warn(...)` |
+| `logger_warning` | stdlib logger `.warning(...)` |
+| `logger_warning_once` | stdlib logger `.warning_once(...)` |
+| `minor_issues_dict` | HF's internal `minor_issues` dict (user-observable via strict-mode raise or log) |
+| `none` | No user-visible emission (silent coercion or bare raise with no warning prefix) |
+| `runtime_exception` | Exception raised at engine construct / runtime |
+
+### `added_by`
+
+The provenance of the rule - which pipeline component produced it.
+
+```
+  AddedBy values and their sources:
+  ─────────────────────────────────────────────────────────────────────
+  static_miner       AST walking of validator methods
+  dynamic_miner      combinatorial probing (raise/no-raise observation)
+  pydantic_lift      model_json_schema() + FieldInfo.metadata
+  msgspec_lift       msgspec.inspect.type_info() + Meta constraints
+  dataclass_lift     dataclasses.fields() + Literal[...] annotations
+  manual_seed        hand-written by a maintainer (pipeline-failure debt;
+                     use sparingly, add justification comment)
+  runtime_warning    proposed by feedback loop from observed logger.warning_once
+                     emissions (needs human generalisation before landing)
+  observed_collision proposed by feedback loop from config-hash collision
+                     detection (needs human generalisation before landing)
+```
+
+```
+  Provenance flow diagram:
+
+  Engine library source
+         │
+         ├──► AST walk ──────────────────────────────────► static_miner
+         │
+         ├──► Combinatorial probes ──────────────────────► dynamic_miner
+         │
+         ├──► pydantic.BaseModel.model_json_schema() ────► pydantic_lift
+         │
+         ├──► msgspec.inspect.type_info() ───────────────► msgspec_lift
+         │
+         ├──► dataclasses.fields() + Literal[...] ───────► dataclass_lift
+         │
+         ├──► Maintainer (coverage gap, justified) ──────► manual_seed
+         │
+         ├──► Runtime warning feedback loop ─────────────► runtime_warning
+         │
+         └──► Observed-collision feedback loop ───────────► observed_collision
+```
+
+### `miner_source`
+
+The `{path, method, line_at_scan}` record pointing back to the library source.
+
+- `path`: relative path within the library's source tree (e.g. `transformers/generation/configuration_utils.py`).
+- `method`: the method name where the detector found this rule.
+- `line_at_scan`: line number at the time of mining. This will drift when the library is updated; it is for human inspection only, not machine comparison.
+
+### `cross_validated_by`
+
+When two or more miners independently emit a rule with the same fingerprint (same `engine + severity + match.fields`), `build_corpus.py` keeps one rule as primary (`added_by` = primary source) and records the secondary source in `cross_validated_by`. Cross-validation is evidence that the rule is real: independent paths agree.
+
+---
+
+## Match predicate operators
+
+Full reference for the `match.fields` operator keys:
+
+| Operator key | Fires when | Notes |
+|---|---|---|
+| `"=="`/ `"equals"` | `field == value` | Word and symbol forms are aliases |
+| `"!="` / `"not_equal"` | `field != value` | None-safe (does not fire if field is None) |
+| `"<"` | `field < value` | None-safe |
+| `"<="` | `field <= value` | None-safe |
+| `">"` | `field > value` | None-safe |
+| `">="` | `field >= value` | None-safe |
+| `"in"` | `field in [v1, v2, ...]` | Spec must be list/tuple/set |
+| `"not_in"` | `field not in [v1, v2, ...]` | None-safe; spec must be list/tuple/set |
+| `"present"` | `field is not None` | |
+| `"absent"` | `field is None` | |
+| `"type_is"` | `type(field).__name__ in name_set` | Accepts string or list of strings |
+| `"type_is_not"` | `type(field).__name__ not in name_set` | None-safe |
+| `"divisible_by"` | `field % divisor == 0` | Both operands must be non-bool ints; `b=0` → False |
+| `"not_divisible_by"` | `field % divisor != 0` | Both operands must be non-bool ints; `b=0` → False |
+
+### Bare value shorthand
+
+A bare value (not a dict) in the `match.fields` spec is shorthand for equality:
+
+```yaml
+# These two are equivalent:
+transformers.sampling.num_beams: 1
+transformers.sampling.num_beams:
+  "==": 1
+```
+
+### `@field_ref` cross-field references
+
+Any operator value that starts with `@` is resolved as a field reference:
+
+```yaml
+transformers.sampling.num_beams:
+  not_divisible_by: "@num_beam_groups"
+  # "@num_beam_groups" resolves as a sibling:
+  # config.transformers.sampling.num_beam_groups
+
+transformers.sampling.num_beams:
+  not_divisible_by: "@transformers.sampling.num_beam_groups"
+  # Dotted ref resolves from the config root.
+  # Equivalent to the sibling form when the parent namespace is the same.
+```
+
+---
+
+## `manual_seed` rules
+
+`manual_seed` rules are hand-written by a maintainer. They exist for coverage gaps where the miner pipeline cannot mechanically derive the constraint (e.g. a type-check rule in a library method the static miner does not walk, or a constraint that requires understanding semantics the AST cannot express).
+
+`manual_seed` is **pipeline-failure debt**: the right long-term fix is extending the miner to cover the gap. Each `manual_seed` entry should carry a justification comment explaining why the miner cannot cover it and what would be needed to close the gap.
+
+```yaml
+- id: bitsandbytes_load_in_4bit_and_8bit_mutually_exclusive
+  ...
+  added_by: manual_seed
+  # Justification: BitsAndBytesConfig.__init__ checks load_in_4bit AND load_in_8bit
+  # in the same branch, but the dynamic miner's BNB cluster was not added in the
+  # refactor (scope decision). Extend the dynamic miner with a bitsandbytes_quant
+  # cluster to close this gap.
+```
+
+---
+
+## Schema version history
+
+| Version | Changes |
+|---------|---------|
+| `1.0.0` | Initial release. `added_by` as single string, `cross_validated_by` optional list, `mined_at` top-level field. Replaces pre-1.0 `walked_at` field name. |
+
+---
+
+## Corpus invariants
+
+The CI pipeline enforces these invariants on every corpus file:
+
+1. `schema_version` major must equal `SUPPORTED_MAJOR_VERSION` in `loader.py`.
+2. Every `added_by` value must be in the `AddedBy` Literal.
+3. Every `severity` value must be in `{"error", "warn", "dormant"}`.
+4. Every `expected_outcome.outcome` must be in `Outcome`.
+5. Every `expected_outcome.emission_channel` must be in `EmissionChannel`.
+6. All `id` values within one corpus file must be unique.
+7. Dormant rules must converge to a stable fixpoint (verified by `_fixpoint_test.py`).
+8. Vendor-CI gate: `kwargs_positive` must trigger the rule, `message_template` must match, `kwargs_negative` must not trigger.
+
+---
+
+## See also
+
+- [parameter-discovery.md](parameter-discovery.md) - how the corpus is consumed at runtime
+- [miner-pipeline.md](miner-pipeline.md) - how the corpus is built
+- [extending-miners.md](extending-miners.md) - adding rules for new engines
+- [architecture-overview.md](architecture-overview.md) - system overview

--- a/docs/validation-rule-corpus.md
+++ b/docs/validation-rule-corpus.md
@@ -114,7 +114,7 @@ Below is a complete rule from the transformers corpus with every field annotated
 
   message_template: >
     `num_beams` has to be divisible by `num_beam_groups`, but got
-    `num_beams`={val} and `num_beam_groups`={val}.
+    `num_beams`={declared_value} and `num_beam_groups`={declared_value}.
   # The static fragment of the library's error message.
   # Used by the vendor-CI gate's message_template_match check:
   # the gate asserts this fragment appears in the live library's exception message.
@@ -126,7 +126,7 @@ Below is a complete rule from the transformers corpus with every field annotated
   # Human-readable provenance citations. Free-form strings.
   # Useful for tracking down the library source line that motivated the rule.
 
-  added_by: static_miner
+  added_by: dynamic_miner
   # Provenance: which pipeline component produced this rule.
   # See AddedBy values below.
 
@@ -160,7 +160,7 @@ Examples:
 
 | Value | When it fires | User sees |
 |-------|--------------|-----------|
-| `error` | Engine would raise at construction / validate time | `ConfigurationError` before initialisation |
+| `error` | Engine would raise at construction / validate time | `ValueError` (surfaced as Pydantic `ValidationError`) before initialisation |
 | `warn` | Engine announces a suboptimal setting but proceeds | Warning message |
 | `dormant` | Engine silently normalises or ignores the field | Annotation: "field X will be coerced to Y" |
 


### PR DESCRIPTION
## Summary

- Adds 6 new docs covering the invariant miner pipeline, config validation pipeline, corpus format, extender guide, and research context
- Updates `parameter-curation.md` with redirector note and cross-link to new `parameter-discovery.md`
- Updates `schema-refresh.md` with cross-links to new miner pipeline docs
- README gets a new "Architecture and Internals" section linking all six new docs

## New documents

| File | Lines | Diagrams |
|------|-------|---------|
| `docs/architecture-overview.md` | 280 | 3 (system overview, broader framework stack, end-to-end data flow) |
| `docs/miner-pipeline.md` | 508 | 6 (component overview, static miner AST walk, Renovate refresh loop, vendor-CI gate, two-tier CI, fail-loud contract) |
| `docs/parameter-discovery.md` | 321 | 3 (data flow sequence, loader grammar tree, severity flow) |
| `docs/validation-rule-corpus.md` | 340 | 2 (file structure, provenance flow) |
| `docs/extending-miners.md` | 485 | 2 (fail-loud contract flow, probe strategy flow) |
| `docs/research-context.md` | 187 | 0 (prose + tables; academic positioning) |

**Diagram count:** 16 ASCII diagrams across the suite.

## Updated documents

- `docs/parameter-curation.md` - adds redirector note pointing to `parameter-discovery.md` for the validation pipeline; preserves all existing content
- `docs/schema-refresh.md` - adds cross-links to `miner-pipeline.md` and `architecture-overview.md` in Related section
- `README.md` - adds "Architecture and Internals" section with links to all six new docs

## Vocabulary check

- Zero instances of stale `walker` vocabulary in new docs (grep confirmed)
- Zero em-dashes/en-dashes in prose (grep confirmed)
- Confidence labels not referenced anywhere

## Open questions for review

1. **TRT-LLM dynamic miner**: The docs describe TRT-LLM as static-only (no dynamic miner, constructor probing yields zero raises). If a future PR adds a dynamic miner for TRT-LLM, `miner-pipeline.md` and `extending-miners.md` will need updating.

2. **vLLM miner**: Docs describe vLLM miner as "in flight". Once #432 lands and vLLM miners are complete, the per-engine comparison table in `miner-pipeline.md` should be updated to remove the "in flight" annotation.

3. **`parameter-curation.md` fate**: The current doc has been updated with a redirector note at the top pointing users to `parameter-discovery.md` for validation-related queries. The alternative was folding it entirely - kept it as a separate doc because the parameter-discovery pipeline (what fields an engine accepts) and the config-validation pipeline (what combinations are invalid) are genuinely distinct topics. Review welcome on whether to fold or keep separate.

4. **`manual_seed` justification format**: The corpus format doc recommends adding a justification comment to every `manual_seed` rule. Should this be enforced by a CI lint step? Currently advisory only.

5. **`research-context.md` citation completeness**: PreInfer (Astorga et al., DSN 2018) and DeepConstr (ISSTA 2024) are cited but full paper details not confirmed against the actual papers. Review recommended before any academic submission.