### PR TITLE
ci(vendor): wire GPU runner for tensorrt vendor gate

### DIFF
--- a/.github/workflows/config-rules-refresh.yml
+++ b/.github/workflows/config-rules-refresh.yml
@@ -8,6 +8,12 @@ name: Config Rules Refresh
 # Sibling of schema-refresh.yml (parameter-discovery). Same shape, same
 # commit-back + labelling + PR-comment pattern, different artifact kind.
 #
+# Two-tier CI per .product/designs/invariant-miner-design-2026-04-26.md §6:
+#   - vendor-transformers : ubuntu-latest GH-hosted runner (CPU-safe import)
+#   - vendor-tensorrt     : self-hosted GPU runner inside the
+#                           llenergymeasure:tensorrt Docker image
+#                           (TRT-LLM 0.21.0 needs CUDA-aware env)
+#
 # Trigger paths (auto):
 #   - docker/Dockerfile.{engine}        (Renovate-driven image bumps)
 #   - configs/validation_rules/{engine}.yaml
@@ -35,6 +41,7 @@ on:
         type: choice
         options:
           - transformers
+          - tensorrt
           - all
       pr_number:
         description: "PR number to comment on and label (optional)"
@@ -223,3 +230,216 @@ jobs:
         if: steps.vendor.outputs.vendor_exit != '0'
         run: |
           echo "::warning::Rules diverge from declared expected_outcome — see ${VENDORED_DIR}/transformers.json > .divergences[]. Tracking re-enable in #424."
+
+  vendor-tensorrt:
+    # TRT-LLM 0.21.0 cannot be imported on a CPU host (loads CUDA bindings on
+    # import), so the vendor gate runs inside the llenergymeasure:tensorrt
+    # Docker image on the project's self-hosted GPU runner. Closes #435.
+    #
+    # Path filters on the pull_request trigger restrict which PRs fire this
+    # workflow; workflow_dispatch always runs when explicitly invoked. The
+    # job runs whenever the workflow fires - the GPU runner is shared infra
+    # and the image is layer-cached, so the marginal cost is small. Per-engine
+    # path-filter scoping is tracked in #382.
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'tensorrt' || inputs.engine == 'all'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - name: Mint llem-ci-bot App token
+        # Mirrors the transformers job's token strategy. Skipped on fork PRs
+        # (secrets unavailable); workflow still runs read-only there.
+        id: app-token
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Clean workspace (fix root-owned files from prior Docker runs)
+        # Mirror gpu-ci.yml: container-written artefacts persist as root-owned
+        # on the self-hosted runner and break subsequent checkouts otherwise.
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "find /workspace -not -user $(id -u) -delete 2>/dev/null || true"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Resolve TRT-LLM version
+        id: version
+        run: |
+          VER=$(grep -oE '^ARG[[:space:]]+TRTLLM_VERSION=[^[:space:]]+' \
+                  docker/Dockerfile.tensorrt | head -1 | cut -d= -f2-)
+          if [[ -z "$VER" ]]; then
+            echo "Could not extract TRTLLM_VERSION from Dockerfile.tensorrt" >&2
+            exit 1
+          fi
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Build or reuse TRT-LLM image
+        # Build only if the version-tagged image is missing - the runner's
+        # Docker layer cache makes the FROM nvcr.io/.../release:VER step a
+        # no-op when the NGC tag is unchanged, so this is a cheap check.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "Building $IMAGE from docker/Dockerfile.tensorrt..."
+            docker build \
+              -f docker/Dockerfile.tensorrt \
+              -t "$IMAGE" \
+              --build-arg TRTLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
+
+      - name: Save current vendored JSON for diffing
+        id: save_old
+        run: |
+          OLD_JSON="${VENDORED_DIR}/tensorrt.json"
+          mkdir -p /tmp/rules-diff
+          if [[ -f "$OLD_JSON" ]]; then
+            cp "$OLD_JSON" /tmp/rules-diff/tensorrt.old.json
+          else
+            echo '{"cases":[],"divergences":[]}' > /tmp/rules-diff/tensorrt.old.json
+          fi
+
+      - name: Compute stable vendor anchor
+        id: anchor
+        # Mirror the transformers anchor: pin the envelope to the SHA + author
+        # date of the most recent commit touching any INPUT path. Stable across
+        # the workflow's own commit-back so re-runs on unchanged source emit
+        # byte-identical envelopes.
+        run: |
+          PATHS=(
+            "docker/Dockerfile.tensorrt"
+            "configs/validation_rules/tensorrt.yaml"
+            "scripts/vendor_rules.py"
+            "scripts/_vendor_common.py"
+            "scripts/miners/tensorrt_miner.py"
+            "scripts/miners/tensorrt_static_miner.py"
+            "scripts/miners/_base.py"
+            "scripts/update_engine_rules.sh"
+          )
+          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
+          DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+
+      - name: Re-vendor tensorrt rules inside container
+        id: vendor
+        env:
+          IMAGE: ${{ steps.version.outputs.image }}
+          ANCHOR_SHA: ${{ steps.anchor.outputs.sha }}
+          ANCHOR_DATE: ${{ steps.anchor.outputs.date }}
+        # NOTE: --fail-on-divergence intentionally OMITTED for the first
+        # operational run of the gate. Issue #435 expects to surface drift -
+        # PR #434 shipped the corpus with --skip-validation, and the gate's
+        # first observation is informational while we triage how to bring the
+        # corpus into alignment with live Pydantic validation behaviour.
+        # LD_LIBRARY_PATH override: the NGC image's bundled CUDA compat libs
+        # must precede the host driver bind-mount path so libtensorrt_llm.so
+        # resolves CUDA 12.4+ symbols against the bundled library on hosts
+        # whose driver predates the NGC image's CUDA target. See
+        # docker/Dockerfile.tensorrt for the full rationale.
+        run: |
+          set +e
+          docker run --rm --gpus all \
+            -e LD_LIBRARY_PATH="/usr/local/cuda/compat/lib.real:/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib" \
+            -e LLENERGY_VENDOR_FROZEN_AT="${ANCHOR_DATE}" \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            --entrypoint python3 \
+            "$IMAGE" \
+            scripts/vendor_rules.py \
+              --engine tensorrt \
+              --corpus "${CORPUS_DIR}/tensorrt.yaml" \
+              --out "${VENDORED_DIR}/tensorrt.json" \
+              --image-ref "$IMAGE" \
+              --base-image-ref "nvcr.io/nvidia/tensorrt-llm/release:${{ steps.version.outputs.version }}" \
+              --vendor-commit "${ANCHOR_SHA}"
+          echo "vendor_exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Fix container-written file ownership
+        # vendor_rules.py wrote the JSON as root inside the container; reclaim
+        # ownership so subsequent steps (git add, commit) can read it.
+        if: always()
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
+
+      - name: Classify diff
+        id: diff
+        run: |
+          mkdir -p /tmp/rules-diff
+          set +e
+          python3 scripts/diff_rules.py \
+            /tmp/rules-diff/tensorrt.old.json \
+            "${VENDORED_DIR}/tensorrt.json" \
+            --out /tmp/rules-diff/tensorrt.md \
+            --title "TensorRT-LLM rules diff"
+          DIFF_EXIT=$?
+          set -e
+          echo "is_breaking=$([[ $DIFF_EXIT -eq 1 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit regenerated rule-observations JSON
+        # Mirror the transformers commit-back: even when divergence was
+        # detected the regenerated JSON is more actionable when paired with
+        # the diff comment. Skipped for forks and when no App token minted.
+        if: steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.name  "llem-ci-bot[bot]"
+          git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
+
+          git add "${VENDORED_DIR}/tensorrt.json"
+
+          if git diff --cached --quiet; then
+            echo "No vendored JSON changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(config): refresh tensorrt rule-observations"
+          git push --force-with-lease
+
+      - name: Post diff comment
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "No PR number available, skipping comment."
+            exit 0
+          fi
+          if [[ -f /tmp/rules-diff/tensorrt.md ]]; then
+            gh pr comment "$PR_NUMBER" --body-file /tmp/rules-diff/tensorrt.md
+          fi
+
+      - name: Apply label
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          if [[ "${{ steps.diff.outputs.is_breaking }}" == "true" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "rules-breaking" --remove-label "rules-safe" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --add-label "rules-safe" --remove-label "rules-breaking" 2>/dev/null || true
+          fi
+
+      - name: Note divergence (non-fatal — first operational run, see #435)
+        if: steps.vendor.outputs.vendor_exit != '0'
+        run: |
+          echo "::warning::TensorRT-LLM rules diverge from declared expected_outcome — see ${VENDORED_DIR}/tensorrt.json > .divergences[]. First operational gate run for this corpus; --fail-on-divergence will be re-enabled once the corpus is brought into alignment with live Pydantic validation."

--- a/scripts/_vendor_common.py
+++ b/scripts/_vendor_common.py
@@ -53,6 +53,19 @@ TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST: frozenset[str] = _DEFAULT_PRIVATE_FIELD_AL
     }
 )
 
+TENSORRT_PRIVATE_FIELD_ALLOWLIST: frozenset[str] = _DEFAULT_PRIVATE_FIELD_ALLOWLIST | frozenset(
+    {
+        # TRT-LLM `*LlmArgs` populate a handful of private bookkeeping fields
+        # during `model_validator(mode='after')` passes; they are not
+        # user-facing normalisations and would pollute the silent-normalisation
+        # diff with non-deterministic state on every vendor run.
+        "_parallel_config",
+        "_speculative_config",
+        "_quant_config",
+        "_build_config",
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # Observation dataclasses

--- a/scripts/vendor_rules.py
+++ b/scripts/vendor_rules.py
@@ -43,6 +43,7 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts._vendor_common import (  # noqa: E402  (late import after sys.path)
+    TENSORRT_PRIVATE_FIELD_ALLOWLIST,
     TRANSFORMERS_PRIVATE_FIELD_ALLOWLIST,
     CaptureBuffers,
     CaseResult,
@@ -175,8 +176,85 @@ def _construct_generic(native_type: str, kwargs: dict[str, Any]) -> Any:
     return cls(**kwargs)
 
 
+# ---------------------------------------------------------------------------
+# TensorRT-LLM runner
+# ---------------------------------------------------------------------------
+#
+# Runs inside the ``llenergymeasure:tensorrt`` Docker image on the self-hosted
+# GPU runner — TRT-LLM 0.21.0 cannot be imported on a CPU host (loads CUDA
+# bindings on import), so this codepath is only exercised in CI by the
+# ``vendor-tensorrt`` job in ``.github/workflows/config-rules-refresh.yml``.
+#
+# The static miner emits short-form ``native_type`` values (``tensorrt_llm.X``)
+# matching the AST symbol it walked. Map those to the deep import paths inside
+# the library, and substitute ``BaseLlmArgs`` -> ``TrtLlmArgs`` because
+# ``BaseLlmArgs`` is the abstract parent and rules tagged on it apply to
+# inherited fields on the concrete subclass.
+
+_TRTLLM_NATIVE_TYPE_MAP: dict[str, str] = {
+    "tensorrt_llm.BaseLlmArgs": "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.TrtLlmArgs": "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.LookaheadDecodingConfig": (
+        "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig"
+    ),
+    "tensorrt_llm.CalibConfig": "tensorrt_llm.llmapi.llm_args.CalibConfig",
+}
+
+# ``BaseLlmArgs`` / ``TrtLlmArgs`` declare ``model`` as a required field. The
+# corpus's ``kwargs_positive`` / ``kwargs_negative`` only carry the field under
+# test, so without an injected default Pydantic raises a "model: field
+# required" error before any rule-relevant validator runs. The placeholder is
+# never resolved to a real checkpoint - construction stops at validator-pass
+# time on either the rule's positive raise (intended) or the negative success
+# (intended), both before the loader would try to read from disk.
+_TRTLLM_LLMARGS_TYPES: frozenset[str] = frozenset(
+    {"tensorrt_llm.BaseLlmArgs", "tensorrt_llm.TrtLlmArgs"}
+)
+_TRTLLM_MODEL_PLACEHOLDER = "/tmp/llem-vendor-gate-model-placeholder"
+
+
+def _run_tensorrt(
+    native_type: str, kwargs: dict[str, Any], *, strict_validate: bool
+) -> CaptureBuffers:
+    """Execute one TRT-LLM rule's kwargs through the live library.
+
+    ``strict_validate`` is accepted for parity with the transformers runner
+    but is not consulted - TRT-LLM has no `.validate(strict=...)` analogue;
+    the constructor itself runs all `model_validator` passes.
+    """
+    del strict_validate  # signature parity only
+    logger_names = (
+        "tensorrt_llm",
+        "tensorrt_llm.llmapi",
+        "tensorrt_llm.llmapi.llm_args",
+    )
+    return run_case(
+        lambda: _construct_trtllm(native_type, kwargs),
+        logger_names=logger_names,
+        private_allowlist=TENSORRT_PRIVATE_FIELD_ALLOWLIST,
+    )
+
+
+def _construct_trtllm(native_type: str, kwargs: dict[str, Any]) -> Any:
+    """Construct a TRT-LLM type by short native_type name.
+
+    Maps short names to deep import paths via :data:`_TRTLLM_NATIVE_TYPE_MAP`
+    and injects the required ``model`` placeholder for ``*LlmArgs`` types
+    when the corpus kwargs don't set it.
+    """
+    actual = _TRTLLM_NATIVE_TYPE_MAP.get(native_type, native_type)
+    module_path, _, class_name = actual.rpartition(".")
+    module = __import__(module_path, fromlist=[class_name])
+    cls = getattr(module, class_name)
+    use_kwargs = dict(kwargs)
+    if native_type in _TRTLLM_LLMARGS_TYPES and "model" not in use_kwargs:
+        use_kwargs["model"] = _TRTLLM_MODEL_PLACEHOLDER
+    return cls(**use_kwargs)
+
+
 _ENGINE_RUNNERS = {
     "transformers": _run_transformers,
+    "tensorrt": _run_tensorrt,
 }
 
 
@@ -588,6 +666,17 @@ def _resolve_engine_version(engine: str) -> str:
         except ImportError as exc:
             raise VendorEngineNotImportable(
                 "transformers is not importable in this environment"
+            ) from exc
+    if engine == "tensorrt":
+        try:
+            import tensorrt_llm  # type: ignore
+
+            return tensorrt_llm.__version__
+        except ImportError as exc:
+            raise VendorEngineNotImportable(
+                "tensorrt_llm is not importable in this environment "
+                "(expected when running outside the llenergymeasure:tensorrt "
+                "Docker image on a GPU host)"
             ) from exc
     return "unknown"
 

--- a/src/llenergymeasure/config/vendored_rules/tensorrt.json
+++ b/src/llenergymeasure/config/vendored_rules/tensorrt.json
@@ -1,0 +1,987 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "tensorrt",
+  "engine_version": "0.21.0",
+  "image_ref": "llenergymeasure:tensorrt-0.21.0",
+  "base_image_ref": "nvcr.io/nvidia/tensorrt-llm/release:0.21.0",
+  "vendored_at": "2026-04-27T18:16:44+02:00",
+  "vendor_commit": "1672962eb4f635bc2f6b21db75696b0b5215a3d3",
+  "cases": [
+    {
+      "id": "tensorrt_basellmargs_load_format_in_2_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nload_format\n  Input should be 'auto' or 'dummy' [type=literal_error, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/literal_error"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_basellmargs_tokenizer_mode_in_2_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\ntokenizer_mode\n  Input should be 'auto' or 'slow' [type=literal_error, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/literal_error"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_batching_type_in_2_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nbatching_type\n  Input should be 'STATIC' or 'INFLIGHT' [type=enum, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/enum"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_calibconfig_device_in_2_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for CalibConfig\ndevice\n  Input should be 'cuda' or 'cpu' [type=literal_error, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/literal_error"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true
+    },
+    {
+      "id": "tensorrt_capacity_scheduler_policy_in_3_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\ncapacity_scheduler_policy\n  Extra inputs are not permitted [type=extra_forbidden, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_context_chunking_policy_in_2_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\ncontext_chunking_policy\n  Extra inputs are not permitted [type=extra_forbidden, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_raises_enable_build_cache_not_type_buildcacheconfig_enable_build_cache",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [
+        "Use tensor_parallel_size/pipeline_parallel_size/xxx_parallel_size instead."
+      ],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Value error, Invalid build_cache_config: x [type=value_error, input_value={'enable_build_cache': 'x...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_raises_max_ngram_size_le_0_positive_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for LookaheadDecodingConfig\nmax_ngram_size\n  Value error, Value must be positive, got 0 [type=value_error, input_value=0, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true
+    },
+    {
+      "id": "tensorrt_raises_max_verification_set_size_le_0_positive_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for LookaheadDecodingConfig\nmax_verification_set_size\n  Value error, Value must be positive, got 0 [type=value_error, input_value=0, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true
+    },
+    {
+      "id": "tensorrt_raises_max_window_size_le_0_positive_values",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for LookaheadDecodingConfig\nmax_window_size\n  Value error, Value must be positive, got 0 [type=value_error, input_value=0, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": true
+    },
+    {
+      "id": "tensorrt_raises_model_not_type_model",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "2 validation errors for TrtLlmArgs\nmodel.str\n  Input should be a valid string [type=string_type, input_value=1, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.11/v/string_type\nmodel.lax-or-strict[lax=union[json-or-python[json=function-after[path_validator(), str],python=is-instance[Path]],function-after[path_validator(), str]],strict=json-or-python[json=function-after[path_validator(), str],python=is-instance[Path]]]\n  Input is not a valid path for <class 'pathlib.Path'> [type=path_type, input_value=1, input_type=int]"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_raises_speculative_config_set_True_speculative_config",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "6 validation errors for TrtLlmArgs\nspeculative_config.LookaheadDecodingConfig\n  Input should be a valid dictionary or instance of LookaheadDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.MedusaDecodingConfig\n  Input should be a valid dictionary or instance of MedusaDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.EagleDecodingConfig\n  Input should be a valid dictionary or instance of EagleDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.MTPDecodingConfig\n  Input should be a valid dictionary or instance of MTPDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.NGramDecodingConfig\n  Input should be a valid dictionary or instance of NGramDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.DraftTargetDecodingConfig\n  Input should be a valid dictionary or instance of DraftTargetDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type"
+      },
+      "positive_confirmed": true,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "2 validation errors for TrtLlmArgs\nenable_lora\n  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/bool_parsing\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_build_config_set_True_model_format_misc",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Assertion failed, build_config is not initialized: x [type=assertion_error, input_value={'backend': '__static_min...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/assertion_error"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_lora_config_set_True_lora_config_consistency",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_batch_size\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_beam_width_set_True_build_config_with_runtime_params",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_beam_width\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_beam_width\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_input_len_set_True_build_config_with_runtime_params",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_input_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_input_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "2 validation errors for TrtLlmArgs\nmax_lora_rank\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_num_tokens\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_seq_len_set_True_build_config_with_runtime_params",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_seq_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    },
+    {
+      "id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "outcome": "error",
+      "emission_channel": "none",
+      "observed_messages": [],
+      "observed_silent_normalisations": {},
+      "observed_exception": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nmax_seq_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+      },
+      "positive_confirmed": false,
+      "negative_confirmed": false
+    }
+  ],
+  "divergences": [
+    {
+      "rule_id": "tensorrt_basellmargs_load_format_in_2_values",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_basellmargs_load_format_in_2_values",
+      "field": "message_template",
+      "expected": "`load_format` must be one of ['auto', 'dummy']",
+      "observed": "1 validation error for TrtLlmArgs\nload_format\n  Input should be 'auto' or 'dummy' [type=literal_error, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/literal_error",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_basellmargs_tokenizer_mode_in_2_values",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_basellmargs_tokenizer_mode_in_2_values",
+      "field": "message_template",
+      "expected": "`tokenizer_mode` must be one of ['auto', 'slow']",
+      "observed": "1 validation error for TrtLlmArgs\ntokenizer_mode\n  Input should be 'auto' or 'slow' [type=literal_error, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/literal_error",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_batching_type_in_2_values",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_batching_type_in_2_values",
+      "field": "message_template",
+      "expected": "`batching_type` must be one of BatchingType members: ['STATIC', 'INFLIGHT']",
+      "observed": "1 validation error for TrtLlmArgs\nbatching_type\n  Input should be 'STATIC' or 'INFLIGHT' [type=enum, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/enum",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_calibconfig_device_in_2_values",
+      "field": "message_template",
+      "expected": "`device` must be one of ['cuda', 'cpu']",
+      "observed": "1 validation error for CalibConfig\ndevice\n  Input should be 'cuda' or 'cpu' [type=literal_error, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/literal_error",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_capacity_scheduler_policy_in_3_values",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_capacity_scheduler_policy_in_3_values",
+      "field": "message_template",
+      "expected": "`capacity_scheduler_policy` must be one of CapacitySchedulerPolicy members: ['MAX_UTILIZATION', 'GUARANTEED_NO_EVICT', 'STATIC_BATCH']",
+      "observed": "1 validation error for TrtLlmArgs\ncapacity_scheduler_policy\n  Extra inputs are not permitted [type=extra_forbidden, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_capacity_scheduler_policy_in_3_values",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\ncapacity_scheduler_policy\n  Extra inputs are not permitted [type=extra_forbidden, input_value='MAX_UTILIZATION', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_context_chunking_policy_in_2_values",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_context_chunking_policy_in_2_values",
+      "field": "message_template",
+      "expected": "`context_chunking_policy` must be one of ContextChunkingPolicy members: ['FIRST_COME_FIRST_SERVED', 'EQUAL_PROGRESS']",
+      "observed": "1 validation error for TrtLlmArgs\ncontext_chunking_policy\n  Extra inputs are not permitted [type=extra_forbidden, input_value='<invalid_static_miner_probe>', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_context_chunking_policy_in_2_values",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\ncontext_chunking_policy\n  Extra inputs are not permitted [type=extra_forbidden, input_value='FIRST_COME_FIRST_SERVED', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_raises_enable_build_cache_not_type_buildcacheconfig_enable_build_cache",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_raises_enable_build_cache_not_type_buildcacheconfig_enable_build_cache",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Value error, Invalid build_cache_config: x_neg [type=value_error, input_value={'enable_build_cache': 'x...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_raises_model_not_type_model",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_raises_model_not_type_model",
+      "field": "message_template",
+      "expected": "Invalid model: ",
+      "observed": "2 validation errors for TrtLlmArgs\nmodel.str\n  Input should be a valid string [type=string_type, input_value=1, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.11/v/string_type\nmodel.lax-or-strict[lax=union[json-or-python[json=function-after[path_validator(), str],python=is-instance[Path]],function-after[path_validator(), str]],strict=json-or-python[json=function-after[path_validator(), str],python=is-instance[Path]]]\n  Input is not a valid path for <class 'pathlib.Path'> [type=path_type, input_value=1, input_type=int]",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_raises_speculative_config_set_True_speculative_config",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_raises_speculative_config_set_True_speculative_config",
+      "field": "message_template",
+      "expected": "Speculative config type not recognized: ",
+      "observed": "6 validation errors for TrtLlmArgs\nspeculative_config.LookaheadDecodingConfig\n  Input should be a valid dictionary or instance of LookaheadDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.MedusaDecodingConfig\n  Input should be a valid dictionary or instance of MedusaDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.EagleDecodingConfig\n  Input should be a valid dictionary or instance of EagleDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.MTPDecodingConfig\n  Input should be a valid dictionary or instance of MTPDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.NGramDecodingConfig\n  Input should be a valid dictionary or instance of NGramDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type\nspeculative_config.DraftTargetDecodingConfig\n  Input should be a valid dictionary or instance of DraftTargetDecodingConfig [type=model_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/model_type",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "field": "message_template",
+      "expected": "enable_lora is ignored when lora_config is provided for ",
+      "observed": "2 validation errors for TrtLlmArgs\nenable_lora\n  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/bool_parsing\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_backend_in_lora_config_consistency",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "2 validation errors for TrtLlmArgs\nenable_lora\n  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/bool_parsing\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_warns_build_config_set_True_model_format_misc",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_build_config_set_True_model_format_misc",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_build_config_set_True_model_format_misc",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_build_config_set_True_model_format_misc",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_build_config_set_True_model_format_misc",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_build_config_set_True_model_format_misc",
+      "field": "message_template",
+      "expected": "The build_config is ignored for model format of TLLM_ENGINE.",
+      "observed": "1 validation error for TrtLlmArgs\n  Assertion failed, build_config is not initialized: x [type=assertion_error, input_value={'backend': '__static_min...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/assertion_error",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_lora_config_set_True_lora_config_consistency",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_lora_config_set_True_lora_config_consistency",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_lora_config_set_True_lora_config_consistency",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_lora_config_set_True_lora_config_consistency",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_lora_config_set_True_lora_config_consistency",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_lora_config_set_True_lora_config_consistency",
+      "field": "message_template",
+      "expected": "max_loras is ignored when lora_config is provided.",
+      "observed": "1 validation error for TrtLlmArgs\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "field": "message_template",
+      "expected": " from build_config",
+      "observed": "1 validation error for TrtLlmArgs\nmax_batch_size\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_batch_size_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Assertion failed, build_config is not initialized: x [type=assertion_error, input_value={'backend': 'pytorch', 'b...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/assertion_error"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_build_config_with_runtime_params",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_build_config_with_runtime_params",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_build_config_with_runtime_params",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_build_config_with_runtime_params",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_build_config_with_runtime_params",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_build_config_with_runtime_params",
+      "field": "message_template",
+      "expected": "] is overridden by build_config.max_beam_width [",
+      "observed": "1 validation error for TrtLlmArgs\nmax_beam_width\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "field": "message_template",
+      "expected": " from build_config",
+      "observed": "1 validation error for TrtLlmArgs\nmax_beam_width\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_beam_width_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Assertion failed, build_config is not initialized: x [type=assertion_error, input_value={'backend': 'pytorch', 'b...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/assertion_error"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_build_config_with_runtime_params",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_build_config_with_runtime_params",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_build_config_with_runtime_params",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_build_config_with_runtime_params",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_build_config_with_runtime_params",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_build_config_with_runtime_params",
+      "field": "message_template",
+      "expected": "] is overridden by build_config.max_input_len [",
+      "observed": "1 validation error for TrtLlmArgs\nmax_input_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "message_template",
+      "expected": " from build_config",
+      "observed": "1 validation error for TrtLlmArgs\nmax_input_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_input_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Assertion failed, build_config is not initialized: x [type=assertion_error, input_value={'backend': 'pytorch', 'b...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/assertion_error"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "field": "message_template",
+      "expected": "max_lora_rank is ignored when lora_config is provided.",
+      "observed": "2 validation errors for TrtLlmArgs\nmax_lora_rank\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_lora_rank_set_True_lora_config_consistency",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\nlora_config\n  Input should be a dictionary or an instance of LoraConfig [type=dataclass_type, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/dataclass_type"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "field": "message_template",
+      "expected": " from build_config",
+      "observed": "1 validation error for TrtLlmArgs\nmax_num_tokens\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_num_tokens_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Assertion failed, build_config is not initialized: x [type=assertion_error, input_value={'backend': 'pytorch', 'b...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/assertion_error"
+      },
+      "check_failed": "negative_does_not_raise"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_build_config_with_runtime_params",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_build_config_with_runtime_params",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_build_config_with_runtime_params",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_build_config_with_runtime_params",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_build_config_with_runtime_params",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_build_config_with_runtime_params",
+      "field": "message_template",
+      "expected": "] is overridden by build_config.max_seq_len [",
+      "observed": "1 validation error for TrtLlmArgs\nmax_seq_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "outcome",
+      "expected": "warn",
+      "observed": "error"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "emission_channel",
+      "expected": "logger_warning",
+      "observed": "none"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "positive_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "negative_confirmed",
+      "expected": true,
+      "observed": false
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_positive",
+      "expected": "emits_warning_or_announce",
+      "observed": "error",
+      "check_failed": "positive_raises"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "message_template",
+      "expected": " from build_config",
+      "observed": "1 validation error for TrtLlmArgs\nmax_seq_len\n  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='x', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+      "check_failed": "message_template_match"
+    },
+    {
+      "rule_id": "tensorrt_warns_max_seq_len_set_True_set_runtime_knobs_from_build_config",
+      "field": "kwargs_negative",
+      "expected": "does_not_raise",
+      "observed": {
+        "type": "ValidationError",
+        "message": "1 validation error for TrtLlmArgs\n  Assertion failed, build_config is not initialized: x [type=assertion_error, input_value={'backend': 'pytorch', 'b...gate-model-placeholder'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/assertion_error"
+      },
+      "check_failed": "negative_does_not_raise"
+    }
+  ]
+}

--- a/src/llenergymeasure/config/vendored_rules/transformers.json
+++ b/src/llenergymeasure/config/vendored_rules/transformers.json
@@ -4,8 +4,8 @@
   "engine_version": "4.57.3",
   "image_ref": "llenergymeasure:transformers",
   "base_image_ref": "llenergymeasure:transformers",
-  "vendored_at": "2026-04-27T16:26:01+02:00",
-  "vendor_commit": "9d267931585ecdc8a0a4692f9fac78b37be65fb4",
+  "vendored_at": "2026-04-27T18:16:44+02:00",
+  "vendor_commit": "1672962eb4f635bc2f6b21db75696b0b5215a3d3",
   "cases": [
     {
       "id": "transformers_beam_search_num_beams_eq_1",


### PR DESCRIPTION
Closes #435.

Adds a ``vendor-tensorrt`` job to ``config-rules-refresh.yml`` that runs the vendor-CI gate inside the ``llenergymeasure:tensorrt`` Docker image on the self-hosted GPU runner (``ds01-gpu``). TRT-LLM 0.21.0 cannot be imported on a CPU host because it loads CUDA bindings at import time, so the gate must run in a CUDA-aware environment.

## Changes

- ``.github/workflows/config-rules-refresh.yml`` (+220) — new ``vendor-tensorrt`` job mirroring transformers' commit-back + diff-comment pattern. ``runs-on: self-hosted``, 60-minute timeout (large image, first cold pull may take several minutes).
- ``scripts/vendor_rules.py`` (+89) — adds ``_run_tensorrt`` + ``_construct_trtllm`` with short-to-deep ``native_type`` mapping (corpus rules tag ``BaseLlmArgs`` but the concrete class is ``TrtLlmArgs``). Injects a model-path placeholder for ``*LlmArgs`` construction since corpus rules only carry the field under test.
- ``scripts/_vendor_common.py`` (+13) — ``TENSORRT_PRIVATE_FIELD_ALLOWLIST`` extends the default with TRT-LLM's ``_parallel_config`` / ``_speculative_config`` / ``_quant_config`` / ``_build_config`` private fields that get populated by ``model_validator`` passes.

## Why this matters

PR #434 manually quarantined three over-eager TRT-LLM rules because the gate wasn't running. With the gate operational, the recall-first / vendor-CI-prune split actually works for TRT-LLM:
- ``kwargs_positive`` must raise → tightens predicates that fire on too-broad presence checks
- ``message_template`` substring match → catches the literal f-string source bug pattern
- ``kwargs_negative`` must not raise → catches predicates that fire on valid configs

Initial run will likely surface drift; the divergence count drives whether we re-mine the corpus or quarantine specific rules.

## Risk

- First CI run may surface unexpected divergences. We'll triage based on count.
- ``_TRTLLM_NATIVE_TYPE_MAP`` assumes TRT-LLM 0.21.0's module layout; on bump this may need updating (tracked by Renovate's Dockerfile.tensorrt watch).