### PR TITLE
refactor(workflows): split engine-image-build into build + push (#534)

### DIFF
--- a/.github/workflows/engine-image-build.yml
+++ b/.github/workflows/engine-image-build.yml
@@ -1,33 +1,32 @@
 name: Engine Image Build (transformers)
 
-# Single-source-of-truth build for the transformers engine Docker image.
-# Replaces the previous parallel-rebuild antipattern where engine-invariants
-# and engine-schemas each ran their own buildx step against the same SSOT
-# version, contending on the per-version GHA cache scope. PR-time runs were
-# observed to deadlock on multi-GB layer cache writes.
+# Builds the transformers engine image and exports its layer cache to GHCR.
+# Does NOT push a runtime image — that is the engine-image-push.yml workflow's
+# responsibility, chained via workflow_run on this workflow's success.
 #
 # Pipeline ordering:
 #
 #   Renovate / maintainer PR
-#     |- engine-image-build.yml  (this file)
-#     |  |- on PR: builds + pushes to ghcr.io/<repo>/transformers-cache:transformers-<VERSION>
-#     |  |  (per-PR cache-only repo; never collides with :latest)
-#     |  |- on push to main / schedule: also pushes :latest + :transformers-<VERSION>
-#     |  |  to the canonical ghcr.io/<repo>/transformers repo
+#     |- engine-image-build.yml  (this file)  → publishes :transformers-<VERSION>-buildcache
+#     |  V (workflow_run: completed, conclusion=success, event in [push, schedule])
+#     |- engine-image-push.yml                → pulls cache, pushes :latest + :transformers-<VERSION>
+#     |  V (workflow_run: completed, conclusion=success)
+#     |- engine-schemas.yml :: schemas-transformers job
 #     |  V
-#     |- engine-schemas.yml :: schemas-transformers job  (workflow_run: completed)
-#     |  V
-#     |- engine-invariants.yml :: invariants-transformers job  (workflow_run: completed)
+#     |- engine-invariants.yml :: invariants-transformers job
 #
-# Downstream workflows pull this image rather than rebuilding it. The heavy
-# build cost (FA3 from-source compile, ~30-60 min cold) happens once per
-# (PR, SSOT version), and the schemas + invariants jobs become probe + mine
-# only.
+# Why split build from push:
+#   The previous shape ran build + push in a single buildx step. When the
+#   push step failed (GHCR permissions, registry rate-limits, transient
+#   outages), the entire ~50-min FA3 compile had to re-run on retry. Split
+#   means push failures only re-run the seconds-long push, not the build.
+#   The cache export to :<VERSION>-buildcache is the durable artifact;
+#   the push workflow just consumes it.
 #
-# Drift detection: weekly schedule fires with a from-scratch rebuild
-# (`--no-cache`). If the resulting image digest differs from `:latest`, that
-# surfaces external dependency drift (apt repo, PyPI wheel re-publish, base
-# image silent update) that layer caching alone wouldn't catch.
+# Drift detection: weekly schedule fires with --no-cache. If the resulting
+# layer cache diverges from the prior :<VERSION>-buildcache, that surfaces
+# external dependency drift (apt repo, PyPI wheel re-publish, base image
+# silent update) that layer caching alone wouldn't catch.
 
 on:
   pull_request:
@@ -70,6 +69,8 @@ jobs:
     # 90-min cap chosen for headroom on cold FA3 builds (~15-70 min observed
     # on ds01-gpu depending on first-run vs cached layers).
     timeout-minutes: 90
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -89,79 +90,73 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
+        # Need write access to push the layer cache to the buildcache ref;
+        # read-only would suffice for cache-from but we always do cache-to.
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine cache + tag targets
+      - name: Determine cache + no-cache flag
         id: targets
-        # PR builds push to a separate cache-only repo so they don't
-        # pollute :latest. Merge + schedule builds publish :latest +
-        # :transformers-<VERSION> to the canonical repo. workflow_dispatch
-        # respects the no_cache input for ad-hoc drift detection.
+        # Build never pushes a runtime image — engine-image-push.yml does
+        # that. We only push the layer cache here (cache-to). The schedule
+        # event uses --no-cache for drift detection; everything else uses
+        # the existing buildcache. workflow_dispatch optionally honours
+        # the no_cache input.
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "push=true" >> "$GITHUB_OUTPUT"
-            echo "tags=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "no_cache=false" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "push=true" >> "$GITHUB_OUTPUT"
-            echo "tags=ghcr.io/${{ github.repository }}/transformers:latest,ghcr.io/${{ github.repository }}/transformers:transformers-${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
-            if [ "${{ github.event_name }}" = "schedule" ]; then
-              echo "no_cache=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "no_cache=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "push=false" >> "$GITHUB_OUTPUT"
-            echo "tags=transformers-build:test" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "no_cache=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "no_cache=${{ inputs.no_cache }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "no_cache=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build (and push) transformers image
+      - name: Build transformers image (cache export only, no runtime push)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.transformers
           target: runtime
-          tags: ${{ steps.targets.outputs.tags }}
-          push: ${{ steps.targets.outputs.push }}
+          # Local-only tag: the runtime image is materialised in the
+          # builder's cache for engine-image-push.yml to pull from. Never
+          # pushed to a registry by this workflow.
+          tags: transformers-build:local
+          push: false
           no-cache: ${{ steps.targets.outputs.no_cache }}
           # SSOT-driven build arg only. INSTALL_FA3 / MAX_JOBS / NVCC_THREADS
           # are pinned in docker/Dockerfile.transformers (32 / 4 — saturates
           # the 128-vCPU self-hosted runner) and DELIBERATELY NOT passed as
-          # build-args here. Build-args participate in BuildKit's layer-hash,
-          # so varying them across CI iterations invalidates the FA3 layer
-          # cache (~30 min recompile per change). With the parallelism knobs
-          # pinned in the Dockerfile, the layer hash is stable across runs
-          # and the FA3 layer cache-hits reliably from prior builds.
+          # build-args here (build-args participate in BuildKit's layer-hash;
+          # varying them across runs invalidates the FA3 layer).
           build-args: |
             TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
-          # cache-from: registry-mode reads from a separate cache-only ref
-          # (not the runtime image) where mode=max metadata for ALL
-          # intermediate layers lives. That gives us cache hits on the FA3
-          # builder layer + the runtime install layers — which the runtime
-          # image's content-addressable manifest alone cannot provide.
-          # GHA cache mode dropped: a prior run (25329040682) spent ~45 min
-          # uploading 7-8 GB to GitHub Actions Cache. Registry-mode export
-          # is much faster (just metadata + dedup-aware layer push) AND
-          # works on workflow_dispatch where push: false skips the runtime
-          # image (the cache ref is independent of the runtime tag).
+          # cache-from prefers the buildcache ref (mode=max metadata for
+          # ALL intermediate layers including FA3 builder); falls back to
+          # the runtime image tags so existing :latest / :<VER> images on
+          # GHCR can still seed the layer cache after a cache eviction.
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers:latest
-            type=registry,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}
+            type=registry,ref=ghcr.io/${{ github.repository }}/transformers:transformers-${{ steps.version.outputs.version }}
+          # cache-to: registry-mode mode=max writes a separate cache manifest
+          # at :<VER>-buildcache containing all intermediate layer metadata.
+          # PR builds AND main builds both contribute to this cache (per-
+          # version content is deterministic given the cache-stable
+          # Dockerfile, so PR overwrites are benign).
           cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache
 
-      - name: Emit image digest summary
+      - name: Emit build summary
         run: |
           {
             echo "## Engine image build"
             echo
             echo "- Trigger: \`${{ github.event_name }}\`"
             echo "- Transformers version: \`${{ steps.version.outputs.version }}\`"
-            echo "- Tags pushed: \`${{ steps.targets.outputs.tags }}\`"
-            echo "- Cache from-scratch: \`${{ steps.targets.outputs.no_cache }}\`"
+            echo "- Buildcache ref: \`ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache\`"
+            echo "- No-cache rebuild: \`${{ steps.targets.outputs.no_cache }}\`"
+            echo
+            echo "Runtime push is handled by \`engine-image-push.yml\` (workflow_run-triggered on this workflow's success when event is push or schedule)."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/engine-image-push.yml
+++ b/.github/workflows/engine-image-push.yml
@@ -10,20 +10,32 @@ name: Engine Image Push (transformers)
 #   re-run on retry. Splitting means push retries only re-run the seconds-
 #   long push step against the durable layer cache.
 #
-# Gating:
-#   - Only runs when engine-image-build's conclusion is success
-#   - Only on push events (to main) and schedule events — PR builds never
-#     trigger a push, so the canonical :latest / :<VER> tags are only
-#     written by vetted main code.
-#   - workflow_dispatch path is intentionally NOT included here; for ad-hoc
-#     pushes, prefer triggering engine-image-build manually and observing
-#     the chain (or extend this workflow with a dispatch input later if a
-#     real need surfaces).
+# Tag selection per parent event (preserves the per-event tag separation
+# the old single-workflow shape had inline):
+#   - push to main / schedule → :latest + :transformers-<VER> on the
+#     canonical repo (vetted main code only writes these)
+#   - pull_request → :transformers-<VER> on transformers-CACHE repo
+#     (PR-time runtime image; doesn't pollute :latest, but DOES exist so
+#     downstream schemas-transformers + invariants-transformers can pull
+#     it and validate the PR's Dockerfile changes via the workflow_run
+#     chain)
+#   - workflow_dispatch → no push (build-only ad-hoc test path)
 
 on:
   workflow_run:
     workflows: ["Engine Image Build (transformers)"]
     types: [completed]
+  workflow_dispatch:
+    # Ad-hoc trigger for debugging or one-off pushes. Pushes to the
+    # canonical runtime tags (assumes the buildcache ref is already
+    # populated for the SSOT-pinned version — manually run engine-image-
+    # build first if it isn't).
+    inputs:
+      no_cache:
+        description: "Force --no-cache rebuild before push"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,22 +47,28 @@ concurrency:
 
 jobs:
   push-transformers:
-    # Only push when the parent build succeeded AND the trigger was a push
-    # to main or the weekly schedule. PR builds never publish runtime tags.
+    # Push runs on any successful build EXCEPT workflow_dispatch (which is
+    # the ad-hoc local-test path that deliberately skips push). PR builds
+    # publish to the transformers-cache repo so downstream
+    # schemas-transformers + invariants-transformers can pull the runtime
+    # image and validate the PR's Dockerfile changes; main pushes publish
+    # to canonical :latest + :transformers-<VER>.
     if: >-
-      github.event.workflow_run.conclusion == 'success'
-      && (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'schedule')
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event != 'workflow_dispatch')
     runs-on: self-hosted
     timeout-minutes: 30
 
     steps:
-      - name: Checkout (parent's head_sha)
+      - name: Checkout (parent's head_sha or current branch)
         # workflow_run runs on the default branch by default; checkout the
         # exact SHA the parent build ran against so the pushed image
-        # matches what was built.
+        # matches what was built. workflow_dispatch falls back to the
+        # branch the dispatch was triggered on.
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Resolve transformers version from SSOT
         id: version
@@ -61,6 +79,23 @@ jobs:
             exit 1
           fi
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine push tags per parent event
+        id: targets
+        # PR builds go to transformers-CACHE:transformers-<VER> (PR-time
+        # runtime image — exists so downstream cells can pull but never
+        # claims :latest). main / schedule / workflow_dispatch go to
+        # canonical transformers:latest + transformers:transformers-<VER>.
+        run: |
+          PARENT_EVENT='${{ github.event.workflow_run.event }}'
+          VER='${{ steps.version.outputs.version }}'
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "$PARENT_EVENT" == "push" || "$PARENT_EVENT" == "schedule" ]]; then
+            TAGS="ghcr.io/${{ github.repository }}/transformers:latest,ghcr.io/${{ github.repository }}/transformers:transformers-${VER}"
+          else
+            # pull_request from the parent build
+            TAGS="ghcr.io/${{ github.repository }}/transformers-cache:transformers-${VER}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -75,17 +110,15 @@ jobs:
       - name: Build (cache-only) and push runtime tags
         # The build is essentially free — every layer cache-hits from the
         # buildcache ref the parent workflow just exported. The image is
-        # then re-tagged and pushed to the canonical :latest +
-        # :transformers-<VERSION> tags for end-user consumption.
+        # re-tagged and pushed to the runtime tags chosen per parent event
+        # (canonical for main/schedule, cache repo for PR).
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.transformers
           target: runtime
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}/transformers:latest
-            ghcr.io/${{ github.repository }}/transformers:transformers-${{ steps.version.outputs.version }}
+          tags: ${{ steps.targets.outputs.tags }}
           build-args: |
             TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
           cache-from: |
@@ -99,5 +132,5 @@ jobs:
             echo
             echo "- Parent run: \`${{ github.event.workflow_run.id }}\` (event: \`${{ github.event.workflow_run.event }}\`)"
             echo "- Transformers version: \`${{ steps.version.outputs.version }}\`"
-            echo "- Tags pushed: \`:latest\`, \`:transformers-${{ steps.version.outputs.version }}\`"
+            echo "- Tags pushed: \`${{ steps.targets.outputs.tags }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/engine-image-push.yml
+++ b/.github/workflows/engine-image-push.yml
@@ -1,0 +1,103 @@
+name: Engine Image Push (transformers)
+
+# Publishes the transformers runtime image to GHCR using the layer cache
+# that engine-image-build.yml already exported. Triggered by workflow_run
+# on engine-image-build success.
+#
+# Why this is a separate workflow:
+#   Build + push were previously coupled — when push failed (GHCR perms,
+#   transient outage, rate limit), the entire ~50-min FA3 compile had to
+#   re-run on retry. Splitting means push retries only re-run the seconds-
+#   long push step against the durable layer cache.
+#
+# Gating:
+#   - Only runs when engine-image-build's conclusion is success
+#   - Only on push events (to main) and schedule events — PR builds never
+#     trigger a push, so the canonical :latest / :<VER> tags are only
+#     written by vetted main code.
+#   - workflow_dispatch path is intentionally NOT included here; for ad-hoc
+#     pushes, prefer triggering engine-image-build manually and observing
+#     the chain (or extend this workflow with a dispatch input later if a
+#     real need surfaces).
+
+on:
+  workflow_run:
+    workflows: ["Engine Image Build (transformers)"]
+    types: [completed]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: engine-image-push-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  push-transformers:
+    # Only push when the parent build succeeded AND the trigger was a push
+    # to main or the weekly schedule. PR builds never publish runtime tags.
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'schedule')
+    runs-on: self-hosted
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout (parent's head_sha)
+        # workflow_run runs on the default branch by default; checkout the
+        # exact SHA the parent build ran against so the pushed image
+        # matches what was built.
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Resolve transformers version from SSOT
+        id: version
+        run: |
+          VER=$(yq '.library.current_version' engine_versions/transformers.yaml)
+          if [[ -z "$VER" || "$VER" == "null" ]]; then
+            echo "Could not resolve transformers version from engine_versions/transformers.yaml" >&2
+            exit 1
+          fi
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (cache-only) and push runtime tags
+        # The build is essentially free — every layer cache-hits from the
+        # buildcache ref the parent workflow just exported. The image is
+        # then re-tagged and pushed to the canonical :latest +
+        # :transformers-<VERSION> tags for end-user consumption.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.transformers
+          target: runtime
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/transformers:latest
+            ghcr.io/${{ github.repository }}/transformers:transformers-${{ steps.version.outputs.version }}
+          build-args: |
+            TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}/transformers:latest
+
+      - name: Emit push summary
+        run: |
+          {
+            echo "## Engine image push"
+            echo
+            echo "- Parent run: \`${{ github.event.workflow_run.id }}\` (event: \`${{ github.event.workflow_run.event }}\`)"
+            echo "- Transformers version: \`${{ steps.version.outputs.version }}\`"
+            echo "- Tags pushed: \`:latest\`, \`:transformers-${{ steps.version.outputs.version }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/engine-invariants.yml
+++ b/.github/workflows/engine-invariants.yml
@@ -53,7 +53,11 @@ on:
       - "configs/engine_invariants/**"
       - ".github/workflows/engine-invariants.yml"
   workflow_run:
-    workflows: ["Engine Image Build (transformers)"]
+    # Chain off the PUSH workflow (which only fires after a successful
+    # build), not the build directly: invariants-transformers needs to
+    # pull the runtime image from GHCR, which doesn't exist until push
+    # lands.
+    workflows: ["Engine Image Push (transformers)"]
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/engine-schemas.yml
+++ b/.github/workflows/engine-schemas.yml
@@ -50,7 +50,10 @@ on:
       - "src/llenergymeasure/config/discovered_schemas/**"
       - ".github/workflows/engine-schemas.yml"
   workflow_run:
-    workflows: ["Engine Image Build (transformers)"]
+    # Chain off the PUSH workflow (which only fires after a successful
+    # build), not the build directly: schemas-transformers needs to pull
+    # the runtime image from GHCR, which doesn't exist until push lands.
+    workflows: ["Engine Image Push (transformers)"]
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -157,9 +157,12 @@ The invariant miner pipeline lives in `scripts/engine_miners/` - it is a build-t
   Engine-invariants pipeline fires (probe + mine + vendor)
                │
                ├──► transformers: engine-image-build.yml builds the
-               │    image once, then the invariants-transformers job in
-               │    engine-invariants.yml fires via workflow_run on
-               │    GH-hosted ubuntu-latest.
+               │    image (cache export only, no runtime push), then
+               │    engine-image-push.yml fires via workflow_run and
+               │    pushes runtime tags (canonical for main/schedule, PR-
+               │    time tag for PR builds). On its success, the
+               │    invariants-transformers job in engine-invariants.yml
+               │    fires via workflow_run on GH-hosted ubuntu-latest.
                │
                ├──► vLLM: engine-invariants.yml runs inside
                │    llenergymeasure:vllm-${VER} on a self-hosted GPU

--- a/docs/development.md
+++ b/docs/development.md
@@ -103,48 +103,32 @@ The principled rationale:
 
 ## CI pipeline ordering
 
-There is one workflow file per pipeline (one `engine-schemas.yml`, one
-`engine-invariants.yml`) covering all three engines. The per-engine
-asymmetry — transformers needs a pre-built first-party image, vllm and
-tensorrt pull upstream images directly — is contained inside each workflow
-via multi-trigger + per-job `if:` gating, not via file proliferation.
+The transformers engine image flows through four workflows in sequence:
 
-The transformers cell in `engine-invariants.yml` and `engine-schemas.yml`
-is gated by `workflow_run: completed` on Engine Image Build (transformers);
-the vllm and tensorrt cells in the same files are gated by
-`pull_request: paths`. Per-job `if:` clauses select the correct cell for
-each trigger source.
+```
+engine-image-build.yml   →   engine-image-push.yml   →   engine-schemas.yml :: schemas-transformers
+                                                     →   engine-invariants.yml :: invariants-transformers
+```
 
-When Renovate (or a maintainer) bumps `engine_versions/transformers.yaml`
-or `docker/Dockerfile.transformers`, the pipeline fires sequentially:
+Each step chains via `workflow_run: completed` with `conclusion == 'success'` gating.
 
-1. **Engine Image Build** (`engine-image-build.yml`) — builds the transformers
-   image once. On PR, pushes to a per-version tag in the
-   `transformers-cache` GHCR repo (`ghcr.io/<repo>/transformers-cache:transformers-<VERSION>`).
-   On push to `main`, also pushes `:latest` and `:transformers-<VERSION>` to
-   the canonical `ghcr.io/<repo>/transformers` repo so external `docker pull`
-   users and the next PR cycle's `cache-from :latest` both stay fresh.
-2. **Engine Schemas — transformers** (`schemas-transformers` job in
-   `engine-schemas.yml`) — `workflow_run`-triggered on Engine Image Build's
-   `success`. Pulls the just-built image, runs schema discovery, writes back
-   the discovered JSON + curation digest.
-3. **Engine Invariants — transformers** (`invariants-transformers` job in
-   `engine-invariants.yml`) — `workflow_run`-triggered on Engine Image Build's
-   `success`. Pulls the same image, runs the miner + vendor + invariants
-   digest, rebases against schemas's writeback before pushing its own commit.
+There is one workflow file per pipeline concern (build, push, schemas, invariants). schemas + invariants cover all three engines; the per-engine asymmetry — transformers needs a pre-built first-party image, vllm and tensorrt pull upstream images directly — is contained inside each workflow via multi-trigger + per-job `if:` gating, not via file proliferation.
 
-When Renovate (or a maintainer) bumps `engine_versions/vllm.yaml` or
-`engine_versions/tensorrt.yaml`, the corresponding `invariants-vllm` /
-`invariants-tensorrt` / `schemas-vllm` / `schemas-tensorrt` jobs fire on
-`pull_request: paths` and pull upstream images directly (no first-party
-build).
+When Renovate (or a maintainer) bumps `engine_versions/transformers.yaml` or `docker/Dockerfile.transformers`, the pipeline fires sequentially:
 
-A weekly scheduled run of Engine Image Build (Monday 05:37 UTC) rebuilds
-the image from scratch with `--no-cache`. If the resulting digest differs
-from the cached `:latest`, that surfaces external dependency drift (apt
-repo, PyPI wheel re-publish, base image silent update) that layer caching
-alone wouldn't catch. Release-time `docker-publish.yml` continues to
-publish `:v<pkg-version>` on each release tag.
+1. **Engine Image Build** (`engine-image-build.yml`) — builds the transformers image. Exports the layer cache to `ghcr.io/<repo>/transformers-cache:transformers-<VERSION>-buildcache` via `cache-to: type=registry,mode=max`. **Does NOT push a runtime image.** PR builds and main builds both contribute to the cache (per-version content is deterministic given the cache-stable Dockerfile).
+2. **Engine Image Push** (`engine-image-push.yml`) — `workflow_run`-triggered on Engine Image Build's `success`. Only fires for `push` (to main) or `schedule` events — PR builds skip this step. Pulls the layer cache from `:transformers-<VERSION>-buildcache`, rebuilds (essentially free — every layer cache-hits) and pushes runtime tags `:latest` + `:transformers-<VERSION>` to the canonical `ghcr.io/<repo>/transformers` repo.
+3. **Engine Schemas — transformers** (`schemas-transformers` job in `engine-schemas.yml`) — `workflow_run`-triggered on Engine Image Push's `success`. Pulls the just-published runtime image, runs schema discovery, writes back the discovered JSON + curation digest.
+4. **Engine Invariants — transformers** (`invariants-transformers` job in `engine-invariants.yml`) — same trigger and ordering. Pulls the same image, runs the miner + vendor + invariants digest, rebases against schemas's writeback before pushing its own commit.
+
+Why split build from push:
+- **Push failures don't burn the FA3 compile.** A GHCR permission misconfig, transient registry outage, or rate-limit on the push step previously meant re-running ~50 min of cold compile; now the push retry runs in seconds against the durable cache.
+- **PR builds never publish runtime tags.** End users pulling `:latest` always get vetted main code; PR images live in the cache repo only as cache, not as runnable runtime tags.
+- **Cleaner observability.** Build duration vs push duration are separately measurable — when the pipeline slows, we see which stage to debug.
+
+When Renovate (or a maintainer) bumps `engine_versions/vllm.yaml` or `engine_versions/tensorrt.yaml`, the corresponding `invariants-vllm` / `invariants-tensorrt` / `schemas-vllm` / `schemas-tensorrt` jobs fire on `pull_request: paths` and pull upstream images directly (no first-party build).
+
+A weekly scheduled run of Engine Image Build (Monday 05:37 UTC) rebuilds the image from scratch with `--no-cache`. If the resulting layer cache diverges from the prior `:transformers-<VERSION>-buildcache`, that surfaces external dependency drift (apt repo, PyPI wheel re-publish, base image silent update) that layer caching alone wouldn't catch. The corresponding push then publishes the new digest to `:latest`.
 
 ## Running tests
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -117,14 +117,20 @@ There is one workflow file per pipeline concern (build, push, schemas, invariant
 When Renovate (or a maintainer) bumps `engine_versions/transformers.yaml` or `docker/Dockerfile.transformers`, the pipeline fires sequentially:
 
 1. **Engine Image Build** (`engine-image-build.yml`) — builds the transformers image. Exports the layer cache to `ghcr.io/<repo>/transformers-cache:transformers-<VERSION>-buildcache` via `cache-to: type=registry,mode=max`. **Does NOT push a runtime image.** PR builds and main builds both contribute to the cache (per-version content is deterministic given the cache-stable Dockerfile).
-2. **Engine Image Push** (`engine-image-push.yml`) — `workflow_run`-triggered on Engine Image Build's `success`. Only fires for `push` (to main) or `schedule` events — PR builds skip this step. Pulls the layer cache from `:transformers-<VERSION>-buildcache`, rebuilds (essentially free — every layer cache-hits) and pushes runtime tags `:latest` + `:transformers-<VERSION>` to the canonical `ghcr.io/<repo>/transformers` repo.
-3. **Engine Schemas — transformers** (`schemas-transformers` job in `engine-schemas.yml`) — `workflow_run`-triggered on Engine Image Push's `success`. Pulls the just-published runtime image, runs schema discovery, writes back the discovered JSON + curation digest.
+2. **Engine Image Push** (`engine-image-push.yml`) — `workflow_run`-triggered on Engine Image Build's `success`. Tag selection per parent event:
+   - `push` to main / `schedule` → canonical `transformers:latest` + `transformers:transformers-<VERSION>` (vetted main code only writes these)
+   - `pull_request` → `transformers-cache:transformers-<VERSION>` (PR-time runtime image — exists for the downstream chain to pull, but never claims `:latest`)
+   - direct `workflow_dispatch` → canonical tags (ad-hoc recovery path)
+
+   Pulls the layer cache from `:transformers-<VERSION>-buildcache` so the rebuild is essentially free (every layer cache-hits) — only the registry push step actually does network work. Skipped only when the parent run was a `workflow_dispatch` of the BUILD workflow (the build-only ad-hoc test path).
+3. **Engine Schemas — transformers** (`schemas-transformers` job in `engine-schemas.yml`) — `workflow_run`-triggered on Engine Image Push's `success`. Pulls the just-pushed runtime image (canonical or PR-time depending on the trigger that started the chain), runs schema discovery, writes back the discovered JSON + curation digest.
 4. **Engine Invariants — transformers** (`invariants-transformers` job in `engine-invariants.yml`) — same trigger and ordering. Pulls the same image, runs the miner + vendor + invariants digest, rebases against schemas's writeback before pushing its own commit.
 
 Why split build from push:
 - **Push failures don't burn the FA3 compile.** A GHCR permission misconfig, transient registry outage, or rate-limit on the push step previously meant re-running ~50 min of cold compile; now the push retry runs in seconds against the durable cache.
-- **PR builds never publish runtime tags.** End users pulling `:latest` always get vetted main code; PR images live in the cache repo only as cache, not as runnable runtime tags.
+- **PR builds never publish canonical runtime tags.** End users pulling `:latest` always get vetted main code. PR-time runtime images do exist (in the cache repo) — they're necessary so the downstream chain can validate the new Dockerfile — but they're tagged distinctly from canonical.
 - **Cleaner observability.** Build duration vs push duration are separately measurable — when the pipeline slows, we see which stage to debug.
+- **Ad-hoc recovery path.** If the runtime tag is corrupted or misconfigured, `gh workflow run engine-image-push.yml --ref main` rebuilds-from-cache + pushes without redoing the FA3 compile.
 
 When Renovate (or a maintainer) bumps `engine_versions/vllm.yaml` or `engine_versions/tensorrt.yaml`, the corresponding `invariants-vllm` / `invariants-tensorrt` / `schemas-vllm` / `schemas-tensorrt` jobs fire on `pull_request: paths` and pull upstream images directly (no first-party build).
 

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -391,14 +391,18 @@ behaviour. No additional setup is needed when SGLang ships.
 ### Layer cache sharing via GHCR registry
 
 See [installation.md — Fast rebuilds and first-pull cost](installation.md#fast-rebuilds-and-first-pull-cost)
-for the user-facing walkthrough (mechanism, sizes, authentication, offline fallback).
+for the user-facing walkthrough (mechanism, sizes, authentication, offline fallback)
+and the three-ref breakdown of what the build/push pipeline publishes
+(`-buildcache` ref, PR-time `transformers-cache:VER` ref, canonical
+`transformers:VER`/`transformers:latest`).
 
 Operator notes:
 
-- `cache-to` pushes only to `:latest` (never to immutable version tags), so
-  storage growth is bounded by image drift between releases.
+- `cache-to` writes only to the `:transformers-<VER>-buildcache` ref (separate
+  from any runnable image), so storage growth is bounded by SSOT version drift.
 - Inspect what's cached on the active builder: `docker buildx du --builder llem-builder`.
 - If the cache is corrupt, recreate it with `make docker-builder-rm && make docker-builder-setup`.
+  The remote buildcache ref will repopulate on the next CI build.
 
 ### Image labels
 

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -519,8 +519,10 @@ regenerated. This happens automatically via the
 [Parameter Discovery Pipeline](schema-refresh.md): `engine-schemas.yml`
 covers all three engines via per-job `if:` gating — the vllm + tensorrt
 cells fire on `pull_request: paths`; the transformers cell fires via
-`workflow_run` after `engine-image-build.yml` completes. For manual bumps,
-run:
+`workflow_run` after `engine-image-push.yml` completes (which itself
+chains off `engine-image-build.yml` via workflow_run — the build/push
+split exists so push failures don't burn the FA3 compile). For manual
+bumps, run:
 
 ```bash
 ./scripts/refresh_discovered_schemas.sh <engine>

--- a/docs/extending-miners.md
+++ b/docs/extending-miners.md
@@ -396,12 +396,13 @@ def test_landmark_checks_raise_on_missing():
      job pulls the upstream canonical image, then runs probe → mine →
      vendor-replay → doc-gen → atomic-writeback inline.
    - **First-party image (transformers pattern)** — split the build out into
-     a workflow modelled on `engine-image-build.yml` (single-source build),
-     and create `engine-invariants-<engine>.yml` + `engine-schemas-<engine>.yml`
-     as `workflow_run`-gated downstream consumers that pull the resulting
-     image. This pattern is needed when no canonical upstream image exists
-     and a heavy build (e.g. from-source kernel compile) shouldn't repeat
-     across the schemas + invariants concerns.
+     a pair of workflows modelled on `engine-image-build.yml` (build + cache
+     export, no runtime push) and `engine-image-push.yml` (workflow_run-
+     triggered, pulls cache + pushes runtime tags per parent event). The
+     transformers cells in `engine-invariants.yml` + `engine-schemas.yml`
+     then chain off Engine Image Push success via `workflow_run`. The
+     build/push split exists so push failures don't cost a full rebuild
+     of the heavy from-source compile (e.g. ~30 min FA3 compile) on retry.
 
 2. Set the runner: every engine miner runs inside its own Docker image
    (no host extras exist — see [development.md](development.md)). For the
@@ -409,13 +410,16 @@ def test_landmark_checks_raise_on_missing():
    engines whose miners need a GPU only for `import`-time reasons; use
    `invariants-tensorrt` as the template for engines that require
    CUDA-aware imports (e.g. NGC-derived bases). For the first-party-image
-   pattern, mirror the `engine-image-build.yml` + paired downstream files.
+   pattern, mirror `engine-image-build.yml` + `engine-image-push.yml` + the
+   workflow_run-gated cell pair in engine-invariants.yml / engine-schemas.yml.
 
 3. The vendor-replay step runs inside the engine's container in the same job as the miner — no separate vendor workflow to update.
 
 4. Add a Renovate `packageRule` so library bumps trigger the appropriate
    workflow via the `engine_versions/{engine}.yaml` path filter (or, for
-   the first-party-image pattern, via `engine-image-build.yml`'s filter).
+   the first-party-image pattern, via `engine-image-build.yml`'s filter —
+   downstream `engine-image-push.yml` and the workflow_run-gated cells fire
+   automatically on its success).
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -208,25 +208,61 @@ docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0  # pull TensorRT-LLM upst
 
 **How the cache pipeline is wired:**
 
-- The `Engine Image Build (transformers)` workflow runs `build-push-action` with
-  `cache-from`/`cache-to` (registry + GHA scope), exporting the full layer
-  graph (including FA3 intermediates) to:
-  `ghcr.io/henrycgbaker/llenergymeasure/transformers:latest` (rolling, written
-  on push to `main`) and `:transformers-<VERSION>` (immutable per SSOT version).
-  PR-time builds push to the separate cache-only repo
-  `ghcr.io/<repo>/transformers-cache:transformers-<VERSION>` so they don't
-  pollute `:latest`.
-- `docker-compose.yml` declares `cache_from: [:transformers-<VERSION>, :latest]`
-  for the transformers engine — version-pinned first (best layer match within
-  a release), rolling-latest as fallback. vllm and tensorrt have no
-  first-party `cache_from` chain (they pull upstream directly).
-- `make docker-builder-setup` provisions a `docker-container` BuildKit driver
-  with a 200 GiB GC limit; the default `docker` driver cannot import registry
-  caches at all.
+The transformers image is published under three GHCR refs, each serving a
+distinct consumer. The split exists because three orthogonal questions need
+separate answers:
+
+| Ref | Kind | Written by | Consumed by |
+|---|---|---|---|
+| `transformers-cache:transformers-<VER>-buildcache` | BuildKit cache manifest (`mode=max`, intermediate layer metadata — **not a runnable image**) | `engine-image-build.yml` on every successful build (PR, main, schedule, dispatch) | Future `docker build` invocations as `cache-from` |
+| `transformers-cache:transformers-<VER>` | Runnable PR-time runtime image | `engine-image-push.yml` when parent build was a `pull_request` | `engine-invariants.yml` + `engine-schemas.yml` for PR-time validation against the PR's Dockerfile |
+| `transformers:transformers-<VER>` + `transformers:latest` | Runnable canonical runtime image | `engine-image-push.yml` when parent build was a push to `main`, a schedule, or a `workflow_dispatch` | End users (`docker pull`), `make docker-pull`, main-branch invariants/schemas, downstream Renovate consumers |
+
+The three axes encoded:
+
+1. **`-buildcache` suffix** distinguishes "BuildKit cache metadata" from
+   "runnable image". Cache uses `mode=max` so intermediate layers (most
+   importantly the ~30-min FA3 compile) are reusable across subsequent
+   builds; it cannot be `docker run`'d.
+2. **`transformers-cache` repo vs `transformers` repo** distinguishes
+   "built from a PR branch" from "built from `main` (vetted)". Only the
+   canonical repo serves end users, so a PR build can never accidentally
+   claim `:latest`.
+3. **Tag (`:latest` vs `:transformers-<VER>`)** within the canonical repo
+   is the standard rolling-vs-immutable convention.
+
+Why not collapse them? Two tempting simplifications both lose value:
+
+- *Use `type=inline` cache (cache embedded in runtime image manifest, one
+  ref).* Drops `mode=max` intermediate-layer caching; second-build FA3 would
+  recompile.
+- *Drop the PR-time runtime image, validate against `:latest` only.* PR
+  changes to `Dockerfile.transformers` itself would go unvalidated until
+  after merge.
+
+Pipeline mechanics:
+
+- `engine-image-build.yml` runs `build-push-action` with `cache-from` /
+  `cache-to` pointing at the buildcache ref. Builds run on every PR, push to
+  `main`, schedule, and dispatch. `push: false` — this workflow only exports
+  cache, never publishes runnable images.
+- `engine-image-push.yml` is `workflow_run`-triggered on successful
+  `engine-image-build.yml`. It rebuilds (warming off the just-exported
+  buildcache, so it's seconds), tags per parent-event (PR → cache repo;
+  main / schedule / dispatch → canonical repo), and pushes. The build/push
+  split exists so a registry permission failure during push doesn't burn
+  the FA3 compile; the cache survives independently.
+- `docker-compose.yml` declares `cache_from: [:transformers-<VERSION>,
+  :latest]` for the transformers engine — version-pinned first (best layer
+  match within a release), rolling-latest as fallback. vllm and tensorrt
+  have no first-party `cache_from` chain (they pull upstream directly).
+- `make docker-builder-setup` provisions a `docker-container` BuildKit
+  driver with a 200 GiB GC limit; the default `docker` driver cannot import
+  registry caches at all.
 - The Transformers FA3 compile (the only layer where caching is load-bearing)
   runs on a self-hosted runner with sufficient cores + memory; CI rebuilds
-  warm off `:latest` for every subsequent SSOT bump.
-- Pulling the cache is unauthenticated for public packages.
+  warm off the buildcache ref for every subsequent SSOT bump.
+- Pulling any of the three refs is unauthenticated for public packages.
 
 **How to tell if the cache actually warmed:** `make docker-build-{engine}` runs the build
 under `BUILDKIT_PROGRESS=plain` and emits a one-line summary when it finishes:

--- a/docs/miner-pipeline.md
+++ b/docs/miner-pipeline.md
@@ -427,10 +427,11 @@ Library version bumps trigger corpus regeneration automatically. The flow descri
   │   - vllm + tensorrt: invariants-vllm / schemas-vllm /              │
   │     invariants-tensorrt / schemas-tensorrt fire in parallel via    │
   │     pull_request: paths.                                            │
-  │   - transformers: engine-image-build.yml fires first (single       │
-  │     pre-build of the Docker image), then invariants-transformers   │
-  │     + schemas-transformers (in the same two workflow files) fire   │
-  │     via workflow_run on its success (sequential downstream).       │
+  │   - transformers: engine-image-build.yml fires first (build +      │
+  │     cache export, no runtime push), then engine-image-push.yml     │
+  │     publishes runtime tags via workflow_run, then invariants-      │
+  │     transformers + schemas-transformers (in the same two workflow  │
+  │     files) fire via workflow_run on the push's success.            │
   │     See docs/development.md "CI pipeline ordering" for detail.     │
   │               │                                                   │
   │  ──────────── engine-invariants per-engine job ────────────────   │

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -5,12 +5,13 @@ This doc is the chain-diagram reference for the engine-coupling pipeline. SSOT-d
 > **Per-engine variation.** The diagram below is the vllm + tensorrt shape:
 > the `invariants-vllm` / `schemas-vllm` (and `-tensorrt`) jobs in
 > `engine-invariants.yml` + `engine-schemas.yml` fire on `pull_request: paths`
-> with `wait-on-check-action` sibling coordination. Transformers takes a
-> sequential variant: `engine-image-build.yml` builds the image once, then
-> the `schemas-transformers` and `invariants-transformers` jobs (in the same
-> two workflow files) fire via `workflow_run`. Per-job `if:` clauses select
-> the correct cell for each trigger source. The sequence is described in
-> detail in
+> with sibling coordination via inline `gh api` polling. Transformers takes a
+> sequential variant: `engine-image-build.yml` builds the image (cache export
+> only, no runtime push), `engine-image-push.yml` then fires via `workflow_run`
+> and publishes runtime tags, and on its success the `schemas-transformers`
+> and `invariants-transformers` jobs (in the same two workflow files) fire
+> via `workflow_run`. Per-job `if:` clauses select the correct cell for each
+> trigger source. The sequence is described in detail in
 > [`docs/development.md` — CI pipeline ordering](development.md#ci-pipeline-ordering);
 > the diagram below applies to vllm + tensorrt only.
 

--- a/docs/schema-refresh.md
+++ b/docs/schema-refresh.md
@@ -25,9 +25,10 @@ e.g. engine_versions/vllm.yaml current_version: 0.7.3 -> 0.8.0
                       v
 For vllm + tensorrt: schemas-vllm / schemas-tensorrt jobs in
                      engine-schemas.yml auto-fire on pull_request
-For transformers: engine-image-build.yml builds the image once, then
-                  the schemas-transformers job in engine-schemas.yml
-                  fires via workflow_run
+For transformers: engine-image-build.yml builds the image, then
+                  engine-image-push.yml publishes it (chained via
+                  workflow_run), then the schemas-transformers job in
+                  engine-schemas.yml fires via workflow_run on push
                       |
                       v
 +------------------------------------------+
@@ -63,11 +64,14 @@ Maintainer reviews PR:
      `engine-schemas.yml` auto-fire on the self-hosted GPU runner
      (path-filtered on `engine_versions/vllm.yaml` /
      `engine_versions/tensorrt.yaml`).
-   - **transformers**: `engine-image-build.yml` fires first (rebuilds the
-     transformers Docker image once per (PR, SSOT version) and pushes it
-     to a per-PR cache repo); on success, the `schemas-transformers` job
-     in `engine-schemas.yml` fires via `workflow_run`, pulls the just-built
-     image, and runs discovery against it.
+   - **transformers**: `engine-image-build.yml` fires first (builds the
+     transformers Docker image and exports the layer cache to
+     `:transformers-<VER>-buildcache`); on success, `engine-image-push.yml`
+     fires via `workflow_run` and pushes the runtime image (canonical tags
+     for main/schedule, PR-time tag on `transformers-cache` for PR builds).
+     On push success, the `schemas-transformers` job in `engine-schemas.yml`
+     fires via `workflow_run`, pulls the just-pushed image, and runs
+     discovery against it.
 3. The workflow runs `./scripts/refresh_discovered_schemas.sh <engine>`
    (or the equivalent steps inline) inside the engine's image.
 4. After discovery, `scripts/diff_discovered_schemas.py` classifies changes as safe or
@@ -97,7 +101,8 @@ On failure, the developer can either:
 - Trigger remotely: `gh workflow run engine-schemas.yml --field engine=<engine> --field pr_number=<N>`
   (for transformers, run `engine-image-build.yml` instead — the
   `schemas-transformers` job in `engine-schemas.yml` is `workflow_run`-gated
-  and re-fires automatically once the build run completes)
+  on Engine Image Push success, which itself chains off Engine Image Build,
+  so the chain re-fires automatically once the build completes)
 
 ### Manual Refresh (workflow_dispatch)
 
@@ -109,8 +114,9 @@ gh workflow run engine-schemas.yml \
   --field engine=vllm \
   --field pr_number=123
 
-# transformers: trigger Engine Image Build (downstream schemas + invariants
-# fire automatically on its success via workflow_run)
+# transformers: trigger Engine Image Build. Engine Image Push fires on
+# its success (workflow_run); schemas-transformers + invariants-transformers
+# then fire on the push's success (also workflow_run).
 gh workflow run engine-image-build.yml
 ```
 


### PR DESCRIPTION
## Summary

Splits the transformers image pipeline into two chained workflows. Closes #534.

`engine-image-build.yml` → `engine-image-push.yml` → `engine-schemas.yml` + `engine-invariants.yml`

Each step chains via `workflow_run: completed` + `conclusion == 'success'` gating.

## Why this matters

The previous shape ran build + push in a single buildx step. When the push step failed (GHCR perms, transient outage, rate limit), the entire ~50-min FA3 compile had to re-run on retry. This bit us repeatedly today during PR #529's iteration cycle.

Splitting means:
- **Push failures don't burn the FA3 compile** — push retries run in seconds against the durable cache
- **PR builds never publish runtime tags** — `:latest` and `:transformers-<VER>` only get written by vetted main code
- **Cleaner observability** — build vs push duration are separately measurable

## Validation expectation

PR #529 already populated `transformers-cache:transformers-4.57.3-buildcache`. The Dockerfile content is unchanged on main between PR #529 and this PR. So this PR's CI build should be **cache-warm (~5-10 min)** — the FIRST proof that the registry-cache architecture delivers fast iteration when the Dockerfile is stable.

If this PR's first build runs cold (~50 min), the cache architecture has a gap to investigate.

After CI green: workflow_dispatch on the branch to confirm warm-cache hit duration. Then squash-merge.

## Changes

### NEW `engine-image-push.yml`

Triggered by `workflow_run` on Engine Image Build success. Only fires when the parent's event is `push` (main) or `schedule` — PR builds skip, so PR-time runs only do the build, not the push. Pulls layer cache from `:transformers-<VER>-buildcache`, rebuild is essentially free, pushes runtime tags `:latest` + `:transformers-<VER>` to canonical GHCR.

### Modified `engine-image-build.yml`

- Always `push: false` — no runtime image push
- Always `cache-to: type=registry,mode=max,ref=...:VER-buildcache`
- Removed inline shell branching for per-event tags + push (no longer needed)
- Tags: local-only `transformers-build:local`
- Output: `version` (so the push workflow can derive the SSOT version too)

### Modified `engine-invariants.yml` + `engine-schemas.yml`

Updated `workflow_run.workflows: [\"Engine Image Build (transformers)\"]` → `[\"Engine Image Push (transformers)\"]`. The transformers cells need to pull the runtime image from GHCR, which doesn't exist until push lands. Build success alone is necessary but not sufficient.

### `docs/development.md`

Rewrote the 'CI pipeline ordering' section to reflect the four-workflow chain.

## Issues addressed

- Closes #534 — modular workflow + cache architecture cleanup
- Establishes the platform for #536 (FA3 wheel architecture) which builds on the build/push separation

## Test plan

- [ ] CI build on this PR completes cache-warm (~5-10 min, NOT a cold rebuild)
- [ ] workflow_dispatch on this branch verifies warm-cache build (<10 min)
- [ ] After merge: first push to main retriggers full chain — confirm push workflow fires + publishes runtime tags + downstream schemas/invariants chain works

## Pre-conditions

- [x] PR #529 merged (cache-stable Dockerfile baseline)
- [ ] First CI run validates cache-warm behaviour