### PR TITLE
feat(engines): per-engine SSOT for library versions and miner pins

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -274,6 +274,10 @@ The trade-off is staleness risk: the corpus must be regenerated when the engine 
   └── vendored_rules/
       ├── loader.py                    Runtime corpus consumer + predicate engine
       └── __init__.py
+
+  engine_versions/
+  └── {engine}.yaml                    Per-engine SSOT: library version, miner pins,
+                                       artefact paths. Renovate-authored.
 ```
 
 ---

--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -36,16 +36,18 @@ Create `scripts/engine_miners/{engine}_miner.py` (the orchestration entry point)
 
 ```python
 import importlib.metadata
-from packaging.specifiers import SpecifierSet
 from scripts.engine_miners._base import check_installed_version, MinerLandmarkMissingError
+from scripts.engine_miners._ssot import load_miner_pin
 
-TESTED_AGAINST_VERSIONS = SpecifierSet(">=X.Y,<X.Z")
-# Set this to the specific version range you have tested against.
+# Pin source-of-truth lives in ``engine_versions/{engine}.yaml`` under
+# ``miner_pins.{static|dynamic|discovery}``. Pick the producer matching this
+# miner's role; ``load_miner_pin`` returns a ``packaging.SpecifierSet``.
 # Keep the upper bound tight (e.g. <4.60 not <99.0) so
 # MinerVersionMismatchError fires on a library bump.
 
+_envelope = load_miner_pin("myengine", "static")
 _installed = importlib.metadata.version("your-engine-library")
-check_installed_version("your-engine-library", _installed, TESTED_AGAINST_VERSIONS)
+check_installed_version("your-engine-library", _installed, _envelope)
 # Raises MinerVersionMismatchError if installed version is outside the range.
 # This is CI-fatal: the miner will not emit partial output.
 ```
@@ -354,7 +356,7 @@ Each per-engine miner ships with parametrised tests:
 # tests/unit/scripts/engine_miners/test_myengine_miner.py
 
 import pytest
-from scripts.engine_miners.myengine_miner import CLUSTERS, TESTED_AGAINST_VERSIONS
+from scripts.engine_miners.myengine_miner import CLUSTERS
 
 @pytest.mark.parametrize("cluster", CLUSTERS, ids=lambda c: c.name)
 def test_cluster_probes_without_crashing(cluster):
@@ -362,11 +364,13 @@ def test_cluster_probes_without_crashing(cluster):
     rows = probe_cluster(cluster)
     assert isinstance(rows, list)
 
-def test_version_envelope_set():
-    """TESTED_AGAINST_VERSIONS must be a non-empty SpecifierSet."""
+def test_version_envelope_resolves():
+    """The miner pin loaded from the engine SSOT must be a non-empty SpecifierSet."""
     from packaging.specifiers import SpecifierSet
-    assert isinstance(TESTED_AGAINST_VERSIONS, SpecifierSet)
-    assert str(TESTED_AGAINST_VERSIONS) != ""
+    from scripts.engine_miners._ssot import load_miner_pin
+    envelope = load_miner_pin("myengine", "static")
+    assert isinstance(envelope, SpecifierSet)
+    assert str(envelope) != ""
 
 def test_landmark_checks_raise_on_missing():
     """find_class returning None must raise MinerLandmarkMissingError."""
@@ -488,8 +492,8 @@ When Renovate bumps an engine library, the miner pipeline must catch behavioural
 
 The miner pipeline's import-time contract (Step 1 above) raises hard CI errors when the library has drifted out of the envelope the miner was written against:
 
-- **`MinerVersionMismatchError`** - installed library version is outside the miner's `TESTED_AGAINST_VERSIONS` `SpecifierSet`. Forces the maintainer to read release notes and either widen the envelope or update the miner to match new validator semantics.
-  - Example: vLLM 0.7.3 against a miner with `TESTED_AGAINST_VERSIONS = SpecifierSet(">=0.17,<0.18")` raises `MinerVersionMismatchError` at import. Observed empirically on PR #459's `mine-vllm` job.
+- **`MinerVersionMismatchError`** - installed library version is outside the miner's pinned envelope (read from `engine_versions/{engine}.yaml miner_pins.{producer}` via `load_miner_pin`). Forces the maintainer to read release notes and either widen the envelope or update the miner to match new validator semantics.
+  - Example: vLLM 0.7.3 against an SSOT pin of `>=0.17,<0.18` raises `MinerVersionMismatchError` at import. Observed empirically on PR #459's `mine-vllm` job.
 
 - **`MinerLandmarkMissingError`** - an expected class or method symbol is no longer present in the library source. Catches refactors where a class was renamed, moved to a different module, or an API was deprecated and removed.
   - Example: a hypothetical vLLM release dropping `vllm.sampling_params.StructuredOutputsParams` would raise `MinerLandmarkMissingError` at the landmark-check step before any AST walking begins.
@@ -532,7 +536,7 @@ This is the reason the pipeline is split into two stages instead of being unifie
 
 The fail-loud envelope and the YAML diff together cover the failure modes that trip on a routine library bump. Three planned tools extend this for harder cases:
 
-- **Pre-mining envelope check (#469).** Verifies the installed library version is inside `TESTED_AGAINST_VERSIONS` *before* CI invests effort in mining. Today the check happens at miner import time, which is fine but late - if mining takes 5 minutes and the version is wrong, the maintainer waits 5 minutes to find out.
+- **Pre-mining envelope check (#469).** Verifies the installed library version is inside the SSOT-pinned envelope *before* CI invests effort in mining. Today the check happens at miner import time, which is fine but late - if mining takes 5 minutes and the version is wrong, the maintainer waits 5 minutes to find out.
 - **Compat-matrix sweep (#470).** Runs the miner against every library version in a declared support range and reports per-version `(rule_count, divergences, errors)`. Surfaces "this miner mostly works on the new version but loses 3 rules" before a Renovate PR ever opens.
 - **Coordinated bump command `llem bump-engine` (#471).** A single CLI entry point that updates the Dockerfile ARG, regenerates the corpus, runs the vendor gate, and reports the diff in one local invocation - used by maintainers handling library bumps that need manual intervention (e.g. `MinerVersionMismatchError` resolution).
 
@@ -542,7 +546,7 @@ The fail-loud envelope and the YAML diff together cover the failure modes that t
 
 | Mistake | Consequence | Fix |
 |---------|-------------|-----|
-| Not setting `TESTED_AGAINST_VERSIONS` | Miner runs against wrong library version silently | Add `TESTED_AGAINST_VERSIONS = SpecifierSet(">=X,<Y")` and call `check_installed_version` at import |
+| Not pinning the miner envelope in `engine_versions/{engine}.yaml` | Miner runs against wrong library version silently | Set `miner_pins.{static\|dynamic\|discovery}` in the SSOT and call `check_installed_version(load_miner_pin(...))` at import |
 | Catching `ImportError` on landmark imports | Silent degradation (returns `[]` on failure) | Let `ImportError` propagate; or raise `MinerLandmarkMissingError` explicitly |
 | Cartesian-only probing with large clusters | Exponential probe count; CI timeouts | Add Hypothesis supplement for clusters > 200 combinations |
 | Adding `manual_seed` rules for automatable constraints | Pipeline-failure debt | Extend the miner instead |

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -279,19 +279,26 @@ The three engines have structurally different config surfaces, which determines 
 
 ## Fail-loud import contract
 
-Every miner module must declare its version envelope and validate it at import time. This is a structural contract, not a guideline.
+Every miner module must resolve its version envelope from the engine SSOT and validate it at import time. This is a structural contract, not a guideline.
 
 ```python
-# Every *_miner.py must declare this:
-TESTED_AGAINST_VERSIONS = SpecifierSet(">=4.50,<4.60")
+# Every *_miner.py must resolve its envelope from the engine's SSOT:
+from scripts.engine_miners._ssot import load_miner_pin
+
+_envelope = load_miner_pin("transformers", "static")  # SpecifierSet
 
 # And call this at import time:
 check_installed_version(
     "transformers",
     importlib.metadata.version("transformers"),
-    TESTED_AGAINST_VERSIONS,
+    _envelope,
 )
 ```
+
+The envelope itself lives in `engine_versions/{engine}.yaml` under
+`miner_pins.{static|dynamic|discovery}` — one pin per producer role. There
+is no per-module `TESTED_AGAINST_VERSIONS` constant; Renovate updates the
+SSOT and every miner reads through `load_miner_pin`.
 
 If the installed library version falls outside the envelope, the miner raises `MinerVersionMismatchError` - a hard CI failure.
 
@@ -300,7 +307,7 @@ If an expected class or method is missing from the library source (e.g. a class 
 ```
   check_installed_version()
        │
-       ├── version in TESTED_AGAINST_VERSIONS → continue
+       ├── version inside SSOT envelope → continue
        │
        └── version out of range → MinerVersionMismatchError (CI fatal)
 
@@ -475,14 +482,14 @@ Library version bumps trigger corpus regeneration automatically. The flow descri
 
 ### Version mismatch as CI signal
 
-When `TESTED_AGAINST_VERSIONS` in a miner module does not cover the newly bumped library version, `MinerVersionMismatchError` is raised and CI fails. This is intentional: it forces a maintainer to update the miner against the new library version before the corpus is regenerated.
+When `engine_versions/{engine}.yaml miner_pins.{producer}` does not cover the newly bumped library version, `MinerVersionMismatchError` is raised and CI fails. This is intentional: it forces a maintainer to update the miner against the new library version before the corpus is regenerated.
 
 The update workflow:
 
 1. Renovate opens PR bumping library version.
 2. CI fires, `MinerVersionMismatchError` raised for the affected miner.
 3. Maintainer checks the library's release notes for validator changes.
-4. Maintainer updates `TESTED_AGAINST_VERSIONS` and any landmark names that changed.
+4. Maintainer updates `miner_pins` in the engine SSOT and any landmark names that changed.
 5. CI re-runs with updated miner; vendor-CI gate runs.
 6. If any rules now diverge, they are quarantined; maintainer updates the corpus.
 
@@ -537,7 +544,7 @@ The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transforme
 
 **What did not work on this PR (separate blockers, not chain-validation failures):**
 
-- `mine-vllm` - Dockerfile.vllm ARG (v0.7.3) is outside the vLLM miner's `TESTED_AGAINST_VERSIONS` envelope (`>=0.17,<0.18`); raised `MinerVersionMismatchError` as designed. Resolution requires the per-engine version-bundle work (#468-#471).
+- `mine-vllm` - Dockerfile.vllm ARG (v0.7.3) is outside the vLLM miner's SSOT-pinned envelope (`engine_versions/vllm.yaml miner_pins.* = >=0.17,<0.18`); raised `MinerVersionMismatchError` as designed. Resolution requires the per-engine version-bundle work (#468-#471).
 - `mine-tensorrt` - runtime-symlink script bug inside the NGC container (#472).
 
 Both are tracked as engine-specific follow-ups; neither invalidates the chain-validation outcome.

--- a/docs/parameter-discovery.md
+++ b/docs/parameter-discovery.md
@@ -229,7 +229,7 @@ The vendored YAML carries the engine version the corpus was validated against. W
 1. It checks `schema_version` major against `SUPPORTED_MAJOR_VERSION`. A major-version mismatch raises `UnsupportedSchemaVersionError` (the package is incompatible with the installed corpus version).
 2. It parses all rules with strict enum validation: unknown `added_by` values raise `UnknownAddedByError`; unknown severity values raise `UnknownSeverityError`.
 
-The loader does not check whether the currently installed engine library version matches the corpus version. That alignment is enforced at corpus-build time (the miner's `TESTED_AGAINST_VERSIONS` + `check_installed_version`) and at runtime via the engine's own constructor validation.
+The loader does not check whether the currently installed engine library version matches the corpus version. That alignment is enforced at corpus-build time (the miner's SSOT-pinned envelope from `engine_versions/{engine}.yaml miner_pins.{producer}` + `check_installed_version`) and at runtime via the engine's own constructor validation.
 
 ---
 

--- a/docs/research-context.md
+++ b/docs/research-context.md
@@ -133,7 +133,7 @@ The lift output is deterministic: no probing, no randomness, pure function of th
 
 The Haiku-era TRT-LLM extractor (PRs #415-#417, reverted in #423) demonstrated a failure mode not discussed in the prior-art literature: a miner that silently degraded on import errors. When `LlmConfig` (a class that does not exist in TRT-LLM 0.21.0) failed to import, the extractor caught the `ImportError` and returned `[]`. The empty return was indistinguishable from "no rules found for this engine".
 
-The fail-loud import contract - `TESTED_AGAINST_VERSIONS` + `check_installed_version` + `MinerLandmarkMissingError` - makes silent coverage loss impossible. This is a design contribution specifically for the setting where the miner is a CI artefact that runs against a pinned library version: the version pin and the landmark check together guarantee that a miner either mines at the version it was tested against or fails loudly.
+The fail-loud import contract - the SSOT-pinned envelope read via `load_miner_pin` + `check_installed_version` + `MinerLandmarkMissingError` - makes silent coverage loss impossible. This is a design contribution specifically for the setting where the miner is a CI artefact that runs against a pinned library version: the version pin and the landmark check together guarantee that a miner either mines at the version it was tested against or fails loudly.
 
 ---
 

--- a/engine_versions/tensorrt.yaml
+++ b/engine_versions/tensorrt.yaml
@@ -1,0 +1,29 @@
+# Per-engine version-bundle SSOT for tensorrt-llm.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, vendored gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+schema_version: 1
+engine: tensorrt
+library:
+  pep503_name: tensorrt-llm
+  current_version: "0.21.0"
+  current_commit_sha: null
+image:
+  base_image_ref: "nvcr.io/nvidia/tensorrt-llm/release:0.21.0"
+  llem_image_ref: null
+miner_pins:
+  static: ">=0.21.0,<0.22.0"
+  dynamic: ">=0.21.0,<0.22.0"
+  discovery: ">=0.21.0,<0.22.0"
+artefact_paths:
+  rules_corpus: configs/engine_invariants/tensorrt.proposed.yaml
+  vendored_rules: configs/engine_invariants/tensorrt.vendored.yaml
+  discovered_schemas: src/llenergymeasure/config/discovered_schemas/tensorrt.json
+last_probe:
+  verdict: unrun
+  version_inside_envelope: null
+  fingerprint: null
+  fingerprint_drift: []
+  ran_at: null

--- a/engine_versions/transformers.yaml
+++ b/engine_versions/transformers.yaml
@@ -1,0 +1,33 @@
+# Per-engine version-bundle SSOT for transformers.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, vendored gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+#
+# `last_probe.verdict: unrun` is the honest seed shape for a fresh SSOT
+# that no probe has executed against yet. The probe primitive overwrites
+# this block on each per-PR run.
+schema_version: 1
+engine: transformers
+library:
+  pep503_name: transformers
+  current_version: "4.57.3"
+  current_commit_sha: null
+image:
+  base_image_ref: "llenergymeasure:transformers-4.57.3"
+  llem_image_ref: null
+miner_pins:
+  static: ">=4.56,<4.57"
+  dynamic: ">=4.56,<4.57"
+  discovery: ">=4.56,<4.57"
+artefact_paths:
+  rules_corpus: configs/engine_invariants/transformers.proposed.yaml
+  vendored_rules: configs/engine_invariants/transformers.vendored.yaml
+  discovered_schemas: src/llenergymeasure/config/discovered_schemas/transformers.json
+last_probe:
+  verdict: unrun
+  version_inside_envelope: null
+  fingerprint: null
+  fingerprint_drift: []
+  ran_at: null

--- a/engine_versions/vllm.yaml
+++ b/engine_versions/vllm.yaml
@@ -1,0 +1,35 @@
+# Per-engine version-bundle SSOT for vllm.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, vendored gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+#
+# Existing drift between `library.current_version` (Dockerfile-pinned 0.7.3)
+# and `miner_pins.*` (host-installed 0.17.x range) is intentional: the
+# miner is a CI-time tool whose host install diverges from the published
+# container image. Tracked in #378; Renovate will reconcile on the next
+# bump cycle.
+schema_version: 1
+engine: vllm
+library:
+  pep503_name: vllm
+  current_version: "0.7.3"
+  current_commit_sha: null
+image:
+  base_image_ref: "vllm/vllm-openai:v0.7.3"
+  llem_image_ref: null
+miner_pins:
+  static: ">=0.17,<0.18"
+  dynamic: ">=0.17,<0.18"
+  discovery: ">=0.17,<0.18"
+artefact_paths:
+  rules_corpus: configs/engine_invariants/vllm.proposed.yaml
+  vendored_rules: configs/engine_invariants/vllm.vendored.yaml
+  discovered_schemas: src/llenergymeasure/config/discovered_schemas/vllm.json
+last_probe:
+  verdict: unrun
+  version_inside_envelope: null
+  fingerprint: null
+  fingerprint_drift: []
+  ran_at: null

--- a/scripts/engine_miners/_base.py
+++ b/scripts/engine_miners/_base.py
@@ -10,7 +10,8 @@ PRs per engine.
   corpus entry shape in :mod:`llenergymeasure.config.vendored_rules.loader`.
 - :class:`MinerVersionMismatchError`, :class:`MinerLandmarkMissingError` —
   fail-loud exceptions CI treats as fatal.
-- :func:`check_installed_version` — version-envelope guard for each miner.
+- :func:`check_installed_version` — version-envelope guard for each miner;
+  reads the pin from the engine SSOT (``engine_versions/{engine}.yaml``).
 - AST helpers (:func:`extract_condition_fields`, :func:`resolve_local_assign`,
   etc.) — deterministic, stateless primitives for AST-based miners.
 - Pattern detectors (``ConditionalRaiseDetector``, etc.) — one class per
@@ -28,6 +29,8 @@ from typing import Any, Literal
 
 from packaging import version as pkg_version
 from packaging.specifiers import SpecifierSet
+
+from scripts.engine_miners._ssot import Producer, load_miner_pin
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -57,9 +60,9 @@ class MinerSource:
 class RuleCandidate:
     """One extracted rule candidate.
 
-    Serialised verbatim into ``configs/engine_invariants/{engine}.proposed.yaml`` after
-    human review. Field names match the corpus schema so no translation step
-    is needed between walker output and corpus entry.
+    Serialised verbatim into ``configs/engine_invariants/{engine}.proposed.yaml``
+    after human review. Field names match the corpus schema so no
+    translation step is needed between walker output and corpus entry.
     """
 
     id: str
@@ -93,19 +96,31 @@ class MinerVersionMismatchError(MinerError):
     """Raised when the installed library version is outside the miner's pin.
 
     The miner is pinned to the library version it was authored against; on
-    library-bump PRs, Renovate will trip this error and the maintainer updates
-    the miner. See runtime-config-validation.md §4.2.
+    library-bump PRs, Renovate will trip this error and the maintainer
+    widens the SSOT range or updates the miner. The pin lives in
+    ``engine_versions/{engine}.yaml`` under ``miner_pins.{producer}``;
+    ``producer`` is one of ``static`` | ``dynamic`` | ``discovery``.
     """
 
-    def __init__(self, library: str, installed: str, expected: SpecifierSet) -> None:
+    def __init__(
+        self,
+        library: str,
+        installed: str,
+        expected: SpecifierSet,
+        *,
+        engine: str,
+        producer: Producer,
+    ) -> None:
         super().__init__(
             f"Installed {library}=={installed} is outside miner-pinned range "
-            f"{expected!s}. Update scripts/engine_miners/{library}.py "
-            f"(bump TESTED_AGAINST_VERSIONS and re-run against the new source)."
+            f"{expected!s}. Widen engine_versions/{engine}.yaml "
+            f"miner_pins.{producer} or update the miner against the new source."
         )
         self.library = library
         self.installed = installed
         self.expected = expected
+        self.engine = engine
+        self.producer = producer
 
 
 class MinerLandmarkMissingError(MinerError):
@@ -130,19 +145,27 @@ class MinerLandmarkMissingError(MinerError):
 # ---------------------------------------------------------------------------
 
 
-def check_installed_version(library: str, installed: str, expected: SpecifierSet) -> None:
-    """Raise :class:`MinerVersionMismatchError` if ``installed`` isn't in ``expected``.
+def check_installed_version(
+    library: str, installed: str, *, engine: str, producer: Producer
+) -> None:
+    """Raise :class:`MinerVersionMismatchError` if ``installed`` isn't in the SSOT pin.
 
-    ``SpecifierSet.contains(..., prereleases=True)`` allows rc / beta tags,
-    which is what we want for Renovate-opened PRs that bump to a prerelease
-    tag before a stable one exists.
+    The expected range is read from ``engine_versions/{engine}.yaml`` under
+    ``miner_pins.{producer}``. ``SpecifierSet.contains(..., prereleases=True)``
+    allows rc / beta tags, which is what we want for Renovate-opened PRs
+    that bump to a prerelease tag before a stable one exists.
     """
+    expected = load_miner_pin(engine, producer)
     try:
         parsed = pkg_version.Version(installed)
     except pkg_version.InvalidVersion as exc:
-        raise MinerVersionMismatchError(library, installed, expected) from exc
+        raise MinerVersionMismatchError(
+            library, installed, expected, engine=engine, producer=producer
+        ) from exc
     if not expected.contains(parsed, prereleases=True):
-        raise MinerVersionMismatchError(library, installed, expected)
+        raise MinerVersionMismatchError(
+            library, installed, expected, engine=engine, producer=producer
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/engine_miners/_ssot.py
+++ b/scripts/engine_miners/_ssot.py
@@ -1,0 +1,63 @@
+"""Per-engine version-bundle SSOT loader for miners.
+
+The SSOT lives at ``<repo_root>/engine_versions/{engine}.yaml``. This
+module exposes a single helper, :func:`load_miner_pin`, that returns the
+:class:`~packaging.specifiers.SpecifierSet` for one ``(engine, producer)``
+pair, where ``producer`` is one of the keys under ``miner_pins:`` in the
+SSOT (``static`` | ``dynamic`` | ``discovery``).
+
+The SSOT path is resolved by walking up from this file until a
+``pyproject.toml`` marker is found — the canonical project-root marker
+across the codebase. Failing to find the SSOT raises ``FileNotFoundError``
+loud (no silent fallback to a hard-coded default).
+
+Cached via :func:`functools.lru_cache` so repeated calls within one CI run
+re-parse the YAML at most once per engine.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from packaging.specifiers import SpecifierSet
+
+Producer = Literal["static", "dynamic", "discovery"]
+
+
+def _find_repo_root(start: Path) -> Path:
+    """Walk up from ``start`` until a ``pyproject.toml`` marker appears."""
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    raise FileNotFoundError(f"Could not locate repo root (no pyproject.toml above {start}).")
+
+
+def ssot_path(engine: str) -> Path:
+    """Return the absolute path to ``engine_versions/{engine}.yaml``."""
+    return _find_repo_root(Path(__file__).resolve()) / "engine_versions" / f"{engine}.yaml"
+
+
+@cache
+def load_miner_pin(engine: str, producer: Producer) -> SpecifierSet:
+    """Return the SpecifierSet for ``miner_pins.{producer}`` in the engine's SSOT.
+
+    Raises :class:`FileNotFoundError` if the SSOT file is missing,
+    :class:`KeyError` if ``miner_pins.{producer}`` is unset.
+    """
+    path = ssot_path(engine)
+    try:
+        text = path.read_text()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Engine SSOT not found at {path}. "
+            f"Every engine miner reads its version pin from "
+            f"engine_versions/{engine}.yaml miner_pins.{producer}."
+        ) from exc
+    data = yaml.safe_load(text)
+    pins = (data or {}).get("miner_pins") or {}
+    if producer not in pins:
+        raise KeyError(f"miner_pins.{producer} missing from {path}; present keys: {sorted(pins)}.")
+    return SpecifierSet(str(pins[producer]))

--- a/scripts/engine_miners/tensorrt_miner.py
+++ b/scripts/engine_miners/tensorrt_miner.py
@@ -15,9 +15,10 @@ Pipeline this orchestrator drives:
    0.21.0 (CUDA 12.6.x); v1.x requires CUDA 13 and is a separate
    infrastructure milestone.
 2. Read ``tensorrt_llm/version.py`` from the source tree (no import) and
-   pin against :data:`TESTED_AGAINST_VERSIONS`.
-3. Run :mod:`scripts.engine_miners.tensorrt_static_miner` and emit the staging
-   YAML.
+   pin against the SSOT miner range
+   (``engine_versions/tensorrt.yaml miner_pins.static``).
+3. Run :mod:`scripts.engine_miners.tensorrt_static_miner` and emit the
+   staging YAML.
 
 This orchestrator never imports ``tensorrt_llm``. The host has 1.1.0
 installed and importing it would mine the wrong source — exactly the
@@ -56,7 +57,6 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
 )
 from scripts.engine_miners.tensorrt_static_miner import (  # noqa: E402
     _DEFAULT_SOURCE_ROOT,
-    TESTED_AGAINST_VERSIONS,
     emit_yaml,
     walk_tensorrt,
 )
@@ -82,10 +82,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     candidates, source_version, rel_path = walk_tensorrt(args.source_root)
-    # Pin the source-tree version against TESTED_AGAINST_VERSIONS — any drift
+    # Pin the source-tree version against the SSOT miner range — any drift
     # (e.g. someone pointed --source-root at a 1.x checkout) becomes a fatal
     # MinerVersionMismatchError instead of silently emitting drifted rules.
-    check_installed_version("tensorrt_llm", source_version, TESTED_AGAINST_VERSIONS)
+    check_installed_version("tensorrt_llm", source_version, engine="tensorrt", producer="static")
 
     text = emit_yaml(candidates, engine_version=source_version, rel_path=rel_path)
     args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/engine_miners/tensorrt_static_miner.py
+++ b/scripts/engine_miners/tensorrt_static_miner.py
@@ -52,8 +52,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from packaging.specifiers import SpecifierSet
-
 # Make sibling modules importable when run as a plain script.
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
@@ -61,8 +59,8 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 # Strip the script directory and any "" entry from sys.path before any third-
 # party imports — same defensive measure as the transformers static miner.
-# A sibling ``transformers.py`` etc. inside scripts/engine_miners/ would otherwise
-# shadow the real installed packages.
+# A sibling ``transformers.py`` etc. inside scripts/engine_miners/ would
+# otherwise shadow the real installed packages.
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 sys.path[:] = [p for p in sys.path if Path(p).resolve() != Path(_SCRIPT_DIR).resolve()]
 sys.path[:] = [p for p in sys.path if p != ""]
@@ -76,6 +74,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     find_method,
     first_string_arg,
 )
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -84,25 +83,10 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
 ENGINE = "tensorrt"
 LIBRARY = "tensorrt_llm"
 
-TESTED_AGAINST_VERSIONS: SpecifierSet = SpecifierSet(">=0.21.0,<0.22.0")
-"""Range of TRT-LLM versions this miner has been validated against.
-
-Pinned tightly to 0.21.x because:
-
-- TRT-LLM 1.x requires CUDA 13 (a separate infrastructure milestone).
-- The 1.x ``BaseLlmArgs`` family added ``StrictBaseModel``, ``MoeConfig``,
-  ``CudaGraphConfig`` and ~4 new validators on top of the 0.21 surface.
-  Mining against 1.x with a 0.21-built corpus would emit drifted rules.
-- The corpus loader uses validator method names + landmark line numbers as
-  provenance; mismatched-version mining produces stale provenance even when
-  the rule shapes still match.
-
-On mismatch, ``check_installed_version`` raises ``MinerVersionMismatchError``
-and CI fails. The miner does NOT call ``check_installed_version`` itself
-because it never imports the library — but the orchestrator
-:mod:`scripts.engine_miners.tensorrt_miner` is responsible for asserting the
-extracted source-tree version against this pin.
-"""
+# The miner does NOT call ``check_installed_version`` itself because it never
+# imports the library — the orchestrator :mod:`scripts.engine_miners.tensorrt_miner`
+# asserts the extracted source-tree version against
+# ``engine_versions/tensorrt.yaml miner_pins.static`` instead.
 
 # Project-side namespace for TRT-LLM config fields. Aligns with
 # ``TensorRTConfig`` in ``src/llenergymeasure/config/engine_configs.py`` —
@@ -1206,7 +1190,7 @@ def walk_tensorrt(source_root: Path | None = None) -> tuple[list[RuleCandidate],
     _verify_method_landmarks(tree)
 
     # Read the version from the source tree so the orchestrator can pin
-    # against TESTED_AGAINST_VERSIONS without importing the library.
+    # against the SSOT miner range without importing the library.
     version = _read_source_version(root)
 
     today = dt.date.today().isoformat()
@@ -1334,7 +1318,7 @@ def emit_yaml(
         "schema_version": "1.0.0",
         "engine": ENGINE,
         "engine_version": engine_version,
-        "walker_pinned_range": str(TESTED_AGAINST_VERSIONS),
+        "walker_pinned_range": str(load_miner_pin("tensorrt", "static")),
         "mined_at": mined_at,
         "rules": [_candidate_to_dict(c) for c in sorted_candidates],
     }

--- a/scripts/engine_miners/transformers_miner.py
+++ b/scripts/engine_miners/transformers_miner.py
@@ -3,10 +3,10 @@
 Composes two extraction paths to emit a deterministic rules corpus:
 
 1. **GenerationConfig rules via library-API introspection** — delegated to
-   :mod:`scripts.engine_miners.transformers_dynamic_miner`. Every dormancy rule is
-   discovered by probing ``GenerationConfig.validate(strict=True)`` against a
-   synthesised per-type probe value; every error-class rule's message is
-   lifted from the library's own ``ValueError``. Rules emitted:
+   :mod:`scripts.engine_miners.transformers_dynamic_miner`. Every dormancy
+   rule is discovered by probing ``GenerationConfig.validate(strict=True)``
+   against a synthesised per-type probe value; every error-class rule's
+   message is lifted from the library's own ``ValueError``. Rules emitted:
    ``added_by: dynamic_miner``.
 
 2. **BitsAndBytesConfig type-check rules** — hand-curated here. BNB import
@@ -18,10 +18,11 @@ Composes two extraction paths to emit a deterministic rules corpus:
 Landmark verification: imports ``transformers`` and confirms
 ``GenerationConfig``, ``BitsAndBytesConfig``, ``validate`` and ``post_init``
 exist. Missing landmark → :class:`MinerLandmarkMissingError`. Version
-envelope: :data:`TESTED_AGAINST_VERSIONS` pins the walker to a known range;
-a mismatch raises :class:`MinerVersionMismatchError` at CI time. Source
-paths and line numbers are derived via :func:`inspect.getsourcefile` and a
-text grep — informational only, not used for rule matching.
+envelope: :func:`check_installed_version` reads the dynamic miner pin from
+``engine_versions/transformers.yaml`` (``miner_pins.dynamic``); a mismatch
+raises :class:`MinerVersionMismatchError` at CI time. Source paths and line
+numbers are derived via :func:`inspect.getsourcefile` and a text grep —
+informational only, not used for rule matching.
 
 Flash-attention validation (``validate_transformers_flash_attn_dtype``) is
 out of scope: its check lives in ``PreTrainedModel._autoset_attn_implementation``,
@@ -31,7 +32,8 @@ not reachable via this walker's landmarks. Stays hand-written in
 
 Usage::
 
-    python -m scripts.engine_miners.transformers --out configs/engine_invariants/transformers.proposed.yaml
+    python -m scripts.engine_miners.transformers_miner \\
+        --out configs/engine_invariants/transformers.proposed.yaml
 
 With ``LLENERGY_WALKER_FROZEN_AT`` set for byte-stable reproducibility.
 """
@@ -47,11 +49,10 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from packaging.specifiers import SpecifierSet
-
 # NOTE: the walkers package is a sibling; when run via ``python -m
-# scripts.engine_miners.transformers`` the implicit ``scripts`` package makes this
-# work. When run as a script directly, we need the project root on sys.path.
+# scripts.engine_miners.transformers_miner`` the implicit ``scripts``
+# package makes this work. When run as a script directly, we need the
+# project root on sys.path.
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
@@ -62,34 +63,10 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     RuleCandidate,
     check_installed_version,
 )
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 from scripts.engine_miners.transformers_dynamic_miner import (  # noqa: E402
     walk_generation_config_rules,
 )
-
-TESTED_AGAINST_VERSIONS: SpecifierSet = SpecifierSet(">=4.56,<4.57")
-"""Range of transformers versions this walker has been validated against.
-
-Narrowed to 4.56.x because the introspection walker relies on
-``GenerationConfig.validate(strict=True)`` — that kwarg was introduced in
-4.56 and the 4.56 composed-issue message shape is what the corpus was
-built against. Earlier versions either lack ``strict=`` entirely
-(``TypeError: got an unexpected keyword argument 'strict'``) or expose a
-differently-shaped ``minor_issues`` output. 4.57 restructured
-``validate()`` again — dropped several ``minor_issues`` branches
-(``num_beam_groups``, ``diversity_penalty``, ``constraints`` single-beam
-dormancies) and the watermarking auto-coercion.
-
-On mismatch, :func:`check_installed_version` raises
-:class:`MinerVersionMismatchError` and CI fails.
-
-Note: the project's own ``transformers`` extra in ``pyproject.toml``
-still floors at ``>=4.49`` for user runtime compatibility. The walker is
-a CI-time maintainer tool, not a runtime dependency, so the narrower pin
-doesn't affect end users. Follow-up: align CI's resolved transformers
-version with this pin (currently ``uv.lock`` resolves to 4.51.0) so the
-vendor-rules-refresh workflow can regenerate the corpus in-band.
-"""
-
 
 # ---------------------------------------------------------------------------
 # BitsAndBytesConfig type-check rules (kept hand-curated — CPU-safe)
@@ -269,7 +246,9 @@ def walk() -> tuple[list[RuleCandidate], dict[str, Any]]:
     ``added_by`` tag; the envelope captures the shared version pin.
     """
     installed_version, abs_source_path = _check_landmarks()
-    check_installed_version("transformers", installed_version, TESTED_AGAINST_VERSIONS)
+    check_installed_version(
+        "transformers", installed_version, engine="transformers", producer="dynamic"
+    )
 
     # Corpus paths are relative to site-packages so the committed YAML is
     # reproducible across checkouts with different ``~/.local`` roots.
@@ -311,7 +290,7 @@ def walk() -> tuple[list[RuleCandidate], dict[str, Any]]:
         "schema_version": "1.0.0",
         "engine": "transformers",
         "engine_version": installed_version,
-        "walker_pinned_range": str(TESTED_AGAINST_VERSIONS),
+        "walker_pinned_range": str(load_miner_pin("transformers", "dynamic")),
         "mined_at": mined_at,
     }
     return candidates, envelope

--- a/scripts/engine_miners/vllm_dynamic_miner.py
+++ b/scripts/engine_miners/vllm_dynamic_miner.py
@@ -81,9 +81,7 @@ from scripts.engine_miners._base import (  # noqa: E402
 )
 from scripts.engine_miners._msgspec_lift import lift as _msgspec_lift  # noqa: E402
 from scripts.engine_miners._pydantic_lift import lift as _pydantic_lift  # noqa: E402
-from scripts.engine_miners.vllm_static_miner import (  # noqa: E402
-    TESTED_AGAINST_VERSIONS,
-)
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -711,7 +709,7 @@ def walk_vllm_dynamic(*, today: str | None = None) -> tuple[list[RuleCandidate],
     var, then to ``dt.date.today()``.
     """
     installed_version = _check_landmarks()
-    check_installed_version("vllm", installed_version, TESTED_AGAINST_VERSIONS)
+    check_installed_version("vllm", installed_version, engine="vllm", producer="dynamic")
 
     if today is None:
         frozen = os.environ.get("LLENERGY_MINER_FROZEN_AT")
@@ -842,7 +840,7 @@ def emit_yaml(candidates: list[RuleCandidate], engine_version: str) -> str:
         "schema_version": "1.0.0",
         "engine": ENGINE,
         "engine_version": engine_version,
-        "walker_pinned_range": str(TESTED_AGAINST_VERSIONS),
+        "walker_pinned_range": str(load_miner_pin("vllm", "dynamic")),
         "mined_at": mined_at,
         "rules": [_candidate_to_dict(c) for c in sorted_candidates],
     }

--- a/scripts/engine_miners/vllm_static_miner.py
+++ b/scripts/engine_miners/vllm_static_miner.py
@@ -41,19 +41,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from packaging.specifiers import SpecifierSet
-
 # Project root on sys.path for direct script + module-style invocation.
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 # Defend against the script directory shadowing site-packages: when invoked
-# as ``python scripts/engine_miners/vllm_static_miner.py``, ``scripts/engine_miners/`` is
-# prepended to sys.path. The directory does not currently contain a
-# ``vllm.py`` stub (which would shadow the installed ``vllm`` package), but
-# we strip it for symmetry with the transformers miner and to defend against
-# future stub additions.
+# as ``python scripts/engine_miners/vllm_static_miner.py``,
+# ``scripts/engine_miners/`` is prepended to sys.path. The directory does
+# not currently contain a ``vllm.py`` stub (which would shadow the
+# installed ``vllm`` package), but we strip it for symmetry with the
+# transformers miner and to defend against future stub additions.
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 sys.path[:] = [p for p in sys.path if Path(p).resolve() != Path(_SCRIPT_DIR).resolve()]
 sys.path[:] = [p for p in sys.path if p != ""]
@@ -68,23 +66,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     find_method,
     first_string_arg,
 )
-
-# ---------------------------------------------------------------------------
-# Version pin
-# ---------------------------------------------------------------------------
-
-TESTED_AGAINST_VERSIONS: SpecifierSet = SpecifierSet(">=0.17,<0.18")
-"""vLLM versions this miner has been validated against.
-
-Matches the host install used during research (0.17.1). The Docker pin
-(``v0.7.3``) and the open-ended ``vllm>=0.6`` in ``pyproject.toml`` diverge
-from this — see issue #378 for the SSOT alignment work. The miner is a
-CI-time tool, not a runtime dep, so the narrower pin doesn't affect end
-users; the canonical vendor-CI invocation runs on the host install.
-
-On mismatch, :func:`check_installed_version` raises
-:class:`MinerVersionMismatchError` and CI breaks loud."""
-
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Engine + namespace conventions
@@ -1091,7 +1073,7 @@ def walk_vllm_static(*, today: str | None = None) -> tuple[list[RuleCandidate], 
     var, then to ``dt.date.today()``.
     """
     installed_version, abs_paths = _check_landmarks()
-    check_installed_version("vllm", installed_version, TESTED_AGAINST_VERSIONS)
+    check_installed_version("vllm", installed_version, engine="vllm", producer="static")
 
     if today is None:
         frozen = os.environ.get("LLENERGY_MINER_FROZEN_AT")
@@ -1174,7 +1156,7 @@ def emit_yaml(candidates: list[RuleCandidate], engine_version: str) -> str:
         "schema_version": "1.0.0",
         "engine": ENGINE,
         "engine_version": engine_version,
-        "walker_pinned_range": str(TESTED_AGAINST_VERSIONS),
+        "walker_pinned_range": str(load_miner_pin("vllm", "static")),
         "mined_at": mined_at,
         "rules": [_candidate_to_dict(c) for c in sorted_candidates],
     }

--- a/tests/unit/scripts/engine_miners/test_base.py
+++ b/tests/unit/scripts/engine_miners/test_base.py
@@ -19,6 +19,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.engine_miners import _ssot  # noqa: E402
 from scripts.engine_miners._base import (  # noqa: E402
     ConditionalLoggerWarningDetector,
     ConditionalRaiseDetector,
@@ -340,20 +341,44 @@ def test_filter_kwargs_positive_derivable_accepts_isinstance() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_check_installed_version_in_range() -> None:
-    check_installed_version("transformers", "4.56.0", SpecifierSet(">=4.50,<5.0"))
+@pytest.fixture
+def _stub_ssot_pin(monkeypatch):
+    """Replace SSOT loader with a synthetic SpecifierSet for unit tests."""
+
+    def _factory(spec: str) -> None:
+        _ssot.load_miner_pin.cache_clear()
+
+        def _fake(engine: str, producer: str) -> SpecifierSet:
+            return SpecifierSet(spec)
+
+        monkeypatch.setattr(_ssot, "load_miner_pin", _fake)
+        # _base.py imports load_miner_pin by name; patch the binding there too.
+        from scripts.engine_miners import _base as base_mod
+
+        monkeypatch.setattr(base_mod, "load_miner_pin", _fake)
+
+    return _factory
 
 
-def test_check_installed_version_out_of_range() -> None:
+def test_check_installed_version_in_range(_stub_ssot_pin) -> None:
+    _stub_ssot_pin(">=4.50,<5.0")
+    check_installed_version("transformers", "4.56.0", engine="transformers", producer="static")
+
+
+def test_check_installed_version_out_of_range(_stub_ssot_pin) -> None:
+    _stub_ssot_pin(">=4.50,<5.0")
     with pytest.raises(MinerVersionMismatchError) as exc_info:
-        check_installed_version("transformers", "5.0.0", SpecifierSet(">=4.50,<5.0"))
+        check_installed_version("transformers", "5.0.0", engine="transformers", producer="static")
     assert "transformers" in str(exc_info.value)
     assert "5.0.0" in str(exc_info.value)
 
 
-def test_check_installed_version_invalid_version_string() -> None:
+def test_check_installed_version_invalid_version_string(_stub_ssot_pin) -> None:
+    _stub_ssot_pin(">=4.50,<5.0")
     with pytest.raises(MinerVersionMismatchError):
-        check_installed_version("transformers", "not-a-version", SpecifierSet(">=4.50,<5.0"))
+        check_installed_version(
+            "transformers", "not-a-version", engine="transformers", producer="static"
+        )
 
 
 def test_walker_landmark_missing_error_carries_detail() -> None:

--- a/tests/unit/scripts/engine_miners/test_ssot_pin_fixpoint.py
+++ b/tests/unit/scripts/engine_miners/test_ssot_pin_fixpoint.py
@@ -1,0 +1,130 @@
+"""Structural fixpoint tests for the per-engine version-bundle SSOT.
+
+These tests pin the contract that miner version pins live exclusively in
+``engine_versions/{engine}.yaml`` and are read via
+:func:`scripts.engine_miners._ssot.load_miner_pin`. If a future change
+re-introduces a hard-coded ``TESTED_AGAINST_VERSIONS`` constant, drops a
+required SSOT key, or silently swallows a missing-engine lookup, one of
+these assertions will fail.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from packaging.specifiers import SpecifierSet
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_miners import _ssot  # noqa: E402
+
+ENGINES = ("transformers", "vllm", "tensorrt")
+PRODUCERS = ("static", "dynamic", "discovery")
+
+_MINERS_DIR = _PROJECT_ROOT / "scripts" / "engine_miners"
+_ENGINE_VERSIONS_DIR = _PROJECT_ROOT / "engine_versions"
+
+
+def _miner_python_files() -> list[Path]:
+    return sorted(p for p in _MINERS_DIR.rglob("*.py") if p.is_file())
+
+
+def _module_assign_target_names(tree: ast.AST) -> set[str]:
+    """Collect every module-level assignment target name in ``tree``."""
+    if not isinstance(tree, ast.Module):
+        return set()
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def test_no_tested_against_versions_constant_survives() -> None:
+    """No miner module may define ``TESTED_AGAINST_VERSIONS`` at module scope."""
+    offenders: list[Path] = []
+    for path in _miner_python_files():
+        tree = ast.parse(path.read_text())
+        if "TESTED_AGAINST_VERSIONS" in _module_assign_target_names(tree):
+            offenders.append(path)
+    assert not offenders, (
+        "TESTED_AGAINST_VERSIONS was reintroduced as a module-level constant in: "
+        f"{[str(p.relative_to(_PROJECT_ROOT)) for p in offenders]}. "
+        f"Pins live in engine_versions/<engine>.yaml miner_pins.<producer>; "
+        f"read via scripts.engine_miners._ssot.load_miner_pin."
+    )
+
+
+REQUIRED_TOP_LEVEL_KEYS = ("schema_version", "engine")
+REQUIRED_LIBRARY_KEYS = ("pep503_name", "current_version")
+REQUIRED_IMAGE_KEYS = ("base_image_ref",)
+REQUIRED_ARTEFACT_PATH_KEYS = ("rules_corpus", "vendored_rules", "discovered_schemas")
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_every_engine_versions_yaml_parses_and_has_required_keys(engine: str) -> None:
+    """Every engine SSOT parses as YAML and exposes the documented schema."""
+    path = _ENGINE_VERSIONS_DIR / f"{engine}.yaml"
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict), f"{path} did not parse to a mapping."
+
+    for key in REQUIRED_TOP_LEVEL_KEYS:
+        assert key in data, f"{path} missing top-level key {key!r}."
+
+    library = data.get("library")
+    assert isinstance(library, dict), f"{path} library: must be a mapping."
+    for key in REQUIRED_LIBRARY_KEYS:
+        assert key in library, f"{path} library.{key} missing."
+
+    image = data.get("image")
+    assert isinstance(image, dict), f"{path} image: must be a mapping."
+    for key in REQUIRED_IMAGE_KEYS:
+        assert key in image, f"{path} image.{key} missing."
+
+    miner_pins = data.get("miner_pins")
+    assert isinstance(miner_pins, dict), f"{path} miner_pins: must be a mapping."
+    for producer in PRODUCERS:
+        assert producer in miner_pins, f"{path} miner_pins.{producer} missing."
+
+    artefact_paths = data.get("artefact_paths")
+    assert isinstance(artefact_paths, dict), f"{path} artefact_paths: must be a mapping."
+    for key in REQUIRED_ARTEFACT_PATH_KEYS:
+        assert key in artefact_paths, f"{path} artefact_paths.{key} missing."
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("producer", PRODUCERS)
+def test_miner_pins_parse_as_valid_specifier_sets(engine: str, producer: str) -> None:
+    """Each ``miner_pins.<producer>`` value is a valid PEP 440 specifier set."""
+    data = yaml.safe_load((_ENGINE_VERSIONS_DIR / f"{engine}.yaml").read_text())
+    raw = data["miner_pins"][producer]
+    SpecifierSet(str(raw))  # raises InvalidSpecifier on malformed input
+
+
+def test_load_miner_pin_returns_specifier_set() -> None:
+    """``load_miner_pin`` returns a ``SpecifierSet`` matching the SSOT value."""
+    pin = _ssot.load_miner_pin("transformers", "static")
+    assert isinstance(pin, SpecifierSet)
+    assert pin == SpecifierSet(">=4.56,<4.57")
+
+
+def test_load_miner_pin_raises_on_unknown_engine() -> None:
+    """A missing engine SSOT surfaces as ``FileNotFoundError`` — no silent fallback."""
+    with pytest.raises(FileNotFoundError):
+        _ssot.load_miner_pin("does_not_exist", "static")
+
+
+def test_load_miner_pin_raises_on_unknown_producer() -> None:
+    """An unknown ``miner_pins`` key surfaces as ``KeyError`` — no silent default."""
+    with pytest.raises(KeyError):
+        _ssot.load_miner_pin("transformers", "not_a_producer")  # type: ignore[arg-type]

--- a/tests/unit/scripts/engine_miners/test_tensorrt_miner.py
+++ b/tests/unit/scripts/engine_miners/test_tensorrt_miner.py
@@ -8,8 +8,9 @@ against the source-tree's own ``__version__``) in one named place.
 Coverage:
 
 - TRT-LLM is registered in :data:`scripts.engine_miners.build_corpus._ENGINE_EXTRACTORS`.
-- The orchestrator pins against :data:`TESTED_AGAINST_VERSIONS` and refuses
-  source trees whose version disagrees.
+- The orchestrator pins against the SSOT miner range
+  (``engine_versions/tensorrt.yaml miner_pins.static``) and refuses source
+  trees whose version disagrees.
 - The orchestrator never imports ``tensorrt_llm`` at module load.
 """
 
@@ -27,7 +28,6 @@ if str(_PROJECT_ROOT) not in sys.path:
 from scripts.engine_miners import (  # noqa: E402
     build_corpus,
     tensorrt_miner,
-    tensorrt_static_miner,
 )
 from scripts.engine_miners._base import MinerVersionMismatchError  # noqa: E402
 
@@ -100,6 +100,11 @@ def test_orchestrator_main_rejects_version_mismatch(tmp_path: Path) -> None:
         tensorrt_miner.main(["--out", str(out), "--source-root", str(stub_root)])
 
 
-def test_orchestrator_imports_tested_against_versions() -> None:
-    """The orchestrator must re-export the static miner's pin for clarity."""
-    assert tensorrt_miner.TESTED_AGAINST_VERSIONS is tensorrt_static_miner.TESTED_AGAINST_VERSIONS
+def test_orchestrator_reads_pin_from_ssot() -> None:
+    """The orchestrator's version check resolves through the SSOT loader."""
+    from scripts.engine_miners._ssot import load_miner_pin
+
+    pin = load_miner_pin("tensorrt", "static")
+    # 0.21.x is in pin; 1.x is rejected.
+    assert pin.contains("0.21.0", prereleases=True)
+    assert not pin.contains("1.1.0", prereleases=True)

--- a/tests/unit/scripts/engine_miners/test_tensorrt_static_miner.py
+++ b/tests/unit/scripts/engine_miners/test_tensorrt_static_miner.py
@@ -4,7 +4,8 @@ Covers:
 
 - Source-extraction landmarks (fail-loud on missing source root / class /
   validator method).
-- ``TESTED_AGAINST_VERSIONS`` declared and pin-shape sane.
+- SSOT miner pin (``engine_versions/tensorrt.yaml miner_pins.static``) is
+  in shape and pins 0.21.x.
 - Method resolution via :func:`scripts.engine_miners._base.find_class` /
   :func:`find_method` (so refactors that drop those helpers fail loudly).
 - Per-validator AST extraction emits the predicate shapes we expect for
@@ -40,6 +41,7 @@ from scripts.engine_miners._base import (  # noqa: E402
     find_method,
 )
 from scripts.engine_miners._fixpoint_test import assert_gate_soundness_fixpoint  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Source-availability fixture
@@ -75,15 +77,16 @@ _REQUIRES_SOURCE = pytest.mark.skipif(
 class TestModuleContract:
     """Static-shape contract that holds regardless of source availability."""
 
-    def test_tested_against_versions_declared(self) -> None:
-        assert isinstance(trt_miner.TESTED_AGAINST_VERSIONS, SpecifierSet)
+    def test_ssot_miner_pin_declared(self) -> None:
+        assert isinstance(load_miner_pin("tensorrt", "static"), SpecifierSet)
 
-    def test_tested_against_versions_pins_021(self) -> None:
+    def test_ssot_miner_pin_pins_021(self) -> None:
         # The miner must reject 1.x — that's a separate library generation.
         # The pin must accept 0.21.x and reject 1.x.
-        assert trt_miner.TESTED_AGAINST_VERSIONS.contains("0.21.0", prereleases=True)
-        assert not trt_miner.TESTED_AGAINST_VERSIONS.contains("1.1.0", prereleases=True)
-        assert not trt_miner.TESTED_AGAINST_VERSIONS.contains("0.20.5", prereleases=True)
+        pin = load_miner_pin("tensorrt", "static")
+        assert pin.contains("0.21.0", prereleases=True)
+        assert not pin.contains("1.1.0", prereleases=True)
+        assert not pin.contains("0.20.5", prereleases=True)
 
     def test_method_landmarks_use_find_class_and_find_method(self) -> None:
         """Pin the contract that the miner uses the shared landmark helpers.

--- a/tests/unit/scripts/engine_miners/test_transformers_dynamic_miner.py
+++ b/tests/unit/scripts/engine_miners/test_transformers_dynamic_miner.py
@@ -36,7 +36,7 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.engine_miners import transformers_dynamic_miner as intro  # noqa: E402
-from scripts.engine_miners import transformers_miner as tf_walker  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 
 # Every test in this module needs transformers importable — the walker
 # observes the real library. Skip the whole module if it's not installed.
@@ -44,21 +44,20 @@ pytest.importorskip("transformers")
 
 # Pin-check: these tests compare the committed corpus (generated against
 # the walker's version envelope) to live-library output. If the test env's
-# transformers is outside ``TESTED_AGAINST_VERSIONS``, live-library output
-# drifts from the corpus and every Tier B / D / E test fails noisily for a
-# reason that has nothing to do with the PR. Skip the module up-front so
-# the signal stays clean.
+# transformers is outside the SSOT miner pin, live-library output drifts
+# from the corpus and every Tier B / D / E test fails noisily for a reason
+# that has nothing to do with the PR. Skip the module up-front so the
+# signal stays clean.
 import transformers as _tf  # noqa: E402
 from packaging import version as _pkg_version  # noqa: E402
 
-if not tf_walker.TESTED_AGAINST_VERSIONS.contains(
-    _pkg_version.Version(_tf.__version__), prereleases=True
-):
+_TF_DYNAMIC_PIN = load_miner_pin("transformers", "dynamic")
+if not _TF_DYNAMIC_PIN.contains(_pkg_version.Version(_tf.__version__), prereleases=True):
     pytest.skip(
-        f"transformers=={_tf.__version__} is outside walker pin "
-        f"{tf_walker.TESTED_AGAINST_VERSIONS!s} — introspection tests "
-        f"would compare drifted library output against corpus generated "
-        f"on a different version. Install a pinned transformers to run.",
+        f"transformers=={_tf.__version__} is outside SSOT miner pin "
+        f"{_TF_DYNAMIC_PIN!s} — introspection tests would compare drifted "
+        f"library output against corpus generated on a different version. "
+        f"Install a pinned transformers to run.",
         allow_module_level=True,
     )
 

--- a/tests/unit/scripts/engine_miners/test_transformers_miner.py
+++ b/tests/unit/scripts/engine_miners/test_transformers_miner.py
@@ -21,22 +21,22 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from scripts.engine_miners import transformers_miner as tf_walker  # noqa: E402
 from scripts.engine_miners._base import MinerSource, RuleCandidate  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 
 # Pin guard: tests that actually invoke ``tf_walker.walk()`` depend on
-# transformers being inside ``TESTED_AGAINST_VERSIONS``. CI environments that
-# resolve an older version (e.g. 4.51 via ``uv.lock``) lack
+# transformers being inside the SSOT miner pin
+# (``engine_versions/transformers.yaml miner_pins.dynamic``). CI environments
+# that resolve an older version (e.g. 4.51 via ``uv.lock``) lack
 # ``GenerationConfig.validate(strict=True)``. Mark those tests skipped rather
 # than let them fail with a TypeError unrelated to the change under test.
 try:
     import transformers as _tf  # type: ignore
     from packaging import version as _pkg_version
 
-    _TRANSFORMERS_IN_PIN = tf_walker.TESTED_AGAINST_VERSIONS.contains(
-        _pkg_version.Version(_tf.__version__), prereleases=True
-    )
+    _TF_PIN = load_miner_pin("transformers", "dynamic")
+    _TRANSFORMERS_IN_PIN = _TF_PIN.contains(_pkg_version.Version(_tf.__version__), prereleases=True)
     _TRANSFORMERS_PIN_REASON = (
-        f"transformers=={_tf.__version__} is outside walker pin "
-        f"{tf_walker.TESTED_AGAINST_VERSIONS!s}"
+        f"transformers=={_tf.__version__} is outside SSOT miner pin {_TF_PIN!s}"
     )
 except ImportError:
     _TRANSFORMERS_IN_PIN = False
@@ -244,8 +244,17 @@ def test_walk_emits_version_mismatch_when_out_of_range(
     # Force the pinned range to something the installed version can't satisfy.
     from packaging.specifiers import SpecifierSet
 
-    monkeypatch.setattr(tf_walker, "TESTED_AGAINST_VERSIONS", SpecifierSet(">=99.0"))
+    from scripts.engine_miners import _base as base_mod
+    from scripts.engine_miners import _ssot
     from scripts.engine_miners._base import MinerVersionMismatchError
+
+    _ssot.load_miner_pin.cache_clear()
+
+    def _fake(engine: str, producer: str) -> SpecifierSet:
+        return SpecifierSet(">=99.0")
+
+    monkeypatch.setattr(base_mod, "load_miner_pin", _fake)
+    monkeypatch.setattr(tf_walker, "load_miner_pin", _fake)
 
     with pytest.raises(MinerVersionMismatchError):
         tf_walker.walk()

--- a/tests/unit/scripts/engine_miners/test_vllm_miner.py
+++ b/tests/unit/scripts/engine_miners/test_vllm_miner.py
@@ -36,6 +36,7 @@ from scripts.engine_miners._base import (  # noqa: E402
 from scripts.engine_miners._dataclass_lift import lift as dataclass_lift  # noqa: E402
 from scripts.engine_miners._msgspec_lift import lift as msgspec_lift  # noqa: E402
 from scripts.engine_miners._pydantic_lift import lift as pydantic_lift  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
 from scripts.engine_miners.vllm_dynamic_miner import (  # noqa: E402
     _PYDANTIC_LIFT_TARGETS,
     CLUSTERS,
@@ -43,7 +44,6 @@ from scripts.engine_miners.vllm_dynamic_miner import (  # noqa: E402
 )
 from scripts.engine_miners.vllm_static_miner import (  # noqa: E402
     _AST_TARGETS,
-    TESTED_AGAINST_VERSIONS,
     _check_landmarks,
     walk_vllm_static,
 )
@@ -220,8 +220,8 @@ class TestWalkerSmoke:
     def test_static_miner_emits_rules(self) -> None:
         """Static miner produces a non-trivial number of rules on the live library."""
         candidates, version = walk_vllm_static()
-        assert TESTED_AGAINST_VERSIONS.contains(version, prereleases=True), (
-            f"Installed vllm=={version} outside miner pin"
+        assert load_miner_pin("vllm", "static").contains(version, prereleases=True), (
+            f"Installed vllm=={version} outside SSOT miner pin"
         )
         assert len(candidates) >= 30, (
             f"Static miner emitted only {len(candidates)} candidates; "


### PR DESCRIPTION
## Summary

- Adds `engine_versions/{transformers,vllm,tensorrt}.yaml` as the single source of truth for each engine's library version, miner pins, image refs, and artefact paths.
- Miners now read their version envelope from `miner_pins.{static|dynamic|discovery}` via `scripts.engine_miners._ssot.load_miner_pin` instead of the per-module `TESTED_AGAINST_VERSIONS` constant, which is deleted everywhere.
- Updates `_base.check_installed_version` signature: takes `engine` + `producer` keyword args and reads the SpecifierSet from the SSOT internally.
- Adds `tests/unit/scripts/engine_miners/test_ssot_pin_fixpoint.py`: 16-case structural test pinning the contract — no `TESTED_AGAINST_VERSIONS` constant survives, every SSOT parses with the required keys, every miner pin is a valid SpecifierSet, and `load_miner_pin` round-trips.
- Doc updates in `docs/extending-miners.md`, `docs/miner-pipeline.md`, and `docs/architecture-overview.md` for the SSOT-driven pin narrative.

This is the third of three stacked PRs delivering the engine-coupling restructure. The first stack renames `scripts/miners/` and splits the introspector monolith; the second renames `validation_rules` to `engine_invariants` and unifies on YAML; this stack wires the SSOT.

Renovate continues to bump Dockerfile ARGs in this commit; retargeting Renovate to the SSOT lands separately.

## Base

Stacked on `refactor/engine-invariants-naming`. The diff against that branch is incremental — only the SSOT files, miner pin migration, and structural fixpoint test.

## Test plan

- [x] `pytest tests/unit/scripts/engine_miners/` (114 passed, 8 skipped — including the new 16-case `test_ssot_pin_fixpoint.py`)
- [x] `pytest tests/unit/engine_miners/ tests/unit/config/vendored_rules/ tests/unit/scripts/test_engine_introspectors.py tests/unit/study/test_library_resolution.py tests/integration/test_invariant_miner_workflow.py tests/unit/scripts/test_diff_engine_invariants.py` (223 passed)
- [x] `ruff format` and `ruff check` (no new findings; pre-existing warnings unchanged)
- [ ] CI green