### PR TITLE
Revert "feat(workflows): enable buildx GHA cache for engine images, flip INSTALL_FA3=true (#507)"

### DIFF
--- a/.github/workflows/engine-invariants.yml
+++ b/.github/workflows/engine-invariants.yml
@@ -103,28 +103,25 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:transformers-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build or reuse transformers image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. GHA layer cache (scoped per-engine + per-
-        # version) persists across ephemeral runners, so the FA3 stage
-        # only recompiles on a cold cache; warm runs reuse the cached
-        # layer. INSTALL_FA3=true matches production — the CI image is
-        # byte-equivalent to what users get from the documented build.
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.transformers
-          tags: ${{ steps.version.outputs.image }}
-          build-args: |
-            TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
-            INSTALL_FA3=true
-          cache-from: type=gha,scope=transformers-${{ steps.version.outputs.version }}
-          cache-to: type=gha,mode=max,scope=transformers-${{ steps.version.outputs.version }}
-          load: true
+        # the two cannot drift. Layer cache makes the FROM step a no-op
+        # when the upstream torch/transformers tag is unchanged.
+        # INSTALL_FA3=false keeps the build fast (FA3 from-source is ~1h);
+        # the miners + vendor pass don't need flash-attn.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.transformers \
+              -t "$IMAGE" \
+              --build-arg TRANSFORMERS_VERSION="${{ steps.version.outputs.version }}" \
+              --build-arg INSTALL_FA3=false \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
 
       - name: Compute stable mining + vendor anchor
         id: anchor
@@ -492,27 +489,22 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build or reuse vLLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. GHA layer cache (scoped per-engine + per-
-        # version) persists across runs; on the self-hosted runner this
-        # layers on top of the daemon's own image cache, both contributing
-        # to fast warm rebuilds. vLLM's Dockerfile pulls a pre-built base
-        # image, so there's no FA3 equivalent to flip here.
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.vllm
-          tags: ${{ steps.version.outputs.image }}
-          build-args: |
-            VLLM_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=vllm-${{ steps.version.outputs.version }}
-          cache-to: type=gha,mode=max,scope=vllm-${{ steps.version.outputs.version }}
-          load: true
+        # the two cannot drift. Layer cache makes the FROM step a no-op
+        # when the upstream tag is unchanged.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.vllm \
+              -t "$IMAGE" \
+              --build-arg VLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
 
       - name: Compute stable mining + vendor anchor
         id: anchor
@@ -875,26 +867,22 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build or reuse TRT-LLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
-        # local-build fallback. GHA layer cache (scoped per-engine + per-
-        # version) persists across runs; on the self-hosted runner this
-        # layers on top of the daemon's own image cache. The NGC base image
-        # is the dominant layer; warm rebuilds are near-instant. Dockerfile
-        # ARG is named TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.tensorrt
-          tags: ${{ steps.version.outputs.image }}
-          build-args: |
-            TRTLLM_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=tensorrt-${{ steps.version.outputs.version }}
-          cache-to: type=gha,mode=max,scope=tensorrt-${{ steps.version.outputs.version }}
-          load: true
+        # local-build fallback. Layer cache keeps rebuilds fast when the
+        # NGC tag is unchanged. Note Dockerfile ARG is named
+        # TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.tensorrt \
+              -t "$IMAGE" \
+              --build-arg TRTLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
 
       - name: Compute stable mining + vendor anchor
         id: anchor

--- a/.github/workflows/engine-schemas.yml
+++ b/.github/workflows/engine-schemas.yml
@@ -94,28 +94,23 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:transformers-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build or reuse transformers image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. GHA layer cache (scoped per-engine + per-
-        # version) persists across ephemeral runners, so the FA3 stage
-        # only recompiles on a cold cache; warm runs reuse the cached
-        # layer. INSTALL_FA3=true matches production — the CI image is
-        # byte-equivalent to what users get from the documented build.
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.transformers
-          tags: ${{ steps.version.outputs.image }}
-          build-args: |
-            TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
-            INSTALL_FA3=true
-          cache-from: type=gha,scope=transformers-${{ steps.version.outputs.version }}
-          cache-to: type=gha,mode=max,scope=transformers-${{ steps.version.outputs.version }}
-          load: true
+        # the two cannot drift. INSTALL_FA3=false keeps the build fast
+        # (FA3 from-source is ~1h); discovery doesn't need flash-attn.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.transformers \
+              -t "$IMAGE" \
+              --build-arg TRANSFORMERS_VERSION="${{ steps.version.outputs.version }}" \
+              --build-arg INSTALL_FA3=false \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
 
       - name: Compute stable discovery anchor
         id: anchor
@@ -403,27 +398,22 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:vllm-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build or reuse vLLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
         # local-build fallback. CI passes the SSOT value at build time so
-        # the two cannot drift. GHA layer cache (scoped per-engine + per-
-        # version) persists across runs; on the self-hosted runner this
-        # layers on top of the daemon's own image cache, both contributing
-        # to fast warm rebuilds. vLLM's Dockerfile pulls a pre-built base
-        # image, so there's no FA3 equivalent to flip here.
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.vllm
-          tags: ${{ steps.version.outputs.image }}
-          build-args: |
-            VLLM_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=vllm-${{ steps.version.outputs.version }}
-          cache-to: type=gha,mode=max,scope=vllm-${{ steps.version.outputs.version }}
-          load: true
+        # the two cannot drift. Layer cache makes the FROM step a no-op
+        # when the upstream tag is unchanged.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.vllm \
+              -t "$IMAGE" \
+              --build-arg VLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
 
       - name: Compute stable discovery anchor
         id: anchor
@@ -720,26 +710,22 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:tensorrt-${VER}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build or reuse TRT-LLM image
         # SSOT is the canonical version; the Dockerfile ARG default is a
-        # local-build fallback. GHA layer cache (scoped per-engine + per-
-        # version) persists across runs; on the self-hosted runner this
-        # layers on top of the daemon's own image cache. The NGC base image
-        # is the dominant layer; warm rebuilds are near-instant. Dockerfile
-        # ARG is named TRTLLM_VERSION (not TENSORRT_VERSION) — preserved.
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.tensorrt
-          tags: ${{ steps.version.outputs.image }}
-          build-args: |
-            TRTLLM_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=tensorrt-${{ steps.version.outputs.version }}
-          cache-to: type=gha,mode=max,scope=tensorrt-${{ steps.version.outputs.version }}
-          load: true
+        # local-build fallback. Layer cache keeps rebuilds fast when the
+        # NGC tag is unchanged. Dockerfile ARG is named TRTLLM_VERSION
+        # (not TENSORRT_VERSION) — preserved.
+        run: |
+          IMAGE="${{ steps.version.outputs.image }}"
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            docker build \
+              -f docker/Dockerfile.tensorrt \
+              -t "$IMAGE" \
+              --build-arg TRTLLM_VERSION="${{ steps.version.outputs.version }}" \
+              .
+          else
+            echo "Reusing cached $IMAGE."
+          fi
 
       - name: Compute stable discovery anchor
         id: anchor

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -65,9 +65,8 @@ Unknown fields under `pytorch:` are forwarded to HuggingFace APIs.
 
 Note: `flash_attention_3` requires the `flash_attn_3` package (built separately from the
 flash-attn repo's `hopper/` directory) and an Ampere+ GPU (SM80+, e.g. A100 or H100).
-The Docker Transformers image includes FA3 by default and CI builds with it on too (so the
-CI image matches what production users get). To skip FA3 for faster local iteration, rebuild
-with `--build-arg INSTALL_FA3=false`. See
+The Docker Transformers image includes FA3 by default. To skip it (e.g. for faster CI builds),
+rebuild with `--build-arg INSTALL_FA3=false`. See
 [Installation - FlashAttention-3](installation.md#flashattention-3) for details.
 
 **Compilation:**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -257,7 +257,7 @@ build completes in minutes.
 FA3 provides Hopper-optimised attention kernels. Use it via
 `transformers.attn_implementation: flash_attention_3` in your experiment configs.
 
-**To skip FA3** for faster local iteration (CI builds with FA3 to match the production image profile, using GHA layer cache to keep cold-build cost amortised):
+**To skip FA3** (e.g. for faster CI builds):
 
 ```bash
 docker build -f docker/Dockerfile.transformers \


### PR DESCRIPTION
Reverts #507 at the user's request. The merge happened before the user could intervene; this revert undoes it. The work will be re-opened with additional doc edits + a Dockerfile-touch so the path-filter actually fires the engine workflows on next iteration.

PR-507 itself was implementation-correct; the issue was scope (CI/prod parity framing in docs) + observability (workflow YAML changes alone don't trigger the engine workflows because path-filter doesn't include .github/workflows/*.yml; Dockerfile content needs to change to fire the trigger).