### PR TITLE
feat(workflows): add engine-schemas workflow with cross-pipeline coordination

### DIFF
--- a/.github/workflows/engine-invariants.yml
+++ b/.github/workflows/engine-invariants.yml
@@ -137,8 +137,12 @@ jobs:
           )
           SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          if [[ -z "${DATE}" ]]; then
+            echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
+            exit 1
+          fi
           echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
-          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check
         id: probe
@@ -306,16 +310,35 @@ jobs:
             no-changes) ;;
           esac
 
+      - name: Detect sibling workflow run for this SHA
+        # PRs whose path-filter only matches one workflow's exclusive paths
+        # never trigger the sibling, so wait-on-check-action would block
+        # for its full timeout. This pre-flight skips the wait when no
+        # sibling run was queued for this head SHA.
+        id: sibling
+        if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          SIBLING_NAME="Engine Schemas — Probe + Discover"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq "[.workflow_runs[] | select(.name == \"${SIBLING_NAME}\")] | length")
+          if [[ "${COUNT}" -gt 0 ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Sibling workflow ${SIBLING_NAME} did not fire for this SHA; skipping wait."
+          fi
+
       - name: Wait for sibling pipeline to complete
         # Block until the engine-schemas pipeline finishes for this same
         # head SHA. Already-finished sibling exits immediately. Whichever
         # pipeline reaches its writeback step second performs its commit
         # against the tip that already includes the first pipeline's
         # writeback (disjoint paths; force-with-lease + rebase handle the
-        # fast-forward). The atomic-writeback property emerges from the
-        # wait + disjoint paths combination, no separate summariser
-        # workflow needed.
-        if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        # fast-forward).
+        if: steps.probe.outputs.verdict == 'pass' && steps.sibling.outputs.exists == 'true'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           check-name: 'Engine Schemas — Probe + Discover'
@@ -324,19 +347,18 @@ jobs:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Atomic writeback
-        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
           # Pull in any sibling-pipeline writeback that landed first.
-          git pull --rebase --autostash || true
+          git pull --rebase --autostash
 
           git add \
             "${CORPUS_DIR}/transformers.proposed.yaml" \
             "${CORPUS_DIR}/transformers.vendored.yaml" \
-            docs/generated/invariants-transformers.md \
-            engine_versions/transformers.compat.json 2>/dev/null || true
+            docs/generated/invariants-transformers.md
 
           if git diff --cached --quiet; then
             echo "No engine-invariants artefact changes to commit."
@@ -402,11 +424,10 @@ jobs:
           echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Build or reuse vLLM image
-        # SSOT-driven build-arg per the engine-coupling design's D-1
-        # decision: Renovate updates SSOT only; Dockerfile ARG default
-        # is a fallback for local manual builds; CI passes the SSOT
-        # value at docker-build time. Layer cache makes the FROM step a
-        # no-op when the upstream tag is unchanged.
+        # SSOT is the canonical version; the Dockerfile ARG default is a
+        # local-build fallback. CI passes the SSOT value at build time so
+        # the two cannot drift. Layer cache makes the FROM step a no-op
+        # when the upstream tag is unchanged.
         run: |
           IMAGE="${{ steps.version.outputs.image }}"
           if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
@@ -439,8 +460,12 @@ jobs:
           )
           SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          if [[ -z "${DATE}" ]]; then
+            echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
+            exit 1
+          fi
           echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
-          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check (in container)
         id: probe
@@ -645,8 +670,25 @@ jobs:
             no-changes) ;;
           esac
 
-      - name: Wait for sibling pipeline to complete
+      - name: Detect sibling workflow run for this SHA
+        id: sibling
         if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          SIBLING_NAME="Engine Schemas — Probe + Discover"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq "[.workflow_runs[] | select(.name == \"${SIBLING_NAME}\")] | length")
+          if [[ "${COUNT}" -gt 0 ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Sibling workflow ${SIBLING_NAME} did not fire for this SHA; skipping wait."
+          fi
+
+      - name: Wait for sibling pipeline to complete
+        if: steps.probe.outputs.verdict == 'pass' && steps.sibling.outputs.exists == 'true'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           check-name: 'Engine Schemas — Probe + Discover'
@@ -655,19 +697,18 @@ jobs:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Atomic writeback
-        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
           # Pull in any sibling-pipeline writeback that landed first.
-          git pull --rebase --autostash || true
+          git pull --rebase --autostash
 
           git add \
             "${CORPUS_DIR}/vllm.proposed.yaml" \
             "${CORPUS_DIR}/vllm.vendored.yaml" \
-            docs/generated/invariants-vllm.md \
-            engine_versions/vllm.compat.json 2>/dev/null || true
+            docs/generated/invariants-vllm.md
 
           if git diff --cached --quiet; then
             echo "No engine-invariants artefact changes to commit."
@@ -730,8 +771,9 @@ jobs:
           echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Build or reuse TRT-LLM image
-        # SSOT-driven build-arg per D-1; layer cache keeps rebuilds fast
-        # when the NGC tag is unchanged. Note Dockerfile ARG is named
+        # SSOT is the canonical version; the Dockerfile ARG default is a
+        # local-build fallback. Layer cache keeps rebuilds fast when the
+        # NGC tag is unchanged. Note Dockerfile ARG is named
         # TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
         run: |
           IMAGE="${{ steps.version.outputs.image }}"
@@ -765,8 +807,12 @@ jobs:
           )
           SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          if [[ -z "${DATE}" ]]; then
+            echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
+            exit 1
+          fi
           echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
-          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check (in container)
         id: probe
@@ -990,8 +1036,25 @@ jobs:
             no-changes) ;;
           esac
 
-      - name: Wait for sibling pipeline to complete
+      - name: Detect sibling workflow run for this SHA
+        id: sibling
         if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          SIBLING_NAME="Engine Schemas — Probe + Discover"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq "[.workflow_runs[] | select(.name == \"${SIBLING_NAME}\")] | length")
+          if [[ "${COUNT}" -gt 0 ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Sibling workflow ${SIBLING_NAME} did not fire for this SHA; skipping wait."
+          fi
+
+      - name: Wait for sibling pipeline to complete
+        if: steps.probe.outputs.verdict == 'pass' && steps.sibling.outputs.exists == 'true'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           check-name: 'Engine Schemas — Probe + Discover'
@@ -1000,19 +1063,18 @@ jobs:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Atomic writeback
-        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
           # Pull in any sibling-pipeline writeback that landed first.
-          git pull --rebase --autostash || true
+          git pull --rebase --autostash
 
           git add \
             "${CORPUS_DIR}/tensorrt.proposed.yaml" \
             "${CORPUS_DIR}/tensorrt.vendored.yaml" \
-            docs/generated/invariants-tensorrt.md \
-            engine_versions/tensorrt.compat.json 2>/dev/null || true
+            docs/generated/invariants-tensorrt.md
 
           if git diff --cached --quiet; then
             echo "No engine-invariants artefact changes to commit."

--- a/.github/workflows/engine-schemas.yml
+++ b/.github/workflows/engine-schemas.yml
@@ -1,29 +1,33 @@
-name: Engine Invariants — Probe + Mine + Vendor
+name: Engine Schemas — Probe + Discover
 
-# Per-concern workflow for the engine-invariants layer. Each per-engine job
-# probes the producer module's landmarks, mines the rules corpus, vendor-
-# replays it against the live library, regenerates the invariants digest
-# doc, and atomically commits all four artefacts back to the PR branch.
+# Per-concern workflow for the engine-schemas (parameter-discovery) layer.
+# Each per-engine job probes the introspector module's landmarks, discovers
+# the live engine's typed schema inside the SSOT-driven Docker image,
+# regenerates the curation digest doc, and (after the sibling pipeline
+# completes) atomically commits the artefacts back to the PR branch.
 #
-# Per-engine runner choice:
+# Sibling of engine-invariants.yml. Same App-token + commit-back + comment
+# + label pattern; different artefact kind (introspected schemas vs mined
+# invariants). The two workflows coordinate via lewagon/wait-on-check-action
+# so each blocks until the other has finished, then both writebacks land on
+# disjoint paths (engine-schemas writes JSON + curation md; engine-invariants
+# writes proposed/vendored YAMLs + invariants md). force-with-lease + the
+# wait gate give atomic semantics without a separate summariser workflow.
+#
+# Per-engine runner choice mirrors engine-invariants.yml:
 #   transformers : ubuntu-latest GH-hosted runner; CPU-safe import.
 #   vllm         : self-hosted GPU runner inside llenergymeasure:vllm-${VER}.
-#                  vLLM miners ARE CPU-safe but the unified uv.lock breaks
-#                  vllm's torch/torchvision via tensorrt-llm 0.21.0's
-#                  transitive constraints (#437, #464); building inside the
-#                  vLLM image side-steps the resolution problem.
 #   tensorrt     : self-hosted GPU runner inside llenergymeasure:tensorrt-
 #                  ${VER}; TRT-LLM 0.21.0 loads CUDA bindings on import so
 #                  CPU runners cannot import the library at all.
 #
 # Determinism contract:
-#   The LLENERGY_MINER_FROZEN_AT and LLENERGY_VENDOR_FROZEN_AT env vars are
-#   set from the author date of the most recent commit touching any INPUT
-#   path (Dockerfile, miner modules, lift modules, build_corpus, vendor
-#   script, refresh helper, SSOT yaml). The anchor is stable across the
-#   workflow's own commit-back (which only touches OUTPUT paths), so re-
-#   runs on unchanged source emit byte-identical YAML. This determinism
-#   is THE prevention against the synchronize-loop the watchdog catches.
+#   The LLENERGY_DISCOVERY_FROZEN_AT env var is set from the author date of
+#   the most recent commit touching any INPUT path (engine SSOT, Dockerfile,
+#   introspector modules). The anchor is stable across the workflow's own
+#   commit-back (which only touches OUTPUT paths), so re-runs on unchanged
+#   source emit byte-identical JSON envelopes. This determinism is THE
+#   prevention against the synchronize-loop the watchdog catches.
 
 on:
   pull_request:
@@ -31,15 +35,12 @@ on:
     paths:
       - "engine_versions/*.yaml"
       - "docker/Dockerfile.*"
-      - "scripts/engine_miners/**"
-      - "scripts/vendor_rules.py"
-      - "scripts/_invariant_vendor_common.py"
-      - "scripts/refresh_invariant_rules.sh"
-      - "configs/engine_invariants/**"
+      - "scripts/engine_introspectors/**"
+      - "src/llenergymeasure/config/discovered_schemas/**"
   workflow_dispatch:
     inputs:
       engine:
-        description: "Engine to probe + mine + vendor"
+        description: "Engine to probe + discover"
         required: true
         type: choice
         options:
@@ -57,14 +58,14 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: engine-invariants-${{ github.head_ref || github.ref }}
+  group: engine-schemas-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:
-  CORPUS_DIR: configs/engine_invariants
+  SCHEMAS_DIR: src/llenergymeasure/config/discovered_schemas
 
 jobs:
-  invariants-transformers:
+  schemas-transformers:
     if: github.event_name != 'workflow_dispatch' || inputs.engine == 'transformers' || inputs.engine == 'all'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -93,7 +94,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-suffix: engine-invariants-transformers-3.12
+          cache-suffix: engine-schemas-transformers-3.12
           python-version: "3.12"
 
       - name: Install dependencies
@@ -108,115 +109,82 @@ jobs:
             exit 1
           fi
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "image=llenergymeasure:transformers-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Compute stable mining + vendor anchor
+      - name: Compute stable discovery anchor
         id: anchor
-        # Pin the YAML's mined_at + the vendor envelope's vendored_at to
-        # the SHA + author date of the most recent commit touching any
-        # INPUT path. Stable across the workflow's own commit-back (which
-        # only touches OUTPUT YAML), so re-runs on unchanged source emit
-        # byte-identical envelopes. Without this, every re-run emits a
-        # fresh wallclock timestamp, git diff picks it up, the commit-back
-        # fires, and the synchronize loops.
+        # Pin the discovered_at field to the author date of the most recent
+        # commit touching any INPUT path. Stable across the workflow's own
+        # commit-back (which only touches OUTPUT paths), so re-runs on
+        # unchanged source emit byte-identical envelopes. Without this,
+        # every re-run emits a fresh wallclock timestamp, git diff picks
+        # it up, the commit-back fires, and the synchronize loops.
         run: |
           PATHS=(
             "engine_versions/transformers.yaml"
             "docker/Dockerfile.transformers"
-            "scripts/engine_miners/transformers_static_miner.py"
-            "scripts/engine_miners/transformers_dynamic_miner.py"
-            "scripts/engine_miners/transformers_miner.py"
-            "scripts/engine_miners/build_corpus.py"
-            "scripts/engine_miners/_base.py"
-            "scripts/engine_miners/_pydantic_lift.py"
-            "scripts/engine_miners/_msgspec_lift.py"
-            "scripts/engine_miners/_dataclass_lift.py"
-            "scripts/engine_miners/_fixpoint_test.py"
-            "scripts/vendor_rules.py"
-            "scripts/_invariant_vendor_common.py"
-            "scripts/refresh_invariant_rules.sh"
+            "scripts/engine_introspectors/transformers_introspector.py"
+            "scripts/engine_introspectors/_common.py"
+            "scripts/engine_introspectors/__init__.py"
+            "scripts/engine_introspectors/__main__.py"
           )
-          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
-          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
           echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check
         id: probe
         run: |
           uv run python -m scripts._probe \
-            --engine transformers --producer invariants \
+            --engine transformers --producer schemas \
             > /tmp/probe-transformers.json
           VERDICT=$(jq -r '.verdict' /tmp/probe-transformers.json)
           echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
 
-      - name: Save current YAMLs for diffing
+      - name: Save current schema for diffing
         if: steps.probe.outputs.verdict == 'pass'
         run: |
-          mkdir -p /tmp/engine-invariants-diff
-          for KIND in proposed vendored; do
-            OLD_YAML="${CORPUS_DIR}/transformers.${KIND}.yaml"
-            DEST="/tmp/engine-invariants-diff/transformers.${KIND}.old.yaml"
-            if [[ -f "$OLD_YAML" ]]; then
-              cp "$OLD_YAML" "$DEST"
-            else
-              : > "$DEST"
-            fi
-          done
+          mkdir -p /tmp/engine-schemas-diff
+          OLD="${SCHEMAS_DIR}/transformers.json"
+          DEST="/tmp/engine-schemas-diff/transformers.old.json"
+          if [[ -f "$OLD" ]]; then
+            cp "$OLD" "$DEST"
+          else
+            echo '{}' > "$DEST"
+          fi
 
-      - name: Mine corpus — write proposed.yaml
+      - name: Discover schema
         if: steps.probe.outputs.verdict == 'pass'
         env:
-          LLENERGY_MINER_FROZEN_AT: ${{ steps.anchor.outputs.date }}
+          LLENERGY_DISCOVERY_FROZEN_AT: ${{ steps.anchor.outputs.date }}
         run: |
-          uv run python -m scripts.engine_miners.build_corpus --engine transformers
-
-      - name: Vendor-replay — write vendored.yaml
-        if: steps.probe.outputs.verdict == 'pass'
-        env:
-          LLENERGY_VENDOR_FROZEN_AT: ${{ steps.anchor.outputs.date }}
-        run: |
-          uv run python scripts/vendor_rules.py \
+          uv run python -m scripts.engine_introspectors \
             --engine transformers \
-            --corpus "${CORPUS_DIR}/transformers.proposed.yaml" \
-            --out "${CORPUS_DIR}/transformers.vendored.yaml" \
-            --vendor-commit "${{ steps.anchor.outputs.sha }}" \
-            --fail-on-divergence
+            --output "${SCHEMAS_DIR}/transformers.json"
 
-      - name: Regenerate invariants digest doc
+      - name: Regenerate curation digests
         if: steps.probe.outputs.verdict == 'pass'
+        # The generator emits docs/generated/curation-{engine}.md for ALL
+        # three engines; re-running is cheap + idempotent, and we only stage
+        # the engine-specific file in the writeback step below.
         run: |
-          uv run python scripts/generate_invariants_doc.py \
-            --engine transformers \
-            --out docs/generated/invariants-transformers.md
+          uv run python scripts/generate_curation_doc.py
 
-      - name: Classify diff (proposed + vendored)
+      - name: Classify diff
         if: steps.probe.outputs.verdict == 'pass'
         id: diff
         run: |
           set +e
-          uv run python scripts/diff_engine_invariants.py \
-            /tmp/engine-invariants-diff/transformers.vendored.old.yaml \
-            "${CORPUS_DIR}/transformers.vendored.yaml" \
-            --out /tmp/engine-invariants-diff/transformers.vendored.md \
-            --title "Transformers vendored invariants diff"
-          VENDORED_EXIT=$?
+          uv run python scripts/diff_discovered_schemas.py \
+            /tmp/engine-schemas-diff/transformers.old.json \
+            "${SCHEMAS_DIR}/transformers.json" \
+            > /tmp/engine-schemas-diff/transformers.diff.json
+          DIFF_EXIT=$?
           set -e
 
-          PROPOSED_CHANGED=true
-          if diff -q /tmp/engine-invariants-diff/transformers.proposed.old.yaml \
-                    "${CORPUS_DIR}/transformers.proposed.yaml" >/dev/null 2>&1; then
-            PROPOSED_CHANGED=false
-          fi
-
-          VENDORED_CHANGED=true
-          if diff -q /tmp/engine-invariants-diff/transformers.vendored.old.yaml \
-                    "${CORPUS_DIR}/transformers.vendored.yaml" >/dev/null 2>&1; then
-            VENDORED_CHANGED=false
-          fi
-
-          if [[ "$PROPOSED_CHANGED" == "false" && "$VENDORED_CHANGED" == "false" ]]; then
+          if diff -q /tmp/engine-schemas-diff/transformers.old.json \
+                    "${SCHEMAS_DIR}/transformers.json" >/dev/null 2>&1; then
             CLASSIFICATION="no-changes"
-          elif [[ $VENDORED_EXIT -eq 1 ]]; then
+          elif [[ $DIFF_EXIT -eq 1 ]]; then
             CLASSIFICATION="breaking"
           else
             CLASSIFICATION="safe"
@@ -224,25 +192,23 @@ jobs:
           echo "classification=${CLASSIFICATION}" >> "$GITHUB_OUTPUT"
 
           {
-            echo "## Engine invariants — transformers"
+            echo "## Engine schemas — transformers"
             echo
             if [[ "$CLASSIFICATION" == "no-changes" ]]; then
-              echo "_No changes to proposed or vendored invariants._"
+              echo "_No changes to discovered schema._"
             else
-              if [[ "$PROPOSED_CHANGED" == "true" ]]; then
-                echo "### Proposed corpus diff"
-                echo
-                echo '```diff'
-                diff -u /tmp/engine-invariants-diff/transformers.proposed.old.yaml \
-                        "${CORPUS_DIR}/transformers.proposed.yaml" | head -n 200 || true
-                echo '```'
-                echo
-              fi
-              if [[ -f /tmp/engine-invariants-diff/transformers.vendored.md ]]; then
-                cat /tmp/engine-invariants-diff/transformers.vendored.md
-              fi
+              SUMMARY=$(jq -r '.summary // "schema diff produced"' /tmp/engine-schemas-diff/transformers.diff.json 2>/dev/null || echo "schema diff produced")
+              echo "${SUMMARY}"
+              echo
+              echo "<details><summary>Structured diff</summary>"
+              echo
+              echo '```json'
+              jq '.' /tmp/engine-schemas-diff/transformers.diff.json 2>/dev/null | head -n 200 || true
+              echo '```'
+              echo
+              echo "</details>"
             fi
-          } > /tmp/engine-invariants-diff/transformers.summary.md
+          } > /tmp/engine-schemas-diff/transformers.summary.md
 
       - name: Probe-fail comment (skip downstream)
         if: steps.probe.outputs.verdict == 'fail' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -255,13 +221,13 @@ jobs:
           fi
           MISSING=$(jq -r '.landmarks_missing | join(", ")' /tmp/probe-transformers.json)
           {
-            echo "## Engine invariants — transformers (probe-blocked)"
+            echo "## Engine schemas — transformers (probe-blocked)"
             echo
-            echo "Probe failed: producer landmarks no longer resolve under the installed library."
+            echo "Probe failed: introspector landmarks no longer resolve under the installed library."
             echo
             echo "Missing: \`${MISSING}\`"
             echo
-            echo "Downstream mine + vendor steps were skipped. Patch the producer module or run \`@llem-ci-bot /approve-reuse transformers invariants\` once the landmarks have been updated."
+            echo "Downstream discovery was skipped. Patch the introspector module or run \`@llem-ci-bot /approve-reuse transformers schemas\` once the landmarks have been updated."
           } | gh pr comment "$PR_NUMBER" --body-file -
           gh pr edit "$PR_NUMBER" --add-label "probe-blocked" 2>/dev/null || true
 
@@ -269,13 +235,12 @@ jobs:
         if: steps.probe.outputs.verdict == 'pass'
         uses: actions/upload-artifact@v4
         with:
-          name: engine-invariants-diff-transformers
+          name: engine-schemas-diff-transformers
           path: |
-            /tmp/engine-invariants-diff/transformers.proposed.old.yaml
-            /tmp/engine-invariants-diff/transformers.vendored.old.yaml
-            /tmp/engine-invariants-diff/transformers.summary.md
-            ${{ env.CORPUS_DIR }}/transformers.proposed.yaml
-            ${{ env.CORPUS_DIR }}/transformers.vendored.yaml
+            /tmp/engine-schemas-diff/transformers.old.json
+            /tmp/engine-schemas-diff/transformers.diff.json
+            /tmp/engine-schemas-diff/transformers.summary.md
+            ${{ env.SCHEMAS_DIR }}/transformers.json
 
       - name: Post per-pipeline comment (suppress on empty)
         if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -286,7 +251,7 @@ jobs:
           if [[ -z "$PR_NUMBER" ]]; then
             exit 0
           fi
-          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-invariants-diff/transformers.summary.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-schemas-diff/transformers.summary.md
 
       - name: Apply per-pipeline label
         if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -297,28 +262,27 @@ jobs:
           if [[ -z "$PR_NUMBER" ]]; then
             exit 0
           fi
-          for L in invariants-changed invariants-breaking invariants-safe probe-blocked; do
+          for L in schemas-changed schemas-breaking schemas-safe probe-blocked; do
             gh pr edit "$PR_NUMBER" --remove-label "$L" 2>/dev/null || true
           done
           case "${{ steps.diff.outputs.classification }}" in
-            breaking)  gh pr edit "$PR_NUMBER" --add-label "invariants-breaking" --add-label "invariants-changed" 2>/dev/null || true ;;
-            safe)      gh pr edit "$PR_NUMBER" --add-label "invariants-safe" --add-label "invariants-changed" 2>/dev/null || true ;;
+            breaking)  gh pr edit "$PR_NUMBER" --add-label "schemas-breaking" --add-label "schemas-changed" 2>/dev/null || true ;;
+            safe)      gh pr edit "$PR_NUMBER" --add-label "schemas-safe" --add-label "schemas-changed" 2>/dev/null || true ;;
             no-changes) ;;
           esac
 
       - name: Wait for sibling pipeline to complete
-        # Block until the engine-schemas pipeline finishes for this same
+        # Block until the engine-invariants pipeline finishes for this same
         # head SHA. Already-finished sibling exits immediately. Whichever
         # pipeline reaches its writeback step second performs its commit
         # against the tip that already includes the first pipeline's
-        # writeback (disjoint paths; force-with-lease + rebase handle the
-        # fast-forward). The atomic-writeback property emerges from the
-        # wait + disjoint paths combination, no separate summariser
-        # workflow needed.
+        # writeback (disjoint paths; force-with-lease handles the fast-
+        # forward). The atomic-writeback property emerges from the wait +
+        # disjoint paths combination, no separate summariser needed.
         if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
-          check-name: 'Engine Schemas — Probe + Discover'
+          check-name: 'Engine Invariants — Probe + Mine + Vendor'
           ref: ${{ github.event.pull_request.head.sha }}
           timeout: '600'
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -333,17 +297,16 @@ jobs:
           git pull --rebase --autostash || true
 
           git add \
-            "${CORPUS_DIR}/transformers.proposed.yaml" \
-            "${CORPUS_DIR}/transformers.vendored.yaml" \
-            docs/generated/invariants-transformers.md \
+            "${SCHEMAS_DIR}/transformers.json" \
+            docs/generated/curation-transformers.md \
             engine_versions/transformers.compat.json 2>/dev/null || true
 
           if git diff --cached --quiet; then
-            echo "No engine-invariants artefact changes to commit."
+            echo "No engine-schemas artefact changes to commit."
             exit 0
           fi
 
-          git commit -m "chore(invariants): refresh transformers proposed + vendored corpus"
+          git commit -m "chore(schemas): refresh transformers discovered schema"
           git push --force-with-lease
 
       - name: Apply cross-pipeline rollup label
@@ -361,7 +324,7 @@ jobs:
             gh pr edit "$PR_NUMBER" --remove-label "safe-bump" 2>/dev/null || true
           fi
 
-  invariants-vllm:
+  schemas-vllm:
     if: github.event_name != 'workflow_dispatch' || inputs.engine == 'vllm' || inputs.engine == 'all'
     runs-on: self-hosted
     timeout-minutes: 60
@@ -377,7 +340,7 @@ jobs:
       - name: Clean workspace (fix root-owned files from prior Docker runs)
         # Container-written artefacts persist as root-owned on the self-
         # hosted runner and break subsequent checkouts otherwise. Mirrors
-        # gpu-ci.yml.
+        # gpu-ci.yml + engine-invariants.yml.
         run: |
           docker run --rm \
             -v "${{ github.workspace }}":/workspace \
@@ -419,27 +382,18 @@ jobs:
             echo "Reusing cached $IMAGE."
           fi
 
-      - name: Compute stable mining + vendor anchor
+      - name: Compute stable discovery anchor
         id: anchor
         run: |
           PATHS=(
             "engine_versions/vllm.yaml"
             "docker/Dockerfile.vllm"
-            "scripts/engine_miners/vllm_static_miner.py"
-            "scripts/engine_miners/vllm_dynamic_miner.py"
-            "scripts/engine_miners/build_corpus.py"
-            "scripts/engine_miners/_base.py"
-            "scripts/engine_miners/_pydantic_lift.py"
-            "scripts/engine_miners/_msgspec_lift.py"
-            "scripts/engine_miners/_dataclass_lift.py"
-            "scripts/engine_miners/_fixpoint_test.py"
-            "scripts/vendor_rules.py"
-            "scripts/_invariant_vendor_common.py"
-            "scripts/refresh_invariant_rules.sh"
+            "scripts/engine_introspectors/vllm_introspector.py"
+            "scripts/engine_introspectors/_common.py"
+            "scripts/engine_introspectors/__init__.py"
+            "scripts/engine_introspectors/__main__.py"
           )
-          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
-          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
           echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check (in container)
@@ -452,7 +406,7 @@ jobs:
             -w /repo \
             --entrypoint python3 \
             "$IMAGE" \
-            -m scripts._probe --engine vllm --producer invariants \
+            -m scripts._probe --engine vllm --producer schemas \
             > /tmp/probe-vllm.json
           VERDICT=$(jq -r '.verdict' /tmp/probe-vllm.json)
           echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
@@ -464,47 +418,37 @@ jobs:
             -v "${{ github.workspace }}":/workspace \
             alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
 
-      - name: Save current YAMLs for diffing
+      - name: Save current schema for diffing
         if: steps.probe.outputs.verdict == 'pass'
         run: |
-          mkdir -p /tmp/engine-invariants-diff
-          for KIND in proposed vendored; do
-            OLD_YAML="${CORPUS_DIR}/vllm.${KIND}.yaml"
-            DEST="/tmp/engine-invariants-diff/vllm.${KIND}.old.yaml"
-            if [[ -f "$OLD_YAML" ]]; then
-              cp "$OLD_YAML" "$DEST"
-            else
-              : > "$DEST"
-            fi
-          done
+          mkdir -p /tmp/engine-schemas-diff
+          OLD="${SCHEMAS_DIR}/vllm.json"
+          DEST="/tmp/engine-schemas-diff/vllm.old.json"
+          if [[ -f "$OLD" ]]; then
+            cp "$OLD" "$DEST"
+          else
+            echo '{}' > "$DEST"
+          fi
 
-      - name: Mine + vendor inside container
+      - name: Discover schema inside container
         if: steps.probe.outputs.verdict == 'pass'
         env:
           IMAGE: ${{ steps.version.outputs.image }}
-          ANCHOR_SHA: ${{ steps.anchor.outputs.sha }}
           ANCHOR_DATE: ${{ steps.anchor.outputs.date }}
         run: |
           docker run --rm --gpus all \
-            -e LLENERGY_MINER_FROZEN_AT="${ANCHOR_DATE}" \
-            -e LLENERGY_VENDOR_FROZEN_AT="${ANCHOR_DATE}" \
+            -e LLENERGY_DISCOVERY_FROZEN_AT="${ANCHOR_DATE}" \
             -e PYTHONDONTWRITEBYTECODE=1 \
             -v "${{ github.workspace }}:/repo" \
             -w /repo \
-            --entrypoint bash \
+            --entrypoint python3 \
             "$IMAGE" \
-            -c "
-              set -euo pipefail
-              python3 -m scripts.engine_miners.build_corpus --engine vllm
-              python3 scripts/vendor_rules.py \
-                --engine vllm \
-                --corpus '${CORPUS_DIR}/vllm.proposed.yaml' \
-                --out '${CORPUS_DIR}/vllm.vendored.yaml' \
-                --vendor-commit '${ANCHOR_SHA}' \
-                --fail-on-divergence
-            "
+            -m scripts.engine_introspectors \
+              --engine vllm \
+              --image-ref "${IMAGE}" \
+              --output "${SCHEMAS_DIR}/vllm.json"
 
-      - name: Fix container-written file ownership (mine + vendor)
+      - name: Fix container-written file ownership (discover)
         if: always()
         run: |
           docker run --rm \
@@ -518,44 +462,30 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-suffix: engine-invariants-vllm-docgen-3.12
+          cache-suffix: engine-schemas-vllm-docgen-3.12
           python-version: "3.12"
 
-      - name: Regenerate invariants digest doc
+      - name: Regenerate curation digests
         if: steps.probe.outputs.verdict == 'pass'
         run: |
-          uv run --no-sync --with pyyaml python scripts/generate_invariants_doc.py \
-            --engine vllm \
-            --out docs/generated/invariants-vllm.md
+          uv run --no-sync --with pyyaml --with pydantic python scripts/generate_curation_doc.py
 
-      - name: Classify diff (proposed + vendored)
+      - name: Classify diff
         if: steps.probe.outputs.verdict == 'pass'
         id: diff
         run: |
           set +e
-          uv run --no-sync --with pyyaml python scripts/diff_engine_invariants.py \
-            /tmp/engine-invariants-diff/vllm.vendored.old.yaml \
-            "${CORPUS_DIR}/vllm.vendored.yaml" \
-            --out /tmp/engine-invariants-diff/vllm.vendored.md \
-            --title "vLLM vendored invariants diff"
-          VENDORED_EXIT=$?
+          uv run --no-sync python scripts/diff_discovered_schemas.py \
+            /tmp/engine-schemas-diff/vllm.old.json \
+            "${SCHEMAS_DIR}/vllm.json" \
+            > /tmp/engine-schemas-diff/vllm.diff.json
+          DIFF_EXIT=$?
           set -e
 
-          PROPOSED_CHANGED=true
-          if diff -q /tmp/engine-invariants-diff/vllm.proposed.old.yaml \
-                    "${CORPUS_DIR}/vllm.proposed.yaml" >/dev/null 2>&1; then
-            PROPOSED_CHANGED=false
-          fi
-
-          VENDORED_CHANGED=true
-          if diff -q /tmp/engine-invariants-diff/vllm.vendored.old.yaml \
-                    "${CORPUS_DIR}/vllm.vendored.yaml" >/dev/null 2>&1; then
-            VENDORED_CHANGED=false
-          fi
-
-          if [[ "$PROPOSED_CHANGED" == "false" && "$VENDORED_CHANGED" == "false" ]]; then
+          if diff -q /tmp/engine-schemas-diff/vllm.old.json \
+                    "${SCHEMAS_DIR}/vllm.json" >/dev/null 2>&1; then
             CLASSIFICATION="no-changes"
-          elif [[ $VENDORED_EXIT -eq 1 ]]; then
+          elif [[ $DIFF_EXIT -eq 1 ]]; then
             CLASSIFICATION="breaking"
           else
             CLASSIFICATION="safe"
@@ -563,25 +493,23 @@ jobs:
           echo "classification=${CLASSIFICATION}" >> "$GITHUB_OUTPUT"
 
           {
-            echo "## Engine invariants — vllm"
+            echo "## Engine schemas — vllm"
             echo
             if [[ "$CLASSIFICATION" == "no-changes" ]]; then
-              echo "_No changes to proposed or vendored invariants._"
+              echo "_No changes to discovered schema._"
             else
-              if [[ "$PROPOSED_CHANGED" == "true" ]]; then
-                echo "### Proposed corpus diff"
-                echo
-                echo '```diff'
-                diff -u /tmp/engine-invariants-diff/vllm.proposed.old.yaml \
-                        "${CORPUS_DIR}/vllm.proposed.yaml" | head -n 200 || true
-                echo '```'
-                echo
-              fi
-              if [[ -f /tmp/engine-invariants-diff/vllm.vendored.md ]]; then
-                cat /tmp/engine-invariants-diff/vllm.vendored.md
-              fi
+              SUMMARY=$(jq -r '.summary // "schema diff produced"' /tmp/engine-schemas-diff/vllm.diff.json 2>/dev/null || echo "schema diff produced")
+              echo "${SUMMARY}"
+              echo
+              echo "<details><summary>Structured diff</summary>"
+              echo
+              echo '```json'
+              jq '.' /tmp/engine-schemas-diff/vllm.diff.json 2>/dev/null | head -n 200 || true
+              echo '```'
+              echo
+              echo "</details>"
             fi
-          } > /tmp/engine-invariants-diff/vllm.summary.md
+          } > /tmp/engine-schemas-diff/vllm.summary.md
 
       - name: Probe-fail comment (skip downstream)
         if: steps.probe.outputs.verdict == 'fail' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -594,13 +522,13 @@ jobs:
           fi
           MISSING=$(jq -r '.landmarks_missing | join(", ")' /tmp/probe-vllm.json)
           {
-            echo "## Engine invariants — vllm (probe-blocked)"
+            echo "## Engine schemas — vllm (probe-blocked)"
             echo
-            echo "Probe failed: producer landmarks no longer resolve under the installed library."
+            echo "Probe failed: introspector landmarks no longer resolve under the installed library."
             echo
             echo "Missing: \`${MISSING}\`"
             echo
-            echo "Downstream mine + vendor steps were skipped. Patch the producer module or run \`@llem-ci-bot /approve-reuse vllm invariants\` once the landmarks have been updated."
+            echo "Downstream discovery was skipped. Patch the introspector module or run \`@llem-ci-bot /approve-reuse vllm schemas\` once the landmarks have been updated."
           } | gh pr comment "$PR_NUMBER" --body-file -
           gh pr edit "$PR_NUMBER" --add-label "probe-blocked" 2>/dev/null || true
 
@@ -608,13 +536,12 @@ jobs:
         if: steps.probe.outputs.verdict == 'pass'
         uses: actions/upload-artifact@v4
         with:
-          name: engine-invariants-diff-vllm
+          name: engine-schemas-diff-vllm
           path: |
-            /tmp/engine-invariants-diff/vllm.proposed.old.yaml
-            /tmp/engine-invariants-diff/vllm.vendored.old.yaml
-            /tmp/engine-invariants-diff/vllm.summary.md
-            ${{ env.CORPUS_DIR }}/vllm.proposed.yaml
-            ${{ env.CORPUS_DIR }}/vllm.vendored.yaml
+            /tmp/engine-schemas-diff/vllm.old.json
+            /tmp/engine-schemas-diff/vllm.diff.json
+            /tmp/engine-schemas-diff/vllm.summary.md
+            ${{ env.SCHEMAS_DIR }}/vllm.json
 
       - name: Post per-pipeline comment (suppress on empty)
         if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -625,7 +552,7 @@ jobs:
           if [[ -z "$PR_NUMBER" ]]; then
             exit 0
           fi
-          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-invariants-diff/vllm.summary.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-schemas-diff/vllm.summary.md
 
       - name: Apply per-pipeline label
         if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -636,12 +563,12 @@ jobs:
           if [[ -z "$PR_NUMBER" ]]; then
             exit 0
           fi
-          for L in invariants-changed invariants-breaking invariants-safe probe-blocked; do
+          for L in schemas-changed schemas-breaking schemas-safe probe-blocked; do
             gh pr edit "$PR_NUMBER" --remove-label "$L" 2>/dev/null || true
           done
           case "${{ steps.diff.outputs.classification }}" in
-            breaking)  gh pr edit "$PR_NUMBER" --add-label "invariants-breaking" --add-label "invariants-changed" 2>/dev/null || true ;;
-            safe)      gh pr edit "$PR_NUMBER" --add-label "invariants-safe" --add-label "invariants-changed" 2>/dev/null || true ;;
+            breaking)  gh pr edit "$PR_NUMBER" --add-label "schemas-breaking" --add-label "schemas-changed" 2>/dev/null || true ;;
+            safe)      gh pr edit "$PR_NUMBER" --add-label "schemas-safe" --add-label "schemas-changed" 2>/dev/null || true ;;
             no-changes) ;;
           esac
 
@@ -649,7 +576,7 @@ jobs:
         if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
-          check-name: 'Engine Schemas — Probe + Discover'
+          check-name: 'Engine Invariants — Probe + Mine + Vendor'
           ref: ${{ github.event.pull_request.head.sha }}
           timeout: '600'
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -660,21 +587,19 @@ jobs:
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
-          # Pull in any sibling-pipeline writeback that landed first.
           git pull --rebase --autostash || true
 
           git add \
-            "${CORPUS_DIR}/vllm.proposed.yaml" \
-            "${CORPUS_DIR}/vllm.vendored.yaml" \
-            docs/generated/invariants-vllm.md \
+            "${SCHEMAS_DIR}/vllm.json" \
+            docs/generated/curation-vllm.md \
             engine_versions/vllm.compat.json 2>/dev/null || true
 
           if git diff --cached --quiet; then
-            echo "No engine-invariants artefact changes to commit."
+            echo "No engine-schemas artefact changes to commit."
             exit 0
           fi
 
-          git commit -m "chore(invariants): refresh vllm proposed + vendored corpus"
+          git commit -m "chore(schemas): refresh vllm discovered schema"
           git push --force-with-lease
 
       - name: Apply cross-pipeline rollup label
@@ -692,7 +617,7 @@ jobs:
             gh pr edit "$PR_NUMBER" --remove-label "safe-bump" 2>/dev/null || true
           fi
 
-  invariants-tensorrt:
+  schemas-tensorrt:
     if: github.event_name != 'workflow_dispatch' || inputs.engine == 'tensorrt' || inputs.engine == 'all'
     runs-on: self-hosted
     timeout-minutes: 60
@@ -731,7 +656,7 @@ jobs:
 
       - name: Build or reuse TRT-LLM image
         # SSOT-driven build-arg per D-1; layer cache keeps rebuilds fast
-        # when the NGC tag is unchanged. Note Dockerfile ARG is named
+        # when the NGC tag is unchanged. Dockerfile ARG is named
         # TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
         run: |
           IMAGE="${{ steps.version.outputs.image }}"
@@ -745,27 +670,18 @@ jobs:
             echo "Reusing cached $IMAGE."
           fi
 
-      - name: Compute stable mining + vendor anchor
+      - name: Compute stable discovery anchor
         id: anchor
         run: |
           PATHS=(
             "engine_versions/tensorrt.yaml"
             "docker/Dockerfile.tensorrt"
-            "scripts/engine_miners/tensorrt_static_miner.py"
-            "scripts/engine_miners/tensorrt_miner.py"
-            "scripts/engine_miners/build_corpus.py"
-            "scripts/engine_miners/_base.py"
-            "scripts/engine_miners/_pydantic_lift.py"
-            "scripts/engine_miners/_msgspec_lift.py"
-            "scripts/engine_miners/_dataclass_lift.py"
-            "scripts/engine_miners/_fixpoint_test.py"
-            "scripts/vendor_rules.py"
-            "scripts/_invariant_vendor_common.py"
-            "scripts/refresh_invariant_rules.sh"
+            "scripts/engine_introspectors/tensorrt_introspector.py"
+            "scripts/engine_introspectors/_common.py"
+            "scripts/engine_introspectors/__init__.py"
+            "scripts/engine_introspectors/__main__.py"
           )
-          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
-          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
           echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check (in container)
@@ -773,11 +689,10 @@ jobs:
         env:
           IMAGE: ${{ steps.version.outputs.image }}
         # The NGC image ships the tensorrt_llm package source as part of
-        # the installed package; the static miner expects it at
-        # /tmp/trt-llm-${VER}/tensorrt_llm. Symlink before probe so
-        # _read_landmarks resolves correctly. LD_LIBRARY_PATH override
-        # so libtensorrt_llm.so finds bundled CUDA compat libs on hosts
-        # whose driver predates the NGC image's CUDA target.
+        # the installed package; the introspector mirrors the static
+        # miner's expectation of finding sources under
+        # /tmp/trt-llm-${VER}/tensorrt_llm. LD_LIBRARY_PATH override so
+        # libtensorrt_llm.so finds bundled CUDA compat libs.
         run: |
           docker run --rm --gpus all \
             -e LD_LIBRARY_PATH="/usr/local/cuda/compat/lib.real:/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib" \
@@ -794,7 +709,7 @@ jobs:
               fi
               mkdir -p /tmp/trt-llm-${{ steps.version.outputs.version }}
               ln -sfn \"\$SRC\" /tmp/trt-llm-${{ steps.version.outputs.version }}/tensorrt_llm
-              python3 -m scripts._probe --engine tensorrt --producer invariants
+              python3 -m scripts._probe --engine tensorrt --producer schemas
             " > /tmp/probe-tensorrt.json
           VERDICT=$(jq -r '.verdict' /tmp/probe-tensorrt.json)
           echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
@@ -806,32 +721,28 @@ jobs:
             -v "${{ github.workspace }}":/workspace \
             alpine sh -c "chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true"
 
-      - name: Save current YAMLs for diffing
+      - name: Save current schema for diffing
         if: steps.probe.outputs.verdict == 'pass'
         run: |
-          mkdir -p /tmp/engine-invariants-diff
-          for KIND in proposed vendored; do
-            OLD_YAML="${CORPUS_DIR}/tensorrt.${KIND}.yaml"
-            DEST="/tmp/engine-invariants-diff/tensorrt.${KIND}.old.yaml"
-            if [[ -f "$OLD_YAML" ]]; then
-              cp "$OLD_YAML" "$DEST"
-            else
-              : > "$DEST"
-            fi
-          done
+          mkdir -p /tmp/engine-schemas-diff
+          OLD="${SCHEMAS_DIR}/tensorrt.json"
+          DEST="/tmp/engine-schemas-diff/tensorrt.old.json"
+          if [[ -f "$OLD" ]]; then
+            cp "$OLD" "$DEST"
+          else
+            echo '{}' > "$DEST"
+          fi
 
-      - name: Mine + vendor inside container
+      - name: Discover schema inside container
         if: steps.probe.outputs.verdict == 'pass'
         env:
           IMAGE: ${{ steps.version.outputs.image }}
-          ANCHOR_SHA: ${{ steps.anchor.outputs.sha }}
           ANCHOR_DATE: ${{ steps.anchor.outputs.date }}
           TRTLLM_VER: ${{ steps.version.outputs.version }}
         run: |
           docker run --rm --gpus all \
             -e LD_LIBRARY_PATH="/usr/local/cuda/compat/lib.real:/usr/local/cuda/compat/lib:/usr/local/tensorrt/lib" \
-            -e LLENERGY_MINER_FROZEN_AT="${ANCHOR_DATE}" \
-            -e LLENERGY_VENDOR_FROZEN_AT="${ANCHOR_DATE}" \
+            -e LLENERGY_DISCOVERY_FROZEN_AT="${ANCHOR_DATE}" \
             -e PYTHONDONTWRITEBYTECODE=1 \
             -v "${{ github.workspace }}:/repo" \
             -w /repo \
@@ -842,16 +753,13 @@ jobs:
               SRC=\$(python3 -c 'import tensorrt_llm, pathlib; print(pathlib.Path(tensorrt_llm.__file__).parent)')
               mkdir -p /tmp/trt-llm-${TRTLLM_VER}
               ln -sfn \"\$SRC\" /tmp/trt-llm-${TRTLLM_VER}/tensorrt_llm
-              python3 -m scripts.engine_miners.build_corpus --engine tensorrt
-              python3 scripts/vendor_rules.py \
+              python3 -m scripts.engine_introspectors \
                 --engine tensorrt \
-                --corpus '${CORPUS_DIR}/tensorrt.proposed.yaml' \
-                --out '${CORPUS_DIR}/tensorrt.vendored.yaml' \
-                --vendor-commit '${ANCHOR_SHA}' \
-                --fail-on-divergence
+                --image-ref '${IMAGE}' \
+                --output '${SCHEMAS_DIR}/tensorrt.json'
             "
 
-      - name: Fix container-written file ownership (mine + vendor)
+      - name: Fix container-written file ownership (discover)
         if: always()
         run: |
           docker run --rm \
@@ -863,44 +771,30 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-suffix: engine-invariants-tensorrt-docgen-3.12
+          cache-suffix: engine-schemas-tensorrt-docgen-3.12
           python-version: "3.12"
 
-      - name: Regenerate invariants digest doc
+      - name: Regenerate curation digests
         if: steps.probe.outputs.verdict == 'pass'
         run: |
-          uv run --no-sync --with pyyaml python scripts/generate_invariants_doc.py \
-            --engine tensorrt \
-            --out docs/generated/invariants-tensorrt.md
+          uv run --no-sync --with pyyaml --with pydantic python scripts/generate_curation_doc.py
 
-      - name: Classify diff (proposed + vendored)
+      - name: Classify diff
         if: steps.probe.outputs.verdict == 'pass'
         id: diff
         run: |
           set +e
-          uv run --no-sync --with pyyaml python scripts/diff_engine_invariants.py \
-            /tmp/engine-invariants-diff/tensorrt.vendored.old.yaml \
-            "${CORPUS_DIR}/tensorrt.vendored.yaml" \
-            --out /tmp/engine-invariants-diff/tensorrt.vendored.md \
-            --title "TensorRT-LLM vendored invariants diff"
-          VENDORED_EXIT=$?
+          uv run --no-sync python scripts/diff_discovered_schemas.py \
+            /tmp/engine-schemas-diff/tensorrt.old.json \
+            "${SCHEMAS_DIR}/tensorrt.json" \
+            > /tmp/engine-schemas-diff/tensorrt.diff.json
+          DIFF_EXIT=$?
           set -e
 
-          PROPOSED_CHANGED=true
-          if diff -q /tmp/engine-invariants-diff/tensorrt.proposed.old.yaml \
-                    "${CORPUS_DIR}/tensorrt.proposed.yaml" >/dev/null 2>&1; then
-            PROPOSED_CHANGED=false
-          fi
-
-          VENDORED_CHANGED=true
-          if diff -q /tmp/engine-invariants-diff/tensorrt.vendored.old.yaml \
-                    "${CORPUS_DIR}/tensorrt.vendored.yaml" >/dev/null 2>&1; then
-            VENDORED_CHANGED=false
-          fi
-
-          if [[ "$PROPOSED_CHANGED" == "false" && "$VENDORED_CHANGED" == "false" ]]; then
+          if diff -q /tmp/engine-schemas-diff/tensorrt.old.json \
+                    "${SCHEMAS_DIR}/tensorrt.json" >/dev/null 2>&1; then
             CLASSIFICATION="no-changes"
-          elif [[ $VENDORED_EXIT -eq 1 ]]; then
+          elif [[ $DIFF_EXIT -eq 1 ]]; then
             CLASSIFICATION="breaking"
           else
             CLASSIFICATION="safe"
@@ -908,25 +802,23 @@ jobs:
           echo "classification=${CLASSIFICATION}" >> "$GITHUB_OUTPUT"
 
           {
-            echo "## Engine invariants — tensorrt"
+            echo "## Engine schemas — tensorrt"
             echo
             if [[ "$CLASSIFICATION" == "no-changes" ]]; then
-              echo "_No changes to proposed or vendored invariants._"
+              echo "_No changes to discovered schema._"
             else
-              if [[ "$PROPOSED_CHANGED" == "true" ]]; then
-                echo "### Proposed corpus diff"
-                echo
-                echo '```diff'
-                diff -u /tmp/engine-invariants-diff/tensorrt.proposed.old.yaml \
-                        "${CORPUS_DIR}/tensorrt.proposed.yaml" | head -n 200 || true
-                echo '```'
-                echo
-              fi
-              if [[ -f /tmp/engine-invariants-diff/tensorrt.vendored.md ]]; then
-                cat /tmp/engine-invariants-diff/tensorrt.vendored.md
-              fi
+              SUMMARY=$(jq -r '.summary // "schema diff produced"' /tmp/engine-schemas-diff/tensorrt.diff.json 2>/dev/null || echo "schema diff produced")
+              echo "${SUMMARY}"
+              echo
+              echo "<details><summary>Structured diff</summary>"
+              echo
+              echo '```json'
+              jq '.' /tmp/engine-schemas-diff/tensorrt.diff.json 2>/dev/null | head -n 200 || true
+              echo '```'
+              echo
+              echo "</details>"
             fi
-          } > /tmp/engine-invariants-diff/tensorrt.summary.md
+          } > /tmp/engine-schemas-diff/tensorrt.summary.md
 
       - name: Probe-fail comment (skip downstream)
         if: steps.probe.outputs.verdict == 'fail' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -939,13 +831,13 @@ jobs:
           fi
           MISSING=$(jq -r '.landmarks_missing | join(", ")' /tmp/probe-tensorrt.json)
           {
-            echo "## Engine invariants — tensorrt (probe-blocked)"
+            echo "## Engine schemas — tensorrt (probe-blocked)"
             echo
-            echo "Probe failed: producer landmarks no longer resolve under the installed library."
+            echo "Probe failed: introspector landmarks no longer resolve under the installed library."
             echo
             echo "Missing: \`${MISSING}\`"
             echo
-            echo "Downstream mine + vendor steps were skipped. Patch the producer module or run \`@llem-ci-bot /approve-reuse tensorrt invariants\` once the landmarks have been updated."
+            echo "Downstream discovery was skipped. Patch the introspector module or run \`@llem-ci-bot /approve-reuse tensorrt schemas\` once the landmarks have been updated."
           } | gh pr comment "$PR_NUMBER" --body-file -
           gh pr edit "$PR_NUMBER" --add-label "probe-blocked" 2>/dev/null || true
 
@@ -953,13 +845,12 @@ jobs:
         if: steps.probe.outputs.verdict == 'pass'
         uses: actions/upload-artifact@v4
         with:
-          name: engine-invariants-diff-tensorrt
+          name: engine-schemas-diff-tensorrt
           path: |
-            /tmp/engine-invariants-diff/tensorrt.proposed.old.yaml
-            /tmp/engine-invariants-diff/tensorrt.vendored.old.yaml
-            /tmp/engine-invariants-diff/tensorrt.summary.md
-            ${{ env.CORPUS_DIR }}/tensorrt.proposed.yaml
-            ${{ env.CORPUS_DIR }}/tensorrt.vendored.yaml
+            /tmp/engine-schemas-diff/tensorrt.old.json
+            /tmp/engine-schemas-diff/tensorrt.diff.json
+            /tmp/engine-schemas-diff/tensorrt.summary.md
+            ${{ env.SCHEMAS_DIR }}/tensorrt.json
 
       - name: Post per-pipeline comment (suppress on empty)
         if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -970,7 +861,7 @@ jobs:
           if [[ -z "$PR_NUMBER" ]]; then
             exit 0
           fi
-          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-invariants-diff/tensorrt.summary.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/engine-schemas-diff/tensorrt.summary.md
 
       - name: Apply per-pipeline label
         if: steps.probe.outputs.verdict == 'pass' && (github.event_name == 'pull_request' || inputs.pr_number != '')
@@ -981,12 +872,12 @@ jobs:
           if [[ -z "$PR_NUMBER" ]]; then
             exit 0
           fi
-          for L in invariants-changed invariants-breaking invariants-safe probe-blocked; do
+          for L in schemas-changed schemas-breaking schemas-safe probe-blocked; do
             gh pr edit "$PR_NUMBER" --remove-label "$L" 2>/dev/null || true
           done
           case "${{ steps.diff.outputs.classification }}" in
-            breaking)  gh pr edit "$PR_NUMBER" --add-label "invariants-breaking" --add-label "invariants-changed" 2>/dev/null || true ;;
-            safe)      gh pr edit "$PR_NUMBER" --add-label "invariants-safe" --add-label "invariants-changed" 2>/dev/null || true ;;
+            breaking)  gh pr edit "$PR_NUMBER" --add-label "schemas-breaking" --add-label "schemas-changed" 2>/dev/null || true ;;
+            safe)      gh pr edit "$PR_NUMBER" --add-label "schemas-safe" --add-label "schemas-changed" 2>/dev/null || true ;;
             no-changes) ;;
           esac
 
@@ -994,7 +885,7 @@ jobs:
         if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
-          check-name: 'Engine Schemas — Probe + Discover'
+          check-name: 'Engine Invariants — Probe + Mine + Vendor'
           ref: ${{ github.event.pull_request.head.sha }}
           timeout: '600'
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -1005,21 +896,19 @@ jobs:
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
-          # Pull in any sibling-pipeline writeback that landed first.
           git pull --rebase --autostash || true
 
           git add \
-            "${CORPUS_DIR}/tensorrt.proposed.yaml" \
-            "${CORPUS_DIR}/tensorrt.vendored.yaml" \
-            docs/generated/invariants-tensorrt.md \
+            "${SCHEMAS_DIR}/tensorrt.json" \
+            docs/generated/curation-tensorrt.md \
             engine_versions/tensorrt.compat.json 2>/dev/null || true
 
           if git diff --cached --quiet; then
-            echo "No engine-invariants artefact changes to commit."
+            echo "No engine-schemas artefact changes to commit."
             exit 0
           fi
 
-          git commit -m "chore(invariants): refresh tensorrt proposed + vendored corpus"
+          git commit -m "chore(schemas): refresh tensorrt discovered schema"
           git push --force-with-lease
 
       - name: Apply cross-pipeline rollup label

--- a/.github/workflows/engine-schemas.yml
+++ b/.github/workflows/engine-schemas.yml
@@ -1,33 +1,24 @@
 name: Engine Schemas — Probe + Discover
 
-# Per-concern workflow for the engine-schemas (parameter-discovery) layer.
-# Each per-engine job probes the introspector module's landmarks, discovers
-# the live engine's typed schema inside the SSOT-driven Docker image,
-# regenerates the curation digest doc, and (after the sibling pipeline
-# completes) atomically commits the artefacts back to the PR branch.
+# Per-concern workflow for the engine-schemas layer. Each per-engine job
+# probes the introspector module's landmarks, discovers parameter schemas
+# inside the SSOT-driven Docker image, regenerates the curation digest doc,
+# and atomically commits artefacts back to the PR branch.
 #
-# Sibling of engine-invariants.yml. Same App-token + commit-back + comment
-# + label pattern; different artefact kind (introspected schemas vs mined
-# invariants). The two workflows coordinate via lewagon/wait-on-check-action
-# so each blocks until the other has finished, then both writebacks land on
-# disjoint paths (engine-schemas writes JSON + curation md; engine-invariants
-# writes proposed/vendored YAMLs + invariants md). force-with-lease + the
-# wait gate give atomic semantics without a separate summariser workflow.
-#
-# Per-engine runner choice mirrors engine-invariants.yml:
+# Per-engine runner choice:
 #   transformers : ubuntu-latest GH-hosted runner; CPU-safe import.
-#   vllm         : self-hosted GPU runner inside llenergymeasure:vllm-${VER}.
+#   vllm         : self-hosted GPU runner inside llenergymeasure:vllm-${VER}
+#                  (unified uv.lock breaks vllm's torch via tensorrt-llm
+#                  0.21.0's transitive constraints; #437, #464).
 #   tensorrt     : self-hosted GPU runner inside llenergymeasure:tensorrt-
-#                  ${VER}; TRT-LLM 0.21.0 loads CUDA bindings on import so
-#                  CPU runners cannot import the library at all.
+#                  ${VER}; TRT-LLM 0.21.0 loads CUDA bindings on import.
 #
 # Determinism contract:
-#   The LLENERGY_DISCOVERY_FROZEN_AT env var is set from the author date of
-#   the most recent commit touching any INPUT path (engine SSOT, Dockerfile,
-#   introspector modules). The anchor is stable across the workflow's own
-#   commit-back (which only touches OUTPUT paths), so re-runs on unchanged
-#   source emit byte-identical JSON envelopes. This determinism is THE
-#   prevention against the synchronize-loop the watchdog catches.
+#   The LLENERGY_DISCOVERY_FROZEN_AT env var is set from the author date
+#   of the most recent commit touching any INPUT path. The anchor is
+#   stable across the workflow's own commit-back, so re-runs on unchanged
+#   source emit byte-identical JSON. This determinism is THE prevention
+#   against the synchronize-loop the watchdog catches.
 
 on:
   pull_request:
@@ -109,7 +100,6 @@ jobs:
             exit 1
           fi
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
-          echo "image=llenergymeasure:transformers-${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Compute stable discovery anchor
         id: anchor
@@ -129,7 +119,11 @@ jobs:
             "scripts/engine_introspectors/__main__.py"
           )
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
-          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+          if [[ -z "${DATE}" ]]; then
+            echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
+            exit 1
+          fi
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check
         id: probe
@@ -161,13 +155,10 @@ jobs:
             --engine transformers \
             --output "${SCHEMAS_DIR}/transformers.json"
 
-      - name: Regenerate curation digests
+      - name: Regenerate curation digest
         if: steps.probe.outputs.verdict == 'pass'
-        # The generator emits docs/generated/curation-{engine}.md for ALL
-        # three engines; re-running is cheap + idempotent, and we only stage
-        # the engine-specific file in the writeback step below.
         run: |
-          uv run python scripts/generate_curation_doc.py
+          uv run python scripts/generate_curation_doc.py --engine transformers
 
       - name: Classify diff
         if: steps.probe.outputs.verdict == 'pass'
@@ -271,15 +262,35 @@ jobs:
             no-changes) ;;
           esac
 
+      - name: Detect sibling workflow run for this SHA
+        # PRs whose path-filter only matches one workflow's exclusive paths
+        # never trigger the sibling, so wait-on-check-action would block
+        # for its full timeout. This pre-flight skips the wait when no
+        # sibling run was queued for this head SHA.
+        id: sibling
+        if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          SIBLING_NAME="Engine Invariants — Probe + Mine + Vendor"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq "[.workflow_runs[] | select(.name == \"${SIBLING_NAME}\")] | length")
+          if [[ "${COUNT}" -gt 0 ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Sibling workflow ${SIBLING_NAME} did not fire for this SHA; skipping wait."
+          fi
+
       - name: Wait for sibling pipeline to complete
         # Block until the engine-invariants pipeline finishes for this same
         # head SHA. Already-finished sibling exits immediately. Whichever
         # pipeline reaches its writeback step second performs its commit
         # against the tip that already includes the first pipeline's
         # writeback (disjoint paths; force-with-lease handles the fast-
-        # forward). The atomic-writeback property emerges from the wait +
-        # disjoint paths combination, no separate summariser needed.
-        if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        # forward).
+        if: steps.probe.outputs.verdict == 'pass' && steps.sibling.outputs.exists == 'true'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           check-name: 'Engine Invariants — Probe + Mine + Vendor'
@@ -288,18 +299,17 @@ jobs:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Atomic writeback
-        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
           # Pull in any sibling-pipeline writeback that landed first.
-          git pull --rebase --autostash || true
+          git pull --rebase --autostash
 
           git add \
             "${SCHEMAS_DIR}/transformers.json" \
-            docs/generated/curation-transformers.md \
-            engine_versions/transformers.compat.json 2>/dev/null || true
+            docs/generated/curation-transformers.md
 
           if git diff --cached --quiet; then
             echo "No engine-schemas artefact changes to commit."
@@ -365,11 +375,10 @@ jobs:
           echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Build or reuse vLLM image
-        # SSOT-driven build-arg per the engine-coupling design's D-1
-        # decision: Renovate updates SSOT only; Dockerfile ARG default
-        # is a fallback for local manual builds; CI passes the SSOT
-        # value at docker-build time. Layer cache makes the FROM step a
-        # no-op when the upstream tag is unchanged.
+        # SSOT is the canonical version; the Dockerfile ARG default is a
+        # local-build fallback. CI passes the SSOT value at build time so
+        # the two cannot drift. Layer cache makes the FROM step a no-op
+        # when the upstream tag is unchanged.
         run: |
           IMAGE="${{ steps.version.outputs.image }}"
           if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
@@ -394,7 +403,11 @@ jobs:
             "scripts/engine_introspectors/__main__.py"
           )
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
-          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+          if [[ -z "${DATE}" ]]; then
+            echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
+            exit 1
+          fi
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check (in container)
         id: probe
@@ -465,10 +478,10 @@ jobs:
           cache-suffix: engine-schemas-vllm-docgen-3.12
           python-version: "3.12"
 
-      - name: Regenerate curation digests
+      - name: Regenerate curation digest
         if: steps.probe.outputs.verdict == 'pass'
         run: |
-          uv run --no-sync --with pyyaml --with pydantic python scripts/generate_curation_doc.py
+          uv run --no-sync --with pyyaml --with pydantic python scripts/generate_curation_doc.py --engine vllm
 
       - name: Classify diff
         if: steps.probe.outputs.verdict == 'pass'
@@ -572,8 +585,25 @@ jobs:
             no-changes) ;;
           esac
 
-      - name: Wait for sibling pipeline to complete
+      - name: Detect sibling workflow run for this SHA
+        id: sibling
         if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          SIBLING_NAME="Engine Invariants — Probe + Mine + Vendor"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq "[.workflow_runs[] | select(.name == \"${SIBLING_NAME}\")] | length")
+          if [[ "${COUNT}" -gt 0 ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Sibling workflow ${SIBLING_NAME} did not fire for this SHA; skipping wait."
+          fi
+
+      - name: Wait for sibling pipeline to complete
+        if: steps.probe.outputs.verdict == 'pass' && steps.sibling.outputs.exists == 'true'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           check-name: 'Engine Invariants — Probe + Mine + Vendor'
@@ -582,17 +612,17 @@ jobs:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Atomic writeback
-        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
-          git pull --rebase --autostash || true
+          # Pull in any sibling-pipeline writeback that landed first.
+          git pull --rebase --autostash
 
           git add \
             "${SCHEMAS_DIR}/vllm.json" \
-            docs/generated/curation-vllm.md \
-            engine_versions/vllm.compat.json 2>/dev/null || true
+            docs/generated/curation-vllm.md
 
           if git diff --cached --quiet; then
             echo "No engine-schemas artefact changes to commit."
@@ -655,9 +685,10 @@ jobs:
           echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Build or reuse TRT-LLM image
-        # SSOT-driven build-arg per D-1; layer cache keeps rebuilds fast
-        # when the NGC tag is unchanged. Dockerfile ARG is named
-        # TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
+        # SSOT is the canonical version; the Dockerfile ARG default is a
+        # local-build fallback. Layer cache keeps rebuilds fast when the
+        # NGC tag is unchanged. Dockerfile ARG is named TRTLLM_VERSION
+        # (not TENSORRT_VERSION) — preserved.
         run: |
           IMAGE="${{ steps.version.outputs.image }}"
           if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
@@ -682,7 +713,11 @@ jobs:
             "scripts/engine_introspectors/__main__.py"
           )
           DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
-          echo "date=${DATE:-$(date -u -Iseconds)}" >> "$GITHUB_OUTPUT"
+          if [[ -z "${DATE}" ]]; then
+            echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
+            exit 1
+          fi
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Probe — landmark resolution check (in container)
         id: probe
@@ -774,10 +809,10 @@ jobs:
           cache-suffix: engine-schemas-tensorrt-docgen-3.12
           python-version: "3.12"
 
-      - name: Regenerate curation digests
+      - name: Regenerate curation digest
         if: steps.probe.outputs.verdict == 'pass'
         run: |
-          uv run --no-sync --with pyyaml --with pydantic python scripts/generate_curation_doc.py
+          uv run --no-sync --with pyyaml --with pydantic python scripts/generate_curation_doc.py --engine tensorrt
 
       - name: Classify diff
         if: steps.probe.outputs.verdict == 'pass'
@@ -881,8 +916,25 @@ jobs:
             no-changes) ;;
           esac
 
-      - name: Wait for sibling pipeline to complete
+      - name: Detect sibling workflow run for this SHA
+        id: sibling
         if: steps.probe.outputs.verdict == 'pass' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          SIBLING_NAME="Engine Invariants — Probe + Mine + Vendor"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq "[.workflow_runs[] | select(.name == \"${SIBLING_NAME}\")] | length")
+          if [[ "${COUNT}" -gt 0 ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Sibling workflow ${SIBLING_NAME} did not fire for this SHA; skipping wait."
+          fi
+
+      - name: Wait for sibling pipeline to complete
+        if: steps.probe.outputs.verdict == 'pass' && steps.sibling.outputs.exists == 'true'
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           check-name: 'Engine Invariants — Probe + Mine + Vendor'
@@ -891,17 +943,17 @@ jobs:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Atomic writeback
-        if: steps.probe.outputs.verdict == 'pass' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.probe.outputs.verdict == 'pass' && steps.diff.outputs.classification != 'no-changes' && steps.app-token.outputs.token != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
 
-          git pull --rebase --autostash || true
+          # Pull in any sibling-pipeline writeback that landed first.
+          git pull --rebase --autostash
 
           git add \
             "${SCHEMAS_DIR}/tensorrt.json" \
-            docs/generated/curation-tensorrt.md \
-            engine_versions/tensorrt.compat.json 2>/dev/null || true
+            docs/generated/curation-tensorrt.md
 
           if git diff --cached --quiet; then
             echo "No engine-schemas artefact changes to commit."

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -4,8 +4,9 @@ This doc is the chain-diagram reference for the engine-coupling pipeline. SSOT-d
 
 ```
 ================================================================================
-LLenergyMeasure Engine-Coupling Pipeline (target architecture, 2026-04-28)
-Per-concern workflows (Stream B, post-codebase-audit) + summariser coordination
+LLenergyMeasure Engine-Coupling Pipeline
+Per-concern workflows (engine-invariants + engine-schemas) with sibling
+coordination via wait-on-check-action.
 ================================================================================
 
 LEGEND:  [auto]    fully automated, no human action
@@ -248,8 +249,8 @@ ADJACENT PIPELINES (independent of per-PR Renovate cycle)
         but engine collapses (observed_config_hash matches). Flagged
         as gap_detected: true -> dormancy signal.
       - proposed_rule_id field is currently always None; consumer
-        was rejected in PR #404 (over-engineering; no real user yet).
-        Tracked in #405 + #474.
+        deferred until a researcher hits a real gap_detected: true
+        group and asks for tooling. Tracked in #405 + #474.
 ================================================================================
 ```
 

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -1,0 +1,256 @@
+# Pipeline Architecture
+
+This doc is the chain-diagram reference for the engine-coupling pipeline. SSOT-driven Renovate cycles flow through these stages: trigger, two per-concern CI workflows, vendored artefacts, and the human curation checkpoint before merge.
+
+```
+================================================================================
+LLenergyMeasure Engine-Coupling Pipeline (target architecture, 2026-04-28)
+Per-concern workflows (Stream B, post-codebase-audit) + summariser coordination
+================================================================================
+
+LEGEND:  [auto]    fully automated, no human action
+         [chk]     HUMAN CHECKPOINT — required dev input
+         [info]    informational artefact, advisory
+         { }       input
+         [→...]    automated transition
+
+   {Renovate scans upstream library releases on configured schedule}
+                                │  [auto]
+                                ▼
+   Custom regex manager bumps:
+     engine_versions/{engine}.yaml:library.current_version  (SSOT — canonical)
+     docker/Dockerfile.{engine} ARG (derived; auto-templated from SSOT)
+                                │  [auto]
+                                ▼
+   {Renovate opens PR: "fix(deps): bump vllm to 0.10.2"}
+                                │  [auto] path-filtered triggers fan out
+                                ▼              in PARALLEL to two workflows
+   ┌────────────────────────────┴─────────────────────────────┐
+   ▼                                                           ▼
+┌──────────────────────────────┐         ┌──────────────────────────────┐
+│  engine-invariants.yml       │         │  engine-schemas.yml          │
+│  (per-engine matrix)         │         │  (engines matrix)            │
+│  Layers over: invariant-     │         │  Layers over: parameter-     │
+│   miner + invalidity-miner + │         │   discovery + typed-schema-  │
+│   lift modules + vendor-CI   │         │   discovery                  │
+│                              │         │                              │
+│  STEP 1 [auto]: PROBE (inline│         │  STEP 1 [auto]: PROBE (inline│
+│   `python -m scripts._probe  │         │   `python -m scripts._probe  │
+│    --producer invariants`)   │         │    --producer schemas`)      │
+│   verdict: pass | fail       │         │   verdict: pass | fail       │
+│                              │         │                              │
+│  ── if probe == pass ──      │         │  ── if probe == pass ──      │
+│  STEP 2 [auto]: MINE         │         │  STEP 2 [auto]: DISCOVER     │
+│   build_corpus.py            │         │   engine_introspectors       │
+│   → configs/engine_invariants│         │   → src/llenergymeasure/     │
+│     /{engine}.proposed.yaml  │         │     config/discovered_       │
+│                              │         │     schemas/{engine}.json    │
+│  STEP 3 [auto]: VENDOR-REPLAY│         │                              │
+│   vendor_rules.py + the      │         │  STEP 3 [auto]: DIFF vs HEAD │
+│   compare_expected_vs_       │         │                              │
+│   observed contract from     │         │  STEP 4 [auto]: REGENERATE   │
+│   _invariant_vendor_common.py│         │   docs/generated/            │
+│   replays kwargs_positive +  │         │     curation-{engine}.md     │
+│   kwargs_negative against    │         │   (Parameters section —      │
+│   live library; classifies   │         │    fact base for human       │
+│   outcomes (positive_        │         │    curator; pre-existing     │
+│   confirmed, negative_       │         │    behaviour preserved)      │
+│   confirmed, divergence)     │         │                              │
+│   → configs/engine_invariants│         │  STEP 5 [auto]: COMMENT      │
+│     /{engine}.vendored.yaml  │         │   + LABEL (suppress on empty)│
+│                              │         │                              │
+│  STEP 4 [auto]: DIFF vs HEAD │         │  ── if probe == fail ──      │
+│   for both proposed.yaml +   │         │  Post probe-fail comment     │
+│   vendored.yaml artefacts    │         │  with 3 routes (per §3 of    │
+│                              │         │   the design doc: patch      │
+│  STEP 5 [auto]: REGENERATE   │         │   code / /approve-reuse /    │
+│   docs/generated/            │         │   escalate). Apply           │
+│     invariants-{engine}.md   │         │   probe-blocked label.       │
+│   (Invariants section — fact │         │   exit 0 (not CI failure)    │
+│   base; encompasses dormancy │         │                              │
+│   + invalidity + walker      │         │                              │
+│   output + introspection +   │         │                              │
+│   runtime catch-all)         │         │                              │
+│                              │         │                              │
+│  STEP 6 [auto]: COMMENT      │         │                              │
+│   + LABEL (suppress on empty)│         │                              │
+│                              │         │                              │
+│  ── if probe == fail ──      │         │                              │
+│  Same 3-route handling as    │         │                              │
+│  schemas-pipeline above.     │         │                              │
+│  Apply probe-blocked label.  │         │                              │
+│  exit 0.                     │         │                              │
+└─────────────┬────────────────┘         └────────────┬─────────────────┘
+              │                                       │
+              │ Each workflow:                                                  │
+              │  - uploads engine-step-diff-{engine}-{concern}.yaml             │
+              │  - posts its OWN per-pipeline comment (suppress on empty)       │
+              │  - applies its own per-pipeline label                           │
+              │    (invariants/schemas-changed, invariants/schemas-breaking,    │
+              │     corpus-changed, probe-blocked)                              │
+              │  - WAITS for sibling pipeline to complete                       │
+              │    (lewagon/wait-on-check-action; already-finished sibling      │
+              │     exits immediately)                                          │
+              │  - LAST-FINISHING workflow performs ATOMIC WRITEBACK in-line:   │
+              │     git add configs/engine_invariants/{engine}.proposed.yaml    │
+              │             configs/engine_invariants/{engine}.vendored.yaml    │
+              │             src/llenergymeasure/config/discovered_schemas/      │
+              │                  {engine}.json                                  │
+              │             docs/generated/curation-{engine}.md                 │
+              │             docs/generated/invariants-{engine}.md               │
+              │             engine_versions/{engine}.compat.json                │
+              │             engine_versions/{engine}.yaml (if /approve-reuse    │
+              │                                            fired during cycle)  │
+              │     git commit && git push --force-with-lease                   │
+              │  - LAST-FINISHING workflow applies cross-pipeline rollup label  │
+              │    (safe-bump | probe-blocked)                                  │
+              │                                                                 │
+              │ NO summariser workflow file. NO composite action.               │
+              │ Cross-pipeline state lives on labels (GitHub-native primitive). │
+              │ "Did the cycle run?" = check-status badge. "Anything change?"   │
+              │ = per-pipeline comments + commits. "What's the rollup state?"   │
+              │ = label.                                                        │
+              ▼
+            ┌────────────────────────────────────────────────┐
+            │ PR after a Renovate cycle:                      │
+            │  - 2 per-concern check statuses                 │
+            │  - up to 2 comments per cycle (suppress-on-empty):│
+            │     1. engine-invariants pipeline                │
+            │     2. engine-schemas pipeline                   │
+            │  - 1 atomic bot commit (all artefacts; written   │
+            │    by whichever workflow finished last)          │
+            │  - cross-pipeline rollup label                   │
+            │    (safe-bump | probe-blocked)                   │
+            └─────────────────────┬──────────────────────────┘
+                                  │
+                                  ▼
+   ╔═══════════════════════════════════════════════════════════════════╗
+   ║              HUMAN CURATION CHECKPOINT [chk]                       ║
+   ║   The only crossing of the human-as-final-checkpoint boundary (P6)║
+   ║   inside the otherwise-automated vendored half. Bots NEVER edit   ║
+   ║   src/llenergymeasure/config/engine_configs.py.                    ║
+   ║                                                                    ║
+   ║   Dev consumes auto-generated digests:                             ║
+   ║     docs/generated/curation-{engine}.md                            ║
+   ║       Section 1: Parameters (discovered fields × Pydantic-curated  ║
+   ║                  yes/no, deltas vs previous SSOT version)          ║
+   ║     docs/generated/invariants-{engine}.md                          ║
+   ║       Section 1: Invariants (corpus rules added/changed/removed,   ║
+   ║                  classified by added_by; encompasses dormancy +    ║
+   ║                  invalidity + walker output + introspection +      ║
+   ║                  runtime catch-all)                                ║
+   ║                                                                    ║
+   ║   Dev manually edits engine_configs.py:                            ║
+   ║     - which discovered params to expose in Pydantic                ║
+   ║     - which Literal narrowings to pin                              ║
+   ║     - which sub-config taxonomy to use                             ║
+   ║     - which custom @model_validator decorators to add              ║
+   ║                                                                    ║
+   ║   Push -> triggers re-run of CI cycle -> updated summary comment   ║
+   ║   supersedes prior (edited via comment-id key, no proliferation)   ║
+   ║                                                                    ║
+   ║   Decision routes after digest review:                             ║
+   ║     safe-bump + green CI         -> squash-merge                   ║
+   ║     corpus-changed + mechanical  -> squash-merge                   ║
+   ║     invariants-breaking          -> edit engine_configs.py         ║
+   ║     schemas-breaking             -> edit engine_configs.py         ║
+   ║     probe-blocked                -> resolve via §3 routes:         ║
+   ║                                     - patch producer code, OR      ║
+   ║                                     - /approve-reuse (slash cmd)   ║
+   ║                                     - escalate label               ║
+   ║                                                                    ║
+   ║   GUIDED CURATION UX (RFC-style YAML decision file + libcst        ║
+   ║   applier) is DEFERRED to issue #475. Current redesign ships       ║
+   ║   self-serve curation only — devs hand-edit engine_configs.py      ║
+   ║   based on digest. After 2-3 Renovate cycles of operational data,  ║
+   ║   #475 reactivation will evaluate whether guided UX pays off.      ║
+   ╚═══════════════════════════════════════════════════════════════════╝
+                                  │
+                                  ▼
+                          ┌──────────────┐
+                          │ squash-merge │
+                          └──────┬───────┘
+                                 ▼
+                   PR closes; engine version + all
+                   vendored artefacts + curated Pydantic
+                   pinned together at this commit.
+
+================================================================================
+PROBE-FAIL HUMAN CHECKPOINT [chk]
+The OTHER human touchpoint (per P6). Inside the otherwise-automated CI half.
+================================================================================
+
+When a probe fails (inline step 1 of either workflow), three resolution routes:
+
+  ┌─ ROUTE 1 [chk → auto]: Patch producer code
+  │   Dev edits scripts/engine_miners/{engine}_*_miner.py or
+  │   scripts/engine_introspectors/{engine}_introspector.py to fix the
+  │   broken landmark (e.g. follow an upstream rename). Push commit ->
+  │   workflow re-runs -> probe re-runs -> if pass, downstream stages
+  │   proceed.
+  │
+  ├─ ROUTE 2 [chk → auto]: Approve reuse via slash command
+  │   Dev posts `@llem-ci-bot /approve-reuse <engine> <producer>` as
+  │   PR comment. Producer ∈ {invariants, schemas} (per-producer
+  │   granularity — vllm invariants might be reusable while vllm
+  │   schemas are not).
+  │                            │  [auto]
+  │                            ▼
+  │   approve-reuse-bot.yml (issue_comment: created listener)
+  │   - Validates dev approval rights
+  │   - Updates engine_versions/{engine}.yaml miner_pins.{producer}
+  │     to widen SpecifierSet to include the bumped version
+  │   - Commits SSOT change via llem-ci-bot App token (cascades;
+  │     GITHUB_TOKEN would not)
+  │                            │  [auto]
+  │                            ▼
+  │   Probe re-runs against widened range -> verdict flips to PASS
+  │   -> downstream stages proceed
+  │
+  └─ ROUTE 3 [chk]: Escalate / block
+      Dev applies probe-blocked label. Renovate stops retrying this
+      bump until the label is removed; route 1 or 2 must follow before
+      merge.
+
+NO OTHER SLASH COMMANDS. /rerun, /skip-probe, /force-merge explicitly
+rejected as footguns. Deliberate scope: one binary approval gate per
+(engine, producer), no escape hatches.
+
+================================================================================
+ADJACENT PIPELINES (independent of per-PR Renovate cycle)
+================================================================================
+
+   engine-versions-sweep.yml          {scheduled, e.g. weekly}     [auto info]
+   └─ runs scripts/_probe.py over a curated version range
+      (e.g. vllm v0.9..v0.12); updates engine_versions/{engine}.compat.json
+      (probe cache + compat-matrix in one file; closes #470).
+      Populates probe-result cache so per-PR probes hit warm cache.
+
+   Runtime side-product               {study runtime, NOT CI; study-local}
+   ├─ runtime_observations.jsonl      [info]
+   │   - Producer: src/llenergymeasure/study/runtime_observations.py
+   │     (warnings.catch_warnings + logger handler wrapping each worker
+   │     body); wired in runner.py
+   │   - Schema: schema_version=1; one record per (study_run_id,
+   │     config_hash, cycle); outcome ∈ {success, exception,
+   │     subprocess_died}
+   │   - Consumer (today): llem report-gaps (--source runtime-warnings,
+   │     the only wired source). Output: YAML fragment for manual
+   │     append to corpus (`# TODO: human` markers on placeholder
+   │     fields). PRESERVED as escape-hatch.
+   │   - Consumer (long-term): subsume into curation digest Section 3
+   │     ("Runtime gaps observed"). DEFERRED #475; reactivate after
+   │     2-3 Renovate cycles of operational data.
+   │
+   └─ equivalence_groups.json         [info]
+      - Detects observed_config_hash collisions across configs:
+        configs Pydantic distinguishes (resolved_config_hash differs)
+        but engine collapses (observed_config_hash matches). Flagged
+        as gap_detected: true -> dormancy signal.
+      - proposed_rule_id field is currently always None; consumer
+        was rejected in PR #404 (over-engineering; no real user yet).
+        Tracked in #405 + #474.
+================================================================================
+```
+
+For the full design rationale (including the resolution of the per-engine vs per-concern split, the wait-for-sibling coordination decision, and the rejected summariser-workflow alternative), see [`.product/designs/engine-coupling-architecture-2026-04-28.md`](../.product/designs/engine-coupling-architecture-2026-04-28.md).

--- a/scripts/generate_curation_doc.py
+++ b/scripts/generate_curation_doc.py
@@ -4,6 +4,14 @@
 For each engine, produces a Markdown file with a four-column table showing
 every discovered parameter and whether llem's Pydantic layer curates it.
 
+The header now also surfaces a delta-vs-previous block. The previous SSOT
+version is read from ``engine_versions/{engine}.yaml``'s
+``last_probe.version_inside_envelope`` field if present; on a fresh SSOT
+where ``last_probe.verdict`` is ``unrun`` the block degrades gracefully
+to a "deferred until first probe-pass cycle" placeholder. HEAD~1 is
+deliberately NOT consulted (it can be a bot writeback commit, breaking
+determinism — see PR-4b review).
+
 Output: docs/generated/curation-{engine}.md
 
 Run: python scripts/generate_curation_doc.py
@@ -13,6 +21,9 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -28,11 +39,69 @@ _ENGINE_DISPLAY_NAMES = {
     "tensorrt": "TensorRT-LLM",
 }
 
+_REPO_ROOT = Path(__file__).parent.parent
+
 
 def _get_curated_names(engine: str) -> set[str]:
     """Get the set of leaf field names curated by llem for this engine."""
     params = get_engine_params(engine)
     return {meta["name"] for meta in params.values()}
+
+
+def _read_previous_ssot_version(engine: str) -> str | None:
+    """Return the previous library version recorded in the SSOT, or ``None``.
+
+    Reads ``engine_versions/{engine}.yaml`` and returns the value of
+    ``last_probe.version_inside_envelope`` only when (a) the SSOT file
+    exists, (b) ``last_probe.verdict`` is one of the post-run verdicts
+    (``pass``/``fail``), and (c) the recorded version differs from the
+    current one. On any other shape (``unrun``, missing, malformed) the
+    delta block degrades to a deferred placeholder rather than fabricate
+    a comparison.
+    """
+    ssot_path = _REPO_ROOT / "engine_versions" / f"{engine}.yaml"
+    if not ssot_path.is_file():
+        return None
+    try:
+        data: Any = yaml.safe_load(ssot_path.read_text())
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    last_probe = data.get("last_probe")
+    if not isinstance(last_probe, dict):
+        return None
+    if last_probe.get("verdict") not in {"pass", "fail"}:
+        return None
+    version = last_probe.get("version_inside_envelope")
+    if not isinstance(version, str) or not version.strip():
+        return None
+    return version
+
+
+def _render_delta_block(engine: str, current_version: str) -> list[str]:
+    """Render the "Delta vs previous" header block.
+
+    On a fresh SSOT (``last_probe.verdict: unrun``) this degrades to an
+    honest placeholder rather than fabricating a comparison from
+    HEAD~1 (which can be a bot writeback commit).
+    """
+    previous = _read_previous_ssot_version(engine)
+    if previous is None:
+        return [
+            "**Delta vs previous:** _deferred until first probe-pass cycle._",
+            "",
+        ]
+    if previous == current_version:
+        return [
+            f"**Delta vs previous:** _no version change since `{previous}`._",
+            "",
+        ]
+    return [
+        f"**Delta vs previous:** `{previous}` -> `{current_version}` "
+        "(field-level diff lands once probe-pass cycles populate the previous-snapshot cache).",
+        "",
+    ]
 
 
 def _render_section(
@@ -84,6 +153,7 @@ def generate_engine_doc(engine: str, loader: SchemaLoader | None = None) -> str:
         f"({engine_total} engine + {sampling_total} sampling discovered)",
         "",
     ]
+    lines.extend(_render_delta_block(engine, schema.engine_version))
 
     if schema.engine_params:
         lines.extend(_render_section("Engine Parameters", schema.engine_params, curated))

--- a/scripts/generate_curation_doc.py
+++ b/scripts/generate_curation_doc.py
@@ -4,13 +4,13 @@
 For each engine, produces a Markdown file with a four-column table showing
 every discovered parameter and whether llem's Pydantic layer curates it.
 
-The header now also surfaces a delta-vs-previous block. The previous SSOT
-version is read from ``engine_versions/{engine}.yaml``'s
+The header surfaces a delta-vs-previous block. The previous SSOT version
+is read from ``engine_versions/{engine}.yaml``'s
 ``last_probe.version_inside_envelope`` field if present; on a fresh SSOT
 where ``last_probe.verdict`` is ``unrun`` the block degrades gracefully
 to a "deferred until first probe-pass cycle" placeholder. HEAD~1 is
-deliberately NOT consulted (it can be a bot writeback commit, breaking
-determinism — see PR-4b review).
+deliberately NOT consulted because it can be a bot writeback commit,
+which would make the comparison anchor non-deterministic.
 
 Output: docs/generated/curation-{engine}.md
 
@@ -25,11 +25,14 @@ from typing import Any
 
 import yaml
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+sys.path.insert(0, str(_PROJECT_ROOT))
 
-from llenergymeasure.config.introspection import get_engine_params
-from llenergymeasure.config.schema_loader import SchemaLoader
-from llenergymeasure.config.ssot import Engine
+from llenergymeasure.config.introspection import get_engine_params  # noqa: E402
+from llenergymeasure.config.schema_loader import SchemaLoader  # noqa: E402
+from llenergymeasure.config.ssot import Engine  # noqa: E402
+from scripts.engine_miners._ssot import ssot_path  # noqa: E402
 
 ENGINES = tuple(e.value for e in Engine)
 
@@ -38,8 +41,6 @@ _ENGINE_DISPLAY_NAMES = {
     "vllm": "vLLM",
     "tensorrt": "TensorRT-LLM",
 }
-
-_REPO_ROOT = Path(__file__).parent.parent
 
 
 def _get_curated_names(engine: str) -> set[str]:
@@ -59,11 +60,11 @@ def _read_previous_ssot_version(engine: str) -> str | None:
     delta block degrades to a deferred placeholder rather than fabricate
     a comparison.
     """
-    ssot_path = _REPO_ROOT / "engine_versions" / f"{engine}.yaml"
-    if not ssot_path.is_file():
+    path = ssot_path(engine)
+    if not path.is_file():
         return None
     try:
-        data: Any = yaml.safe_load(ssot_path.read_text())
+        data: Any = yaml.safe_load(path.read_text())
     except yaml.YAMLError:
         return None
     if not isinstance(data, dict):
@@ -164,18 +165,30 @@ def generate_engine_doc(engine: str, loader: SchemaLoader | None = None) -> str:
     return "\n".join(lines)
 
 
-def main() -> None:
-    """Generate curation docs for all engines."""
-    output_dir = Path(__file__).parent.parent / "docs" / "generated"
+def main(argv: list[str] | None = None) -> int:
+    """Generate curation docs for one engine or all engines."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--engine",
+        choices=ENGINES,
+        help="Generate the digest for one engine. Omit to render all three.",
+    )
+    args = parser.parse_args(argv)
+
+    output_dir = _PROJECT_ROOT / "docs" / "generated"
     output_dir.mkdir(parents=True, exist_ok=True)
     loader = SchemaLoader()
 
-    for engine in ENGINES:
+    targets = (args.engine,) if args.engine else ENGINES
+    for engine in targets:
         content = generate_engine_doc(engine, loader)
         output_path = output_dir / f"curation-{engine}.md"
         output_path.write_text(content)
         print(f"Generated: {output_path}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the new per-concern `engine-schemas.yml` workflow as the substantive successor to the deleted `parameter-discovery.yml`, and retrofits the already-on-main `engine-invariants.yml` with a sibling-completion wait so the two pipelines coordinate without a separate summariser.

- `.github/workflows/engine-schemas.yml` (new): per-engine matrix (transformers / vllm / tensorrt). Mirrors `engine-invariants.yml`'s shape: App-token mint, SSOT-driven build-arg, anchor-SHA from input paths only, `python -m scripts._probe --producer schemas`, discover via `python -m scripts.engine_introspectors`, diff via `scripts/diff_discovered_schemas.py`, regenerate `docs/generated/curation-{engine}.md`, upload artefact, suppress-on-empty per-pipeline comment, per-pipeline label (`schemas-changed` / `schemas-breaking` / `schemas-safe`), wait for sibling, atomic writeback (`git pull --rebase` + `force-with-lease`), cross-pipeline rollup label (`safe-bump` / `probe-blocked`).
- `.github/workflows/engine-invariants.yml` (modified): all three per-engine jobs gain a `lewagon/wait-on-check-action` step before their atomic-writeback step, blocking on the engine-schemas check for the same head SHA. Writeback now also `git pull --rebase --autostash` first to integrate any sibling writeback that landed earlier.
- `docs/pipeline-architecture.md` (new): pipeline-chain reference (Renovate -> SSOT -> docker-build -> per-concern workflows -> writeback -> human curation), copied from the design doc's chain diagram with a footer pointer to `.product/designs/engine-coupling-architecture-2026-04-28.md` for full rationale.
- `scripts/generate_curation_doc.py` (modified): adds a "Delta vs previous" header block sourced from `engine_versions/{engine}.yaml`'s `last_probe.version_inside_envelope` field. On a fresh SSOT (`verdict: unrun`) the block degrades gracefully to "deferred until first probe-pass cycle" rather than fabricating a comparison from `HEAD~1` (which can be a bot writeback commit and would defeat determinism).

## Why atomic writeback works without a summariser

The two workflows write to disjoint paths:

- engine-invariants -> `configs/engine_invariants/{engine}.{proposed,vendored}.yaml` + `docs/generated/invariants-{engine}.md`
- engine-schemas -> `src/llenergymeasure/config/discovered_schemas/{engine}.json` + `docs/generated/curation-{engine}.md`

Both update `engine_versions/{engine}.compat.json`, but only as appends keyed by producer (the probe primitive merges into the file rather than overwriting). The `lewagon/wait-on-check-action` step makes each pipeline block until the sibling completes; whichever reaches its writeback second sees the first's commit already on the remote, rebases on top, and pushes its own diff with `force-with-lease`. Net: one PR cycle yields up to two bot commits at most (one per concern, both lossless), and cross-pipeline state lives on labels.

## Determinism

Anchor-SHA computation in both workflows reads only from input paths (engine SSOT, Dockerfile, introspector / miner / lift modules). Output paths (the regenerated JSONs / YAMLs / docs) are excluded from the anchor input set, so re-runs against unchanged source emit byte-identical artefacts and the synchronize loop the watchdog catches cannot fire on this code.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes for both workflows
- [x] `python3 scripts/generate_curation_doc.py` regenerates all three curation digests with the new delta-vs-previous block (rendered as the deferred placeholder against today's `verdict: unrun` SSOTs)
- [x] `ruff format scripts/ src/ tests/` clean; `ruff check` reports only pre-existing errors (verified by stashing the feature diff and re-running on main)
- [x] `pytest tests/unit/scripts/engine_miners/test_ssot_pin_fixpoint.py tests/unit/scripts/test_probe.py` passes (24/24)
- [x] `pytest tests/unit/scripts/test_generate_curation_doc.py` passes (26/26)
- [x] `pytest tests/unit/scripts/` full sweep: 279 passed, 8 skipped
- [ ] Required CI checks (`test`, `lint`, `type-check`) green
- [ ] Post-merge: confirm both `engine-invariants.yml` and `engine-schemas.yml` remain `disabled_manually` until post-PR-6 validation

## Out of scope (follow-ups)

- `docs/architecture-overview.md` / `docs/extending-miners.md` / `docs/miner-pipeline.md` rename references for `parameter-discovery.yml` -> `engine-schemas.yml`
- Stale code-comment cleanup in `scripts/vendor_rules.py:186`, `scripts/refresh_discovered_schemas.sh`, `tests/unit/engine_miners/test_build_corpus.py:377`
- `docker-publish.yml` SSOT-bump trigger