### PR TITLE
docs(arch): Phase C — verified-behaviour operational reference

### DIFF
--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -480,6 +480,64 @@ Both static and dynamic miners err toward recall. The vendor-CI gate is the prun
 
 ---
 
+## Failure modes when libraries evolve
+
+When Renovate bumps an engine library, the miner pipeline must catch behavioural drift before stale rules ship. Failures fall into three categories: loud failures caught by the miner pipeline at mining time, loud failures caught by the vendor gate at validation time, and one silent failure mode the YAML/JSON split was specifically designed to make visible.
+
+### Loud failures caught by the miner pipeline
+
+The miner pipeline's import-time contract (Step 1 above) raises hard CI errors when the library has drifted out of the envelope the miner was written against:
+
+- **`MinerVersionMismatchError`** — installed library version is outside the miner's `TESTED_AGAINST_VERSIONS` `SpecifierSet`. Forces the maintainer to read release notes and either widen the envelope or update the miner to match new validator semantics.
+  - Example: vLLM 0.7.3 against a miner with `TESTED_AGAINST_VERSIONS = SpecifierSet(">=0.17,<0.18")` raises `MinerVersionMismatchError` at import. Observed empirically on PR #459's `mine-vllm` job.
+
+- **`MinerLandmarkMissingError`** — an expected class or method symbol is no longer present in the library source. Catches refactors where a class was renamed, moved to a different module, or an API was deprecated and removed.
+  - Example: a hypothetical vLLM release dropping `vllm.sampling_params.StructuredOutputsParams` would raise `MinerLandmarkMissingError` at the landmark-check step before any AST walking begins.
+
+- **`ImportError` / `AttributeError`** — propagated raw if the miner uses a library symbol that has been refactored without a landmark guard. The fail-loud principle requires letting these propagate; never wrap landmark imports in a `try/except` that returns `[]`. The Haiku-era TRT-LLM extractor was reverted in #423 specifically because it caught `ImportError` and silently degraded.
+
+These three errors all surface as red CI on the Renovate PR, blocking merge until the miner is updated.
+
+### Loud failures caught by the vendor gate
+
+After mining completes and a YAML corpus is written, `vendor_rules.py --fail-on-divergence` replays each rule's `kwargs_positive` and `kwargs_negative` against the live library inside the engine's Docker container:
+
+- **`--fail-on-divergence`** flips the vendor gate to non-zero exit when an existing rule's declared `expected_outcome` no longer matches the library's actual behaviour. This catches three distinct kinds of behavioural drift:
+  1. The library changed its validation behaviour for an existing rule (e.g. relaxed a numeric bound, changed an error type).
+  2. The library dropped a rule entirely (the constraint no longer fires).
+  3. The library added a new constraint path that the existing rule's `kwargs_negative` example now happens to trip.
+
+All three engines (transformers, vLLM, TRT-LLM) have `--fail-on-divergence` operational as of Phase A (#445). Gate-breaking divergences are P0 incidents — they block the Renovate PR from merging.
+
+### Silent failure: recall regression
+
+The vendor gate above validates the rules that *exist* in the corpus. It cannot tell you about rules that *should* exist but no longer do, because the miner regressed and stopped finding them.
+
+Concrete scenario: a refactor in `_pydantic_lift.py` changes how it walks `FieldInfo.metadata`, and the lift now finds 12 rules where it previously found 30. The 18 lost rules silently disappear from the corpus.
+
+- The vendor gate runs only on the 12 surviving rules — every one of them passes.
+- CI is green.
+- The Renovate PR merges with a corpus that has 60% the recall it had before.
+- Users hitting the lost validations get no constraint check at runtime.
+
+**Mitigation: the Stage 1 / Stage 2 split (the trust seam).**
+
+Stage 1 (`auto-mine.yml`) regenerates the YAML corpus and the bot writes the new YAML to the PR branch as a commit. Stage 2 (`invariant-miner.yml`) only runs the vendor gate against the YAML.
+
+Because Stage 1 commits the YAML *before* Stage 2 runs, the YAML diff is reviewable in the PR. A miner refactor that silently drops 18 rules shows up as 18 deletions in the YAML diff — a maintainer reading the PR notices the regression before the JSON gate's green tick lands.
+
+This is the reason the pipeline is split into two stages instead of being unified into one workflow that mines + vendors + commits a single artefact. The split forces YAML-diff visibility *before* the JSON gate's authority is exercised. Cross-reference: #450 (trust seam architecture decision), #465 (auto-mine writeback contract).
+
+### Tooling for diagnosis
+
+The fail-loud envelope and the YAML diff together cover the failure modes that trip on a routine library bump. Three planned tools extend this for harder cases:
+
+- **Pre-mining envelope check (#469).** Verifies the installed library version is inside `TESTED_AGAINST_VERSIONS` *before* CI invests effort in mining. Today the check happens at miner import time, which is fine but late — if mining takes 5 minutes and the version is wrong, the maintainer waits 5 minutes to find out.
+- **Compat-matrix sweep (#470).** Runs the miner against every library version in a declared support range and reports per-version `(rule_count, divergences, errors)`. Surfaces "this miner mostly works on the new version but loses 3 rules" before a Renovate PR ever opens.
+- **Coordinated bump command `llem bump-engine` (#471).** A single CLI entry point that updates the Dockerfile ARG, regenerates the corpus, runs the vendor gate, and reports the diff in one local invocation — used by maintainers handling library bumps that need manual intervention (e.g. `MinerVersionMismatchError` resolution).
+
+---
+
 ## Common mistakes
 
 | Mistake | Consequence | Fix |

--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -488,13 +488,13 @@ When Renovate bumps an engine library, the miner pipeline must catch behavioural
 
 The miner pipeline's import-time contract (Step 1 above) raises hard CI errors when the library has drifted out of the envelope the miner was written against:
 
-- **`MinerVersionMismatchError`** — installed library version is outside the miner's `TESTED_AGAINST_VERSIONS` `SpecifierSet`. Forces the maintainer to read release notes and either widen the envelope or update the miner to match new validator semantics.
+- **`MinerVersionMismatchError`** - installed library version is outside the miner's `TESTED_AGAINST_VERSIONS` `SpecifierSet`. Forces the maintainer to read release notes and either widen the envelope or update the miner to match new validator semantics.
   - Example: vLLM 0.7.3 against a miner with `TESTED_AGAINST_VERSIONS = SpecifierSet(">=0.17,<0.18")` raises `MinerVersionMismatchError` at import. Observed empirically on PR #459's `mine-vllm` job.
 
-- **`MinerLandmarkMissingError`** — an expected class or method symbol is no longer present in the library source. Catches refactors where a class was renamed, moved to a different module, or an API was deprecated and removed.
+- **`MinerLandmarkMissingError`** - an expected class or method symbol is no longer present in the library source. Catches refactors where a class was renamed, moved to a different module, or an API was deprecated and removed.
   - Example: a hypothetical vLLM release dropping `vllm.sampling_params.StructuredOutputsParams` would raise `MinerLandmarkMissingError` at the landmark-check step before any AST walking begins.
 
-- **`ImportError` / `AttributeError`** — propagated raw if the miner uses a library symbol that has been refactored without a landmark guard. The fail-loud principle requires letting these propagate; never wrap landmark imports in a `try/except` that returns `[]`. The Haiku-era TRT-LLM extractor was reverted in #423 specifically because it caught `ImportError` and silently degraded.
+- **`ImportError` / `AttributeError`** - propagated raw if the miner uses a library symbol that has been refactored without a landmark guard. The fail-loud principle requires letting these propagate; never wrap landmark imports in a `try/except` that returns `[]`. The Haiku-era TRT-LLM extractor was reverted in #423 specifically because it caught `ImportError` and silently degraded.
 
 These three errors all surface as red CI on the Renovate PR, blocking merge until the miner is updated.
 
@@ -507,7 +507,7 @@ After mining completes and a YAML corpus is written, `vendor_rules.py --fail-on-
   2. The library dropped a rule entirely (the constraint no longer fires).
   3. The library added a new constraint path that the existing rule's `kwargs_negative` example now happens to trip.
 
-All three engines (transformers, vLLM, TRT-LLM) have `--fail-on-divergence` operational as of Phase A (#445). Gate-breaking divergences are P0 incidents — they block the Renovate PR from merging.
+All three engines (transformers, vLLM, TRT-LLM) have `--fail-on-divergence` operational as of Phase A (#445). Gate-breaking divergences are P0 incidents - they block the Renovate PR from merging.
 
 ### Silent failure: recall regression
 
@@ -515,7 +515,7 @@ The vendor gate above validates the rules that *exist* in the corpus. It cannot 
 
 Concrete scenario: a refactor in `_pydantic_lift.py` changes how it walks `FieldInfo.metadata`, and the lift now finds 12 rules where it previously found 30. The 18 lost rules silently disappear from the corpus.
 
-- The vendor gate runs only on the 12 surviving rules — every one of them passes.
+- The vendor gate runs only on the 12 surviving rules - every one of them passes.
 - CI is green.
 - The Renovate PR merges with a corpus that has 60% the recall it had before.
 - Users hitting the lost validations get no constraint check at runtime.
@@ -524,7 +524,7 @@ Concrete scenario: a refactor in `_pydantic_lift.py` changes how it walks `Field
 
 Stage 1 (`auto-mine.yml`) regenerates the YAML corpus and the bot writes the new YAML to the PR branch as a commit. Stage 2 (`invariant-miner.yml`) only runs the vendor gate against the YAML.
 
-Because Stage 1 commits the YAML *before* Stage 2 runs, the YAML diff is reviewable in the PR. A miner refactor that silently drops 18 rules shows up as 18 deletions in the YAML diff — a maintainer reading the PR notices the regression before the JSON gate's green tick lands.
+Because Stage 1 commits the YAML *before* Stage 2 runs, the YAML diff is reviewable in the PR. A miner refactor that silently drops 18 rules shows up as 18 deletions in the YAML diff - a maintainer reading the PR notices the regression before the JSON gate's green tick lands.
 
 This is the reason the pipeline is split into two stages instead of being unified into one workflow that mines + vendors + commits a single artefact. The split forces YAML-diff visibility *before* the JSON gate's authority is exercised. Cross-reference: #450 (trust seam architecture decision), #465 (auto-mine writeback contract).
 
@@ -532,9 +532,9 @@ This is the reason the pipeline is split into two stages instead of being unifie
 
 The fail-loud envelope and the YAML diff together cover the failure modes that trip on a routine library bump. Three planned tools extend this for harder cases:
 
-- **Pre-mining envelope check (#469).** Verifies the installed library version is inside `TESTED_AGAINST_VERSIONS` *before* CI invests effort in mining. Today the check happens at miner import time, which is fine but late — if mining takes 5 minutes and the version is wrong, the maintainer waits 5 minutes to find out.
+- **Pre-mining envelope check (#469).** Verifies the installed library version is inside `TESTED_AGAINST_VERSIONS` *before* CI invests effort in mining. Today the check happens at miner import time, which is fine but late - if mining takes 5 minutes and the version is wrong, the maintainer waits 5 minutes to find out.
 - **Compat-matrix sweep (#470).** Runs the miner against every library version in a declared support range and reports per-version `(rule_count, divergences, errors)`. Surfaces "this miner mostly works on the new version but loses 3 rules" before a Renovate PR ever opens.
-- **Coordinated bump command `llem bump-engine` (#471).** A single CLI entry point that updates the Dockerfile ARG, regenerates the corpus, runs the vendor gate, and reports the diff in one local invocation — used by maintainers handling library bumps that need manual intervention (e.g. `MinerVersionMismatchError` resolution).
+- **Coordinated bump command `llem bump-engine` (#471).** A single CLI entry point that updates the Dockerfile ARG, regenerates the corpus, runs the vendor gate, and reports the diff in one local invocation - used by maintainers handling library bumps that need manual intervention (e.g. `MinerVersionMismatchError` resolution).
 
 ---
 

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -396,61 +396,79 @@ The gate runs inside the Docker container for each engine so that the live libra
 
 ## Renovate-driven refresh loop
 
-Library version bumps trigger corpus regeneration automatically.
+Library version bumps trigger corpus regeneration automatically. The flow described below reflects what was empirically observed during the Phase B.6 forced E2E run on PR #459 (transformers 4.57.3 → 4.57.6); see ["Phase B.6 observed flow"](#phase-b6-observed-flow) below for the actual commit timeline.
 
 ```
   ┌───────────────────────────────────────────────────────────────────┐
   │                    RENOVATE REFRESH LOOP                          │
   │                                                                   │
   │  Upstream library releases new version                            │
-  │  (e.g. transformers 4.56.0 → 4.57.0)                             │
+  │  (e.g. transformers 4.57.3 → 4.57.6)                              │
   │               │                                                   │
   │               ▼                                                   │
   │  Renovate detects version bump                                    │
-  │  (weekly schedule, 3-day stability window)                        │
+  │  (weekly schedule, "before 9am on Monday";                        │
+  │   Dashboard #446 checkbox bypasses on demand)                     │
   │               │                                                   │
   │               ▼                                                   │
   │  Renovate opens PR bumping Dockerfile ARG                         │
-  │  or PyPI version pin in requirements file                         │
+  │  (e.g. ARG TRANSFORMERS_VERSION=...)                              │
   │               │                                                   │
-  │               ▼                                                   │
-  │  Stage 1: auto-mine.yml fires (mining)                            │
-  │  (guarded: only Renovate PRs touching engine version files)       │
+  │     ┌─────────┴──────────────┬────────────────────┐               │
+  │     ▼                        ▼                    ▼               │
+  │  invariant-miner.yml   parameter-discovery   auto-mine.yml        │
+  │  (Stage 2 vendor gate)   .yml                (Stage 1 mining)     │
+  │                                                                   │
+  │  Path filters fire all three workflows in parallel on the         │
+  │  Renovate PR. They write back to the PR branch independently.     │
   │               │                                                   │
-  │         ┌─────┴─────────────────┬────────────────────────┐        │
-  │         ▼                       ▼                        ▼        │
-  │  GH-hosted runner       Self-hosted GPU runner   Self-hosted GPU  │
-  │  (ubuntu-latest)        inside vllm/vllm-openai  inside           │
-  │  - transformers          Docker image            llenergymeasure: │
-  │    static miner         - vLLM static miner     tensorrt image    │
-  │  - transformers         - vLLM dynamic miner    - TRT-LLM static  │
-  │    dynamic miner        (Docker isolates from    miner (CUDA-     │
-  │  (uv sync --extra        unified uv.lock; #437)  aware import     │
-  │   transformers)                                  required)        │
-  │         │                       │                        │        │
-  │         └───────────────────────┴────────────────────────┘        │
+  │  ─────────────┴ Stage 1: auto-mine.yml ─────────────────          │
+  │         ┌─────────────────┬────────────────────┐                  │
+  │         ▼                 ▼                    ▼                  │
+  │  GH-hosted runner   Self-hosted GPU      Self-hosted GPU          │
+  │  (ubuntu-latest)    inside vllm/vllm-    inside llenergymeasure:  │
+  │  - transformers     openai Docker        tensorrt Docker          │
+  │    static miner     - vLLM static        - TRT-LLM static         │
+  │  - transformers     - vLLM dynamic         miner (CUDA-aware      │
+  │    dynamic miner    (Docker isolates       import required)       │
+  │  (uv sync --extra   from unified uv.lock;                         │
+  │   transformers)     #437, #464)                                   │
+  │         │                 │                    │                  │
+  │         └─────────────────┴────────────────────┘                  │
   │                       ▼                                           │
-  │         build_corpus.py merges staging files                      │
-  │         → configs/validation_rules/{engine}.yaml                  │
+  │  build_corpus.py merges staging → configs/validation_rules/       │
+  │  {engine}.yaml; bot commits the new YAML to the PR branch         │
+  │  with `--force-with-lease` and posts a diff comment.              │
   │                       │                                           │
   │                       ▼                                           │
-  │  Stage 2: invariant-miner.yml fires (vendor gate)                 │
+  │  Stage 1 writeback retriggers invariant-miner.yml on the new      │
+  │  YAML commit (chain validation).                                  │
+  │                                                                   │
+  │  ─────────────── Stage 2: invariant-miner.yml ─────────────       │
+  │                       ▼                                           │
+  │  vendor_rules.py --fail-on-divergence replays each rule against   │
+  │  the live library inside the engine's Docker container.           │
   │                       │                                           │
   │                       ▼                                           │
-  │         vendor_rules.py replays rules against live library        │
-  │         (inside Docker container for engine)                      │
+  │  Bot writes updated vendored JSON                                 │
+  │  (src/llenergymeasure/config/vendored_rules/{engine}.json)        │
+  │  to the PR branch and posts a diff comment.                       │
+  │                       │                                           │
+  │  ─────────────── parameter-discovery.yml (parallel) ───────       │
+  │                       ▼                                           │
+  │  discover_engine_schemas.py introspects engine config classes     │
+  │  inside Docker, regenerates discovered_schemas/{engine}.json,     │
+  │  bot commits and posts a diff comment.                            │
   │                       │                                           │
   │                       ▼                                           │
-  │         Bot writes updated vendored JSON to PR branch             │
-  │         (llem-ci-bot GitHub App; see reference_llem_ci_bot.md)   │
+  │  CI green required before merge.                                  │
+  │  Divergences from --fail-on-divergence are P0 incidents.          │
   │                       │                                           │
   │                       ▼                                           │
-  │         CI green required before merge                            │
-  │         Divergences are P0 incidents (block merge)                │
-  │                       │                                           │
-  │                       ▼                                           │
-  │         Maintainer reviews corpus diff in PR                      │
-  │         (gate-breaking = action required before merge)            │
+  │  Maintainer reviews corpus diff (YAML), vendored JSON diff, and   │
+  │  schema diff in the PR. Stage 1's YAML commit is the trust seam:  │
+  │  recall regressions show up as YAML rule drops BEFORE the JSON    │
+  │  gate runs.                                                       │
   └───────────────────────────────────────────────────────────────────┘
 ```
 
@@ -466,6 +484,76 @@ The update workflow:
 4. Maintainer updates `TESTED_AGAINST_VERSIONS` and any landmark names that changed.
 5. CI re-runs with updated miner; vendor-CI gate runs.
 6. If any rules now diverge, they are quarantined; maintainer updates the corpus.
+
+### Phase B.6 observed flow
+
+The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transformers v4.57.3 → v4.57.6) is the first naturally-Renovate-authored exercise of the full chain. The actual commit sequence on the PR branch:
+
+```
+  Commit (PR #459 branch)   Author       Producing workflow / event
+  ──────────────────────    ─────────    ──────────────────────────────────────
+  2599ef21                  renovate     Renovate's initial Dockerfile bump
+                                         (TRANSFORMERS_VERSION → 4.57.6)
+                                                  │
+                                                  ▼
+  a77aa185                  llem-ci-bot  invariant-miner.yml — vendor-tensorrt
+                                         (first cycle; replays existing
+                                          tensorrt rules against live library)
+                                                  │
+                                                  ▼
+  ae22d224                  llem-ci-bot  parameter-discovery.yml
+                                         (first cycle; rediscovered transformers
+                                          schema, 1 safe change)
+                                                  │
+                                                  ▼
+  45e0d75a                  llem-ci-bot  invariant-miner.yml — vendor-transformers
+                                         (first cycle; replays existing
+                                          transformers rules against new library)
+                                                  │
+                                                  ▼
+  96d811fb                  llem-ci-bot  auto-mine.yml — mine-transformers
+                                         (Stage 1: regenerated YAML corpus
+                                          from miners against new library)
+                                                  │
+                                                  ▼  (chain validation re-fire)
+  fb473a22                  llem-ci-bot  invariant-miner.yml — vendor-transformers
+                                         (Stage 2 RE-FIRES on auto-mine's
+                                          new YAML; vendors against new YAML)
+                                                  │
+                                                  ▼  (delayed; serial runner)
+  75d4c0c1                  llem-ci-bot  invariant-miner.yml — vendor-vllm
+                                         (delayed: self-hosted GPU runner is
+                                          serial, vLLM job queued behind others)
+```
+
+**What this proves empirically:**
+
+- **All three workflows fire on a single Renovate-authored Dockerfile bump.** No actor-gate intervention; path filters alone are sufficient.
+- **Stage 1 → Stage 2 chain validation works as designed.** auto-mine writes YAML at `96d811fb`; invariant-miner re-fires at `fb473a22` against the new YAML. The trust seam (YAML diff visible to reviewers before JSON gate runs) is exercised end-to-end.
+- **App-token + `--force-with-lease` writebacks succeed across all three workflows** without recursion-guard issues.
+- **Determinism holds.** Of the ~14 bot comments posted across the cycle, 8 were "No changes" after subsequent runs — proving the `LLENERGY_*_FROZEN_AT` env-var contracts produce reproducible outputs once the corpus has converged.
+- **Self-hosted GPU runner serialisation is observable.** The vLLM vendor gate (`75d4c0c1`) was queued behind vendor-tensorrt and arrived after the transformers chain had already converged.
+
+**What did not work on this PR (separate blockers, not chain-validation failures):**
+
+- `mine-vllm` — Dockerfile.vllm ARG (v0.7.3) is outside the vLLM miner's `TESTED_AGAINST_VERSIONS` envelope (`>=0.17,<0.18`); raised `MinerVersionMismatchError` as designed. Resolution requires the per-engine version-bundle work (#468–#471).
+- `mine-tensorrt` — runtime-symlink script bug inside the NGC container (#472).
+
+Both are tracked as engine-specific follow-ups; neither invalidates the chain-validation outcome.
+
+For the full closure summary and bot-comment audit, see PR #459's final comment (PR closed without merge; the PR was the test instrument, not a real upstream bump record).
+
+### Status: #394 (check-vs-commit semantics)
+
+Issue #394 raised the question of whether Stage 2's bot writeback should commit the vendored JSON back to the PR or merely check it (a "check-only" mode without a writeback). At the time of writing the simplification looked attractive — the YAML at Stage 1 already serves the trust-seam role.
+
+Status note as of Phase C closure:
+
+- The runtime currently reads the vendored JSON via `_apply_vendored_rules` in `src/llenergymeasure/config/models.py` (search for `_get_rules_loader().load_rules`). Removing the JSON commit-back without first migrating the runtime path would break runtime validation.
+- This makes the blast radius of #394's proposed simplification larger than the issue thread implied. A clean resolution depends on the Docker-only target architecture being settled first (#467), since the JSON consumption pattern is a function of how the runtime resolves rules at experiment-run time.
+- Cross-references: #394 (the original check-vs-commit question), #467 (Docker-only architecture that affects the runtime side), #393 (the auto-mine automation gap, partially closed by Phase B.4).
+
+Decision: leave the JSON commit-back in place; revisit when #467 lands.
 
 ---
 

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -531,13 +531,13 @@ The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transforme
 - **All three workflows fire on a single Renovate-authored Dockerfile bump.** No actor-gate intervention; path filters alone are sufficient.
 - **Stage 1 → Stage 2 chain validation works as designed.** auto-mine writes YAML at `96d811fb`; invariant-miner re-fires at `fb473a22` against the new YAML. The trust seam (YAML diff visible to reviewers before JSON gate runs) is exercised end-to-end.
 - **App-token + `--force-with-lease` writebacks succeed across all three workflows** without recursion-guard issues.
-- **Determinism holds.** Of the ~14 bot comments posted across the cycle, 8 were "No changes" after subsequent runs — proving the `LLENERGY_*_FROZEN_AT` env-var contracts produce reproducible outputs once the corpus has converged.
+- **Determinism holds.** Of the ~14 bot comments posted across the cycle, 8 were "No changes" after subsequent runs - proving the `LLENERGY_*_FROZEN_AT` env-var contracts produce reproducible outputs once the corpus has converged.
 - **Self-hosted GPU runner serialisation is observable.** The vLLM vendor gate (`75d4c0c1`) was queued behind vendor-tensorrt and arrived after the transformers chain had already converged.
 
 **What did not work on this PR (separate blockers, not chain-validation failures):**
 
-- `mine-vllm` — Dockerfile.vllm ARG (v0.7.3) is outside the vLLM miner's `TESTED_AGAINST_VERSIONS` envelope (`>=0.17,<0.18`); raised `MinerVersionMismatchError` as designed. Resolution requires the per-engine version-bundle work (#468–#471).
-- `mine-tensorrt` — runtime-symlink script bug inside the NGC container (#472).
+- `mine-vllm` - Dockerfile.vllm ARG (v0.7.3) is outside the vLLM miner's `TESTED_AGAINST_VERSIONS` envelope (`>=0.17,<0.18`); raised `MinerVersionMismatchError` as designed. Resolution requires the per-engine version-bundle work (#468-#471).
+- `mine-tensorrt` - runtime-symlink script bug inside the NGC container (#472).
 
 Both are tracked as engine-specific follow-ups; neither invalidates the chain-validation outcome.
 
@@ -545,11 +545,11 @@ For the full closure summary and bot-comment audit, see PR #459's final comment 
 
 ### Status: #394 (check-vs-commit semantics)
 
-Issue #394 raised the question of whether Stage 2's bot writeback should commit the vendored JSON back to the PR or merely check it (a "check-only" mode without a writeback). At the time of writing the simplification looked attractive — the YAML at Stage 1 already serves the trust-seam role.
+Issue #394 raised the question of whether Stage 2's bot writeback should commit the vendored JSON back to the PR or merely check it (a "check-only" mode without a writeback). At the time of writing the simplification looked attractive - the YAML at Stage 1 already serves the trust-seam role.
 
 Status note as of Phase C closure:
 
-- The runtime currently reads the vendored JSON via `_apply_vendored_rules` in `src/llenergymeasure/config/models.py` (search for `_get_rules_loader().load_rules`). Removing the JSON commit-back without first migrating the runtime path would break runtime validation.
+- The runtime currently reads the vendored JSON via `_apply_vendored_rules` in `src/llenergymeasure/config/models.py` (which calls `_get_rules_loader().load_rules`). Removing the JSON commit-back without first migrating the runtime path would break runtime validation.
 - This makes the blast radius of #394's proposed simplification larger than the issue thread implied. A clean resolution depends on the Docker-only target architecture being settled first (#467), since the JSON consumption pattern is a function of how the runtime resolves rules at experiment-run time.
 - Cross-references: #394 (the original check-vs-commit question), #467 (Docker-only architecture that affects the runtime side), #393 (the auto-mine automation gap, partially closed by Phase B.4).
 


### PR DESCRIPTION
## Summary

Phase C of the Vendored-CI Pipeline Refresh plan (`~/.claude/plans/re-renovate-decision-staged-naur.md`). Captures the empirically-observed flow from Phase B.6's Renovate-driven forced E2E run (PR #459, `renovate/transformers-4.x`, transformers v4.57.3 → v4.57.6) and adds a comprehensive failure-modes reference for engine extenders.

Scope was narrowed by the per-PR docs/arch-sync rule that ran on PR #460 + PR #466 — those caught most of the architectural drift in-flight, so this PR focuses on observed behaviour + failure modes only. Architectural / WHY-shaped material is deferred to Phase D.

## Files modified

### `docs/miner-pipeline.md`
- Replaced the aspirational "Renovate-driven refresh loop" diagram with one that reflects the three-workflow parallel fan-out empirically observed on PR #459 (path filters fire `invariant-miner.yml`, `parameter-discovery.yml`, and `auto-mine.yml` in parallel; Stage 1's YAML writeback retriggers Stage 2 for chain validation).
- Added a new "Phase B.6 observed flow" subsection walking through the actual commit sequence on PR #459's branch (`2599ef21` → `a77aa185` → `ae22d224` → `45e0d75a` → `96d811fb` → `fb473a22` → `75d4c0c1`) with author + producing workflow per commit, the determinism observation, and the per-engine blockers (mine-vllm version envelope, mine-tensorrt symlink bug).
- Added a "Status: #394 (check-vs-commit semantics)" subsection noting that the runtime reads JSON via `_apply_vendored_rules` in `src/llenergymeasure/config/models.py`, so the simplification proposed in #394 has a larger blast radius than the issue thread implied. Cross-links #394, #467, #393.

### `docs/extending-miners.md`
- New "Failure modes when libraries evolve" section with four sub-categories:
  - Loud failures caught by the miner pipeline (`MinerVersionMismatchError`, `MinerLandmarkMissingError`, `ImportError`/`AttributeError`).
  - Loud failures caught by the vendor gate (`--fail-on-divergence` and the three drift kinds it catches).
  - The silent recall-regression failure mode and why the Stage 1/Stage 2 split (the trust seam) is its mitigation. Cross-links #450, #465.
  - Planned diagnostic tooling (#469, #470, #471).

## Verification

- `grep -rn "schema-refresh\|config-rules-refresh\|update_engine_rules\|update_engine_schema\|diff_rules\.py\|diff_schemas\|check_schema_versions" docs/` — all hits are deliberate cross-references to the existing `docs/schema-refresh.md` filename (PR #460's renames already addressed workflow-name / script-name references).
- `grep -c "MinerVersionMismatchError\|MinerLandmarkMissingError" docs/extending-miners.md` returns 20 (≥ 4 required).
- Read-through pass confirms internal consistency, cross-links resolve.

## Plan reference

- Plan: `~/.claude/plans/re-renovate-decision-staged-naur.md`, "Phase C — verified-behaviour docs"
- Phase B.6 closure: PR #459 final comment (PR closed without merge; the PR was the test instrument for chain validation, not a real upstream-bump record).
- Out of scope (Phase D): `docs/architecture-overview.md`, `docs/parameter-discovery.md`, `docs/schema-refresh.md` content.

## Test plan

- [ ] Read-through review of `docs/miner-pipeline.md` Renovate-loop diagram + Phase B.6 flow + #394 status note
- [ ] Read-through review of `docs/extending-miners.md` Failure-modes section
- [ ] Confirm PR #459 commit sequence in the observed-flow section matches the actual commit log (cross-checked during authoring; see report)
- [ ] `/simplify` review (coordinator, not subagent)