### PR TITLE
fix(miners): canonicalise int/float thresholds for rule fingerprinting

### DIFF
--- a/scripts/miners/build_corpus.py
+++ b/scripts/miners/build_corpus.py
@@ -236,13 +236,38 @@ def _provenance_rank(added_by: str) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _canonicalise_numbers(value: Any) -> Any:
+    """Coerce ints (excluding bool) to float for fingerprint purposes.
+
+    Predicate thresholds derived independently by the static and dynamic
+    miners can differ in numeric type — the static miner reads literals
+    from source (``0.0``), the dynamic miner emits int probes (``0``).
+    Both encode the same constraint. ``canonical_serialise`` preserves the
+    int/float distinction (``json.dumps(0)`` -> ``"0"``;
+    ``json.dumps(0.0)`` -> ``"0.0"``), which would split the cross-
+    validation safety net. Pre-canonicalise here, isolated from global
+    config hashing (which depends on type-stable Pydantic-validated input).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return float(value)
+    if isinstance(value, dict):
+        return {k: _canonicalise_numbers(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_canonicalise_numbers(v) for v in value]
+    return value
+
+
 def fingerprint_rule(rule: dict[str, Any]) -> bytes:
     """Return the canonical-serialised fingerprint bytes for a rule dict.
 
     Two rules with identical fingerprints are the same constraint discovered
     by two independent paths and get merged. The fingerprint uses
     :func:`canonical_serialise` so float jitter, dict-key ordering, and
-    NaN don't break dedup.
+    NaN don't break dedup. Numeric thresholds are int/float-canonicalised
+    via :func:`_canonicalise_numbers` so static and dynamic miners agree
+    on ``0`` vs ``0.0``.
 
     The fingerprint deliberately excludes ``id`` (extractors should already
     agree on deterministic ids, but a one-character drift shouldn't break
@@ -256,7 +281,7 @@ def fingerprint_rule(rule: dict[str, Any]) -> bytes:
         {
             "engine": rule.get("engine"),
             "severity": rule.get("severity"),
-            "match_fields": fields or {},
+            "match_fields": _canonicalise_numbers(fields or {}),
         }
     )
 

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.57.3",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-27T16:16:08+02:00",
-  "vendor_commit": "f8db90e201898c68b95e188a9ebaf8b4e4bea6b6",
+  "vendored_at": "2026-04-27T16:26:01+02:00",
+  "vendor_commit": "9d267931585ecdc8a0a4692f9fac78b37be65fb4",
   "cases": [
     {
       "id": "transformers_beam_search_num_beams_eq_1",

--- a/tests/unit/miners/test_build_corpus.py
+++ b/tests/unit/miners/test_build_corpus.py
@@ -185,6 +185,23 @@ class TestFingerprint:
         rule_b = _ast_rule(severity="warn")
         assert build_corpus.fingerprint_rule(rule_a) != build_corpus.fingerprint_rule(rule_b)
 
+    def test_fingerprint_collapses_int_and_float_thresholds(self) -> None:
+        # Static miners read literals from source (`0.0` -> float); dynamic
+        # miners emit Python int probes (`0` -> int). Same constraint, two
+        # numeric types. Without canonicalisation the cross-validation safety
+        # net would split a single library invariant into two corpus rules.
+        rule_int = _ast_rule(fields={"vllm.sampling.repetition_penalty": {"<=": 0}})
+        rule_float = _ast_rule(fields={"vllm.sampling.repetition_penalty": {"<=": 0.0}})
+        assert build_corpus.fingerprint_rule(rule_int) == build_corpus.fingerprint_rule(rule_float)
+
+    def test_fingerprint_preserves_bool_distinct_from_int(self) -> None:
+        # Bool must NOT collapse into int despite ``True == 1``: a rule that
+        # fires on ``do_sample is True`` is semantically different from one
+        # that fires on ``num_beams == 1``.
+        rule_bool = _ast_rule(fields={"transformers.sampling.do_sample": True})
+        rule_int = _ast_rule(fields={"transformers.sampling.do_sample": 1})
+        assert build_corpus.fingerprint_rule(rule_bool) != build_corpus.fingerprint_rule(rule_int)
+
 
 # ---------------------------------------------------------------------------
 # Merge: cross-validation


### PR DESCRIPTION
## What

Fixes a silent split in the corpus cross-validation safety net: two miners discovering the same library invariant with different numeric types (static reads ``0.0`` from source literal; dynamic emits int probes ``0``) ship as separate corpus rules instead of merging into one cross-validated rule.

Surfaced concretely on PR #436 (vLLM) where:
- ``vllm_samplingparams_raises_repetition_penalty_le_0p0`` (static_miner, threshold ``0.0``)
- ``vllm_sampling_penalties_repetition_penalty_le_zero`` (dynamic_miner, threshold ``0``)

ship as two distinct rules despite encoding the same predicate. The reuse-review of #436 traced this to ``canonical_serialise`` preserving ``json.dumps(0)`` -> ``"0"`` vs ``json.dumps(0.0)`` -> ``"0.0"``, so the rule fingerprints differ.

## Why localised in ``fingerprint_rule`` rather than ``domain.hashing._normalise``

``canonical_serialise`` is also used by ``study/hashing.py`` (config hash for sweep dedup), ``harness/__init__.py`` (observed-config sidecar), and ``study/runner.py``. Those callers have type-stable Pydantic-validated input so they never hit the int-vs-float collision in practice — but changing the global function would invalidate every previously-computed config hash. The fix here pre-canonicalises numbers in ``fingerprint_rule`` only.

## Bool stays distinct from int

The ``True == 1`` Python equality is deliberately NOT collapsed in the fingerprint: a rule that fires on ``do_sample=True`` is semantically different from one that fires on ``num_beams==1``. New test ``test_fingerprint_preserves_bool_distinct_from_int`` pins this invariant.

## Tests

- ``test_fingerprint_collapses_int_and_float_thresholds`` — int/float canonicalisation
- ``test_fingerprint_preserves_bool_distinct_from_int`` — bool stays distinct
- 29 ``TestFingerprint`` + ``TestCrossValidation`` etc. existing tests still pass

## Related

- Foundation for restructured PR β (replacing #436 — vLLM ships)
- Adversarial-review Challenge 4 from the multi-agent /simplify pass on #436