### PR TITLE
docs: align pipeline terminology with post-rename canonical names

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See [Installation](docs/installation.md) for system requirements, Docker setup, 
 | [Validation Rule Corpus Format](docs/validation-rule-corpus.md) | YAML schema reference for corpus rules |
 | [Extending the Miner](docs/extending-miners.md) | How to add a new engine to the invariant miner |
 | [Research Context](docs/research-context.md) | Academic positioning: Daikon, Houdini, NeuRI, and what is novel |
-| [Schema Refresh Pipeline](docs/schema-refresh.md) | Renovate-driven engine schema refresh |
+| [Parameter Discovery Pipeline](docs/schema-refresh.md) | Renovate-driven engine schema refresh |
 
 ---
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -151,7 +151,7 @@ The invariant miner pipeline lives in `scripts/miners/` - it is a build-time too
   Renovate opens PR bumping Dockerfile ARG
                │
                ▼
-  CI fires invariant-miner.yml
+  Stage 1: auto-mine.yml fires (mining)
                │
                ├──► static miner runs (GH-hosted runner, CPU only)
                │
@@ -163,6 +163,10 @@ The invariant miner pipeline lives in `scripts/miners/` - it is a build-time too
   build_corpus.py merges staging files
   (dedup by fingerprint; static miner wins on match.fields,
    dynamic miner wins on message_template)
+  → produces configs/validation_rules/{engine}.yaml   (YAML corpus)
+               │
+               ▼
+  Stage 2: invariant-miner.yml fires (vendor gate)
                │
                ▼
   vendor_rules.py replays every rule against the live library
@@ -172,7 +176,6 @@ The invariant miner pipeline lives in `scripts/miners/` - it is a build-time too
                ├──► divergent rules quarantined to _failed_validation_*.yaml
                │
                └──► confirmed rules written to:
-                    configs/validation_rules/{engine}.yaml   (YAML corpus)
                     src/.../vendored_rules/{engine}.json     (vendored JSON)
                │
                ▼
@@ -277,4 +280,4 @@ The trade-off is staleness risk: the corpus must be regenerated when the engine 
 - [research-context.md](research-context.md) - academic positioning
 - [engines.md](engines.md) - engine configuration reference
 - [methodology.md](methodology.md) - energy measurement methodology
-- [schema-refresh.md](schema-refresh.md) - Renovate-driven schema refresh pipeline
+- [schema-refresh.md](schema-refresh.md) - parameter-discovery pipeline (Renovate-driven schema refresh)

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -514,14 +514,14 @@ llem run experiment.yaml --skip-preflight
 
 When you update an engine version (by bumping the `ARG` in a Dockerfile), the
 vendored parameter schemas must be regenerated. This happens automatically via
-the [Schema Refresh Pipeline](schema-refresh.md) (parameter-discovery workflow)
+the [Parameter Discovery Pipeline](schema-refresh.md) (`parameter-discovery.yml` workflow)
 for Renovate-managed bumps. For manual bumps, run:
 
 ```bash
 ./scripts/refresh_discovered_schemas.sh <engine>
 ```
 
-See [Schema Refresh Pipeline](schema-refresh.md) for the full workflow.
+See [Parameter Discovery Pipeline](schema-refresh.md) for the full workflow.
 
 ---
 

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -414,7 +414,7 @@ Library version bumps trigger corpus regeneration automatically.
   │  or PyPI version pin in requirements file                         │
   │               │                                                   │
   │               ▼                                                   │
-  │  invariant-miner.yml fires                                        │
+  │  Stage 1: auto-mine.yml fires (mining)                            │
   │  (guarded: only Renovate PRs touching engine version files)       │
   │               │                                                   │
   │         ┌─────┴─────────────────────────────┐                    │
@@ -428,7 +428,14 @@ Library version bumps trigger corpus regeneration automatically.
   │         │                                   │                    │
   │         └─────────────┬─────────────────────┘                    │
   │                       ▼                                           │
-  │         build_corpus.py + vendor_rules.py run                    │
+  │         build_corpus.py merges staging files                      │
+  │         → configs/validation_rules/{engine}.yaml                  │
+  │                       │                                           │
+  │                       ▼                                           │
+  │  Stage 2: invariant-miner.yml fires (vendor gate)                 │
+  │                       │                                           │
+  │                       ▼                                           │
+  │         vendor_rules.py replays rules against live library        │
   │         (inside Docker container for engine)                      │
   │                       │                                           │
   │                       ▼                                           │
@@ -505,4 +512,4 @@ The templates NOT adopted from Daikon's full library: linear arithmetic ternary 
 - [parameter-discovery.md](parameter-discovery.md) - runtime validation pipeline
 - [research-context.md](research-context.md) - academic positioning
 - [engines.md](engines.md) - engine configuration reference
-- [schema-refresh.md](schema-refresh.md) - Renovate-driven schema refresh
+- [schema-refresh.md](schema-refresh.md) - parameter-discovery pipeline (Renovate-driven schema refresh)

--- a/docs/parameter-curation.md
+++ b/docs/parameter-curation.md
@@ -35,7 +35,7 @@ llem exposes engine parameters to users through hand-authored Pydantic models. T
 
 `scripts/discover_*.py` introspects each engine's public Python API (e.g. `inspect.signature(vllm.LLM.__init__)`, `inspect.signature(AutoModelForCausalLM.from_pretrained)`) and writes the result to `src/llenergymeasure/config/discovered_schemas/{engine}.json`.
 
-These JSON files are the ground truth for "what parameters does this engine version accept". They are vendored into the repo and regenerated via the schema-refresh pipeline when an engine version bumps (see [schema-refresh.md](schema-refresh.md)).
+These JSON files are the ground truth for "what parameters does this engine version accept". They are vendored into the repo and regenerated via the parameter-discovery pipeline when an engine version bumps (see [schema-refresh.md](schema-refresh.md)).
 
 ---
 
@@ -92,5 +92,5 @@ These are listed in `LLEM_NATIVE_FIELDS` in the drift checker. Each entry suppre
 ## See also
 
 - [parameter-discovery.md](parameter-discovery.md) - config validation pipeline (how invalid combinations are caught)
-- [schema-refresh.md](schema-refresh.md) - Renovate-driven schema refresh
+- [schema-refresh.md](schema-refresh.md) - parameter-discovery pipeline (Renovate-driven schema refresh)
 - [engines.md](engines.md) - engine configuration reference

--- a/docs/schema-refresh.md
+++ b/docs/schema-refresh.md
@@ -1,4 +1,4 @@
-# Schema Refresh Pipeline
+# Parameter Discovery Pipeline
 
 Engine parameter schemas are vendored as JSON files in
 `src/llenergymeasure/config/discovered_schemas/`. When an upstream engine
@@ -24,7 +24,7 @@ e.g. ARG VLLM_VERSION=v0.7.3 -> v0.8.0
                       |
                       v
 parameter-discovery.yml auto-fires
-(guarded: only for renovate[bot] PRs touching Dockerfiles)
+(guarded: only for Renovate-bot PRs touching Dockerfiles)
                       |
                       v
 +------------------------------------------+


### PR DESCRIPTION
## Summary

Terminology audit across all `docs/` files and `README.md` following the Phase A/B pipeline workflow renames. No code changes; docs-only.

## Files changed and what changed

- **`docs/schema-refresh.md`** - H1 title renamed from "Schema Refresh Pipeline" to "Parameter Discovery Pipeline". One prose instance of "renovate[bot]" tidied to "Renovate-bot" for consistency (no terminology impact).
- **`docs/architecture-overview.md`** - Two fixes: (1) "See also" link description updated from "Renovate-driven schema refresh pipeline" to "parameter-discovery pipeline (Renovate-driven schema refresh)". (2) Data-flow diagram updated to reflect the two-stage invariant-miner split: `auto-mine.yml` (Stage 1, mining) → `invariant-miner.yml` (Stage 2, vendor gate), with the corpus YAML produced between stages made explicit.
- **`docs/miner-pipeline.md`** - Two fixes: (1) "See also" link description updated to match. (2) Renovate refresh-loop diagram updated to show the two-stage split, mirroring the architecture-overview change.
- **`docs/parameter-curation.md`** - "schema-refresh pipeline" in prose replaced with "parameter-discovery pipeline". "See also" link description updated.
- **`docs/docker-setup.md`** - Two link texts "Schema Refresh Pipeline" replaced with "Parameter Discovery Pipeline"; link target `schema-refresh.md` (the file name) is unchanged.
- **`README.md`** - Table row "Schema Refresh Pipeline" replaced with "Parameter Discovery Pipeline"; link target `docs/schema-refresh.md` unchanged.

## Intentional remaining old-name references

All remaining `schema-refresh` hits in the verification grep are the **file name** `schema-refresh.md` used as a link target (href). The file itself is not renamed in this PR - that is a follow-up decision (file rename would break inbound links and require redirect config). The canonical display text in every link now says "Parameter Discovery Pipeline".

`_invariant_vendor_common.py` in `docs/architecture-overview.md` is the **new canonical name** (not stale).

## Verification grep output

```
grep -rn "config-rules-refresh|schema-refresh|update_engine_rules|update_engine_schema|diff_rules\.py|diff_schemas|check_schema_versions|_vendor_common" docs/ README.md CLAUDE.md
```

All remaining hits: `schema-refresh.md` used as link href (intentional - file not renamed); `_invariant_vendor_common.py` at architecture-overview line 258 (canonical new name, not stale).

No stale pipeline-name prose ("schema-refresh pipeline", "Schema Refresh Pipeline") remains in any doc.

## Deliberately untouched

- `CHANGELOG.md` - historical record
- `.product/` - gitignored, separate process
- `docs/generated/` - machine-generated files
- Branch protection refs

## Reference

Plan section: `~/.claude/plans/re-renovate-decision-staged-naur.md` "Locked design decisions"