### PR TITLE
feat(scripts): add probe primitive for binary miner reusability check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ scripts/probe_*_results.json
 # Rule-extractor staging outputs (regenerated each run; consumed by the
 # corpus merger — never hand-edited, never committed).
 configs/engine_invariants/_staging/
+
+# Probe primitive cache (rewritten on every probe run; tracks the
+# previous-run fingerprint per (engine, producer) for drift detection).
+engine_versions/*.compat.json

--- a/scripts/_probe.py
+++ b/scripts/_probe.py
@@ -1,0 +1,389 @@
+"""Probe primitive — binary reusability check for per-engine producers.
+
+The probe is the first step of each per-concern workflow (engine-invariants
++ engine-schemas). It answers one question: do the landmarks the producer
+relies on still resolve under the currently-installed library?
+
+Verdict semantics (binary, per the engine-coupling design doc §3):
+
+    pass : every landmark in ``producer.LANDMARKS`` resolves to a live
+           class / method / module attribute under ``import {library}``.
+    fail : at least one landmark is missing, OR the producer module
+           itself fails to import after one retry.
+
+Diagnostic fields (``version_inside_envelope``, ``fingerprint_drift``)
+ride along on every report and are surfaced in workflow comments. They
+NEVER affect the verdict — those signals steer the human's attention on
+``pass``-but-suspicious bumps without gating the pipeline.
+
+Producer-module discovery uses a per-engine convention table (see
+``_PRODUCER_MODULES``); each producer module exposes a
+``LANDMARKS: tuple[str, ...]`` constant of dotted attribute paths
+(e.g. ``"transformers.GenerationConfig"``,
+``"vllm.config.parallel.ParallelConfig.__post_init__"``).
+
+Usage::
+
+    python -m scripts._probe --engine transformers --producer invariants
+
+Emits a JSON ``ProbeReport`` to stdout. Exit 0 on either verdict — the
+binary verdict travels in the JSON, and downstream workflow steps gate
+on it. Exit 2 only on infrastructure failure (SSOT missing, producer
+module unimportable, SSOT malformed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import importlib
+import inspect
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from types import ModuleType
+from typing import Literal
+
+import yaml
+from packaging.specifiers import SpecifierSet
+
+# Make the top-level ``scripts`` package importable when invoked as a
+# plain script (``python scripts/_probe.py``) as well as via
+# ``python -m scripts._probe``.
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_miners._base import MinerLandmarkMissingError  # noqa: E402
+from scripts.engine_miners._ssot import ssot_path  # noqa: E402
+
+ProducerKind = Literal["invariants", "schemas"]
+
+# Per-engine producer module map. The probe lives one layer above the
+# producers; this table is the single seam where (engine, producer) cells
+# resolve to a Python module path. Keep it exhaustive — adding a new
+# engine means adding a row here.
+_PRODUCER_MODULES: dict[tuple[str, ProducerKind], str] = {
+    ("transformers", "invariants"): "scripts.engine_miners.transformers_miner",
+    ("vllm", "invariants"): "scripts.engine_miners.vllm_static_miner",
+    ("tensorrt", "invariants"): "scripts.engine_miners.tensorrt_static_miner",
+    ("transformers", "schemas"): "scripts.engine_introspectors.transformers_introspector",
+    ("vllm", "schemas"): "scripts.engine_introspectors.vllm_introspector",
+    ("tensorrt", "schemas"): "scripts.engine_introspectors.tensorrt_introspector",
+}
+
+# SSOT ``miner_pins.*`` keys are typed by extraction strategy
+# (``static | dynamic | discovery``); the probe's user-facing producer
+# kinds are typed by concern (``invariants | schemas``). One layer of
+# translation lives here.
+_SSOT_PIN_FOR_PRODUCER: dict[ProducerKind, str] = {
+    "invariants": "static",
+    "schemas": "discovery",
+}
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    """Structured report of one probe run.
+
+    Serialised to stdout JSON and to ``engine_versions/{engine}.compat.json``
+    for cross-run cache + fingerprint-drift detection.
+    """
+
+    engine: str
+    producer: ProducerKind
+    verdict: Literal["pass", "fail"]
+    library_version: str
+    version_inside_envelope: bool
+    fingerprint: str
+    fingerprint_drift: list[str] = field(default_factory=list)
+    landmarks_missing: list[str] = field(default_factory=list)
+    ran_at: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Landmark resolution
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ResolvedLandmark:
+    """One successfully-resolved landmark and its source coordinates.
+
+    The fingerprint is a sorted hash of these tuples; ``filename`` +
+    ``lineno`` are advisory but track real refactors (a method moving
+    from line 142 to 187 across a patch release).
+    """
+
+    landmark: str
+    qualname: str
+    filename: str | None
+    lineno: int | None
+
+
+def _resolve_landmark(landmark: str) -> _ResolvedLandmark:
+    """Resolve a dotted landmark like ``"vllm.config.parallel.ParallelConfig.__post_init__"``.
+
+    Strategy: try progressively-shorter module prefixes; whatever doesn't
+    import is treated as attribute access on the deepest importable
+    module. Raises :class:`AttributeError` / :class:`ImportError` on
+    miss; the caller catches and folds the failure into ``landmarks_missing``.
+    """
+    parts = landmark.split(".")
+    module: ModuleType | None = None
+    module_idx = 0
+    # Find the longest importable prefix.
+    for split in range(len(parts), 0, -1):
+        module_path = ".".join(parts[:split])
+        try:
+            module = importlib.import_module(module_path)
+            module_idx = split
+            break
+        except ImportError:
+            continue
+    if module is None:
+        raise ImportError(f"No importable prefix in landmark {landmark!r}")
+
+    obj: object = module
+    for attr in parts[module_idx:]:
+        obj = getattr(obj, attr)
+
+    try:
+        filename = inspect.getsourcefile(obj)  # type: ignore[arg-type]
+    except TypeError:
+        filename = None
+    try:
+        _, lineno = inspect.getsourcelines(obj)  # type: ignore[arg-type]
+    except (TypeError, OSError):
+        lineno = None
+
+    qualname = getattr(obj, "__qualname__", None) or getattr(obj, "__name__", landmark)
+    return _ResolvedLandmark(
+        landmark=landmark,
+        qualname=str(qualname),
+        filename=filename,
+        lineno=lineno,
+    )
+
+
+def _fingerprint(resolved: list[_ResolvedLandmark]) -> str:
+    """Stable hash of the resolved landmarks' (qualname, filename, lineno) tuples."""
+    parts = sorted(
+        f"{r.landmark}|{r.qualname}|{r.filename or ''}|{r.lineno or 0}" for r in resolved
+    )
+    return hashlib.sha256("\n".join(parts).encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# SSOT helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_ssot(engine: str) -> dict[str, object]:
+    """Read + parse ``engine_versions/{engine}.yaml``.
+
+    Raises :class:`FileNotFoundError` if missing. The probe treats SSOT
+    absence as an infrastructure error (exit code 2) — every supported
+    engine must have a SSOT before the probe is wired up for it.
+    """
+    path = ssot_path(engine)
+    text = path.read_text()  # FileNotFoundError surfaces here
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"SSOT at {path} did not parse to a mapping.")
+    return data
+
+
+def _check_envelope(ssot: dict[str, object], producer: ProducerKind, library_version: str) -> bool:
+    """True iff ``library_version`` falls inside ``miner_pins.{ssot_key}``."""
+    pins = ssot.get("miner_pins") or {}
+    if not isinstance(pins, dict):
+        return False
+    raw = pins.get(_SSOT_PIN_FOR_PRODUCER[producer])
+    if raw is None:
+        return False
+    spec = SpecifierSet(str(raw))
+    return spec.contains(library_version, prereleases=True)
+
+
+def _compat_path(engine: str) -> Path:
+    """Return the path to the cached fingerprint file for ``engine``."""
+    return ssot_path(engine).parent / f"{engine}.compat.json"
+
+
+def _read_cached_fingerprint(engine: str, producer: ProducerKind) -> str | None:
+    """Return the previous-run fingerprint for this (engine, producer), or ``None``."""
+    path = _compat_path(engine)
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return None
+    try:
+        cache = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    entry = (cache.get(producer) if isinstance(cache, dict) else None) or {}
+    fp = entry.get("fingerprint") if isinstance(entry, dict) else None
+    return str(fp) if isinstance(fp, str) else None
+
+
+def _write_cached_report(engine: str, report: ProbeReport) -> None:
+    """Atomically merge ``report`` into ``engine_versions/{engine}.compat.json``."""
+    path = _compat_path(engine)
+    cache: dict[str, object] = {}
+    try:
+        existing = json.loads(path.read_text())
+        if isinstance(existing, dict):
+            cache = existing
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    cache[report.producer] = asdict(report)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(cache, indent=2, sort_keys=True) + "\n")
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# Producer module loading
+# ---------------------------------------------------------------------------
+
+
+def _import_producer(engine: str, producer: ProducerKind) -> ModuleType:
+    """Import the producer module for ``(engine, producer)``.
+
+    Retries once on :class:`MinerLandmarkMissingError` raised at import
+    time (per design D-8) — a flaky import is treated as transient and
+    retried before the verdict is finalised. A second failure escalates
+    to caller; the CLI maps it to exit code 2 (infrastructure failure).
+    """
+    key = (engine, producer)
+    if key not in _PRODUCER_MODULES:
+        raise KeyError(f"Unsupported (engine, producer) pair: {key}")
+    module_path = _PRODUCER_MODULES[key]
+    try:
+        return importlib.import_module(module_path)
+    except MinerLandmarkMissingError:
+        return importlib.import_module(module_path)
+
+
+def _read_landmarks(module: ModuleType) -> tuple[str, ...]:
+    """Read ``LANDMARKS`` from ``module``; raises :class:`AttributeError` if absent."""
+    landmarks = module.LANDMARKS  # type: ignore[attr-defined]
+    if not isinstance(landmarks, tuple) or not all(isinstance(x, str) for x in landmarks):
+        raise TypeError(
+            f"{module.__name__}.LANDMARKS must be a tuple[str, ...]; got {type(landmarks).__name__}."
+        )
+    return landmarks
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def probe(*, engine: str, producer: ProducerKind) -> ProbeReport:
+    """Run the probe for one ``(engine, producer)`` cell.
+
+    Returns a :class:`ProbeReport` with verdict ``pass`` iff every
+    landmark resolves; ``fail`` iff one or more landmarks raise
+    :class:`AttributeError` / :class:`ImportError` during resolution.
+
+    Diagnostic fields (envelope check, fingerprint drift) are computed
+    regardless of verdict.
+    """
+    ssot = _load_ssot(engine)  # FileNotFoundError -> caller handles as infra error
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(f"SSOT for {engine} missing library.current_version.")
+    library_version = str(library["current_version"])
+
+    producer_module = _import_producer(engine, producer)
+    landmarks = _read_landmarks(producer_module)
+
+    resolved: list[_ResolvedLandmark] = []
+    missing: list[str] = []
+    for landmark in landmarks:
+        try:
+            resolved.append(_resolve_landmark(landmark))
+        except (AttributeError, ImportError):
+            missing.append(landmark)
+
+    fingerprint = _fingerprint(resolved)
+    cached = _read_cached_fingerprint(engine, producer)
+    drift: list[str] = []
+    if cached is not None and cached != fingerprint:
+        # Per-landmark drift would require caching per-landmark hashes;
+        # the binary "fingerprint shifted at all" signal is what the
+        # writeback comment surfaces, so the list captures the affected
+        # landmarks, not the cause.
+        drift = [r.landmark for r in resolved]
+
+    verdict: Literal["pass", "fail"] = "fail" if missing else "pass"
+
+    return ProbeReport(
+        engine=engine,
+        producer=producer,
+        verdict=verdict,
+        library_version=library_version,
+        version_inside_envelope=_check_envelope(ssot, producer, library_version),
+        fingerprint=fingerprint,
+        fingerprint_drift=drift,
+        landmarks_missing=missing,
+        ran_at=dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="scripts._probe", description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--engine", required=True, help="Engine name (transformers / vllm / tensorrt)."
+    )
+    parser.add_argument(
+        "--producer",
+        required=True,
+        choices=("invariants", "schemas"),
+        help="Concern produced by the underlying module.",
+    )
+    parser.add_argument(
+        "--no-write-cache",
+        action="store_true",
+        help="Skip updating engine_versions/{engine}.compat.json (useful for CI dry-runs).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        report = probe(engine=args.engine, producer=args.producer)
+    except (FileNotFoundError, KeyError, ImportError, AttributeError, TypeError, ValueError) as exc:
+        # Infrastructure failure: SSOT missing / malformed / producer
+        # module unimportable / LANDMARKS missing or malformed. Distinct
+        # from a fail-verdict probe (which writes JSON to stdout).
+        print(json.dumps({"error": type(exc).__name__, "message": str(exc)}), file=sys.stderr)
+        return 2
+
+    if not args.no_write_cache:
+        try:
+            _write_cached_report(args.engine, report)
+        except OSError as exc:
+            print(
+                json.dumps({"error": "CacheWriteFailed", "message": str(exc)}),
+                file=sys.stderr,
+            )
+            return 2
+
+    print(json.dumps(asdict(report), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/engine_introspectors/tensorrt_introspector.py
+++ b/scripts/engine_introspectors/tensorrt_introspector.py
@@ -26,6 +26,16 @@ from scripts.engine_introspectors._common import (
     read_dockerfile_from,
 )
 
+# Symbols this introspector relies on inside the live ``tensorrt_llm``
+# package. Read by ``scripts._probe`` before discovery runs; a missing
+# landmark flips the probe verdict to ``fail`` and skips downstream
+# discovery.
+LANDMARKS: tuple[str, ...] = (
+    "tensorrt_llm.SamplingParams",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
+)
+
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover TensorRT-LLM engine and sampling schemas.

--- a/scripts/engine_introspectors/transformers_introspector.py
+++ b/scripts/engine_introspectors/transformers_introspector.py
@@ -20,6 +20,19 @@ from scripts.engine_introspectors._common import (
     read_dockerfile_from,
 )
 
+# Symbols this introspector relies on inside the live ``transformers``
+# package. Read by ``scripts._probe`` before discovery runs; a missing
+# landmark flips the probe verdict to ``fail`` and skips downstream
+# discovery. Mirrors the imports inside :func:`discover`.
+LANDMARKS: tuple[str, ...] = (
+    "transformers.AutoModelForCausalLM",
+    "transformers.AutoModelForCausalLM.from_pretrained",
+    "transformers.PreTrainedModel",
+    "transformers.PreTrainedModel.from_pretrained",
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.to_dict",
+)
+
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover HuggingFace Transformers schemas.

--- a/scripts/engine_introspectors/vllm_introspector.py
+++ b/scripts/engine_introspectors/vllm_introspector.py
@@ -16,6 +16,14 @@ from scripts.engine_introspectors._common import (
     read_dockerfile_from,
 )
 
+# Symbols this introspector relies on inside the live ``vllm`` package.
+# Read by ``scripts._probe`` before discovery runs; a missing landmark
+# flips the probe verdict to ``fail`` and skips downstream discovery.
+LANDMARKS: tuple[str, ...] = (
+    "vllm.SamplingParams",
+    "vllm.engine.arg_utils.EngineArgs",
+)
+
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover vLLM engine and sampling schemas.

--- a/scripts/engine_miners/tensorrt_static_miner.py
+++ b/scripts/engine_miners/tensorrt_static_miner.py
@@ -101,6 +101,34 @@ _DEFAULT_SOURCE_ROOT = Path("/tmp/trt-llm-0.21.0/tensorrt_llm")
 LLM_ARGS_REL = Path("llmapi/llm_args.py")
 BUILDER_REL = Path("builder.py")
 
+# Symbols this miner relies on resolving inside the live ``tensorrt_llm``
+# package. Read by ``scripts._probe`` before mining runs; a missing
+# landmark flips the probe verdict to ``fail`` and skips downstream
+# stages. The miner itself walks /tmp source AST rather than the live
+# package (see ``_load_source``), but probe uses live-package landmarks
+# because that is the seam Renovate's library bumps shift first.
+LANDMARKS: tuple[str, ...] = (
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_dtype",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model_format_misc",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.set_runtime_knobs_from_build_config",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_with_runtime_params",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_remaining",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_speculative_config",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_lora_config_consistency",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.validate_enable_build_cache",
+    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig",
+    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig.validate_positive_values",
+    "tensorrt_llm.llmapi.llm_args.CalibConfig",
+    "tensorrt_llm.llmapi.llm_args.BatchingType",
+    "tensorrt_llm.llmapi.llm_args.CapacitySchedulerPolicy",
+    "tensorrt_llm.llmapi.llm_args.ContextChunkingPolicy",
+    "tensorrt_llm.builder.Builder",
+    "tensorrt_llm.builder.Builder.build_engine",
+)
+
 # Class-level landmarks. Each entry is ``(class_name, file_relative_path)``.
 _CLASS_LANDMARKS: tuple[tuple[str, Path], ...] = (
     ("BaseLlmArgs", LLM_ARGS_REL),

--- a/scripts/engine_miners/transformers_miner.py
+++ b/scripts/engine_miners/transformers_miner.py
@@ -68,6 +68,17 @@ from scripts.engine_miners.transformers_dynamic_miner import (  # noqa: E402
     walk_generation_config_rules,
 )
 
+# Symbols this orchestrator (and its delegated dynamic miner) relies on
+# inside the live ``transformers`` package. Read by ``scripts._probe``
+# before mining runs; a missing landmark flips the probe verdict to
+# ``fail`` and skips the downstream stages without re-importing here.
+LANDMARKS: tuple[str, ...] = (
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.validate",
+    "transformers.BitsAndBytesConfig",
+    "transformers.BitsAndBytesConfig.post_init",
+)
+
 # ---------------------------------------------------------------------------
 # BitsAndBytesConfig type-check rules (kept hand-curated — CPU-safe)
 # ---------------------------------------------------------------------------

--- a/scripts/engine_miners/vllm_static_miner.py
+++ b/scripts/engine_miners/vllm_static_miner.py
@@ -86,6 +86,41 @@ NS_STRUCTURED = "vllm.sampling.structured_outputs"
 NS_ENGINE = "vllm.engine"
 
 
+# Symbols this miner relies on resolving inside the live ``vllm`` package.
+# Read by ``scripts._probe`` before mining runs; a missing landmark flips
+# the probe verdict to ``fail`` and skips downstream stages. Mirrors the
+# ``_AST_TARGETS`` rows below at the dotted-path level so the probe can
+# detect upstream class / method renames without re-parsing the AST.
+LANDMARKS: tuple[str, ...] = (
+    "vllm.sampling_params.SamplingParams",
+    "vllm.sampling_params.SamplingParams._verify_args",
+    "vllm.sampling_params.SamplingParams.__post_init__",
+    "vllm.sampling_params.SamplingParams._verify_greedy_sampling",
+    "vllm.sampling_params.StructuredOutputsParams",
+    "vllm.sampling_params.StructuredOutputsParams.__post_init__",
+    "vllm.config.parallel.ParallelConfig",
+    "vllm.config.parallel.ParallelConfig._validate_parallel_config",
+    "vllm.config.parallel.ParallelConfig._verify_args",
+    "vllm.config.parallel.ParallelConfig.__post_init__",
+    "vllm.config.parallel.EPLBConfig",
+    "vllm.config.parallel.EPLBConfig._validate_eplb_config",
+    "vllm.config.lora.LoRAConfig",
+    "vllm.config.lora.LoRAConfig._validate_lora_config",
+    "vllm.config.multimodal.MultiModalConfig",
+    "vllm.config.multimodal.MultiModalConfig._validate_multimodal_config",
+    "vllm.config.structured_outputs.StructuredOutputsConfig",
+    "vllm.config.structured_outputs.StructuredOutputsConfig._validate_structured_output_config",
+    "vllm.config.cache.CacheConfig",
+    "vllm.config.cache.CacheConfig._validate_cache_dtype",
+    "vllm.config.model.ModelConfig",
+    "vllm.config.model.ModelConfig.__post_init__",
+    "vllm.config.compilation.CompilationConfig",
+    "vllm.config.compilation.CompilationConfig.__post_init__",
+    "vllm.config.scheduler.SchedulerConfig",
+    "vllm.config.scheduler.SchedulerConfig.__post_init__",
+)
+
+
 # ---------------------------------------------------------------------------
 # AST landmark registry — what to walk and where
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_probe.py
+++ b/tests/unit/scripts/test_probe.py
@@ -1,0 +1,258 @@
+"""Tests for :mod:`scripts._probe` — the probe primitive.
+
+The probe primitive answers a binary question ("do all landmarks resolve
+under the live library?") and emits a richly-diagnosed report. These
+tests verify pass/fail verdict derivation, fingerprint stability + drift,
+SSOT envelope checks, and round-tripping through the cache file.
+
+Synthetic LANDMARKS pinned to the live ``transformers`` package keep
+the suite stable across library versions without depending on private
+symbols.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts import _probe  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_synthetic_producer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    engine: str,
+    producer: _probe.ProducerKind,
+    landmarks: tuple[str, ...],
+    module_name: str = "scripts._probe_synthetic_producer",
+) -> types.ModuleType:
+    """Register a fake producer module + retarget the ``_PRODUCER_MODULES`` map.
+
+    The probe loads producer modules by ``importlib.import_module``;
+    placing one in ``sys.modules`` is sufficient. Tests use this to
+    decouple LANDMARKS contents from the real miner / introspector
+    bodies, which live elsewhere on the repo's release cadence.
+    """
+    module = types.ModuleType(module_name)
+    module.LANDMARKS = landmarks  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, module)
+    monkeypatch.setitem(_probe._PRODUCER_MODULES, (engine, producer), module_name)
+    return module
+
+
+def _redirect_compat_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, engine: str = "transformers"
+) -> Path:
+    """Point both SSOT path and compat cache writes at ``tmp_path``.
+
+    Copies the real engine SSOT into ``tmp_path`` so envelope checks can
+    still read it; redirects ``ssot_path`` to the temporary copy.
+    """
+    real_ssot = _PROJECT_ROOT / "engine_versions" / f"{engine}.yaml"
+    fake_ssot = tmp_path / f"{engine}.yaml"
+    fake_ssot.write_text(real_ssot.read_text())
+
+    def _fake_path(name: str) -> Path:
+        return tmp_path / f"{name}.yaml"
+
+    monkeypatch.setattr(_probe, "ssot_path", _fake_path)
+    return fake_ssot
+
+
+# ---------------------------------------------------------------------------
+# Verdict cases
+# ---------------------------------------------------------------------------
+
+
+def test_probe_pass_when_all_landmarks_resolve(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """All landmarks resolve → verdict ``pass``, ``landmarks_missing`` empty."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=(
+            "transformers.GenerationConfig",
+            "transformers.PreTrainedModel",
+        ),
+    )
+
+    report = _probe.probe(engine="transformers", producer="invariants")
+
+    assert report.verdict == "pass"
+    assert report.landmarks_missing == []
+    assert report.engine == "transformers"
+    assert report.producer == "invariants"
+    assert report.fingerprint  # non-empty hex digest
+    assert report.ran_at  # ISO timestamp present
+
+
+def test_probe_fail_when_landmark_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """One missing landmark → verdict ``fail`` with the offender enumerated."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=(
+            "transformers.GenerationConfig",
+            "transformers.NonExistentSymbolXYZ",
+        ),
+    )
+
+    report = _probe.probe(engine="transformers", producer="invariants")
+
+    assert report.verdict == "fail"
+    assert report.landmarks_missing == ["transformers.NonExistentSymbolXYZ"]
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_probe_fingerprint_stable_across_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same library, same landmarks → identical fingerprint across runs."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("transformers.GenerationConfig",),
+    )
+
+    first = _probe.probe(engine="transformers", producer="invariants")
+    second = _probe.probe(engine="transformers", producer="invariants")
+
+    assert first.fingerprint == second.fingerprint
+
+
+def test_probe_fingerprint_drift_listed_on_change(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fingerprint shift across runs surfaces in ``fingerprint_drift``."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("transformers.GenerationConfig",),
+    )
+
+    first = _probe.probe(engine="transformers", producer="invariants")
+    assert first.fingerprint_drift == []  # no cache yet
+    _probe._write_cached_report("transformers", first)
+
+    # Swap the LANDMARKS so the fingerprint shifts; the cached value is
+    # the previous one. Drift should be reported.
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("transformers.PreTrainedModel",),
+    )
+    second = _probe.probe(engine="transformers", producer="invariants")
+
+    assert second.fingerprint != first.fingerprint
+    assert second.fingerprint_drift  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics + envelope
+# ---------------------------------------------------------------------------
+
+
+def test_probe_version_inside_envelope_matches_ssot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``version_inside_envelope`` reflects the SSOT ``miner_pins.static`` range."""
+    fake_ssot = _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("transformers.GenerationConfig",),
+    )
+
+    # Rewrite the SSOT so the current version sits OUTSIDE the static pin —
+    # version_inside_envelope must flip to False without touching verdict.
+    fake_ssot.write_text(
+        "schema_version: 1\n"
+        "engine: transformers\n"
+        "library:\n"
+        "  pep503_name: transformers\n"
+        '  current_version: "0.0.1"\n'
+        "miner_pins:\n"
+        '  static: ">=99.0,<100.0"\n'
+        '  dynamic: ">=99.0,<100.0"\n'
+        '  discovery: ">=99.0,<100.0"\n'
+    )
+
+    report = _probe.probe(engine="transformers", producer="invariants")
+
+    assert report.verdict == "pass"  # landmarks still resolve
+    assert report.version_inside_envelope is False
+    assert report.library_version == "0.0.1"
+
+
+def test_probe_writes_compat_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``main`` writes a round-trippable ``{engine}.compat.json`` cache file."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("transformers.GenerationConfig",),
+    )
+
+    rc = _probe.main(["--engine", "transformers", "--producer", "invariants"])
+    assert rc == 0
+
+    cache_path = tmp_path / "transformers.compat.json"
+    assert cache_path.is_file()
+    cache = json.loads(cache_path.read_text())
+    assert "invariants" in cache
+    assert cache["invariants"]["verdict"] == "pass"
+    assert cache["invariants"]["fingerprint"]
+
+
+def test_probe_ssot_missing_returns_infra_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No SSOT for the engine → CLI exits 2 with a stderr error envelope."""
+    monkeypatch.setattr(_probe, "ssot_path", lambda name: tmp_path / f"{name}.yaml")
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="ghost_engine",
+        producer="invariants",
+        landmarks=("transformers.GenerationConfig",),
+    )
+
+    rc = _probe.main(["--engine", "ghost_engine", "--producer", "invariants"])
+    assert rc == 2
+
+
+def test_probe_unsupported_engine_producer_pair_returns_infra_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unknown ``(engine, producer)`` mapping → exit 2, no JSON on stdout."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(_probe, "_PRODUCER_MODULES", {})  # empty map
+    rc = _probe.main(["--engine", "transformers", "--producer", "invariants"])
+    assert rc == 2


### PR DESCRIPTION
## Summary

Adds the probe primitive that gates the per-concern engine workflows
(engine-invariants + engine-schemas, landing later). The probe answers
one binary question: do the landmarks each producer relies on still
resolve under the live library?

- `scripts/_probe.py` — CLI + library API. `python -m scripts._probe --engine <e> --producer <invariants|schemas>` emits a JSON `ProbeReport` to stdout (verdict `pass | fail`, plus diagnostic fields). Exit 0 on either verdict; 2 on infrastructure failure.
- `LANDMARKS: tuple[str, ...]` constants added to the three static miners + three introspectors. The probe reads these via the `_PRODUCER_MODULES` table and walks dotted paths inside the live library.
- Diagnostic fields (`version_inside_envelope`, `fingerprint_drift`) ride along on every report and never gate the verdict — they steer the human's attention on `pass`-but-suspicious bumps.
- Cache file `engine_versions/{engine}.compat.json` (gitignored) tracks per-(engine, producer) fingerprints across runs for drift detection.

## API shape

```python
ProbeReport(
    engine: str,
    producer: Literal["invariants", "schemas"],
    verdict: Literal["pass", "fail"],
    library_version: str,
    version_inside_envelope: bool,
    fingerprint: str,
    fingerprint_drift: list[str],
    landmarks_missing: list[str],
    ran_at: str,  # ISO-8601 UTC
)
```

`invariants -> static` and `schemas -> discovery` translation hits the SSOT `miner_pins.{static|dynamic|discovery}` keys for the envelope check.

## What this PR does NOT do

- Does NOT add a workflow file. Probe is "inline-as-script"; workflow consumers will call it via `python -m scripts._probe ...` in later PRs.
- Does NOT change miner orchestration. Existing `_check_landmarks()` calls inside miners stay untouched; the probe is parallel infrastructure.
- Does NOT touch the `last_probe` block in any `engine_versions/*.yaml`. That stays at `verdict: unrun` until a workflow wires the probe in.

## Test plan

- [x] 8 new unit tests in `tests/unit/scripts/test_probe.py` cover pass/fail, fingerprint stability + drift, envelope check, cache round-trip, SSOT-missing infra error, unsupported (engine, producer) infra error.
- [x] Existing 16-test SSOT pin fixpoint suite still green (no producer-module surprises).
- [x] End-to-end CLI sanity check against the real `transformers==4.57.3` install: `verdict: pass`, `version_inside_envelope: false` (the host install is outside the SSOT static pin — a real diagnostic surfacing as designed).
- [x] Wider miner + introspector tests (`tests/unit/scripts/engine_miners/`, `tests/unit/scripts/test_engine_introspectors.py`) all pass: 136 passed, 8 skipped.
- [x] Ruff format + lint clean on new + edited files.