### PR TITLE
chore(renovate): add pep621 + github-actions + vllm/tensorrt regex managers + concurrency limit + vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["dockerfile", "custom.regex"],
+  "enabledManagers": ["dockerfile", "custom.regex", "pep621", "github-actions"],
   "dockerfile": {
     "fileMatch": ["docker/Dockerfile\\..*"]
+  },
+  "pep621": {
+    "fileMatch": ["(^|/)pyproject\\.toml$"]
   },
   "customManagers": [
     {
@@ -11,6 +14,20 @@
       "fileMatch": ["docker/Dockerfile\\.transformers$"],
       "matchStrings": ["ARG TRANSFORMERS_VERSION=(?<currentValue>\\S+)"],
       "depNameTemplate": "transformers",
+      "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["docker/Dockerfile\\.vllm$"],
+      "matchStrings": ["ARG VLLM_VERSION=v?(?<currentValue>\\S+)"],
+      "depNameTemplate": "vllm",
+      "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["docker/Dockerfile\\.tensorrt$"],
+      "matchStrings": ["ARG TRTLLM_VERSION=(?<currentValue>\\S+)"],
+      "depNameTemplate": "tensorrt-llm",
       "datasourceTemplate": "pypi"
     }
   ],
@@ -43,8 +60,27 @@
       "labels": ["renovate", "engine-transformers"],
       "automerge": false,
       "stabilityDays": 3
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["vllm"],
+      "labels": ["renovate", "engine-vllm"],
+      "automerge": false,
+      "stabilityDays": 3
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["tensorrt-llm"],
+      "labels": ["renovate", "engine-tensorrt"],
+      "automerge": false,
+      "stabilityDays": 3
     }
   ],
   "schedule": ["before 9am on Monday"],
+  "prConcurrentLimit": 3,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security", "renovate"]
+  },
   "labels": ["renovate"]
 }


### PR DESCRIPTION
## Summary

Implements Phase B.1 of the vendored-CI pipeline refresh plan (`~/.claude/plans/re-renovate-decision-staged-naur.md`). Five additions to `renovate.json`:

1. **`pep621` manager** — adds PyPI-dep management for `pyproject.toml`. Required so Renovate proposes version bumps to base/optional dependency declarations. `fileMatch: ["(^|/)pyproject\\.toml$"]`.
2. **`github-actions` manager** — adds `uses:` version management for `.github/workflows/*.yml`. Default `fileMatch` covers workflows; no extra config required.
3. **`prConcurrentLimit: 3`** — caps simultaneous open Renovate PRs. Prevents flooding when several library bumps land at once.
4. **`vulnerabilityAlerts`** — `enabled: true`, `labels: ["security", "renovate"]`. Cuts a separate triage stream for CVE-driven bumps.
5. **Two new `custom.regex` managers** — mirror the existing `transformers` regex shape:
   - `Dockerfile.vllm` -> `ARG VLLM_VERSION=v?(?<currentValue>\\S+)` -> pypi `vllm` (the `v?` strips the `v` prefix from `v0.7.3` so it matches PyPI versions cleanly).
   - `Dockerfile.tensorrt` -> `ARG TRTLLM_VERSION=(?<currentValue>\\S+)` -> pypi `tensorrt-llm` (single-token ARG, no underscore).

Plus mirrored per-package label rules in `packageRules` for the two new regex managers (`engine-vllm`, `engine-tensorrt`), matching the existing transformers entry's `automerge: false` + `stabilityDays: 3` shape.

## Schedule

`schedule: ["before 9am on Monday"]` is **kept**. The Renovate Dashboard's "Create/Rebase" checkbox is the on-demand bypass — faster and less invasive than dropping the schedule.

## Out of scope (per plan)

- No `ignoreDeps` (none requested).
- No `lockFileMaintenance` — that's part of #437, deliberately exposed by Phase B.6 of the plan.
- No other files touched.

## Verification

```
$ npx --yes --package renovate -- renovate-config-validator renovate.json
...
 INFO: Config validated successfully
```

Diff: `renovate.json` only, +37/-1 lines.

## Reference

Plan: `~/.claude/plans/re-renovate-decision-staged-naur.md` (Phase B.1).

## Test plan

- [ ] CI green
- [ ] After merge, Renovate Dashboard #446 refreshes within minutes to show new managers (`pep621`, `github-actions`) and any pending updates they detect
- [ ] Confirm `vulnerabilityAlerts` is enabled (no immediate visible signal unless a CVE matches)
- [ ] Confirm `prConcurrentLimit: 3` is reflected in dashboard config block