### PR TITLE
refactor(renovate): retarget customManager from Dockerfile ARGs to engine_versions SSOT

### DIFF
--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -8,9 +8,13 @@
 # Usage:
 #   docker build -f docker/Dockerfile.tensorrt -t llenergymeasure-tensorrt .
 #
-# Version pin policy: update TRTLLM_VERSION on each milestone release.
-# Must be compatible with pyproject.toml tensorrt-llm>=0.12 constraint.
+# Version pin policy: must be compatible with pyproject.toml tensorrt-llm>=0.12 constraint.
 # ============================================================
+
+# Source of truth: engine_versions/tensorrt.yaml `library.current_version`.
+# Renovate authors that file; CI passes the value via
+# `--build-arg TRTLLM_VERSION=$(yq '.library.current_version' engine_versions/tensorrt.yaml)`
+# at build time. The ARG default below is a fallback for local manual builds only.
 ARG TRTLLM_VERSION=0.21.0
 
 FROM nvcr.io/nvidia/tensorrt-llm/release:${TRTLLM_VERSION} AS runtime

--- a/docker/Dockerfile.transformers
+++ b/docker/Dockerfile.transformers
@@ -10,11 +10,15 @@
 #   docker build -f docker/Dockerfile.transformers -t llenergymeasure-transformers .
 #
 # Version pin policy: update PYTORCH_VERSION on each milestone release.
-# TRANSFORMERS_VERSION is monitored by Renovate (PyPI datasource).
 # Must be compatible with pyproject.toml torch>=2.5 / transformers>=4.49 constraints.
 # ============================================================
 ARG PYTORCH_VERSION=2.5.1-cuda12.4-cudnn9-runtime
 ARG PYTORCH_DEVEL_VERSION=2.5.1-cuda12.4-cudnn9-devel
+
+# Source of truth: engine_versions/transformers.yaml `library.current_version`.
+# Renovate authors that file; CI passes the value via
+# `--build-arg TRANSFORMERS_VERSION=$(yq '.library.current_version' engine_versions/transformers.yaml)`
+# at build time. The ARG default below is a fallback for local manual builds only.
 ARG TRANSFORMERS_VERSION=4.57.3
 
 # Build stage: compile flash-attn FA2 + FA3 (needs nvcc from devel image)

--- a/docker/Dockerfile.vllm
+++ b/docker/Dockerfile.vllm
@@ -8,12 +8,18 @@
 # Usage:
 #   docker build -f docker/Dockerfile.vllm -t llenergymeasure-vllm .
 #
-# Version pin policy: update VLLM_VERSION on each milestone release.
-# Must be compatible with pyproject.toml vllm>=0.6 constraint.
+# Version pin policy: must be compatible with pyproject.toml vllm>=0.6 constraint.
 # ============================================================
-ARG VLLM_VERSION=v0.7.3
 
-FROM vllm/vllm-openai:${VLLM_VERSION} AS runtime
+# Source of truth: engine_versions/vllm.yaml `library.current_version`.
+# Renovate authors that file; CI passes the value via
+# `--build-arg VLLM_VERSION=$(yq '.library.current_version' engine_versions/vllm.yaml)`
+# at build time. The ARG default below is a fallback for local manual builds only.
+# Upstream image tags are prefixed with `v` (e.g. `v0.7.3`); the ARG carries the
+# bare PyPI version and the FROM line adds the prefix.
+ARG VLLM_VERSION=0.7.3
+
+FROM vllm/vllm-openai:v${VLLM_VERSION} AS runtime
 
 # Reset upstream ENTRYPOINT — vLLM sets ENTRYPOINT to its API server,
 # which conflicts with DockerRunner's command override pattern.

--- a/renovate.json
+++ b/renovate.json
@@ -11,23 +11,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["docker/Dockerfile\\.transformers$"],
-      "matchStrings": ["ARG TRANSFORMERS_VERSION=(?<currentValue>\\S+)"],
-      "depNameTemplate": "transformers",
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["docker/Dockerfile\\.vllm$"],
-      "matchStrings": ["ARG VLLM_VERSION=v?(?<currentValue>\\S+)"],
-      "depNameTemplate": "vllm",
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["docker/Dockerfile\\.tensorrt$"],
-      "matchStrings": ["ARG TRTLLM_VERSION=(?<currentValue>\\S+)"],
-      "depNameTemplate": "tensorrt-llm",
+      "fileMatch": ["^engine_versions/(?:transformers|vllm|tensorrt)\\.yaml$"],
+      "matchStrings": [
+        "pep503_name: (?<depName>[\\w-]+)\\s*\\n\\s*current_version: \"(?<currentValue>[^\"]+)\""
+      ],
       "datasourceTemplate": "pypi"
     }
   ],


### PR DESCRIPTION
## Summary

Renovate's three Dockerfile-targeted `customManager` entries collapse into a single entry that bumps `library.current_version` in `engine_versions/{engine}.yaml`. The Dockerfile ARG defaults stay as fallbacks for local manual builds; CI will pass the SSOT value via `--build-arg` at image-build time.

## What changes

- `renovate.json`: three Dockerfile-ARG `customManager` entries replaced with one regex over `engine_versions/(transformers|vllm|tensorrt).yaml`. Anchors on `pep503_name:` / `current_version:` so Renovate writes `depName` per file. All other Renovate config (presets, packageRules, schedule, vulnerability alerts) is unchanged.
- `docker/Dockerfile.{transformers,vllm,tensorrt}`: ARG values unchanged in spirit, but now documented as a fallback for local manual builds. Comment explains the SSOT/ARG/`--build-arg` templating contract.
- `docker/Dockerfile.vllm`: ARG default flipped from `v0.7.3` to `0.7.3` to match SSOT (PyPI versioning); FROM line absorbs the literal `v` prefix needed by the upstream image tag.

## Why

`engine_versions/*.yaml` is the canonical source of truth (D-1 in `.product/designs/engine-coupling-architecture-2026-04-28.md`). Pre-change, Renovate authored Dockerfile ARGs and the SSOT had to track them by hand. Post-change, Renovate authors the SSOT and CI propagates the value into the build — single canonical file, no two-files-to-keep-in-sync problem.

## Out of scope

- CI workflow `--build-arg` plumbing (lands in a separate workflow-update PR).
- Re-enabling disabled workflows (`auto-mine.yml` etc.). That happens once Renovate has bumped at least one SSOT.
- SSOT YAML content (values are user-confirmed).

## Test plan

- [x] `renovate.json` is valid JSON.
- [x] The customManager regex matches each engine's SSOT and yields the expected `depName` (`transformers`, `vllm`, `tensorrt-llm`) and `currentValue`.
- [x] `tests/unit/scripts/engine_miners/test_ssot_pin_fixpoint.py` passes (16/16).
- [x] `ruff format` and `ruff check` show no new errors.
- [ ] Live verification: a forced Renovate bump on a test branch picks up the new file path (deferred — bypasses prod schedule).