### PR TITLE
fix(ci): pivot auto-mine vllm + tensorrt jobs to Docker (closes #463, #464)

### DIFF
--- a/.github/workflows/auto-mine.yml
+++ b/.github/workflows/auto-mine.yml
@@ -16,15 +16,29 @@ name: Auto-Mine — Generate Validation Rules
 #
 # Per-engine runner choice:
 #   mine-transformers : ubuntu-latest GH-hosted runner (CPU-safe import)
-#   mine-vllm         : ubuntu-latest GH-hosted runner. The vLLM miners
-#                       deliberately avoid EngineArgs.create_engine_config()
-#                       and other CUDA-context paths (see vllm_dynamic_miner.py
-#                       docstring §6); confirmed by PR #444's successful
-#                       ubuntu-latest run. Distinct from invariant-miner.yml's
-#                       vendor-vllm job, which DOES hit CUDA paths during rule
-#                       replay and must run inside the vLLM Docker image.
+#   mine-vllm         : self-hosted GPU runner inside llenergymeasure:vllm.
+#                       The vLLM miners are CPU-safe by construction (they
+#                       avoid EngineArgs.create_engine_config() and other
+#                       CUDA-context paths — see vllm_dynamic_miner.py
+#                       docstring §6) and PR #444 proved they import cleanly
+#                       against vllm's own published constraints. They DO
+#                       NOT import cleanly under the unified uv.lock that the
+#                       repo uses on ubuntu-latest: tensorrt-llm 0.21.0's
+#                       transitive constraints cascade into the vllm extra's
+#                       torch/torchvision resolution and break vllm at import
+#                       time (`operator torchvision::nms does not exist`).
+#                       See #437 (parent dependency-isolation issue) and
+#                       #464 for the full empirical trail. Pivoting to the
+#                       vLLM Docker image side-steps the unified-lock problem
+#                       and aligns with vendor-vllm's runtime env.
 #   mine-tensorrt     : self-hosted GPU runner inside llenergymeasure:tensorrt
-#                       (TRT-LLM 0.21.0 loads CUDA bindings on import)
+#                       (TRT-LLM 0.21.0 loads CUDA bindings on import). The
+#                       NGC image already carries the tensorrt_llm Python
+#                       source as part of the installed package — the workflow
+#                       symlinks it into the miner's expected default path
+#                       (/tmp/trt-llm-0.21.0/tensorrt_llm) before invoking
+#                       build_corpus, so no separate tarball extraction is
+#                       needed. Closes #463.
 #
 # Determinism note:
 #   build_corpus.py and every miner read LLENERGY_MINER_FROZEN_AT from the env
@@ -231,15 +245,21 @@ jobs:
           fi
 
   mine-vllm:
-    # vLLM miners are CPU-safe by design (they avoid EngineArgs.create_engine_config()
-    # and other CUDA-context paths — see vllm_dynamic_miner.py docstring §6).
-    # PR #444 confirmed empirically that the full mine + corpus build runs on
-    # ubuntu-latest. This is distinct from invariant-miner.yml's vendor-vllm
-    # job, which replays kwargs against live config classes and DOES hit CUDA
-    # paths the miners deliberately avoid.
+    # The vLLM miners are CPU-safe by construction (they avoid
+    # EngineArgs.create_engine_config() and other CUDA-context paths — see
+    # vllm_dynamic_miner.py docstring §6) but cannot run against the repo's
+    # unified uv.lock on ubuntu-latest: tensorrt-llm 0.21.0's transitive
+    # constraints cascade into the vllm extra's torch/torchvision resolution
+    # and break `from vllm import ...` at import time (`operator
+    # torchvision::nms does not exist`). PR #459 surfaced this empirically.
+    #
+    # Pivot: run the miner inside the llenergymeasure:vllm Docker image on
+    # the project's self-hosted GPU runner, mirroring invariant-miner.yml's
+    # vendor-vllm job. The image carries vLLM's own published torch/vllm
+    # combo, so the miners import cleanly. Closes #464.
     if: github.event_name != 'workflow_dispatch' || inputs.engine == 'vllm' || inputs.engine == 'all'
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+    runs-on: self-hosted
+    timeout-minutes: 60
     steps:
       - name: Mint llem-ci-bot App token
         id: app-token
@@ -249,6 +269,14 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Clean workspace (fix root-owned files from prior Docker runs)
+        # Mirror gpu-ci.yml: container-written artefacts persist as root-owned
+        # on the self-hosted runner and break subsequent checkouts otherwise.
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "find /workspace -not -user $(id -u) -delete 2>/dev/null || true"
+
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
@@ -256,16 +284,34 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          # vLLM wheels are large; per-engine cache key keeps reuse high.
-          cache-suffix: auto-mine-vllm-3.12
-          python-version: "3.12"
+      - name: Resolve vLLM version
+        id: version
+        run: |
+          VER=$(grep -oE '^ARG[[:space:]]+VLLM_VERSION=[^[:space:]]+' \
+                  docker/Dockerfile.vllm | head -1 | cut -d= -f2-)
+          if [[ -z "$VER" ]]; then
+            echo "Could not extract VLLM_VERSION from Dockerfile.vllm" >&2
+            exit 1
+          fi
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Install dependencies
-        run: uv sync --dev --extra vllm
+      - name: Build or reuse vLLM image
+        # Build only if the version-tagged image is missing - the runner's
+        # Docker layer cache makes the FROM vllm/vllm-openai:VER step a no-op
+        # when the upstream tag is unchanged, so this is a cheap check.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "Building $IMAGE from docker/Dockerfile.vllm..."
+            docker build \
+              -f docker/Dockerfile.vllm \
+              -t "$IMAGE" \
+              --build-arg VLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
 
       - name: Save current YAML for diffing
         run: |
@@ -295,11 +341,28 @@ jobs:
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
           echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
 
-      - name: Re-mine vllm corpus
+      - name: Re-mine vllm corpus inside container
         env:
-          LLENERGY_MINER_FROZEN_AT: ${{ steps.anchor.outputs.date }}
+          IMAGE: ${{ steps.version.outputs.image }}
+          ANCHOR_DATE: ${{ steps.anchor.outputs.date }}
         run: |
-          uv run python -m scripts.miners.build_corpus --engine vllm
+          docker run --rm --gpus all \
+            -e LLENERGY_MINER_FROZEN_AT="${ANCHOR_DATE}" \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            --entrypoint python3 \
+            "$IMAGE" \
+            -m scripts.miners.build_corpus --engine vllm
+
+      - name: Fix container-written file ownership
+        # build_corpus.py wrote the YAML as root inside the container; reclaim
+        # ownership so subsequent steps (git add, commit) can read it.
+        if: always()
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
 
       - name: Classify YAML diff
         id: diff
@@ -466,6 +529,15 @@ jobs:
         # job — required so libtensorrt_llm.so resolves CUDA 12.4+ symbols
         # against the bundled NGC compat libs on hosts whose driver predates
         # the NGC image's CUDA target. See docker/Dockerfile.tensorrt.
+        #
+        # Source-root symlink rationale (closes #463):
+        # tensorrt_static_miner walks the tensorrt_llm 0.21.0 Python source
+        # tree and defaults to /tmp/trt-llm-0.21.0/tensorrt_llm. The NGC
+        # image already ships that source as part of the installed
+        # tensorrt_llm package, so we resolve its location with
+        # `tensorrt_llm.__file__` and symlink it into the miner's expected
+        # default path before invoking build_corpus. No tarball extraction
+        # required, no build_corpus.py changes required.
         run: |
           docker run --rm --gpus all \
             -e LD_LIBRARY_PATH="/usr/local/cuda/compat/lib.real:/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib" \
@@ -473,9 +545,19 @@ jobs:
             -e PYTHONDONTWRITEBYTECODE=1 \
             -v "${{ github.workspace }}:/repo" \
             -w /repo \
-            --entrypoint python3 \
+            --entrypoint bash \
             "$IMAGE" \
-            -m scripts.miners.build_corpus --engine tensorrt
+            -c '
+              set -euo pipefail
+              SRC=$(python3 -c "import tensorrt_llm, pathlib; print(pathlib.Path(tensorrt_llm.__file__).parent)")
+              if [[ -z "$SRC" || ! -d "$SRC" ]]; then
+                echo "Could not locate installed tensorrt_llm package source" >&2
+                exit 1
+              fi
+              mkdir -p /tmp/trt-llm-0.21.0
+              ln -sfn "$SRC" /tmp/trt-llm-0.21.0/tensorrt_llm
+              python3 -m scripts.miners.build_corpus --engine tensorrt
+            '
 
       - name: Fix container-written file ownership
         # build_corpus.py wrote the YAML as root inside the container; reclaim

--- a/.github/workflows/auto-mine.yml
+++ b/.github/workflows/auto-mine.yml
@@ -245,18 +245,9 @@ jobs:
           fi
 
   mine-vllm:
-    # The vLLM miners are CPU-safe by construction (they avoid
-    # EngineArgs.create_engine_config() and other CUDA-context paths — see
-    # vllm_dynamic_miner.py docstring §6) but cannot run against the repo's
-    # unified uv.lock on ubuntu-latest: tensorrt-llm 0.21.0's transitive
-    # constraints cascade into the vllm extra's torch/torchvision resolution
-    # and break `from vllm import ...` at import time (`operator
-    # torchvision::nms does not exist`). PR #459 surfaced this empirically.
-    #
-    # Pivot: run the miner inside the llenergymeasure:vllm Docker image on
-    # the project's self-hosted GPU runner, mirroring invariant-miner.yml's
-    # vendor-vllm job. The image carries vLLM's own published torch/vllm
-    # combo, so the miners import cleanly. Closes #464.
+    # Runner + image rationale (unified-lock import failure, Docker pivot,
+    # closes #464): see file-level header above. Mirrors invariant-miner.yml's
+    # vendor-vllm job.
     if: github.event_name != 'workflow_dispatch' || inputs.engine == 'vllm' || inputs.engine == 'all'
     runs-on: self-hosted
     timeout-minutes: 60

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -153,9 +153,14 @@ The invariant miner pipeline lives in `scripts/miners/` - it is a build-time too
                ▼
   Stage 1: auto-mine.yml fires (mining)
                │
-               ├──► static miner runs (GH-hosted runner, CPU only)
+               ├──► transformers miners run (GH-hosted ubuntu-latest, uv sync)
                │
-               ├──► dynamic miner runs (GH-hosted runner)
+               ├──► vLLM miners run (self-hosted GPU runner, inside the
+               │    vllm/vllm-openai Docker image — Docker isolates from
+               │    the unified uv.lock, see #437/#464)
+               │
+               ├──► TRT-LLM miner runs (self-hosted GPU runner, inside the
+               │    llenergymeasure:tensorrt image; CUDA-aware import)
                │
                ├──► lift modules run (pydantic / msgspec / dataclass)
                │

--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -394,8 +394,9 @@ def test_landmark_checks_raise_on_missing():
 ```
 
 2. Set the runner tier:
-   - CPU-safe imports (`import myenginelib` works without CUDA): add to the GH-hosted job.
-   - CUDA-aware import required: add to the self-hosted GPU runner job.
+   - CPU-safe import AND clean resolution under the repo's unified `uv.lock` (e.g. transformers): add to the GH-hosted `ubuntu-latest` job with `uv sync --extra <engine>`.
+   - CPU-safe import but unified-lock resolution breaks the engine (e.g. vLLM, where tensorrt-llm 0.21.0's transitive constraints corrupt vllm's torch/torchvision; #437): add to the self-hosted GPU runner inside the engine's published Docker image, mirroring `mine-vllm` in `auto-mine.yml`.
+   - CUDA-aware import required (e.g. TRT-LLM): add to the self-hosted GPU runner inside the engine's Docker image, mirroring `mine-tensorrt`.
 
 3. Add the engine's Dockerfile to the vendor-rules step so `vendor_rules.py` can replay rules inside the engine's container.
 

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -417,16 +417,18 @@ Library version bumps trigger corpus regeneration automatically.
   │  Stage 1: auto-mine.yml fires (mining)                            │
   │  (guarded: only Renovate PRs touching engine version files)       │
   │               │                                                   │
-  │         ┌─────┴─────────────────────────────┐                    │
-  │         ▼                                   ▼                    │
-  │  GH-hosted runner                   Self-hosted GPU runner       │
-  │  - transformers static miner        - TRT-LLM static miner       │
-  │  - transformers dynamic miner       (CUDA-aware import required)  │
-  │  - vLLM static miner                                              │
-  │  - vLLM dynamic miner                                             │
-  │  (CPU-safe imports confirmed)                                     │
-  │         │                                   │                    │
-  │         └─────────────┬─────────────────────┘                    │
+  │         ┌─────┴─────────────────┬────────────────────────┐        │
+  │         ▼                       ▼                        ▼        │
+  │  GH-hosted runner       Self-hosted GPU runner   Self-hosted GPU  │
+  │  (ubuntu-latest)        inside vllm/vllm-openai  inside           │
+  │  - transformers          Docker image            llenergymeasure: │
+  │    static miner         - vLLM static miner     tensorrt image    │
+  │  - transformers         - vLLM dynamic miner    - TRT-LLM static  │
+  │    dynamic miner        (Docker isolates from    miner (CUDA-     │
+  │  (uv sync --extra        unified uv.lock; #437)  aware import     │
+  │   transformers)                                  required)        │
+  │         │                       │                        │        │
+  │         └───────────────────────┴────────────────────────┘        │
   │                       ▼                                           │
   │         build_corpus.py merges staging files                      │
   │         → configs/validation_rules/{engine}.yaml                  │
@@ -469,14 +471,15 @@ The update workflow:
 
 ## Two-tier CI
 
-Miners run on two runner tiers based on their import requirements.
+Miners run on two runner tiers. The choice is driven both by import requirements and by whether the miner can resolve cleanly against the repo's unified `uv.lock`.
 
-| Tier | Runner | What runs |
-|------|--------|-----------|
-| GH-hosted | `ubuntu-latest` | All static miners (pure file I/O); transformers + vLLM dynamic miners (CPU-safe imports confirmed) |
-| Self-hosted | GPU runner (closes issue #389) | TRT-LLM static miner (requires CUDA-aware `import tensorrt_llm`); the TRT-LLM Docker image `llenergymeasure:tensorrt` at pin v0.21.0 is the runtime |
+| Tier | Runner | Image | What runs |
+|------|--------|-------|-----------|
+| GH-hosted | `ubuntu-latest` | host (`uv sync --extra transformers`) | transformers static + dynamic miners (CPU-safe import; resolves cleanly under unified lock) |
+| Self-hosted | GPU runner (closes issue #389) | `vllm/vllm-openai:${VLLM_VERSION}` | vLLM static + dynamic miners (CPU-safe imports, but unified `uv.lock` cascades tensorrt-llm 0.21.0 constraints into vllm's torch/torchvision and breaks `import vllm`; #437, #464). Docker isolates the miner against vLLM's own published torch/vllm combo. |
+| Self-hosted | GPU runner | `llenergymeasure:tensorrt-${TRTLLM_VERSION}` | TRT-LLM static miner (CUDA-aware `import tensorrt_llm`). The NGC-derived image carries the `tensorrt_llm` Python source as part of the installed package; the workflow symlinks it into the miner's expected default path before invoking `build_corpus`. |
 
-TRT-LLM is pinned at v0.21.0 (CUDA 12.6.x) because v1.x requires CUDA 13.x, which is not available on the current A100 (SM80) runner fleet.
+Pivoting vLLM and TRT-LLM into Docker on the self-hosted runner mirrors the project's broader principle that engine-touching activity runs inside the same image the user's multi-backend orchestration uses (multi-backend without Docker is a hard error). TRT-LLM is pinned at v0.21.0 (CUDA 12.6.x) because v1.x requires CUDA 13.x, which is not available on the current A100 (SM80) runner fleet.
 
 ---
 


### PR DESCRIPTION
## Summary

Both `mine-vllm` and `mine-tensorrt` jobs in `.github/workflows/auto-mine.yml` failed on PR #459's forced E2E run. This PR is a YAML-only fix that pivots both jobs to the Docker pattern already used by `invariant-miner.yml`'s `vendor-vllm` + `vendor-tensorrt`. `mine-transformers` is unchanged — it already runs successfully on `ubuntu-latest`.

### Why each job failed

- **#464 (mine-vllm)**: `runs-on: ubuntu-latest` + `uv sync --dev --extra vllm` produced an env in which `from vllm import ...` raised `RuntimeError: operator torchvision::nms does not exist`. Root cause is the unified `uv.lock` (#437): tensorrt-llm 0.21.0's transitive constraints cascade into the vllm extra's torch/torchvision resolution. Fix: run inside `llenergymeasure:vllm-${VLLM_VERSION}`, which carries vLLM's own published torch/vllm combo. Mirrors `vendor-vllm`.
- **#463 (mine-tensorrt)**: already on `self-hosted` + `llenergymeasure:tensorrt`, but `tensorrt_static_miner.py` requires the tensorrt_llm 0.21.0 Python source at `/tmp/trt-llm-0.21.0/tensorrt_llm`, which the workflow never produced. The NGC image already ships that source as part of the installed `tensorrt_llm` package, so the docker step now resolves it via `tensorrt_llm.__file__` and symlinks the package directory into the miner's default path before calling `build_corpus`. No `build_corpus.py` change required.

### What stayed the same

- `mine-transformers` job: unchanged. `ubuntu-latest` + `uv sync --dev --extra transformers` works (PR #459 confirmed).
- App-token mint, anchor SHA computation, diff classifier, commit-back, comment, label steps: all on host, outside Docker.
- `LLENERGY_MINER_FROZEN_AT` determinism contract: passed through via `docker run -e`.
- `invariant-miner.yml` and `parameter-discovery.yml`: not touched.

## Empirical reference

Workflow run https://github.com/henrycgbaker/llenergymeasure/actions/runs/25022513072 surfaced both failures. Job-level links:
- mine-vllm: https://github.com/henrycgbaker/llenergymeasure/actions/runs/25022513072/job/73286143054
- mine-tensorrt: https://github.com/henrycgbaker/llenergymeasure/actions/runs/25022513072/job/73286143064

## Test plan

- [ ] CI: `auto-mine` job triggers on this PR (Dockerfile path filter doesn't fire on a `.github/workflows/` change, so we'll need a `workflow_dispatch` test)
- [ ] On dispatch, mine-vllm builds/reuses `llenergymeasure:vllm-v0.7.3`, runs `build_corpus --engine vllm` inside, no torchvision::nms error
- [ ] On dispatch, mine-tensorrt symlinks the installed `tensorrt_llm` source, runs `build_corpus --engine tensorrt`, miner's landmark check passes
- [ ] mine-transformers continues to pass on `ubuntu-latest` (regression)
- [ ] No corpus drift on idempotent re-run (anchor determinism preserved)