### PR TITLE
refactor(ci): docs.yml push-only; drop src/ from path filter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,12 @@ name: Build docs site
 
 # Builds the Docusaurus site under website/ and deploys to GitHub Pages
 # on push to main. PR-time previews are handled separately by Cloudflare
-# Pages (see docs/architecture/preview-deployments.md) — this workflow
+# Pages (see docs/architecture/preview-deployments.md) - this workflow
 # does not run on pull_request.
 #
 # Path-trigger self-test: this workflow's own filename is included in
 # `on.push.paths` below, so edits to this file fire the workflow on
-# merge and exercise its current behaviour (per the convention in
-# CLAUDE.md §"Path-trigger self-tests").
+# merge and exercise its current behaviour.
 
 on:
   push:
@@ -25,7 +24,7 @@ permissions:
   id-token: write
 
 concurrency:
-  # Read-only / stateless — safe to cancel in-flight runs.
+  # Read-only / stateless - safe to cancel in-flight runs.
   group: pages
   cancel-in-progress: true
 
@@ -50,7 +49,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install package
-        # Base install only — no GPU extras needed. Brings in pyyaml,
+        # Base install only - no GPU extras needed. Brings in pyyaml,
         # pydantic, etc. so llenergymeasure is importable by the generator.
         run: pip install -e .
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,28 +1,21 @@
 name: Build docs site
 
 # Builds the Docusaurus site under website/ and deploys to GitHub Pages
-# on push to main. PR-time runs build only (no deploy) so reviewers can
-# verify the build is clean before merge.
+# on push to main. PR-time previews are handled separately by Cloudflare
+# Pages (see docs/architecture/preview-deployments.md) — this workflow
+# does not run on pull_request.
 #
 # Path-trigger self-test: this workflow's own filename is included in
-# `on.pull_request.paths` and `on.push.paths` below, so edits to this
-# file fire the workflow at PR time and exercise its current behaviour
-# (per the convention in CLAUDE.md §"Path-trigger self-tests").
+# `on.push.paths` below, so edits to this file fire the workflow on
+# merge and exercise its current behaviour (per the convention in
+# CLAUDE.md §"Path-trigger self-tests").
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "website/**"
-      - "docs/**"
-      - "src/llenergymeasure/**"
-      - ".github/workflows/docs.yml"
   push:
     branches: [main]
     paths:
       - "website/**"
       - "docs/**"
-      - "src/llenergymeasure/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -41,7 +34,7 @@ jobs:
     name: Build docs site
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Node
@@ -73,20 +66,12 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        # Upload on every run (PR + push). On push to main this is what
-        # the deploy job consumes; on PR runs it's a downloadable preview
-        # — reviewers can fetch the built site as a zip from the Actions
-        # UI without cloning + building locally.
         uses: actions/upload-pages-artifact@v3
         with:
           path: website/build
 
   deploy:
     name: Deploy docs site
-    # Fires on push to main (the standard publish path) and on
-    # workflow_dispatch (manual re-deploy lever, useful for emergency
-    # republish without a no-op commit). Skipped on pull_request.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/docs/architecture/preview-deployments.md
+++ b/docs/architecture/preview-deployments.md
@@ -109,15 +109,17 @@ main push ──► docs.yml ──► GitHub Pages ──► henrycgbaker.githu
 ```
 
 If CF availability degrades, PRs lose preview URLs but production remains
-deployable. The GH Actions build job in `docs.yml` still runs on PRs, so
-build correctness is verified independently of CF.
+deployable — `docs.yml` runs only on push to `main` (not on PRs), so a
+broken CF build doesn't block merging if the change is otherwise sound;
+the deploy job re-validates the build at merge time.
 
 ## Troubleshooting
 
 **"Preview URL doesn't appear on my PR"**
-- Confirm the PR diff touches `docs/**`, `website/**`, `src/llenergymeasure/**`,
-  or `scripts/cloudflare-build.sh`. CF rebuilds on every push regardless,
-  but path-irrelevant PRs don't always get prominent UI.
+- CF rebuilds on every push regardless of paths (no path filter applied
+  in CF dashboard at time of writing). Path-irrelevant PRs still get
+  previews but the GitHub UI sometimes hides the deployment status until
+  the comment is posted.
 - Check the PR's "Checks" tab for a `cloudflare-pages` entry — if the
   build failed, click through to the CF dashboard logs.
 - If the GitHub App is mis-authorised, the comment won't post but the

--- a/docs/architecture/preview-deployments.md
+++ b/docs/architecture/preview-deployments.md
@@ -45,7 +45,7 @@ from docstrings on every build (it's gitignored, so without this step the
 API reference pillar is empty in the preview).
 
 `onBrokenLinks: 'throw'` in `website/docusaurus.config.ts` gates the
-build — broken internal links fail the preview just as they fail the
+build - broken internal links fail the preview just as they fail the
 production build.
 
 ## Runtime versions
@@ -63,7 +63,7 @@ vars needed for version selection.
 ## One-time maintainer setup
 
 These steps activate the CF Pages integration. Until they're done, the
-build script and config files in this PR sit dormant — no preview URL is
+build script and config files in this PR sit dormant - no preview URL is
 generated. Once complete, every existing open PR (including ones merged
 in before this setup) gets previews on next push.
 
@@ -84,12 +84,12 @@ in before this setup) gets previews on next push.
    | Build command | `bash scripts/cloudflare-build.sh` |
    | Build output directory | `website/build` |
    | Root directory (advanced) | `/` (default) |
-   | Environment variables | *(none required — see Runtime versions)* |
+   | Environment variables | *(none required - see Runtime versions)* |
 
 4. **Verify** by triggering a manual deploy of `main` from the CF dashboard.
    Expected: ~40 s build, output URL serves the Docusaurus site.
 
-5. **Open or push to any docs-touching PR** — the CF GitHub App posts a
+5. **Open or push to any docs-touching PR** - the CF GitHub App posts a
    preview-URL comment within ~1 minute of build completion.
 
 No GitHub Actions secrets are needed; the GitHub App handles auth.
@@ -101,15 +101,15 @@ This setup intentionally does not migrate production to CF Pages.
 every push. The two paths are independent:
 
 ```
-PR push  ───────────────► CF Pages ────► <hash>.llenergymeasure-docs.pages.dev
-                                          (preview, comment on PR)
+PR push  --------------> CF Pages ----> <hash>.llenergymeasure-docs.pages.dev
+                                         (preview, comment on PR)
 
-main push ──► docs.yml ──► GitHub Pages ──► henrycgbaker.github.io/llenergymeasure
+main push --> docs.yml --> GitHub Pages --> henrycgbaker.github.io/llenergymeasure
                                             (production)
 ```
 
 If CF availability degrades, PRs lose preview URLs but production remains
-deployable — `docs.yml` runs only on push to `main` (not on PRs), so a
+deployable - `docs.yml` runs only on push to `main` (not on PRs), so a
 broken CF build doesn't block merging if the change is otherwise sound;
 the deploy job re-validates the build at merge time.
 
@@ -120,7 +120,7 @@ the deploy job re-validates the build at merge time.
   in CF dashboard at time of writing). Path-irrelevant PRs still get
   previews but the GitHub UI sometimes hides the deployment status until
   the comment is posted.
-- Check the PR's "Checks" tab for a `cloudflare-pages` entry — if the
+- Check the PR's "Checks" tab for a `cloudflare-pages` entry - if the
   build failed, click through to the CF dashboard logs.
 - If the GitHub App is mis-authorised, the comment won't post but the
   build may still succeed. Re-authorise from the repo's Settings →
@@ -133,10 +133,10 @@ the deploy job re-validates the build at merge time.
   is always fresh per commit.
 
 **"`pip install -e .` fails on CF"**
-- Verify `.python-version` resolves to a CF-supported Python (3.6–3.13
+- Verify `.python-version` resolves to a CF-supported Python (3.6-3.13
   are available in the V2 image).
 - Engine extras (`zeus`, `codecarbon`) are intentionally not installed
-  for previews — they're not needed to import `llenergymeasure` for the
+  for previews - they're not needed to import `llenergymeasure` for the
   API doc generator.
 
 **"Build succeeds but a page 404s in the preview"**
@@ -150,7 +150,7 @@ Free tier is sized for a project this size with margin:
 
 | Limit | Free tier | Project usage estimate |
 |---|---|---|
-| Builds | 500 / month | ~30–50 (generous PR cadence) |
+| Builds | 500 / month | ~30-50 (generous PR cadence) |
 | Bandwidth | unlimited | n/a |
 | Concurrent builds | 1 | sequential per PR |
 | Preview retention | unlimited | n/a |

--- a/scripts/cloudflare-build.sh
+++ b/scripts/cloudflare-build.sh
@@ -8,19 +8,19 @@
 #   1. install llenergymeasure (base deps only) so generate_api_docs.py
 #      can `import llenergymeasure` to render the API reference page
 #   2. run the API docs generator (writes docs/api/llenergymeasure.md,
-#      which is gitignored — must be regenerated on every build)
+#      which is gitignored - must be regenerated on every build)
 #   3. install Docusaurus deps + build the static site to website/build/
 #
 # Runtime versions are pinned in .nvmrc (Node) and .python-version
 # (Python); the CF V2 build image auto-activates them via nvm/pyenv.
-# CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID are not used here — direct
+# CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID are not used here - direct
 # GitHub App integration handles auth, this script only builds.
 
 set -euo pipefail
 
 # CF Pages serves at root (*.pages.dev), unlike GH Pages which serves
 # under the /llenergymeasure/ subpath. Override docusaurus.config.ts's
-# default baseUrl here rather than via dashboard env vars — the new
+# default baseUrl here rather than via dashboard env vars - the new
 # Workers Builds UI doesn't expose a clean Production/Preview-scoped
 # build-time env-var panel. Hardcoding here is unambiguous and only
 # affects CF builds (GH Pages uses .github/workflows/docs.yml, which


### PR DESCRIPTION
## Summary

Cloudflare Pages now handles PR-time docs previews (#575), so `docs.yml`'s PR-time build is redundant. Two scoped changes:

1. **Remove `pull_request` trigger** - `docs.yml` now runs only on `push` to `main` and `workflow_dispatch`. Cuts the duplicate ~40s GH Actions build per PR push. CF Pages becomes the sole PR-time build gate.
2. **Drop `src/llenergymeasure/**` from `paths`** - source-code commits no longer trigger docs builds. API-ref drift between source and docs is acceptable until the next `docs/**` or `website/**` push, which re-runs the API generator and refreshes the deployed site.

Path filter after change:
- `website/**`
- `docs/**`
- `.github/workflows/docs.yml` (self-test)

## Why now

Validates the leaner docs CI pipeline before #574 (large docs restructure) lands. Cleaner to confirm the new shape works against `main` first; #574 will pick up the changes on rebase.

## Doc + text hygiene

- Updated `docs/architecture/preview-deployments.md` to remove the now-stale "GH Actions build job in docs.yml still runs on PRs" claim, and to clarify that CF Pages currently has no path filter (every push triggers a CF rebuild).
- Replaced all em-dashes and en-dashes in the docs-CI surface (`docs.yml`, `preview-deployments.md`, `cloudflare-build.sh`) with ASCII hyphens. Box-drawing arrows in the deploy-flow diagram swapped for ASCII (\`--->\` / \`-->\`).

## Outstanding (deliberately not in this PR)

- CF dashboard build path scoping (Settings -> Builds -> Build watch paths). Manual user action, no repo change. Recommended scope: same as the new \`docs.yml\` paths above.

## Test plan

- [x] Workflow shape validates locally (no syntax change to job structure)
- [ ] After merge: confirm docs build does NOT trigger on a \`src/\`-only PR
- [ ] After merge: confirm docs build DOES trigger + deploy on a \`docs/\` push to main
- [ ] After both verified: CF dashboard scoping (separate manual step)