### PR TITLE
refactor(ci): scope ci.yml jobs by path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
       docker: ${{ steps.changes.outputs.docker }}
       workflows: ${{ steps.changes.outputs.workflows }}
+      docs_inputs: ${{ steps.changes.outputs.docs_inputs }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -55,6 +56,19 @@ jobs:
               - 'pyproject.toml'
             workflows:
               - '.github/workflows/**'
+            docs_inputs:
+              # Inputs to the docs-freshness job: Pydantic models the
+              # generators introspect, the generator scripts themselves,
+              # and this workflow file (self-test). pyproject/uv.lock
+              # excluded: env-break would surface in lint/type-check/test
+              # before docs-freshness anyway.
+              - 'src/**'
+              - 'scripts/generate_config_docs.py'
+              - 'scripts/generate_cli_reference.py'
+              - 'scripts/generate_invalid_combos_doc.py'
+              - 'scripts/generate_curation_doc.py'
+              - 'scripts/check_pydantic_matches_discovered.py'
+              - '.github/workflows/ci.yml'
 
   lint:
     if: >-
@@ -164,10 +178,16 @@ jobs:
           [ "$PYPROJECT_VER" = "$VERSION_VER" ] || { echo "ERROR: Version mismatch: pyproject.toml=${PYPROJECT_VER}, _version.py=${VERSION_VER}"; exit 1; }
 
   docs-freshness:
+    needs: filter
     if: >-
-      github.event_name != 'workflow_dispatch'
-      || inputs.job == 'all'
-      || inputs.job == 'docs-freshness'
+      (
+        github.event_name != 'workflow_dispatch'
+        && needs.filter.outputs.docs_inputs == 'true'
+      )
+      || (
+        github.event_name == 'workflow_dispatch'
+        && (inputs.job == 'all' || inputs.job == 'docs-freshness')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,23 +58,23 @@ jobs:
               - '.github/workflows/**'
             docs_inputs:
               # Inputs to the docs-freshness job: Pydantic models the
-              # generators introspect, the generator scripts themselves,
+              # generators introspect, anything under scripts/ (generators
+              # plus their transitive helpers like engine_miners/_ssot.py),
               # and this workflow file (self-test). pyproject/uv.lock
-              # excluded: env-break would surface in lint/type-check/test
-              # before docs-freshness anyway.
+              # excluded: env-break would surface in lint / type-check /
+              # test / package-validation before docs-freshness anyway.
               - 'src/**'
-              - 'scripts/generate_config_docs.py'
-              - 'scripts/generate_cli_reference.py'
-              - 'scripts/generate_invalid_combos_doc.py'
-              - 'scripts/generate_curation_doc.py'
-              - 'scripts/check_pydantic_matches_discovered.py'
+              - 'scripts/**'
               - '.github/workflows/ci.yml'
 
   lint:
+    needs: filter
     if: >-
-      github.event_name != 'workflow_dispatch'
-      || inputs.job == 'all'
-      || inputs.job == 'lint'
+      always()
+      && (
+        (github.event_name == 'workflow_dispatch' && (inputs.job == 'all' || inputs.job == 'lint'))
+        || needs.filter.outputs.src == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -92,10 +92,13 @@ jobs:
         run: uv run lint-imports
 
   type-check:
+    needs: filter
     if: >-
-      github.event_name != 'workflow_dispatch'
-      || inputs.job == 'all'
-      || inputs.job == 'type-check'
+      always()
+      && (
+        (github.event_name == 'workflow_dispatch' && (inputs.job == 'all' || inputs.job == 'type-check'))
+        || needs.filter.outputs.src == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -148,10 +151,13 @@ jobs:
         run: uv run python -c "from llenergymeasure import run_experiment, ExperimentConfig, ExperimentResult; print('OK')"
 
   package-validation:
+    needs: filter
     if: >-
-      github.event_name != 'workflow_dispatch'
-      || inputs.job == 'all'
-      || inputs.job == 'package-validation'
+      always()
+      && (
+        (github.event_name == 'workflow_dispatch' && (inputs.job == 'all' || inputs.job == 'package-validation'))
+        || needs.filter.outputs.src == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -180,13 +186,10 @@ jobs:
   docs-freshness:
     needs: filter
     if: >-
-      (
-        github.event_name != 'workflow_dispatch'
-        && needs.filter.outputs.docs_inputs == 'true'
-      )
-      || (
-        github.event_name == 'workflow_dispatch'
-        && (inputs.job == 'all' || inputs.job == 'docs-freshness')
+      always()
+      && (
+        (github.event_name == 'workflow_dispatch' && (inputs.job == 'all' || inputs.job == 'docs-freshness'))
+        || needs.filter.outputs.docs_inputs == 'true'
       )
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ clean:
 # Generate documentation from SSOT sources
 generate-docs:
 	python scripts/generate_invalid_combos_doc.py
-	python scripts/generate_param_matrix.py
 	python scripts/generate_config_docs.py
 	@echo "Generated docs in docs/generated/"
 


### PR DESCRIPTION
## Summary

Address #577 part 1: scope ci.yml's substantive jobs by path filter so PRs that don't touch the relevant inputs skip the corresponding jobs. Saves ~100s of CI runtime per docs-only PR.

## Changes

**`docs-freshness` (new gate):** add `needs: filter` + `if:` referencing a new `docs_inputs` output covering Pydantic models the generators introspect (`src/**`), generator scripts and their transitive helpers (`scripts/**`), and this workflow file (self-test).

**`lint`, `type-check`, `package-validation` (new gates):** mirror the existing `test` job pattern. Each now has `needs: filter` + `if:` that uses the existing `src` filter (`src/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `ci.yml`).

**`scripts/**` rather than explicit script list:** initial commit listed the 5 specific generator scripts, but AST walk found `scripts/generate_curation_doc.py` imports `scripts/engine_miners/_ssot.py` - silent coverage gap. Broadening to `scripts/**` covers transitive helpers and future-proofs against new generators. False-positive cost (~13s of `docs-freshness` when an unrelated script changes) is negligible.

**Makefile:** drop the dead reference to `scripts/generate_param_matrix.py` in the `generate-docs` target (file doesn't exist; target was previously broken).

## Behaviour preserved

`workflow_dispatch` with `job=all` or `job=<job-name>` still runs the targeted job(s) regardless of paths. Each job's `if:` uses `always() && ((dispatch path) || (filter path))`, matching the existing `test` job idiom.

## Out of scope

- **scripts/ refactor** (subdirectory grouping + stale-script cleanup): tracked separately, opening as a follow-up PR with phased plan to avoid conflict with #574.
- **gpu-ci.yml** path filter: investigated, deliberately NOT changed. The workflow's design uses PR label-based gating (`pull_request: types: [labeled, synchronize]` + job-level `if: contains(labels, 'gpu-ci')`); adding a workflow-level `paths:` filter would break label-only re-runs on already-pushed commits (the `labeled` event would not fire if the original push's diff didn't match the filter).
- **CF Pages 2-URL comment** (issue #577 part 2): SHA permalink is intrinsic per CF docs ("atomic and may always be visited in the future"); CF App's comment template is not documented as configurable. Realistic path to one-URL-on-PR requires either an undocumented dashboard toggle (to disable CF's auto-comment) plus a custom GH Actions workflow, or accepting two URLs. Deferred until the noise actually bites.

## Test plan

- [x] All 4 gated jobs use the same `if:` idiom (`always() && ((dispatch path) || (filter path))`)
- [x] `docs_inputs` filter broadened to `scripts/**` after AST walk found transitive-import coverage gap
- [ ] After merge: confirm a docs-only PR (e.g. README typo) skips lint/type-check/test/package-validation/docs-freshness
- [ ] After merge: confirm a `src/` PR runs all of them
- [ ] After merge: `gh workflow run ci.yml -f job=lint` still runs lint regardless of paths

Closes #577 (part 1; issue stays open for the CF comment customisation work).