### PR TITLE
feat(workflows): bake buildx GHA cache + flip INSTALL_FA3=true for engine images

### DIFF
--- a/.github/workflows/engine-invariants.yml
+++ b/.github/workflows/engine-invariants.yml
@@ -103,25 +103,28 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:transformers-${VER}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build or reuse transformers image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. Layer cache makes the FROM step a no-op
-        # when the upstream torch/transformers tag is unchanged.
-        # INSTALL_FA3=false keeps the build fast (FA3 from-source is ~1h);
-        # the miners + vendor pass don't need flash-attn.
-        run: |
-          IMAGE="${{ steps.version.outputs.image }}"
-          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            docker build \
-              -f docker/Dockerfile.transformers \
-              -t "$IMAGE" \
-              --build-arg TRANSFORMERS_VERSION="${{ steps.version.outputs.version }}" \
-              --build-arg INSTALL_FA3=false \
-              .
-          else
-            echo "Reusing cached $IMAGE."
-          fi
+        # the two cannot drift. GHA layer cache (scoped per-engine + per-
+        # version) persists across ephemeral runners, so the FA3 stage
+        # only recompiles on a cold cache; warm runs reuse the cached
+        # layer. INSTALL_FA3=true matches production — the CI image is
+        # byte-equivalent to what users get from the documented build.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.transformers
+          tags: ${{ steps.version.outputs.image }}
+          build-args: |
+            TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
+            INSTALL_FA3=true
+          cache-from: type=gha,scope=transformers-${{ steps.version.outputs.version }}
+          cache-to: type=gha,mode=max,scope=transformers-${{ steps.version.outputs.version }}
+          load: true
 
       - name: Compute stable mining + vendor anchor
         id: anchor
@@ -489,22 +492,27 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build or reuse vLLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. Layer cache makes the FROM step a no-op
-        # when the upstream tag is unchanged.
-        run: |
-          IMAGE="${{ steps.version.outputs.image }}"
-          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            docker build \
-              -f docker/Dockerfile.vllm \
-              -t "$IMAGE" \
-              --build-arg VLLM_VERSION="${{ steps.version.outputs.version }}" \
-              .
-          else
-            echo "Reusing cached $IMAGE."
-          fi
+        # the two cannot drift. GHA layer cache (scoped per-engine + per-
+        # version) persists across runs; on the self-hosted runner this
+        # layers on top of the daemon's own image cache, both contributing
+        # to fast warm rebuilds. vLLM's Dockerfile pulls a pre-built base
+        # image, so there's no FA3 equivalent to flip here.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.vllm
+          tags: ${{ steps.version.outputs.image }}
+          build-args: |
+            VLLM_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=vllm-${{ steps.version.outputs.version }}
+          cache-to: type=gha,mode=max,scope=vllm-${{ steps.version.outputs.version }}
+          load: true
 
       - name: Compute stable mining + vendor anchor
         id: anchor
@@ -867,22 +875,26 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build or reuse TRT-LLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
-        # local-build fallback. Layer cache keeps rebuilds fast when the
-        # NGC tag is unchanged. Note Dockerfile ARG is named
-        # TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
-        run: |
-          IMAGE="${{ steps.version.outputs.image }}"
-          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            docker build \
-              -f docker/Dockerfile.tensorrt \
-              -t "$IMAGE" \
-              --build-arg TRTLLM_VERSION="${{ steps.version.outputs.version }}" \
-              .
-          else
-            echo "Reusing cached $IMAGE."
-          fi
+        # local-build fallback. GHA layer cache (scoped per-engine + per-
+        # version) persists across runs; on the self-hosted runner this
+        # layers on top of the daemon's own image cache. The NGC base image
+        # is the dominant layer; warm rebuilds are near-instant. Dockerfile
+        # ARG is named TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.tensorrt
+          tags: ${{ steps.version.outputs.image }}
+          build-args: |
+            TRTLLM_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=tensorrt-${{ steps.version.outputs.version }}
+          cache-to: type=gha,mode=max,scope=tensorrt-${{ steps.version.outputs.version }}
+          load: true
 
       - name: Compute stable mining + vendor anchor
         id: anchor

--- a/.github/workflows/engine-schemas.yml
+++ b/.github/workflows/engine-schemas.yml
@@ -94,23 +94,28 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:transformers-${VER}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build or reuse transformers image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. INSTALL_FA3=false keeps the build fast
-        # (FA3 from-source is ~1h); discovery doesn't need flash-attn.
-        run: |
-          IMAGE="${{ steps.version.outputs.image }}"
-          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            docker build \
-              -f docker/Dockerfile.transformers \
-              -t "$IMAGE" \
-              --build-arg TRANSFORMERS_VERSION="${{ steps.version.outputs.version }}" \
-              --build-arg INSTALL_FA3=false \
-              .
-          else
-            echo "Reusing cached $IMAGE."
-          fi
+        # the two cannot drift. GHA layer cache (scoped per-engine + per-
+        # version) persists across ephemeral runners, so the FA3 stage
+        # only recompiles on a cold cache; warm runs reuse the cached
+        # layer. INSTALL_FA3=true matches production — the CI image is
+        # byte-equivalent to what users get from the documented build.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.transformers
+          tags: ${{ steps.version.outputs.image }}
+          build-args: |
+            TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
+            INSTALL_FA3=true
+          cache-from: type=gha,scope=transformers-${{ steps.version.outputs.version }}
+          cache-to: type=gha,mode=max,scope=transformers-${{ steps.version.outputs.version }}
+          load: true
 
       - name: Compute stable discovery anchor
         id: anchor
@@ -398,22 +403,27 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build or reuse vLLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. Layer cache makes the FROM step a no-op
-        # when the upstream tag is unchanged.
-        run: |
-          IMAGE="${{ steps.version.outputs.image }}"
-          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            docker build \
-              -f docker/Dockerfile.vllm \
-              -t "$IMAGE" \
-              --build-arg VLLM_VERSION="${{ steps.version.outputs.version }}" \
-              .
-          else
-            echo "Reusing cached $IMAGE."
-          fi
+        # the two cannot drift. GHA layer cache (scoped per-engine + per-
+        # version) persists across runs; on the self-hosted runner this
+        # layers on top of the daemon's own image cache, both contributing
+        # to fast warm rebuilds. vLLM's Dockerfile pulls a pre-built base
+        # image, so there's no FA3 equivalent to flip here.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.vllm
+          tags: ${{ steps.version.outputs.image }}
+          build-args: |
+            VLLM_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=vllm-${{ steps.version.outputs.version }}
+          cache-to: type=gha,mode=max,scope=vllm-${{ steps.version.outputs.version }}
+          load: true
 
       - name: Compute stable discovery anchor
         id: anchor
@@ -710,22 +720,26 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build or reuse TRT-LLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
-        # local-build fallback. Layer cache keeps rebuilds fast when the
-        # NGC tag is unchanged. Dockerfile ARG is named TRTLLM_VERSION
-        # (not TENSORRT_VERSION) — preserved.
-        run: |
-          IMAGE="${{ steps.version.outputs.image }}"
-          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            docker build \
-              -f docker/Dockerfile.tensorrt \
-              -t "$IMAGE" \
-              --build-arg TRTLLM_VERSION="${{ steps.version.outputs.version }}" \
-              .
-          else
-            echo "Reusing cached $IMAGE."
-          fi
+        # local-build fallback. GHA layer cache (scoped per-engine + per-
+        # version) persists across runs; on the self-hosted runner this
+        # layers on top of the daemon's own image cache. The NGC base image
+        # is the dominant layer; warm rebuilds are near-instant. Dockerfile
+        # ARG is named TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.tensorrt
+          tags: ${{ steps.version.outputs.image }}
+          build-args: |
+            TRTLLM_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=tensorrt-${{ steps.version.outputs.version }}
+          cache-to: type=gha,mode=max,scope=tensorrt-${{ steps.version.outputs.version }}
+          load: true
 
       - name: Compute stable discovery anchor
         id: anchor

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -65,8 +65,9 @@ Unknown fields under `pytorch:` are forwarded to HuggingFace APIs.
 
 Note: `flash_attention_3` requires the `flash_attn_3` package (built separately from the
 flash-attn repo's `hopper/` directory) and an Ampere+ GPU (SM80+, e.g. A100 or H100).
-The Docker Transformers image includes FA3 by default. To skip it (e.g. for faster CI builds),
-rebuild with `--build-arg INSTALL_FA3=false`. See
+The Docker Transformers image includes FA3 by default and CI builds with it on too (so the
+CI image matches what production users get). To skip FA3 for faster local iteration, rebuild
+with `--build-arg INSTALL_FA3=false`. See
 [Installation - FlashAttention-3](installation.md#flashattention-3) for details.
 
 **Compilation:**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -257,7 +257,7 @@ build completes in minutes.
 FA3 provides Hopper-optimised attention kernels. Use it via
 `transformers.attn_implementation: flash_attention_3` in your experiment configs.
 
-**To skip FA3** (e.g. for faster CI builds):
+**To skip FA3** for faster local iteration (CI builds with FA3 to match the production image profile, using GHA layer cache to keep cold-build cost amortised):
 
 ```bash
 docker build -f docker/Dockerfile.transformers \


### PR DESCRIPTION
## Summary

Bake `docker/setup-buildx-action@v4` + `docker/build-push-action@v7` + GHA layer cache (per-engine + per-version scope) into all six engine-image build steps. Flip `INSTALL_FA3=true` for the transformers cells so the CI image is byte-equivalent to what production users get from `Dockerfile.transformers`.

Closes #506. Plausibly closes #501 (message_template diffs caused by attn-availability differences resolve when CI image's flash-attn profile matches production's).

## What changed

- **`engine-invariants.yml` + `engine-schemas.yml`** — three engine cells per file, each replaced its inline `docker build` block with `docker/setup-buildx-action@v4` + `docker/build-push-action@v7`. Cache scope is `type=gha,scope={engine}-${version}` for both `cache-from` and `cache-to: mode=max`. `load: true` keeps the built image in the local docker daemon for the subsequent `docker run` mining/probing steps.
- **Transformers cells flip `INSTALL_FA3=false → INSTALL_FA3=true`** — the CI image now includes flash-attn 3 from-source, matching production. Cold-cache cost: ~1h on first build per `(engine, version)` pair; subsequent runs hit the GHA cache. vllm/tensorrt cells don't have an `INSTALL_FA3` ARG (their Dockerfiles get FA3-equivalent functionality from upstream base images).
- **`docs/installation.md` + `docs/engines.md`** — reframe the `INSTALL_FA3=false` override: it's now for *local fast iteration*, not "for faster CI builds." CI builds with FA3 to match production.

## Doc audit outcome (per /squash-merge §0.5)

Greppped `docs/` + `README.md` + `src/` for `INSTALL_FA3` references after the contract change. Hits resolved: 2 doc files updated (`installation.md`, `engines.md`) — both had previously framed `INSTALL_FA3=false` as the CI-builds path; now framed as local-iteration override. No remaining stale references.

## Simplify outcome

Inline review (per rigour-scales-with-PR-shape: workflow-only diff, 4 files, ~200 lines — inline is appropriate vs 3-agent fan-out): buildx pattern applied consistently across all 6 cells, cache scope is per-engine + per-version (correct granularity — SSOT bumps invalidate cache as expected), `load: true` plumbed for downstream `docker run` steps, comments are substantive. No issues to fix inline.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/engine-invariants.yml'))"` — clean
- [x] `uv run pytest tests/ -m "not gpu and not docker" -q` — 2440 passed, 52 skipped
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` + `ruff format --check` — clean
- [x] CI required checks (lint, test, type-check) green on this PR
- [ ] Post-merge first warm-cache miss observation: when the engine workflows are next re-enabled and a real engine bump fires through, verify the FA3 cold-build runs once and subsequent runs hit cache (~5-10 min instead of ~1h)
- [ ] Post-merge: verify #501 message_template noise resolves (re-run the same Renovate dispatch twice; the second cycle should produce zero message_template diffs)

## Follow-ups

- Re-enable `engine-invariants.yml` + `engine-schemas.yml` (currently `disabled_manually` per the engine-coupling validation gate). The workflow-only diff in this PR didn't trigger them; first FA3 cold-build observation will happen on the next real cycle.