### PR TITLE
feat(miners): vLLM static + dynamic miners

### DIFF
--- a/configs/validation_rules/vllm.yaml
+++ b/configs/validation_rules/vllm.yaml
@@ -1,0 +1,1585 @@
+schema_version: 1.0.0
+engine: vllm
+engine_version: 0.17.1
+walker_pinned_range: <0.18,>=0.17
+mined_at: '2026-04-26'
+rules:
+- id: vllm_cacheconfig_cache_dtype_in_7_values
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.cache_dtype must be one of ['auto', 'bfloat16', 'fp8', 'fp8_e4m3', 'fp8_e5m2',
+    'fp8_inc', 'fp8_ds_mla']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.cache_dtype:
+        not_in:
+        - auto
+        - bfloat16
+        - fp8
+        - fp8_e4m3
+        - fp8_e5m2
+        - fp8_inc
+        - fp8_ds_mla
+  kwargs_positive:
+    cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_cpu_offload_gb_ge_0
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.cpu_offload_gb requires >= 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.cpu_offload_gb:
+        <: 0
+  kwargs_positive:
+    cpu_offload_gb: -1
+  kwargs_negative:
+    cpu_offload_gb: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_gpu_memory_utilization_gt_0
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.gpu_memory_utilization requires > 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.gpu_memory_utilization:
+        <=: 0
+  kwargs_positive:
+    gpu_memory_utilization: 0
+  kwargs_negative:
+    gpu_memory_utilization: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_gpu_memory_utilization_le_1
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.gpu_memory_utilization requires <= 1
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.gpu_memory_utilization:
+        '>': 1
+  kwargs_positive:
+    gpu_memory_utilization: 2
+  kwargs_negative:
+    gpu_memory_utilization: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_kv_offloading_backend_in_2_values
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.kv_offloading_backend must be one of ['native', 'lmcache']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.kv_offloading_backend:
+        not_in:
+        - native
+        - lmcache
+  kwargs_positive:
+    kv_offloading_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    kv_offloading_backend: native
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_mamba_block_size_gt_0
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.mamba_block_size requires > 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_block_size:
+        <=: 0
+  kwargs_positive:
+    mamba_block_size: 0
+  kwargs_negative:
+    mamba_block_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_mamba_cache_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.mamba_cache_dtype must be one of ['auto', 'float32', 'float16']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_cache_dtype:
+        not_in:
+        - auto
+        - float32
+        - float16
+  kwargs_positive:
+    mamba_cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_mamba_cache_mode_in_3_values
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.mamba_cache_mode must be one of ['all', 'align', 'none']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_cache_mode:
+        not_in:
+        - all
+        - align
+        - none
+  kwargs_positive:
+    mamba_cache_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_cache_mode: all
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_mamba_ssm_cache_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.mamba_ssm_cache_dtype must be one of ['auto', 'float32', 'float16']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_ssm_cache_dtype:
+        not_in:
+        - auto
+        - float32
+        - float16
+  kwargs_positive:
+    mamba_ssm_cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_ssm_cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_prefix_caching_hash_algo_in_4_values
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.prefix_caching_hash_algo must be one of ['sha256', 'sha256_cbor', 'xxhash',
+    'xxhash_cbor']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.prefix_caching_hash_algo:
+        not_in:
+        - sha256
+        - sha256_cbor
+        - xxhash
+        - xxhash_cbor
+  kwargs_positive:
+    prefix_caching_hash_algo: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    prefix_caching_hash_algo: sha256
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_cacheconfig_swap_space_ge_0
+  engine: vllm
+  library: vllm
+  rule_under_test: CacheConfig.swap_space requires >= 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.swap_space:
+        <: 0
+  kwargs_positive:
+    swap_space: -1
+  kwargs_negative:
+    swap_space: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_compilationconfig_compile_cache_save_format_in_2_values
+  engine: vllm
+  library: vllm
+  rule_under_test: CompilationConfig.compile_cache_save_format must be one of ['binary', 'unpacked']
+  severity: error
+  native_type: vllm.config.CompilationConfig
+  miner_source:
+    path: vllm/config/compilation.py
+    method: <pydantic_lift>
+    line_at_scan: 336
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.compile_cache_save_format:
+        not_in:
+        - binary
+        - unpacked
+  kwargs_positive:
+    compile_cache_save_format: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    compile_cache_save_format: binary
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CompilationConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_compilationconfig_dormant_backend_eq
+  engine: vllm
+  library: vllm
+  rule_under_test: 'CompilationConfig.__post_init__: marks dormant when backend == '
+  severity: dormant
+  native_type: vllm.config.CompilationConfig
+  miner_source:
+    path: vllm/config/compilation.py
+    method: __post_init__
+    line_at_scan: 905
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.backend: ''
+  kwargs_positive:
+    backend: ''
+  kwargs_negative:
+    backend: _x
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - backend
+  message_template: null
+  references:
+  - vllm/config/compilation.py:905 (vllm.config.CompilationConfig.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_eplbconfig_num_redundant_experts_ge_0
+  engine: vllm
+  library: vllm
+  rule_under_test: EPLBConfig.num_redundant_experts requires >= 0
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 50
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.num_redundant_experts:
+        <: 0
+  kwargs_positive:
+    num_redundant_experts: -1
+  kwargs_negative:
+    num_redundant_experts: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_eplbconfig_policy_in_1_values
+  engine: vllm
+  library: vllm
+  rule_under_test: EPLBConfig.policy must be one of ['default']
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 50
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.policy:
+        not_in:
+        - default
+  kwargs_positive:
+    policy: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    policy: default
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_eplbconfig_raises_log_balancedness_interval_le_0
+  engine: vllm
+  library: vllm
+  rule_under_test: 'EPLBConfig._validate_eplb_config: raises when log_balancedness present True AND log_balancedness_interval
+    <= 0'
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_eplb_config
+    line_at_scan: 89
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.log_balancedness:
+        present: true
+      vllm.engine.log_balancedness_interval:
+        <=: 0
+  kwargs_positive:
+    log_balancedness: 1
+    log_balancedness_interval: 0
+  kwargs_negative:
+    log_balancedness: 1
+    log_balancedness_interval: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: log_balancedness_interval must be greater than 0.
+  references:
+  - vllm/config/parallel.py:89 (vllm.config.EPLBConfig._validate_eplb_config)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_loraconfig_dormant_max_cpu_loras_unset_true
+  engine: vllm
+  library: vllm
+  rule_under_test: 'LoRAConfig._validate_lora_config: marks dormant when max_cpu_loras absent True'
+  severity: dormant
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: _validate_lora_config
+    line_at_scan: 94
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_cpu_loras:
+        absent: true
+  kwargs_positive:
+    max_cpu_loras: null
+  kwargs_negative:
+    max_cpu_loras: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - max_cpu_loras
+  message_template: null
+  references:
+  - vllm/config/lora.py:94 (vllm.config.LoRAConfig._validate_lora_config)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_loraconfig_lora_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  rule_under_test: LoRAConfig.lora_dtype must be one of ['auto', 'float16', 'bfloat16']
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.lora_dtype:
+        not_in:
+        - auto
+        - float16
+        - bfloat16
+  kwargs_positive:
+    lora_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    lora_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_loraconfig_max_lora_rank_in_9_values
+  engine: vllm
+  library: vllm
+  rule_under_test: LoRAConfig.max_lora_rank must be one of [1, 8, 16, 32, 64, 128, 256, 320, 512]
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_lora_rank:
+        not_in:
+        - 1
+        - 8
+        - 16
+        - 32
+        - 64
+        - 128
+        - 256
+        - 320
+        - 512
+  kwargs_positive:
+    max_lora_rank: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    max_lora_rank: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_loraconfig_max_loras_ge_1
+  engine: vllm
+  library: vllm
+  rule_under_test: LoRAConfig.max_loras requires >= 1
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_loras:
+        <: 1
+  kwargs_positive:
+    max_loras: 0
+  kwargs_negative:
+    max_loras: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_modelconfig_convert_in_4_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ModelConfig.convert must be one of ['auto', 'none', 'embed', 'classify']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.convert:
+        not_in:
+        - auto
+        - none
+        - embed
+        - classify
+  kwargs_positive:
+    convert: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    convert: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_modelconfig_logprobs_mode_in_4_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ModelConfig.logprobs_mode must be one of ['raw_logits', 'raw_logprobs', 'processed_logits',
+    'processed_logprobs']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.logprobs_mode:
+        not_in:
+        - raw_logits
+        - raw_logprobs
+        - processed_logits
+        - processed_logprobs
+  kwargs_positive:
+    logprobs_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    logprobs_mode: raw_logits
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_modelconfig_mm_encoder_tp_mode_in_2_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ModelConfig.mm_encoder_tp_mode must be one of ['weights', 'data']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_encoder_tp_mode:
+        not_in:
+        - weights
+        - data
+  kwargs_positive:
+    mm_encoder_tp_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mm_encoder_tp_mode: weights
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_encoder_tp_mode_in_2_values''; pydantic_lift
+    -> ''vllm_multimodalconfig_mm_encoder_tp_mode_in_2_values'''
+- id: vllm_modelconfig_mm_processor_cache_type_in_2_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ModelConfig.mm_processor_cache_type must be one of ['shm', 'lru']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_processor_cache_type:
+        not_in:
+        - shm
+        - lru
+  kwargs_positive:
+    mm_processor_cache_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mm_processor_cache_type: shm
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_processor_cache_type_in_2_values''; pydantic_lift
+    -> ''vllm_multimodalconfig_mm_processor_cache_type_in_2_values'''
+- id: vllm_modelconfig_runner_in_4_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ModelConfig.runner must be one of ['auto', 'generate', 'pooling', 'draft']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.runner:
+        not_in:
+        - auto
+        - generate
+        - pooling
+        - draft
+  kwargs_positive:
+    runner: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    runner: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_multimodalconfig_mm_processor_cache_gb_ge_0
+  engine: vllm
+  library: vllm
+  rule_under_test: MultiModalConfig.mm_processor_cache_gb requires >= 0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_processor_cache_gb:
+        <: 0
+  kwargs_positive:
+    mm_processor_cache_gb: -1
+  kwargs_negative:
+    mm_processor_cache_gb: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_multimodalconfig_video_pruning_rate_ge_0p0
+  engine: vllm
+  library: vllm
+  rule_under_test: MultiModalConfig.video_pruning_rate requires >= 0.0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.video_pruning_rate:
+        <: 0.0
+  kwargs_positive:
+    video_pruning_rate: -1.0
+  kwargs_negative:
+    video_pruning_rate: 0.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_multimodalconfig_video_pruning_rate_lt_1p0
+  engine: vllm
+  library: vllm
+  rule_under_test: MultiModalConfig.video_pruning_rate requires < 1.0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.video_pruning_rate:
+        '>=': 1.0
+  kwargs_positive:
+    video_pruning_rate: 1.0
+  kwargs_negative:
+    video_pruning_rate: 0.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig__api_process_count_gt_0
+  engine: vllm
+  library: vllm
+  rule_under_test: ParallelConfig._api_process_count requires > 0
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_count:
+        <=: 0
+  kwargs_positive:
+    _api_process_count: 0
+  kwargs_negative:
+    _api_process_count: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig__api_process_rank_ge_neg1
+  engine: vllm
+  library: vllm
+  rule_under_test: ParallelConfig._api_process_rank requires >= -1
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_rank:
+        <: -1
+  kwargs_positive:
+    _api_process_rank: -2
+  kwargs_negative:
+    _api_process_rank: -1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig_all2all_backend_in_7_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ParallelConfig.all2all_backend must be one of ['naive', 'pplx', 'deepep_high_throughput',
+    'deepep_low_latency', 'mori', 'allgather_reducescatter', 'flashinfer_all2allv']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.all2all_backend:
+        not_in:
+        - naive
+        - pplx
+        - deepep_high_throughput
+        - deepep_low_latency
+        - mori
+        - allgather_reducescatter
+        - flashinfer_all2allv
+  kwargs_positive:
+    all2all_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    all2all_backend: naive
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig_data_parallel_backend_in_2_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ParallelConfig.data_parallel_backend must be one of ['ray', 'mp']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_backend:
+        not_in:
+        - ray
+        - mp
+  kwargs_positive:
+    data_parallel_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    data_parallel_backend: ray
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig_dormant_all2all_backend_eq_pplx
+  engine: vllm
+  library: vllm
+  rule_under_test: 'ParallelConfig._validate_parallel_config: marks dormant when all2all_backend == pplx'
+  severity: dormant
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 348
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.all2all_backend: pplx
+  kwargs_positive:
+    all2all_backend: pplx
+  kwargs_negative:
+    all2all_backend: allgather_reducescatter
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - all2all_backend
+  message_template: null
+  references:
+  - vllm/config/parallel.py:348 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig_dormant_data_parallel_rank_set_true
+  engine: vllm
+  library: vllm
+  rule_under_test: 'ParallelConfig.__post_init__: marks dormant when distributed_executor_backend == external_launcher
+    AND data_parallel_rank present True'
+  severity: dormant
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: __post_init__
+    line_at_scan: 676
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.distributed_executor_backend: external_launcher
+      vllm.engine.data_parallel_rank:
+        present: true
+  kwargs_positive:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 1
+  kwargs_negative:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 0
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - data_parallel_rank
+  message_template: null
+  references:
+  - vllm/config/parallel.py:676 (vllm.config.ParallelConfig.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig_expert_placement_strategy_in_2_values
+  engine: vllm
+  library: vllm
+  rule_under_test: ParallelConfig.expert_placement_strategy must be one of ['linear', 'round_robin']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.expert_placement_strategy:
+        not_in:
+        - linear
+        - round_robin
+  kwargs_positive:
+    expert_placement_strategy: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    expert_placement_strategy: linear
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig_raises_api_process_rank_ge_ref_api_process_count
+  engine: vllm
+  library: vllm
+  rule_under_test: 'ParallelConfig._validate_parallel_config: raises when _api_process_rank >= @_api_process_count'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 337
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_rank:
+        '>=': '@_api_process_count'
+  kwargs_positive:
+    _api_process_count: 2
+    _api_process_rank: 2
+  kwargs_negative:
+    _api_process_count: 2
+    _api_process_rank: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: 'f''Invalid value of `_api_process_rank`. Expected to be `-1` or `[0, {self._api_process_count})`,
+    but found: {self._api_process_rank}'''
+  references:
+  - vllm/config/parallel.py:337 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_parallelconfig_raises_data_parallel_external_lb_set_true
+  engine: vllm
+  library: vllm
+  rule_under_test: 'ParallelConfig._validate_parallel_config: raises when data_parallel_size <= 1 AND
+    data_parallel_external_lb present True'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 357
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_size:
+        <=: 1
+      vllm.engine.data_parallel_external_lb:
+        present: true
+  kwargs_positive:
+    data_parallel_size: 1
+    data_parallel_external_lb: 1
+  kwargs_negative:
+    data_parallel_size: 1
+    data_parallel_external_lb: false
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: data_parallel_external_lb can only be set when data_parallel_size > 1
+  references:
+  - vllm/config/parallel.py:357 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_poolerconfig_seq_pooling_type_in_3_values
+  engine: vllm
+  library: vllm
+  rule_under_test: PoolerConfig.seq_pooling_type must be one of ['CLS', 'LAST', 'MEAN']
+  severity: error
+  native_type: vllm.config.PoolerConfig
+  miner_source:
+    path: vllm/config/pooler.py
+    method: <pydantic_lift>
+    line_at_scan: 19
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.seq_pooling_type:
+        not_in:
+        - CLS
+        - LAST
+        - MEAN
+  kwargs_positive:
+    seq_pooling_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    seq_pooling_type: CLS
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_poolerconfig_tok_pooling_type_in_2_values
+  engine: vllm
+  library: vllm
+  rule_under_test: PoolerConfig.tok_pooling_type must be one of ['ALL', 'STEP']
+  severity: error
+  native_type: vllm.config.PoolerConfig
+  miner_source:
+    path: vllm/config/pooler.py
+    method: <pydantic_lift>
+    line_at_scan: 19
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.tok_pooling_type:
+        not_in:
+        - ALL
+        - STEP
+  kwargs_positive:
+    tok_pooling_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    tok_pooling_type: ALL
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'
+- id: vllm_sampling_penalties_repetition_penalty_le_zero
+  engine: vllm
+  library: vllm
+  rule_under_test: 'sampling_penalties: error when repetition_penalty <= 0'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: <probe>
+    line_at_scan: 0
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.repetition_penalty:
+        <=: 0
+  kwargs_positive:
+    presence_penalty: -2.0
+    frequency_penalty: -2.0
+    repetition_penalty: -1.0
+  kwargs_negative:
+    presence_penalty: -2.0
+    frequency_penalty: -2.0
+    repetition_penalty: 0.5
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: repetition_penalty must be greater than zero, got -1.0.
+  references:
+  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  added_by: dynamic_miner
+  added_at: '2026-04-26'
+- id: vllm_sampling_token_counts_max_tokens_lt_min_tokens
+  engine: vllm
+  library: vllm
+  rule_under_test: 'sampling_token_counts: error when max_tokens < min_tokens'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: <probe>
+    line_at_scan: 0
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.max_tokens:
+        <: '@min_tokens'
+  kwargs_positive:
+    max_tokens: 1
+    min_tokens: 5
+  kwargs_negative:
+    max_tokens: null
+    min_tokens: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: min_tokens must be less than or equal to max_tokens=1, got 5.
+  references:
+  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  added_by: dynamic_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_dormant_bad_words_unset_true
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams.__post_init__: marks dormant when bad_words absent True'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 389
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.bad_words:
+        absent: true
+  kwargs_positive:
+    bad_words: null
+  kwargs_negative:
+    bad_words: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - bad_words
+  message_template: null
+  references:
+  - vllm/sampling_params.py:389 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_dormant_seed_eq_neg1
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams.__post_init__: marks dormant when seed == -1'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 378
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.seed: -1
+  kwargs_positive:
+    seed: -1
+  kwargs_negative:
+    seed: 0
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - seed
+  message_template: null
+  references:
+  - vllm/sampling_params.py:378 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams.__post_init__: marks dormant when skip_reading_prefix_cache absent
+    True'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 418
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.skip_reading_prefix_cache:
+        absent: true
+  kwargs_positive:
+    skip_reading_prefix_cache: null
+  kwargs_negative:
+    skip_reading_prefix_cache: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - skip_reading_prefix_cache
+  message_template: null
+  references:
+  - vllm/sampling_params.py:418 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams._verify_args: raises when max_tokens present True AND min_tokens >
+    @max_tokens'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 472
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.max_tokens:
+        present: true
+      vllm.sampling.min_tokens:
+        '>': '@max_tokens'
+  kwargs_positive:
+    max_tokens: 1
+    min_tokens: 2
+  kwargs_negative:
+    max_tokens: 1
+    min_tokens: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'min_tokens must be less than or equal to max_tokens={self.max_tokens}, got {self.min_tokens}.'
+  references:
+  - vllm/sampling_params.py:472 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_raises_min_tokens_lt_0
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams._verify_args: raises when min_tokens < 0'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 468
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.min_tokens:
+        <: 0
+  kwargs_positive:
+    min_tokens: -1
+  kwargs_negative:
+    min_tokens: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: min_tokens must be greater than or equal to 0, got -1.
+  references:
+  - vllm/sampling_params.py:468 (vllm.SamplingParams._verify_args)
+  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  added_by: static_miner
+  cross_validated_by:
+  - dynamic_miner
+  added_at: '2026-04-26'
+  conflict_note: 'message_template: dynamic miner text overrode static_miner''s template; id: static_miner
+    -> ''vllm_samplingparams_raises_min_tokens_lt_0''; dynamic_miner -> ''vllm_sampling_token_counts_min_tokens_lt_zero'''
+- id: vllm_samplingparams_raises_n_lt_1
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams._verify_args: raises when n < 1'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 424
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.n:
+        <: 1
+  kwargs_positive:
+    n: 0
+  kwargs_negative:
+    n: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'n must be at least 1, got {self.n}.'
+  references:
+  - vllm/sampling_params.py:424 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_raises_n_not_type_int
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams._verify_args: raises when n type_is_not int'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 422
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.n:
+        type_is_not: int
+  kwargs_positive:
+    n: x
+  kwargs_negative:
+    n: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'n must be an int, but is of type {type(self.n)}'
+  references:
+  - vllm/sampling_params.py:422 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_raises_repetition_penalty_le_0p0
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams._verify_args: raises when repetition_penalty <= 0.0'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 434
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.repetition_penalty:
+        <=: 0.0
+  kwargs_positive:
+    repetition_penalty: 0.0
+  kwargs_negative:
+    repetition_penalty: 1.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'repetition_penalty must be greater than zero, got {self.repetition_penalty}.'
+  references:
+  - vllm/sampling_params.py:434 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_raises_temperature_lt_0p0
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams._verify_args: raises when temperature < 0.0'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 439
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.temperature:
+        <: 0.0
+  kwargs_positive:
+    temperature: -1.0
+  kwargs_negative:
+    temperature: 0.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'temperature must be non-negative, got {self.temperature}.'
+  references:
+  - vllm/sampling_params.py:439 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_samplingparams_raises_top_k_lt_neg1
+  engine: vllm
+  library: vllm
+  rule_under_test: 'SamplingParams._verify_args: raises when top_k < -1'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 452
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.top_k:
+        <: -1
+  kwargs_positive:
+    top_k: -2
+  kwargs_negative:
+    top_k: -1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'top_k must be 0 (disable), or at least 1, got {self.top_k}.'
+  references:
+  - vllm/sampling_params.py:452 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-26'
+- id: vllm_structuredoutputsconfig_backend_in_5_values
+  engine: vllm
+  library: vllm
+  rule_under_test: StructuredOutputsConfig.backend must be one of ['auto', 'xgrammar', 'guidance', 'outlines',
+    'lm-format-enforcer']
+  severity: error
+  native_type: vllm.config.StructuredOutputsConfig
+  miner_source:
+    path: vllm/config/structured_outputs.py
+    method: <pydantic_lift>
+    line_at_scan: 17
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.backend:
+        not_in:
+        - auto
+        - xgrammar
+        - guidance
+        - outlines
+        - lm-format-enforcer
+  kwargs_positive:
+    backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    backend: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.StructuredOutputsConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-26'

--- a/scripts/miners/build_corpus.py
+++ b/scripts/miners/build_corpus.py
@@ -185,6 +185,16 @@ _ENGINE_EXTRACTORS: dict[str, tuple[_Extractor, ...]] = {
             staging_basename="tensorrt_static_miner.yaml",
         ),
     ),
+    "vllm": (
+        _Extractor(
+            module="scripts.miners.vllm_static_miner",
+            staging_basename="vllm_static_miner.yaml",
+        ),
+        _Extractor(
+            module="scripts.miners.vllm_dynamic_miner",
+            staging_basename="vllm_dynamic_miner.yaml",
+        ),
+    ),
 }
 
 

--- a/scripts/miners/vllm_dynamic_miner.py
+++ b/scripts/miners/vllm_dynamic_miner.py
@@ -1,0 +1,858 @@
+"""Dynamic (introspection + probe) miner for the vLLM library.
+
+Composes three sub-library lifts against vLLM's config classes plus a small
+combinatorial probe loop for cross-field invariants the lifts cannot reach
+on their own:
+
+1. **Pydantic lift** over the 12 ``vllm.config.*`` pydantic-dataclasses
+   (``CacheConfig``, ``ParallelConfig``, ``ModelConfig``, …). Each emits one
+   rule per ``annotated-types`` constraint (``Gt``, ``Le``, ``MultipleOf``,
+   …) and per ``Literal[...]`` allowlist annotation.
+2. **msgspec lift** over ``vllm.SamplingParams``. Per the research doc,
+   vLLM ships zero ``msgspec.Meta(...)`` annotations on SamplingParams, so
+   this currently emits zero candidates — wired so that any future vLLM
+   release adopting msgspec.Meta is captured automatically.
+3. **dataclass lift** over ``vllm.engine.arg_utils.EngineArgs`` (a 175-field
+   stdlib dataclass). Picks up every ``Literal[...]`` allowlist annotation
+   on the user-facing ``LLM(...)`` kwargs.
+
+Plus a runtime probe pass over ``SamplingParams`` cluster grids — small
+Cartesian sweeps that surface cross-field rules (``min_tokens > max_tokens``,
+``stop AND not detokenize``) the AST static miner already catches but
+re-confirms via observed library behaviour.
+
+CPU-safety
+----------
+``import vllm`` is CPU-safe on Ampere hardware (per the research doc),
+emits stderr noise about libamd_smi but returns successfully. No CUDA
+contexts are created during dynamic-miner execution; ``SamplingParams``
+construction is pure Python validation. ``vllm.config.*`` classes
+instantiate cleanly with no GPU; only ``EngineArgs(...).create_engine_config()``
+reaches GPU-dependent code, which we deliberately avoid.
+
+No LLM components anywhere
+--------------------------
+Per ``feedback_miner_pipeline_deterministic.md``: this miner is a pure
+function of (vllm SHA, lift modules, probe seed). No model-as-author,
+model-as-AST-parser, model-as-template-suggester. Hypothesis is not used
+here; Cartesian probing only.
+
+Output
+------
+Writes ``configs/validation_rules/_staging/vllm_dynamic_miner.yaml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import inspect
+import itertools
+import logging
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Project root on sys.path for direct script + module-style invocation.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Mirror the static miner's defence: strip the script directory from sys.path
+# so a future ``vllm.py`` stub here couldn't shadow the installed library.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+sys.path[:] = [p for p in sys.path if Path(p).resolve() != Path(_SCRIPT_DIR).resolve()]
+sys.path[:] = [p for p in sys.path if p != ""]
+
+from scripts.miners._base import (  # noqa: E402
+    MinerLandmarkMissingError,
+    MinerSource,
+    RuleCandidate,
+    check_installed_version,
+)
+from scripts.miners._msgspec_lift import lift as _msgspec_lift  # noqa: E402
+from scripts.miners._pydantic_lift import lift as _pydantic_lift  # noqa: E402
+from scripts.miners.vllm_static_miner import (  # noqa: E402
+    TESTED_AGAINST_VERSIONS,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ENGINE = "vllm"
+LIBRARY = "vllm"
+
+NS_SAMPLING = "vllm.sampling"
+NS_ENGINE = "vllm.engine"
+
+
+# ---------------------------------------------------------------------------
+# Lift composition: vllm.config.* pydantic-dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _LiftTarget:
+    """One pydantic-dataclass to lift via ``_pydantic_lift.lift``.
+
+    ``module_attr`` is the dotted path under ``vllm`` (e.g.
+    ``"config.cache.CacheConfig"``). ``namespace`` is the field path-prefix
+    used in emitted rules.
+    """
+
+    module_attr: str
+    namespace: str
+
+    @property
+    def class_name(self) -> str:
+        return self.module_attr.rsplit(".", 1)[-1]
+
+    @property
+    def module_path(self) -> str:
+        return f"vllm.{self.module_attr.rsplit('.', 1)[0]}"
+
+
+_PYDANTIC_LIFT_TARGETS: tuple[_LiftTarget, ...] = (
+    _LiftTarget("config.cache.CacheConfig", NS_ENGINE),
+    _LiftTarget("config.parallel.ParallelConfig", NS_ENGINE),
+    _LiftTarget("config.parallel.EPLBConfig", NS_ENGINE),
+    _LiftTarget("config.lora.LoRAConfig", NS_ENGINE),
+    _LiftTarget("config.model.ModelConfig", NS_ENGINE),
+    _LiftTarget("config.scheduler.SchedulerConfig", NS_ENGINE),
+    _LiftTarget("config.multimodal.MultiModalConfig", NS_ENGINE),
+    _LiftTarget("config.speculative.SpeculativeConfig", NS_ENGINE),
+    _LiftTarget("config.compilation.CompilationConfig", NS_ENGINE),
+    _LiftTarget("config.load.LoadConfig", NS_ENGINE),
+    _LiftTarget("config.pooler.PoolerConfig", NS_ENGINE),
+    _LiftTarget("config.structured_outputs.StructuredOutputsConfig", NS_ENGINE),
+)
+
+
+# ---------------------------------------------------------------------------
+# Probe clusters (combinatorial)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Cluster:
+    """One probe cluster.
+
+    ``probe_class_factory`` constructs the probe target — vLLM has multiple
+    probe classes (SamplingParams, vllm.config.* dataclasses), so unlike
+    transformers we pass a callable that takes a kwargs dict and returns
+    a constructed instance (or raises).
+
+    ``namespace`` is the field-path prefix used when emitting rules from
+    this cluster.
+    """
+
+    name: str
+    values_per_field: dict[str, list[Any]]
+    namespace: str
+    probe_class_factory: Callable[[dict[str, Any]], Any]
+    native_type: str
+    preconditions: dict[str, Any] = field(default_factory=dict)
+
+
+def _sampling_factory(kw: dict[str, Any]) -> Any:
+    from vllm import SamplingParams  # type: ignore
+
+    return SamplingParams(**kw)
+
+
+CLUSTERS: tuple[_Cluster, ...] = (
+    _Cluster(
+        name="sampling_token_counts",
+        values_per_field={
+            "max_tokens": [None, 1, 5, 10],
+            "min_tokens": [-1, 0, 5, 15],
+        },
+        namespace=NS_SAMPLING,
+        probe_class_factory=_sampling_factory,
+        native_type="vllm.SamplingParams",
+    ),
+    _Cluster(
+        name="sampling_basic_ranges",
+        values_per_field={
+            "temperature": [-0.5, 0.0, 0.5, 1.0, 2.0],
+            "top_p": [0.0, 0.5, 1.0, 1.5],
+        },
+        namespace=NS_SAMPLING,
+        probe_class_factory=_sampling_factory,
+        native_type="vllm.SamplingParams",
+    ),
+    _Cluster(
+        name="sampling_topk_minp",
+        values_per_field={
+            "top_k": [-2, -1, 0, 1, 50],
+            "min_p": [-0.1, 0.0, 0.5, 1.0, 1.5],
+        },
+        namespace=NS_SAMPLING,
+        probe_class_factory=_sampling_factory,
+        native_type="vllm.SamplingParams",
+    ),
+    _Cluster(
+        name="sampling_penalties",
+        values_per_field={
+            "presence_penalty": [-2.5, -2.0, 0.0, 2.0, 2.5],
+            "frequency_penalty": [-2.5, -2.0, 0.0, 2.0, 2.5],
+            "repetition_penalty": [-1.0, 0.0, 0.5, 1.0],
+        },
+        namespace=NS_SAMPLING,
+        probe_class_factory=_sampling_factory,
+        native_type="vllm.SamplingParams",
+    ),
+    _Cluster(
+        name="sampling_n_greedy",
+        values_per_field={
+            "n": [1, 2, 3],
+            "temperature": [0.0, 0.005, 0.5, 1.0],
+        },
+        namespace=NS_SAMPLING,
+        probe_class_factory=_sampling_factory,
+        native_type="vllm.SamplingParams",
+    ),
+    _Cluster(
+        name="sampling_stop_pair",
+        values_per_field={
+            "stop": [None, [], ["done"]],
+            "detokenize": [True, False],
+        },
+        namespace=NS_SAMPLING,
+        probe_class_factory=_sampling_factory,
+        native_type="vllm.SamplingParams",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Probe runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ProbeRow:
+    """One trial row from a Cartesian probe matrix."""
+
+    kwargs: dict[str, Any]
+    error_message: str | None
+    error_type: str | None
+
+
+def _silence_vllm_loggers() -> tuple[logging.Logger, int]:
+    """Quiet the noisy vLLM init loggers during probing.
+
+    Returns (logger, prev_level) so caller can restore — vLLM emits warnings
+    on every greedy-clamp probe, which spams the miner's stderr.
+    """
+    lg = logging.getLogger("vllm")
+    prev = lg.level
+    lg.setLevel(logging.ERROR)
+    return lg, prev
+
+
+def _run_cluster(cluster: _Cluster) -> list[_ProbeRow]:
+    """Run the Cartesian product for a cluster; return one row per trial."""
+    field_names = list(cluster.values_per_field.keys())
+    grids = [cluster.values_per_field[name] for name in field_names]
+
+    lg, prev = _silence_vllm_loggers()
+    rows: list[_ProbeRow] = []
+    try:
+        for combo in itertools.product(*grids):
+            kwargs = dict(zip(field_names, combo, strict=True))
+            full_kwargs = {**cluster.preconditions, **kwargs}
+            try:
+                cluster.probe_class_factory(full_kwargs)
+            except Exception as exc:  # pragma: no cover — vLLM raises broadly
+                rows.append(
+                    _ProbeRow(
+                        kwargs=kwargs,
+                        error_message=str(exc),
+                        error_type=type(exc).__name__,
+                    )
+                )
+            else:
+                rows.append(_ProbeRow(kwargs=kwargs, error_message=None, error_type=None))
+    finally:
+        lg.setLevel(prev)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Predicate inference (cross-field comparison + single-field threshold)
+# ---------------------------------------------------------------------------
+
+
+def _is_int(v: Any) -> bool:
+    return isinstance(v, int) and not isinstance(v, bool)
+
+
+def _is_num(v: Any) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _split(rows: list[_ProbeRow]) -> tuple[list[_ProbeRow], list[_ProbeRow]]:
+    err = [r for r in rows if r.error_message is not None]
+    ok = [r for r in rows if r.error_message is None]
+    return err, ok
+
+
+_COMPARATORS: tuple[tuple[str, Callable[[Any, Any], bool]], ...] = (
+    (">", lambda a, b: a > b),
+    ("<", lambda a, b: a < b),
+    (">=", lambda a, b: a >= b),
+    ("<=", lambda a, b: a <= b),
+)
+
+
+def _explains(
+    all_rows: list[_ProbeRow],
+    err_rows: list[_ProbeRow],
+    pred: Callable[[_ProbeRow], bool],
+) -> bool:
+    """True iff ``pred`` fires on ``err_rows`` and on NO clean rows.
+
+    Other-class errored rows (errors that aren't in ``err_rows``) are
+    skipped from the consistency check — they're not evidence for or
+    against this class's predicate. Without this skip, divisibility and
+    range predicates inside one cluster would contaminate each other.
+    """
+    err_ids = {id(r) for r in err_rows}
+    saw_err = False
+    saw_ok = False
+    for row in all_rows:
+        is_this_class_error = id(row) in err_ids
+        is_any_error = row.error_message is not None
+        is_other_class_error = is_any_error and not is_this_class_error
+        if is_other_class_error:
+            continue
+        try:
+            holds = pred(row)
+        except (TypeError, KeyError):
+            continue
+        if holds and not is_this_class_error:
+            return False
+        if not holds and is_this_class_error:
+            return False
+        if holds and is_this_class_error:
+            saw_err = True
+        if not holds and not is_this_class_error:
+            saw_ok = True
+    return saw_err and saw_ok
+
+
+def _infer_cross_field_comparison(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    err_rows: list[_ProbeRow],
+) -> tuple[str, str, str] | None:
+    """Find a pair (a, b, op) where errors fire iff ``kwargs[a] op kwargs[b]``."""
+    int_fields = [
+        name for name, vals in cluster.values_per_field.items() if any(_is_int(v) for v in vals)
+    ]
+    for a, b in itertools.permutations(int_fields, 2):
+        for op_name, op_fn in _COMPARATORS:
+
+            def pred(
+                row: _ProbeRow, _a: str = a, _b: str = b, _op: Callable[..., bool] = op_fn
+            ) -> bool:
+                va, vb = row.kwargs.get(_a), row.kwargs.get(_b)
+                if not (_is_int(va) and _is_int(vb)):
+                    raise TypeError
+                return _op(va, vb)
+
+            if _explains(all_rows, err_rows, pred):
+                return a, b, op_name
+    return None
+
+
+def _infer_single_field_threshold(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    err_rows: list[_ProbeRow],
+) -> tuple[str, str, Any] | None:
+    """Find a kwarg ``a`` and threshold V where errors fire iff ``kwargs[a] op V``."""
+    for a, vals in cluster.values_per_field.items():
+        if not any(_is_num(v) for v in vals):
+            continue
+        for op, threshold, op_fn in [
+            ("<", 0, lambda x: _is_num(x) and x < 0),
+            ("<=", 0, lambda x: _is_num(x) and x <= 0),
+            ("<", 1, lambda x: _is_num(x) and x < 1),
+        ]:
+
+            def pred(row: _ProbeRow, _a: str = a, _fn: Callable[[Any], bool] = op_fn) -> bool:
+                va = row.kwargs.get(_a)
+                if va is None:
+                    raise TypeError
+                return _fn(va)
+
+            if _explains(all_rows, err_rows, pred):
+                return a, op, threshold
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cluster -> rule candidate
+# ---------------------------------------------------------------------------
+
+
+_OP_NAMES = {">": "exceeds", "<": "lt", ">=": "ge", "<=": "le", "==": "eq", "!=": "ne"}
+
+
+def _value_label(v: Any) -> str:
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    if v is None:
+        return "none"
+    if isinstance(v, int):
+        if v < 0:
+            return f"neg{abs(v)}"
+        if v == 0:
+            return "zero"
+        return str(v)
+    if isinstance(v, float):
+        s = str(v).replace(".", "p").replace("-", "neg")
+        return s
+    return "".join(ch for ch in str(v) if ch.isalnum() or ch == "_").lower()
+
+
+def _normalise_message_class(msg: str) -> str:
+    """Collapse a raised-error message to its template form for grouping.
+
+    Strips backtick-wrapped value tokens and bare numbers so messages that
+    differ only in the offending value still hash to one class. Mirrors the
+    transformers dynamic miner's normalisation.
+    """
+    import re as _re
+
+    msg = _re.sub(r"`[^`]*`", "`X`", msg or "")
+    msg = _re.sub(r"-?\d+\.?\d*", "N", msg)
+    msg = _re.sub(r"\s+", " ", msg).strip()
+    return msg
+
+
+def _group_errors_by_class(rows: list[_ProbeRow]) -> dict[str, list[_ProbeRow]]:
+    """Group errored rows by normalised error-message class."""
+    groups: dict[str, list[_ProbeRow]] = {}
+    for r in rows:
+        if r.error_message is None:
+            continue
+        key = _normalise_message_class(r.error_message)
+        groups.setdefault(key, []).append(r)
+    return groups
+
+
+def _cluster_rules(
+    cluster: _Cluster,
+    rows: list[_ProbeRow],
+    rel_source_path: str,
+    today: str,
+) -> list[RuleCandidate]:
+    """Run predicate inference per error-class and emit one RuleCandidate per fit.
+
+    Splits errored rows by normalised message-class so each underlying rule
+    in the cluster gets its own inference pass. Without grouping, a cluster
+    that hits multiple validators (``temperature < 0`` AND ``top_p > 1``)
+    fails to find any single predicate explaining all errors and emits zero
+    rules — the symptom this grouping fixes.
+    """
+    err_rows, ok_rows = _split(rows)
+    if not err_rows or not ok_rows:
+        return []
+
+    out: list[RuleCandidate] = []
+    seen_ids: set[str] = set()
+    for msg_class, group_rows in _group_errors_by_class(err_rows).items():
+        del msg_class  # used only for grouping
+        for rule in _infer_for_group(cluster, rows, group_rows, rel_source_path, today):
+            if rule.id in seen_ids:
+                continue
+            seen_ids.add(rule.id)
+            out.append(rule)
+    return out
+
+
+def _infer_for_group(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    group_rows: list[_ProbeRow],
+    rel_source_path: str,
+    today: str,
+) -> list[RuleCandidate]:
+    out: list[RuleCandidate] = []
+    cmp_result = _infer_cross_field_comparison(cluster, all_rows, group_rows)
+    if cmp_result is not None:
+        a, b, op = cmp_result
+        ok_rows = [r for r in all_rows if r.error_message is None]
+        out.append(
+            _make_cluster_rule(
+                cluster=cluster,
+                id_suffix=f"{a}_{_OP_NAMES[op]}_{b}",
+                rule_under_test=f"{cluster.name}: error when {a} {op} {b}",
+                match_fields={f"{cluster.namespace}.{a}": {op: f"@{b}"}},
+                kwargs_positive=group_rows[0].kwargs,
+                kwargs_negative=ok_rows[0].kwargs,
+                message_template=group_rows[0].error_message,
+                rel_source_path=rel_source_path,
+                today=today,
+            )
+        )
+
+    thr_result = _infer_single_field_threshold(cluster, all_rows, group_rows)
+    if thr_result is not None:
+        a, op, threshold = thr_result
+        ok_rows = [r for r in all_rows if r.error_message is None]
+        out.append(
+            _make_cluster_rule(
+                cluster=cluster,
+                id_suffix=f"{a}_{_OP_NAMES[op]}_{_value_label(threshold)}",
+                rule_under_test=f"{cluster.name}: error when {a} {op} {threshold}",
+                match_fields={f"{cluster.namespace}.{a}": {op: threshold}},
+                kwargs_positive=group_rows[0].kwargs,
+                kwargs_negative=ok_rows[0].kwargs,
+                message_template=group_rows[0].error_message,
+                rel_source_path=rel_source_path,
+                today=today,
+            )
+        )
+
+    return out
+
+
+def _make_cluster_rule(
+    *,
+    cluster: _Cluster,
+    id_suffix: str,
+    rule_under_test: str,
+    match_fields: dict[str, Any],
+    kwargs_positive: dict[str, Any],
+    kwargs_negative: dict[str, Any],
+    message_template: str | None,
+    rel_source_path: str,
+    today: str,
+) -> RuleCandidate:
+    rid = f"vllm_{cluster.name}_{id_suffix}"
+    return RuleCandidate(
+        id=rid,
+        engine=ENGINE,
+        library=LIBRARY,
+        rule_under_test=rule_under_test,
+        severity="error",
+        native_type=cluster.native_type,
+        miner_source=MinerSource(
+            path=rel_source_path,
+            method="<probe>",
+            line_at_scan=0,
+        ),
+        match_fields=match_fields,
+        kwargs_positive=_yaml_safe_kwargs(kwargs_positive),
+        kwargs_negative=_yaml_safe_kwargs(kwargs_negative),
+        expected_outcome={
+            "outcome": "error",
+            "emission_channel": "none",
+            "normalised_fields": [],
+        },
+        message_template=message_template,
+        references=[
+            f"vllm.{cluster.native_type.rsplit('.', 1)[-1]} — observed via combinatorial probing"
+        ],
+        added_by="dynamic_miner",
+        added_at=today,
+    )
+
+
+# Operator inversion: the lift modules emit ``match_fields`` shaped as the
+# *constraint* the field must satisfy (e.g. ``{">": 0}`` for ``Gt(0)``). The
+# corpus loader's convention is that ``match_fields`` encodes the rule's
+# *firing condition* — i.e. the violation predicate. The transformers static
+# miner emits violation-shape predicates because it walks ``if X: raise``
+# AST. The lift modules emit constraint-shape predicates and we invert here
+# at the per-engine driver level (per the brief: do not modify the lifts
+# directly; engine-level adaptation is allowed).
+_OP_INVERSE: dict[str, str] = {
+    ">": "<=",
+    ">=": "<",
+    "<": ">=",
+    "<=": ">",
+    "==": "!=",
+    "!=": "==",
+    "in": "not_in",
+    "not_in": "in",
+}
+
+
+def _invert_match_fields(match_fields: dict[str, Any]) -> dict[str, Any]:
+    """Invert lift-emitted ``match_fields`` so they fire on the violation.
+
+    For each path, replace operator keys with their loader-vocabulary
+    inverse. Length operators (``min_len`` / ``max_len``) and the
+    ``multiple_of`` predicate have no clean single-op inverse — we leave
+    those entries as-is and let vendor-CI prune them; that's the lift's
+    edge case to fix at the type-system level.
+    """
+    out: dict[str, Any] = {}
+    for path, spec in match_fields.items():
+        if not isinstance(spec, dict):
+            # Bare value spec — equality. The inverted form is ``!=`` against
+            # the same value, but bare-equality lift output is the Literal
+            # path which already uses ``in`` not ``==``; leave alone.
+            out[path] = spec
+            continue
+        new_spec: dict[str, Any] = {}
+        for op, value in spec.items():
+            inverse = _OP_INVERSE.get(op)
+            if inverse is None:
+                new_spec[op] = value
+            else:
+                new_spec[inverse] = value
+        out[path] = new_spec
+    return out
+
+
+_SAFE_TYPES: tuple[type, ...] = (str, int, float, bool, type(None), list, tuple, dict)
+
+
+def _is_yaml_safe(value: Any) -> bool:
+    if not isinstance(value, _SAFE_TYPES):
+        return False
+    if isinstance(value, dict):
+        return all(_is_yaml_safe(k) and _is_yaml_safe(v) for k, v in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_is_yaml_safe(v) for v in value)
+    return True
+
+
+def _yaml_safe_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    return {k: (v if _is_yaml_safe(v) else None) for k, v in kwargs.items()}
+
+
+# ---------------------------------------------------------------------------
+# Source-path helpers + landmark verification
+# ---------------------------------------------------------------------------
+
+
+def _site_packages_relative(abs_path: str) -> str:
+    marker = "site-packages/"
+    idx = abs_path.find(marker)
+    if idx >= 0:
+        return abs_path[idx + len(marker) :]
+    return Path(abs_path).name
+
+
+def _check_landmarks() -> str:
+    """Import vLLM, verify SamplingParams + lift targets exist; return version.
+
+    Mirrors the static miner's fail-loud contract: missing class -> raise.
+    """
+    try:
+        import vllm  # type: ignore
+    except ImportError as exc:
+        raise MinerLandmarkMissingError("vllm.__init__", detail="vllm not importable") from exc
+
+    try:
+        from vllm import SamplingParams  # type: ignore  # noqa: F401
+    except ImportError as exc:
+        raise MinerLandmarkMissingError(
+            "vllm.SamplingParams", detail="symbol not importable"
+        ) from exc
+
+    try:
+        from vllm.engine.arg_utils import EngineArgs  # type: ignore  # noqa: F401
+    except ImportError as exc:
+        raise MinerLandmarkMissingError(
+            "vllm.engine.arg_utils.EngineArgs", detail="symbol not importable"
+        ) from exc
+
+    for target in _PYDANTIC_LIFT_TARGETS:
+        try:
+            module = __import__(target.module_path, fromlist=[target.class_name])
+        except ImportError as exc:
+            raise MinerLandmarkMissingError(
+                target.module_path, detail=f"module not importable: {exc}"
+            ) from exc
+        if not hasattr(module, target.class_name):
+            raise MinerLandmarkMissingError(
+                f"{target.module_path}.{target.class_name}",
+                detail="class symbol missing",
+            )
+
+    return vllm.__version__
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def walk_vllm_dynamic() -> tuple[list[RuleCandidate], str]:
+    """Return ``(candidates, vllm_version)`` for the dynamic mining pass.
+
+    Composes (a) lift modules over SamplingParams + EngineArgs +
+    vllm.config.* dataclasses, then (b) cluster probes. Emission order is
+    deterministic across runs.
+    """
+    installed_version = _check_landmarks()
+    check_installed_version("vllm", installed_version, TESTED_AGAINST_VERSIONS)
+
+    today = dt.date.today().isoformat()
+    candidates: list[RuleCandidate] = []
+
+    # Lift 1: msgspec — SamplingParams. (``vllm.SamplingParams`` re-export
+    # exists, so the lift's default native_type is dotted-importable.)
+    from vllm import SamplingParams  # type: ignore
+
+    sp_source = inspect.getsourcefile(SamplingParams) or "<unknown>"
+    sp_rel = _site_packages_relative(sp_source)
+    sp_lifted = _msgspec_lift(
+        SamplingParams,
+        namespace=NS_SAMPLING,
+        today=today,
+        source_path=sp_rel,
+    )
+    for cand in sp_lifted:
+        # The lift synthesises its own message templates from
+        # ``annotated-types`` operator names; vLLM's runtime messages come
+        # from msgspec / pydantic and don't match. Drop the synthesised
+        # template so the vendor-CI gate skips the substring check (the
+        # rule's ``kwargs_positive`` raises and ``kwargs_negative`` doesn't,
+        # which is sufficient signal for a lift-derived rule). Per
+        # ``feedback_corpus_is_measurement_not_authoring``, the corpus
+        # records what fires, not how the library worded the message.
+        cand.message_template = None
+        cand.match_fields = _invert_match_fields(cand.match_fields)
+    candidates.extend(sp_lifted)
+
+    # Lift 2: pydantic — vllm.config.* family. The lift sets
+    # ``native_type=f"{library}.{type_name}"`` from ``cls.__module__.split('.', 1)[0]``,
+    # which yields ``"vllm.CacheConfig"`` — but the actual import path is
+    # ``vllm.config.cache.CacheConfig`` (re-exported as ``vllm.config.CacheConfig``).
+    # Fixing this in ``_pydantic_lift`` would change every other engine's
+    # behaviour (the lift is library-agnostic). Instead, rewrite the
+    # native_type per-engine here so vendor-CI's ``_construct_generic`` can
+    # reach the class via dotted import. ``native_type`` is the only field
+    # that needs adjusting; ``library`` (used for diagnostics) stays as
+    # ``"vllm"``.
+    for target in _PYDANTIC_LIFT_TARGETS:
+        module = __import__(target.module_path, fromlist=[target.class_name])
+        cls = getattr(module, target.class_name)
+        cls_source = inspect.getsourcefile(module) or "<unknown>"
+        cls_rel = _site_packages_relative(cls_source)
+        lifted = _pydantic_lift(
+            cls,
+            namespace=target.namespace,
+            today=today,
+            source_path=cls_rel,
+        )
+        # Use the ``vllm.config.<Name>`` re-export form (rather than the
+        # deeper ``vllm.config.parallel.ParallelConfig`` actual location) —
+        # vLLM re-exports every config class from ``vllm.config`` and this
+        # is the form the static miner uses, so cross-validation /
+        # fingerprint readability stays uniform.
+        canonical_native = f"vllm.config.{target.class_name}"
+        for cand in lifted:
+            cand.native_type = canonical_native
+            # Synthesised templates don't match Pydantic's runtime errors;
+            # see the SamplingParams lift loop above for rationale.
+            cand.message_template = None
+            cand.match_fields = _invert_match_fields(cand.match_fields)
+        candidates.extend(lifted)
+
+    # Lift 3: stdlib dataclass — DELIBERATELY OMITTED for EngineArgs.
+    #
+    # ``EngineArgs`` is a 175-field stdlib dataclass with rich
+    # ``Literal[...]`` annotations. Calling ``_dataclass_lift`` over it
+    # produces ~23 candidate rules — all of which fail vendor-CI because
+    # stdlib dataclass does NOT enforce Literal types at construction:
+    # ``EngineArgs(runner="bogus")`` succeeds and only triggers a runtime
+    # warning. Real validation lives on the depth-1 ``vllm.config.*``
+    # pydantic-dataclasses (covered by the pydantic lift above) and on
+    # the AST-walked validators (covered by the static miner).
+    #
+    # Recall-first would say "emit and let vendor-CI prune", but that
+    # bloats the quarantine file with unenforceable rules. This is the
+    # type-system mismatch the design's "skip dynamic-TRT-LLM" decision
+    # also encountered: not every lift × class produces real rules.
+    # Symmetric resolution is to omit the lift call when the class isn't
+    # the actual validation site. Per-engine adaptation, no lift-module
+    # change.
+
+    # Probe path: SamplingParams cluster runs.
+    for cluster in CLUSTERS:
+        rows = _run_cluster(cluster)
+        candidates.extend(_cluster_rules(cluster, rows, sp_rel, today))
+
+    return candidates, installed_version
+
+
+def _candidate_to_dict(c: RuleCandidate) -> dict[str, Any]:
+    return {
+        "id": c.id,
+        "engine": c.engine,
+        "library": c.library,
+        "rule_under_test": c.rule_under_test,
+        "severity": c.severity,
+        "native_type": c.native_type,
+        "miner_source": {
+            "path": c.miner_source.path,
+            "method": c.miner_source.method,
+            "line_at_scan": c.miner_source.line_at_scan,
+        },
+        "match": {
+            "engine": c.engine,
+            "fields": c.match_fields,
+        },
+        "kwargs_positive": c.kwargs_positive,
+        "kwargs_negative": c.kwargs_negative,
+        "expected_outcome": c.expected_outcome,
+        "message_template": c.message_template,
+        "references": c.references,
+        "added_by": c.added_by,
+        "added_at": c.added_at,
+    }
+
+
+def emit_yaml(candidates: list[RuleCandidate], engine_version: str) -> str:
+    import yaml
+
+    sorted_candidates = sorted(candidates, key=lambda c: (c.miner_source.method, c.id))
+    doc = {
+        "schema_version": "1.0.0",
+        "engine": ENGINE,
+        "engine_version": engine_version,
+        "walker_pinned_range": str(TESTED_AGAINST_VERSIONS),
+        "mined_at": dt.date.today().isoformat(),
+        "rules": [_candidate_to_dict(c) for c in sorted_candidates],
+    }
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=100)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("configs/validation_rules/_staging/vllm_dynamic_miner.yaml"),
+        help="Where to write the staging YAML.",
+    )
+    args = parser.parse_args(argv)
+
+    candidates, version = walk_vllm_dynamic()
+    text = emit_yaml(candidates, version)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(text)
+    print(
+        f"Wrote {len(candidates)} vLLM dynamic-miner rule candidates to {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/miners/vllm_miner.py
+++ b/scripts/miners/vllm_miner.py
@@ -1,0 +1,155 @@
+"""vLLM validation-rules miner — landmark-verified orchestrator.
+
+Composes :mod:`scripts.miners.vllm_static_miner` (AST walks) with
+:mod:`scripts.miners.vllm_dynamic_miner` (sub-library lifts + cluster
+probing) into a single corpus-shape YAML output. Mirrors
+:mod:`scripts.miners.transformers_miner` structurally so the pipeline is
+uniform per engine.
+
+Landmark verification + version envelope guard happen inside the two
+sub-miners; this orchestrator delegates and aggregates. Both sub-miners
+share :data:`scripts.miners.vllm_static_miner.TESTED_AGAINST_VERSIONS` so
+the version pin is single-sourced — drift the pin in one place and both
+halves see it.
+
+Usage::
+
+    python -m scripts.miners.vllm_miner --out configs/validation_rules/vllm.yaml
+
+This module is normally invoked via :mod:`scripts.miners.build_corpus`
+(which writes per-miner staging YAMLs and merges + vendor-validates them
+into the canonical corpus). The standalone ``--out`` path exists for ad-hoc
+local development.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Project root on sys.path for both ``-m`` and direct invocation.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.miners._base import RuleCandidate  # noqa: E402
+from scripts.miners.vllm_dynamic_miner import walk_vllm_dynamic  # noqa: E402
+from scripts.miners.vllm_static_miner import (  # noqa: E402
+    TESTED_AGAINST_VERSIONS,
+    walk_vllm_static,
+)
+
+# ---------------------------------------------------------------------------
+# YAML emission
+# ---------------------------------------------------------------------------
+
+
+def _candidate_to_dict(c: RuleCandidate) -> dict[str, Any]:
+    return {
+        "id": c.id,
+        "engine": c.engine,
+        "library": c.library,
+        "rule_under_test": c.rule_under_test,
+        "severity": c.severity,
+        "native_type": c.native_type,
+        "miner_source": {
+            "path": c.miner_source.path,
+            "method": c.miner_source.method,
+            "line_at_scan": c.miner_source.line_at_scan,
+        },
+        "match": {
+            "engine": c.engine,
+            "fields": c.match_fields,
+        },
+        "kwargs_positive": c.kwargs_positive,
+        "kwargs_negative": c.kwargs_negative,
+        "expected_outcome": c.expected_outcome,
+        "message_template": c.message_template,
+        "references": c.references,
+        "added_by": c.added_by,
+        "added_at": c.added_at,
+    }
+
+
+def walk() -> tuple[list[RuleCandidate], dict[str, Any]]:
+    """Return ``(candidates, envelope_metadata)`` for both halves combined.
+
+    Both sub-miners run the version-envelope guard; if either fails, the
+    miner exits non-zero and CI breaks.
+    """
+    static_candidates, version_static = walk_vllm_static()
+    dynamic_candidates, version_dynamic = walk_vllm_dynamic()
+
+    # Both halves see the same installed library; mismatches would be a
+    # serious bug — fail-loud rather than paper over.
+    if version_static != version_dynamic:
+        raise RuntimeError(
+            f"vLLM static / dynamic miners disagree on installed version: "
+            f"{version_static!r} vs {version_dynamic!r}. Mid-flight library "
+            f"swap?"
+        )
+
+    candidates = [*static_candidates, *dynamic_candidates]
+
+    frozen = os.environ.get("LLENERGY_MINER_FROZEN_AT")
+    mined_at = (
+        frozen
+        if frozen
+        else dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+    envelope = {
+        "schema_version": "1.0.0",
+        "engine": "vllm",
+        "engine_version": version_static,
+        "walker_pinned_range": str(TESTED_AGAINST_VERSIONS),
+        "mined_at": mined_at,
+    }
+    return candidates, envelope
+
+
+def emit_yaml(candidates: list[RuleCandidate], envelope: dict[str, Any]) -> str:
+    """Serialise candidates + envelope as deterministic YAML.
+
+    Sort key matches the per-miner staging files: ``(method, id)``.
+    """
+    import yaml
+
+    sorted_candidates = sorted(candidates, key=lambda c: (c.miner_source.method, c.id))
+    doc = {
+        "schema_version": envelope["schema_version"],
+        "engine": envelope["engine"],
+        "engine_version": envelope["engine_version"],
+        "walker_pinned_range": envelope["walker_pinned_range"],
+        "mined_at": envelope["mined_at"],
+        "rules": [_candidate_to_dict(c) for c in sorted_candidates],
+    }
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=100)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Write extracted YAML to this path.",
+    )
+    args = parser.parse_args(argv)
+
+    candidates, envelope = walk()
+    text = emit_yaml(candidates, envelope)
+    args.out.write_text(text)
+    print(
+        f"Wrote {len(candidates)} vLLM rules to {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/miners/vllm_static_miner.py
+++ b/scripts/miners/vllm_static_miner.py
@@ -1,0 +1,1192 @@
+"""AST static miner for the vLLM library.
+
+Walks ``SamplingParams._verify_args`` / ``__post_init__`` /
+``_verify_greedy_sampling``, ``StructuredOutputsParams.__post_init__`` and
+the ``vllm.config.*`` validator methods listed in the design, emitting one
+:class:`RuleCandidate` per ``if cond: raise ...`` and ``if cond: self.x = y``
+shape it can structurally translate.
+
+Why a fresh static miner rather than reusing ``transformers_static_miner``
+-------------------------------------------------------------------------
+The HF static miner is paired tightly with HF's ``minor_issues`` channel and
+the strict-validate composed-error message shape — neither of which exist
+in vLLM. Trying to share the per-engine driver would leak HF concepts into
+vLLM emission. The shared infrastructure that DOES carry over is the lift
+modules (``_pydantic_lift`` / ``_msgspec_lift`` / ``_dataclass_lift``) and
+the AST primitives in ``_base.py`` (``find_class``, ``find_method``,
+``call_func_path``, ``first_string_arg``, ``extract_condition_fields``).
+
+Recall first
+------------
+The miner errs toward emitting candidates with conservative kwargs;
+vendor-CI prunes any rule that doesn't actually fire against the live
+library. False positives are cheap; missed invariants are not. Per
+``feedback_corpus_is_measurement_not_authoring``, the corpus is the
+measurement output, not authorship.
+
+Output
+------
+Writes ``configs/validation_rules/_staging/vllm_static_miner.yaml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import datetime as dt
+import inspect
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from packaging.specifiers import SpecifierSet
+
+# Project root on sys.path for direct script + module-style invocation.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Defend against the script directory shadowing site-packages: when invoked
+# as ``python scripts/miners/vllm_static_miner.py``, ``scripts/miners/`` is
+# prepended to sys.path. The directory does not currently contain a
+# ``vllm.py`` stub (which would shadow the installed ``vllm`` package), but
+# we strip it for symmetry with the transformers miner and to defend against
+# future stub additions.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+sys.path[:] = [p for p in sys.path if Path(p).resolve() != Path(_SCRIPT_DIR).resolve()]
+sys.path[:] = [p for p in sys.path if p != ""]
+
+from scripts.miners._base import (  # noqa: E402  (late import after sys.path)
+    MinerLandmarkMissingError,
+    MinerSource,
+    RuleCandidate,
+    call_func_path,
+    check_installed_version,
+    find_class,
+    find_method,
+    first_string_arg,
+)
+
+# ---------------------------------------------------------------------------
+# Version pin
+# ---------------------------------------------------------------------------
+
+TESTED_AGAINST_VERSIONS: SpecifierSet = SpecifierSet(">=0.17,<0.18")
+"""vLLM versions this miner has been validated against.
+
+Matches the host install used during research (0.17.1). The Docker pin
+(``v0.7.3``) and the open-ended ``vllm>=0.6`` in ``pyproject.toml`` diverge
+from this — see issue #378 for the SSOT alignment work. The miner is a
+CI-time tool, not a runtime dep, so the narrower pin doesn't affect end
+users; the canonical vendor-CI invocation runs on the host install.
+
+On mismatch, :func:`check_installed_version` raises
+:class:`MinerVersionMismatchError` and CI breaks loud."""
+
+
+# ---------------------------------------------------------------------------
+# Engine + namespace conventions
+# ---------------------------------------------------------------------------
+
+ENGINE = "vllm"
+LIBRARY = "vllm"
+
+# Field-path namespaces. Project's ``VLLMConfig`` Pydantic model exposes
+# SamplingParams under ``vllm.sampling``, ``BeamSearchParams`` under
+# ``vllm.beam_search``, and engine-construction kwargs under ``vllm.engine``
+# (per ``src/llenergymeasure/config/engine_configs.py``). The
+# ``vllm.config.*`` family doesn't yet have its own sub-model, so its rules
+# go under ``vllm.engine``; vendor CI surfaces any path mismatch.
+NS_SAMPLING = "vllm.sampling"
+NS_STRUCTURED = "vllm.sampling.structured_outputs"
+NS_ENGINE = "vllm.engine"
+
+
+# ---------------------------------------------------------------------------
+# AST landmark registry — what to walk and where
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ASTTarget:
+    """One method to AST-walk on a given class/module pair.
+
+    ``module_attr`` is the dotted attribute path under ``vllm`` from which
+    to import the class (e.g. ``"sampling_params.SamplingParams"``).
+    ``method`` is the method name on the class. ``namespace`` is the field
+    path-prefix used when emitting rules from this method's body.
+    ``native_type`` is the corpus's ``native_type`` value for these rules.
+    ``severity_default`` filters the default outcome shape for self-assigns
+    (``dormant``) vs raises (``error``).
+    """
+
+    module_attr: str
+    method: str
+    namespace: str
+    native_type: str
+
+    @property
+    def class_name(self) -> str:
+        return self.module_attr.rsplit(".", 1)[-1]
+
+    @property
+    def module_path(self) -> str:
+        # ``"sampling_params.SamplingParams"`` -> ``"vllm.sampling_params"``
+        return f"vllm.{self.module_attr.rsplit('.', 1)[0]}"
+
+
+_AST_TARGETS: tuple[_ASTTarget, ...] = (
+    # SamplingParams family — sampling_params.py
+    _ASTTarget(
+        module_attr="sampling_params.SamplingParams",
+        method="_verify_args",
+        namespace=NS_SAMPLING,
+        native_type="vllm.SamplingParams",
+    ),
+    _ASTTarget(
+        module_attr="sampling_params.SamplingParams",
+        method="__post_init__",
+        namespace=NS_SAMPLING,
+        native_type="vllm.SamplingParams",
+    ),
+    _ASTTarget(
+        module_attr="sampling_params.SamplingParams",
+        method="_verify_greedy_sampling",
+        namespace=NS_SAMPLING,
+        native_type="vllm.SamplingParams",
+    ),
+    _ASTTarget(
+        module_attr="sampling_params.StructuredOutputsParams",
+        method="__post_init__",
+        namespace=NS_STRUCTURED,
+        native_type="vllm.sampling_params.StructuredOutputsParams",
+    ),
+    # vllm.config.* family
+    _ASTTarget(
+        module_attr="config.parallel.ParallelConfig",
+        method="_validate_parallel_config",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.ParallelConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.parallel.ParallelConfig",
+        method="_verify_args",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.ParallelConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.parallel.ParallelConfig",
+        method="__post_init__",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.ParallelConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.parallel.EPLBConfig",
+        method="_validate_eplb_config",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.EPLBConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.lora.LoRAConfig",
+        method="_validate_lora_config",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.LoRAConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.multimodal.MultiModalConfig",
+        method="_validate_multimodal_config",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.MultiModalConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.structured_outputs.StructuredOutputsConfig",
+        method="_validate_structured_output_config",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.StructuredOutputsConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.cache.CacheConfig",
+        method="_validate_cache_dtype",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.CacheConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.model.ModelConfig",
+        method="__post_init__",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.ModelConfig",
+    ),
+    # SpeculativeConfig.__post_init__ is 264 lines of nested-config wiring;
+    # AST-walking it produces 30+ raw rules that all fail vendor-CI because
+    # the predicates depend on cross-config references (model_config,
+    # parallel_config) the static miner can't synthesise from kwargs alone.
+    # The pydantic-lift over SpeculativeConfig (in the dynamic miner) covers
+    # the field-bound constraints that DO fire; AST-walking the validator
+    # methods would only contribute noise to the quarantine. Skip.
+    #
+    # If a future version exposes simpler standalone validators, add
+    # ``_validate_*`` targets explicitly here rather than ``__post_init__``.
+    _ASTTarget(
+        module_attr="config.compilation.CompilationConfig",
+        method="__post_init__",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.CompilationConfig",
+    ),
+    _ASTTarget(
+        module_attr="config.scheduler.SchedulerConfig",
+        method="__post_init__",
+        namespace=NS_ENGINE,
+        native_type="vllm.config.SchedulerConfig",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Detected pattern + rule emission
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Detected:
+    """One detected raise/dormancy site within an ``if`` body."""
+
+    severity: str  # "error" | "warn" | "dormant"
+    outcome: str  # "error" | "warn" | "dormant_announced" | "dormant_silent"
+    emission_channel: str
+    affected_field: str | None
+    message_template: str | None
+    detail: str
+    line: int
+
+
+def _detect_raise(stmt: ast.stmt) -> _Detected | None:
+    if not isinstance(stmt, ast.Raise) or stmt.exc is None:
+        return None
+    if isinstance(stmt.exc, ast.Call):
+        func = stmt.exc.func
+        if isinstance(func, ast.Name):
+            exc_type = func.id
+        elif isinstance(func, ast.Attribute):
+            exc_type = func.attr
+        else:
+            exc_type = "Exception"
+        msg = first_string_arg(stmt.exc)
+        return _Detected(
+            severity="error",
+            outcome="error",
+            emission_channel="none",
+            affected_field=None,
+            message_template=msg,
+            detail=f"raise {exc_type}",
+            line=stmt.lineno,
+        )
+    return None
+
+
+def _detect_self_assign(stmt: ast.stmt) -> _Detected | None:
+    """``self.X = Y`` inside an ``if`` body — silent normalisation."""
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if not (
+        isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "self"
+    ):
+        return None
+    rhs = ast.unparse(stmt.value)
+    return _Detected(
+        severity="dormant",
+        outcome="dormant_silent",
+        emission_channel="none",
+        affected_field=target.attr,
+        message_template=None,
+        detail=f"self.{target.attr} = {rhs}",
+        line=stmt.lineno,
+    )
+
+
+def _detect_logger_warning(stmt: ast.stmt) -> _Detected | None:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return None
+    path = call_func_path(stmt.value)
+    if path is None or len(path) != 2 or path[0] != "logger":
+        return None
+    method = path[-1]
+    if method not in {"warning", "warning_once", "error"}:
+        return None
+    severity = "error" if method == "error" else "warn"
+    outcome = "error" if method == "error" else "warn"
+    channel = "logger_warning_once" if method == "warning_once" else "logger_warning"
+    return _Detected(
+        severity=severity,
+        outcome=outcome,
+        emission_channel=channel,
+        affected_field=None,
+        message_template=first_string_arg(stmt.value),
+        detail=f"logger.{method}",
+        line=stmt.lineno,
+    )
+
+
+def _detect_warnings_warn(stmt: ast.stmt) -> _Detected | None:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return None
+    path = call_func_path(stmt.value)
+    if path != ["warnings", "warn"]:
+        return None
+    return _Detected(
+        severity="warn",
+        outcome="warn",
+        emission_channel="warnings_warn",
+        affected_field=None,
+        message_template=first_string_arg(stmt.value),
+        detail="warnings.warn",
+        line=stmt.lineno,
+    )
+
+
+_DETECTORS = (
+    _detect_raise,
+    _detect_logger_warning,
+    _detect_warnings_warn,
+    _detect_self_assign,
+)
+
+
+def _detect_body_stmts(body: list[ast.stmt]) -> list[_Detected]:
+    """Return all detected sites in an ``if`` body, preserving order.
+
+    Iterates over EVERY statement, not just the first — this fixes the bug
+    PR #417 documented where greedy-block multi-assignment lost two of three
+    rules. Recurses into nested ``if`` blocks via the parent walker.
+    """
+    out: list[_Detected] = []
+    for stmt in body:
+        for det in _DETECTORS:
+            result = det(stmt)
+            if result is not None:
+                out.append(result)
+                break
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Predicate translation (AST condition -> match.fields shape)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Predicate:
+    """One self-attribute predicate distilled from an ``if`` condition."""
+
+    field: str
+    op: str
+    rhs: Any  # literal or ``"@<field>"`` cross-field reference
+    confidence_penalty: int = 0
+
+
+_COMPARE_OPS: dict[type[ast.cmpop], str] = {
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+    ast.In: "in",
+    ast.NotIn: "not_in",
+}
+
+_FLIPPED_OPS: dict[str, str] = {
+    "<": ">",
+    "<=": ">=",
+    ">": "<",
+    ">=": "<=",
+    "==": "==",
+    "!=": "!=",
+}
+
+_INVERSE_OPS: dict[str, str] = {
+    "==": "!=",
+    "!=": "==",
+    "<": ">=",
+    "<=": ">",
+    ">": "<=",
+    ">=": "<",
+    "in": "not_in",
+    "not_in": "in",
+    "present": "absent",
+    "absent": "present",
+    "type_is": "type_is_not",
+    "type_is_not": "type_is",
+}
+
+
+def _self_attr(node: ast.expr) -> str | None:
+    """Return ``X`` if ``node`` is ``self.X``, else None."""
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    ):
+        return node.attr
+    return None
+
+
+def _literal(node: ast.expr) -> tuple[bool, Any]:
+    """Resolve ``node`` to a Python literal."""
+    if isinstance(node, ast.Constant):
+        return True, node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        ok, v = _literal(node.operand)
+        if ok and isinstance(v, (int, float)):
+            return True, -v
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        out: list[Any] = []
+        for elt in node.elts:
+            ok, v = _literal(elt)
+            if not ok:
+                return False, None
+            out.append(v)
+        return True, list(out)
+    if isinstance(node, ast.Name) and node.id in {"True", "False", "None"}:
+        return True, {"True": True, "False": False, "None": None}[node.id]
+    return False, None
+
+
+def _rhs_value(node: ast.expr) -> tuple[bool, Any]:
+    """Resolve a comparator RHS into either a literal or ``"@field"`` ref."""
+    ok, v = _literal(node)
+    if ok:
+        return True, v
+    name = _self_attr(node)
+    if name is not None:
+        return True, f"@{name}"
+    return False, None
+
+
+def _extract_compare(cmp: ast.Compare) -> list[_Predicate]:
+    """Translate ``ast.Compare`` chain into a list of self-field predicates."""
+    preds: list[_Predicate] = []
+    operands = [cmp.left, *cmp.comparators]
+    for left, op, right in zip(operands, cmp.ops, cmp.comparators, strict=False):
+        if isinstance(op, (ast.Is, ast.IsNot)):
+            field_name = _self_attr(left)
+            ok, rhs = _literal(right)
+            if field_name is not None and ok and rhs is None:
+                preds.append(
+                    _Predicate(
+                        field=field_name,
+                        op="absent" if isinstance(op, ast.Is) else "present",
+                        rhs=True,
+                    )
+                )
+            continue
+        op_name = _COMPARE_OPS.get(type(op))
+        if op_name is None:
+            continue
+        left_field = _self_attr(left)
+        right_field = _self_attr(right)
+        if left_field is not None:
+            ok, rhs = _rhs_value(right)
+            if ok:
+                preds.append(_Predicate(field=left_field, op=op_name, rhs=rhs))
+        elif right_field is not None:
+            flipped = _FLIPPED_OPS.get(op_name)
+            ok, rhs = _rhs_value(left)
+            if flipped is not None and ok:
+                preds.append(_Predicate(field=right_field, op=flipped, rhs=rhs))
+    return preds
+
+
+def _extract_call(call: ast.Call) -> list[_Predicate]:
+    """``isinstance(self.x, T)`` -> type_is predicate."""
+    path = call_func_path(call)
+    if path is None:
+        return []
+    head = path[-1]
+    if head == "isinstance" and len(call.args) == 2:
+        target = call.args[0]
+        type_arg = call.args[1]
+        field_name = _self_attr(target)
+        if field_name is None:
+            return []
+        names: list[str] = []
+        if isinstance(type_arg, ast.Name):
+            names = [type_arg.id]
+        elif isinstance(type_arg, ast.Attribute):
+            names = [type_arg.attr]
+        elif isinstance(type_arg, (ast.Tuple, ast.List)):
+            for elt in type_arg.elts:
+                if isinstance(elt, ast.Name):
+                    names.append(elt.id)
+                elif isinstance(elt, ast.Attribute):
+                    names.append(elt.attr)
+        if not names:
+            return []
+        rhs: Any = names[0] if len(names) == 1 else names
+        return [_Predicate(field=field_name, op="type_is", rhs=rhs)]
+    return []
+
+
+def _extract_predicates(condition: ast.expr) -> list[_Predicate]:
+    """Translate an arbitrary boolean condition into AND-combined predicates.
+
+    BoolOp(And) -> recurse and concat. BoolOp(Or) is dropped entirely (the
+    loader operator vocabulary cannot express OR; the rule would emit
+    incorrectly). UnaryOp(Not) inverts a single inner predicate when the
+    operator is invertible. Bare ``self.X`` is treated as ``present True``.
+    """
+    if isinstance(condition, ast.BoolOp) and isinstance(condition.op, ast.And):
+        out: list[_Predicate] = []
+        for value in condition.values:
+            out.extend(_extract_predicates(value))
+        return out
+    if isinstance(condition, ast.BoolOp) and isinstance(condition.op, ast.Or):
+        return []
+    if isinstance(condition, ast.Compare):
+        return _extract_compare(condition)
+    if isinstance(condition, ast.Call):
+        return _extract_call(condition)
+    if isinstance(condition, ast.UnaryOp) and isinstance(condition.op, ast.Not):
+        inner = _extract_predicates(condition.operand)
+        if len(inner) == 1 and inner[0].op in _INVERSE_OPS:
+            p = inner[0]
+            return [_Predicate(field=p.field, op=_INVERSE_OPS[p.op], rhs=p.rhs)]
+        return []
+    field_name = _self_attr(condition)
+    if field_name is not None:
+        return [_Predicate(field=field_name, op="present", rhs=True, confidence_penalty=1)]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# kwargs synthesis (positive = trips the rule; negative = doesn't)
+# ---------------------------------------------------------------------------
+
+
+def _value_satisfying(op: str, rhs: Any) -> Any:
+    """Concrete value of the right type that satisfies the predicate."""
+    if op == "present" and rhs is True:
+        return 1
+    if op == "absent":
+        return None
+    if op == "==":
+        return rhs
+    if op == "!=":
+        if isinstance(rhs, bool):
+            return not rhs
+        if isinstance(rhs, (int, float)):
+            return rhs + 1
+        if isinstance(rhs, str):
+            return rhs + "_x"
+        return None
+    if op == "<":
+        if isinstance(rhs, bool):
+            return False
+        if isinstance(rhs, int):
+            return rhs - 1
+        if isinstance(rhs, float):
+            return rhs - 1.0
+        return rhs
+    if op == "<=":
+        return rhs
+    if op == ">":
+        if isinstance(rhs, bool):
+            return True
+        if isinstance(rhs, int):
+            return rhs + 1
+        if isinstance(rhs, float):
+            return rhs + 1.0
+        return rhs
+    if op == ">=":
+        return rhs
+    if op == "in":
+        if isinstance(rhs, (list, tuple, set)) and rhs:
+            return next(iter(rhs))
+        return rhs
+    if op == "not_in":
+        return "__vllm_static_synth__"
+    if op == "type_is":
+        return _type_label_default(rhs)
+    if op == "type_is_not":
+        return _other_type_default(rhs)
+    return rhs
+
+
+def _type_label_default(label: Any) -> Any:
+    label_str = label if isinstance(label, str) else (label[0] if label else "str")
+    return {
+        "bool": True,
+        "int": 1,
+        "float": 1.0,
+        "str": "x",
+        "list": [],
+        "dict": {},
+        "tuple": (),
+    }.get(label_str)
+
+
+def _other_type_default(label: Any) -> Any:
+    label_str = label if isinstance(label, str) else (label[0] if label else "str")
+    if label_str == "str":
+        return 1
+    if label_str in {"int", "float"}:
+        return "x"
+    if label_str == "bool":
+        return 1
+    return "x"
+
+
+def _synthesise_kwargs(preds: list[_Predicate]) -> dict[str, Any]:
+    """Build a kwargs dict where every predicate is satisfied.
+
+    For cross-field (@ref) predicates, the companion field gets a
+    neutral integer default so the comparison has both sides set.
+    """
+    out: dict[str, Any] = {}
+    for p in preds:
+        if isinstance(p.rhs, str) and p.rhs.startswith("@"):
+            companion = p.rhs[1:].split(".")[-1]
+            out.setdefault(companion, 2)
+            out.setdefault(p.field, _value_satisfying(p.op, out[companion]))
+        else:
+            out.setdefault(p.field, _value_satisfying(p.op, p.rhs))
+    return out
+
+
+def _negate_predicates(preds: list[_Predicate]) -> list[_Predicate]:
+    """Flip the last predicate so the resulting kwargs DON'T trip the rule."""
+    if not preds:
+        return []
+    last = preds[-1]
+    flipped_op = _INVERSE_OPS.get(last.op, last.op)
+    return [
+        *preds[:-1],
+        _Predicate(field=last.field, op=flipped_op, rhs=last.rhs),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# match_fields construction
+# ---------------------------------------------------------------------------
+
+
+def _build_match_fields(preds: list[_Predicate], namespace: str) -> dict[str, Any]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for p in preds:
+        path = f"{namespace}.{p.field}"
+        spec = grouped.setdefault(path, {})
+        spec[p.op] = p.rhs
+    out: dict[str, Any] = {}
+    for path, spec in grouped.items():
+        if len(spec) == 1 and "==" in spec:
+            out[path] = spec["=="]
+        else:
+            out[path] = spec
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Walker proper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Frame:
+    """Predicate accumulator while descending nested ``if`` bodies."""
+
+    predicates: list[_Predicate] = field(default_factory=list)
+
+
+def _walk_function(
+    func: ast.FunctionDef,
+    *,
+    target: _ASTTarget,
+    rel_source_path: str,
+    today: str,
+) -> list[RuleCandidate]:
+    """Walk one method body and emit rule candidates."""
+    rules: list[RuleCandidate] = []
+    seen_ids: set[str] = set()
+
+    public_fields = _public_field_names_from_target(target)
+
+    def descend(body: list[ast.stmt], frame: _Frame) -> None:
+        # Emit rules for top-level detector hits first (rare but possible:
+        # bare ``raise`` in a method body — we skip those because they have
+        # no condition to translate).
+        # Then recurse into ``if`` / ``for`` blocks.
+        for stmt in body:
+            if isinstance(stmt, ast.If):
+                _handle_if(stmt, frame)
+            elif isinstance(stmt, ast.For):
+                # Don't accumulate the for's iterable as a predicate; just
+                # descend so any nested ``if`` is visited.
+                descend(stmt.body, frame)
+
+    def _handle_if(if_node: ast.If, frame: _Frame) -> None:
+        own_preds = _extract_predicates(if_node.test)
+        # Filter: rule's condition must reference at least one self.<field>
+        # that is a public, configurable field of the native type. Drops
+        # internal-state guards (``if self._initialized``) and argument-
+        # gated rules without configuration meaning.
+        if public_fields and not any(p.field in public_fields for p in own_preds):
+            # Recurse anyway — nested predicates on different fields may still
+            # be public-field-referencing.
+            descend(if_node.body, frame)
+            return
+        local = _Frame(predicates=[*frame.predicates, *own_preds])
+        # Emit rules for every detected statement in this body (not just
+        # the first — multiple self-assigns in one branch must each emit).
+        for det in _detect_body_stmts(if_node.body):
+            rule = _build_rule(
+                target=target,
+                preds=local.predicates,
+                detected=det,
+                rel_source_path=rel_source_path,
+                today=today,
+            )
+            if rule is None:
+                continue
+            if rule.id in seen_ids:
+                # Append a numeric suffix on collision rather than dropping —
+                # multiple rules at the same predicate shape can be real
+                # (e.g. greedy block sets top_p, top_k, min_p — three rules
+                # on the same predicate).
+                suffix = 2
+                while f"{rule.id}__{suffix}" in seen_ids:
+                    suffix += 1
+                rule.id = f"{rule.id}__{suffix}"
+            seen_ids.add(rule.id)
+            rules.append(rule)
+        # Recurse into the if body for nested ``if``s.
+        descend(if_node.body, local)
+        # Walk the elif/else chain as separate frames at sibling depth.
+        for sub in if_node.orelse:
+            if isinstance(sub, ast.If):
+                _handle_if(sub, frame)
+            elif isinstance(sub, (ast.Assign, ast.Raise, ast.Expr)):
+                # Bare statements in else — no condition to translate.
+                continue
+
+    descend(func.body, _Frame())
+    return rules
+
+
+def _build_rule(
+    *,
+    target: _ASTTarget,
+    preds: list[_Predicate],
+    detected: _Detected,
+    rel_source_path: str,
+    today: str,
+) -> RuleCandidate | None:
+    """Assemble one RuleCandidate from accumulated predicates + detected body."""
+    # If the detected body affects a field via self-assign, append a
+    # ``present True`` predicate on that field so the loader's "subject"
+    # convention picks it up.
+    effective_preds = list(preds)
+    subject_field = detected.affected_field
+    if subject_field is not None and not any(p.field == subject_field for p in effective_preds):
+        effective_preds.append(_Predicate(field=subject_field, op="present", rhs=True))
+
+    if not effective_preds:
+        return None
+
+    match_fields = _build_match_fields(effective_preds, target.namespace)
+    if not match_fields:
+        return None
+
+    kwargs_pos = _synthesise_kwargs(effective_preds)
+    kwargs_neg = _synthesise_kwargs(_negate_predicates(effective_preds))
+    if kwargs_pos == kwargs_neg:
+        # Force distinct: tweak the last field by flipping its value.
+        kwargs_neg = _force_distinct(kwargs_pos, effective_preds)
+
+    # Use the field's runtime default for the negative when available —
+    # raw-flipped values (None on an int field, "_neg" on an int) trip
+    # pydantic type validation on the negative path which would
+    # quarantine an otherwise-correct rule. Falling back to the
+    # pydantic-declared default keeps the negative inside the type
+    # envelope.
+    last_pred = effective_preds[-1]
+    known, default = _field_default_from_target(target, last_pred.field)
+    if known and default != kwargs_pos.get(last_pred.field):
+        kwargs_neg = {**kwargs_neg, last_pred.field: default}
+
+    rule_id = _make_rule_id(target=target, preds=effective_preds, detected=detected)
+
+    rule_under_test = _describe_rule(target=target, preds=effective_preds, detected=detected)
+
+    return RuleCandidate(
+        id=rule_id,
+        engine=ENGINE,
+        library=LIBRARY,
+        rule_under_test=rule_under_test,
+        severity=detected.severity,  # type: ignore[arg-type]
+        native_type=target.native_type,
+        miner_source=MinerSource(
+            path=rel_source_path,
+            method=target.method,
+            line_at_scan=detected.line,
+        ),
+        match_fields=match_fields,
+        kwargs_positive=kwargs_pos,
+        kwargs_negative=kwargs_neg,
+        expected_outcome={
+            "outcome": detected.outcome,
+            "emission_channel": detected.emission_channel,
+            # Bare field name (no namespace prefix) — matches the runtime
+            # observation shape ``vendor_rules`` returns. Namespacing this
+            # would cause every dormancy rule to diverge on
+            # ``normalised_fields`` in vendor-CI.
+            "normalised_fields": (
+                [subject_field]
+                if subject_field is not None and detected.outcome.startswith("dormant")
+                else []
+            ),
+        },
+        message_template=detected.message_template,
+        references=[f"{rel_source_path}:{detected.line} ({target.native_type}.{target.method})"],
+        added_by="static_miner",
+        added_at=today,
+    )
+
+
+def _force_distinct(pos: dict[str, Any], preds: list[_Predicate]) -> dict[str, Any]:
+    """Tweak a negative kwargs dict so it differs from the positive."""
+    if not preds:
+        return pos
+    last = preds[-1]
+    out = dict(pos)
+    cur = out.get(last.field)
+    if isinstance(cur, bool):
+        out[last.field] = not cur
+    elif isinstance(cur, (int, float)):
+        out[last.field] = cur + 1
+    elif isinstance(cur, str):
+        out[last.field] = cur + "_neg"
+    elif cur is None:
+        out[last.field] = 0
+    else:
+        out[last.field] = None
+    return out
+
+
+_OP_WORDS = {
+    "==": "eq",
+    "!=": "ne",
+    "<": "lt",
+    "<=": "le",
+    ">": "gt",
+    ">=": "ge",
+    "in": "in",
+    "not_in": "not_in",
+    "present": "set",
+    "absent": "unset",
+    "type_is": "type",
+    "type_is_not": "not_type",
+}
+
+
+def _slug(value: Any) -> str:
+    s = str(value).replace(".", "p").replace("-", "neg").replace(" ", "_")
+    return "".join(ch for ch in s if ch.isalnum() or ch == "_").lower()[:24]
+
+
+def _make_rule_id(
+    *,
+    target: _ASTTarget,
+    preds: list[_Predicate],
+    detected: _Detected,
+) -> str:
+    """Stable, descriptive rule-id."""
+    severity_tag = {"error": "raises", "warn": "warns", "dormant": "dormant"}.get(
+        detected.severity, "rule"
+    )
+    short = target.class_name.lower()
+    parts: list[str] = ["vllm", short, severity_tag]
+    last = preds[-1]
+    parts.append(last.field)
+    parts.append(_OP_WORDS.get(last.op, last.op))
+    if isinstance(last.rhs, str) and last.rhs.startswith("@"):
+        parts.append("ref_" + last.rhs[1:])
+    elif isinstance(last.rhs, (int, float, bool, str)):
+        parts.append(_slug(last.rhs))
+    rid = "_".join(p for p in parts if p)
+    while "__" in rid:
+        rid = rid.replace("__", "_")
+    return rid.strip("_")
+
+
+def _describe_rule(*, target: _ASTTarget, preds: list[_Predicate], detected: _Detected) -> str:
+    pred_str = " AND ".join(f"{p.field} {p.op} {p.rhs}" for p in preds)
+    sev_word = {"error": "raises", "warn": "warns", "dormant": "marks dormant"}.get(
+        detected.severity, "fires"
+    )
+    return f"{target.class_name}.{target.method}: {sev_word} when {pred_str}"
+
+
+# ---------------------------------------------------------------------------
+# Public-field discovery for filtering
+# ---------------------------------------------------------------------------
+
+
+def _public_field_names_from_target(target: _ASTTarget) -> frozenset[str]:
+    """Return the set of public field names of the target class.
+
+    Uses runtime introspection — lists ``__pydantic_fields__`` for
+    pydantic-dataclasses, ``__struct_fields__`` for msgspec-Struct,
+    ``dataclasses.fields`` for stdlib dataclasses, and the union of
+    instance ``vars(cls())`` keys as a last-resort fallback.
+
+    On import failure returns an empty set, which makes the caller's
+    public-field filter degrade to "no filter" (recall over precision).
+    """
+    try:
+        module = __import__(target.module_path, fromlist=[target.class_name])
+        cls = getattr(module, target.class_name)
+    except (ImportError, AttributeError):
+        return frozenset()
+
+    # Pydantic-v2 surface.
+    pyd_fields = getattr(cls, "__pydantic_fields__", None)
+    if pyd_fields:
+        # Include private fields too — vLLM's ``ParallelConfig._api_process_count``
+        # is a real config knob exposed via the pydantic model, just spelt
+        # with a leading underscore. The public-field filter uses this set
+        # as "is the field a real configurable field" — leading-underscore
+        # fields qualify if pydantic registers them.
+        return frozenset(pyd_fields.keys())
+    # msgspec.Struct surface.
+    struct_fields = getattr(cls, "__struct_fields__", None)
+    if struct_fields:
+        return frozenset(n for n in struct_fields if not n.startswith("_"))
+    # stdlib dataclass.
+    import dataclasses as _dc
+
+    if _dc.is_dataclass(cls):
+        return frozenset(f.name for f in _dc.fields(cls) if not f.name.startswith("_"))
+    # Fallback: best-effort instance vars.
+    try:
+        instance = cls()
+        return frozenset(n for n in vars(instance) if not n.startswith("_"))
+    except Exception:
+        return frozenset()
+
+
+def _field_default_from_target(target: _ASTTarget, field_name: str) -> tuple[bool, Any]:
+    """Return ``(known, default_value)`` from runtime introspection.
+
+    Used by ``_force_distinct`` to make ``kwargs_negative`` use the field's
+    actual default rather than a synthesised value, which avoids tripping
+    pydantic's type validation on the negative path.
+    """
+    try:
+        module = __import__(target.module_path, fromlist=[target.class_name])
+        cls = getattr(module, target.class_name)
+    except (ImportError, AttributeError):
+        return False, None
+    pyd_fields = getattr(cls, "__pydantic_fields__", None)
+    if pyd_fields and field_name in pyd_fields:
+        info = pyd_fields[field_name]
+        default = getattr(info, "default", None)
+        # PydanticUndefined sentinel means "no default declared" — skip it.
+        if default is not None and type(default).__name__ == "PydanticUndefinedType":
+            return False, None
+        return True, default
+    return False, None
+
+
+# ---------------------------------------------------------------------------
+# Source location + landmark verification
+# ---------------------------------------------------------------------------
+
+
+def _site_packages_relative(abs_path: str) -> str:
+    marker = "site-packages/"
+    idx = abs_path.find(marker)
+    if idx >= 0:
+        return abs_path[idx + len(marker) :]
+    return Path(abs_path).name
+
+
+def _check_landmarks() -> tuple[str, dict[str, str]]:
+    """Import vLLM, verify landmarks, return ``(version, {abs_path_per_module})``.
+
+    Raises :class:`MinerLandmarkMissingError` on any missing class/method,
+    making the contract enforced rather than guideline. The path map keys
+    are module dotted-paths (``"vllm.sampling_params"`` etc.).
+    """
+    try:
+        import vllm  # type: ignore
+    except ImportError as exc:
+        raise MinerLandmarkMissingError("vllm.__init__", detail="vllm not importable") from exc
+
+    paths: dict[str, str] = {}
+    for target in _AST_TARGETS:
+        try:
+            module = __import__(target.module_path, fromlist=[target.class_name])
+        except ImportError as exc:
+            raise MinerLandmarkMissingError(
+                target.module_path, detail=f"module not importable: {exc}"
+            ) from exc
+        cls = getattr(module, target.class_name, None)
+        if cls is None:
+            raise MinerLandmarkMissingError(
+                f"{target.module_path}.{target.class_name}",
+                detail="class symbol missing",
+            )
+        if not hasattr(cls, target.method):
+            raise MinerLandmarkMissingError(
+                f"{target.module_path}.{target.class_name}.{target.method}",
+                detail="method missing on class",
+            )
+        # AST find_class / find_method on the parsed source — fail-loud if
+        # the symbol is on the runtime class but not in the source AST
+        # (e.g. dynamically attached method). This is the structural
+        # check Decision #3 of the design + adversarial review #3 demand.
+        abs_path = inspect.getsourcefile(module)
+        if abs_path is None:
+            raise MinerLandmarkMissingError(target.module_path, detail="source file unavailable")
+        paths[target.module_path] = abs_path
+        module_ast = ast.parse(Path(abs_path).read_text())
+        cls_ast = find_class(module_ast, target.class_name)
+        if cls_ast is None:
+            raise MinerLandmarkMissingError(
+                f"{target.module_path}.{target.class_name}",
+                detail="ClassDef not in AST",
+            )
+        method_ast = find_method(cls_ast, target.method)
+        if method_ast is None:
+            raise MinerLandmarkMissingError(
+                f"{target.module_path}.{target.class_name}.{target.method}",
+                detail="FunctionDef not in AST",
+            )
+
+    return vllm.__version__, paths
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def walk_vllm_static() -> tuple[list[RuleCandidate], str]:
+    """Walk all vLLM AST targets, return (candidates, vllm_version).
+
+    Raises :class:`MinerVersionMismatchError` /
+    :class:`MinerLandmarkMissingError` on drift; both are CI-fatal.
+    """
+    installed_version, abs_paths = _check_landmarks()
+    check_installed_version("vllm", installed_version, TESTED_AGAINST_VERSIONS)
+
+    today = dt.date.today().isoformat()
+
+    candidates: list[RuleCandidate] = []
+    # Cache parsed module ASTs so methods sharing a file parse once.
+    ast_cache: dict[str, ast.Module] = {}
+    for target in _AST_TARGETS:
+        abs_path = abs_paths[target.module_path]
+        rel_path = _site_packages_relative(abs_path)
+        if abs_path not in ast_cache:
+            ast_cache[abs_path] = ast.parse(Path(abs_path).read_text())
+        module_ast = ast_cache[abs_path]
+        cls_ast = find_class(module_ast, target.class_name)
+        # _check_landmarks already verified non-None; ``find_method`` on a
+        # missing method would land here only if the AST changed between
+        # the landmark check and now, which it doesn't.
+        if cls_ast is None:
+            raise MinerLandmarkMissingError(
+                f"{target.module_path}.{target.class_name}", detail="vanished mid-walk"
+            )
+        method_ast = find_method(cls_ast, target.method)
+        if method_ast is None:
+            raise MinerLandmarkMissingError(
+                f"{target.module_path}.{target.class_name}.{target.method}",
+                detail="vanished mid-walk",
+            )
+        candidates.extend(
+            _walk_function(
+                method_ast,
+                target=target,
+                rel_source_path=rel_path,
+                today=today,
+            )
+        )
+
+    return candidates, installed_version
+
+
+# ---------------------------------------------------------------------------
+# YAML emission
+# ---------------------------------------------------------------------------
+
+
+def _candidate_to_dict(c: RuleCandidate) -> dict[str, Any]:
+    return {
+        "id": c.id,
+        "engine": c.engine,
+        "library": c.library,
+        "rule_under_test": c.rule_under_test,
+        "severity": c.severity,
+        "native_type": c.native_type,
+        "miner_source": {
+            "path": c.miner_source.path,
+            "method": c.miner_source.method,
+            "line_at_scan": c.miner_source.line_at_scan,
+        },
+        "match": {
+            "engine": c.engine,
+            "fields": c.match_fields,
+        },
+        "kwargs_positive": c.kwargs_positive,
+        "kwargs_negative": c.kwargs_negative,
+        "expected_outcome": c.expected_outcome,
+        "message_template": c.message_template,
+        "references": c.references,
+        "added_by": c.added_by,
+        "added_at": c.added_at,
+    }
+
+
+def emit_yaml(candidates: list[RuleCandidate], engine_version: str) -> str:
+    import yaml
+
+    sorted_candidates = sorted(candidates, key=lambda c: (c.miner_source.method, c.id))
+    doc = {
+        "schema_version": "1.0.0",
+        "engine": ENGINE,
+        "engine_version": engine_version,
+        "walker_pinned_range": str(TESTED_AGAINST_VERSIONS),
+        "mined_at": dt.date.today().isoformat(),
+        "rules": [_candidate_to_dict(c) for c in sorted_candidates],
+    }
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=100)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("configs/validation_rules/_staging/vllm_static_miner.yaml"),
+        help="Where to write the staging YAML.",
+    )
+    args = parser.parse_args(argv)
+
+    candidates, version = walk_vllm_static()
+    text = emit_yaml(candidates, version)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(text)
+    print(
+        f"Wrote {len(candidates)} vLLM static-miner rule candidates to {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vendor_rules.py
+++ b/scripts/vendor_rules.py
@@ -175,8 +175,102 @@ def _construct_generic(native_type: str, kwargs: dict[str, Any]) -> Any:
     return cls(**kwargs)
 
 
+def _run_vllm(native_type: str, kwargs: dict[str, Any], *, strict_validate: bool) -> CaptureBuffers:
+    """Execute one rule's kwargs through the vLLM library.
+
+    ``strict_validate`` is unused — vLLM has no analog to HF's ``strict``
+    flag; sampling-param errors raise during construction and dormancy
+    surfaces via ``logger.warning_once`` from inside ``__post_init__`` /
+    ``_verify_args``. Both paths run on plain construction.
+
+    Dispatch: ``vllm.SamplingParams``, ``vllm.config.<X>``, and the dotted
+    ``vllm.<module>.<Class>`` fallback all flow through the generic
+    ``_construct_generic`` path. Logger names are vLLM's module loggers
+    (vLLM uses ``init_logger(__name__)`` per ``vllm/config/cache.py:20``).
+
+    INFO-level vLLM logs are pre-suppressed before delegating to
+    ``run_case``: vLLM logs ``INFO 04-26 [model.py] Resolved architecture``
+    on every ``ModelConfig`` construction, which the capture handler would
+    otherwise classify as ``dormant_announced`` and trip ``negative_confirms``.
+    The rule's intended channel is ``logger.warning`` / ``warning_once`` /
+    ``warnings.warn`` only; INFO is plumbing.
+
+    A handful of import-time warnings (``_SixMetaPathImporter``, SWIG type
+    metadata, ROCm probe failures) leak into ``warnings.catch_warnings``
+    on the first run-case invocation per process. These are torch/vLLM
+    bootstrap noise unrelated to the rule under test, so we strip them
+    from the captured warnings tuple before returning.
+    """
+    del strict_validate  # currently unused for vLLM
+    logger_names = (
+        "vllm",
+        "vllm.config",
+        "vllm.sampling_params",
+        "vllm.engine",
+    )
+    result = run_case(
+        lambda: _construct_generic(native_type, kwargs),
+        logger_names=logger_names,
+        # vLLM doesn't expose a strict private-field allowlist concept; the
+        # corpus loader will re-validate per-field anyway.
+        private_allowlist=frozenset(),
+    )
+
+    # Drop INFO-level vLLM bootstrap messages from the captured log stream:
+    # ``Resolved architecture``, ``Using max model len`` etc. all surface
+    # via ``vllm.config.model`` / ``vllm.config.scheduler`` and would
+    # otherwise classify the negative case as ``dormant_announced``,
+    # tripping ``negative_confirms`` for every rule that constructs one of
+    # these classes. The captured records carry no level prefix in the
+    # plain-message handler (``%(message)s`` formatter), so we filter on
+    # known-bootstrap message substrings instead — vLLM's
+    # ``init_logger(__name__)`` uses standard logging without a level
+    # marker baked into the message.
+    filtered_logs = tuple(m for m in result.logger_messages if not _VLLM_BOOTSTRAP_NOISE.search(m))
+    if filtered_logs != result.logger_messages:
+        from dataclasses import replace as _replace
+
+        result = _replace(result, logger_messages=filtered_logs)
+    # Strip torch/SWIG/ROCm bootstrap noise that has nothing to do with the
+    # rule under test.
+    filtered_warnings = tuple(
+        w for w in result.warnings_captured if not _VLLM_IMPORT_NOISE.search(w)
+    )
+    if filtered_warnings != result.warnings_captured:
+        from dataclasses import replace as _replace
+
+        result = _replace(result, warnings_captured=filtered_warnings)
+    return result
+
+
+_VLLM_IMPORT_NOISE = __import__("re").compile(
+    # Torch / ROCm import probe noise.
+    r"_SixMetaPathImporter|SwigPy|swigvarlink|VendorImporter|"
+    r"libamd_smi|amd-smi|distutils|sysconfig|"
+    r"builtin type \w+ has no __module__ attribute|"
+    # vLLM startup compile-config note.
+    r"`compile_config` is set to .* but `mode`",
+)
+
+_VLLM_BOOTSTRAP_NOISE = __import__("re").compile(
+    r"^Resolved architecture:|"
+    r"^Using max model len|"
+    r"^Using cuda graph capture|"
+    r"^Defaulting to use mp for distributed|"
+    r"^The 'pplx' all2all backend|"
+    r"^Using external launcher|"
+    r"^Disabling V1 multiprocessing|"
+    r"^max_parallel_loading_workers|"
+    r"^Setting LD_LIBRARY_PATH|"
+    r"^load_general_plugins|"
+    r"^Initializing distributed environment|"
+    r"^This model supports multiple tasks"
+)
+
+
 _ENGINE_RUNNERS = {
     "transformers": _run_transformers,
+    "vllm": _run_vllm,
 }
 
 
@@ -589,6 +683,13 @@ def _resolve_engine_version(engine: str) -> str:
             raise VendorEngineNotImportable(
                 "transformers is not importable in this environment"
             ) from exc
+    if engine == "vllm":
+        try:
+            import vllm  # type: ignore
+
+            return vllm.__version__
+        except ImportError as exc:
+            raise VendorEngineNotImportable("vllm is not importable in this environment") from exc
     return "unknown"
 
 

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -1,41 +1,63 @@
 {
   "schema_version": "1.0.0",
   "engine": "transformers",
-  "engine_version": "4.57.3",
+  "engine_version": "4.51.0",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-27T16:16:08+02:00",
-  "vendor_commit": "f8db90e201898c68b95e188a9ebaf8b4e4bea6b6",
+  "vendored_at": "2026-04-26T17:18:35+02:00",
+  "vendor_commit": "c99aec2df907949531556d431ecc4650df1333d1",
   "cases": [
     {
-      "id": "transformers_beam_search_num_beams_eq_1",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "id": "transformers_beam_search_diversity_penalty_eq_0p0",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "Detected torch version: 2.9.1",
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0",
+        "Detected torch version: 2.6.0"
       ],
       "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "`diversity_penalty` is not 0.0 or `num_beam_groups` is not 1, triggering group beam search. In this generation mode, `diversity_penalty` should be greater than `0.0`, otherwise your groups will be identical."
+      },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
+    },
+    {
+      "id": "transformers_beam_search_num_beams_eq_1",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "`diversity_penalty` is not 0.0 or `num_beam_groups` is not 1, triggering group beam search. In this generation mode, `num_beams` should be divisible by `num_beam_groups`"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
@@ -45,29 +67,27 @@
       "observed_silent_normalisations": {},
       "observed_exception": {
         "type": "ValueError",
-        "message": "Invalid `cache_implementation` (nonsense). Choose one of: ('static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'offloaded_hybrid', 'offloaded_hybrid_chunked', 'dynamic', 'dynamic_full', 'offloaded', 'quantized')"
+        "message": "Invalid `cache_implementation` (nonsense). Choose one of: ['static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'mamba', 'quantized', 'static', 'offloaded', 'dynamic']"
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_cache_choice_use_cache_eq_false",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['cache_implementation'].",
-        "The following generation flags are not valid and may be ignored: ['cache_implementation'].",
-        "The following generation flags are not valid and may be ignored: ['cache_implementation'].",
-        "- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
+        "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
+        "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_compile_config_type_compile_config_exceeds_zero",
@@ -80,7 +100,7 @@
         "message": "You provided `compile_config` as an instance of <class 'int'>, but it must be an instance of `CompileConfig`."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
@@ -93,64 +113,67 @@
         "message": "You provided `compile_config` as an instance of <class 'str'>, but it must be an instance of `CompileConfig`."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
+    },
+    {
+      "id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "`num_beams` is set to 1. However, `diversity_penalty` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_dormant_early_stopping_set_true",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
@@ -163,7 +186,7 @@
         "message": "`early_stopping` must be a boolean or 'never', but is 1.5."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
@@ -176,7 +199,7 @@
         "message": "`early_stopping` must be a boolean or 'never', but is sometimes."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
@@ -189,216 +212,172 @@
         "message": "`early_stopping` must be a boolean or 'never', but is 1.5."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_greedy_strips_epsilon_cutoff",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_greedy_strips_eta_cutoff",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_greedy_strips_min_p",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['min_p'].",
-        "The following generation flags are not valid and may be ignored: ['min_p'].",
-        "The following generation flags are not valid and may be ignored: ['min_p'].",
-        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_greedy_strips_temperature",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['temperature'].",
-        "The following generation flags are not valid and may be ignored: ['temperature'].",
-        "The following generation flags are not valid and may be ignored: ['temperature'].",
-        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_greedy_strips_top_k",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['top_k'].",
-        "The following generation flags are not valid and may be ignored: ['top_k'].",
-        "The following generation flags are not valid and may be ignored: ['top_k'].",
-        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_greedy_strips_top_p",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['top_p'].",
-        "The following generation flags are not valid and may be ignored: ['top_p'].",
-        "The following generation flags are not valid and may be ignored: ['top_p'].",
-        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_greedy_strips_typical_p",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['typical_p'].",
-        "The following generation flags are not valid and may be ignored: ['typical_p'].",
-        "The following generation flags are not valid and may be ignored: ['typical_p'].",
-        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_negative_pad_token_id",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation"
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_no_return_dict_strips_output_attentions",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['output_attentions'].",
-        "The following generation flags are not valid and may be ignored: ['output_attentions'].",
-        "The following generation flags are not valid and may be ignored: ['output_attentions'].",
-        "- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_no_return_dict_strips_output_hidden_states",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['output_hidden_states'].",
-        "The following generation flags are not valid and may be ignored: ['output_hidden_states'].",
-        "The following generation flags are not valid and may be ignored: ['output_hidden_states'].",
-        "- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_no_return_dict_strips_output_scores",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['output_scores'].",
-        "The following generation flags are not valid and may be ignored: ['output_scores'].",
-        "The following generation flags are not valid and may be ignored: ['output_scores'].",
-        "- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
@@ -411,7 +390,7 @@
         "message": "Greedy methods without beam search do not support `num_return_sequences` different than 1 (got 2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
@@ -424,7 +403,7 @@
         "message": "`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
@@ -437,7 +416,7 @@
         "message": "`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_output_token_ids_max_new_tokens_le_zero",
@@ -450,7 +429,7 @@
         "message": "`max_new_tokens` must be greater than 0, but is -1."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
@@ -463,24 +442,33 @@
         "message": "`max_new_tokens` must be greater than 0, but is -1."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation"
       ],
       "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "transformers_raises_bnb_4bit_compute_dtype_not_type_dtype",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValueError",
+        "message": "bnb_4bit_compute_dtype must be a string or a torch.dtype"
+      },
       "positive_confirmed": true,
       "negative_confirmed": true
     },
@@ -521,7 +509,7 @@
         "message": "You provided `compile_config` as an instance of <class 'bool'>, but it must be an instance of `CompileConfig`."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     },
     {
       "id": "transformers_raises_llm_int8_enable_fp32_cpu_offload_not_type_bool",
@@ -612,45 +600,52 @@
         "message": "Greedy methods without beam search do not support `num_return_sequences` different than 1 (got 2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
+    },
+    {
+      "id": "transformers_single_beam_strips_diversity_penalty",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "`num_beams` is set to 1. However, `diversity_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_single_beam_strips_early_stopping",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_single_beam_strips_length_penalty",
-      "outcome": "dormant_announced",
-      "emission_channel": "logger_warning_once",
+      "outcome": "error",
+      "emission_channel": "none",
       "observed_messages": [
-        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
-        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
-        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
-        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
-        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
-        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
+        "`num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
       ],
       "observed_silent_normalisations": {},
-      "positive_confirmed": true,
-      "negative_confirmed": true
+      "observed_exception": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
     },
     {
       "id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
@@ -663,8 +658,1287 @@
         "message": "transformers.generation.configuration_utils.WatermarkingConfig() argument after ** must be a mapping, not int"
       },
       "positive_confirmed": true,
-      "negative_confirmed": true
+      "negative_confirmed": false
     }
   ],
-  "divergences": []
+  "divergences": [
+    {
+      "rule_id": "transformers_beam_search_diversity_penalty_eq_0p0",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_beam_search_diversity_penalty_eq_0p0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "message_template",
+      "expected": "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_eq_1",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
+      "field": "message_template",
+      "expected": "Invalid `cache_implementation` (nonsense). Choose one of: ('static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'offloaded_hybrid', 'offloaded_hybrid_chunked', 'dynamic', 'dynamic_full', 'offloaded', 'quantized')",
+      "observed": "Invalid `cache_implementation` (nonsense). Choose one of: ['static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'mamba', 'quantized', 'static', 'offloaded', 'dynamic']",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "message_template",
+      "expected": "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_cache_choice_use_cache_eq_false",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_compile_config_type_compile_config_exceeds_zero",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_compile_config_type_compile_config_exceeds_zero",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValueError",
+        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValueError",
+        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "message_template",
+      "expected": "single_beam_wrong_parameter_msg.format(flag_name='diversity_penalty', flag_value=self.diversity_penalty)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "message_template",
+      "expected": "single_beam_wrong_parameter_msg.format(flag_name='early_stopping', flag_value=self.early_stopping)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_early_stopping_set_true",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "message_template",
+      "expected": "greedy_wrong_parameter_msg.format(flag_name='epsilon_cutoff', flag_value=self.epsilon_cutoff)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "message_template",
+      "expected": "greedy_wrong_parameter_msg.format(flag_name='eta_cutoff', flag_value=self.eta_cutoff)",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_eta_cutoff",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_min_p",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_temperature",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_k",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_top_p",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_greedy_strips_typical_p",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "message_template",
+      "expected": "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_negative_pad_token_id",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "message_template",
+      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_attentions",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "message_template",
+      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "message_template",
+      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_no_return_dict_strips_output_scores",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_max_new_tokens_le_zero",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_output_token_ids_max_new_tokens_le_zero",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "message_template",
+      "expected": "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_raises_bnb_4bit_compute_dtype_not_type_dtype",
+      "field": "message_template",
+      "expected": "bnb_4bit_compute_dtype must be torch.dtype",
+      "observed": "bnb_4bit_compute_dtype must be a string or a torch.dtype",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_raises_compile_config_not_type_compileconfig",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_raises_compile_config_not_type_compileconfig",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValueError",
+        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_raises_num_beams_eq_1",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_raises_num_beams_eq_1",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_diversity_penalty",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_early_stopping",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "outcome",
+      "expected": "dormant_announced",
+      "observed": "error"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "emission_channel",
+      "expected": "logger_warning_once",
+      "observed": "none"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "message_template",
+      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "transformers_single_beam_strips_length_penalty",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "TypeError",
+        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
+      },
+      "check_failed": "negative_does_not_raise"
+    }
+  ]
 }

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -1,63 +1,41 @@
 {
   "schema_version": "1.0.0",
   "engine": "transformers",
-  "engine_version": "4.51.0",
+  "engine_version": "4.57.3",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
   "vendored_at": "2026-04-26T17:18:35+02:00",
-  "vendor_commit": "c99aec2df907949531556d431ecc4650df1333d1",
+  "vendor_commit": "6710381994668d813d3e870135df145db9151ff0",
   "cases": [
     {
-      "id": "transformers_beam_search_diversity_penalty_eq_0p0",
-      "outcome": "error",
-      "emission_channel": "none",
-      "observed_messages": [
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0",
-        "Detected torch version: 2.6.0"
-      ],
-      "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "ValueError",
-        "message": "`diversity_penalty` is not 0.0 or `num_beam_groups` is not 1, triggering group beam search. In this generation mode, `diversity_penalty` should be greater than `0.0`, otherwise your groups will be identical."
-      },
-      "positive_confirmed": true,
-      "negative_confirmed": false
-    },
-    {
       "id": "transformers_beam_search_num_beams_eq_1",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "Detected torch version: 2.9.1",
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
-    },
-    {
-      "id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
-      "outcome": "error",
-      "emission_channel": "none",
-      "observed_messages": [],
-      "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "ValueError",
-        "message": "`diversity_penalty` is not 0.0 or `num_beam_groups` is not 1, triggering group beam search. In this generation mode, `num_beams` should be divisible by `num_beam_groups`"
-      },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
@@ -67,27 +45,29 @@
       "observed_silent_normalisations": {},
       "observed_exception": {
         "type": "ValueError",
-        "message": "Invalid `cache_implementation` (nonsense). Choose one of: ['static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'mamba', 'quantized', 'static', 'offloaded', 'dynamic']"
+        "message": "Invalid `cache_implementation` (nonsense). Choose one of: ('static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'offloaded_hybrid', 'offloaded_hybrid_chunked', 'dynamic', 'dynamic_full', 'offloaded', 'quantized')"
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_cache_choice_use_cache_eq_false",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
-        "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
-        "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect."
+        "The following generation flags are not valid and may be ignored: ['cache_implementation'].",
+        "The following generation flags are not valid and may be ignored: ['cache_implementation'].",
+        "The following generation flags are not valid and may be ignored: ['cache_implementation'].",
+        "- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_compile_config_type_compile_config_exceeds_zero",
@@ -100,7 +80,7 @@
         "message": "You provided `compile_config` as an instance of <class 'int'>, but it must be an instance of `CompileConfig`."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
@@ -113,67 +93,64 @@
         "message": "You provided `compile_config` as an instance of <class 'str'>, but it must be an instance of `CompileConfig`."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
-    },
-    {
-      "id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "outcome": "error",
-      "emission_channel": "none",
-      "observed_messages": [
-        "`num_beams` is set to 1. However, `diversity_penalty` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
-      ],
-      "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_dormant_early_stopping_set_true",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `True` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
@@ -186,7 +163,7 @@
         "message": "`early_stopping` must be a boolean or 'never', but is 1.5."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
@@ -199,7 +176,7 @@
         "message": "`early_stopping` must be a boolean or 'never', but is sometimes."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
@@ -212,172 +189,216 @@
         "message": "`early_stopping` must be a boolean or 'never', but is 1.5."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_greedy_strips_epsilon_cutoff",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['epsilon_cutoff'].",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_greedy_strips_eta_cutoff",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "The following generation flags are not valid and may be ignored: ['eta_cutoff'].",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_greedy_strips_min_p",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['min_p'].",
+        "The following generation flags are not valid and may be ignored: ['min_p'].",
+        "The following generation flags are not valid and may be ignored: ['min_p'].",
+        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_greedy_strips_temperature",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['temperature'].",
+        "The following generation flags are not valid and may be ignored: ['temperature'].",
+        "The following generation flags are not valid and may be ignored: ['temperature'].",
+        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `temperature`: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_greedy_strips_top_k",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['top_k'].",
+        "The following generation flags are not valid and may be ignored: ['top_k'].",
+        "The following generation flags are not valid and may be ignored: ['top_k'].",
+        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_greedy_strips_top_p",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['top_p'].",
+        "The following generation flags are not valid and may be ignored: ['top_p'].",
+        "The following generation flags are not valid and may be ignored: ['top_p'].",
+        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_greedy_strips_typical_p",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['typical_p'].",
+        "The following generation flags are not valid and may be ignored: ['typical_p'].",
+        "The following generation flags are not valid and may be ignored: ['typical_p'].",
+        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_negative_pad_token_id",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation"
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_no_return_dict_strips_output_attentions",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored."
+        "The following generation flags are not valid and may be ignored: ['output_attentions'].",
+        "The following generation flags are not valid and may be ignored: ['output_attentions'].",
+        "The following generation flags are not valid and may be ignored: ['output_attentions'].",
+        "- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_no_return_dict_strips_output_hidden_states",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored."
+        "The following generation flags are not valid and may be ignored: ['output_hidden_states'].",
+        "The following generation flags are not valid and may be ignored: ['output_hidden_states'].",
+        "The following generation flags are not valid and may be ignored: ['output_hidden_states'].",
+        "- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_no_return_dict_strips_output_scores",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored."
+        "The following generation flags are not valid and may be ignored: ['output_scores'].",
+        "The following generation flags are not valid and may be ignored: ['output_scores'].",
+        "The following generation flags are not valid and may be ignored: ['output_scores'].",
+        "- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
@@ -390,7 +411,7 @@
         "message": "Greedy methods without beam search do not support `num_return_sequences` different than 1 (got 2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
@@ -403,7 +424,7 @@
         "message": "`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
@@ -416,7 +437,7 @@
         "message": "`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_output_token_ids_max_new_tokens_le_zero",
@@ -429,7 +450,7 @@
         "message": "`max_new_tokens` must be greater than 0, but is -1."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
@@ -442,33 +463,24 @@
         "message": "`max_new_tokens` must be greater than 0, but is -1."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation"
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "The following generation flags are not valid and may be ignored: ['pad_token_id'].",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
-    },
-    {
-      "id": "transformers_raises_bnb_4bit_compute_dtype_not_type_dtype",
-      "outcome": "error",
-      "emission_channel": "none",
-      "observed_messages": [],
-      "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "ValueError",
-        "message": "bnb_4bit_compute_dtype must be a string or a torch.dtype"
-      },
       "positive_confirmed": true,
       "negative_confirmed": true
     },
@@ -509,7 +521,7 @@
         "message": "You provided `compile_config` as an instance of <class 'bool'>, but it must be an instance of `CompileConfig`."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_raises_llm_int8_enable_fp32_cpu_offload_not_type_bool",
@@ -600,52 +612,45 @@
         "message": "Greedy methods without beam search do not support `num_return_sequences` different than 1 (got 2)."
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
-    },
-    {
-      "id": "transformers_single_beam_strips_diversity_penalty",
-      "outcome": "error",
-      "emission_channel": "none",
-      "observed_messages": [
-        "`num_beams` is set to 1. However, `diversity_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
-      ],
-      "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "negative_confirmed": true
     },
     {
       "id": "transformers_single_beam_strips_early_stopping",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "The following generation flags are not valid and may be ignored: ['early_stopping'].",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_single_beam_strips_length_penalty",
-      "outcome": "error",
-      "emission_channel": "none",
+      "outcome": "dormant_announced",
+      "emission_channel": "logger_warning_once",
       "observed_messages": [
-        "`num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed."
+        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
+        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
+        "The following generation flags are not valid and may be ignored: ['length_penalty'].",
+        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file.",
+        "- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set to `0.5` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
+        "If you're using a pretrained model, note that some of these attributes may be set through the model's `generation_config.json` file."
       ],
       "observed_silent_normalisations": {},
-      "observed_exception": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "positive_confirmed": false,
-      "negative_confirmed": false
+      "positive_confirmed": true,
+      "negative_confirmed": true
     },
     {
       "id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
@@ -658,1287 +663,8 @@
         "message": "transformers.generation.configuration_utils.WatermarkingConfig() argument after ** must be a mapping, not int"
       },
       "positive_confirmed": true,
-      "negative_confirmed": false
+      "negative_confirmed": true
     }
   ],
-  "divergences": [
-    {
-      "rule_id": "transformers_beam_search_diversity_penalty_eq_0p0",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_beam_search_diversity_penalty_eq_0p0",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_eq_1",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_eq_1",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_eq_1",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_eq_1",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_eq_1",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_eq_1",
-      "field": "message_template",
-      "expected": "`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_eq_1",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_beam_search_num_beams_not_divisible_by_num_beam_groups",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
-      "field": "message_template",
-      "expected": "Invalid `cache_implementation` (nonsense). Choose one of: ('static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'offloaded_hybrid', 'offloaded_hybrid_chunked', 'dynamic', 'dynamic_full', 'offloaded', 'quantized')",
-      "observed": "Invalid `cache_implementation` (nonsense). Choose one of: ['static', 'offloaded_static', 'sliding_window', 'hybrid', 'hybrid_chunked', 'mamba', 'quantized', 'static', 'offloaded', 'dynamic']",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_cache_choice_cache_implementation_not_in_allowlist",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_cache_choice_use_cache_eq_false",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_cache_choice_use_cache_eq_false",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_cache_choice_use_cache_eq_false",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_cache_choice_use_cache_eq_false",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_cache_choice_use_cache_eq_false",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_cache_choice_use_cache_eq_false",
-      "field": "message_template",
-      "expected": "You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation will have no effect.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_cache_choice_use_cache_eq_false",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_compile_config_type_compile_config_exceeds_zero",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_compile_config_type_compile_config_exceeds_zero",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "ValueError",
-        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_compile_config_type_compile_config_type_not_in_CompileConfig",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "ValueError",
-        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "field": "message_template",
-      "expected": "single_beam_wrong_parameter_msg.format(flag_name='diversity_penalty', flag_value=self.diversity_penalty)",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_dormant_diversity_penalty_ne_0_0",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_dormant_early_stopping_set_true",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_dormant_early_stopping_set_true",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_dormant_early_stopping_set_true",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_early_stopping_set_true",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_early_stopping_set_true",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_dormant_early_stopping_set_true",
-      "field": "message_template",
-      "expected": "single_beam_wrong_parameter_msg.format(flag_name='early_stopping', flag_value=self.early_stopping)",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_dormant_early_stopping_set_true",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "field": "message_template",
-      "expected": "greedy_wrong_parameter_msg.format(flag_name='epsilon_cutoff', flag_value=self.epsilon_cutoff)",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "field": "message_template",
-      "expected": "greedy_wrong_parameter_msg.format(flag_name='eta_cutoff', flag_value=self.eta_cutoff)",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_dormant_eta_cutoff_ne_0_0",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_early_stopping_type_early_stopping_exceeds_zero",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_early_stopping_type_early_stopping_not_in_allowlist",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `epsilon_cutoff`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_epsilon_cutoff",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_eta_cutoff",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_eta_cutoff",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_eta_cutoff",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_eta_cutoff",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_eta_cutoff",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_eta_cutoff",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `eta_cutoff`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_eta_cutoff",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_min_p",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_min_p",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_min_p",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_min_p",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_min_p",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_min_p",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_min_p",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_temperature",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_temperature",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_temperature",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_temperature",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_temperature",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_temperature",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_temperature",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_k",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_k",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_k",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_k",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_k",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_k",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_k",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_p",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_p",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_p",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_p",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_p",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_p",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_top_p",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_typical_p",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_typical_p",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_typical_p",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_typical_p",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_greedy_strips_typical_p",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_typical_p",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `typical_p`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_greedy_strips_typical_p",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_negative_pad_token_id",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_negative_pad_token_id",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_negative_pad_token_id",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_negative_pad_token_id",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_negative_pad_token_id",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_negative_pad_token_id",
-      "field": "message_template",
-      "expected": "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_negative_pad_token_id",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_attentions",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_attentions",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_attentions",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_attentions",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_attentions",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_attentions",
-      "field": "message_template",
-      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_attentions",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
-      "field": "message_template",
-      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_hidden_states",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_scores",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_scores",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_scores",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_scores",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_scores",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_scores",
-      "field": "message_template",
-      "expected": "`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_no_return_dict_strips_output_scores",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_output_token_ids_max_new_tokens_le_zero",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_output_token_ids_max_new_tokens_le_zero",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_output_token_ids_max_new_tokens_not_in_allowlist",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "field": "message_template",
-      "expected": "`pad_token_id` should be positive but got -1. This will cause errors when batch generating, if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_output_token_ids_pad_token_id_not_in_allowlist",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_raises_bnb_4bit_compute_dtype_not_type_dtype",
-      "field": "message_template",
-      "expected": "bnb_4bit_compute_dtype must be torch.dtype",
-      "observed": "bnb_4bit_compute_dtype must be a string or a torch.dtype",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_raises_compile_config_not_type_compileconfig",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_raises_compile_config_not_type_compileconfig",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "ValueError",
-        "message": "You provided `compile_config` as an instance of <class 'NoneType'>, but it must be an instance of `CompileConfig`."
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_raises_num_beams_eq_1",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_raises_num_beams_eq_1",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_diversity_penalty",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_diversity_penalty",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_diversity_penalty",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_diversity_penalty",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_diversity_penalty",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_diversity_penalty",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `diversity_penalty`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_diversity_penalty",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_early_stopping",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_early_stopping",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_early_stopping",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_early_stopping",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_early_stopping",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_early_stopping",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_early_stopping",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "outcome",
-      "expected": "dormant_announced",
-      "observed": "error"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "emission_channel",
-      "expected": "logger_warning_once",
-      "observed": "none"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "positive_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "kwargs_positive",
-      "expected": "emits_warning_or_announce",
-      "observed": "error",
-      "check_failed": "positive_raises"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "message_template",
-      "expected": "` -- this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.",
-      "observed": "GenerationConfig.validate() got an unexpected keyword argument 'strict'",
-      "check_failed": "message_template_match"
-    },
-    {
-      "rule_id": "transformers_single_beam_strips_length_penalty",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    },
-    {
-      "rule_id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
-      "field": "negative_confirmed",
-      "expected": true,
-      "observed": false
-    },
-    {
-      "rule_id": "transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig",
-      "field": "kwargs_negative",
-      "expected": "does_not_raise",
-      "observed": {
-        "type": "TypeError",
-        "message": "GenerationConfig.validate() got an unexpected keyword argument 'strict'"
-      },
-      "check_failed": "negative_does_not_raise"
-    }
-  ]
+  "divergences": []
 }

--- a/tests/unit/scripts/miners/test_vllm_miner.py
+++ b/tests/unit/scripts/miners/test_vllm_miner.py
@@ -1,0 +1,298 @@
+"""Tests for the vLLM static + dynamic miners.
+
+Covers:
+- Lift call-site: ``_pydantic_lift`` and ``_msgspec_lift`` produce
+  candidates over the real vLLM types they're configured against.
+- ``_dataclass_lift`` is intentionally NOT called by the vLLM dynamic miner
+  (EngineArgs Literal rules don't fire at construction); the lift module
+  itself has its own unit tests in ``test_dataclass_lift.py``.
+- Static miner method-resolution: every declared landmark exists on the
+  installed library, raising :class:`MinerLandmarkMissingError` if any
+  drifts away.
+- Fixpoint gate-soundness: ``assert_gate_soundness_fixpoint`` succeeds on
+  the real vendor gate, mirroring the transformers test.
+
+Tests are skipped when ``vllm`` isn't importable in the test environment
+(GH-hosted ``ubuntu-latest`` without the optional extra installed).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+vllm = pytest.importorskip("vllm", reason="vLLM not installed in this environment")
+
+from scripts.miners._base import (  # noqa: E402
+    MinerLandmarkMissingError,
+    RuleCandidate,
+)
+from scripts.miners._dataclass_lift import lift as dataclass_lift  # noqa: E402
+from scripts.miners._msgspec_lift import lift as msgspec_lift  # noqa: E402
+from scripts.miners._pydantic_lift import lift as pydantic_lift  # noqa: E402
+from scripts.miners.vllm_dynamic_miner import (  # noqa: E402
+    _PYDANTIC_LIFT_TARGETS,
+    CLUSTERS,
+    walk_vllm_dynamic,
+)
+from scripts.miners.vllm_static_miner import (  # noqa: E402
+    _AST_TARGETS,
+    TESTED_AGAINST_VERSIONS,
+    _check_landmarks,
+    walk_vllm_static,
+)
+
+# ---------------------------------------------------------------------------
+# Lift call-site smoke tests — confirm the per-engine driver composes the
+# library-level lifts correctly against real vLLM types.
+# ---------------------------------------------------------------------------
+
+
+class TestLiftCallSites:
+    """Verify the dynamic miner's lift composition produces non-empty output
+    on classes the design says it should."""
+
+    def test_msgspec_lift_called_on_sampling_params(self) -> None:
+        """msgspec_lift on ``SamplingParams`` returns a list (possibly empty).
+
+        Per the research doc, vLLM 0.17.1 ships zero ``msgspec.Meta(...)``
+        annotations on SamplingParams. The lift therefore returns ``[]``
+        today — the test pins the call-site (lift IS invoked) and the
+        contract that the result is a list of :class:`RuleCandidate`. The
+        day vLLM adopts ``Meta(ge=...)`` annotations, the count flips
+        positive without code change.
+        """
+        from vllm import SamplingParams
+
+        result = msgspec_lift(
+            SamplingParams,
+            namespace="vllm.sampling",
+            today="2026-04-26",
+            source_path="vllm/sampling_params.py",
+        )
+        assert isinstance(result, list)
+        for cand in result:
+            assert isinstance(cand, RuleCandidate)
+            assert cand.added_by == "msgspec_lift"
+
+    def test_pydantic_lift_called_on_cache_config(self) -> None:
+        """pydantic_lift on ``CacheConfig`` produces multiple rules.
+
+        Anchors the lift's behaviour on a class the research doc identifies
+        as having rich annotated-types metadata
+        (``gpu_memory_utilization: Annotated[float, Gt(0), Le(1)]``).
+        """
+        from vllm.config import CacheConfig
+
+        result = pydantic_lift(
+            CacheConfig,
+            namespace="vllm.engine",
+            today="2026-04-26",
+            source_path="vllm/config/cache.py",
+        )
+        assert len(result) >= 5, (
+            f"Expected pydantic_lift to find at least 5 rules on CacheConfig "
+            f"(gpu_memory_utilization, swap_space, block_size etc.); got {len(result)}"
+        )
+        for cand in result:
+            assert isinstance(cand, RuleCandidate)
+            assert cand.added_by == "pydantic_lift"
+
+    def test_dataclass_lift_call_site_dropped_for_engine_args(self) -> None:
+        """The dynamic miner intentionally skips ``_dataclass_lift(EngineArgs)``.
+
+        Stdlib dataclass doesn't enforce Literal types — running the lift
+        here would emit ~23 unenforceable rules that all fail vendor-CI.
+        Pin the omission so a future refactor doesn't accidentally re-add
+        the call.
+        """
+        # Sanity check the lift module DOES handle EngineArgs structurally
+        # (the lift itself is fine; the engine-level decision is to skip it).
+        from vllm.engine.arg_utils import EngineArgs
+
+        candidates_if_called = dataclass_lift(
+            EngineArgs,
+            namespace="vllm.engine",
+            today="2026-04-26",
+            source_path="vllm/engine/arg_utils.py",
+        )
+        # Sanity: the lift is structurally functional (would emit something).
+        assert isinstance(candidates_if_called, list)
+        # The actual dynamic-miner output must NOT include EngineArgs rules.
+        candidates, _ = walk_vllm_dynamic()
+        engineargs_rules = [c for c in candidates if "EngineArgs" in c.native_type]
+        assert engineargs_rules == [], (
+            f"Dynamic miner unexpectedly emitted {len(engineargs_rules)} "
+            f"EngineArgs rules; the dataclass-lift call is supposed to be "
+            f"skipped for EngineArgs (see vllm_dynamic_miner.py for rationale)."
+        )
+
+    @pytest.mark.parametrize(
+        "target",
+        _PYDANTIC_LIFT_TARGETS,
+        ids=[t.class_name for t in _PYDANTIC_LIFT_TARGETS],
+    )
+    def test_every_pydantic_target_imports(
+        self,
+        target: object,  # _LiftTarget; using object to avoid private-type leak
+    ) -> None:
+        """Each target the dynamic miner lifts must be importable.
+
+        Mirrors the static miner's fail-loud landmark contract for the
+        dynamic-miner side: missing class -> clear failure rather than
+        silent zero-rule output.
+        """
+        from scripts.miners.vllm_dynamic_miner import _LiftTarget
+
+        assert isinstance(target, _LiftTarget)
+        module = __import__(target.module_path, fromlist=[target.class_name])
+        cls = getattr(module, target.class_name, None)
+        assert cls is not None, (
+            f"Pydantic lift target {target.module_path}.{target.class_name} is not importable"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Static miner method resolution
+# ---------------------------------------------------------------------------
+
+
+class TestStaticMinerLandmarks:
+    """Decision #3 of the locked design: every declared landmark must
+    resolve via ``find_class`` / ``find_method`` at miner-import time."""
+
+    def test_check_landmarks_passes_on_pinned_version(self) -> None:
+        """``_check_landmarks()`` returns cleanly on the pinned vLLM version.
+
+        Implicitly verifies every entry in ``_AST_TARGETS`` resolves; if any
+        method has been renamed / split, the test fails with the specific
+        landmark name, not a silent zero-rule output.
+        """
+        version, paths = _check_landmarks()
+        assert version, "vLLM version string was empty"
+        assert paths, "No source paths returned from landmark check"
+
+    @pytest.mark.parametrize(
+        "target",
+        _AST_TARGETS,
+        ids=[f"{t.class_name}.{t.method}" for t in _AST_TARGETS],
+    )
+    def test_each_ast_landmark_present(self, target: object) -> None:
+        """Each (class, method) target lives where the miner expects it.
+
+        Parametrised so a missing landmark surfaces in the test name,
+        making CI failures actionable.
+        """
+        from scripts.miners.vllm_static_miner import _ASTTarget
+
+        assert isinstance(target, _ASTTarget)
+        module = __import__(target.module_path, fromlist=[target.class_name])
+        cls = getattr(module, target.class_name, None)
+        assert cls is not None, f"AST target class {target.module_path}.{target.class_name} missing"
+        method = getattr(cls, target.method, None)
+        assert method is not None, f"AST target method {target.class_name}.{target.method} missing"
+
+    def test_landmark_missing_raises_loud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Removing a landmark on the imported class makes ``_check_landmarks`` raise."""
+        from vllm.config import CacheConfig
+
+        # Hide the validator method on the class for the duration of this test.
+        monkeypatch.delattr(CacheConfig, "_validate_cache_dtype")
+        with pytest.raises(MinerLandmarkMissingError):
+            _check_landmarks()
+
+
+# ---------------------------------------------------------------------------
+# Walker top-level smoke
+# ---------------------------------------------------------------------------
+
+
+class TestWalkerSmoke:
+    """Confirm the full walker returns plausible output."""
+
+    def test_static_miner_emits_rules(self) -> None:
+        """Static miner produces a non-trivial number of rules on the live library."""
+        candidates, version = walk_vllm_static()
+        assert TESTED_AGAINST_VERSIONS.contains(version, prereleases=True), (
+            f"Installed vllm=={version} outside miner pin"
+        )
+        assert len(candidates) >= 30, (
+            f"Static miner emitted only {len(candidates)} candidates; "
+            f"expected >=30 across the AST-target list."
+        )
+        # Every emitted rule must reference a real vLLM source path.
+        for c in candidates:
+            assert c.miner_source.path.startswith("vllm/"), (
+                f"Source path {c.miner_source.path!r} not rooted at vllm/"
+            )
+
+    def test_dynamic_miner_emits_rules(self) -> None:
+        """Dynamic miner's lift composition produces a non-trivial corpus."""
+        candidates, _version = walk_vllm_dynamic()
+        # Pydantic lift over 12 vllm.config.* classes alone produces ~50+
+        # rules; assert at least 30 to leave headroom for vLLM minor bumps.
+        assert len(candidates) >= 30, f"Dynamic miner emitted only {len(candidates)} candidates"
+        for c in candidates:
+            assert c.engine == "vllm"
+            assert c.added_by in {
+                "pydantic_lift",
+                "msgspec_lift",
+                "dataclass_lift",
+                "dynamic_miner",
+            }
+
+
+# ---------------------------------------------------------------------------
+# Cluster registry sanity
+# ---------------------------------------------------------------------------
+
+
+class TestClusters:
+    @pytest.mark.parametrize("cluster", CLUSTERS, ids=[c.name for c in CLUSTERS])
+    def test_cluster_factory_constructs(self, cluster: object) -> None:
+        """Each cluster's probe factory accepts a representative kwargs dict.
+
+        Smoke-tests the per-cluster ``probe_class_factory`` so a typo in
+        cluster definition fails loudly rather than silently emitting zero
+        probe rows.
+        """
+        from scripts.miners.vllm_dynamic_miner import _Cluster
+
+        assert isinstance(cluster, _Cluster)
+        # Pick the FIRST value of each grid as a positive trial.
+        kwargs = {name: vals[0] for name, vals in cluster.values_per_field.items()}
+        # Some combinations may legitimately raise — that's fine; we just
+        # need the factory to be callable without TypeError on the kwargs
+        # shape.
+        try:
+            cluster.probe_class_factory(kwargs)
+        except (ValueError, TypeError) as exc:
+            # ValueError / TypeError from the library itself is fine —
+            # construction-time validation, not factory misconfiguration.
+            assert "probe_class_factory" not in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Gate-soundness fixpoint regression
+# ---------------------------------------------------------------------------
+
+
+class TestGateSoundnessOnVllmCorpus:
+    """Pin Decision #12 of the adversarial review against the vLLM corpus.
+
+    The structural gate-soundness fixpoint is library-agnostic — it
+    synthesises malformed rules and asserts the gate flags each — but we
+    re-run it from the vLLM test file so the contract is also exercised
+    in the vLLM CI lane.
+    """
+
+    def test_gate_soundness_passes(self) -> None:
+        from scripts.miners._fixpoint_test import assert_gate_soundness_fixpoint
+
+        assert_gate_soundness_fixpoint()


### PR DESCRIPTION
Second non-transformers miner: vLLM static + dynamic + lift composition.

## Summary

- **52 rules** in ``configs/validation_rules/vllm.yaml`` (target was 80-110 - **see Open Questions**)
- Composes ``_pydantic_lift`` against ``vllm.config.*`` (33 rules) + AST-walked validators (17 static_miner) + Cartesian probing on SamplingParams (2 dynamic_miner)
- 7 dormant + 45 error severity
- ``_msgspec_lift`` wired but yielded no rules on the target classes (msgspec ``Meta`` annotations are sparse on vLLM's SamplingParams)
- 298 new tests in ``test_vllm_miner.py``

## Open questions for review

1. **Rule count gap (52 vs 80-110 target)** - is this an under-yield from the dynamic miner (only 2 rules), or did the agent's predicate inference templates not match vLLM's error-message shapes? Worth a sanity-check during /simplify.
2. **dynamic_miner = 2 rules** - vLLM's SamplingParams should produce more error-class diversity. The agent may have grouped too aggressively or the Cartesian product was too small.
3. **CPU-safe at miner runtime** - per the brief, the dynamic miner must not require GPU at import. Verify via ``test_vllm_miner.py`` does not import vllm in a way that triggers CUDA context.
4. **build_corpus.py registry** - both this PR and #434 edit ``_ENGINE_EXTRACTORS``. After #434 merges, this PR will need a rebase; conflict resolution pre-baked in the brief is "keep both entries."
5. **Vendor-CI gate** - vLLM dynamic miner can run on GH-hosted CPU runners (per locked design two-tier CI); verify the gate runs and prunes any over-eager candidates similar to those quarantined in #434.

## Constraint compliance

- No LLM components (deterministic pipeline)
- ``TESTED_AGAINST_VERSIONS`` declared
- ``find_class`` / ``find_method`` fail-loud contract used
- No ``walker_confidence`` field
- 4199 LoC across miner + tests + corpus