### PR TITLE
fix(ci): remove redundant actor guards (closes #455)

### DIFF
--- a/.github/workflows/invariant-miner.yml
+++ b/.github/workflows/invariant-miner.yml
@@ -75,10 +75,8 @@ env:
 jobs:
   vendor-transformers:
     # Path filters on the pull_request trigger restrict which PRs fire this
-    # workflow; workflow_dispatch always runs when explicitly invoked. The
-    # `github.actor` guard skips runs triggered by the bot's own commit-back
-    # — belt-and-braces with the deterministic vendor anchor below.
-    if: github.actor != 'llem-ci-bot[bot]' && (github.event_name != 'workflow_dispatch' || inputs.engine == 'transformers' || inputs.engine == 'all')
+    # workflow; workflow_dispatch always runs when explicitly invoked.
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'transformers' || inputs.engine == 'all'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -253,9 +251,7 @@ jobs:
     # imports paths the miners avoid. So the gate runs inside the
     # llenergymeasure:vllm Docker image on the project's self-hosted GPU
     # runner, mirroring the vendor-tensorrt pattern. Closes #445.
-    # The `github.actor` guard skips runs triggered by the bot's own
-    # commit-back — belt-and-braces with the deterministic vendor anchor.
-    if: github.actor != 'llem-ci-bot[bot]' && (github.event_name != 'workflow_dispatch' || inputs.engine == 'vllm' || inputs.engine == 'all')
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'vllm' || inputs.engine == 'all'
     runs-on: self-hosted
     timeout-minutes: 60
     steps:
@@ -471,10 +467,8 @@ jobs:
     # workflow; workflow_dispatch always runs when explicitly invoked. The
     # job runs whenever the workflow fires - the GPU runner is shared infra
     # and the image is layer-cached, so the marginal cost is small. Per-engine
-    # path-filter scoping is tracked in #382. The `github.actor` guard skips
-    # runs triggered by the bot's own commit-back — belt-and-braces with the
-    # deterministic vendor anchor below.
-    if: github.actor != 'llem-ci-bot[bot]' && (github.event_name != 'workflow_dispatch' || inputs.engine == 'tensorrt' || inputs.engine == 'all')
+    # path-filter scoping is tracked in #382.
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'tensorrt' || inputs.engine == 'all'
     runs-on: self-hosted
     timeout-minutes: 60
     steps:

--- a/.github/workflows/parameter-discovery.yml
+++ b/.github/workflows/parameter-discovery.yml
@@ -54,10 +54,6 @@ concurrency:
 
 jobs:
   refresh:
-    # Skip runs triggered by the bot's own commit-back. Belt-and-braces with
-    # the deterministic LLENERGY_DISCOVERY_FROZEN_AT anchor below: even if a
-    # diff sneaks through, the workflow won't re-fire on its own push.
-    if: github.actor != 'llem-ci-bot[bot]'
     runs-on: self-hosted
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
## Summary

Removes the `github.actor != 'llem-ci-bot[bot]'` guards from the three vendor jobs in `invariant-miner.yml` (vendor-transformers, vendor-vllm, vendor-tensorrt) and the single `refresh` job in `parameter-discovery.yml`. Engine selectors on `workflow_dispatch` are kept intact — only the actor-clause is stripped. Inline comments explaining the guard's belt-and-braces purpose were removed alongside the predicate.

## Why

The actor guards were added in PR #449 as a defensive layer on top of the deterministic vendor / discovery anchors (`LLENERGY_VENDOR_FROZEN_AT`, `LLENERGY_DISCOVERY_FROZEN_AT`). Determinism is the real loop prevention: re-running on identical inputs produces byte-identical files, `git diff --cached --quiet` is true, no commit fires, no push fires, no synchronize event re-triggers the workflow. The actor guard added nothing on top of that.

It does, however, break the auto-mine -> invariant-miner chain validation. When `auto-mine.yml` (PR #456) pushes a refreshed YAML as `llem-ci-bot[bot]`, the actor guard previously skipped `invariant-miner.yml`'s re-run, leaving the PR in an incoherent state where the JSON observation file was vendored against the OLD YAML while the YAML was NEW.

`auto-mine.yml` itself never had an actor guard (per #455's reasoning) and is untouched here.

Closes #455.

## Test plan

- [x] `actionlint` clean on both edited workflows (Docker `rhysd/actionlint:latest`, exit 0)
- [x] `grep -c "github.actor"` on both files returns 0
- [ ] Real-world chain validation: open a PR that bumps `docker/Dockerfile.transformers`, observe both `auto-mine` and `invariant-miner` writebacks fire correctly with no JSON-vs-YAML mismatch