### PR TITLE
[PoC] docs(architecture): rename VENDOR-REPLAY -> VALIDATE-REPLAY in pipeline diagram

### DIFF
--- a/docs/explanation/architecture/pipeline-architecture.md
+++ b/docs/explanation/architecture/pipeline-architecture.md
@@ -97,7 +97,7 @@ LEGEND:  [auto]    fully automated, no human action
 │   → src/llenergymeasure/engines│         │   → src/llenergymeasure/     │
 │     /{engine}/invariants.proposed.yaml  │         │     config/discovered_       │
 │                              │         │     schemas/{engine}/schema.discovered.json    │
-│  STEP 3 [auto]: VENDOR-REPLAY│         │                              │
+│  STEP 3 [auto]: VALIDATE-REPLAY│         │                              │
 │   validate_invariants.py + the      │         │  STEP 3 [auto]: DIFF vs HEAD │
 │   compare_expected_vs_       │         │                              │
 │   observed contract from     │         │  STEP 4 [auto]: REGENERATE   │


### PR DESCRIPTION
**Stacked on PR #574** (\`docs/restructure-ia\`). PoC for cherry-pick consideration.

## What this is

Single-line rename in the ASCII pipeline diagram of \`docs/explanation/architecture/pipeline-architecture.md\`. STEP 3's label changes from \`VENDOR-REPLAY\` to \`VALIDATE-REPLAY\`, aligning the user-facing terminology in the diagram with the canonical "validated.yaml" file naming this step produces and with the workflow YAML's step names.

## Why PoC

The locked terminology mapping in \`docs/CLAUDE.md\` retires \`vendor\` in favour of \`validate\` / \`validated.yaml\`. This step label is the last user-facing holdout. The rest of the same diagram already uses \`validated.yaml\` for the output filename. Internal source-side variables retain \`VENDORED_*\` legacy names but those are not user-facing.

The reason this is a PoC and not a direct PR-574 commit: ASCII tree alignment is fragile. \`VALIDATE-REPLAY\` is 2 chars longer than \`VENDOR-REPLAY\`. The surrounding column already has variable widths (lines 85-118 range from 32 to 35 chars between borders), so the change reads cleanly - but I wanted you to see the diff and confirm before merging.

## How to consume

- **Cherry-pick** if the rendering reads OK in your view (Docusaurus + GitHub markdown both render this as \`\`\`text\`\`\` block; check the preview).
- **Close** if the visual hiccup is too distracting.
- **Counter-propose** if there's a shorter rename that fits column width better (e.g. just \`VALIDATE\` without \`-REPLAY\` would be 8 chars, fitting strictly, but loses the "replays mined kwargs" meaning conveyed by REPLAY).

## Caveat at merge time

Per memory: when PR-574 squash-merges, use plain \`gh pr merge --squash\` (NOT \`--squash --delete-branch\`); the auto-retarget races branch deletion. After PR-574 merges, manually retarget this PR's base to \`main\`, then sweep branches.