### PR TITLE
feat(workflows): add /approve-reuse slash command for SSOT pin widening

### DIFF
--- a/.github/workflows/approve-reuse-bot.yml
+++ b/.github/workflows/approve-reuse-bot.yml
@@ -1,0 +1,218 @@
+name: Approve Reuse — Slash Command Bot
+
+# Listens for /approve-reuse <engine> <producer> slash commands posted as
+# PR comments. When the commenter has write/maintain/admin permission on
+# this repo, the bot widens the SSOT's miner_pins SpecifierSet for the
+# requested (engine, producer) so the bumped library.current_version
+# falls inside the envelope. Subsequent re-runs of engine-invariants.yml
+# or engine-schemas.yml then probe under the new envelope and proceed.
+#
+# Producer naming
+# ---------------
+# Producer is `invariants | schemas` — matches the probe primitive's
+# user-facing producer kinds and the suggestion text emitted in probe-
+# fail PR comments. The mapping to SSOT miner_pins keys
+# (`static | dynamic | discovery`) lives in
+# scripts/widen_miner_pin.py.
+#
+# Determinism contract
+# --------------------
+# The widening is a pure function of (current SSOT, engine, producer):
+# same inputs always produce the same SSOT mutation. The commit-back is
+# gated on actual diff to the SSOT YAML (no commit when the version is
+# already inside the envelope). The line-surgical YAML edit preserves
+# every comment, quote, and adjacent line, so re-running the same slash
+# command emits zero diff after the first widening lands.
+#
+# Auth model
+# ----------
+# `issue_comment` fires on every PR comment. The job-level `if:` filter
+# narrows to comments containing `/approve-reuse`. Inside the job, the
+# FIRST step after token mint is the permission check. Read-only,
+# triage, and external commenters get a polite rejection comment, never
+# a silent ignore.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: approve-reuse-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  approve-reuse:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/approve-reuse')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mint llem-ci-bot App token
+        # Short-lived (~1 hour) GitHub App token. Events the App produces
+        # are NOT subject to the default GITHUB_TOKEN recursive-workflow
+        # guard, so the SSOT commit-back below can legitimately retrigger
+        # downstream engine-invariants / engine-schemas runs.
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Validate commenter has approval rights
+        # `issue_comment` fires on every comment. Permission gate is the
+        # FIRST behavioural step — anything below it must be guarded by
+        # `steps.auth.outputs.authorised == 'true'`. Acceptable repo
+        # roles: admin | maintain | write. Read-only, triage, and non-
+        # collaborators are rejected.
+        id: auth
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          PERMISSION=$(gh api \
+            "repos/${OWNER}/${REPO}/collaborators/${COMMENTER}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          case "${PERMISSION}" in
+            admin|maintain|write)
+              echo "authorised=true" >> "$GITHUB_OUTPUT"
+              echo "Commenter ${COMMENTER} has ${PERMISSION} permission."
+              ;;
+            *)
+              echo "authorised=false" >> "$GITHUB_OUTPUT"
+              echo "Commenter ${COMMENTER} has ${PERMISSION:-none} permission; rejecting."
+              ;;
+          esac
+
+      - name: Reject unauthorised commenter
+        if: steps.auth.outputs.authorised == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "@${COMMENTER}: \`/approve-reuse\` requires write, maintain, or admin permission on this repository. Your comment was ignored. If you should have access, ask a maintainer to grant the appropriate role."
+
+      - name: Parse slash command arguments
+        # Match the FIRST `/approve-reuse <engine> <producer>` token in
+        # the comment body. Engine + producer are constrained to fixed
+        # vocabularies — no shell injection risk downstream.
+        id: parse
+        if: steps.auth.outputs.authorised == 'true'
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          ARGS=$(printf '%s\n' "$BODY" \
+            | grep -oE '/approve-reuse[[:space:]]+[a-z]+[[:space:]]+[a-z]+' \
+            | head -1 || true)
+          if [[ -z "$ARGS" ]]; then
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ENGINE=$(printf '%s\n' "$ARGS" | awk '{print $2}')
+          PRODUCER=$(printf '%s\n' "$ARGS" | awk '{print $3}')
+          case "$ENGINE" in
+            transformers|vllm|tensorrt) ;;
+            *) echo "valid=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+          esac
+          case "$PRODUCER" in
+            invariants|schemas) ;;
+            *) echo "valid=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+          esac
+          {
+            echo "valid=true"
+            echo "engine=$ENGINE"
+            echo "producer=$PRODUCER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Reject malformed slash command
+        if: steps.auth.outputs.authorised == 'true' && steps.parse.outputs.valid == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "@${COMMENTER}: \`/approve-reuse\` requires \`<engine> <producer>\` arguments. Engines: \`transformers | vllm | tensorrt\`. Producers: \`invariants | schemas\`. Example: \`/approve-reuse transformers invariants\`."
+
+      - name: Resolve PR head ref
+        id: pr
+        if: steps.auth.outputs.authorised == 'true' && steps.parse.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          REF=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        if: steps.auth.outputs.authorised == 'true' && steps.parse.outputs.valid == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        if: steps.auth.outputs.authorised == 'true' && steps.parse.outputs.valid == 'true'
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: approve-reuse-bot-3.12
+          python-version: "3.12"
+
+      - name: Widen SSOT miner_pins
+        id: widen
+        if: steps.auth.outputs.authorised == 'true' && steps.parse.outputs.valid == 'true'
+        env:
+          ENGINE: ${{ steps.parse.outputs.engine }}
+          PRODUCER: ${{ steps.parse.outputs.producer }}
+        run: |
+          uv run --no-sync --with pyyaml --with packaging \
+            python scripts/widen_miner_pin.py \
+            --engine "$ENGINE" --producer "$PRODUCER"
+
+      - name: Commit + push SSOT update
+        if: steps.auth.outputs.authorised == 'true' && steps.parse.outputs.valid == 'true' && steps.widen.outputs.changed == 'true'
+        env:
+          ENGINE: ${{ steps.parse.outputs.engine }}
+          PRODUCER: ${{ steps.parse.outputs.producer }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          git config user.name  "llem-ci-bot[bot]"
+          git config user.email "${{ secrets.APP_ID }}+llem-ci-bot[bot]@users.noreply.github.com"
+          git add "engine_versions/${ENGINE}.yaml"
+          if git diff --cached --quiet; then
+            echo "No SSOT change to commit; skipping push."
+            exit 0
+          fi
+          git commit -m "chore(engines): widen ${ENGINE} miner_pins.${PRODUCER} per /approve-reuse from @${COMMENTER}"
+          git push
+
+      - name: Post confirmation comment
+        if: steps.auth.outputs.authorised == 'true' && steps.parse.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          ENGINE: ${{ steps.parse.outputs.engine }}
+          PRODUCER: ${{ steps.parse.outputs.producer }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          CHANGED: ${{ steps.widen.outputs.changed }}
+          OLD_RANGE: ${{ steps.widen.outputs.old_range }}
+          NEW_RANGE: ${{ steps.widen.outputs.new_range }}
+        run: |
+          if [[ "$CHANGED" == "true" ]]; then
+            BODY="Widened \`${ENGINE}\` \`miner_pins.${PRODUCER}\`: \`${OLD_RANGE}\` -> \`${NEW_RANGE}\` per @${COMMENTER}'s /approve-reuse. Re-run engine-invariants or engine-schemas to probe under the new envelope."
+          else
+            BODY="\`${ENGINE}\` \`miner_pins.${PRODUCER}\` already covers \`library.current_version\`; no SSOT change needed."
+          fi
+          gh pr comment "$PR_NUMBER" --body "$BODY"

--- a/.github/workflows/approve-reuse-bot.yml
+++ b/.github/workflows/approve-reuse-bot.yml
@@ -48,7 +48,7 @@ jobs:
   approve-reuse:
     if: |
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/approve-reuse')
+      startsWith(github.event.comment.body, '/approve-reuse')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -101,17 +101,22 @@ jobs:
           gh pr comment "$PR_NUMBER" --body "@${COMMENTER}: \`/approve-reuse\` requires write, maintain, or admin permission on this repository. Your comment was ignored. If you should have access, ask a maintainer to grant the appropriate role."
 
       - name: Parse slash command arguments
-        # Match the FIRST `/approve-reuse <engine> <producer>` token in
-        # the comment body. Engine + producer are constrained to fixed
-        # vocabularies — no shell injection risk downstream.
+        # Parse from the FIRST line of the body only. The job-level `if:`
+        # already requires the body to startWith `/approve-reuse`, so the
+        # first line is the slash-command line. Restricting the regex to
+        # this line prevents quoted-reply blocks (`> /approve-reuse ...`
+        # in a reply) from being silently accepted as commands. Engine +
+        # producer are constrained to fixed vocabularies — no shell
+        # injection risk downstream.
         id: parse
         if: steps.auth.outputs.authorised == 'true'
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          ARGS=$(printf '%s\n' "$BODY" \
-            | grep -oE '/approve-reuse[[:space:]]+[a-z]+[[:space:]]+[a-z]+' \
+          FIRST_LINE=$(printf '%s' "$BODY" | head -n 1)
+          ARGS=$(printf '%s' "$FIRST_LINE" \
+            | grep -oE '^/approve-reuse[[:space:]]+[a-z]+[[:space:]]+[a-z]+' \
             | head -1 || true)
           if [[ -z "$ARGS" ]]; then
             echo "valid=false" >> "$GITHUB_OUTPUT"

--- a/scripts/widen_miner_pin.py
+++ b/scripts/widen_miner_pin.py
@@ -1,0 +1,276 @@
+"""Widen ``miner_pins.{producer}`` SpecifierSet in an engine's SSOT.
+
+Helper for the ``/approve-reuse`` slash-command workflow. Reads the
+per-engine SSOT (``engine_versions/{engine}.yaml``), inspects the current
+``library.current_version`` and the ``miner_pins.{ssot_key}`` SpecifierSet
+for the requested producer, and widens the SpecifierSet so the bumped
+version falls inside the envelope.
+
+Determinism contract
+--------------------
+For a given (SSOT contents, engine, producer) input, the widening output
+is a pure function of the inputs. Re-running with no change to the SSOT
+emits ``changed=false`` and exits 0 without mutating the file. The
+"already widened" short-circuit prevents the workflow from looping when
+the same slash command runs twice.
+
+The mutation is line-surgical: only the ``miner_pins.{key}: <range>``
+line is rewritten. Header comments, string-quoting style, key order, and
+every other line are preserved byte-for-byte. Roundtripping the YAML
+through ``yaml.safe_load`` + ``yaml.safe_dump`` would strip comments and
+re-quote scalars, breaking the determinism contract on subsequent runs.
+
+User-facing producer naming
+---------------------------
+``producer`` is ``invariants | schemas`` — matching the probe primitive's
+user-facing producer kinds and the suggestion text emitted in probe-fail
+PR comments. The mapping to the SSOT's ``miner_pins`` keys
+(``static | dynamic | discovery``) is the same one the probe uses
+(``_SSOT_PIN_FOR_PRODUCER``):
+
+    invariants -> static
+    schemas    -> discovery
+
+Outputs
+-------
+When invoked with ``$GITHUB_OUTPUT`` set, emits three keys for the
+workflow to consume:
+
+    changed=<true|false>
+    old_range=<existing SpecifierSet, e.g. ">=4.56,<4.57">
+    new_range=<post-widening SpecifierSet>
+
+CLI
+---
+    python scripts/widen_miner_pin.py --engine transformers --producer invariants
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_miners._ssot import ssot_path  # noqa: E402
+
+ProducerKind = Literal["invariants", "schemas"]
+
+# Mirrors ``scripts._probe._SSOT_PIN_FOR_PRODUCER``. Duplicated rather
+# than imported so this script stays decoupled from the probe primitive
+# (the probe imports producer modules at runtime; we only need the
+# string-to-string translation).
+_SSOT_PIN_FOR_PRODUCER: dict[ProducerKind, str] = {
+    "invariants": "static",
+    "schemas": "discovery",
+}
+
+
+def _widen_range_string(existing: str, version: Version) -> str:
+    """Return a ``>=A,<B``-shaped range string that includes ``version``.
+
+    Recognised shape: ``>=A,<B`` (the convention in every
+    ``engine_versions/*.yaml`` miner_pin today). When ``version >= B``,
+    the upper bound is widened to the next minor above ``version``
+    (e.g. ``4.58.0`` -> ``<4.59``).
+
+    Falls back to appending ``,<=current_version`` for unrecognised
+    shapes — loud-but-functional; the workflow will still commit a
+    deterministic result. The returned string preserves the order
+    callers expect to see in the SSOT (lower bound first).
+    """
+    parts = [p.strip() for p in existing.split(",") if p.strip()]
+    lower: str | None = None
+    upper: str | None = None
+    extras: list[str] = []
+    for part in parts:
+        if part.startswith((">=", ">")):
+            lower = part
+        elif part.startswith(("<=", "<")):
+            upper = part
+        else:
+            extras.append(part)
+
+    if lower is None or upper is None or extras:
+        # Unrecognised shape — preserve every original constraint and
+        # add a ``<=current_version`` ceiling so the bumped version is
+        # covered. Ordering: original parts in original order, then the
+        # new ceiling appended.
+        return ",".join([*parts, f"<={version}"])
+
+    next_minor = f"{version.major}.{version.minor + 1}"
+    return f"{lower},<{next_minor}"
+
+
+def _emit_outputs(*, changed: bool, old_range: str, new_range: str) -> None:
+    """Write step outputs to ``$GITHUB_OUTPUT`` if running under Actions."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as fh:
+        fh.write(f"changed={'true' if changed else 'false'}\n")
+        fh.write(f"old_range={old_range}\n")
+        fh.write(f"new_range={new_range}\n")
+
+
+# Match `  static: ">=4.56,<4.57"` (or single-quoted, or unquoted). Captures
+# the indent + key prefix, the optional opening quote, the value, and the
+# optional closing quote. Anchored to BOL so we never substitute inside a
+# nested mapping where the same key might appear at greater indentation.
+_PIN_LINE_RE = re.compile(
+    r"^(?P<prefix>(?P<indent> {2,})(?P<key>[a-z]+):\s*)"
+    r"(?P<oq>['\"])?(?P<value>[^'\"\n]+?)(?P=oq)?\s*$"
+)
+
+
+def _replace_pin_line(text: str, pin_key: str, new_value: str) -> tuple[str, str | None]:
+    """Replace the ``miner_pins.{pin_key}`` line; return (new_text, old_value).
+
+    ``old_value`` is ``None`` if no matching line was found inside the
+    ``miner_pins:`` block. The block is identified by the literal
+    ``miner_pins:`` line at the start of a line (zero indent). Mutation is
+    confined to the indented child lines that follow.
+    """
+    lines = text.splitlines(keepends=True)
+    in_block = False
+    block_indent: str | None = None
+    old_value: str | None = None
+    for idx, line in enumerate(lines):
+        if line.startswith("miner_pins:"):
+            in_block = True
+            continue
+        if in_block:
+            stripped = line.lstrip(" ")
+            if stripped == line and stripped != "\n" and stripped != "":
+                # Dedent below `miner_pins:` -> block ended without a hit.
+                break
+            match = _PIN_LINE_RE.match(line.rstrip("\n"))
+            if match is None:
+                continue
+            if block_indent is None:
+                block_indent = match.group("indent")
+            elif match.group("indent") != block_indent:
+                # Deeper-indented child of a nested mapping; skip.
+                continue
+            if match.group("key") != pin_key:
+                continue
+            old_value = match.group("value")
+            quote = match.group("oq") or '"'
+            newline = "\n" if line.endswith("\n") else ""
+            lines[idx] = f"{match.group('prefix')}{quote}{new_value}{quote}{newline}"
+            return "".join(lines), old_value
+    return text, old_value
+
+
+def widen(*, engine: str, producer: ProducerKind) -> int:
+    """Widen ``miner_pins.{producer}`` for ``engine``; return exit status."""
+    if producer not in _SSOT_PIN_FOR_PRODUCER:
+        print(
+            f"Unknown producer {producer!r}; expected one of {sorted(_SSOT_PIN_FOR_PRODUCER)}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    pin_key = _SSOT_PIN_FOR_PRODUCER[producer]
+    path = ssot_path(engine)
+    text = path.read_text()
+
+    # Parse for value extraction only; never write the parsed dict back.
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        print(f"SSOT at {path} is not a mapping.", file=sys.stderr)
+        return 2
+
+    library = data.get("library") or {}
+    current_version_raw = library.get("current_version")
+    if not current_version_raw:
+        print(f"library.current_version missing from {path}.", file=sys.stderr)
+        return 2
+
+    miner_pins = data.get("miner_pins") or {}
+    if pin_key not in miner_pins:
+        print(
+            f"miner_pins.{pin_key} missing from {path}; present keys: {sorted(miner_pins)}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    version = Version(str(current_version_raw))
+    old_range = str(miner_pins[pin_key])
+
+    if version in SpecifierSet(old_range):
+        print(
+            f"{engine} miner_pins.{pin_key} = {old_range!r} already covers "
+            f"library.current_version={version}; no change."
+        )
+        _emit_outputs(changed=False, old_range=old_range, new_range=old_range)
+        return 0
+
+    new_range = _widen_range_string(old_range, version)
+    if new_range == old_range or version not in SpecifierSet(new_range):
+        # Either widening was a no-op or the result still doesn't cover the
+        # version (defensive: the SpecifierSet round-trip should always
+        # succeed for the recognised shape, but fail loud rather than
+        # commit a wrong-result widening).
+        print(
+            f"Refusing to widen {engine} miner_pins.{pin_key}: computed "
+            f"{new_range!r} does not cover {version} (input was {old_range!r}).",
+            file=sys.stderr,
+        )
+        return 2
+
+    new_text, old_line_value = _replace_pin_line(text, pin_key, new_range)
+    if old_line_value is None:
+        # Parser saw the key but the regex missed it — inconsistent shape.
+        print(
+            f"Could not locate miner_pins.{pin_key} line in {path}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    path.write_text(new_text)
+    print(
+        f"Widened {engine} miner_pins.{pin_key}: {old_range!r} -> {new_range!r} "
+        f"(library.current_version={version})."
+    )
+    _emit_outputs(changed=True, old_range=old_range, new_range=new_range)
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="scripts.widen_miner_pin",
+        description="Widen miner_pins.{producer} SpecifierSet in an engine SSOT.",
+    )
+    parser.add_argument(
+        "--engine",
+        required=True,
+        choices=("transformers", "vllm", "tensorrt"),
+        help="Engine whose SSOT to mutate.",
+    )
+    parser.add_argument(
+        "--producer",
+        required=True,
+        choices=("invariants", "schemas"),
+        help="User-facing producer kind (matches the probe primitive).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    return widen(engine=args.engine, producer=args.producer)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/widen_miner_pin.py
+++ b/scripts/widen_miner_pin.py
@@ -52,7 +52,6 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Literal
 
 import yaml
 from packaging.specifiers import SpecifierSet
@@ -62,18 +61,8 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts._probe import _SSOT_PIN_FOR_PRODUCER, ProducerKind  # noqa: E402
 from scripts.engine_miners._ssot import ssot_path  # noqa: E402
-
-ProducerKind = Literal["invariants", "schemas"]
-
-# Mirrors ``scripts._probe._SSOT_PIN_FOR_PRODUCER``. Duplicated rather
-# than imported so this script stays decoupled from the probe primitive
-# (the probe imports producer modules at runtime; we only need the
-# string-to-string translation).
-_SSOT_PIN_FOR_PRODUCER: dict[ProducerKind, str] = {
-    "invariants": "static",
-    "schemas": "discovery",
-}
 
 
 def _widen_range_string(existing: str, version: Version) -> str:

--- a/tests/unit/scripts/test_widen_miner_pin.py
+++ b/tests/unit/scripts/test_widen_miner_pin.py
@@ -1,0 +1,210 @@
+"""Tests for :mod:`scripts.widen_miner_pin` — the SSOT pin-widener helper.
+
+The helper backs the ``/approve-reuse`` slash command. These tests pin
+the determinism contract (idempotency, line-surgical edits, no-op when
+the version is already covered) and the producer-kind translation
+(``invariants`` -> ``static``, ``schemas`` -> ``discovery``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts import widen_miner_pin  # noqa: E402
+
+_BASE_SSOT = """\
+# Header comment block must survive every widening.
+#
+# Multi-line context block.
+schema_version: 1
+engine: transformers
+library:
+  pep503_name: transformers
+  current_version: "4.57.3"
+  current_commit_sha: null
+image:
+  base_image_ref: "llenergymeasure:transformers-4.57.3"
+  llem_image_ref: null
+miner_pins:
+  static: ">=4.56,<4.57"
+  dynamic: ">=4.56,<4.57"
+  discovery: ">=4.56,<4.57"
+artefact_paths:
+  rules_corpus: configs/engine_invariants/transformers.proposed.yaml
+  vendored_rules: configs/engine_invariants/transformers.vendored.yaml
+  discovered_schemas: src/llenergymeasure/config/discovered_schemas/transformers.json
+last_probe:
+  verdict: unrun
+  version_inside_envelope: null
+  fingerprint: null
+  fingerprint_drift: []
+  ran_at: null
+"""
+
+
+def _seed_ssot(tmp_path: Path, engine: str, body: str) -> Path:
+    """Write ``body`` to ``tmp_path/{engine}.yaml`` and return its path."""
+    target = tmp_path / f"{engine}.yaml"
+    target.write_text(body)
+    return target
+
+
+@pytest.fixture()
+def fake_ssot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect ``widen_miner_pin.ssot_path`` to a temporary SSOT copy."""
+    target = _seed_ssot(tmp_path, "transformers", _BASE_SSOT)
+
+    def _fake_path(engine: str) -> Path:
+        return tmp_path / f"{engine}.yaml"
+
+    monkeypatch.setattr(widen_miner_pin, "ssot_path", _fake_path)
+    return target
+
+
+def test_invariants_maps_to_static_miner_pin(
+    fake_ssot: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``invariants`` widens the ``static`` SSOT key, leaves ``discovery`` alone."""
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    rc = widen_miner_pin.widen(engine="transformers", producer="invariants")
+    assert rc == 0
+    text = fake_ssot.read_text()
+    assert 'static: ">=4.56,<4.58"' in text
+    assert 'discovery: ">=4.56,<4.57"' in text  # untouched
+
+
+def test_schemas_maps_to_discovery_miner_pin(
+    fake_ssot: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``schemas`` widens the ``discovery`` SSOT key, leaves ``static`` alone."""
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    rc = widen_miner_pin.widen(engine="transformers", producer="schemas")
+    assert rc == 0
+    text = fake_ssot.read_text()
+    assert 'static: ">=4.56,<4.57"' in text  # untouched
+    assert 'discovery: ">=4.56,<4.58"' in text
+
+
+def test_version_already_inside_envelope_is_noop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bumped version inside the existing range -> no file mutation."""
+    body = _BASE_SSOT.replace('static: ">=4.56,<4.57"', 'static: ">=4.56,<4.99"')
+    target = _seed_ssot(tmp_path, "transformers", body)
+    monkeypatch.setattr(widen_miner_pin, "ssot_path", lambda _e: target)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    before = target.read_text()
+    rc = widen_miner_pin.widen(engine="transformers", producer="invariants")
+    after = target.read_text()
+
+    assert rc == 0
+    assert before == after
+
+
+def test_widening_is_idempotent(fake_ssot: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Running the widener twice in a row produces zero diff after the first."""
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    assert widen_miner_pin.widen(engine="transformers", producer="invariants") == 0
+    after_first = fake_ssot.read_text()
+    assert widen_miner_pin.widen(engine="transformers", producer="invariants") == 0
+    after_second = fake_ssot.read_text()
+    assert after_first == after_second
+
+
+def test_line_surgical_edit_preserves_comments_and_quoting(fake_ssot: Path) -> None:
+    """Header comments, key order, and string quoting all survive the edit."""
+    widen_miner_pin.widen(engine="transformers", producer="invariants")
+    text = fake_ssot.read_text()
+    assert text.startswith("# Header comment block must survive every widening.\n")
+    assert 'current_version: "4.57.3"' in text  # quoting preserved
+    # Key order in miner_pins block preserved.
+    static_idx = text.index("  static:")
+    dynamic_idx = text.index("  dynamic:")
+    discovery_idx = text.index("  discovery:")
+    assert static_idx < dynamic_idx < discovery_idx
+
+
+def test_emits_github_outputs(
+    fake_ssot: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When ``$GITHUB_OUTPUT`` is set, emits ``changed``, ``old_range``, ``new_range``."""
+    output_file = tmp_path / "gh-output"
+    output_file.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    rc = widen_miner_pin.widen(engine="transformers", producer="invariants")
+    assert rc == 0
+    output = output_file.read_text()
+    assert "changed=true" in output
+    assert "old_range=>=4.56,<4.57" in output
+    assert "new_range=>=4.56,<4.58" in output
+
+
+def test_emits_changed_false_when_noop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """No-op widening still emits ``changed=false`` for the workflow to read."""
+    body = _BASE_SSOT.replace('static: ">=4.56,<4.57"', 'static: ">=4.56,<4.99"')
+    target = _seed_ssot(tmp_path, "transformers", body)
+    monkeypatch.setattr(widen_miner_pin, "ssot_path", lambda _e: target)
+
+    output_file = tmp_path / "gh-output"
+    output_file.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    widen_miner_pin.widen(engine="transformers", producer="invariants")
+    output = output_file.read_text()
+    assert "changed=false" in output
+
+
+def test_missing_miner_pin_key_fails_loud(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Missing SSOT ``miner_pins.<key>`` -> non-zero exit, no mutation."""
+    body = _BASE_SSOT.replace('  static: ">=4.56,<4.57"\n', "")
+    target = _seed_ssot(tmp_path, "transformers", body)
+    monkeypatch.setattr(widen_miner_pin, "ssot_path", lambda _e: target)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    rc = widen_miner_pin.widen(engine="transformers", producer="invariants")
+    assert rc == 2
+
+
+def test_widening_below_lower_bound_refuses_to_commit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bumped version below the lower bound -> refuse rather than emit a wrong widening."""
+    body = _BASE_SSOT.replace('current_version: "4.57.3"', 'current_version: "4.50.0"')
+    target = _seed_ssot(tmp_path, "transformers", body)
+    monkeypatch.setattr(widen_miner_pin, "ssot_path", lambda _e: target)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    before = target.read_text()
+    rc = widen_miner_pin.widen(engine="transformers", producer="invariants")
+    after = target.read_text()
+
+    assert rc == 2
+    assert before == after
+
+
+def test_widen_range_string_recognised_shape() -> None:
+    """``>=A,<B`` widens to ``>=A,<{next_minor}`` with lower bound preserved."""
+    from packaging.version import Version
+
+    result = widen_miner_pin._widen_range_string(">=4.56,<4.57", Version("4.57.3"))
+    assert result == ">=4.56,<4.58"
+
+
+def test_widen_range_string_fallback_for_unrecognised_shape() -> None:
+    """Multi-clause / equality ranges -> append ``<=current_version`` ceiling."""
+    from packaging.version import Version
+
+    result = widen_miner_pin._widen_range_string(">=4.56,<4.57,!=4.56.5", Version("4.57.3"))
+    assert "<=4.57.3" in result
+    # Original constraints all preserved.
+    for clause in (">=4.56", "<4.57", "!=4.56.5"):
+        assert clause in result


### PR DESCRIPTION
## Summary

Adds an issue_comment-triggered workflow that lets approvers widen the SSOT's `miner_pins` SpecifierSet via PR comments when a probe-fail is determined acceptable. After widening, subsequent re-runs of `engine-invariants.yml` or `engine-schemas.yml` probe under the new envelope and proceed.

When a probe fails (e.g. landmark drift on a non-load-bearing symbol), an approver posts:

```
@llem-ci-bot /approve-reuse <engine> <producer>
```

The bot:
1. Validates the commenter has `write | maintain | admin` permission on the repository.
2. Parses `engine` (`transformers | vllm | tensorrt`) and `producer` (`invariants | schemas`) from the comment.
3. Reads `engine_versions/{engine}.yaml`, gets `library.current_version` and the existing `miner_pins.<key>` range, and widens the SpecifierSet's upper bound to the next minor when the version sits above the ceiling.
4. Commits the SSOT update via the `llem-ci-bot` App token (cascades to downstream workflows; `GITHUB_TOKEN` would not).
5. Posts a confirmation comment with the old and new ranges (or a no-op message if the version was already covered).

Producer naming matches the probe primitive's user-facing kinds (`invariants | schemas`) — the same strings the probe-fail comments emitted by `engine-invariants.yml` and `engine-schemas.yml` already tell users to type. The mapping to SSOT keys (`invariants` -> `static`, `schemas` -> `discovery`) lives in `scripts/widen_miner_pin.py` alongside the equivalent table in `scripts/_probe.py`.

## Files

- `.github/workflows/approve-reuse-bot.yml` — issue_comment-triggered workflow with auth gate, arg parsing, SSOT widening, commit-back, and confirmation comment.
- `scripts/widen_miner_pin.py` — pure helper that computes the widening and rewrites the `miner_pins.{key}:` line surgically (preserves comments, quoting, and adjacent lines so determinism holds).
- `tests/unit/scripts/test_widen_miner_pin.py` — 11 unit tests covering producer-kind mapping, idempotency, line-surgical edits, GITHUB_OUTPUT emission, missing-key + below-lower-bound failure modes, and recognised/unrecognised range shapes.

## Security model

- `issue_comment` fires on every PR comment. The job-level `if:` filter narrows to PR comments containing `/approve-reuse`.
- The FIRST behavioural step inside the job is the permission check. Acceptable: `admin | maintain | write`. Read-only, triage, and non-collaborators get a polite rejection comment; never a silent ignore.
- Engine + producer values are constrained to fixed vocabularies (`case ... esac`); no shell injection vector through arg parsing.

## Determinism

- Widening is a pure function of (SSOT contents, engine, producer). Same inputs produce the same SSOT mutation.
- The commit-back is gated on actual diff to the YAML; running the same slash command twice in a row emits one widening, then a confirmation-only second run.
- The YAML edit is line-surgical: only the matching `miner_pins.{key}: <range>` line is rewritten. Header comments, quoting style, and key order all survive byte-for-byte.

## Out of scope

- Does NOT enable `engine-invariants.yml` or `engine-schemas.yml` (they remain `disabled_manually`).
- Does NOT trigger any probe — this PR only adds the SSOT-widening primitive that re-enables the next probe cycle.
- Does NOT modify the existing engine-* workflows or the probe primitive.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/approve-reuse-bot.yml'))"` parses
- [x] `uv run --no-sync python -m pytest tests/unit/scripts/test_widen_miner_pin.py -v` (11 / 11 passed)
- [x] `uv run --no-sync python -m pytest tests/unit/scripts/test_probe.py tests/unit/scripts/engine_miners/test_ssot_pin_fixpoint.py -q` (35 / 35 passed; pre-existing tests still green)
- [x] `ruff format --check scripts/widen_miner_pin.py tests/unit/scripts/test_widen_miner_pin.py` clean
- [x] `ruff check scripts/widen_miner_pin.py tests/unit/scripts/test_widen_miner_pin.py` clean
- [x] `mypy scripts/widen_miner_pin.py tests/unit/scripts/test_widen_miner_pin.py` clean
- [x] Manual end-to-end: ran helper against `engine_versions/transformers.yaml`; confirmed line-surgical edit, idempotent re-run, and version-below-lower-bound refusal; reverted SSOT before commit
- [ ] First-real-use cycle on a Renovate bump PR validates end-to-end (post-merge; depends on `engine-invariants.yml` re-enable)