### PR TITLE
refactor: complete transformers kernel-substrate transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       job:
-        description: "Job to run (all, lint, type-check, test, package-validation, docs-freshness, docker-smoke)"
+        description: "Job to run (all, lint, type-check, test, package-validation, docs-freshness)"
         required: false
         default: "all"
         type: choice
@@ -15,7 +15,6 @@ on:
           - test
           - package-validation
           - docs-freshness
-          - docker-smoke
   pull_request:
     branches: [main]
   push:
@@ -182,38 +181,6 @@ jobs:
           uv run python scripts/generate_curation_doc.py > /dev/null
       - name: Check Pydantic-discovered schema alignment
         run: uv run python scripts/check_pydantic_matches_discovered.py > /dev/null
-
-  docker-smoke:
-    needs: filter
-    if: >-
-      always()
-      && (
-        (github.event_name == 'workflow_dispatch' && (inputs.job == 'all' || inputs.job == 'docker-smoke'))
-        || needs.filter.outputs.docker == 'true'
-      )
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - dockerfile: transformers
-            blocking: true
-    continue-on-error: ${{ !matrix.blocking }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Free disk space
-        run: |
-          # Remove large pre-installed packages that aren't needed
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          df -h /
-      - name: Build ${{ matrix.dockerfile }} image
-        run: docker build -f docker/Dockerfile.${{ matrix.dockerfile }} --build-arg INSTALL_FA3=false . -t smoke-${{ matrix.dockerfile }}
-      - name: Smoke test ${{ matrix.dockerfile }}
-        run: |
-          docker run --rm smoke-${{ matrix.dockerfile }} llem --version
-          docker run --rm smoke-${{ matrix.dockerfile }} llem config
 
   schema-version-check:
     needs: filter

--- a/.github/workflows/engine-image-build.yml
+++ b/.github/workflows/engine-image-build.yml
@@ -139,11 +139,21 @@ jobs:
           # and the FA3 layer cache-hits reliably from prior builds.
           build-args: |
             TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
+          # cache-from: registry-mode reads from a separate cache-only ref
+          # (not the runtime image) where mode=max metadata for ALL
+          # intermediate layers lives. That gives us cache hits on the FA3
+          # builder layer + the runtime install layers — which the runtime
+          # image's content-addressable manifest alone cannot provide.
+          # GHA cache mode dropped: a prior run (25329040682) spent ~45 min
+          # uploading 7-8 GB to GitHub Actions Cache. Registry-mode export
+          # is much faster (just metadata + dedup-aware layer push) AND
+          # works on workflow_dispatch where push: false skips the runtime
+          # image (the cache ref is independent of the runtime tag).
           cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers:latest
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}
-            type=gha,scope=transformers-${{ steps.version.outputs.version }}
-          cache-to: type=gha,mode=max,scope=transformers-${{ steps.version.outputs.version }}
+          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache
 
       - name: Emit image digest summary
         run: |

--- a/.github/workflows/engine-image-build.yml
+++ b/.github/workflows/engine-image-build.yml
@@ -134,13 +134,17 @@ jobs:
           # production-equivalent image users get. Two parallelism knobs
           # multiply: MAX_JOBS caps parallel nvcc invocations (ninja -j);
           # NVCC_THREADS caps threads per nvcc call. flash-attention/hopper
-          # reads NVCC_THREADS with default 2 — the prior 60-min build used
-          # only ~2 cc1plus workers despite MAX_JOBS=16 because the nvcc
-          # internal cap dominated. NVCC_THREADS=4 + MAX_JOBS=16 gives up to
-          # ~64 effective workers on the 128-vCPU / 528 GB host.
+          # reads NVCC_THREADS with default 2 — a prior 60-min build used
+          # only ~2 cc1plus workers despite a high MAX_JOBS because the nvcc
+          # internal cap dominated. MAX_JOBS=32 × NVCC_THREADS=4 = 128
+          # effective workers, one per vCPU on the 128-vCPU / 528 GB self-
+          # hosted runner — the saturation point. The earlier MAX_JOBS=16
+          # cap left half the cores idle (49-min cold build observed); the
+          # 528 GB RAM headroom comfortably absorbs the ~128 GB peak that
+          # MAX_JOBS=32 produces.
           build-args: |
             TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
-            MAX_JOBS=16
+            MAX_JOBS=32
             NVCC_THREADS=4
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers:latest

--- a/.github/workflows/engine-image-build.yml
+++ b/.github/workflows/engine-image-build.yml
@@ -129,23 +129,16 @@ jobs:
           tags: ${{ steps.targets.outputs.tags }}
           push: ${{ steps.targets.outputs.push }}
           no-cache: ${{ steps.targets.outputs.no_cache }}
-          # SSOT-driven build arg. INSTALL_FA3 deliberately NOT overridden
-          # here — the Dockerfile defaults to true, so CI builds the same
-          # production-equivalent image users get. Two parallelism knobs
-          # multiply: MAX_JOBS caps parallel nvcc invocations (ninja -j);
-          # NVCC_THREADS caps threads per nvcc call. flash-attention/hopper
-          # reads NVCC_THREADS with default 2 — a prior 60-min build used
-          # only ~2 cc1plus workers despite a high MAX_JOBS because the nvcc
-          # internal cap dominated. MAX_JOBS=32 × NVCC_THREADS=4 = 128
-          # effective workers, one per vCPU on the 128-vCPU / 528 GB self-
-          # hosted runner — the saturation point. The earlier MAX_JOBS=16
-          # cap left half the cores idle (49-min cold build observed); the
-          # 528 GB RAM headroom comfortably absorbs the ~128 GB peak that
-          # MAX_JOBS=32 produces.
+          # SSOT-driven build arg only. INSTALL_FA3 / MAX_JOBS / NVCC_THREADS
+          # are pinned in docker/Dockerfile.transformers (32 / 4 — saturates
+          # the 128-vCPU self-hosted runner) and DELIBERATELY NOT passed as
+          # build-args here. Build-args participate in BuildKit's layer-hash,
+          # so varying them across CI iterations invalidates the FA3 layer
+          # cache (~30 min recompile per change). With the parallelism knobs
+          # pinned in the Dockerfile, the layer hash is stable across runs
+          # and the FA3 layer cache-hits reliably from prior builds.
           build-args: |
             TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
-            MAX_JOBS=32
-            NVCC_THREADS=4
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers:latest
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}

--- a/docker/Dockerfile.transformers
+++ b/docker/Dockerfile.transformers
@@ -47,6 +47,10 @@ ARG INSTALL_FA3
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV TORCH_CUDA_ARCH_LIST="8.0;9.0+PTX"
 
+# Make apt resilient to transient Ubuntu mirror flakes (3 build failures
+# in 6 hours on 2026-05-04 were all archive.ubuntu.com transient errors).
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 # FA2: install from PyPI (cache mount persists compiled wheel across rebuilds)
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system flash-attn --no-build-isolation
@@ -90,6 +94,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Suppress hardlink warnings when cache mount is on a different filesystem
 ENV UV_LINK_MODE=copy
+
+# Same apt-retry resilience as the builder stage (separate stage = separate apt config).
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 
 # Required for torch.compile (inductor JIT-compiles Triton kernels via C/C++ compiler)
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential \

--- a/docker/Dockerfile.transformers
+++ b/docker/Dockerfile.transformers
@@ -64,9 +64,19 @@ ARG MAX_JOBS=32
 ARG NVCC_THREADS=4
 ENV MAX_JOBS=${MAX_JOBS}
 ENV NVCC_THREADS=${NVCC_THREADS}
+# apt cache mounts persist /var/cache/apt + /var/lib/apt/lists between
+# builds on the same BuildKit instance — subsequent builds reuse the
+# fetched .deb packages and Packages metadata without hitting the mirror.
+# Eliminates the dominant build-flake mode (Ubuntu archive intermittently
+# returning incomplete or malformed package lists). The trailing
+# `rm -rf /var/lib/apt/lists/*` is a no-op when the cache mount is in
+# place — it scrubs the in-image copy after the install layer commits,
+# but the mount-backed cache survives.
 RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     if [ "$INSTALL_FA3" = "true" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && \
+        apt-get update && apt-get install -y --no-install-recommends git && \
         git clone --depth 1 --branch ${FLASH_ATTN_VERSION} https://github.com/Dao-AILab/flash-attention.git /tmp/flash-attention && \
         pip install /tmp/flash-attention/hopper --no-build-isolation && \
         rm -rf /tmp/flash-attention; \
@@ -95,12 +105,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # Suppress hardlink warnings when cache mount is on a different filesystem
 ENV UV_LINK_MODE=copy
 
-# Same apt-retry resilience as the builder stage (separate stage = separate apt config).
+# Same apt-retry + cache-mount resilience as the builder stage. Cache mounts
+# persist /var/cache/apt + /var/lib/apt/lists across builds — subsequent
+# builds reuse cached .debs and metadata, avoiding mirror-flake exposure.
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 
 # Required for torch.compile (inductor JIT-compiles Triton kernels via C/C++ compiler)
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends build-essential
 
 # Copy compiled flash-attn from builder (package dir + dist-info + CUDA extensions)
 COPY --from=builder /flash-attn-staging/ /opt/conda/lib/python3.11/site-packages/

--- a/docker/Dockerfile.transformers
+++ b/docker/Dockerfile.transformers
@@ -1,16 +1,27 @@
 # syntax=docker/dockerfile:1
 # ============================================================
-# Transformers engine — llenergymeasure on PyTorch base image
+# Transformers engine substrate on PyTorch base image
 # ============================================================
-# Uses pytorch/pytorch as the tensor substrate, then installs llenergymeasure
-# with the HuggingFace Transformers engine on top.
-# CUDA and PyTorch compatibility is guaranteed by the upstream image.
+# Uses pytorch/pytorch as the tensor substrate, then layers the HuggingFace
+# Transformers engine substrate (transformers + FA2 + FA3 + accelerate +
+# bitsandbytes + calflops + sentencepiece + einops) plus llenergymeasure's
+# runtime non-engine deps on top. CUDA and PyTorch compatibility is
+# guaranteed by the upstream image.
+#
+# The llenergymeasure package itself is NOT installed into this image. The
+# project source is bind-mounted at runtime by the caller — see the engine-
+# invariants/engine-schemas workflows and docs/development.md for the canonical
+# `docker run -v $(pwd):/llem-src -e PYTHONPATH=/llem-src --entrypoint python3`
+# pattern. Symmetric with the vllm + tensorrt cells, which mount the same way
+# against upstream-direct images. This makes image rebuilds depend only on the
+# engine substrate, not on project source edits.
 #
 # Usage:
 #   docker build -f docker/Dockerfile.transformers -t llenergymeasure-transformers .
 #
 # Version pin policy: update PYTORCH_VERSION on each milestone release.
 # Must be compatible with pyproject.toml torch>=2.5 / transformers>=4.49 constraints.
+# TRANSFORMERS_VERSION comes from engine_versions/transformers.yaml SSOT.
 # ============================================================
 ARG PYTORCH_VERSION=2.5.1-cuda12.4-cudnn9-runtime
 ARG PYTORCH_DEVEL_VERSION=2.5.1-cuda12.4-cudnn9-devel
@@ -89,40 +100,42 @@ COPY --from=builder /flash-attn-staging/ /opt/conda/lib/python3.11/site-packages
 
 WORKDIR /app
 
-# Install llenergymeasure from source plus the transformers engine deps inline.
+# Install the transformers engine substrate plus llenergymeasure's runtime
+# non-engine deps. The project source itself is NOT installed — it is bind-
+# mounted at runtime via PYTHONPATH (see header).
+#
 # Engine deps (transformers/accelerate/bitsandbytes/calflops + sentencepiece/einops)
-# are declared HERE rather than via a host-side pyproject extra: the engine
-# runs only inside this image, so its dependency list belongs in the image's
-# install spec, not in a host extra that nothing else uses.
-# Bind mounts: pyproject.toml/uv.lock/README.md are build-only (not needed at runtime).
-# Cache mount: uv reuses cached wheels across rebuilds without bloating the image.
-COPY src/ ./src/
+# belong in the image because the engine runs only inside this image.
+#
+# Project runtime deps (pydantic, typer, pyyaml, platformdirs, nvidia-ml-py,
+# numpy, pyarrow, tqdm, rich, python-dotenv, filelock) are baked in here
+# because the upstream pytorch/pytorch base does not bring them transitively
+# and the project is no longer pip-installed into this image.
 ARG TRANSFORMERS_VERSION
-RUN --mount=type=bind,source=pyproject.toml,target=/app/pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=/app/uv.lock \
-    --mount=type=bind,source=README.md,target=/app/README.md \
-    --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system "." \
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system \
         "transformers==${TRANSFORMERS_VERSION}" \
         "accelerate>=1.4" \
         "bitsandbytes>=0.45" \
         "calflops>=0.2" \
-        sentencepiece einops
+        sentencepiece einops \
+        "pydantic>=2.0" \
+        "typer>=0.9" \
+        "pyyaml>=6.0" \
+        "platformdirs>=3.0" \
+        "nvidia-ml-py>=12.0" \
+        "numpy>=1.24" \
+        "pyarrow>=14.0" \
+        "tqdm>=4.66" \
+        "rich>=13.0" \
+        "python-dotenv>=1.0" \
+        filelock
 
 # HuggingFace cache — writable for non-root users
 ENV HF_HOME=/app/.cache/huggingface
 RUN mkdir -p /app/.cache/huggingface && chmod 777 /app/.cache/huggingface
 
-# Host/container schema handshake labels (see infra/version_handshake.py).
-# LLEM_PKG_VERSION is the llenergymeasure release; LLEM_EXPCONF_SCHEMA_FINGERPRINT
-# is a SHA-256 of ExperimentConfig.model_json_schema() at build time.
-ARG LLEM_PKG_VERSION=dev
-ARG LLEM_EXPCONF_SCHEMA_FINGERPRINT=unknown
-LABEL org.opencontainers.image.version="${LLEM_PKG_VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/henrycgbaker/llenergymeasure"
-LABEL llem.expconf.schema.fingerprint="${LLEM_EXPCONF_SCHEMA_FINGERPRINT}"
-
-CMD ["python3", "-m", "llenergymeasure.entrypoints.container"]
 
 # Dev stage — adds development tools for local iteration
 FROM runtime AS dev

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,7 +81,14 @@ The principled rationale:
    has transformers but no FA3 (the hopper-extension build is niche and
    compiled from source). `docker/Dockerfile.transformers` ships transformers
    plus FA2 (PyPI wheel) plus FA3 (compiled from source) plus accelerate /
-   bitsandbytes / calflops / sentencepiece / einops pre-installed.
+   bitsandbytes / calflops / sentencepiece / einops pre-installed, plus
+   llenergymeasure's runtime non-engine deps (pydantic, typer, pyyaml,
+   platformdirs, nvidia-ml-py, numpy, pyarrow, tqdm, rich, python-dotenv,
+   filelock). The llenergymeasure package itself is NOT installed into the
+   image — it is bind-mounted at runtime via `-v <repo>:/llem-src` +
+   `PYTHONPATH=/llem-src`, identically to the vllm + tensorrt cells. This
+   keeps image rebuilds dependent only on the engine substrate, not on
+   project source edits, so `src/` changes never invalidate the FA3 layer.
 
 3. **Build once, consume many.** Engine Image Build is the single producer
    of the transformers image; downstream workflows pull rather than rebuild.

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -400,22 +400,13 @@ Operator notes:
 - Inspect what's cached on the active builder: `docker buildx du --builder llem-builder`.
 - If the cache is corrupt, recreate it with `make docker-builder-rm && make docker-builder-setup`.
 
-### Image labels and versioning
+### Image labels
 
-Every engine image is stamped at build time with OCI labels that llem reads at
-study start-up to detect host/container schema skew:
+`docker/Dockerfile.transformers` stamps a single OCI label:
 
-| Label | Source | Purpose |
-|-------|--------|---------|
-| `org.opencontainers.image.version` | `LLEM_PKG_VERSION` build-arg (from `_version.py`) | Human-readable llenergymeasure release baked into the image |
-| `org.opencontainers.image.source` | Dockerfile | Points at the GitHub repository |
-| `llem.expconf.schema.fingerprint` | `LLEM_EXPCONF_SCHEMA_FINGERPRINT` build-arg | SHA-256 of `ExperimentConfig.model_json_schema()`; the blocking signal for schema skew |
-
-The package version is *not* what catches skew during dev: phase PRs don't
-touch `_version.py`, so both host and image report the same version through
-an entire milestone of schema churn. The fingerprint is the blocking signal —
-it changes whenever any `ExperimentConfig` field (or nested model) is added,
-renamed, or restructured.
+| Label | Purpose |
+|-------|---------|
+| `org.opencontainers.image.source` | Points at the GitHub repository |
 
 Inspect the labels on a local image:
 
@@ -424,9 +415,16 @@ docker image inspect llenergymeasure:transformers \
     --format '{{json .Config.Labels}}' | python3 -m json.tool
 ```
 
-`Makefile` and `.github/workflows/docker-publish.yml` both call
-`scripts/compute_expconf_fingerprint.py` so locally-built and CI-published
-images carry identical fingerprints.
+> **Legacy: schema-fingerprint handshake.** Earlier versions stamped
+> `org.opencontainers.image.version` and `llem.expconf.schema.fingerprint`
+> labels at build time so `llem doctor` could detect host/container schema
+> skew via `StudyRunner._prepare_images`. Once the image stopped baking the
+> project source (the project is bind-mounted at runtime — see
+> `docs/development.md`), the bound-in source always matches the host source,
+> so the handshake became structurally redundant. The labels are no longer
+> set on any engine image; `llem doctor` reports `UNVERIFIED` for all engines
+> and does not block. Removing the dead `version_handshake.py` code is
+> tracked separately.
 
 See [troubleshooting.md](troubleshooting.md#schema-skew-between-host-and-docker-image)
 for the remediation flow when a mismatch is reported.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -155,13 +155,14 @@ chain.
 
 Only Transformers has a project Dockerfile, so it is the only engine with a
 GHCR cache. The image declares `cache_from` pointing at the published GHCR
-tags; release-time CI populates the cache with `cache-to=type=registry,mode=max`,
-exporting intermediate layers to
-`ghcr.io/henrycgbaker/llenergymeasure/transformers:latest` (and the immutable
-`:v${LLEM_PKG_VERSION}` tag). This lets fresh machines skip the ~30-min
-flash-attn FA3 Hopper compile. vLLM and TensorRT-LLM are pulled from upstream
-images (`vllm/vllm-openai`, `nvcr.io/nvidia/tensorrt-llm/release`) and need
-no project-side cache.
+tags; the `Engine Image Build (transformers)` workflow populates the cache via
+`docker/build-push-action`, exporting intermediate layers to
+`ghcr.io/henrycgbaker/llenergymeasure/transformers:latest` (rolling) and
+`:transformers-<VERSION>` (immutable per SSOT version, written on push to
+`main`). This lets fresh machines skip the ~30-min flash-attn FA3 Hopper
+compile. vLLM and TensorRT-LLM are pulled from upstream images
+(`vllm/vllm-openai`, `nvcr.io/nvidia/tensorrt-llm/release`) and need no
+project-side cache.
 
 Measured on `ds01` (AMD EPYC 7742, 128 cores, 504 GB RAM — Docker 27.0.3 / Buildx
 v0.32.1 / llenergymeasure 0.9.0):
@@ -179,20 +180,20 @@ machines cold builds scale roughly with `MAX_JOBS` (FA3 compile is CPU-bound).
   first-ever build.
 - **First GHCR pull** — fresh builder, `cache_from` populated. What a new
   contributor gets after `make docker-builder-setup`.
-- **Warm local rebuild** — second and subsequent local builds. Stable layers
-  (FA3, base deps) sit before `COPY src/` in the Dockerfiles, so source-only
-  edits typically rebuild in seconds for all three engines.
+- **Warm local rebuild** — second and subsequent local builds. The transformers
+  image is a kernel substrate (FA3 + engine deps + runtime deps); the
+  llenergymeasure project source is bind-mounted at runtime, never baked in.
+  Source-only edits never invalidate any image layer for any engine.
 
-**Why does the GHCR cache only help Transformers?** The vLLM and TensorRT-LLM
-images are thin layers (`COPY src/` + one `pip install`) on top of heavy
-upstream bases (`vllm/vllm-openai`, `nvcr.io/nvidia/tensorrt-llm/release`).
-The dominant cost on a fresh machine is pulling that upstream base from Docker
-Hub / NGC, which BuildKit's `cache_from` cannot accelerate — only layers from
-*our* Dockerfile are eligible. Our own steps add ~30 s on top, so even a perfect
-cache hit caps the saving at ~30 s. The cache is still wired up (and works for
-`:v${LLEM_PKG_VERSION}`-pinned rebuilds within a release) but the architecture
-limits its impact for these two engines. Transformers benefits because the FA3
-compile is in our Dockerfile, ahead of `COPY src/`, so it gets cached.
+**Why does the GHCR cache only help Transformers?** vLLM and TensorRT-LLM use
+upstream images directly (`vllm/vllm-openai`, `nvcr.io/nvidia/tensorrt-llm/release`)
+with no first-party overlay. The dominant cost on a fresh machine is pulling
+the upstream base from Docker Hub / NGC, which our GHCR cache cannot accelerate
+— there is no first-party Dockerfile to cache. Transformers does have a
+first-party Dockerfile (`docker/Dockerfile.transformers`) because no upstream
+provides an FA3-included transformers image, and the FA3 compile is the
+load-bearing layer that the GHCR cache makes a single-digit-minute pull
+instead of a ~30-min cold compile.
 
 Once the upstream base is in local Docker storage (after the first build),
 subsequent rebuilds for vLLM/TRT are seconds — the slow part doesn't repeat.
@@ -207,22 +208,24 @@ docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0  # pull TensorRT-LLM upst
 
 **How the cache pipeline is wired:**
 
-- CI's `docker-publish.yml` runs `build-push-action` with
-  `cache-to=type=registry,...,mode=max` on each release, exporting the full layer
-  graph (including FA3 intermediates) to two refs:
-  `ghcr.io/henrycgbaker/llenergymeasure/{engine}:v${LLEM_PKG_VERSION}` (immutable
-  per release) and `:latest` (rolling).
-- `docker-compose.yml` declares `cache_from: [:v${LLEM_PKG_VERSION}, :latest]`
-  for every engine — version-pinned first (best layer match within a release),
-  rolling-latest as fallback.
+- The `Engine Image Build (transformers)` workflow runs `build-push-action` with
+  `cache-from`/`cache-to` (registry + GHA scope), exporting the full layer
+  graph (including FA3 intermediates) to:
+  `ghcr.io/henrycgbaker/llenergymeasure/transformers:latest` (rolling, written
+  on push to `main`) and `:transformers-<VERSION>` (immutable per SSOT version).
+  PR-time builds push to the separate cache-only repo
+  `ghcr.io/<repo>/transformers-cache:transformers-<VERSION>` so they don't
+  pollute `:latest`.
+- `docker-compose.yml` declares `cache_from: [:transformers-<VERSION>, :latest]`
+  for the transformers engine — version-pinned first (best layer match within
+  a release), rolling-latest as fallback. vllm and tensorrt have no
+  first-party `cache_from` chain (they pull upstream directly).
 - `make docker-builder-setup` provisions a `docker-container` BuildKit driver
   with a 200 GiB GC limit; the default `docker` driver cannot import registry
   caches at all.
 - The Transformers FA3 compile (the only layer where caching is load-bearing)
-  exceeds GitHub-hosted runner capacity (4 cores / 16 GB), so the seed step is
-  manual: `make docker-seed-transformers` from a host with ≥32 cores and
-  `docker login ghcr.io` (`write:packages`). After the seed, CI rebuilds warm
-  off `:latest` for every subsequent release.
+  runs on a self-hosted runner with sufficient cores + memory; CI rebuilds
+  warm off `:latest` for every subsequent SSOT bump.
 - Pulling the cache is unauthenticated for public packages.
 
 **How to tell if the cache actually warmed:** `make docker-build-{engine}` runs the build

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -285,9 +285,10 @@ of likelihood:
 (b) You are on a fresh buildx builder with no local cache (this is normal
     on the very first build — first-pull cost is paid once).
 (c) You are offline or GHCR is unreachable.
-(d) Your `LLEM_PKG_VERSION` does not match any published tag (cache_from
-    resolves to `:v${LLEM_PKG_VERSION}` and falls through to `:latest` —
-    if neither has usable layers, BuildKit silently cold-builds).
+(d) Your `TRANSFORMERS_VERSION` (from `engine_versions/transformers.yaml`)
+    does not match any published cache tag (`cache_from` resolves to
+    `:transformers-<VERSION>` and falls through to `:latest` — if neither has
+    usable layers, BuildKit silently cold-builds).
 
 The full BuildKit log for the most recent attempt is at
 `/tmp/llem-build-{engine}.log` — grep it for `importing cache manifest` to
@@ -304,9 +305,9 @@ see whether the registry was even reached.
    the registry.
 2. Verify network: `curl -I https://ghcr.io/v2/henrycgbaker/llenergymeasure/transformers/manifests/latest`
    should return 200 or 401 (both fine; 000/timeout means no connectivity).
-3. If you recently bumped version but CI hasn't published yet, fall back to
-   `:latest` by unsetting `LLEM_PKG_VERSION` for the build:
-   `LLEM_PKG_VERSION= docker compose build transformers`.
+3. If you recently bumped the SSOT version but CI hasn't published the
+   per-version tag yet, fall back to `:latest` (which the cache_from chain
+   already lists as a fallback). No env-var override needed.
 4. If the cache is corrupt, recreate the builder:
    `make docker-builder-rm && make docker-builder-setup`. Note this discards
    all local layer cache; the first subsequent build will repopulate from
@@ -339,17 +340,24 @@ The container will reject ExperimentConfig fields added on the host after
 the image was built.
 ```
 
-Or, without the handshake catching it first, a container stack trace full of
-`extra_forbidden` Pydantic errors (often with URLs mixing
-`errors.pydantic.dev/2.10/…` and `errors.pydantic.dev/2.12/…`, a second tell
-for version skew).
+A container stack trace full of `extra_forbidden` Pydantic errors (often with
+URLs mixing `errors.pydantic.dev/2.10/…` and `errors.pydantic.dev/2.12/…`, a
+tell for version skew).
 
-**Cause:** the host's `ExperimentConfig` (or a nested model like
-`BaselineConfig`, `WarmupConfig`, etc.) gained fields after the Docker image
-was built. `llem` stamps every image at build time with a
-`llem.expconf.schema.fingerprint` label computed from
-`ExperimentConfig.model_json_schema()`. `StudyRunner._prepare_images` compares
-that label against the host fingerprint before any experiment starts.
+> **Legacy: the schema-fingerprint handshake no longer catches this.** Earlier
+> versions of `llem` stamped each image with an `llem.expconf.schema.fingerprint`
+> label and `StudyRunner._prepare_images` compared it to the host fingerprint
+> before any experiment ran. Once images stopped baking the project source (it
+> is bind-mounted at runtime), the handshake became structurally redundant: the
+> in-container source always equals the host source. The label is no longer
+> set on any engine image; `llem doctor` reports `UNVERIFIED` and does not
+> block. The dead `version_handshake.py` plumbing is tracked for removal in a
+> follow-up issue.
+
+**Cause:** all three engines now bind-mount the host project source at
+runtime, so a Pydantic-shape error here means the engine library inside the
+image is at a version that no longer matches what the host code expects (e.g.
+the SSOT bumped transformers but the local image is still on an older tag).
 
 **Fix:** rebuild or repull the affected engine image. One of:
 
@@ -360,21 +368,11 @@ docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0  # repull TensorRT-LLM up
 make docker-pull                                        # pull the newest published Transformers tag
 ```
 
-The vLLM and TensorRT-LLM images bind-mount host source at run time and so
-should not skew on a host-source-only edit; if you see a fingerprint
-mismatch on those, the local image is genuinely stale (e.g. an older
-upstream tag) and needs repulling.
-
-Verify with:
+Verify the image actually changed by inspecting the digest:
 
 ```bash
-llem doctor                      # exits 1 on mismatch, 0 when every engine is OK
+docker image inspect llenergymeasure:transformers --format '{{.Id}}'
 ```
-
-**Bypass (last resort):** set `LLEM_SKIP_IMAGE_CHECK=1` to skip the handshake.
-Only safe when you're confident the new field is optional and the container
-silently ignores it. The container will still hard-fail on any required field
-it doesn't know about.
 
 ---
 

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -711,19 +711,22 @@ class DockerRunner:
     ) -> list[str]:
         """Build the ``docker run`` command list.
 
-        For TRT-LLM tensor parallelism (tensor_parallel_size > 1), ``mpirun -n {n}
-        --allow-run-as-root`` wraps the python3 invocation. MPI worker ranks
-        re-import the module but do not call ``main()`` because
-        ``container_entrypoint.py`` is guarded by ``if __name__ == "__main__"``.
+        All three engines (transformers, vllm, tensorrt) follow the same
+        dispatch shape: the image carries only the engine substrate, the host
+        package source is bind-mounted at ``/llem-src`` and exposed via
+        ``PYTHONPATH`` so the in-container Python can import
+        ``llenergymeasure``. ``--entrypoint`` is overridden to ``python3`` so
+        the post-image command consistently invokes the entrypoint module
+        regardless of any default entrypoint set by the upstream image (vLLM
+        intercepts as api_server args; NGC wraps in
+        /opt/nvidia/nvidia_entrypoint.sh; the first-party transformers image
+        sets no default).
 
-        For vllm and tensorrt engines, the upstream Docker images
-        (vllm/vllm-openai, nvcr.io/nvidia/tensorrt-llm/release) are used
-        directly without a first-party overlay. The host package source is
-        bind-mounted at ``/llem-src`` and exposed via ``PYTHONPATH`` so the
-        in-container Python can import ``llenergymeasure``. ``--entrypoint``
-        is overridden because both upstream images set entrypoints
-        incompatible with the command-override pattern (vLLM intercepts as
-        api_server args; NGC wraps in /opt/nvidia/nvidia_entrypoint.sh).
+        For TRT-LLM tensor parallelism (tensor_parallel_size > 1), ``mpirun -n {n}
+        --allow-run-as-root`` is the entrypoint instead, with the python3
+        invocation as its command. MPI worker ranks re-import the module but
+        do not call ``main()`` because ``container_entrypoint.py`` is guarded
+        by ``if __name__ == "__main__"``.
 
         Args:
             config:       ExperimentConfig for the current experiment. Used to
@@ -773,27 +776,25 @@ class DockerRunner:
         if config.engine == Engine.TENSORRT and config.tensorrt is not None:
             tp_size = config.tensorrt.tensor_parallel_size
 
-        # vLLM and TensorRT-LLM use upstream images directly: bind-mount the
-        # host package source and override the entrypoint. PYTHONDONTWRITEBYTECODE
-        # prevents the container from littering the bind-mounted source with
-        # root-owned __pycache__ directories.
-        mount_based_dispatch = config.engine in (Engine.VLLM, Engine.TENSORRT)
-        if mount_based_dispatch:
-            pkg_parent = str(_resolve_package_parent_dir())
-            cmd.extend(
-                [
-                    "-v",
-                    f"{pkg_parent}:/llem-src:ro",
-                    "-e",
-                    "PYTHONPATH=/llem-src",
-                    "-e",
-                    "PYTHONDONTWRITEBYTECODE=1",
-                ]
-            )
-            # For TP > 1, mpirun is the entrypoint and python3 follows in args;
-            # otherwise python3 is the entrypoint directly.
-            entrypoint = "mpirun" if (tp_size is not None and tp_size > 1) else "python3"
-            cmd.extend(["--entrypoint", entrypoint])
+        # All engines: bind-mount the host package source and override the
+        # entrypoint. PYTHONDONTWRITEBYTECODE prevents the container from
+        # littering the bind-mounted source with root-owned __pycache__
+        # directories.
+        pkg_parent = str(_resolve_package_parent_dir())
+        cmd.extend(
+            [
+                "-v",
+                f"{pkg_parent}:/llem-src:ro",
+                "-e",
+                "PYTHONPATH=/llem-src",
+                "-e",
+                "PYTHONDONTWRITEBYTECODE=1",
+            ]
+        )
+        # For TP > 1, mpirun is the entrypoint and python3 follows in args;
+        # otherwise python3 is the entrypoint directly.
+        entrypoint = "mpirun" if (tp_size is not None and tp_size > 1) else "python3"
+        cmd.extend(["--entrypoint", entrypoint])
 
         # Container name and labels for lifecycle management (cleanup, reaper).
         # These must appear before the image name in the docker run command.
@@ -804,30 +805,23 @@ class DockerRunner:
 
         cmd.append(self.image)
 
-        # Post-image arguments. When the entrypoint was overridden to mpirun
-        # (mount-based dispatch with TP > 1), the literal "mpirun" must NOT
-        # appear in the args — it's already the entrypoint. When the
-        # entrypoint was overridden to python3 (mount-based, TP == 1), the
-        # literal "python3" must NOT appear either. The transformers path
-        # (no entrypoint override) keeps the legacy shape.
-        if mount_based_dispatch:
-            if tp_size is not None and tp_size > 1:
-                cmd.extend(
-                    [
-                        "-n",
-                        str(tp_size),
-                        "--allow-run-as-root",
-                        "python3",
-                        "-m",
-                        "llenergymeasure.entrypoints.container",
-                    ]
-                )
-            else:
-                cmd.extend(["-m", "llenergymeasure.entrypoints.container"])
+        # Post-image arguments. The entrypoint override means neither
+        # "mpirun" nor "python3" appears as a literal in the args list — the
+        # entrypoint already provides them. For TP > 1, the args supply
+        # mpirun's flags + the python3 invocation as mpirun's command.
+        if tp_size is not None and tp_size > 1:
+            cmd.extend(
+                [
+                    "-n",
+                    str(tp_size),
+                    "--allow-run-as-root",
+                    "python3",
+                    "-m",
+                    "llenergymeasure.entrypoints.container",
+                ]
+            )
         else:
-            if tp_size is not None and tp_size > 1:
-                cmd.extend(["mpirun", "-n", str(tp_size), "--allow-run-as-root"])
-            cmd.extend(["python3", "-m", "llenergymeasure.entrypoints.container"])
+            cmd.extend(["-m", "llenergymeasure.entrypoints.container"])
 
         return cmd
 

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -883,15 +883,17 @@ class TestExtraMounts:
         assert "/host/b:/container/b" in cmd
 
     def test_no_extra_mounts_no_extra_volumes(self, tmp_path):
-        """Without extra_mounts, only the exchange_dir -v mount is present."""
+        """Without extra_mounts, two -v flags are present: exchange dir + llem-src."""
         config = make_config()
         runner = DockerRunner(image=IMAGE)
         cmd = self._build_cmd(config, tmp_path, runner)
 
-        # Only one -v flag: the exchange dir
+        # Two -v flags: the exchange dir + the llem-src bind mount (all engines
+        # now use mount-based dispatch — see docker_runner._build_docker_cmd).
         v_count = cmd.count("-v")
-        assert v_count == 1
+        assert v_count == 2
         assert f"/tmp/llem-test:{CONTAINER_EXCHANGE_DIR}" in cmd
+        assert any(arg.endswith(":/llem-src:ro") for arg in cmd)
 
     def test_tensorrt_auto_cache_mount(self, tmp_path):
         """TRT-LLM engine auto-mounts ~/.cache/trt-llm:/root/.cache/trt-llm."""
@@ -946,9 +948,9 @@ class TestExtraMounts:
 
 
 class TestEntrypointPerEngine:
-    """The mount-pivot dispatch sets --entrypoint based on (engine, tp_size).
+    """All engines now use mount-based dispatch with --entrypoint set per tp_size.
 
-    - transformers (any tp): no --entrypoint override (legacy shape).
+    - transformers (any tp): --entrypoint python3.
     - vllm (any tp): --entrypoint python3.
     - tensorrt with tp<=1: --entrypoint python3.
     - tensorrt with tp>1: --entrypoint mpirun.
@@ -966,7 +968,7 @@ class TestEntrypointPerEngine:
     @pytest.mark.parametrize(
         "engine,tp_size,expected_entrypoint",
         [
-            (Engine.TRANSFORMERS, 1, None),
+            (Engine.TRANSFORMERS, 1, "python3"),
             (Engine.VLLM, 1, "python3"),
             (Engine.TENSORRT, 1, "python3"),
             (Engine.TENSORRT, 2, "mpirun"),


### PR DESCRIPTION
## Summary

Finishes the kernel-substrate transition that #514 started. After #514, transformers cells in CI workflows bind-mounted llem at runtime, but the transformers IMAGE still baked the project (`COPY src/` + `pip install "."`) and `docker_runner.py` still gated the bind-mount on `engine in (VLLM, TENSORRT)`. This PR closes both gaps so all three engine images are genuinely substrate-only and the runtime dispatch is symmetric.

## What this PR does

### 1. `docker/Dockerfile.transformers` — substrate only

The image now carries:
- The engine substrate: transformers + FA2 + FA3 + accelerate + bitsandbytes + calflops + sentencepiece + einops
- llenergymeasure's runtime non-engine deps: pydantic, typer, pyyaml, platformdirs, nvidia-ml-py, numpy, pyarrow, tqdm, rich, python-dotenv, filelock

It no longer bakes the project source. `COPY src/ ./src/` and `uv pip install --system "."` are gone, along with the build-time bind mounts of `pyproject.toml`/`uv.lock`/`README.md`. The `LLEM_PKG_VERSION` and `LLEM_EXPCONF_SCHEMA_FINGERPRINT` ARGs and labels are removed too — they were already non-functional (CI never passed those build-args, so shipped images carried `dev`/`unknown`). The `CMD` is dropped because the image is a substrate; the runtime entrypoint is set by the caller via `--entrypoint python3 -m llenergymeasure.entrypoints.container` against a bind-mount.

### 2. `src/llenergymeasure/infra/docker_runner.py` — unified dispatch

Drops the `mount_based_dispatch = config.engine in (Engine.VLLM, Engine.TENSORRT)` gate. All three engines now follow the same dispatch shape:
- `-v <pkg-parent>:/llem-src:ro -e PYTHONPATH=/llem-src -e PYTHONDONTWRITEBYTECODE=1`
- `--entrypoint python3` (or `mpirun` for tensorrt with `tensor_parallel_size > 1`)
- Post-image args: `-m llenergymeasure.entrypoints.container` (or the mpirun-prefixed shape for TP > 1)

The post-image-arg branching collapses since both branches now produce the same shape modulo the TP > 1 mpirun handling.

### 3. `.github/workflows/ci.yml` — drop docker-smoke job

The docker-smoke job inline-built transformers with `INSTALL_FA3=false` and smoke-tested `llem --version` / `llem config` inside the container. Both responsibilities have moved:
- Image build → `engine-image-build.yml` (single producer; CI builds the same production-equivalent image users get, `INSTALL_FA3=true`)
- pip install regression coverage → `package-validation` (host-side, every PR)

### 4. Tests

- `TestEntrypointPerEngine.test_entrypoint_for_engine_and_tp_size` — transformers row now expects `--entrypoint python3` (was `None` for the legacy shape)
- `TestExtraMounts.test_no_extra_mounts_no_extra_volumes` — now expects two `-v` flags (exchange dir + llem-src) where it used to expect one

### 5. Docs

- `development.md` — describe the runtime non-engine deps + bind-mount pattern
- `installation.md` — rewrite the cache-explanation section for the current architecture; update tag scheme refs (`:transformers-<VERSION>`, not the obsolete `:v\${LLEM_PKG_VERSION}`)
- `docker-setup.md` — shrink the 'Image labels' section to the only label still set (`org.opencontainers.image.source`); add a 'Legacy: schema-fingerprint handshake' callout
- `troubleshooting.md` — same Legacy callout in the schema-skew section; cache_from troubleshooting updated to use `TRANSFORMERS_VERSION` from SSOT

## Why this is a separate PR from #514

#514's PR body claimed to deliver the symmetric mount pattern + drop `pip install \".\"` + collapse the dispatch conditional, but the diff did not actually do those things — only the workflow-cell bind-mount landed. This PR completes what was claimed.

PR #517 (`refactor/transformers-mount-llem`) was the original holder of this work but had drifted ~3 days behind main while blocked on the cold-FA3-build-runner problem. Rebasing it would have resurrected old code (it predated #509's vllm/tensorrt mount-pivot and #514's pipeline rewire). Closed #517 in favour of this fresh-from-main PR.

## Schema-fingerprint handshake follow-up

Removing the labels from `Dockerfile.transformers` makes `infra/version_handshake.py` structurally redundant: vllm/tensorrt never had the labels (upstream-direct), and now neither does transformers. The handshake code path returns `UNVERIFIED` for every engine and never blocks. Removing the dead module + callers is tracked in #528.

## Test plan

- [x] \`uv run pytest tests/unit/docker/test_docker_runner.py\` — 48/48 pass
- [x] \`uv run pytest tests/ -m \"not gpu and not docker\"\` — 2461 passed, 52 skipped
- [x] \`uv run ruff check + format --check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [x] \`uv run lint-imports\` — 3 contracts kept, 0 broken
- [ ] After merge: first \`engine-image-build.yml\` push run rebuilds the image without \`COPY src/\` — verify warm-cache hit on a no-op manual_dispatch
- [ ] After merge: \`schemas-transformers\` + \`invariants-transformers\` workflow_run cells fire successfully against the rebuilt image (the bind-mount + PYTHONPATH path was already exercised in #514's runs)
- [ ] After merge: \`llem run\` against the transformers image confirms the bind-mounted llenergymeasure import works end-to-end (the image no longer has it on site-packages)

## Known limitations

- The image-rebuild on this PR's first push will be a moderately-warm-cache rebuild because the Dockerfile changed. Subsequent rebuilds will be near-instant warm-cache hits.
- \`scripts/compute_expconf_fingerprint.py\` and \`infra/version_handshake.py\` are now dead code paths. Tracked in #528.

## Issues addressed

- Completes the architectural intent claimed (but not delivered) by #514
- Closes the gap on the kernel-substrate promise: \`src/\` edits will no longer invalidate the FA3 layer
- Replaces #517's intent (which was held by an obsolete branch) with a fresh-from-main implementation