### PR TITLE
fix(renovate): tighten engine-bump policy with stability + confidence + major-gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "matchPackageNames": ["vllm/vllm-openai"],
       "labels": ["renovate", "engine-vllm"],
       "automerge": false,
-      "stabilityDays": 3
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["dockerfile"],
@@ -32,39 +32,64 @@
       "labels": ["renovate", "engine-tensorrt"],
       "registryUrls": ["https://nvcr.io"],
       "automerge": false,
-      "stabilityDays": 3
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["dockerfile"],
       "matchPackageNames": ["pytorch/pytorch"],
       "labels": ["renovate", "engine-transformers"],
       "automerge": false,
-      "stabilityDays": 3
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["transformers"],
       "labels": ["renovate", "engine-transformers"],
       "automerge": false,
-      "stabilityDays": 3
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["vllm"],
       "labels": ["renovate", "engine-vllm"],
       "automerge": false,
-      "stabilityDays": 3
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["tensorrt-llm"],
       "labels": ["renovate", "engine-tensorrt"],
       "automerge": false,
-      "stabilityDays": 3
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["pep621"],
       "rangeStrategy": "replace"
+    },
+    {
+      "description": "Major engine-library bumps require explicit dashboard approval — never auto-PR. Reproducibility-critical: a major version is rarely API-compatible with the previous and demands measurement-result re-baselining.",
+      "matchPackageNames": [
+        "transformers",
+        "vllm",
+        "tensorrt-llm",
+        "vllm/vllm-openai",
+        "nvcr.io/nvidia/tensorrt-llm/release",
+        "pytorch/pytorch"
+      ],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Only auto-PR when Mend merge-confidence signal is high or very-high. Filters out releases that other repos have flagged as unstable via CI / revert patterns.",
+      "matchPackageNames": [
+        "transformers",
+        "vllm",
+        "tensorrt-llm",
+        "vllm/vllm-openai",
+        "nvcr.io/nvidia/tensorrt-llm/release",
+        "pytorch/pytorch"
+      ],
+      "matchConfidence": ["high", "very high"]
     }
   ],
   "schedule": ["before 9am on Monday"],

--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,10 @@
       "labels": ["renovate", "engine-tensorrt"],
       "automerge": false,
       "stabilityDays": 3
+    },
+    {
+      "matchManagers": ["pep621"],
+      "rangeStrategy": "replace"
     }
   ],
   "schedule": ["before 9am on Monday"],


### PR DESCRIPTION
## Summary

Renovate-hygiene fixes prompted by PR #489 (transformers 4.x → 5.x major bump opening the day the major shipped, with an unsatisfiable pep621 lower bound).

Four changes, all in `renovate.json`:

1. **`stabilityDays: 3` → `minimumReleaseAge: "14 days"`** on all 6 engine-tracking package rules. The 3-day floor was too aggressive for a reproducibility-critical measurement framework — research results need to replicate against engine versions that have settled. 14 days is the standard floor for ML library minor releases.
2. **`dependencyDashboardApproval: true`** for major updates on `transformers`, `vllm`, `tensorrt-llm`, `vllm/vllm-openai`, `nvcr.io/nvidia/tensorrt-llm/release`, `pytorch/pytorch`. Major bumps never auto-PR; they land on the Dependency Dashboard awaiting manual click. A major version is rarely API-compatible with the previous and demands measurement-result re-baselining.
3. **`matchConfidence: ["high", "very high"]`** for the same engine package set, using Mend's merge-confidence signal to filter out releases other repos are CI-reverting.
4. **`rangeStrategy: "replace"`** for the `pep621` manager, fixing the immediate breakage where Renovate's default produced `>=5.7,<6` (unsatisfiable, since latest was 5.6.2). This rule becomes obsolete when the engine extras drop in the engines-in-Docker-only follow-up (issue #491 reframed).

## Test plan

- [x] `renovate.json` is valid JSON; 9 packageRules
- [ ] CI green (lint + type-check + filter)
- [ ] Renovate's next cycle (next Monday or manual dashboard re-evaluation) verifies (a) no auto-PR for transformers v5 majors, (b) the pep621 manager produces a satisfiable constraint when it does fire, (c) auto-PRs that DO fire have `confidence ≥ high` per Mend signal

## Related

- PR #489 (the broken transformers v5 PR that surfaced these gaps)
- Issue #491 (host-installable extras follow-up; pep621 rule becomes obsolete after it lands)
- Issue #493 (docs sweep follow-up)