### PR TITLE
feat(workflows): add engine-invariants workflow merging mine + vendor-replay

### DIFF
--- a/.github/workflows/engine-invariants.yml
+++ b/.github/workflows/engine-invariants.yml
@@ -5,17 +5,7 @@ name: Engine Invariants — Probe + Mine + Vendor
 # replays it against the live library, regenerates the invariants digest
 # doc, and atomically commits all four artefacts back to the PR branch.
 #
-# Replaces the deleted auto-mine.yml + invariant-miner.yml pair (the
-# Stage-1/Stage-2 split was honest about the YAML existence but the Python
-# code already runs vendor logic in-process during mining; merging the
-# workflows reflects existing coupling).
-#
-# Cross-pipeline coordination — ONE atomic writeback per PR cycle, gated
-# on a wait-for-sibling check against engine-schemas.yml — lands in a
-# follow-up alongside engine-schemas.yml. For now this workflow performs
-# its writeback unconditionally; there is no sibling to coordinate with.
-#
-# Per-engine runner choice mirrors the deleted workflows:
+# Per-engine runner choice:
 #   transformers : ubuntu-latest GH-hosted runner; CPU-safe import.
 #   vllm         : self-hosted GPU runner inside llenergymeasure:vllm-${VER}.
 #                  vLLM miners ARE CPU-safe but the unified uv.lock breaks
@@ -317,10 +307,6 @@ jobs:
           esac
 
       - name: Atomic writeback
-        # No wait-for-sibling guard yet — engine-schemas.yml lands as a
-        # follow-up; this writeback runs unconditionally for now. The
-        # cross-pipeline rollup label below is also unconditional pending
-        # the sibling.
         if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name  "llem-ci-bot[bot]"

--- a/.github/workflows/engine-invariants.yml
+++ b/.github/workflows/engine-invariants.yml
@@ -1,0 +1,1008 @@
+name: Engine Invariants — Probe + Mine + Vendor
+
+# Per-concern workflow for the engine-invariants layer. Each per-engine job
+# probes the producer module's landmarks, mines the rules corpus, vendor-
+# replays it against the live library, regenerates the invariants digest
+# doc, and atomically commits all four artefacts back to the PR branch.
+#
+# Replaces the deleted auto-mine.yml + invariant-miner.yml pair (the
+# Stage-1/Stage-2 split was honest about the YAML existence but the Python
+# code already runs vendor logic in-process during mining; merging the
+# workflows reflects existing coupling).
+#
+# Cross-pipeline coordination — ONE atomic writeback per PR cycle, gated
+# on a wait-for-sibling check against engine-schemas.yml — lands in a
+# follow-up alongside engine-schemas.yml. For now this workflow performs
+# its writeback unconditionally; there is no sibling to coordinate with.
+#
+# Per-engine runner choice mirrors the deleted workflows:
+#   transformers : ubuntu-latest GH-hosted runner; CPU-safe import.
+#   vllm         : self-hosted GPU runner inside llenergymeasure:vllm-${VER}.
+#                  vLLM miners ARE CPU-safe but the unified uv.lock breaks
+#                  vllm's torch/torchvision via tensorrt-llm 0.21.0's
+#                  transitive constraints (#437, #464); building inside the
+#                  vLLM image side-steps the resolution problem.
+#   tensorrt     : self-hosted GPU runner inside llenergymeasure:tensorrt-
+#                  ${VER}; TRT-LLM 0.21.0 loads CUDA bindings on import so
+#                  CPU runners cannot import the library at all.
+#
+# Determinism contract:
+#   The LLENERGY_MINER_FROZEN_AT and LLENERGY_VENDOR_FROZEN_AT env vars are
+#   set from the author date of the most recent commit touching any INPUT
+#   path (Dockerfile, miner modules, lift modules, build_corpus, vendor
+#   script, refresh helper, SSOT yaml). The anchor is stable across the
+#   workflow's own commit-back (which only touches OUTPUT paths), so re-
+#   runs on unchanged source emit byte-identical YAML. This determinism
+#   is THE prevention against the synchronize-loop the watchdog catches.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "engine_versions/*.yaml"
+      - "docker/Dockerfile.*"
+      - "scripts/engine_miners/**"
+      - "scripts/vendor_rules.py"
+      - "scripts/_invariant_vendor_common.py"
+      - "scripts/refresh_invariant_rules.sh"
+      - "configs/engine_invariants/**"
+  workflow_dispatch:
+    inputs:
+      engine:
+        description: "Engine to probe + mine + vendor"
+        required: true
+        type: choice
+        options:
+          - transformers
+          - vllm
+          - tensorrt
+          - all
+      pr_number:
+        description: "PR number to comment on and label (optional)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: engine-invariants-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CORPUS_DIR: configs/engine_invariants
+
+jobs:
+  invariants-transformers:
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'transformers' || inputs.engine == 'all'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Mint llem-ci-bot App token
+        # Short-lived (~1 hour) GitHub App token. Events it produces are
+        # NOT subject to the default GITHUB_TOKEN recursive-workflow guard,
+        # so the commit-back below can legitimately retrigger downstream
+        # CI. Skipped on fork PRs (secrets are not exposed there) so the
+        # workflow still runs read-only for external contributors.
+        id: app-token
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: engine-invariants-transformers-3.12
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --dev --extra transformers
+
+      - name: Resolve transformers version from SSOT
+        id: version
+        run: |
+          VER=$(yq '.library.current_version' engine_versions/transformers.yaml)
+          if [[ -z "$VER" || "$VER" == "null" ]]; then
+            echo "Could not resolve transformers version from engine_versions/transformers.yaml" >&2
+            exit 1
+          fi
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute stable mining + vendor anchor
+        id: anchor
+        # Pin the YAML's mined_at + the vendor envelope's vendored_at to
+        # the SHA + author date of the most recent commit touching any
+        # INPUT path. Stable across the workflow's own commit-back (which
+        # only touches OUTPUT YAML), so re-runs on unchanged source emit
+        # byte-identical envelopes. Without this, every re-run emits a
+        # fresh wallclock timestamp, git diff picks it up, the commit-back
+        # fires, and the synchronize loops.
+        run: |
+          PATHS=(
+            "engine_versions/transformers.yaml"
+            "docker/Dockerfile.transformers"
+            "scripts/engine_miners/transformers_static_miner.py"
+            "scripts/engine_miners/transformers_dynamic_miner.py"
+            "scripts/engine_miners/transformers_miner.py"
+            "scripts/engine_miners/build_corpus.py"
+            "scripts/engine_miners/_base.py"
+            "scripts/engine_miners/_pydantic_lift.py"
+            "scripts/engine_miners/_msgspec_lift.py"
+            "scripts/engine_miners/_dataclass_lift.py"
+            "scripts/engine_miners/_fixpoint_test.py"
+            "scripts/vendor_rules.py"
+            "scripts/_invariant_vendor_common.py"
+            "scripts/refresh_invariant_rules.sh"
+          )
+          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
+          DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+
+      - name: Probe — landmark resolution check
+        id: probe
+        run: |
+          uv run python -m scripts._probe \
+            --engine transformers --producer invariants \
+            > /tmp/probe-transformers.json
+          VERDICT=$(jq -r '.verdict' /tmp/probe-transformers.json)
+          echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+
+      - name: Save current YAMLs for diffing
+        if: steps.probe.outputs.verdict == 'pass'
+        run: |
+          mkdir -p /tmp/engine-invariants-diff
+          for KIND in proposed vendored; do
+            OLD_YAML="${CORPUS_DIR}/transformers.${KIND}.yaml"
+            DEST="/tmp/engine-invariants-diff/transformers.${KIND}.old.yaml"
+            if [[ -f "$OLD_YAML" ]]; then
+              cp "$OLD_YAML" "$DEST"
+            else
+              : > "$DEST"
+            fi
+          done
+
+      - name: Mine corpus — write proposed.yaml
+        if: steps.probe.outputs.verdict == 'pass'
+        env:
+          LLENERGY_MINER_FROZEN_AT: ${{ steps.anchor.outputs.date }}
+        run: |
+          uv run python -m scripts.engine_miners.build_corpus --engine transformers
+
+      - name: Vendor-replay — write vendored.yaml
+        if: steps.probe.outputs.verdict == 'pass'
+        env:
+          LLENERGY_VENDOR_FROZEN_AT: ${{ steps.anchor.outputs.date }}
+        run: |
+          uv run python scripts/vendor_rules.py \
+            --engine transformers \
+            --corpus "${CORPUS_DIR}/transformers.proposed.yaml" \
+            --out "${CORPUS_DIR}/transformers.vendored.yaml" \
+            --vendor-commit "${{ steps.anchor.outputs.sha }}" \
+            --fail-on-divergence
+
+      - name: Regenerate invariants digest doc
+        if: steps.probe.outputs.verdict == 'pass'
+        run: |
+          uv run python scripts/generate_invariants_doc.py \
+            --engine transformers \
+            --out docs/generated/invariants-transformers.md
+
+      - name: Classify diff (proposed + vendored)
+        if: steps.probe.outputs.verdict == 'pass'
+        id: diff
+        run: |
+          set +e
+          uv run python scripts/diff_engine_invariants.py \
+            /tmp/engine-invariants-diff/transformers.vendored.old.yaml \
+            "${CORPUS_DIR}/transformers.vendored.yaml" \
+            --out /tmp/engine-invariants-diff/transformers.vendored.md \
+            --title "Transformers vendored invariants diff"
+          VENDORED_EXIT=$?
+          set -e
+
+          PROPOSED_CHANGED=true
+          if diff -q /tmp/engine-invariants-diff/transformers.proposed.old.yaml \
+                    "${CORPUS_DIR}/transformers.proposed.yaml" >/dev/null 2>&1; then
+            PROPOSED_CHANGED=false
+          fi
+
+          VENDORED_CHANGED=true
+          if diff -q /tmp/engine-invariants-diff/transformers.vendored.old.yaml \
+                    "${CORPUS_DIR}/transformers.vendored.yaml" >/dev/null 2>&1; then
+            VENDORED_CHANGED=false
+          fi
+
+          if [[ "$PROPOSED_CHANGED" == "false" && "$VENDORED_CHANGED" == "false" ]]; then
+            CLASSIFICATION="no-changes"
+          elif [[ $VENDORED_EXIT -eq 1 ]]; then
+            CLASSIFICATION="breaking"
+          else
+            CLASSIFICATION="safe"
+          fi
+          echo "classification=${CLASSIFICATION}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Engine invariants — transformers"
+            echo
+            if [[ "$CLASSIFICATION" == "no-changes" ]]; then
+              echo "_No changes to proposed or vendored invariants._"
+            else
+              if [[ "$PROPOSED_CHANGED" == "true" ]]; then
+                echo "### Proposed corpus diff"
+                echo
+                echo '```diff'
+                diff -u /tmp/engine-invariants-diff/transformers.proposed.old.yaml \
+                        "${CORPUS_DIR}/transformers.proposed.yaml" | head -n 200 || true
+                echo '```'
+                echo
+              fi
+              if [[ -f /tmp/engine-invariants-diff/transformers.vendored.md ]]; then
+                cat /tmp/engine-invariants-diff/transformers.vendored.md
+              fi
+            fi
+          } > /tmp/engine-invariants-diff/transformers.summary.md
+
+      - name: Probe-fail comment (skip downstream)
+        if: steps.probe.outputs.verdict == 'fail' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          MISSING=$(jq -r '.landmarks_missing | join(", ")' /tmp/probe-transformers.json)
+          {
+            echo "## Engine invariants — transformers (probe-blocked)"
+            echo
+            echo "Probe failed: producer landmarks no longer resolve under the installed library."
+            echo
+            echo "Missing: \`${MISSING}\`"
+            echo
+            echo "Downstream mine + vendor steps were skipped. Patch the producer module or run \`@llem-ci-bot /approve-reuse transformers invariants\` once the landmarks have been updated."
+          } | gh pr comment "$PR_NUMBER" --body-file -
+          gh pr edit "$PR_NUMBER" --add-label "probe-blocked" 2>/dev/null || true
+
+      - name: Upload diff artefact
+        if: steps.probe.outputs.verdict == 'pass'
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-invariants-diff-transformers
+          path: |
+            /tmp/engine-invariants-diff/transformers.proposed.old.yaml
+            /tmp/engine-invariants-diff/transformers.vendored.old.yaml
+            /tmp/engine-invariants-diff/transformers.summary.md
+            ${{ env.CORPUS_DIR }}/transformers.proposed.yaml
+            ${{ env.CORPUS_DIR }}/transformers.vendored.yaml
+
+      - name: Post per-pipeline comment (suppress on empty)
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-invariants-diff/transformers.summary.md
+
+      - name: Apply per-pipeline label
+        if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          for L in invariants-changed invariants-breaking invariants-safe probe-blocked; do
+            gh pr edit "$PR_NUMBER" --remove-label "$L" 2>/dev/null || true
+          done
+          case "${{ steps.diff.outputs.classification }}" in
+            breaking)  gh pr edit "$PR_NUMBER" --add-label "invariants-breaking" --add-label "invariants-changed" 2>/dev/null || true ;;
+            safe)      gh pr edit "$PR_NUMBER" --add-label "invariants-safe" --add-label "invariants-changed" 2>/dev/null || true ;;
+            no-changes) ;;
+          esac
+
+      - name: Atomic writeback
+        # No wait-for-sibling guard yet — engine-schemas.yml lands as a
+        # follow-up; this writeback runs unconditionally for now. The
+        # cross-pipeline rollup label below is also unconditional pending
+        # the sibling.
+        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.name  "llem-ci-bot[bot]"
+          git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
+
+          git add \
+            "${CORPUS_DIR}/transformers.proposed.yaml" \
+            "${CORPUS_DIR}/transformers.vendored.yaml" \
+            docs/generated/invariants-transformers.md \
+            engine_versions/transformers.compat.json 2>/dev/null || true
+
+          if git diff --cached --quiet; then
+            echo "No engine-invariants artefact changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(invariants): refresh transformers proposed + vendored corpus"
+          git push --force-with-lease
+
+      - name: Apply cross-pipeline rollup label
+        if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          if [[ "${{ steps.diff.outputs.classification }}" != "breaking" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "safe-bump" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --remove-label "safe-bump" 2>/dev/null || true
+          fi
+
+  invariants-vllm:
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'vllm' || inputs.engine == 'all'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - name: Mint llem-ci-bot App token
+        id: app-token
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Clean workspace (fix root-owned files from prior Docker runs)
+        # Container-written artefacts persist as root-owned on the self-
+        # hosted runner and break subsequent checkouts otherwise. Mirrors
+        # gpu-ci.yml.
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "find /workspace -not -user $(id -u) -delete 2>/dev/null || true"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Resolve vLLM version from SSOT
+        id: version
+        run: |
+          VER=$(yq '.library.current_version' engine_versions/vllm.yaml)
+          if [[ -z "$VER" || "$VER" == "null" ]]; then
+            echo "Could not resolve vllm version from engine_versions/vllm.yaml" >&2
+            exit 1
+          fi
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Build or reuse vLLM image
+        # SSOT-driven build-arg per the engine-coupling design's D-1
+        # decision: Renovate updates SSOT only; Dockerfile ARG default
+        # is a fallback for local manual builds; CI passes the SSOT
+        # value at docker-build time. Layer cache makes the FROM step a
+        # no-op when the upstream tag is unchanged.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.vllm \
+              -t "$IMAGE" \
+              --build-arg VLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
+
+      - name: Compute stable mining + vendor anchor
+        id: anchor
+        run: |
+          PATHS=(
+            "engine_versions/vllm.yaml"
+            "docker/Dockerfile.vllm"
+            "scripts/engine_miners/vllm_static_miner.py"
+            "scripts/engine_miners/vllm_dynamic_miner.py"
+            "scripts/engine_miners/build_corpus.py"
+            "scripts/engine_miners/_base.py"
+            "scripts/engine_miners/_pydantic_lift.py"
+            "scripts/engine_miners/_msgspec_lift.py"
+            "scripts/engine_miners/_dataclass_lift.py"
+            "scripts/engine_miners/_fixpoint_test.py"
+            "scripts/vendor_rules.py"
+            "scripts/_invariant_vendor_common.py"
+            "scripts/refresh_invariant_rules.sh"
+          )
+          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
+          DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+
+      - name: Probe — landmark resolution check (in container)
+        id: probe
+        env:
+          IMAGE: ${{ steps.version.outputs.image }}
+        run: |
+          docker run --rm --gpus all \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            --entrypoint python3 \
+            "$IMAGE" \
+            -m scripts._probe --engine vllm --producer invariants \
+            > /tmp/probe-vllm.json
+          VERDICT=$(jq -r '.verdict' /tmp/probe-vllm.json)
+          echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+
+      - name: Fix container-written file ownership (probe cache)
+        if: always()
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
+
+      - name: Save current YAMLs for diffing
+        if: steps.probe.outputs.verdict == 'pass'
+        run: |
+          mkdir -p /tmp/engine-invariants-diff
+          for KIND in proposed vendored; do
+            OLD_YAML="${CORPUS_DIR}/vllm.${KIND}.yaml"
+            DEST="/tmp/engine-invariants-diff/vllm.${KIND}.old.yaml"
+            if [[ -f "$OLD_YAML" ]]; then
+              cp "$OLD_YAML" "$DEST"
+            else
+              : > "$DEST"
+            fi
+          done
+
+      - name: Mine + vendor inside container
+        if: steps.probe.outputs.verdict == 'pass'
+        env:
+          IMAGE: ${{ steps.version.outputs.image }}
+          ANCHOR_SHA: ${{ steps.anchor.outputs.sha }}
+          ANCHOR_DATE: ${{ steps.anchor.outputs.date }}
+        run: |
+          docker run --rm --gpus all \
+            -e LLENERGY_MINER_FROZEN_AT="${ANCHOR_DATE}" \
+            -e LLENERGY_VENDOR_FROZEN_AT="${ANCHOR_DATE}" \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            --entrypoint bash \
+            "$IMAGE" \
+            -c "
+              set -euo pipefail
+              python3 -m scripts.engine_miners.build_corpus --engine vllm
+              python3 scripts/vendor_rules.py \
+                --engine vllm \
+                --corpus '${CORPUS_DIR}/vllm.proposed.yaml' \
+                --out '${CORPUS_DIR}/vllm.vendored.yaml' \
+                --vendor-commit '${ANCHOR_SHA}' \
+                --fail-on-divergence
+            "
+
+      - name: Fix container-written file ownership (mine + vendor)
+        if: always()
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
+
+      - name: Set up Python (host) for doc-gen + diff
+        if: steps.probe.outputs.verdict == 'pass'
+        # Doc generator + differ run on the host (no GPU needed); pure
+        # CPU/IO Python.
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: engine-invariants-vllm-docgen-3.12
+          python-version: "3.12"
+
+      - name: Regenerate invariants digest doc
+        if: steps.probe.outputs.verdict == 'pass'
+        run: |
+          uv run --no-sync --with pyyaml python scripts/generate_invariants_doc.py \
+            --engine vllm \
+            --out docs/generated/invariants-vllm.md
+
+      - name: Classify diff (proposed + vendored)
+        if: steps.probe.outputs.verdict == 'pass'
+        id: diff
+        run: |
+          set +e
+          uv run --no-sync --with pyyaml python scripts/diff_engine_invariants.py \
+            /tmp/engine-invariants-diff/vllm.vendored.old.yaml \
+            "${CORPUS_DIR}/vllm.vendored.yaml" \
+            --out /tmp/engine-invariants-diff/vllm.vendored.md \
+            --title "vLLM vendored invariants diff"
+          VENDORED_EXIT=$?
+          set -e
+
+          PROPOSED_CHANGED=true
+          if diff -q /tmp/engine-invariants-diff/vllm.proposed.old.yaml \
+                    "${CORPUS_DIR}/vllm.proposed.yaml" >/dev/null 2>&1; then
+            PROPOSED_CHANGED=false
+          fi
+
+          VENDORED_CHANGED=true
+          if diff -q /tmp/engine-invariants-diff/vllm.vendored.old.yaml \
+                    "${CORPUS_DIR}/vllm.vendored.yaml" >/dev/null 2>&1; then
+            VENDORED_CHANGED=false
+          fi
+
+          if [[ "$PROPOSED_CHANGED" == "false" && "$VENDORED_CHANGED" == "false" ]]; then
+            CLASSIFICATION="no-changes"
+          elif [[ $VENDORED_EXIT -eq 1 ]]; then
+            CLASSIFICATION="breaking"
+          else
+            CLASSIFICATION="safe"
+          fi
+          echo "classification=${CLASSIFICATION}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Engine invariants — vllm"
+            echo
+            if [[ "$CLASSIFICATION" == "no-changes" ]]; then
+              echo "_No changes to proposed or vendored invariants._"
+            else
+              if [[ "$PROPOSED_CHANGED" == "true" ]]; then
+                echo "### Proposed corpus diff"
+                echo
+                echo '```diff'
+                diff -u /tmp/engine-invariants-diff/vllm.proposed.old.yaml \
+                        "${CORPUS_DIR}/vllm.proposed.yaml" | head -n 200 || true
+                echo '```'
+                echo
+              fi
+              if [[ -f /tmp/engine-invariants-diff/vllm.vendored.md ]]; then
+                cat /tmp/engine-invariants-diff/vllm.vendored.md
+              fi
+            fi
+          } > /tmp/engine-invariants-diff/vllm.summary.md
+
+      - name: Probe-fail comment (skip downstream)
+        if: steps.probe.outputs.verdict == 'fail' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          MISSING=$(jq -r '.landmarks_missing | join(", ")' /tmp/probe-vllm.json)
+          {
+            echo "## Engine invariants — vllm (probe-blocked)"
+            echo
+            echo "Probe failed: producer landmarks no longer resolve under the installed library."
+            echo
+            echo "Missing: \`${MISSING}\`"
+            echo
+            echo "Downstream mine + vendor steps were skipped. Patch the producer module or run \`@llem-ci-bot /approve-reuse vllm invariants\` once the landmarks have been updated."
+          } | gh pr comment "$PR_NUMBER" --body-file -
+          gh pr edit "$PR_NUMBER" --add-label "probe-blocked" 2>/dev/null || true
+
+      - name: Upload diff artefact
+        if: steps.probe.outputs.verdict == 'pass'
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-invariants-diff-vllm
+          path: |
+            /tmp/engine-invariants-diff/vllm.proposed.old.yaml
+            /tmp/engine-invariants-diff/vllm.vendored.old.yaml
+            /tmp/engine-invariants-diff/vllm.summary.md
+            ${{ env.CORPUS_DIR }}/vllm.proposed.yaml
+            ${{ env.CORPUS_DIR }}/vllm.vendored.yaml
+
+      - name: Post per-pipeline comment (suppress on empty)
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-invariants-diff/vllm.summary.md
+
+      - name: Apply per-pipeline label
+        if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          for L in invariants-changed invariants-breaking invariants-safe probe-blocked; do
+            gh pr edit "$PR_NUMBER" --remove-label "$L" 2>/dev/null || true
+          done
+          case "${{ steps.diff.outputs.classification }}" in
+            breaking)  gh pr edit "$PR_NUMBER" --add-label "invariants-breaking" --add-label "invariants-changed" 2>/dev/null || true ;;
+            safe)      gh pr edit "$PR_NUMBER" --add-label "invariants-safe" --add-label "invariants-changed" 2>/dev/null || true ;;
+            no-changes) ;;
+          esac
+
+      - name: Atomic writeback
+        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.name  "llem-ci-bot[bot]"
+          git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
+
+          git add \
+            "${CORPUS_DIR}/vllm.proposed.yaml" \
+            "${CORPUS_DIR}/vllm.vendored.yaml" \
+            docs/generated/invariants-vllm.md \
+            engine_versions/vllm.compat.json 2>/dev/null || true
+
+          if git diff --cached --quiet; then
+            echo "No engine-invariants artefact changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(invariants): refresh vllm proposed + vendored corpus"
+          git push --force-with-lease
+
+      - name: Apply cross-pipeline rollup label
+        if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          if [[ "${{ steps.diff.outputs.classification }}" != "breaking" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "safe-bump" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --remove-label "safe-bump" 2>/dev/null || true
+          fi
+
+  invariants-tensorrt:
+    if: github.event_name != 'workflow_dispatch' || inputs.engine == 'tensorrt' || inputs.engine == 'all'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - name: Mint llem-ci-bot App token
+        id: app-token
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Clean workspace (fix root-owned files from prior Docker runs)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "find /workspace -not -user $(id -u) -delete 2>/dev/null || true"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Resolve TRT-LLM version from SSOT
+        id: version
+        run: |
+          VER=$(yq '.library.current_version' engine_versions/tensorrt.yaml)
+          if [[ -z "$VER" || "$VER" == "null" ]]; then
+            echo "Could not resolve tensorrt version from engine_versions/tensorrt.yaml" >&2
+            exit 1
+          fi
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Build or reuse TRT-LLM image
+        # SSOT-driven build-arg per D-1; layer cache keeps rebuilds fast
+        # when the NGC tag is unchanged. Note Dockerfile ARG is named
+        # TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.tensorrt \
+              -t "$IMAGE" \
+              --build-arg TRTLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
+
+      - name: Compute stable mining + vendor anchor
+        id: anchor
+        run: |
+          PATHS=(
+            "engine_versions/tensorrt.yaml"
+            "docker/Dockerfile.tensorrt"
+            "scripts/engine_miners/tensorrt_static_miner.py"
+            "scripts/engine_miners/tensorrt_miner.py"
+            "scripts/engine_miners/build_corpus.py"
+            "scripts/engine_miners/_base.py"
+            "scripts/engine_miners/_pydantic_lift.py"
+            "scripts/engine_miners/_msgspec_lift.py"
+            "scripts/engine_miners/_dataclass_lift.py"
+            "scripts/engine_miners/_fixpoint_test.py"
+            "scripts/vendor_rules.py"
+            "scripts/_invariant_vendor_common.py"
+            "scripts/refresh_invariant_rules.sh"
+          )
+          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
+          DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+
+      - name: Probe — landmark resolution check (in container)
+        id: probe
+        env:
+          IMAGE: ${{ steps.version.outputs.image }}
+        # The NGC image ships the tensorrt_llm package source as part of
+        # the installed package; the static miner expects it at
+        # /tmp/trt-llm-${VER}/tensorrt_llm. Symlink before probe so
+        # _read_landmarks resolves correctly. LD_LIBRARY_PATH override
+        # so libtensorrt_llm.so finds bundled CUDA compat libs on hosts
+        # whose driver predates the NGC image's CUDA target.
+        run: |
+          docker run --rm --gpus all \
+            -e LD_LIBRARY_PATH="/usr/local/cuda/compat/lib.real:/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib" \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            --entrypoint bash \
+            "$IMAGE" \
+            -c "
+              set -euo pipefail
+              SRC=\$(python3 -c 'import tensorrt_llm, pathlib; print(pathlib.Path(tensorrt_llm.__file__).parent)')
+              if [[ -z \"\$SRC\" || ! -d \"\$SRC\" ]]; then
+                echo 'Could not locate installed tensorrt_llm package source' >&2
+                exit 1
+              fi
+              mkdir -p /tmp/trt-llm-${{ steps.version.outputs.version }}
+              ln -sfn \"\$SRC\" /tmp/trt-llm-${{ steps.version.outputs.version }}/tensorrt_llm
+              python3 -m scripts._probe --engine tensorrt --producer invariants
+            " > /tmp/probe-tensorrt.json
+          VERDICT=$(jq -r '.verdict' /tmp/probe-tensorrt.json)
+          echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+
+      - name: Fix container-written file ownership (probe cache)
+        if: always()
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
+
+      - name: Save current YAMLs for diffing
+        if: steps.probe.outputs.verdict == 'pass'
+        run: |
+          mkdir -p /tmp/engine-invariants-diff
+          for KIND in proposed vendored; do
+            OLD_YAML="${CORPUS_DIR}/tensorrt.${KIND}.yaml"
+            DEST="/tmp/engine-invariants-diff/tensorrt.${KIND}.old.yaml"
+            if [[ -f "$OLD_YAML" ]]; then
+              cp "$OLD_YAML" "$DEST"
+            else
+              : > "$DEST"
+            fi
+          done
+
+      - name: Mine + vendor inside container
+        if: steps.probe.outputs.verdict == 'pass'
+        env:
+          IMAGE: ${{ steps.version.outputs.image }}
+          ANCHOR_SHA: ${{ steps.anchor.outputs.sha }}
+          ANCHOR_DATE: ${{ steps.anchor.outputs.date }}
+          TRTLLM_VER: ${{ steps.version.outputs.version }}
+        run: |
+          docker run --rm --gpus all \
+            -e LD_LIBRARY_PATH="/usr/local/cuda/compat/lib.real:/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib" \
+            -e LLENERGY_MINER_FROZEN_AT="${ANCHOR_DATE}" \
+            -e LLENERGY_VENDOR_FROZEN_AT="${ANCHOR_DATE}" \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            --entrypoint bash \
+            "$IMAGE" \
+            -c "
+              set -euo pipefail
+              SRC=\$(python3 -c 'import tensorrt_llm, pathlib; print(pathlib.Path(tensorrt_llm.__file__).parent)')
+              mkdir -p /tmp/trt-llm-${TRTLLM_VER}
+              ln -sfn \"\$SRC\" /tmp/trt-llm-${TRTLLM_VER}/tensorrt_llm
+              python3 -m scripts.engine_miners.build_corpus --engine tensorrt
+              python3 scripts/vendor_rules.py \
+                --engine tensorrt \
+                --corpus '${CORPUS_DIR}/tensorrt.proposed.yaml' \
+                --out '${CORPUS_DIR}/tensorrt.vendored.yaml' \
+                --vendor-commit '${ANCHOR_SHA}' \
+                --fail-on-divergence
+            "
+
+      - name: Fix container-written file ownership (mine + vendor)
+        if: always()
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace \
+            alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
+
+      - name: Set up Python (host) for doc-gen + diff
+        if: steps.probe.outputs.verdict == 'pass'
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: engine-invariants-tensorrt-docgen-3.12
+          python-version: "3.12"
+
+      - name: Regenerate invariants digest doc
+        if: steps.probe.outputs.verdict == 'pass'
+        run: |
+          uv run --no-sync --with pyyaml python scripts/generate_invariants_doc.py \
+            --engine tensorrt \
+            --out docs/generated/invariants-tensorrt.md
+
+      - name: Classify diff (proposed + vendored)
+        if: steps.probe.outputs.verdict == 'pass'
+        id: diff
+        run: |
+          set +e
+          uv run --no-sync --with pyyaml python scripts/diff_engine_invariants.py \
+            /tmp/engine-invariants-diff/tensorrt.vendored.old.yaml \
+            "${CORPUS_DIR}/tensorrt.vendored.yaml" \
+            --out /tmp/engine-invariants-diff/tensorrt.vendored.md \
+            --title "TensorRT-LLM vendored invariants diff"
+          VENDORED_EXIT=$?
+          set -e
+
+          PROPOSED_CHANGED=true
+          if diff -q /tmp/engine-invariants-diff/tensorrt.proposed.old.yaml \
+                    "${CORPUS_DIR}/tensorrt.proposed.yaml" >/dev/null 2>&1; then
+            PROPOSED_CHANGED=false
+          fi
+
+          VENDORED_CHANGED=true
+          if diff -q /tmp/engine-invariants-diff/tensorrt.vendored.old.yaml \
+                    "${CORPUS_DIR}/tensorrt.vendored.yaml" >/dev/null 2>&1; then
+            VENDORED_CHANGED=false
+          fi
+
+          if [[ "$PROPOSED_CHANGED" == "false" && "$VENDORED_CHANGED" == "false" ]]; then
+            CLASSIFICATION="no-changes"
+          elif [[ $VENDORED_EXIT -eq 1 ]]; then
+            CLASSIFICATION="breaking"
+          else
+            CLASSIFICATION="safe"
+          fi
+          echo "classification=${CLASSIFICATION}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Engine invariants — tensorrt"
+            echo
+            if [[ "$CLASSIFICATION" == "no-changes" ]]; then
+              echo "_No changes to proposed or vendored invariants._"
+            else
+              if [[ "$PROPOSED_CHANGED" == "true" ]]; then
+                echo "### Proposed corpus diff"
+                echo
+                echo '```diff'
+                diff -u /tmp/engine-invariants-diff/tensorrt.proposed.old.yaml \
+                        "${CORPUS_DIR}/tensorrt.proposed.yaml" | head -n 200 || true
+                echo '```'
+                echo
+              fi
+              if [[ -f /tmp/engine-invariants-diff/tensorrt.vendored.md ]]; then
+                cat /tmp/engine-invariants-diff/tensorrt.vendored.md
+              fi
+            fi
+          } > /tmp/engine-invariants-diff/tensorrt.summary.md
+
+      - name: Probe-fail comment (skip downstream)
+        if: steps.probe.outputs.verdict == 'fail' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          MISSING=$(jq -r '.landmarks_missing | join(", ")' /tmp/probe-tensorrt.json)
+          {
+            echo "## Engine invariants — tensorrt (probe-blocked)"
+            echo
+            echo "Probe failed: producer landmarks no longer resolve under the installed library."
+            echo
+            echo "Missing: \`${MISSING}\`"
+            echo
+            echo "Downstream mine + vendor steps were skipped. Patch the producer module or run \`@llem-ci-bot /approve-reuse tensorrt invariants\` once the landmarks have been updated."
+          } | gh pr comment "$PR_NUMBER" --body-file -
+          gh pr edit "$PR_NUMBER" --add-label "probe-blocked" 2>/dev/null || true
+
+      - name: Upload diff artefact
+        if: steps.probe.outputs.verdict == 'pass'
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-invariants-diff-tensorrt
+          path: |
+            /tmp/engine-invariants-diff/tensorrt.proposed.old.yaml
+            /tmp/engine-invariants-diff/tensorrt.vendored.old.yaml
+            /tmp/engine-invariants-diff/tensorrt.summary.md
+            ${{ env.CORPUS_DIR }}/tensorrt.proposed.yaml
+            ${{ env.CORPUS_DIR }}/tensorrt.vendored.yaml
+
+      - name: Post per-pipeline comment (suppress on empty)
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-invariants-diff/tensorrt.summary.md
+
+      - name: Apply per-pipeline label
+        if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          for L in invariants-changed invariants-breaking invariants-safe probe-blocked; do
+            gh pr edit "$PR_NUMBER" --remove-label "$L" 2>/dev/null || true
+          done
+          case "${{ steps.diff.outputs.classification }}" in
+            breaking)  gh pr edit "$PR_NUMBER" --add-label "invariants-breaking" --add-label "invariants-changed" 2>/dev/null || true ;;
+            safe)      gh pr edit "$PR_NUMBER" --add-label "invariants-safe" --add-label "invariants-changed" 2>/dev/null || true ;;
+            no-changes) ;;
+          esac
+
+      - name: Atomic writeback
+        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.name  "llem-ci-bot[bot]"
+          git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
+
+          git add \
+            "${CORPUS_DIR}/tensorrt.proposed.yaml" \
+            "${CORPUS_DIR}/tensorrt.vendored.yaml" \
+            docs/generated/invariants-tensorrt.md \
+            engine_versions/tensorrt.compat.json 2>/dev/null || true
+
+          if git diff --cached --quiet; then
+            echo "No engine-invariants artefact changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(invariants): refresh tensorrt proposed + vendored corpus"
+          git push --force-with-lease
+
+      - name: Apply cross-pipeline rollup label
+        if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+          if [[ "${{ steps.diff.outputs.classification }}" != "breaking" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "safe-bump" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --remove-label "safe-bump" 2>/dev/null || true
+          fi

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -150,43 +150,41 @@ The invariant miner pipeline lives in `scripts/engine_miners/` - it is a build-t
   Library version bump (e.g. transformers 4.56.0 → 4.57.0)
                │
                ▼
-  Renovate opens PR bumping Dockerfile ARG
+  Renovate opens PR bumping engine_versions/{engine}.yaml
+  (Dockerfile ARG default is derived at build time from the SSOT)
                │
                ▼
-  Stage 1: auto-mine.yml fires (mining)
+  engine-invariants.yml fires (probe + mine + vendor)
                │
-               ├──► transformers miners run (GH-hosted ubuntu-latest, uv sync)
+               ├──► transformers job runs on GH-hosted ubuntu-latest
+               │    (uv sync; CPU-safe import).
                │
-               ├──► vLLM miners run (self-hosted GPU runner, inside the
-               │    vllm/vllm-openai Docker image — Docker isolates from
-               │    the unified uv.lock, see #437/#464)
+               ├──► vLLM job runs inside llenergymeasure:vllm-${VER} on
+               │    a self-hosted GPU runner (Docker isolates from the
+               │    unified uv.lock; see #437/#464).
                │
-               ├──► TRT-LLM miner runs (self-hosted GPU runner, inside the
-               │    llenergymeasure:tensorrt image; CUDA-aware import)
-               │
-               ├──► lift modules run (pydantic / msgspec / dataclass)
-               │
-               ▼
-  build_corpus.py merges staging files
-  (dedup by fingerprint; static miner wins on match.fields,
-   dynamic miner wins on message_template)
-  → produces configs/engine_invariants/{engine}.proposed.yaml (proposed YAML corpus)
+               ├──► TRT-LLM job runs inside llenergymeasure:tensorrt-${VER}
+               │    on a self-hosted GPU runner (CUDA-aware import).
                │
                ▼
-  Stage 2: invariant-miner.yml fires (vendor gate)
+  Per-engine step sequence inside one job:
+    1. Probe — scripts._probe checks landmarks; `fail` skips downstream.
+    2. Mine — build_corpus.py writes
+       configs/engine_invariants/{engine}.proposed.yaml.
+       (lift modules — pydantic / msgspec / dataclass — run inside
+        build_corpus.py; static miner wins on match.fields, dynamic miner
+        wins on message_template.)
+    3. Vendor-replay — vendor_rules.py replays every rule against the
+       live library (checks: kwargs_positive raises, message matches
+       template, kwargs_negative does NOT raise). Confirmed cases write
+       to configs/engine_invariants/{engine}.vendored.yaml; divergent
+       rules surface as a non-zero exit when --fail-on-divergence is set.
+    4. Doc-gen — generate_invariants_doc.py refreshes
+       docs/generated/invariants-{engine}.md.
+    5. Atomic writeback — one bot commit covers proposed.yaml,
+       vendored.yaml, the digest doc, and engine_versions/{engine}.compat.json.
                │
                ▼
-  vendor_rules.py replays every rule against the live library
-  (checks: kwargs_positive raises, message matches template,
-            kwargs_negative does NOT raise)
-               │
-               ├──► divergent rules quarantined to _failed_validation_*.yaml
-               │
-               └──► confirmed rules written to:
-                    configs/engine_invariants/{engine}.vendored.yaml
-               │
-               ▼
-  Bot writes vendored YAML back to PR branch
   CI must be green before merge
                │
                ▼

--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -389,22 +389,16 @@ def test_landmark_checks_raise_on_missing():
 
 ## Step 7: Add to CI
 
-1. Add the engine to `invariant-miner.yml`:
-
-```yaml
-- name: Run myengine miners
-  run: |
-    python scripts/engine_miners/myengine_miner.py
-```
+1. Add a per-engine job to `engine-invariants.yml` mirroring the existing `invariants-transformers` / `invariants-vllm` / `invariants-tensorrt` jobs. The job runs probe → mine → vendor-replay → doc-gen → atomic-writeback inline; copying one of the existing jobs and swapping the engine name + module paths is the fastest path.
 
 2. Set the runner tier:
    - CPU-safe import AND clean resolution under the repo's unified `uv.lock` (e.g. transformers): add to the GH-hosted `ubuntu-latest` job with `uv sync --extra <engine>`.
-   - CPU-safe import but unified-lock resolution breaks the engine (e.g. vLLM, where tensorrt-llm 0.21.0's transitive constraints corrupt vllm's torch/torchvision; #437): add to the self-hosted GPU runner inside the engine's published Docker image, mirroring `mine-vllm` in `auto-mine.yml`.
-   - CUDA-aware import required (e.g. TRT-LLM): add to the self-hosted GPU runner inside the engine's Docker image, mirroring `mine-tensorrt`.
+   - CPU-safe import but unified-lock resolution breaks the engine (e.g. vLLM, where tensorrt-llm 0.21.0's transitive constraints corrupt vllm's torch/torchvision; #437): mirror `invariants-vllm` — self-hosted GPU runner inside `llenergymeasure:vllm-${VER}`.
+   - CUDA-aware import required (e.g. TRT-LLM): mirror `invariants-tensorrt` — self-hosted GPU runner inside `llenergymeasure:tensorrt-${VER}`.
 
-3. Add the engine's Dockerfile to the vendor-rules step so `vendor_rules.py` can replay rules inside the engine's container.
+3. The vendor-replay step runs inside the engine's container in the same job as the miner — no separate vendor workflow to update.
 
-4. Add a Renovate `packageRule` so library bumps trigger `invariant-miner.yml`.
+4. Add a Renovate `packageRule` so library bumps trigger `engine-invariants.yml` via the `engine_versions/{engine}.yaml` path filter.
 
 ---
 
@@ -524,13 +518,13 @@ Concrete scenario: a refactor in `_pydantic_lift.py` changes how it walks `Field
 - The Renovate PR merges with a corpus that has 60% the recall it had before.
 - Users hitting the lost validations get no constraint check at runtime.
 
-**Mitigation: the Stage 1 / Stage 2 split (the trust seam).**
+**Mitigation: the proposed-vs-vendored YAML pair (the trust seam).**
 
-Stage 1 (`auto-mine.yml`) regenerates the YAML corpus and the bot writes the new YAML to the PR branch as a commit. Stage 2 (`invariant-miner.yml`) only runs the vendor gate against the YAML.
+`engine-invariants.yml` mines the proposed corpus into `configs/engine_invariants/{engine}.proposed.yaml` and then vendor-replays it into `configs/engine_invariants/{engine}.vendored.yaml` in the same job. Both YAMLs land in one atomic commit-back to the PR branch, and the per-pipeline diff comment includes both diffs.
 
-Because Stage 1 commits the YAML *before* Stage 2 runs, the YAML diff is reviewable in the PR. A miner refactor that silently drops 18 rules shows up as 18 deletions in the YAML diff - a maintainer reading the PR notices the regression before the JSON gate's green tick lands.
+Because the proposed-corpus diff is emitted alongside the vendored diff, a miner refactor that silently drops 18 rules shows up as 18 deletions in the proposed-corpus diff - a maintainer reading the PR notices the regression even when the vendor gate's verdict on the surviving rules is green.
 
-This is the reason the pipeline is split into two stages instead of being unified into one workflow that mines + vendors + commits a single artefact. The split forces YAML-diff visibility *before* the JSON gate's authority is exercised. Cross-reference: #450 (trust seam architecture decision), #465 (auto-mine writeback contract).
+The historical Stage-1 / Stage-2 split between `auto-mine.yml` and `invariant-miner.yml` forced the same property by serialising two workflows; the merger preserves the property by emitting two diffs from one workflow. Cross-reference: #450 (trust seam architecture decision), #465 (writeback contract).
 
 ### Tooling for diagnosis
 

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -418,23 +418,26 @@ Library version bumps trigger corpus regeneration automatically. The flow descri
   │   Dashboard #446 checkbox bypasses on demand)                     │
   │               │                                                   │
   │               ▼                                                   │
-  │  Renovate opens PR bumping Dockerfile ARG                         │
-  │  (e.g. ARG TRANSFORMERS_VERSION=...)                              │
+  │  Renovate opens PR bumping engine_versions/{engine}.yaml          │
+  │  (library.current_version; Dockerfile ARG default is derived at   │
+  │   build time via --build-arg from the SSOT)                       │
   │               │                                                   │
-  │     ┌─────────┴──────────────┬────────────────────┐               │
-  │     ▼                        ▼                    ▼               │
-  │  invariant-miner.yml   parameter-discovery   auto-mine.yml        │
-  │  (Stage 2 vendor gate)   .yml                (Stage 1 mining)     │
+  │     ┌─────────┴──────────────┐                                    │
+  │     ▼                        ▼                                    │
+  │  engine-invariants.yml   parameter-discovery.yml                  │
+  │  (per-engine matrix:     (engine schemas; today's existing        │
+  │   probe + mine + vendor)  workflow until engine-schemas.yml       │
+  │                            ships as PR-5b)                        │
   │                                                                   │
-  │  Path filters fire all three workflows in parallel on the         │
-  │  Renovate PR. They write back to the PR branch independently.     │
+  │  Path filters fire both workflows in parallel on the Renovate     │
+  │  PR. Each writes back to the PR branch independently.             │
   │               │                                                   │
-  │  ─────────────┴ Stage 1: auto-mine.yml ─────────────────          │
+  │  ──────────── engine-invariants.yml per-engine job ────────────   │
   │         ┌─────────────────┬────────────────────┐                  │
   │         ▼                 ▼                    ▼                  │
   │  GH-hosted runner   Self-hosted GPU      Self-hosted GPU          │
-  │  (ubuntu-latest)    inside vllm/vllm-    inside llenergymeasure:  │
-  │  - transformers     openai Docker        tensorrt Docker          │
+  │  (ubuntu-latest)    inside llenergy-     inside llenergy-         │
+  │  - transformers     measure:vllm-${VER}  measure:tensorrt-${VER}  │
   │    static miner     - vLLM static        - TRT-LLM static         │
   │  - transformers     - vLLM dynamic         miner (CUDA-aware      │
   │    dynamic miner    (Docker isolates       import required)       │
@@ -443,24 +446,20 @@ Library version bumps trigger corpus regeneration automatically. The flow descri
   │         │                 │                    │                  │
   │         └─────────────────┴────────────────────┘                  │
   │                       ▼                                           │
-  │  build_corpus.py merges staging → configs/engine_invariants/     │
-  │  {engine}.proposed.yaml; bot commits the new YAML to the PR       │
-  │  branch                                                           │
-  │  with `--force-with-lease` and posts a diff comment.              │
-  │                       │                                           │
-  │                       ▼                                           │
-  │  Stage 1 writeback retriggers invariant-miner.yml on the new      │
-  │  YAML commit (chain validation).                                  │
-  │                                                                   │
-  │  ─────────────── Stage 2: invariant-miner.yml ─────────────       │
-  │                       ▼                                           │
-  │  vendor_rules.py --fail-on-divergence replays each rule against   │
-  │  the live library inside the engine's Docker container.           │
-  │                       │                                           │
-  │                       ▼                                           │
-  │  Bot writes updated vendored YAML                                 │
-  │  (configs/engine_invariants/{engine}.vendored.yaml)               │
-  │  to the PR branch and posts a diff comment.                       │
+  │  Per-engine step sequence inside one job:                         │
+  │   1. Probe — scripts._probe checks landmarks; `fail` skips        │
+  │      downstream and posts a `probe-blocked` comment + label.      │
+  │   2. Mine — build_corpus.py merges staging into                   │
+  │      configs/engine_invariants/{engine}.proposed.yaml.            │
+  │   3. Vendor-replay — vendor_rules.py --fail-on-divergence         │
+  │      replays each rule against the live library inside the        │
+  │      engine's Docker container; confirmed cases write to          │
+  │      configs/engine_invariants/{engine}.vendored.yaml.            │
+  │   4. Doc-gen — generate_invariants_doc.py refreshes               │
+  │      docs/generated/invariants-{engine}.md.                       │
+  │   5. Atomic writeback — one bot commit covers proposed.yaml,      │
+  │      vendored.yaml, the digest doc, and engine_versions/          │
+  │      {engine}.compat.json. Pushed with --force-with-lease.        │
   │                       │                                           │
   │  ─────────────── parameter-discovery.yml (parallel) ───────       │
   │                       ▼                                           │
@@ -474,9 +473,10 @@ Library version bumps trigger corpus regeneration automatically. The flow descri
   │                       │                                           │
   │                       ▼                                           │
   │  Maintainer reviews proposed YAML diff, vendored YAML diff, and   │
-  │  schema diff in the PR. Stage 1's proposed YAML commit is the     │
-  │  trust seam: recall regressions show up as rule drops BEFORE      │
-  │  the vendor gate runs.                                            │
+  │  schema diff in the PR. The proposed YAML commit is the trust     │
+  │  seam: recall regressions show up as rule drops in the diff       │
+  │  emitted before the vendor gate's verdict lands in the same       │
+  │  commit.                                                          │
   └───────────────────────────────────────────────────────────────────┘
 ```
 
@@ -493,9 +493,9 @@ The update workflow:
 5. CI re-runs with updated miner; vendor-CI gate runs.
 6. If any rules now diverge, they are quarantined; maintainer updates the corpus.
 
-### Phase B.6 observed flow
+### Phase B.6 observed flow (historical)
 
-The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transformers v4.57.3 → v4.57.6) is the first naturally-Renovate-authored exercise of the full chain. The actual commit sequence on the PR branch:
+The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transformers v4.57.3 → v4.57.6) was the first naturally-Renovate-authored exercise of the full chain. It pre-dates the merge of mining + vendor into `engine-invariants.yml`; the workflow names below (`auto-mine.yml`, `invariant-miner.yml`) are historical and reflect the two-stage split that has since collapsed. The structural lessons (commit-back determinism, self-hosted runner serialisation) carry over to the merged workflow. The actual commit sequence on the PR branch:
 
 ```
   Commit (PR #459 branch)   Author       Producing workflow / event
@@ -534,11 +534,11 @@ The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transforme
                                           serial, vLLM job queued behind others)
 ```
 
-**What this proves empirically:**
+**What this proved empirically (carries over to the merged workflow):**
 
-- **All three workflows fire on a single Renovate-authored Dockerfile bump.** No actor-gate intervention; path filters alone are sufficient.
-- **Stage 1 → Stage 2 chain validation works as designed.** auto-mine writes YAML at `96d811fb`; invariant-miner re-fires at `fb473a22` against the new YAML. The trust seam (YAML diff visible to reviewers before JSON gate runs) is exercised end-to-end.
-- **App-token + `--force-with-lease` writebacks succeed across all three workflows** without recursion-guard issues.
+- **Path-filter-driven fan-out fires on a single Renovate-authored bump.** No actor-gate intervention; path filters alone are sufficient. Same property holds for `engine-invariants.yml`.
+- **Stage 1 → Stage 2 chain validation works as designed.** The historical `auto-mine.yml` writeback at `96d811fb` re-fired the historical `invariant-miner.yml` at `fb473a22` against the new YAML. The trust seam (YAML diff visible to reviewers before JSON gate runs) was exercised end-to-end. The merged `engine-invariants.yml` preserves the trust seam in-process: the proposed-corpus diff is emitted before the vendor-replay's verdict lands in the same commit.
+- **App-token + `--force-with-lease` writebacks succeed** without recursion-guard issues.
 - **Determinism holds.** Of the ~14 bot comments posted across the cycle, 8 were "No changes" after subsequent runs - proving the `LLENERGY_*_FROZEN_AT` env-var contracts produce reproducible outputs once the corpus has converged.
 - **Self-hosted GPU runner serialisation is observable.** The vLLM vendor gate (`75d4c0c1`) was queued behind vendor-tensorrt and arrived after the transformers chain had already converged.
 
@@ -559,7 +559,7 @@ Status note as of Phase C closure:
 
 - The runtime currently reads the vendored JSON via `_apply_vendored_rules` in `src/llenergymeasure/config/models.py` (which calls `_get_rules_loader().load_rules`). Removing the JSON commit-back without first migrating the runtime path would break runtime validation.
 - This makes the blast radius of #394's proposed simplification larger than the issue thread implied. A clean resolution depends on the Docker-only target architecture being settled first (#467), since the JSON consumption pattern is a function of how the runtime resolves rules at experiment-run time.
-- Cross-references: #394 (the original check-vs-commit question), #467 (Docker-only architecture that affects the runtime side), #393 (the auto-mine automation gap, partially closed by Phase B.4).
+- Cross-references: #394 (the original check-vs-commit question), #467 (Docker-only architecture that affects the runtime side), #393 (the historical auto-mine automation gap, partially closed by Phase B.4 and finished by the merge into `engine-invariants.yml`).
 
 Decision: leave the JSON commit-back in place; revisit when #467 lands.
 

--- a/scripts/generate_invariants_doc.py
+++ b/scripts/generate_invariants_doc.py
@@ -16,12 +16,17 @@ Run::
 from __future__ import annotations
 
 import argparse
-import subprocess
+import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_miners.build_corpus import _PROVENANCE_PRIORITY  # noqa: E402
 
 _ENGINE_DISPLAY_NAMES = {
     "transformers": "Transformers",
@@ -29,16 +34,22 @@ _ENGINE_DISPLAY_NAMES = {
     "tensorrt": "TensorRT-LLM",
 }
 
-_ADDED_BY_DISPLAY = {
+_ADDED_BY_DISPLAY: dict[str, str] = {
     "static_miner": "Static miner (AST analysis)",
     "dynamic_miner": "Dynamic miner (constructor probing)",
     "pydantic_lift": "Pydantic field lift",
     "msgspec_lift": "msgspec field lift",
     "dataclass_lift": "dataclass field lift",
+    "manual_seed": "Manual seed",
     "runtime_warning": "Runtime warning observation",
+    "observed_collision": "Observed collision (runtime hash equivalence)",
 }
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+assert set(_ADDED_BY_DISPLAY) == set(_PROVENANCE_PRIORITY), (
+    "_ADDED_BY_DISPLAY must cover every _PROVENANCE_PRIORITY source; "
+    f"missing: {set(_PROVENANCE_PRIORITY) - set(_ADDED_BY_DISPLAY)}, "
+    f"extra: {set(_ADDED_BY_DISPLAY) - set(_PROVENANCE_PRIORITY)}"
+)
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -49,32 +60,6 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     if not text.strip():
         return {}
     data = yaml.safe_load(text)
-    return data if isinstance(data, dict) else {}
-
-
-def _previous_proposed(engine: str) -> dict[str, Any]:
-    """Read the previous-revision corpus from ``HEAD~1`` for delta computation.
-
-    Returns ``{}`` on any failure (no previous version, malformed YAML,
-    not a git checkout). Deltas degrade gracefully — a fresh corpus
-    reports every rule as "added".
-    """
-    rel_path = f"configs/engine_invariants/{engine}.proposed.yaml"
-    try:
-        text = subprocess.check_output(
-            ["git", "show", f"HEAD~1:{rel_path}"],
-            cwd=_PROJECT_ROOT,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-    except subprocess.CalledProcessError:
-        return {}
-    if not text.strip():
-        return {}
-    try:
-        data = yaml.safe_load(text)
-    except yaml.YAMLError:
-        return {}
     return data if isinstance(data, dict) else {}
 
 
@@ -98,34 +83,6 @@ def _group_by_added_by(rules: list[dict[str, Any]]) -> dict[str, list[dict[str, 
     return dict(groups)
 
 
-def _delta_section(current_ids: set[str], previous_ids: set[str]) -> list[str]:
-    """Render the added-vs-removed rule-ID delta against the previous corpus."""
-    added = sorted(current_ids - previous_ids)
-    removed = sorted(previous_ids - current_ids)
-    lines: list[str] = ["## Delta vs previous SSOT version", ""]
-    if not previous_ids:
-        lines.append("_No previous corpus on `HEAD~1`; treating every rule as new._")
-        lines.append("")
-        return lines
-    if not added and not removed:
-        lines.append("_No invariants added or removed since the previous revision._")
-        lines.append("")
-        return lines
-    if added:
-        lines.append(f"**Added ({len(added)}):**")
-        lines.append("")
-        for rule_id in added:
-            lines.append(f"- `{rule_id}`")
-        lines.append("")
-    if removed:
-        lines.append(f"**Removed ({len(removed)}):**")
-        lines.append("")
-        for rule_id in removed:
-            lines.append(f"- `{rule_id}`")
-        lines.append("")
-    return lines
-
-
 def _render(engine: str) -> str:
     """Build the digest Markdown for ``engine``."""
     proposed = _load_yaml(
@@ -144,15 +101,6 @@ def _render(engine: str) -> str:
     vendored_cases = vendored.get("cases") or []
     if not isinstance(vendored_cases, list):
         vendored_cases = []
-
-    previous = _previous_proposed(engine)
-    previous_rules = previous.get("rules") or []
-    previous_ids = {
-        str(r.get("id")) for r in previous_rules if isinstance(r, dict) and r.get("id") is not None
-    }
-    current_ids = {
-        str(r.get("id")) for r in proposed_rules if isinstance(r, dict) and r.get("id") is not None
-    }
 
     display = _ENGINE_DISPLAY_NAMES.get(engine, engine.title())
     lines: list[str] = [
@@ -176,16 +124,25 @@ def _render(engine: str) -> str:
         lines.append("_No invariants in the proposed corpus._")
         lines.append("")
     else:
-        for added_by in sorted(groups):
-            display_label = _ADDED_BY_DISPLAY.get(added_by, added_by)
+        for added_by in _PROVENANCE_PRIORITY:
+            if added_by not in groups:
+                continue
+            display_label = _ADDED_BY_DISPLAY[added_by]
             rules = groups[added_by]
             lines.append(f"### {display_label} ({len(rules)})")
             lines.append("")
             for rule in rules:
                 lines.append(_rule_summary(rule))
             lines.append("")
+        unknown_keys = sorted(set(groups) - set(_PROVENANCE_PRIORITY))
+        for added_by in unknown_keys:
+            rules = groups[added_by]
+            lines.append(f"### {added_by} ({len(rules)})")
+            lines.append("")
+            for rule in rules:
+                lines.append(_rule_summary(rule))
+            lines.append("")
 
-    lines.extend(_delta_section(current_ids, previous_ids))
     return "\n".join(lines)
 
 

--- a/scripts/generate_invariants_doc.py
+++ b/scripts/generate_invariants_doc.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Generate the invariants digest doc for one engine.
+
+Produces ``docs/generated/invariants-{engine}.md`` from the corpus + vendor
+artefacts under ``configs/engine_invariants/`` and the previous corpus state
+in git history. Per the engine-coupling design doc §6, this digest is
+section 2 of the per-engine curation digest (sections 1 + 3 are produced
+by ``generate_curation_doc.py`` + an on-demand runtime-gaps renderer).
+
+Run::
+
+    python scripts/generate_invariants_doc.py --engine transformers \\
+        --out docs/generated/invariants-transformers.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_ENGINE_DISPLAY_NAMES = {
+    "transformers": "Transformers",
+    "vllm": "vLLM",
+    "tensorrt": "TensorRT-LLM",
+}
+
+_ADDED_BY_DISPLAY = {
+    "static_miner": "Static miner (AST analysis)",
+    "dynamic_miner": "Dynamic miner (constructor probing)",
+    "pydantic_lift": "Pydantic field lift",
+    "msgspec_lift": "msgspec field lift",
+    "dataclass_lift": "dataclass field lift",
+    "runtime_warning": "Runtime warning observation",
+}
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Read + parse a YAML file; return ``{}`` if missing or empty."""
+    if not path.exists():
+        return {}
+    text = path.read_text()
+    if not text.strip():
+        return {}
+    data = yaml.safe_load(text)
+    return data if isinstance(data, dict) else {}
+
+
+def _previous_proposed(engine: str) -> dict[str, Any]:
+    """Read the previous-revision corpus from ``HEAD~1`` for delta computation.
+
+    Returns ``{}`` on any failure (no previous version, malformed YAML,
+    not a git checkout). Deltas degrade gracefully — a fresh corpus
+    reports every rule as "added".
+    """
+    rel_path = f"configs/engine_invariants/{engine}.proposed.yaml"
+    try:
+        text = subprocess.check_output(
+            ["git", "show", f"HEAD~1:{rel_path}"],
+            cwd=_PROJECT_ROOT,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return {}
+    if not text.strip():
+        return {}
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _rule_summary(rule: dict[str, Any]) -> str:
+    """One-line summary of a single rule for the digest list."""
+    rule_id = rule.get("id", "<unknown>")
+    severity = rule.get("severity", "?")
+    under_test = rule.get("rule_under_test") or rule.get("message_template") or ""
+    under_test = str(under_test).replace("\n", " ").strip()
+    if len(under_test) > 100:
+        under_test = under_test[:97] + "..."
+    return f"- `{rule_id}` [{severity}] — {under_test}"
+
+
+def _group_by_added_by(rules: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Group rules by the ``added_by`` field, preserving rule order within groups."""
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rule in rules:
+        key = str(rule.get("added_by") or "unknown")
+        groups[key].append(rule)
+    return dict(groups)
+
+
+def _delta_section(current_ids: set[str], previous_ids: set[str]) -> list[str]:
+    """Render the added-vs-removed rule-ID delta against the previous corpus."""
+    added = sorted(current_ids - previous_ids)
+    removed = sorted(previous_ids - current_ids)
+    lines: list[str] = ["## Delta vs previous SSOT version", ""]
+    if not previous_ids:
+        lines.append("_No previous corpus on `HEAD~1`; treating every rule as new._")
+        lines.append("")
+        return lines
+    if not added and not removed:
+        lines.append("_No invariants added or removed since the previous revision._")
+        lines.append("")
+        return lines
+    if added:
+        lines.append(f"**Added ({len(added)}):**")
+        lines.append("")
+        for rule_id in added:
+            lines.append(f"- `{rule_id}`")
+        lines.append("")
+    if removed:
+        lines.append(f"**Removed ({len(removed)}):**")
+        lines.append("")
+        for rule_id in removed:
+            lines.append(f"- `{rule_id}`")
+        lines.append("")
+    return lines
+
+
+def _render(engine: str) -> str:
+    """Build the digest Markdown for ``engine``."""
+    proposed = _load_yaml(
+        _PROJECT_ROOT / "configs" / "engine_invariants" / f"{engine}.proposed.yaml"
+    )
+    vendored = _load_yaml(
+        _PROJECT_ROOT / "configs" / "engine_invariants" / f"{engine}.vendored.yaml"
+    )
+    ssot = _load_yaml(_PROJECT_ROOT / "engine_versions" / f"{engine}.yaml")
+
+    library = ssot.get("library") if isinstance(ssot.get("library"), dict) else {}
+    library_version = str(library.get("current_version", "<unknown>"))
+    proposed_rules = proposed.get("rules") or []
+    if not isinstance(proposed_rules, list):
+        proposed_rules = []
+    vendored_cases = vendored.get("cases") or []
+    if not isinstance(vendored_cases, list):
+        vendored_cases = []
+
+    previous = _previous_proposed(engine)
+    previous_rules = previous.get("rules") or []
+    previous_ids = {
+        str(r.get("id")) for r in previous_rules if isinstance(r, dict) and r.get("id") is not None
+    }
+    current_ids = {
+        str(r.get("id")) for r in proposed_rules if isinstance(r, dict) and r.get("id") is not None
+    }
+
+    display = _ENGINE_DISPLAY_NAMES.get(engine, engine.title())
+    lines: list[str] = [
+        f"# {display} Engine Invariants",
+        "",
+        "<!-- Auto-generated by scripts/generate_invariants_doc.py -- do not edit manually -->",
+        "",
+        f"Library version: **{library_version}**  ",
+        f"Mined at: {proposed.get('mined_at', '<unknown>')}  ",
+        f"Vendored at: {vendored.get('vendored_at', '<unknown>')}",
+        "",
+        f"**Summary:** {len(proposed_rules)} proposed rules, "
+        f"{len(vendored_cases)} vendor-confirmed cases.",
+        "",
+    ]
+
+    lines.append("## Invariants by extraction source")
+    lines.append("")
+    groups = _group_by_added_by(proposed_rules)
+    if not groups:
+        lines.append("_No invariants in the proposed corpus._")
+        lines.append("")
+    else:
+        for added_by in sorted(groups):
+            display_label = _ADDED_BY_DISPLAY.get(added_by, added_by)
+            rules = groups[added_by]
+            lines.append(f"### {display_label} ({len(rules)})")
+            lines.append("")
+            for rule in rules:
+                lines.append(_rule_summary(rule))
+            lines.append("")
+
+    lines.extend(_delta_section(current_ids, previous_ids))
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--engine",
+        required=True,
+        choices=tuple(_ENGINE_DISPLAY_NAMES),
+        help="Engine name.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output Markdown path.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    text = _render(args.engine)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `.github/workflows/engine-invariants.yml` — a single per-concern matrix workflow that replaces the deleted `auto-mine.yml` + `invariant-miner.yml` pair. Each per-engine job runs the full lifecycle in sequence:

1. **Probe** — `python -m scripts._probe --engine <e> --producer invariants` checks landmarks resolve. `fail` posts a `probe-blocked` comment + label and skips downstream (not a CI failure).
2. **SSOT-driven Docker build** — `docker build --build-arg <ENGINE>_VERSION=$(yq '.library.current_version' engine_versions/<e>.yaml)`. Layer cache makes the FROM step a no-op when the upstream tag is unchanged. transformers builds nothing (CPU-safe import; runs on `ubuntu-latest` with `uv sync`).
3. **Mine** — `python -m scripts.engine_miners.build_corpus --engine <e>` writes `configs/engine_invariants/<e>.proposed.yaml`. vllm + tensorrt run inside the engine's container.
4. **Vendor-replay** — `python scripts/vendor_rules.py --fail-on-divergence` replays the corpus against the live library and writes `configs/engine_invariants/<e>.vendored.yaml`.
5. **Doc-gen** — `python scripts/generate_invariants_doc.py --engine <e>` refreshes `docs/generated/invariants-<e>.md` (NEW, this PR). The digest groups invariants by `added_by` (static / dynamic miner; pydantic / msgspec / dataclass lift; runtime warning) and computes added/removed deltas vs `HEAD~1`.
6. **Diff classify** — `safe | breaking | no-changes` from `scripts/diff_engine_invariants.py` exit code + a literal proposed-corpus diff. Per-pipeline comment posted only on non-empty diff (suppress-on-empty); per-pipeline label cycled (`invariants-changed | invariants-breaking | invariants-safe`); cross-pipeline rollup label `safe-bump` / `probe-blocked`.
7. **Atomic writeback** — one bot commit covers all four artefacts (`<e>.proposed.yaml`, `<e>.vendored.yaml`, the digest doc, and `engine_versions/<e>.compat.json` if probe wrote it). `git push --force-with-lease`.

Triggers on `engine_versions/*.yaml`, `docker/Dockerfile.*`, `scripts/engine_miners/**`, `scripts/vendor_rules.py`, `scripts/_invariant_vendor_common.py`, `scripts/refresh_invariant_rules.sh`, `configs/engine_invariants/**`, plus `workflow_dispatch` with engine-choice + optional PR number.

## Determinism guarantees

The recursive-trigger watchdog catches synchronize-loops; this workflow's prevention is determinism, not skip-ci substring tricks (which `feedback_skip_ci_prose_trap.md` flags as a recurring footgun).

- `LLENERGY_MINER_FROZEN_AT` and `LLENERGY_VENDOR_FROZEN_AT` are set from `git log -1 --format=%aI` of the input-path SHA — the SSOT yaml, the Dockerfile, all per-engine miner modules, the lift modules, `build_corpus.py`, `vendor_rules.py`, `_invariant_vendor_common.py`, and `refresh_invariant_rules.sh`. The anchor is stable across the workflow's own commit-back (which only touches OUTPUT paths), so re-runs on unchanged source emit byte-identical YAML.
- `vendor_rules.py` honours `LLENERGY_VENDOR_FROZEN_AT` (verified in `scripts/_invariant_vendor_common.py`); `build_corpus.py` honours `LLENERGY_MINER_FROZEN_AT`. Both already sort their list-typed output fields.
- `--vendor-commit "${{ steps.anchor.outputs.sha }}"` is also derived from input paths — pin doesn't drift on the bot's own commit-back either.
- `--force-with-lease` guards against clobbering concurrent author pushes; on stale-ref the workflow exits non-zero and reruns recover the latest state.

## Cross-pipeline coordination — deferred

This workflow performs its writeback unconditionally. The `wait-for-sibling` + last-finishing-writes-atomically pattern from the design doc §5 requires `engine-schemas.yml` to exist as a sibling. That workflow lands in a follow-up alongside which the wait-for-sibling step will be added to BOTH workflows simultaneously. Today's behaviour is fine because there is no sibling to coordinate with.

`docker-publish.yml` extension to publish images on SSOT bumps lands in a follow-up; seeded `invariants-vllm.md` / `invariants-tensorrt.md` digests will be created naturally on the workflow's first run; stale code comments in `scripts/vendor_rules.py` + `tests/unit/engine_miners/test_build_corpus.py` referencing the deleted workflows are tracked for the same follow-up.

## Test plan

- [x] YAML syntax — `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/engine-invariants.yml'))"` parses cleanly.
- [x] Doc generator runs locally on all three engines:
  - `python3 scripts/generate_invariants_doc.py --engine transformers --out /tmp/inv-t.md` → 63 lines, 41 rules grouped by source.
  - `python3 scripts/generate_invariants_doc.py --engine vllm --out /tmp/inv-v.md` → 74 lines.
  - `python3 scripts/generate_invariants_doc.py --engine tensorrt --out /tmp/inv-tt.md` → 43 lines.
- [x] `ruff format scripts/ src/ tests/` — 291 files unchanged after.
- [x] `ruff check scripts/ src/ tests/` — no errors in the new file (7 pre-existing errors elsewhere are unrelated).
- [x] `uv run --no-sync python -m pytest tests/unit/scripts/engine_miners/test_ssot_pin_fixpoint.py tests/unit/scripts/test_probe.py -q` — 24 / 24 pass.
- [ ] Workflow itself does not fire on this PR (path filters target `engine_versions/`, miners, the Dockerfiles, etc., not workflow file additions). Required CI checks (`test`, `lint`, `type-check`) will run.