### PR TITLE
docs(workflows): sync stale references to deleted predecessor workflows

### DIFF
--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -514,7 +514,7 @@ llem run experiment.yaml --skip-preflight
 
 When you update an engine version (by bumping the `ARG` in a Dockerfile), the
 vendored parameter schemas must be regenerated. This happens automatically via
-the [Parameter Discovery Pipeline](schema-refresh.md) (`parameter-discovery.yml` workflow)
+the [Parameter Discovery Pipeline](schema-refresh.md) (`engine-schemas.yml` workflow)
 for Renovate-managed bumps. For manual bumps, run:
 
 ```bash

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -424,10 +424,9 @@ Library version bumps trigger corpus regeneration automatically. The flow descri
   │               │                                                   │
   │     ┌─────────┴──────────────┐                                    │
   │     ▼                        ▼                                    │
-  │  engine-invariants.yml   parameter-discovery.yml                  │
-  │  (per-engine matrix:     (engine schemas; today's existing        │
-  │   probe + mine + vendor)  workflow until engine-schemas.yml       │
-  │                            ships as PR-5b)                        │
+  │  engine-invariants.yml   engine-schemas.yml                       │
+  │  (per-engine matrix:     (engine schemas:                         │
+  │   probe + mine + vendor)  introspect Pydantic configs)            │
   │                                                                   │
   │  Path filters fire both workflows in parallel on the Renovate     │
   │  PR. Each writes back to the PR branch independently.             │
@@ -461,7 +460,7 @@ Library version bumps trigger corpus regeneration automatically. The flow descri
   │      vendored.yaml, the digest doc, and engine_versions/          │
   │      {engine}.compat.json. Pushed with --force-with-lease.        │
   │                       │                                           │
-  │  ─────────────── parameter-discovery.yml (parallel) ───────       │
+  │  ─────────────── engine-schemas.yml (parallel) ────────────       │
   │                       ▼                                           │
   │  scripts/engine_introspectors introspects engine config classes   │
   │  inside Docker, regenerates discovered_schemas/{engine}.json,     │
@@ -495,7 +494,7 @@ The update workflow:
 
 ### Phase B.6 observed flow (historical)
 
-The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transformers v4.57.3 → v4.57.6) was the first naturally-Renovate-authored exercise of the full chain. It pre-dates the merge of mining + vendor into `engine-invariants.yml`; the workflow names below (`auto-mine.yml`, `invariant-miner.yml`) are historical and reflect the two-stage split that has since collapsed. The structural lessons (commit-back determinism, self-hosted runner serialisation) carry over to the merged workflow. The actual commit sequence on the PR branch:
+The Phase B.6 forced E2E run on PR #459 (`renovate/transformers-4.x`, transformers v4.57.3 → v4.57.6) was the first naturally-Renovate-authored exercise of the full chain. It pre-dates the merge of mining + vendor into `engine-invariants.yml` and the rename of the schema workflow to `engine-schemas.yml`; the workflow names below (`auto-mine.yml`, `invariant-miner.yml`, `parameter-discovery.yml`) are historical and reflect the predecessor pipeline shape that has since collapsed/renamed. The structural lessons (commit-back determinism, self-hosted runner serialisation) carry over to the merged workflow. The actual commit sequence on the PR branch:
 
 ```
   Commit (PR #459 branch)   Author       Producing workflow / event

--- a/docs/schema-refresh.md
+++ b/docs/schema-refresh.md
@@ -23,7 +23,7 @@ Renovate opens PR bumping ARG in Dockerfile
 e.g. ARG VLLM_VERSION=v0.7.3 -> v0.8.0
                       |
                       v
-parameter-discovery.yml auto-fires
+engine-schemas.yml auto-fires
 (guarded: only for Renovate-bot PRs touching Dockerfiles)
                       |
                       v
@@ -55,7 +55,7 @@ Maintainer reviews PR:
    Docker Hub image tags (vLLM), NGC image tags (TensorRT-LLM), and PyPI
    package versions via `customManagers` regex (transformers). Weekly schedule,
    3-day stability window before opening a PR.
-2. When Renovate opens a PR, **parameter-discovery.yml** auto-fires on the
+2. When Renovate opens a PR, **engine-schemas.yml** auto-fires on the
    self-hosted GPU runner.
 3. The workflow determines which engine(s) changed by inspecting the modified
    Dockerfile paths, then runs `./scripts/refresh_discovered_schemas.sh <engine>`.
@@ -83,14 +83,14 @@ Compares ARG version in Dockerfile vs engine_version in schema JSON
 
 On failure, the developer can either:
 - Run locally: `./scripts/refresh_discovered_schemas.sh <engine>`
-- Trigger remotely: `gh workflow run parameter-discovery.yml --field engine=<engine> --field pr_number=<N>`
+- Trigger remotely: `gh workflow run engine-schemas.yml --field engine=<engine> --field pr_number=<N>`
 
 ### Manual Refresh (workflow_dispatch)
 
 For ad-hoc refreshes outside the Renovate flow:
 
 ```bash
-gh workflow run parameter-discovery.yml \
+gh workflow run engine-schemas.yml \
   --field engine=vllm \
   --field pr_number=123
 ```

--- a/scripts/vendor_rules.py
+++ b/scripts/vendor_rules.py
@@ -183,7 +183,7 @@ def _construct_generic(native_type: str, kwargs: dict[str, Any]) -> Any:
 # Runs inside the ``llenergymeasure:tensorrt`` Docker image on the self-hosted
 # GPU runner — TRT-LLM 0.21.0 cannot be imported on a CPU host (loads CUDA
 # bindings on import), so this codepath is only exercised in CI by the
-# ``vendor-tensorrt`` job in ``.github/workflows/invariant-miner.yml``.
+# ``vendor-tensorrt`` job in ``.github/workflows/engine-invariants.yml``.
 #
 # The static miner emits short-form ``native_type`` values (``tensorrt_llm.X``)
 # matching the AST symbol it walked. Map those to the deep import paths inside

--- a/tests/unit/engine_miners/test_build_corpus.py
+++ b/tests/unit/engine_miners/test_build_corpus.py
@@ -374,7 +374,7 @@ class TestStability:
     def test_frozen_at_env_overrides_mined_at(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Contract relied on by .github/workflows/auto-mine.yml: when
+        # Contract relied on by .github/workflows/engine-invariants.yml: when
         # LLENERGY_MINER_FROZEN_AT is set, the merged envelope's ``mined_at``
         # MUST equal that exact value, regardless of staging timestamps. This
         # is the anchor that keeps re-runs on unchanged source byte-identical


### PR DESCRIPTION
## Summary

Sweeps live references to the deleted predecessor workflows (`auto-mine.yml`, `invariant-miner.yml`, `parameter-discovery.yml`) across docs and code comments, redirecting them to the merged successors (`engine-invariants.yml`, `engine-schemas.yml`). Cleans up the accumulated stale-reference debt deferred by the workflow-replacement PRs.

The sweep distinguishes between **live** references (describing the current pipeline shape) and **historical** references (describing specific past CI runs, e.g. the Phase B.6 forced E2E run on PR #459). Live references are updated; historical empirical records are preserved intact with their existing framing — rewriting them would falsify the historical record. The Phase B.6 framing in `miner-pipeline.md` is extended to cover `parameter-discovery.yml` alongside the original `auto-mine.yml` / `invariant-miner.yml` callouts so the historical-vs-current contrast remains legible.

## Changes

- `docs/miner-pipeline.md` — current-shape diagram boxes/headers updated to `engine-schemas.yml`; historical Phase B.6 section preserved with extended framing covering all three predecessor workflow names.
- `docs/schema-refresh.md` — workflow-name references in flow diagram, prose, and `gh workflow run` snippets updated to `engine-schemas.yml`.
- `docs/docker-setup.md` — single inline reference updated to `engine-schemas.yml`.
- `scripts/vendor_rules.py` — TRT-LLM runner code comment redirected to `engine-invariants.yml`.
- `tests/unit/engine_miners/test_build_corpus.py` — `LLENERGY_MINER_FROZEN_AT` contract comment redirected to `engine-invariants.yml`.

## Out of scope

- Workflow YAML — untouched.
- Conceptual layer name "Invariant Miner" in the architecture-overview data-flow diagram — kept (it is a logical layer, not a workflow filename).
- Doc filenames (`parameter-discovery.md`, `schema-refresh.md`) — kept (these are doc files, not workflow files).
- Design-doc filenames and "invariant-miner adversarial review" prose references — kept (these are document/concept names).

## Test plan

- [x] `grep -rn "auto-mine\.yml\|invariant-miner\.yml\|parameter-discovery\.yml" docs/ scripts/ src/ tests/` returns only matches inside historical sections (Phase B.6 timeline + the historical-split prose in `extending-miners.md`).
- [x] `ruff check` + `ruff format` clean on changed Python files.
- [x] Targeted unit tests pass (`test_build_corpus.py`, `test_probe.py`, `test_ssot_pin_fixpoint.py`) — 54 passed.