### PR TITLE
feat(engines): vendor LANDMARKS per-version via dispatcher

### DIFF
--- a/.github/workflows/_engine-invariants-cell.yml
+++ b/.github/workflows/_engine-invariants-cell.yml
@@ -80,7 +80,11 @@ jobs:
             echo "Could not resolve ${ENGINE} version from engine_versions/${ENGINE}.yaml" >&2
             exit 1
           fi
+          # Python-identifier-safe form (dots and hyphens -> underscores) used as the
+          # subpackage name under src/llenergymeasure/_engine_archive/<engine>/.
+          SAFE_VER="v${VER//[.-]/_}"
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "safe_version=${SAFE_VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:${ENGINE}-${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR (read-only, for image pull)
@@ -410,6 +414,24 @@ jobs:
             fi
           } > "/tmp/engine-invariants-diff/${ENGINE}.summary.md"
 
+      - name: Mirror canonical invariants to versioned archive
+        if: steps.probe.outputs.verdict == 'pass'
+        env:
+          ENGINE: ${{ inputs.engine }}
+          SAFE_VER: ${{ steps.version.outputs.safe_version }}
+        run: |
+          # Derivative dual-write: the archive is always a byte-identical
+          # mirror of the canonical mining outputs. Copies happen AFTER the
+          # canonical writes are confirmed (probe pass + miner + validator
+          # all green); on probe-blocked / mining failure the cp step does
+          # not run, leaving the archive in sync with the last successful
+          # run. The dual-tree determinism check in subsequent runs reduces
+          # to ``diff -q canonical archive`` (always 0 by construction).
+          ARCHIVE_DIR="src/llenergymeasure/_engine_archive/${ENGINE}/${SAFE_VER}/outputs"
+          mkdir -p "${ARCHIVE_DIR}"
+          cp "${ENGINES_DIR}/${ENGINE}/invariants.proposed.yaml" "${ARCHIVE_DIR}/invariants.proposed.yaml"
+          cp "${ENGINES_DIR}/${ENGINE}/invariants.validated.yaml" "${ARCHIVE_DIR}/invariants.validated.yaml"
+
       - name: Probe-fail comment (skip downstream)
         if: steps.probe.outputs.verdict == 'fail' && inputs.pr-number != ''
         env:
@@ -458,6 +480,8 @@ jobs:
           path: |
             ${{ env.ENGINES_DIR }}/${{ inputs.engine }}/invariants.proposed.yaml
             ${{ env.ENGINES_DIR }}/${{ inputs.engine }}/invariants.validated.yaml
+            src/llenergymeasure/_engine_archive/${{ inputs.engine }}/${{ steps.version.outputs.safe_version }}/outputs/invariants.proposed.yaml
+            src/llenergymeasure/_engine_archive/${{ inputs.engine }}/${{ steps.version.outputs.safe_version }}/outputs/invariants.validated.yaml
             engine_versions/${{ inputs.engine }}.yaml
             docs/user/generated/invariants-${{ inputs.engine }}.md
           if-no-files-found: error

--- a/.github/workflows/_engine-invariants-cell.yml
+++ b/.github/workflows/_engine-invariants-cell.yml
@@ -209,14 +209,28 @@ jobs:
               ;;
           esac
           PATHS=("${BASE_PATHS[@]}" "${ENGINE_PATHS[@]}")
-          SHA=$(git log -1 --format=%H -- "${PATHS[@]}")
-          DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          # Exclude bot writeback commits from anchor calculation. The
+          # writeback bot updates engine_versions/<engine>.yaml's last_probe
+          # block (and canonical mining outputs) on every successful run,
+          # producing a fresh git author timestamp. Without this filter, the
+          # anchor shifts on each writeback, mining produces a different
+          # mined_at timestamp, the diff classifier fires, writeback fires,
+          # loop. Filtering bot commits anchors mining to the latest
+          # substantive change instead.
+          SHA=$(git log -1 --format=%H \
+            --invert-grep --grep='^chore(bot): writeback' \
+            -- "${PATHS[@]}")
+          DATE=$(git log -1 --format=%aI \
+            --invert-grep --grep='^chore(bot): writeback' \
+            -- "${PATHS[@]}")
           if [[ -z "${DATE}" ]]; then
             echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
             exit 1
           fi
-          echo "sha=${SHA:-${GITHUB_SHA}}" >> "$GITHUB_OUTPUT"
-          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
+          {
+            echo "sha=${SHA:-${GITHUB_SHA}}"
+            echo "date=${DATE}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Probe - landmark resolution check (in container)
         id: probe

--- a/.github/workflows/_engine-invariants-cell.yml
+++ b/.github/workflows/_engine-invariants-cell.yml
@@ -83,9 +83,11 @@ jobs:
           # Python-identifier-safe form (dots and hyphens -> underscores) used as the
           # subpackage name under src/llenergymeasure/_engine_archive/<engine>/.
           SAFE_VER="v${VER//[.-]/_}"
-          echo "version=${VER}" >> "$GITHUB_OUTPUT"
-          echo "safe_version=${SAFE_VER}" >> "$GITHUB_OUTPUT"
-          echo "image=llenergymeasure:${ENGINE}-${VER}" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=${VER}"
+            echo "safe_version=${SAFE_VER}"
+            echo "image=llenergymeasure:${ENGINE}-${VER}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR (read-only, for image pull)
         if: inputs.image-source == 'ghcr-cache'

--- a/.github/workflows/_engine-schemas-cell.yml
+++ b/.github/workflows/_engine-schemas-cell.yml
@@ -78,7 +78,11 @@ jobs:
             echo "Could not resolve ${ENGINE} version from engine_versions/${ENGINE}.yaml" >&2
             exit 1
           fi
+          # Python-identifier-safe form (dots and hyphens -> underscores) used as the
+          # subpackage name under src/llenergymeasure/_engine_archive/<engine>/.
+          SAFE_VER="v${VER//[.-]/_}"
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "safe_version=${SAFE_VER}" >> "$GITHUB_OUTPUT"
           echo "image=llenergymeasure:${ENGINE}-${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR (read-only, for image pull)
@@ -366,6 +370,17 @@ jobs:
             fi
           } > "/tmp/engine-schemas-diff/${ENGINE}.summary.md"
 
+      - name: Mirror canonical schema to versioned archive
+        if: steps.probe.outputs.verdict == 'pass'
+        env:
+          ENGINE: ${{ inputs.engine }}
+          SAFE_VER: ${{ steps.version.outputs.safe_version }}
+        run: |
+          # Derivative dual-write — see invariants cell for rationale.
+          ARCHIVE_DIR="src/llenergymeasure/_engine_archive/${ENGINE}/${SAFE_VER}/outputs"
+          mkdir -p "${ARCHIVE_DIR}"
+          cp "${ENGINES_DIR}/${ENGINE}/schema.discovered.json" "${ARCHIVE_DIR}/schema.discovered.json"
+
       - name: Probe-fail comment (skip downstream)
         if: steps.probe.outputs.verdict == 'fail' && inputs.pr-number != ''
         env:
@@ -413,6 +428,7 @@ jobs:
           name: schemas-writeback-${{ inputs.engine }}
           path: |
             ${{ env.ENGINES_DIR }}/${{ inputs.engine }}/schema.discovered.json
+            src/llenergymeasure/_engine_archive/${{ inputs.engine }}/${{ steps.version.outputs.safe_version }}/outputs/schema.discovered.json
             engine_versions/${{ inputs.engine }}.yaml
             docs/user/generated/curation-${{ inputs.engine }}.md
             docs/user/generated/schema-${{ inputs.engine }}.md

--- a/.github/workflows/_engine-schemas-cell.yml
+++ b/.github/workflows/_engine-schemas-cell.yml
@@ -183,7 +183,12 @@ jobs:
             ENGINE_PATHS=( "docker/Dockerfile.transformers" )
           fi
           PATHS=("${BASE_PATHS[@]}" "${ENGINE_PATHS[@]}")
-          DATE=$(git log -1 --format=%aI -- "${PATHS[@]}")
+          # Exclude bot writeback commits from anchor calculation. See
+          # _engine-invariants-cell.yml for the full rationale; same loop-
+          # breaking pattern applies here.
+          DATE=$(git log -1 --format=%aI \
+            --invert-grep --grep='^chore(bot): writeback' \
+            -- "${PATHS[@]}")
           if [[ -z "${DATE}" ]]; then
             echo "::error::No git history found for any anchor input path; refusing to use wallclock fallback (would break determinism)." >&2
             exit 1

--- a/.github/workflows/_engine-schemas-cell.yml
+++ b/.github/workflows/_engine-schemas-cell.yml
@@ -81,9 +81,11 @@ jobs:
           # Python-identifier-safe form (dots and hyphens -> underscores) used as the
           # subpackage name under src/llenergymeasure/_engine_archive/<engine>/.
           SAFE_VER="v${VER//[.-]/_}"
-          echo "version=${VER}" >> "$GITHUB_OUTPUT"
-          echo "safe_version=${SAFE_VER}" >> "$GITHUB_OUTPUT"
-          echo "image=llenergymeasure:${ENGINE}-${VER}" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=${VER}"
+            echo "safe_version=${SAFE_VER}"
+            echo "image=llenergymeasure:${ENGINE}-${VER}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR (read-only, for image pull)
         if: inputs.image-source == 'ghcr-cache'

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -1,8 +1,9 @@
 # Docker Setup Guide
 
-`llenergymeasure` uses Docker to run vLLM and TensorRT-LLM (and future SGLang) engines in
-isolated containers with GPU access. This guide walks through setting up Docker with GPU support
-from scratch on a Linux host.
+
+`llenergymeasure` uses Docker to run experiments in containers with GPU access. This provides isolation and reproducibility, and lets `llenergymeasure` run engines whose dependency requirements are mutually incompatible (for example, vLLM and TensorRT-LLM pin different CUDA and `transformers` versions and cannot coexist in a single Python environment).
+
+This guide walks through setting up Docker with GPU support from scratch on a Linux host.
 
 > **Docker is the supported path.** All published measurements run in containers - that is
 > what gives you reproducibility, dependency isolation between engines, and access to vLLM

--- a/engine_versions/transformers.yaml
+++ b/engine_versions/transformers.yaml
@@ -28,5 +28,5 @@ artefact_paths:
 last_probe:
   verdict: pass
   version_inside_envelope: false
-  fingerprint: "46664ddbff9a9c9df2974d9d5cbdbbe04ae093b874f50ee92a0cd1b0c4b83860"
+  fingerprint: "14dc1896757dfc00a9a4e1990528ecac45394bb5f2850bfab17e87871aaa29da"
   fingerprint_drift: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ layers = [
     "llenergymeasure.infra",
     "llenergymeasure.device",
     "llenergymeasure.config | llenergymeasure.domain",
-    "llenergymeasure.utils",
+    "llenergymeasure.utils | llenergymeasure._engine_archive",
 ]
 ignore_imports = [
     # Phase 50 M4: config.loader.load_study_config invokes resolve_library_effective
@@ -208,3 +208,25 @@ ignore_imports = [
     # Phase 50 M4: see matching ignore on main-layers contract above.
     "llenergymeasure.config.loader -> llenergymeasure.study.library_resolution",
 ]
+
+[[tool.importlinter.contracts]]
+id = "engine-archive-tooling-only"
+name = "_engine_archive is for CI-time tooling; runtime layers must not import it"
+type = "forbidden"
+source_modules = [
+    "llenergymeasure.cli",
+    "llenergymeasure.entrypoints",
+    "llenergymeasure.api",
+    "llenergymeasure.study",
+    "llenergymeasure.harness",
+    "llenergymeasure.results",
+    "llenergymeasure.engines",
+    "llenergymeasure.energy",
+    "llenergymeasure.datasets",
+    "llenergymeasure.infra",
+    "llenergymeasure.device",
+    "llenergymeasure.config",
+    "llenergymeasure.domain",
+    "llenergymeasure.utils",
+]
+forbidden_modules = ["llenergymeasure._engine_archive"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,15 @@ packages = ["src/llenergymeasure"]
 # Z-engines runtime data (src/llenergymeasure/engines/<engine>/{invariants.*.yaml,
 # schema.discovered.json}) ships automatically in the wheel - no force-include
 # needed (and adding one creates duplicates).
+#
+# Exclude the per-version machinery archive: it's CI-time tooling for
+# probe/mine reproducibility, not runtime. The import-linter contract
+# already forbids runtime layers from importing it; this exclude keeps
+# the same boundary at wheel-build time so end users don't pay for ~MB of
+# historical mining data they cannot use.
+exclude = [
+    "src/llenergymeasure/_engine_archive/**",
+]
 
 [tool.ruff]
 line-length = 100

--- a/scripts/_probe.py
+++ b/scripts/_probe.py
@@ -214,8 +214,24 @@ def _compat_path(engine: str) -> Path:
     return ssot_path(engine).parent / f"{engine}.compat.json"
 
 
-def _read_cached_fingerprint(engine: str, producer: ProducerKind) -> str | None:
-    """Return the previous-run fingerprint for this (engine, producer), or ``None``."""
+def _read_cached_fingerprint(
+    engine: str, producer: ProducerKind, library_version: str
+) -> str | None:
+    """Return the previous-run fingerprint for this (engine, producer), or ``None``.
+
+    Returns ``None`` when:
+
+    - The cache file does not exist or is malformed.
+    - The cached entry is missing a ``library_version`` field.
+    - The cached entry's ``library_version`` differs from the *current*
+      library version. This is the cross-version skip: bumping
+      ``library.current_version`` invalidates the prior fingerprint by
+      definition (it was computed against a different installed library),
+      so reporting "every landmark drifted" would be noise. Returning
+      ``None`` here causes ``probe()`` to treat this as a first-run
+      fingerprint and emit empty ``fingerprint_drift``; the next run at
+      the bumped version writes a fresh cache entry.
+    """
     path = _compat_path(engine)
     try:
         text = path.read_text()
@@ -226,7 +242,13 @@ def _read_cached_fingerprint(engine: str, producer: ProducerKind) -> str | None:
     except json.JSONDecodeError:
         return None
     entry = (cache.get(producer) if isinstance(cache, dict) else None) or {}
-    fp = entry.get("fingerprint") if isinstance(entry, dict) else None
+    if not isinstance(entry, dict):
+        return None
+    cached_library_version = entry.get("library_version")
+    if cached_library_version != library_version:
+        # Cache was written against a different library version; treat as miss.
+        return None
+    fp = entry.get("fingerprint")
     return str(fp) if isinstance(fp, str) else None
 
 
@@ -312,7 +334,7 @@ def probe(*, engine: str, producer: ProducerKind) -> ProbeReport:
             missing.append(landmark)
 
     fingerprint = _fingerprint(resolved)
-    cached = _read_cached_fingerprint(engine, producer)
+    cached = _read_cached_fingerprint(engine, producer, library_version)
     drift: list[str] = []
     if cached is not None and cached != fingerprint:
         # Per-landmark drift would require caching per-landmark hashes;

--- a/scripts/clean_pycache.sh
+++ b/scripts/clean_pycache.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Remove all __pycache__ directories under the repo tree.
+#
+# Pre-existing root-owned __pycache__ entries (written by Docker-run probes)
+# can hold stale .pyc files referencing module shapes that have moved during
+# a session's edits. The pipeline's determinism check after a run treats any
+# diff in tracked files as a fingerprint shift; stale .pyc-loaded code can
+# spoof "diff present" even after a clean re-run.
+#
+# Run before any determinism-sensitive command:
+#   ./scripts/clean_pycache.sh
+#
+# Idempotent and safe to run multiple times.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Descend into all places Python may have compiled bytecode: src/, tests/,
+# scripts/, engine_versions/. -prune on .git and node_modules to skip them.
+find . \
+    \( -path ./.git -o -path ./node_modules -o -path ./.venv -o -path ./venv \) -prune \
+    -o -type d -name __pycache__ -print0 \
+    | xargs -0 -r rm -rf 2>/dev/null || true
+
+echo "Cleaned __pycache__ trees under $REPO_ROOT" >&2

--- a/scripts/engine_introspectors/tensorrt_introspector.py
+++ b/scripts/engine_introspectors/tensorrt_introspector.py
@@ -23,16 +23,47 @@ from scripts.engine_introspectors._common import (
     dataclass_fields_to_specs,
     make_envelope,
 )
+from scripts.engine_miners._ssot import load_ssot
 
 # Symbols this introspector relies on inside the live ``tensorrt_llm``
 # package. Read by ``scripts._probe`` before discovery runs; a missing
 # landmark flips the probe verdict to ``fail`` and skips downstream
 # discovery.
-LANDMARKS: tuple[str, ...] = (
-    "tensorrt_llm.SamplingParams",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.tensorrt.<safe_version>.machinery.discovery``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("tensorrt")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/tensorrt.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="tensorrt",
+        version=str(library["current_version"]),
+        producer="discovery",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:

--- a/scripts/engine_introspectors/transformers_introspector.py
+++ b/scripts/engine_introspectors/transformers_introspector.py
@@ -19,19 +19,47 @@ from scripts.engine_introspectors._common import (
     make_envelope,
     read_dockerfile_from,
 )
+from scripts.engine_miners._ssot import load_ssot
 
 # Symbols this introspector relies on inside the live ``transformers``
 # package. Read by ``scripts._probe`` before discovery runs; a missing
 # landmark flips the probe verdict to ``fail`` and skips downstream
 # discovery. Mirrors the imports inside :func:`discover`.
-LANDMARKS: tuple[str, ...] = (
-    "transformers.AutoModelForCausalLM",
-    "transformers.AutoModelForCausalLM.from_pretrained",
-    "transformers.PreTrainedModel",
-    "transformers.PreTrainedModel.from_pretrained",
-    "transformers.GenerationConfig",
-    "transformers.GenerationConfig.to_dict",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.transformers.<safe_version>.machinery.discovery``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("transformers")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/transformers.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="transformers",
+        version=str(library["current_version"]),
+        producer="discovery",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:

--- a/scripts/engine_introspectors/vllm_introspector.py
+++ b/scripts/engine_introspectors/vllm_introspector.py
@@ -13,14 +13,46 @@ from scripts.engine_introspectors._common import (
     dataclass_fields_to_specs,
     make_envelope,
 )
+from scripts.engine_miners._ssot import load_ssot
 
 # Symbols this introspector relies on inside the live ``vllm`` package.
 # Read by ``scripts._probe`` before discovery runs; a missing landmark
 # flips the probe verdict to ``fail`` and skips downstream discovery.
-LANDMARKS: tuple[str, ...] = (
-    "vllm.SamplingParams",
-    "vllm.engine.arg_utils.EngineArgs",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.vllm.<safe_version>.machinery.discovery``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("vllm")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/vllm.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="vllm",
+        version=str(library["current_version"]),
+        producer="discovery",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:

--- a/scripts/engine_miners/_ssot.py
+++ b/scripts/engine_miners/_ssot.py
@@ -61,3 +61,40 @@ def load_miner_pin(engine: str, producer: Producer) -> SpecifierSet:
     if producer not in pins:
         raise KeyError(f"miner_pins.{producer} missing from {path}; present keys: {sorted(pins)}.")
     return SpecifierSet(str(pins[producer]))
+
+
+@cache
+def load_ssot(engine: str) -> dict[str, object]:
+    """Read + parse ``engine_versions/{engine}.yaml`` into a dict.
+
+    Cached (lru) so repeated calls within one process re-parse at most once
+    per engine. Used by producer modules to discover ``library.current_version``
+    when dispatching to per-version machinery in
+    ``llenergymeasure._engine_archive``.
+
+    Raises :class:`FileNotFoundError` if the SSOT is missing,
+    :class:`ValueError` if it does not parse to a mapping.
+    """
+    path = ssot_path(engine)
+    text = path.read_text()
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"SSOT at {path} did not parse to a mapping.")
+    return data
+
+
+def safe_version(version: str) -> str:
+    """Map a dotted PEP-440 version string to a Python-identifier-safe form.
+
+    ``"0.7.3"`` -> ``"v0_7_3"``. Used to derive subpackage names under
+    ``llenergymeasure._engine_archive.<engine>.<safe_version>.machinery.*``.
+    Raises :class:`ValueError` if the resulting identifier would be illegal
+    (e.g. version contains characters other than ``[0-9a-zA-Z._-]``).
+    """
+    safe = "v" + version.replace(".", "_").replace("-", "_")
+    if not safe.replace("_", "").isalnum():
+        raise ValueError(
+            f"Cannot derive a Python identifier from version {version!r}; "
+            f"resulting candidate {safe!r} contains non-alphanumeric chars."
+        )
+    return safe

--- a/scripts/engine_miners/tensorrt_static_miner.py
+++ b/scripts/engine_miners/tensorrt_static_miner.py
@@ -74,7 +74,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     find_method,
     first_string_arg,
 )
-from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin, load_ssot  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -107,27 +107,42 @@ BUILDER_REL = Path("builder.py")
 # stages. The miner itself walks /tmp source AST rather than the live
 # package (see ``_load_source``), but probe uses live-package landmarks
 # because that is the seam Renovate's library bumps shift first.
-LANDMARKS: tuple[str, ...] = (
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_dtype",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model_format_misc",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.set_runtime_knobs_from_build_config",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_with_runtime_params",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_remaining",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_speculative_config",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_lora_config_consistency",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.validate_enable_build_cache",
-    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig",
-    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig.validate_positive_values",
-    "tensorrt_llm.llmapi.llm_args.CalibConfig",
-    "tensorrt_llm.llmapi.llm_args.BatchingType",
-    "tensorrt_llm.llmapi.llm_args.CapacitySchedulerPolicy",
-    "tensorrt_llm.llmapi.llm_args.ContextChunkingPolicy",
-    "tensorrt_llm.builder.Builder",
-    "tensorrt_llm.builder.Builder.build_engine",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.tensorrt.<safe_version>.machinery.static``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("tensorrt")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/tensorrt.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="tensorrt",
+        version=str(library["current_version"]),
+        producer="static",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Class-level landmarks. Each entry is ``(class_name, file_relative_path)``.
 _CLASS_LANDMARKS: tuple[tuple[str, Path], ...] = (

--- a/scripts/engine_miners/transformers_miner.py
+++ b/scripts/engine_miners/transformers_miner.py
@@ -63,7 +63,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     MinerSource,
     check_installed_version,
 )
-from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin, load_ssot  # noqa: E402
 from scripts.engine_miners.transformers_dynamic_miner import (  # noqa: E402
     walk_generation_config_invariants,
 )
@@ -72,12 +72,48 @@ from scripts.engine_miners.transformers_dynamic_miner import (  # noqa: E402
 # inside the live ``transformers`` package. Read by ``scripts._probe``
 # before mining runs; a missing landmark flips the probe verdict to
 # ``fail`` and skips the downstream stages without re-importing here.
-LANDMARKS: tuple[str, ...] = (
-    "transformers.GenerationConfig",
-    "transformers.GenerationConfig.validate",
-    "transformers.BitsAndBytesConfig",
-    "transformers.BitsAndBytesConfig.post_init",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.transformers.<safe_version>.machinery.static``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until the
+# probe (or in-module code) accesses ``LANDMARKS``; module import stays
+# cheap so unrelated test collection does not drag in the engine machinery.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``.
+
+    Caches in module ``globals()`` after first call so subsequent in-module
+    references (and the probe's ``getattr(module, "LANDMARKS")``) read
+    directly from the module dict without re-dispatching.
+    """
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("transformers")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/transformers.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="transformers",
+        version=str(library["current_version"]),
+        producer="static",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # ---------------------------------------------------------------------------
 # BitsAndBytesConfig type-check invariants (kept hand-curated - CPU-safe)
@@ -117,36 +153,26 @@ _BNB_TYPE_RULES: tuple[tuple[str, str, Any, Any], ...] = (
 
 
 def _check_landmarks() -> tuple[str, str]:
-    """Import transformers, verify the landmarks the miner relies on.
+    """Verify the archived LANDMARKS resolve under the live ``transformers`` package.
 
     Returns ``(installed_version, generation_config_source_path)``.
+
+    Iterates :data:`LANDMARKS` (lazy-loaded from
+    ``llenergymeasure._engine_archive``) and resolves each via the same
+    ``_resolve_landmark`` helper the probe uses, so the miner's runtime
+    landmark check cannot drift from the probe's static check. A missing
+    landmark raises :class:`MinerLandmarkMissingError`.
     """
-    try:
-        import transformers  # type: ignore
-    except ImportError as exc:
-        raise MinerLandmarkMissingError(
-            "transformers.__init__", detail="transformers not importable"
-        ) from exc
+    from scripts._probe import _resolve_landmark
 
-    try:
-        from transformers import GenerationConfig  # type: ignore
-    except ImportError as exc:
-        raise MinerLandmarkMissingError(
-            "transformers.GenerationConfig", detail="symbol not importable"
-        ) from exc
+    for landmark in _get_landmarks():
+        try:
+            _resolve_landmark(landmark)
+        except (AttributeError, ImportError) as exc:
+            raise MinerLandmarkMissingError(landmark, detail=str(exc)) from exc
 
-    if not hasattr(GenerationConfig, "validate"):
-        raise MinerLandmarkMissingError("GenerationConfig.validate")
-
-    try:
-        from transformers import BitsAndBytesConfig  # type: ignore
-    except ImportError as exc:
-        raise MinerLandmarkMissingError(
-            "transformers.BitsAndBytesConfig", detail="symbol not importable"
-        ) from exc
-
-    if not hasattr(BitsAndBytesConfig, "post_init"):
-        raise MinerLandmarkMissingError("BitsAndBytesConfig.post_init")
+    import transformers  # type: ignore
+    from transformers import GenerationConfig  # type: ignore
 
     source_path = inspect.getsourcefile(GenerationConfig) or "<unknown>"
     return transformers.__version__, source_path

--- a/scripts/engine_miners/vllm_static_miner.py
+++ b/scripts/engine_miners/vllm_static_miner.py
@@ -66,7 +66,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     find_method,
     first_string_arg,
 )
-from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin, load_ssot  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Engine + namespace conventions
@@ -88,37 +88,52 @@ NS_ENGINE = "vllm.engine"
 
 # Symbols this miner relies on resolving inside the live ``vllm`` package.
 # Read by ``scripts._probe`` before mining runs; a missing landmark flips
-# the probe verdict to ``fail`` and skips downstream stages. Mirrors the
-# ``_AST_TARGETS`` rows below at the dotted-path level so the probe can
-# detect upstream class / method renames without re-parsing the AST.
-LANDMARKS: tuple[str, ...] = (
-    "vllm.sampling_params.SamplingParams",
-    "vllm.sampling_params.SamplingParams._verify_args",
-    "vllm.sampling_params.SamplingParams.__post_init__",
-    "vllm.sampling_params.SamplingParams._verify_greedy_sampling",
-    "vllm.sampling_params.StructuredOutputsParams",
-    "vllm.sampling_params.StructuredOutputsParams.__post_init__",
-    "vllm.config.parallel.ParallelConfig",
-    "vllm.config.parallel.ParallelConfig._validate_parallel_config",
-    "vllm.config.parallel.ParallelConfig._verify_args",
-    "vllm.config.parallel.ParallelConfig.__post_init__",
-    "vllm.config.parallel.EPLBConfig",
-    "vllm.config.parallel.EPLBConfig._validate_eplb_config",
-    "vllm.config.lora.LoRAConfig",
-    "vllm.config.lora.LoRAConfig._validate_lora_config",
-    "vllm.config.multimodal.MultiModalConfig",
-    "vllm.config.multimodal.MultiModalConfig._validate_multimodal_config",
-    "vllm.config.structured_outputs.StructuredOutputsConfig",
-    "vllm.config.structured_outputs.StructuredOutputsConfig._validate_structured_output_config",
-    "vllm.config.cache.CacheConfig",
-    "vllm.config.cache.CacheConfig._validate_cache_dtype",
-    "vllm.config.model.ModelConfig",
-    "vllm.config.model.ModelConfig.__post_init__",
-    "vllm.config.compilation.CompilationConfig",
-    "vllm.config.compilation.CompilationConfig.__post_init__",
-    "vllm.config.scheduler.SchedulerConfig",
-    "vllm.config.scheduler.SchedulerConfig.__post_init__",
-)
+# the probe verdict to ``fail`` and skips downstream stages.
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.vllm.<safe_version>.machinery.static``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until the
+# probe (or in-module code) accesses ``LANDMARKS``.
+#
+# NOTE: ``_AST_TARGETS`` below remains hardcoded in this module for now.
+# Vendoring it into the per-version archive is deferred to chunk-1 (the
+# vllm 0.7.3 -> 0.16.0 PR), where the AST_TARGETS rewrite is the heart of
+# the work anyway. Until then, ``_check_landmarks()`` continues to do
+# AST-level verification against this in-module ``_AST_TARGETS`` registry.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``.
+
+    Caches in module ``globals()`` after first call so subsequent in-module
+    references read directly from the module dict without re-dispatching.
+    """
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("vllm")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/vllm.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="vllm",
+        version=str(library["current_version"]),
+        producer="static",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/update_last_probe.py
+++ b/scripts/update_last_probe.py
@@ -58,7 +58,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from scripts.engine_miners._ssot import ssot_path  # noqa: E402
+from scripts.engine_miners._ssot import safe_version, ssot_path  # noqa: E402
 
 # Match `  verdict: pass`, `  verdict: "pass"`, `  fingerprint_drift: []`,
 # `  version_inside_envelope: null`, etc. Captures indent + key + the rest
@@ -192,14 +192,58 @@ def _emit_outputs(*, changed: bool, verdict: str) -> None:
         fh.write(f"verdict={verdict}\n")
 
 
+def _write_archive_last_probe(*, engine: str, version: str, report: dict[str, Any]) -> bool:
+    """Mirror the last_probe block to the per-version archive.
+
+    Per the engine-coupling vendoring scaffold (PR-0), each version's
+    archive at ``src/llenergymeasure/_engine_archive/<engine>/<safe>/outputs/``
+    holds a frozen ``last_probe.yaml`` capturing the verdict + diagnostics
+    of the last successful pipeline run at that version. The file is a
+    *derivative* of the SSOT's ``last_probe:`` block; it is NOT the source
+    of truth. The SSOT remains authoritative for downstream consumers.
+
+    Idempotent: returns ``True`` when the file was created or rewritten
+    with new content, ``False`` if the existing file already matches
+    (determinism short-circuit). Mkdirs the archive directory if missing.
+    """
+    safe = safe_version(version)
+    archive_dir = (
+        _PROJECT_ROOT / "src" / "llenergymeasure" / "_engine_archive" / engine / safe / "outputs"
+    )
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = archive_dir / "last_probe.yaml"
+
+    # Build payload: same fields, same scalar formatting as the SSOT block.
+    rendered_lines = [f"{field}: {_format_scalar(report[field])}\n" for field in _MUTABLE_FIELDS]
+    payload = "".join(rendered_lines)
+
+    if archive_path.exists() and archive_path.read_text() == payload:
+        return False
+    archive_path.write_text(payload)
+    return True
+
+
 def update(*, engine: str, report: dict[str, Any]) -> int:
     """Apply *report*'s last_probe-relevant fields to the engine SSOT.
 
     Returns 0 on success (whether or not a change was written), 2 on
     infrastructure failure (SSOT missing / malformed, ProbeReport
     missing required fields).
+
+    Also mirrors the last_probe block as a standalone YAML to the
+    versioned archive at
+    ``src/llenergymeasure/_engine_archive/<engine>/<safe>/outputs/last_probe.yaml``.
+    The archive write happens after the SSOT update succeeds; on archive-
+    write failure the SSOT update is preserved (no rollback). Both paths
+    are idempotent so subsequent runs converge.
     """
-    required = {"verdict", "version_inside_envelope", "fingerprint", "fingerprint_drift"}
+    required = {
+        "verdict",
+        "version_inside_envelope",
+        "fingerprint",
+        "fingerprint_drift",
+        "library_version",
+    }
     missing = required - report.keys()
     if missing:
         print(
@@ -233,6 +277,25 @@ def update(*, engine: str, report: dict[str, Any]) -> int:
         print(f"Updated {path} last_probe block (verdict={verdict}).")
     else:
         print(f"No change to {path} last_probe block (verdict={verdict}).")
+
+    # Mirror to the versioned archive. Failure here is non-fatal; the
+    # SSOT is authoritative and the archive will be regenerated on the
+    # next run. We still surface the failure to stderr so it's visible
+    # in CI logs.
+    library_version = str(report["library_version"])
+    try:
+        archive_changed = _write_archive_last_probe(
+            engine=engine, version=library_version, report=report
+        )
+    except (OSError, ValueError) as exc:
+        print(
+            f"Warning: could not mirror last_probe to archive for {engine} "
+            f"v{library_version}: {exc!r}. SSOT update preserved.",
+            file=sys.stderr,
+        )
+    else:
+        if archive_changed:
+            print(f"Mirrored last_probe to archive at {engine}/v{library_version}.")
 
     _emit_outputs(changed=changed, verdict=verdict)
     return 0

--- a/src/llenergymeasure/_engine_archive/__init__.py
+++ b/src/llenergymeasure/_engine_archive/__init__.py
@@ -1,0 +1,14 @@
+"""Per-engine, per-version archive of probe / mine / introspect machinery.
+
+Importable, ships in the wheel. Holds frozen LANDMARKS tuples (and, in
+later PRs, frozen AST_TARGETS / walker patterns / introspector targets)
+keyed by ``(engine, version)``. Producer modules in
+``scripts/engine_miners/`` and ``scripts/engine_introspectors/`` resolve
+their version-specific data via :func:`._dispatcher.load_machinery`.
+
+Layer rules: this package exists for CI-time tooling reproducibility.
+Runtime engine plugins (under ``llenergymeasure.engines``) MUST NOT
+import from here; they read their canonical invariants/schemas from
+``src/llenergymeasure/engines/<engine>/`` as today. Enforced by an
+import-linter ``forbidden`` contract in ``pyproject.toml``.
+"""

--- a/src/llenergymeasure/_engine_archive/_dispatcher.py
+++ b/src/llenergymeasure/_engine_archive/_dispatcher.py
@@ -47,7 +47,10 @@ def load_machinery(*, engine: str, version: str, producer: ProducerKind) -> Modu
         etc.) from it.
 
     Raises:
-        ModuleNotFoundError: if the versioned subpackage does not exist.
+        ModuleNotFoundError: if the versioned subpackage does not exist. The
+            error message names the exact file path to create — this is the
+            primary signal a maintainer sees when a Renovate-driven SSOT bump
+            outpaces the per-version vendoring (the chunk PR hasn't landed yet).
     """
     # Late import: ``_ssot`` imports yaml/packaging which we'd rather not
     # pay at every ``__getattr__`` call site. Importing here keeps module-
@@ -56,4 +59,18 @@ def load_machinery(*, engine: str, version: str, producer: ProducerKind) -> Modu
 
     safe = safe_version(version)
     qualified = f"llenergymeasure._engine_archive.{engine}.{safe}.machinery.{producer}"
-    return importlib.import_module(qualified)
+    try:
+        return importlib.import_module(qualified)
+    except ModuleNotFoundError as exc:
+        # The import may fail because the engine subpackage, the version
+        # subpackage, or the producer module is missing. All three cases
+        # share the same remediation: vendor this version's machinery.
+        raise ModuleNotFoundError(
+            f"No archived machinery for {engine}=={version} ({producer}). "
+            f"Expected to import `{qualified}`. Create "
+            f"src/llenergymeasure/_engine_archive/{engine}/{safe}/machinery/{producer}.py "
+            f"(with sibling __init__.py files as needed) by copying the prior "
+            f"version's machinery and rewriting LANDMARKS for the new library "
+            f"API. See the version-bump chunk pattern in the engine archive "
+            f"package docstring."
+        ) from exc

--- a/src/llenergymeasure/_engine_archive/_dispatcher.py
+++ b/src/llenergymeasure/_engine_archive/_dispatcher.py
@@ -1,0 +1,59 @@
+"""Version-aware loader for per-engine machinery.
+
+Resolves the importable subpackage
+``llenergymeasure._engine_archive.<engine>.<safe_version>.machinery.<producer>``
+and returns it. Producer modules in ``scripts/engine_miners/`` and
+``scripts/engine_introspectors/`` use this dispatcher (via PEP 562
+``__getattr__`` on the module level) to delegate ``LANDMARKS`` exports
+to the version-pinned archive.
+
+Producer kinds match the SSOT's ``miner_pins`` keys:
+
+- ``static``: validation-invariant miners (probe contract: ``invariants``)
+- ``discovery``: schema introspectors (probe contract: ``schemas``)
+- ``dynamic``: combinatorial miners (no probe contract today; reserved)
+
+The version string is the dotted form from
+``engine_versions/<engine>.yaml`` ``library.current_version`` (e.g.
+``"0.7.3"``); the dispatcher converts it to a Python-identifier-safe form
+(``v0_7_3``) via :func:`scripts.engine_miners._ssot.safe_version`.
+
+No fallback. If the requested subpackage does not exist, the import
+raises ``ModuleNotFoundError`` and the caller (or the probe) surfaces it
+loud. The "no fallback" rule is load-bearing — it makes "missing
+versioned machinery" a visible CI failure, not silent stale-data drift.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Literal
+
+ProducerKind = Literal["static", "dynamic", "discovery"]
+
+
+def load_machinery(*, engine: str, version: str, producer: ProducerKind) -> ModuleType:
+    """Return the ``machinery.<producer>`` submodule for ``(engine, version)``.
+
+    Args:
+        engine: Engine name (``"vllm"`` | ``"tensorrt"`` | ``"transformers"``).
+        version: Dotted PEP-440 version string (e.g. ``"0.7.3"``).
+        producer: One of ``"static"``, ``"dynamic"``, ``"discovery"``.
+
+    Returns:
+        The imported ``llenergymeasure._engine_archive.<engine>.<safe>.machinery.<producer>``
+        module. The caller reads ``LANDMARKS`` (and optionally ``AST_TARGETS``
+        etc.) from it.
+
+    Raises:
+        ModuleNotFoundError: if the versioned subpackage does not exist.
+    """
+    # Late import: ``_ssot`` imports yaml/packaging which we'd rather not
+    # pay at every ``__getattr__`` call site. Importing here keeps module-
+    # load cheap.
+    from scripts.engine_miners._ssot import safe_version
+
+    safe = safe_version(version)
+    qualified = f"llenergymeasure._engine_archive.{engine}.{safe}.machinery.{producer}"
+    return importlib.import_module(qualified)

--- a/src/llenergymeasure/_engine_archive/_machinery_proto.py
+++ b/src/llenergymeasure/_engine_archive/_machinery_proto.py
@@ -1,0 +1,53 @@
+"""Protocol for per-version machinery modules.
+
+Each ``llenergymeasure._engine_archive.<engine>.<safe_version>.machinery.<producer>``
+module is expected to expose the attributes declared here. Optional
+attributes are typed ``Any`` because per-engine shapes diverge:
+
+- vllm static AST_TARGETS use the importable-attribute ``_ASTTarget`` dataclass.
+- tensorrt static targets reference filesystem paths under ``/tmp/trt-llm-<V>/``.
+- transformers AST work is split between an introspection-driven dynamic
+  miner and a BNB-focused static miner, so its ``AST_TARGETS`` shape is
+  not directly comparable.
+
+The probe (``scripts/_probe.py``) only reads ``LANDMARKS`` from the
+producer module via ``getattr``; the other attributes are consumed by
+the per-engine miners themselves. PR-0 vendors LANDMARKS only;
+AST_TARGETS / WALKER_PATTERNS / INTROSPECTOR_TARGETS are deferred to a
+follow-up scaffold PR (or absorbed into the first chunk PR per engine).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Machinery(Protocol):
+    """Per-(engine, version, producer) machinery namespace.
+
+    PR-0 contract: the module MUST expose a ``LANDMARKS`` attribute that
+    is a ``tuple[str, ...]`` of dotted attribute paths the probe will
+    resolve under the installed library.
+
+    Optional attributes (advisory; declared in the Protocol as required
+    would make ``isinstance(m, Machinery)`` fail when a producer module
+    does not need them, so they are documented here instead of typed):
+
+    - ``AST_TARGETS``: engine-specific static-miner walk targets. vllm uses
+      a ``_ASTTarget`` dataclass tuple; tensorrt uses filesystem-rooted
+      ``(class_name, file_relative_path)`` tuples; transformers' AST work
+      currently lives outside the per-version archive (split between a
+      BNB-focused static miner and a combinatorial dynamic miner).
+    - ``WALKER_PATTERNS``: per-version pattern matchers / detector tables.
+    - ``INTROSPECTOR_TARGETS``: class / dataclass targets the introspector
+      walks at runtime.
+
+    Producers that don't need AST_TARGETS / WALKER_PATTERNS /
+    INTROSPECTOR_TARGETS simply omit them. Callers that depend on a
+    specific attribute MUST guard with ``hasattr`` or accept
+    ``AttributeError``. The probe accesses ``LANDMARKS`` only.
+    """
+
+    LANDMARKS: tuple[str, ...]
+    """Dotted attribute paths the probe checks for resolution at probe time."""

--- a/src/llenergymeasure/_engine_archive/tensorrt/__init__.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/__init__.py
@@ -1,0 +1,7 @@
+"""TensorRT-LLM per-version machinery archive.
+
+Subpackages here are version-pinned snapshots. The static miner walks an
+extracted source tarball at ``/tmp/trt-llm-<V>/``; the schemas
+introspector imports the live ``tensorrt_llm`` package inside the NGC
+image. LANDMARKS are co-located here per version.
+"""

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/__init__.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/__init__.py
@@ -1,0 +1,9 @@
+"""Frozen TensorRT-LLM 0.21.0 machinery + outputs.
+
+Initial vendored snapshot. The 0.21.0 pin reflects the CUDA 12.6.x
+compatibility envelope (1.x requires CUDA 13.x, separate infrastructure
+milestone). LANDMARKS for the static miner reference symbols in the
+extracted source tree at ``/tmp/trt-llm-0.21.0/``; LANDMARKS for the
+discovery introspector reference the live ``tensorrt_llm`` package
+inside ``nvcr.io/nvidia/tensorrt-llm/release:0.21.0``.
+"""

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/__init__.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``static`` (invariants), ``discovery`` (schemas)."""

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/discovery.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/discovery.py
@@ -1,0 +1,14 @@
+"""Schema-introspector LANDMARKS for TensorRT-LLM 0.21.0.
+
+The introspector runs inside ``nvcr.io/nvidia/tensorrt-llm/release:0.21.0``
+and lifts engine parameter specs from ``TrtLlmArgs`` (Pydantic v2) and
+sampling parameter specs from ``SamplingParams`` (dataclass).
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "tensorrt_llm.SamplingParams",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
+)

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/static.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/static.py
@@ -1,0 +1,33 @@
+"""Static-miner LANDMARKS for TensorRT-LLM 0.21.0.
+
+The static miner walks an extracted source tree under
+``/tmp/trt-llm-0.21.0/`` rather than the installed library; LANDMARKS
+nevertheless reference the live ``tensorrt_llm`` package because that
+is the seam Renovate's library bumps shift first. A missing landmark
+under the installed library trips the probe; a divergent source tree
+trips ``MinerLandmarkMissingError`` inside the miner.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_dtype",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model_format_misc",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.set_runtime_knobs_from_build_config",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_with_runtime_params",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_remaining",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_speculative_config",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_lora_config_consistency",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.validate_enable_build_cache",
+    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig",
+    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig.validate_positive_values",
+    "tensorrt_llm.llmapi.llm_args.CalibConfig",
+    "tensorrt_llm.llmapi.llm_args.BatchingType",
+    "tensorrt_llm.llmapi.llm_args.CapacitySchedulerPolicy",
+    "tensorrt_llm.llmapi.llm_args.ContextChunkingPolicy",
+    "tensorrt_llm.builder.Builder",
+    "tensorrt_llm.builder.Builder.build_engine",
+)

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.proposed.yaml
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.proposed.yaml
@@ -1,0 +1,93 @@
+schema_version: 1.0.0
+engine: tensorrt
+engine_version: 0.21.0
+miner_pinned_range: <0.22.0,>=0.21.0
+mined_at: '2026-05-06T20:35:47+02:00'
+invariants:
+- id: tensorrt_raises_max_ngram_size_le_0_positive_values
+  engine: tensorrt
+  library: tensorrt_llm
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <= 0 (via
+    raise ValueError)
+  severity: error
+  native_type: tensorrt_llm.LookaheadDecodingConfig
+  miner_source:
+    path: llmapi/llm_args.py
+    method: validate_positive_values
+    line_at_scan: 577
+  match:
+    engine: tensorrt
+    fields:
+      tensorrt.max_ngram_size:
+        <=: 0
+  kwargs_positive:
+    max_ngram_size: 0
+  kwargs_negative:
+    max_ngram_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Value must be positive, got {v}
+  references:
+  - llmapi/llm_args.py:577 (tensorrt_llm.LookaheadDecodingConfig.validate_positive_values)
+  added_by: static_miner
+  added_at: '2026-05-06'
+- id: tensorrt_raises_max_verification_set_size_le_0_positive_values
+  engine: tensorrt
+  library: tensorrt_llm
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_verification_set_size
+    <= 0 (via raise ValueError)
+  severity: error
+  native_type: tensorrt_llm.LookaheadDecodingConfig
+  miner_source:
+    path: llmapi/llm_args.py
+    method: validate_positive_values
+    line_at_scan: 577
+  match:
+    engine: tensorrt
+    fields:
+      tensorrt.max_verification_set_size:
+        <=: 0
+  kwargs_positive:
+    max_verification_set_size: 0
+  kwargs_negative:
+    max_verification_set_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Value must be positive, got {v}
+  references:
+  - llmapi/llm_args.py:577 (tensorrt_llm.LookaheadDecodingConfig.validate_positive_values)
+  added_by: static_miner
+  added_at: '2026-05-06'
+- id: tensorrt_raises_max_window_size_le_0_positive_values
+  engine: tensorrt
+  library: tensorrt_llm
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <= 0 (via
+    raise ValueError)
+  severity: error
+  native_type: tensorrt_llm.LookaheadDecodingConfig
+  miner_source:
+    path: llmapi/llm_args.py
+    method: validate_positive_values
+    line_at_scan: 577
+  match:
+    engine: tensorrt
+    fields:
+      tensorrt.max_window_size:
+        <=: 0
+  kwargs_positive:
+    max_window_size: 0
+  kwargs_negative:
+    max_window_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Value must be positive, got {v}
+  references:
+  - llmapi/llm_args.py:577 (tensorrt_llm.LookaheadDecodingConfig.validate_positive_values)
+  added_by: static_miner
+  added_at: '2026-05-06'

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.validated.yaml
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.validated.yaml
@@ -1,0 +1,45 @@
+schema_version: 1.0.0
+engine: tensorrt
+engine_version: 0.21.0
+image_ref: llenergymeasure:tensorrt
+base_image_ref: llenergymeasure:tensorrt
+validated_at: '2026-05-06T20:35:47+02:00'
+validation_commit: 4ad6ee7b8e43c1282751a5b76ca936c6fe6982a3
+cases:
+- id: tensorrt_raises_max_ngram_size_le_0_positive_values
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for LookaheadDecodingConfig\nmax_ngram_size\n  Value\
+      \ error, Value must be positive, got 0 [type=value_error, input_value=0, input_type=int]\n\
+      \    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: tensorrt_raises_max_verification_set_size_le_0_positive_values
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for LookaheadDecodingConfig\nmax_verification_set_size\n\
+      \  Value error, Value must be positive, got 0 [type=value_error, input_value=0,\
+      \ input_type=int]\n    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: tensorrt_raises_max_window_size_le_0_positive_values
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for LookaheadDecodingConfig\nmax_window_size\n  Value\
+      \ error, Value must be positive, got 0 [type=value_error, input_value=0, input_type=int]\n\
+      \    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+divergences: []

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/schema.discovered.json
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/schema.discovered.json
@@ -1,0 +1,576 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "tensorrt",
+  "engine_version": "0.21.0",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:tensorrt-0.21.0",
+  "base_image_ref": null,
+  "discovered_at": "2026-05-06T20:20:57+02:00",
+  "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+  "discovery_limitations": [
+    {
+      "section": "engine_params",
+      "fields": [
+        "build_config"
+      ],
+      "reason": "BuildConfig is not a Pydantic model; appears as Optional[object] in the schema"
+    },
+    {
+      "section": "sampling_params",
+      "fields": [],
+      "reason": "SamplingParams is a dataclass; no per-field descriptions"
+    }
+  ],
+  "engine_params": {
+    "model": {
+      "type": "string",
+      "default": null,
+      "description": "The path to the model checkpoint or the model name from the Hugging Face Hub.",
+      "deprecated": false
+    },
+    "tokenizer": {
+      "type": "string | None",
+      "default": null,
+      "description": "The path to the tokenizer checkpoint or the tokenizer name from the Hugging Face Hub.",
+      "deprecated": false
+    },
+    "tokenizer_mode": {
+      "type": "Literal['auto', 'slow']",
+      "default": "auto",
+      "description": "The mode to initialize the tokenizer.",
+      "deprecated": false
+    },
+    "skip_tokenizer_init": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to skip the tokenizer initialization.",
+      "deprecated": false
+    },
+    "trust_remote_code": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to trust the remote code.",
+      "deprecated": false
+    },
+    "tensor_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The tensor parallel size.",
+      "deprecated": false
+    },
+    "dtype": {
+      "type": "string",
+      "default": "auto",
+      "description": "The data type to use for the model.",
+      "deprecated": false
+    },
+    "revision": {
+      "type": "string | None",
+      "default": null,
+      "description": "The revision to use for the model.",
+      "deprecated": false
+    },
+    "tokenizer_revision": {
+      "type": "string | None",
+      "default": null,
+      "description": "The revision to use for the tokenizer.",
+      "deprecated": false
+    },
+    "pipeline_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The pipeline parallel size.",
+      "deprecated": false
+    },
+    "context_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The context parallel size.",
+      "deprecated": false
+    },
+    "gpus_per_node": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The number of GPUs per node.",
+      "deprecated": false
+    },
+    "moe_cluster_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The cluster parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "moe_tensor_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The tensor parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "moe_expert_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The expert parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "enable_attention_dp": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable attention data parallel.",
+      "deprecated": false
+    },
+    "cp_config": {
+      "type": "object | None",
+      "default": null,
+      "description": "Context parallel config.",
+      "deprecated": false
+    },
+    "load_format": {
+      "type": "Literal['auto', 'dummy']",
+      "default": "auto",
+      "description": "The format to load the model.",
+      "deprecated": false
+    },
+    "enable_lora": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable LoRA.",
+      "deprecated": false
+    },
+    "max_lora_rank": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum LoRA rank.",
+      "deprecated": true
+    },
+    "max_loras": {
+      "type": "integer",
+      "default": 4,
+      "description": "The maximum number of LoRA.",
+      "deprecated": true
+    },
+    "max_cpu_loras": {
+      "type": "integer",
+      "default": 4,
+      "description": "The maximum number of LoRA on CPU.",
+      "deprecated": true
+    },
+    "lora_config": {
+      "type": "LoraConfig | None",
+      "default": null,
+      "description": "LoRA configuration for the model.",
+      "deprecated": false
+    },
+    "enable_prompt_adapter": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable prompt adapter.",
+      "deprecated": false
+    },
+    "max_prompt_adapter_token": {
+      "type": "integer",
+      "default": 0,
+      "description": "The maximum number of prompt adapter tokens.",
+      "deprecated": false
+    },
+    "quant_config": {
+      "type": "QuantConfig | None",
+      "default": null,
+      "description": "Quantization config.",
+      "deprecated": false
+    },
+    "kv_cache_config": {
+      "type": "KvCacheConfig",
+      "default": null,
+      "description": "KV cache config.",
+      "deprecated": false
+    },
+    "enable_chunked_prefill": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable chunked prefill.",
+      "deprecated": false
+    },
+    "guided_decoding_backend": {
+      "type": "string | None",
+      "default": null,
+      "description": "Guided decoding backend.",
+      "deprecated": false
+    },
+    "batched_logits_processor": {
+      "type": "Optional[tensorrt_llm.sampling_params.BatchedLogitsProcessor]",
+      "default": null,
+      "description": "Batched logits processor.",
+      "deprecated": false
+    },
+    "iter_stats_max_iterations": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of iterations for iter stats.",
+      "deprecated": false
+    },
+    "request_stats_max_iterations": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of iterations for request stats.",
+      "deprecated": false
+    },
+    "peft_cache_config": {
+      "type": "PeftCacheConfig | None",
+      "default": null,
+      "description": "PEFT cache config.",
+      "deprecated": false
+    },
+    "scheduler_config": {
+      "type": "SchedulerConfig",
+      "default": null,
+      "description": "Scheduler config.",
+      "deprecated": false
+    },
+    "cache_transceiver_config": {
+      "type": "CacheTransceiverConfig | None",
+      "default": null,
+      "description": "Cache transceiver config.",
+      "deprecated": false
+    },
+    "speculative_config": {
+      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
+      "default": null,
+      "description": "Speculative decoding config.",
+      "deprecated": false
+    },
+    "batching_type": {
+      "type": "BatchingType | None",
+      "default": null,
+      "description": "Batching type.",
+      "deprecated": false
+    },
+    "normalize_log_probs": {
+      "type": "boolean",
+      "default": false,
+      "description": "Normalize log probabilities.",
+      "deprecated": false
+    },
+    "max_batch_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum batch size.",
+      "deprecated": false
+    },
+    "max_input_len": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum input length.",
+      "deprecated": false
+    },
+    "max_seq_len": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum sequence length.",
+      "deprecated": false
+    },
+    "max_beam_width": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum beam width.",
+      "deprecated": false
+    },
+    "max_num_tokens": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of tokens.",
+      "deprecated": false
+    },
+    "gather_generation_logits": {
+      "type": "boolean",
+      "default": false,
+      "description": "Gather generation logits.",
+      "deprecated": false
+    },
+    "num_postprocess_workers": {
+      "type": "integer",
+      "default": 0,
+      "description": "The number of processes used for postprocessing the generated tokens, including detokenization.",
+      "deprecated": false
+    },
+    "postprocess_tokenizer_dir": {
+      "type": "string | None",
+      "default": null,
+      "description": "The path to the tokenizer directory for postprocessing.",
+      "deprecated": false
+    },
+    "reasoning_parser": {
+      "type": "string | None",
+      "default": null,
+      "description": "The parser to separate reasoning content from output.",
+      "deprecated": false
+    },
+    "garbage_collection_gen0_threshold": {
+      "type": "integer",
+      "default": 20000,
+      "description": "Threshold for Python garbage collection of generation 0 objects.Lower values trigger more frequent garbage collection.",
+      "deprecated": false
+    },
+    "decoding_config": {
+      "type": "Optional[DecodingConfig]",
+      "default": null,
+      "description": "The decoding config.",
+      "deprecated": true
+    },
+    "backend": {
+      "type": "string | None",
+      "default": null,
+      "description": "The backend to use for this LLM instance.",
+      "deprecated": false
+    },
+    "auto_parallel": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable auto parallel mode.",
+      "deprecated": true
+    },
+    "auto_parallel_world_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The world size for auto parallel mode.",
+      "deprecated": true
+    },
+    "enable_tqdm": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable tqdm for progress bar.",
+      "deprecated": false
+    },
+    "workspace": {
+      "type": "string | None",
+      "default": null,
+      "description": "The workspace for the model.",
+      "deprecated": false
+    },
+    "enable_build_cache": {
+      "type": "Union[tensorrt_llm.llmapi.build_cache.BuildCacheConfig, bool]",
+      "default": false,
+      "description": "Enable build cache.",
+      "deprecated": false
+    },
+    "extended_runtime_perf_knob_config": {
+      "type": "ExtendedRuntimePerfKnobConfig | None",
+      "default": null,
+      "description": "Extended runtime perf knob config.",
+      "deprecated": false
+    },
+    "calib_config": {
+      "type": "CalibConfig | None",
+      "default": null,
+      "description": "Calibration config.",
+      "deprecated": false
+    },
+    "embedding_parallel_mode": {
+      "type": "string",
+      "default": "SHARDING_ALONG_VOCAB",
+      "description": "The embedding parallel mode.",
+      "deprecated": false
+    },
+    "fast_build": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable fast build.",
+      "deprecated": false
+    },
+    "build_config": {
+      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "default": null,
+      "description": "Build config.",
+      "deprecated": false
+    }
+  },
+  "sampling_params": {
+    "end_id": {
+      "type": "int | None",
+      "default": null
+    },
+    "pad_id": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_tokens": {
+      "type": "int",
+      "default": 32
+    },
+    "bad": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "bad_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "stop": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "stop_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "include_stop_str_in_output": {
+      "type": "bool",
+      "default": false
+    },
+    "embedding_bias": {
+      "type": "Tensor | None",
+      "default": null
+    },
+    "logits_processor": {
+      "type": "LogitsProcessor | list[LogitsProcessor] | None",
+      "default": null
+    },
+    "apply_batched_logits_processor": {
+      "type": "bool",
+      "default": false
+    },
+    "n": {
+      "type": "int",
+      "default": 1
+    },
+    "best_of": {
+      "type": "int | None",
+      "default": null
+    },
+    "use_beam_search": {
+      "type": "bool",
+      "default": false
+    },
+    "top_k": {
+      "type": "int | None",
+      "default": null
+    },
+    "top_p": {
+      "type": "float | None",
+      "default": null
+    },
+    "top_p_min": {
+      "type": "float | None",
+      "default": null
+    },
+    "top_p_reset_ids": {
+      "type": "int | None",
+      "default": null
+    },
+    "top_p_decay": {
+      "type": "float | None",
+      "default": null
+    },
+    "seed": {
+      "type": "int | None",
+      "default": null
+    },
+    "temperature": {
+      "type": "float | None",
+      "default": null
+    },
+    "min_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "beam_search_diversity_rate": {
+      "type": "float | None",
+      "default": null
+    },
+    "repetition_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "presence_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "frequency_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "length_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "early_stopping": {
+      "type": "int | None",
+      "default": null
+    },
+    "no_repeat_ngram_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "min_p": {
+      "type": "float | None",
+      "default": null
+    },
+    "beam_width_array": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "prompt_logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "return_context_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "return_generation_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "exclude_input_from_output": {
+      "type": "bool",
+      "default": true
+    },
+    "return_encoder_output": {
+      "type": "bool",
+      "default": false
+    },
+    "return_perf_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "additional_model_outputs": {
+      "type": "list[AdditionalModelOutput] | None",
+      "default": null
+    },
+    "lookahead_config": {
+      "type": "LookaheadDecodingConfig | None",
+      "default": null
+    },
+    "guided_decoding": {
+      "type": "GuidedDecodingParams | None",
+      "default": null
+    },
+    "ignore_eos": {
+      "type": "bool",
+      "default": false
+    },
+    "detokenize": {
+      "type": "bool",
+      "default": true
+    },
+    "add_special_tokens": {
+      "type": "bool",
+      "default": true
+    },
+    "truncate_prompt_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "skip_special_tokens": {
+      "type": "bool",
+      "default": true
+    },
+    "spaces_between_special_tokens": {
+      "type": "bool",
+      "default": true
+    }
+  }
+}

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/ssot.yaml
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/ssot.yaml
@@ -1,0 +1,34 @@
+# Per-engine version-bundle SSOT for tensorrt-llm.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, validation gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+schema_version: 1
+engine: tensorrt
+library:
+  pep503_name: tensorrt-llm
+  current_version: "0.21.0"
+  current_commit_sha: null
+image:
+  base_image_ref: "nvcr.io/nvidia/tensorrt-llm/release:0.21.0"
+  llem_image_ref: null
+source_tarball:
+  # Template for the upstream release tarball. Workflow cells that need to
+  # mine TRT-LLM source files (the static miner + introspector) read it via
+  # `yq`, then substitute `{version}` with `library.current_version`. Single
+  # locus to update if NVIDIA changes their tag scheme. See #532.
+  url_template: "https://github.com/NVIDIA/TensorRT-LLM/archive/refs/tags/v{version}.tar.gz"
+miner_pins:
+  static: ">=0.21.0,<0.22.0"
+  dynamic: ">=0.21.0,<0.22.0"
+  discovery: ">=0.21.0,<0.22.0"
+artefact_paths:
+  engine_invariants: src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
+  validated_invariants: src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
+  discovered_schemas: src/llenergymeasure/engines/tensorrt/schema.discovered.json
+last_probe:
+  verdict: pass
+  version_inside_envelope: true
+  fingerprint: "a7902bb13b595121c161edcb00516bb4e1b719c339edd70ab3e9d09802d75e6d"
+  fingerprint_drift: []

--- a/src/llenergymeasure/_engine_archive/transformers/__init__.py
+++ b/src/llenergymeasure/_engine_archive/transformers/__init__.py
@@ -1,0 +1,7 @@
+"""Hugging Face Transformers per-version machinery archive.
+
+Subpackages here are version-pinned snapshots. LANDMARKS for the
+invariants miner reference ``GenerationConfig`` and ``BitsAndBytesConfig``
+runtime symbols; LANDMARKS for the schemas introspector reference
+``AutoModelForCausalLM``, ``PreTrainedModel``, and ``GenerationConfig``.
+"""

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/__init__.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/__init__.py
@@ -1,0 +1,7 @@
+"""Frozen Transformers 4.57.3 machinery + outputs.
+
+Initial vendored snapshot. The static-miner LANDMARKS cover the
+``GenerationConfig.validate`` and ``BitsAndBytesConfig.post_init`` seams
+the miner walks. The discovery LANDMARKS cover the ``from_pretrained``
+signatures and ``GenerationConfig.to_dict`` schema-discovery surface.
+"""

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/__init__.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``static`` (invariants), ``discovery`` (schemas)."""

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/discovery.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/discovery.py
@@ -1,0 +1,17 @@
+"""Schema-introspector LANDMARKS for Transformers 4.57.3.
+
+The introspector runs inside ``llenergymeasure:transformers-<tag>`` and
+lifts engine parameter specs via ``inspect.signature(from_pretrained)``
+and sampling parameter specs via ``GenerationConfig().to_dict()``.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "transformers.AutoModelForCausalLM",
+    "transformers.AutoModelForCausalLM.from_pretrained",
+    "transformers.PreTrainedModel",
+    "transformers.PreTrainedModel.from_pretrained",
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.to_dict",
+)

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/static.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/static.py
@@ -1,0 +1,16 @@
+"""Static-miner LANDMARKS for Transformers 4.57.3.
+
+Read by the probe before the invariants miner orchestrator
+(``scripts.engine_miners.transformers_miner``) runs. Covers the symbols
+the orchestrator's ``_check_landmarks()`` verifies plus the symbols the
+delegated dynamic miner (``transformers_dynamic_miner``) imports.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.validate",
+    "transformers.BitsAndBytesConfig",
+    "transformers.BitsAndBytesConfig.post_init",
+)

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.proposed.yaml
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.proposed.yaml
@@ -1,0 +1,1303 @@
+schema_version: 1.0.0
+engine: transformers
+engine_version: 4.57.3
+mined_at: '2026-05-06T22:57:22+02:00'
+invariants:
+- id: transformers_beam_search_num_beams_eq_1
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate flags `num_beams` (num beams eq 1)
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 345
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+  kwargs_positive:
+    num_beams: 1
+    num_beam_groups: 1
+    diversity_penalty: 0.0
+    early_stopping: true
+  kwargs_negative:
+    num_beams: 1
+    num_beam_groups: 1
+    diversity_penalty: 0.0
+    early_stopping: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: &id001 []
+  message_template: '`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag
+    is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.'
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+  conflict_note: 'id: dynamic_miner -> ''transformers_beam_search_num_beams_eq_1''; dynamic_miner -> ''transformers_early_stopping_type_num_beams_eq_1'''
+- id: transformers_cache_choice_cache_implementation_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `cache_implementation` (cache implementation not
+    in allowlist)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 349
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.cache_implementation:
+        present: true
+        not_in:
+        - dynamic
+        - static
+  kwargs_positive:
+    cache_implementation: nonsense
+    use_cache: true
+  kwargs_negative:
+    cache_implementation: null
+    use_cache: true
+  expected_outcome: &id002
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: 'Invalid `cache_implementation` (nonsense). Choose one of: (''static'', ''offloaded_static'',
+    ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'', ''offloaded_hybrid_chunked'',
+    ''dynamic'', ''dynamic_full'', ''offloaded'', ''quantized'')'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_cache_choice_use_cache_eq_false
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate flags `use_cache` (use cache eq false)
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 348
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.use_cache: false
+  kwargs_positive:
+    cache_implementation: static
+    use_cache: false
+  kwargs_negative:
+    cache_implementation: null
+    use_cache: false
+  expected_outcome: &id003
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: *id001
+  message_template: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation
+    will have no effect.
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_compile_config_type_compile_config_exceeds_zero
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `compile_config` (compile config exceeds zero)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 417
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.compile_config:
+        '>': 0
+  kwargs_positive:
+    compile_config: 42
+  kwargs_negative:
+    compile_config: null
+  expected_outcome: *id002
+  message_template: You provided `compile_config` as an instance of <class 'int'>, but it must be an instance
+    of `CompileConfig`.
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_compile_config_type_compile_config_type_not_in_CompileConfig
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `compile_config` (compile config type not in CompileConfig)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 417
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.compile_config:
+        present: true
+        type_is_not:
+        - CompileConfig
+  kwargs_positive:
+    compile_config: oops
+  kwargs_negative:
+    compile_config: null
+  expected_outcome: *id002
+  message_template: You provided `compile_config` as an instance of <class 'str'>, but it must be an instance
+    of `CompileConfig`.
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_dormant_early_stopping_set_true
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.minor_issues[key]_=_msg: marks dormant when num_beams == 1 AND
+    early_stopping present True (dropped: self.early_stopping is not False)'
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 606
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.early_stopping:
+        present: true
+  kwargs_positive:
+    num_beams: 1
+    early_stopping: true
+  kwargs_negative:
+    num_beams: 1
+    early_stopping: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: null
+  references:
+  - transformers/generation/configuration_utils.py:606 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.early_stopping is not False'
+- id: transformers_dormant_epsilon_cutoff_ne_0_0
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.minor_issues[key]_=_msg: marks dormant when epsilon_cutoff present
+    True AND epsilon_cutoff != 0.0 (dropped: self.do_sample is False)'
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 591
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.epsilon_cutoff:
+        '!=': 0.0
+        present: true
+  kwargs_positive:
+    epsilon_cutoff: true
+  kwargs_negative:
+    epsilon_cutoff: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: null
+  references:
+  - transformers/generation/configuration_utils.py:591 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.do_sample is False'
+- id: transformers_dormant_eta_cutoff_ne_0_0
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.minor_issues[key]_=_msg: marks dormant when eta_cutoff present
+    True AND eta_cutoff != 0.0 (dropped: self.do_sample is False)'
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 595
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.eta_cutoff:
+        '!=': 0.0
+        present: true
+  kwargs_positive:
+    eta_cutoff: true
+  kwargs_negative:
+    eta_cutoff: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: null
+  references:
+  - transformers/generation/configuration_utils.py:595 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.do_sample is False'
+- id: transformers_early_stopping_type_early_stopping_exceeds_zero
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `early_stopping` (early stopping exceeds zero)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.early_stopping:
+        '>': 0
+  kwargs_positive:
+    early_stopping: 1.5
+    num_beams: 1
+  kwargs_negative:
+    early_stopping: false
+    num_beams: 1
+  expected_outcome: *id002
+  message_template: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_early_stopping_type_early_stopping_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `early_stopping` (early stopping not in allowlist)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.early_stopping:
+        present: true
+        not_in:
+        - false
+        - true
+        - never
+  kwargs_positive:
+    early_stopping: sometimes
+    num_beams: 1
+  kwargs_negative:
+    early_stopping: false
+    num_beams: 1
+  expected_outcome: *id002
+  message_template: '`early_stopping` must be a boolean or ''never'', but is sometimes.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `early_stopping` (early stopping type not in bool
+    or int or str)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.early_stopping:
+        present: true
+        type_is_not:
+        - bool
+        - int
+        - str
+  kwargs_positive:
+    early_stopping: 1.5
+    num_beams: 1
+  kwargs_negative:
+    early_stopping: false
+    num_beams: 1
+  expected_outcome: *id002
+  message_template: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_epsilon_cutoff
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `epsilon_cutoff` when do_sample=False
+    and `epsilon_cutoff` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 361
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.epsilon_cutoff:
+        present: true
+        not_equal: 0.0
+  kwargs_positive:
+    do_sample: false
+    epsilon_cutoff: 0.5
+  kwargs_negative:
+    do_sample: true
+    epsilon_cutoff: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `epsilon_cutoff`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~361)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_eta_cutoff
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `eta_cutoff` when do_sample=False
+    and `eta_cutoff` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 362
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.eta_cutoff:
+        present: true
+        not_equal: 0.0
+  kwargs_positive:
+    do_sample: false
+    eta_cutoff: 0.5
+  kwargs_negative:
+    do_sample: true
+    eta_cutoff: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `eta_cutoff` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `eta_cutoff`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~362)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_min_p
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `min_p` when do_sample=False and `min_p`
+    is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 359
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.min_p:
+        present: true
+  kwargs_positive:
+    do_sample: false
+    min_p: 0.5
+  kwargs_negative:
+    do_sample: true
+    min_p: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `min_p` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~359)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_temperature
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `temperature` when do_sample=False
+    and `temperature` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 356
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.temperature:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    do_sample: false
+    temperature: 0.5
+  kwargs_negative:
+    do_sample: true
+    temperature: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `temperature` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `temperature`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~356)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_top_k
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `top_k` when do_sample=False and `top_k`
+    is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 357
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.top_k:
+        present: true
+        not_equal: 50
+  kwargs_positive:
+    do_sample: false
+    top_k: 51
+  kwargs_negative:
+    do_sample: true
+    top_k: 51
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `top_k` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~357)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_top_p
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `top_p` when do_sample=False and `top_p`
+    is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 358
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.top_p:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    do_sample: false
+    top_p: 0.5
+  kwargs_negative:
+    do_sample: true
+    top_p: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `top_p` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~358)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_typical_p
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `typical_p` when do_sample=False and
+    `typical_p` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 360
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.typical_p:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    do_sample: false
+    typical_p: 0.5
+  kwargs_negative:
+    do_sample: true
+    typical_p: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `typical_p` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `typical_p`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~360)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_negative_pad_token_id
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant pad_token_id < 0
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 396
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.pad_token_id:
+        <: 0
+  kwargs_positive:
+    pad_token_id: -1
+  kwargs_negative:
+    pad_token_id: 0
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: *id001
+  message_template: '`pad_token_id` should be positive but got -1. This will cause errors when batch generating,
+    if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID`
+    to avoid errors in generation'
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+  conflict_note: 'id: dynamic_miner -> ''transformers_negative_pad_token_id''; dynamic_miner -> ''transformers_output_token_ids_pad_token_id_lt_zero'''
+- id: transformers_no_return_dict_strips_output_attentions
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `output_attentions` when return_dict_in_generate=False
+    and `output_attentions` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 389
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_attentions:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_attentions: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_attentions: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When
+    `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~389)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_no_return_dict_strips_output_hidden_states
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `output_hidden_states` when return_dict_in_generate=False
+    and `output_hidden_states` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 390
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_hidden_states:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_hidden_states: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_hidden_states: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When
+    `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~390)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_no_return_dict_strips_output_scores
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `output_scores` when return_dict_in_generate=False
+    and `output_scores` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 391
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_scores:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_scores: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_scores: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate`
+    is not `True`, `output_scores` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~391)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `num_beams` (do sample eq false and num beams
+    eq 1)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 344
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.num_return_sequences:
+        '>': 1
+      transformers.sampling.do_sample: false
+  kwargs_positive:
+    num_beams: 1
+    num_return_sequences: 2
+    do_sample: false
+  kwargs_negative:
+    num_beams: 1
+    num_return_sequences: 1
+    do_sample: false
+  expected_outcome: *id002
+  message_template: Greedy methods without beam search do not support `num_return_sequences` different
+    than 1 (got 2).
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_num_return_vs_beams_num_beams_lt_num_return_sequences
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `num_beams` (num beams lt num return sequences)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 345
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams:
+        <: '@num_return_sequences'
+  kwargs_positive:
+    num_beams: 2
+    num_return_sequences: 4
+    do_sample: false
+  kwargs_negative:
+    num_beams: 1
+    num_return_sequences: 4
+    do_sample: true
+  expected_outcome: *id002
+  message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `num_beams` (num beams not divisible by num return
+    sequences)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 345
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams:
+        not_divisible_by: '@num_return_sequences'
+  kwargs_positive:
+    num_beams: 2
+    num_return_sequences: 4
+    do_sample: false
+  kwargs_negative:
+    num_beams: 1
+    num_return_sequences: 4
+    do_sample: true
+  expected_outcome: *id002
+  message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_output_token_ids_max_new_tokens_le_zero
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `max_new_tokens` (max new tokens le zero)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 335
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.max_new_tokens:
+        <=: 0
+  kwargs_positive:
+    max_new_tokens: -1
+    min_new_tokens: -1
+    pad_token_id: -1
+  kwargs_negative:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: 0
+  expected_outcome: *id002
+  message_template: '`max_new_tokens` must be greater than 0, but is -1.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_output_token_ids_max_new_tokens_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `max_new_tokens` (max new tokens not in allowlist)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 335
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.max_new_tokens:
+        present: true
+        not_in:
+        - 1
+        - 16
+  kwargs_positive:
+    max_new_tokens: -1
+    min_new_tokens: -1
+    pad_token_id: -1
+  kwargs_negative:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: 0
+  expected_outcome: *id002
+  message_template: '`max_new_tokens` must be greater than 0, but is -1.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_output_token_ids_pad_token_id_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate flags `pad_token_id` (pad token id not in allowlist)
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 396
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.pad_token_id:
+        present: true
+        not_in:
+        - 0
+        - 50256
+  kwargs_positive:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: -1
+  kwargs_negative:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: 0
+  expected_outcome: *id003
+  message_template: '`pad_token_id` should be positive but got -1. This will cause errors when batch generating,
+    if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID`
+    to avoid errors in generation'
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_raises_bnb_4bit_quant_type_not_type_str
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when bnb_4bit_quant_type type_is_not
+    str'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 563
+  match:
+    engine: transformers
+    fields:
+      transformers.bnb_4bit_quant_type:
+        type_is_not: str
+  kwargs_positive:
+    bnb_4bit_quant_type: 1
+  kwargs_negative:
+    bnb_4bit_quant_type: x
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: bnb_4bit_quant_type must be a string
+  references:
+  - transformers/utils/quantization_config.py:563 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_bnb_4bit_use_double_quant_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when bnb_4bit_use_double_quant type_is_not
+    bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 566
+  match:
+    engine: transformers
+    fields:
+      transformers.bnb_4bit_use_double_quant:
+        type_is_not: bool
+  kwargs_positive:
+    bnb_4bit_use_double_quant: 1
+  kwargs_negative:
+    bnb_4bit_use_double_quant: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: bnb_4bit_use_double_quant must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:566 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_compile_config_not_type_compileconfig
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.raise_ValueError: raises when compile_config present True AND
+    compile_config type_is_not CompileConfig'
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 561
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.compile_config:
+        type_is_not: CompileConfig
+        present: true
+  kwargs_positive:
+    compile_config: true
+  kwargs_negative:
+    compile_config: null
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: You provided `compile_config` as an instance of {type(self.compile_config)}, but it
+    must be an instance of `CompileConfig`.
+  references:
+  - transformers/generation/configuration_utils.py:561 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_enable_fp32_cpu_offload_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_enable_fp32_cpu_offload
+    type_is_not bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 554
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_enable_fp32_cpu_offload:
+        type_is_not: bool
+  kwargs_positive:
+    llm_int8_enable_fp32_cpu_offload: 1
+  kwargs_negative:
+    llm_int8_enable_fp32_cpu_offload: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_enable_fp32_cpu_offload must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:554 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_has_fp16_weight_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_has_fp16_weight type_is_not
+    bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 557
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_has_fp16_weight:
+        type_is_not: bool
+  kwargs_positive:
+    llm_int8_has_fp16_weight: 1
+  kwargs_negative:
+    llm_int8_has_fp16_weight: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_has_fp16_weight must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:557 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_skip_modules_not_type_list
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_skip_modules present
+    True AND llm_int8_skip_modules type_is_not list'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 552
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_skip_modules:
+        type_is_not: list
+        present: true
+  kwargs_positive:
+    llm_int8_skip_modules: true
+  kwargs_negative:
+    llm_int8_skip_modules: []
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_skip_modules must be a list of strings
+  references:
+  - transformers/utils/quantization_config.py:552 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_threshold_not_type_float
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_threshold type_is_not
+    float'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 549
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_threshold:
+        type_is_not: float
+  kwargs_positive:
+    llm_int8_threshold: x
+  kwargs_negative:
+    llm_int8_threshold: 1.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_threshold must be a float
+  references:
+  - transformers/utils/quantization_config.py:549 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_load_in_4bit_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when load_in_4bit type_is_not bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 543
+  match:
+    engine: transformers
+    fields:
+      transformers.load_in_4bit:
+        type_is_not: bool
+  kwargs_positive:
+    load_in_4bit: 1
+  kwargs_negative:
+    load_in_4bit: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: load_in_4bit must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:543 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_load_in_8bit_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when load_in_8bit type_is_not bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 546
+  match:
+    engine: transformers
+    fields:
+      transformers.load_in_8bit:
+        type_is_not: bool
+  kwargs_positive:
+    load_in_8bit: 1
+  kwargs_negative:
+    load_in_8bit: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: load_in_8bit must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:546 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_num_beams_eq_1
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.raise_ValueError: raises when num_return_sequences != 1 AND
+    num_beams == 1 (dropped: self.do_sample is False)'
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 618
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_return_sequences:
+        '!=': 1
+      transformers.sampling.num_beams: 1
+  kwargs_positive:
+    num_return_sequences: 2
+    num_beams: 1
+  kwargs_negative:
+    num_return_sequences: 2
+    num_beams: 2
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Greedy methods without beam search do not support `num_return_sequences` different
+    than 1 (got {num_return_sequences}).
+  references:
+  - transformers/generation/configuration_utils.py:618 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.do_sample is False'
+- id: transformers_single_beam_strips_early_stopping
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `early_stopping` when num_beams=1
+    and `early_stopping` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.early_stopping:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    num_beams: 1
+    early_stopping: true
+  kwargs_negative:
+    num_beams: 4
+    early_stopping: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`num_beams` is set to 1. However, `early_stopping` is set to `{declared_value}` --
+    this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~339)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_single_beam_strips_length_penalty
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `length_penalty` when num_beams=1
+    and `length_penalty` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 365
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.length_penalty:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    num_beams: 1
+    length_penalty: 0.5
+  kwargs_negative:
+    num_beams: 4
+    length_penalty: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`num_beams` is set to 1. However, `length_penalty` is set to `{declared_value}` --
+    this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~365)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `watermarking_config` (watermarking config type
+    not in WatermarkingConfig)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 381
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.watermarking_config:
+        present: true
+        type_is_not:
+        - WatermarkingConfig
+  kwargs_positive:
+    watermarking_config: 42
+  kwargs_negative:
+    watermarking_config: null
+  expected_outcome: *id002
+  message_template: transformers.generation.configuration_utils.WatermarkingConfig() argument after **
+    must be a mapping, not int
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.validated.yaml
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.validated.yaml
@@ -1,0 +1,717 @@
+schema_version: 1.0.0
+engine: transformers
+engine_version: 4.57.3
+image_ref: llenergymeasure:transformers
+base_image_ref: llenergymeasure:transformers
+validated_at: '2026-05-06T22:57:22+02:00'
+validation_commit: b9e7af630c351227389c263573263611402e4700
+cases:
+- id: transformers_beam_search_num_beams_eq_1
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_cache_choice_cache_implementation_not_in_allowlist
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: 'Invalid `cache_implementation` (nonsense). Choose one of: (''static'',
+      ''offloaded_static'', ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'',
+      ''offloaded_hybrid_chunked'', ''dynamic'', ''dynamic_full'', ''offloaded'',
+      ''quantized'')'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_cache_choice_use_cache_eq_false
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''cache_implementation''].'
+  - 'The following generation flags are not valid and may be ignored: [''cache_implementation''].'
+  - 'The following generation flags are not valid and may be ignored: [''cache_implementation''].'
+  - '- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation
+    is set to static. cache_implementation will have no effect.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation
+    is set to static. cache_implementation will have no effect.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation
+    is set to static. cache_implementation will have no effect.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_compile_config_type_compile_config_exceeds_zero
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: You provided `compile_config` as an instance of <class 'int'>, but it
+      must be an instance of `CompileConfig`.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_compile_config_type_compile_config_type_not_in_CompileConfig
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: You provided `compile_config` as an instance of <class 'str'>, but it
+      must be an instance of `CompileConfig`.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_dormant_early_stopping_set_true
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_dormant_epsilon_cutoff_ne_0_0
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `True` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `True` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `True` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_dormant_eta_cutoff_ne_0_0
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `True` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `True` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `True` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_early_stopping_type_early_stopping_exceeds_zero
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_early_stopping_type_early_stopping_not_in_allowlist
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`early_stopping` must be a boolean or ''never'', but is sometimes.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_epsilon_cutoff
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `0.5` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `0.5` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `0.5` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_eta_cutoff
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_min_p
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''min_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''min_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''min_p''].'
+  - '- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `min_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `min_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `min_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_temperature
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''temperature''].'
+  - 'The following generation flags are not valid and may be ignored: [''temperature''].'
+  - 'The following generation flags are not valid and may be ignored: [''temperature''].'
+  - '- `temperature`: `do_sample` is set to `False`. However, `temperature` is set
+    to `0.5` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `temperature`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `temperature`: `do_sample` is set to `False`. However, `temperature` is set
+    to `0.5` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `temperature`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `temperature`: `do_sample` is set to `False`. However, `temperature` is set
+    to `0.5` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `temperature`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_top_k
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''top_k''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_k''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_k''].'
+  - '- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_k`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_k`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_k`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_top_p
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''top_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_p''].'
+  - '- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_typical_p
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''typical_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''typical_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''typical_p''].'
+  - '- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `typical_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `typical_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `typical_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_negative_pad_token_id
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_no_return_dict_strips_output_attentions
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''output_attentions''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_attentions''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_attentions''].'
+  - '- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions`
+    is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions`
+    is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions`
+    is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_no_return_dict_strips_output_hidden_states
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''output_hidden_states''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_hidden_states''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_hidden_states''].'
+  - '- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but
+    `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states`
+    is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but
+    `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states`
+    is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but
+    `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states`
+    is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_no_return_dict_strips_output_scores
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''output_scores''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_scores''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_scores''].'
+  - '- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores`
+    is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores`
+    is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores`
+    is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: Greedy methods without beam search do not support `num_return_sequences`
+      different than 1 (got 2).
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_num_return_vs_beams_num_beams_lt_num_return_sequences
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`num_return_sequences` (4) has to be smaller or equal to `num_beams`
+      (2).'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`num_return_sequences` (4) has to be smaller or equal to `num_beams`
+      (2).'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_output_token_ids_max_new_tokens_le_zero
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`max_new_tokens` must be greater than 0, but is -1.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_output_token_ids_max_new_tokens_not_in_allowlist
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`max_new_tokens` must be greater than 0, but is -1.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_output_token_ids_pad_token_id_not_in_allowlist
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_bnb_4bit_quant_type_not_type_str
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: bnb_4bit_quant_type must be a string
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_bnb_4bit_use_double_quant_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: bnb_4bit_use_double_quant must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_compile_config_not_type_compileconfig
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: You provided `compile_config` as an instance of <class 'bool'>, but it
+      must be an instance of `CompileConfig`.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_enable_fp32_cpu_offload_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_enable_fp32_cpu_offload must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_has_fp16_weight_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_has_fp16_weight must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_skip_modules_not_type_list
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_skip_modules must be a list of strings
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_threshold_not_type_float
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_threshold must be a float
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_load_in_4bit_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: load_in_4bit must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_load_in_8bit_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: load_in_8bit must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_num_beams_eq_1
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: Greedy methods without beam search do not support `num_return_sequences`
+      different than 1 (got 2).
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_single_beam_strips_early_stopping
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_single_beam_strips_length_penalty
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''length_penalty''].'
+  - 'The following generation flags are not valid and may be ignored: [''length_penalty''].'
+  - 'The following generation flags are not valid and may be ignored: [''length_penalty''].'
+  - '- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set
+    to `0.5` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `length_penalty`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set
+    to `0.5` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `length_penalty`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set
+    to `0.5` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `length_penalty`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: transformers.generation.configuration_utils.WatermarkingConfig() argument
+      after ** must be a mapping, not int
+  positive_confirmed: true
+  negative_confirmed: true
+divergences: []

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/schema.discovered.json
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/schema.discovered.json
@@ -1,0 +1,367 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "transformers",
+  "engine_version": "4.57.3",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:transformers-4.57.3",
+  "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
+  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+  "discovery_limitations": [
+    {
+      "section": "engine_params",
+      "fields": [
+        "AutoModelForCausalLM.from_pretrained.**model_args",
+        "AutoModelForCausalLM.from_pretrained.**kwargs",
+        "PreTrainedModel.from_pretrained.**model_args",
+        "PreTrainedModel.from_pretrained.**kwargs"
+      ],
+      "reason": "from_pretrained accepts **kwargs; kwargs are not in the signature (documented kwargs live in the class docstring only)"
+    },
+    {
+      "section": "sampling_params",
+      "fields": [
+        "max_new_tokens",
+        "min_new_tokens",
+        "max_time",
+        "stop_strings",
+        "cache_implementation",
+        "cache_config",
+        "return_legacy_cache",
+        "prefill_chunk_size",
+        "min_p",
+        "bad_words_ids",
+        "forced_bos_token_id",
+        "forced_eos_token_id",
+        "exponential_decay_length_penalty",
+        "suppress_tokens",
+        "begin_suppress_tokens",
+        "sequence_bias",
+        "guidance_scale",
+        "watermarking_config",
+        "output_logits",
+        "pad_token_id",
+        "bos_token_id",
+        "eos_token_id",
+        "decoder_start_token_id",
+        "prompt_lookup_num_tokens",
+        "max_matching_ngram_size",
+        "assistant_early_exit",
+        "low_memory",
+        "penalty_alpha",
+        "dola_layers",
+        "constraints",
+        "force_words_ids"
+      ],
+      "reason": "GenerationConfig has no type annotations; None defaults yield type='unknown'"
+    }
+  ],
+  "engine_params": {
+    "config": {
+      "type": "PretrainedConfig | str | PathLike | None",
+      "default": null
+    },
+    "cache_dir": {
+      "type": "str | PathLike | None",
+      "default": null
+    },
+    "ignore_mismatched_sizes": {
+      "type": "bool",
+      "default": false
+    },
+    "force_download": {
+      "type": "bool",
+      "default": false
+    },
+    "local_files_only": {
+      "type": "bool",
+      "default": false
+    },
+    "token": {
+      "type": "str | bool | None",
+      "default": null
+    },
+    "revision": {
+      "type": "str",
+      "default": "main"
+    },
+    "use_safetensors": {
+      "type": "bool | None",
+      "default": null
+    },
+    "weights_only": {
+      "type": "bool",
+      "default": true
+    }
+  },
+  "sampling_params": {
+    "max_length": {
+      "type": "int",
+      "default": 20
+    },
+    "max_new_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "min_length": {
+      "type": "int",
+      "default": 0
+    },
+    "min_new_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "early_stopping": {
+      "type": "bool",
+      "default": false
+    },
+    "max_time": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop_strings": {
+      "type": "unknown",
+      "default": null
+    },
+    "do_sample": {
+      "type": "bool",
+      "default": false
+    },
+    "num_beams": {
+      "type": "int",
+      "default": 1
+    },
+    "use_cache": {
+      "type": "bool",
+      "default": true
+    },
+    "cache_implementation": {
+      "type": "unknown",
+      "default": null
+    },
+    "cache_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "return_legacy_cache": {
+      "type": "unknown",
+      "default": null
+    },
+    "prefill_chunk_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "temperature": {
+      "type": "float",
+      "default": 1.0
+    },
+    "top_k": {
+      "type": "int",
+      "default": 50
+    },
+    "top_p": {
+      "type": "float",
+      "default": 1.0
+    },
+    "min_p": {
+      "type": "unknown",
+      "default": null
+    },
+    "typical_p": {
+      "type": "float",
+      "default": 1.0
+    },
+    "epsilon_cutoff": {
+      "type": "float",
+      "default": 0.0
+    },
+    "eta_cutoff": {
+      "type": "float",
+      "default": 0.0
+    },
+    "repetition_penalty": {
+      "type": "float",
+      "default": 1.0
+    },
+    "encoder_repetition_penalty": {
+      "type": "float",
+      "default": 1.0
+    },
+    "length_penalty": {
+      "type": "float",
+      "default": 1.0
+    },
+    "no_repeat_ngram_size": {
+      "type": "int",
+      "default": 0
+    },
+    "bad_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "renormalize_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "forced_bos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "forced_eos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "remove_invalid_values": {
+      "type": "bool",
+      "default": false
+    },
+    "exponential_decay_length_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "begin_suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "sequence_bias": {
+      "type": "unknown",
+      "default": null
+    },
+    "token_healing": {
+      "type": "bool",
+      "default": false
+    },
+    "guidance_scale": {
+      "type": "unknown",
+      "default": null
+    },
+    "watermarking_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_return_sequences": {
+      "type": "int",
+      "default": 1
+    },
+    "output_attentions": {
+      "type": "bool",
+      "default": false
+    },
+    "output_hidden_states": {
+      "type": "bool",
+      "default": false
+    },
+    "output_scores": {
+      "type": "bool",
+      "default": false
+    },
+    "output_logits": {
+      "type": "unknown",
+      "default": null
+    },
+    "return_dict_in_generate": {
+      "type": "bool",
+      "default": false
+    },
+    "pad_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "bos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "eos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "encoder_no_repeat_ngram_size": {
+      "type": "int",
+      "default": 0
+    },
+    "decoder_start_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "is_assistant": {
+      "type": "bool",
+      "default": false
+    },
+    "num_assistant_tokens": {
+      "type": "int",
+      "default": 20
+    },
+    "num_assistant_tokens_schedule": {
+      "type": "str",
+      "default": "constant"
+    },
+    "assistant_confidence_threshold": {
+      "type": "float",
+      "default": 0.4
+    },
+    "prompt_lookup_num_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "max_matching_ngram_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "assistant_early_exit": {
+      "type": "unknown",
+      "default": null
+    },
+    "assistant_lookbehind": {
+      "type": "int",
+      "default": 10
+    },
+    "target_lookbehind": {
+      "type": "int",
+      "default": 10
+    },
+    "disable_compile": {
+      "type": "bool",
+      "default": false
+    },
+    "low_memory": {
+      "type": "unknown",
+      "default": null
+    },
+    "penalty_alpha": {
+      "type": "unknown",
+      "default": null
+    },
+    "dola_layers": {
+      "type": "unknown",
+      "default": null
+    },
+    "diversity_penalty": {
+      "type": "float",
+      "default": 0.0
+    },
+    "num_beam_groups": {
+      "type": "int",
+      "default": 1
+    },
+    "constraints": {
+      "type": "unknown",
+      "default": null
+    },
+    "force_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "_from_model_config": {
+      "type": "bool",
+      "default": false
+    },
+    "transformers_version": {
+      "type": "str",
+      "default": "4.57.3"
+    }
+  }
+}

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/ssot.yaml
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/ssot.yaml
@@ -1,0 +1,32 @@
+# Per-engine version-bundle SSOT for transformers.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, validation gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+#
+# `last_probe.verdict: unrun` is the honest seed shape for a fresh SSOT
+# that no probe has executed against yet. The probe primitive overwrites
+# this block on each per-PR run.
+schema_version: 1
+engine: transformers
+library:
+  pep503_name: transformers
+  current_version: "4.57.3"
+  current_commit_sha: null
+image:
+  base_image_ref: "llenergymeasure:transformers-4.57.3"
+  llem_image_ref: null
+miner_pins:
+  static: ">=4.56,<4.57"
+  dynamic: ">=4.56,<4.57"
+  discovery: ">=4.56,<4.57"
+artefact_paths:
+  engine_invariants: src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+  validated_invariants: src/llenergymeasure/engines/transformers/invariants.validated.yaml
+  discovered_schemas: src/llenergymeasure/engines/transformers/schema.discovered.json
+last_probe:
+  verdict: pass
+  version_inside_envelope: false
+  fingerprint: "14dc1896757dfc00a9a4e1990528ecac45394bb5f2850bfab17e87871aaa29da"
+  fingerprint_drift: []

--- a/src/llenergymeasure/_engine_archive/vllm/__init__.py
+++ b/src/llenergymeasure/_engine_archive/vllm/__init__.py
@@ -1,0 +1,7 @@
+"""vLLM per-version machinery archive.
+
+Subpackages here are version-pinned snapshots, one per shipped pipeline
+state. The active version is the one named in ``engine_versions/vllm.yaml``
+``library.current_version``; the dispatcher maps that to the matching
+subpackage via :func:`scripts.engine_miners._ssot.safe_version`.
+"""

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/__init__.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/__init__.py
@@ -1,0 +1,7 @@
+"""Frozen vLLM 0.7.3 machinery + outputs.
+
+Initial vendored snapshot. Holds LANDMARKS for the static miner and
+schema introspector. AST_TARGETS / walker patterns are deferred to a
+follow-up scaffold PR; until then those data structures live in their
+respective producer modules under ``scripts/engine_miners/``.
+"""

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/__init__.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``static`` (invariants), ``discovery`` (schemas)."""

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/discovery.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/discovery.py
@@ -1,0 +1,14 @@
+"""Schema-introspector LANDMARKS for vLLM 0.7.3.
+
+Read by the probe before the introspector runs inside the
+``vllm/vllm-openai:v0.7.3`` image. The introspector extracts engine
+parameter specs from ``EngineArgs`` (dataclass) and sampling parameter
+specs from ``SamplingParams`` (msgspec-typed).
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "vllm.SamplingParams",
+    "vllm.engine.arg_utils.EngineArgs",
+)

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/static.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/static.py
@@ -1,0 +1,42 @@
+"""Static-miner LANDMARKS for vLLM 0.7.3.
+
+These are the dotted attribute paths the probe verifies under the
+installed ``vllm`` package before the static miner runs. Mirrors the
+``_AST_TARGETS`` registry in ``scripts/engine_miners/vllm_static_miner.py``
+at the dotted-path level, plus class targets needed for AST walking.
+
+Frozen at vllm 0.7.3. Subsequent versions live alongside this file as
+sibling subpackages (``v0_16_0``, ``v0_18_1``, ...) populated by the
+chunk PRs that bump ``current_version`` in the SSOT.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "vllm.sampling_params.SamplingParams",
+    "vllm.sampling_params.SamplingParams._verify_args",
+    "vllm.sampling_params.SamplingParams.__post_init__",
+    "vllm.sampling_params.SamplingParams._verify_greedy_sampling",
+    "vllm.sampling_params.StructuredOutputsParams",
+    "vllm.sampling_params.StructuredOutputsParams.__post_init__",
+    "vllm.config.parallel.ParallelConfig",
+    "vllm.config.parallel.ParallelConfig._validate_parallel_config",
+    "vllm.config.parallel.ParallelConfig._verify_args",
+    "vllm.config.parallel.ParallelConfig.__post_init__",
+    "vllm.config.parallel.EPLBConfig",
+    "vllm.config.parallel.EPLBConfig._validate_eplb_config",
+    "vllm.config.lora.LoRAConfig",
+    "vllm.config.lora.LoRAConfig._validate_lora_config",
+    "vllm.config.multimodal.MultiModalConfig",
+    "vllm.config.multimodal.MultiModalConfig._validate_multimodal_config",
+    "vllm.config.structured_outputs.StructuredOutputsConfig",
+    "vllm.config.structured_outputs.StructuredOutputsConfig._validate_structured_output_config",
+    "vllm.config.cache.CacheConfig",
+    "vllm.config.cache.CacheConfig._validate_cache_dtype",
+    "vllm.config.model.ModelConfig",
+    "vllm.config.model.ModelConfig.__post_init__",
+    "vllm.config.compilation.CompilationConfig",
+    "vllm.config.compilation.CompilationConfig.__post_init__",
+    "vllm.config.scheduler.SchedulerConfig",
+    "vllm.config.scheduler.SchedulerConfig.__post_init__",
+)

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.proposed.yaml
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.proposed.yaml
@@ -1,0 +1,1497 @@
+schema_version: 1.0.0
+engine: vllm
+engine_version: 0.17.1
+miner_pinned_range: <0.18,>=0.17
+mined_at: '2026-04-27'
+invariants:
+- id: vllm_cacheconfig_cache_dtype_in_7_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.cache_dtype must be one of ['auto', 'bfloat16', 'fp8', 'fp8_e4m3', 'fp8_e5m2',
+    'fp8_inc', 'fp8_ds_mla']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.cache_dtype:
+        not_in:
+        - auto
+        - bfloat16
+        - fp8
+        - fp8_e4m3
+        - fp8_e5m2
+        - fp8_inc
+        - fp8_ds_mla
+  kwargs_positive:
+    cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_cpu_offload_gb_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.cpu_offload_gb requires >= 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.cpu_offload_gb:
+        <: 0
+  kwargs_positive:
+    cpu_offload_gb: -1
+  kwargs_negative:
+    cpu_offload_gb: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_gpu_memory_utilization_gt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.gpu_memory_utilization requires > 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.gpu_memory_utilization:
+        <=: 0
+  kwargs_positive:
+    gpu_memory_utilization: 0
+  kwargs_negative:
+    gpu_memory_utilization: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_gpu_memory_utilization_le_1
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.gpu_memory_utilization requires <= 1
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.gpu_memory_utilization:
+        '>': 1
+  kwargs_positive:
+    gpu_memory_utilization: 2
+  kwargs_negative:
+    gpu_memory_utilization: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_kv_offloading_backend_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.kv_offloading_backend must be one of ['native', 'lmcache']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.kv_offloading_backend:
+        not_in:
+        - native
+        - lmcache
+  kwargs_positive:
+    kv_offloading_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    kv_offloading_backend: native
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_block_size_gt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_block_size requires > 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_block_size:
+        <=: 0
+  kwargs_positive:
+    mamba_block_size: 0
+  kwargs_negative:
+    mamba_block_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_cache_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_cache_dtype must be one of ['auto', 'float32', 'float16']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_cache_dtype:
+        not_in:
+        - auto
+        - float32
+        - float16
+  kwargs_positive:
+    mamba_cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_cache_mode_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_cache_mode must be one of ['all', 'align', 'none']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_cache_mode:
+        not_in:
+        - all
+        - align
+        - none
+  kwargs_positive:
+    mamba_cache_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_cache_mode: all
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_ssm_cache_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_ssm_cache_dtype must be one of ['auto', 'float32', 'float16']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_ssm_cache_dtype:
+        not_in:
+        - auto
+        - float32
+        - float16
+  kwargs_positive:
+    mamba_ssm_cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_ssm_cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_prefix_caching_hash_algo_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.prefix_caching_hash_algo must be one of ['sha256', 'sha256_cbor', 'xxhash',
+    'xxhash_cbor']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.prefix_caching_hash_algo:
+        not_in:
+        - sha256
+        - sha256_cbor
+        - xxhash
+        - xxhash_cbor
+  kwargs_positive:
+    prefix_caching_hash_algo: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    prefix_caching_hash_algo: sha256
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_swap_space_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.swap_space requires >= 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.swap_space:
+        <: 0
+  kwargs_positive:
+    swap_space: -1
+  kwargs_negative:
+    swap_space: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_compilationconfig_compile_cache_save_format_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CompilationConfig.compile_cache_save_format must be one of ['binary', 'unpacked']
+  severity: error
+  native_type: vllm.config.CompilationConfig
+  miner_source:
+    path: vllm/config/compilation.py
+    method: <pydantic_lift>
+    line_at_scan: 336
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.compile_cache_save_format:
+        not_in:
+        - binary
+        - unpacked
+  kwargs_positive:
+    compile_cache_save_format: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    compile_cache_save_format: binary
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CompilationConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_compilationconfig_dormant_backend_eq
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'CompilationConfig.__post_init__: marks dormant when backend == '
+  severity: dormant
+  native_type: vllm.config.CompilationConfig
+  miner_source:
+    path: vllm/config/compilation.py
+    method: __post_init__
+    line_at_scan: 905
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.backend: ''
+  kwargs_positive:
+    backend: ''
+  kwargs_negative:
+    backend: _x
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - backend
+  message_template: null
+  references:
+  - vllm/config/compilation.py:905 (vllm.config.CompilationConfig.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_eplbconfig_num_redundant_experts_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: EPLBConfig.num_redundant_experts requires >= 0
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 50
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.num_redundant_experts:
+        <: 0
+  kwargs_positive:
+    num_redundant_experts: -1
+  kwargs_negative:
+    num_redundant_experts: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_eplbconfig_policy_in_1_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: EPLBConfig.policy must be one of ['default']
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 50
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.policy:
+        not_in:
+        - default
+  kwargs_positive:
+    policy: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    policy: default
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_eplbconfig_raises_log_balancedness_interval_le_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'EPLBConfig._validate_eplb_config: raises when log_balancedness present True AND log_balancedness_interval
+    <= 0'
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_eplb_config
+    line_at_scan: 89
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.log_balancedness:
+        present: true
+      vllm.engine.log_balancedness_interval:
+        <=: 0
+  kwargs_positive:
+    log_balancedness: 1
+    log_balancedness_interval: 0
+  kwargs_negative:
+    log_balancedness: 1
+    log_balancedness_interval: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: log_balancedness_interval must be greater than 0.
+  references:
+  - vllm/config/parallel.py:89 (vllm.config.EPLBConfig._validate_eplb_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_dormant_max_cpu_loras_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'LoRAConfig._validate_lora_config: marks dormant when max_cpu_loras absent True'
+  severity: dormant
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: _validate_lora_config
+    line_at_scan: 94
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_cpu_loras:
+        absent: true
+  kwargs_positive:
+    max_cpu_loras: null
+  kwargs_negative:
+    max_cpu_loras: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - max_cpu_loras
+  message_template: null
+  references:
+  - vllm/config/lora.py:94 (vllm.config.LoRAConfig._validate_lora_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_lora_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: LoRAConfig.lora_dtype must be one of ['auto', 'float16', 'bfloat16']
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.lora_dtype:
+        not_in:
+        - auto
+        - float16
+        - bfloat16
+  kwargs_positive:
+    lora_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    lora_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_max_lora_rank_in_9_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: LoRAConfig.max_lora_rank must be one of [1, 8, 16, 32, 64, 128, 256, 320, 512]
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_lora_rank:
+        not_in:
+        - 1
+        - 8
+        - 16
+        - 32
+        - 64
+        - 128
+        - 256
+        - 320
+        - 512
+  kwargs_positive:
+    max_lora_rank: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    max_lora_rank: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_max_loras_ge_1
+  engine: vllm
+  library: vllm
+  invariant_under_test: LoRAConfig.max_loras requires >= 1
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_loras:
+        <: 1
+  kwargs_positive:
+    max_loras: 0
+  kwargs_negative:
+    max_loras: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_modelconfig_convert_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.convert must be one of ['auto', 'none', 'embed', 'classify']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.convert:
+        not_in:
+        - auto
+        - none
+        - embed
+        - classify
+  kwargs_positive:
+    convert: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    convert: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_modelconfig_logprobs_mode_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.logprobs_mode must be one of ['raw_logits', 'raw_logprobs', 'processed_logits',
+    'processed_logprobs']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.logprobs_mode:
+        not_in:
+        - raw_logits
+        - raw_logprobs
+        - processed_logits
+        - processed_logprobs
+  kwargs_positive:
+    logprobs_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    logprobs_mode: raw_logits
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_modelconfig_mm_encoder_tp_mode_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.mm_encoder_tp_mode must be one of ['weights', 'data']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_encoder_tp_mode:
+        not_in:
+        - weights
+        - data
+  kwargs_positive:
+    mm_encoder_tp_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mm_encoder_tp_mode: weights
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_encoder_tp_mode_in_2_values''; pydantic_lift
+    -> ''vllm_multimodalconfig_mm_encoder_tp_mode_in_2_values'''
+- id: vllm_modelconfig_mm_processor_cache_type_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.mm_processor_cache_type must be one of ['shm', 'lru']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_processor_cache_type:
+        not_in:
+        - shm
+        - lru
+  kwargs_positive:
+    mm_processor_cache_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mm_processor_cache_type: shm
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_processor_cache_type_in_2_values''; pydantic_lift
+    -> ''vllm_multimodalconfig_mm_processor_cache_type_in_2_values'''
+- id: vllm_modelconfig_runner_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.runner must be one of ['auto', 'generate', 'pooling', 'draft']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.runner:
+        not_in:
+        - auto
+        - generate
+        - pooling
+        - draft
+  kwargs_positive:
+    runner: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    runner: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_multimodalconfig_mm_processor_cache_gb_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: MultiModalConfig.mm_processor_cache_gb requires >= 0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_processor_cache_gb:
+        <: 0
+  kwargs_positive:
+    mm_processor_cache_gb: -1
+  kwargs_negative:
+    mm_processor_cache_gb: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_multimodalconfig_video_pruning_rate_ge_0p0
+  engine: vllm
+  library: vllm
+  invariant_under_test: MultiModalConfig.video_pruning_rate requires >= 0.0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.video_pruning_rate:
+        <: 0.0
+  kwargs_positive:
+    video_pruning_rate: -1.0
+  kwargs_negative:
+    video_pruning_rate: 0.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_multimodalconfig_video_pruning_rate_lt_1p0
+  engine: vllm
+  library: vllm
+  invariant_under_test: MultiModalConfig.video_pruning_rate requires < 1.0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.video_pruning_rate:
+        '>=': 1.0
+  kwargs_positive:
+    video_pruning_rate: 1.0
+  kwargs_negative:
+    video_pruning_rate: 0.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig__api_process_count_gt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig._api_process_count requires > 0
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_count:
+        <=: 0
+  kwargs_positive:
+    _api_process_count: 0
+  kwargs_negative:
+    _api_process_count: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig__api_process_rank_ge_neg1
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig._api_process_rank requires >= -1
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_rank:
+        <: -1
+  kwargs_positive:
+    _api_process_rank: -2
+  kwargs_negative:
+    _api_process_rank: -1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_all2all_backend_in_7_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig.all2all_backend must be one of ['naive', 'pplx', 'deepep_high_throughput',
+    'deepep_low_latency', 'mori', 'allgather_reducescatter', 'flashinfer_all2allv']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.all2all_backend:
+        not_in:
+        - naive
+        - pplx
+        - deepep_high_throughput
+        - deepep_low_latency
+        - mori
+        - allgather_reducescatter
+        - flashinfer_all2allv
+  kwargs_positive:
+    all2all_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    all2all_backend: naive
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_data_parallel_backend_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig.data_parallel_backend must be one of ['ray', 'mp']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_backend:
+        not_in:
+        - ray
+        - mp
+  kwargs_positive:
+    data_parallel_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    data_parallel_backend: ray
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_dormant_all2all_backend_eq_pplx
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: marks dormant when all2all_backend == pplx'
+  severity: dormant
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 348
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.all2all_backend: pplx
+  kwargs_positive:
+    all2all_backend: pplx
+  kwargs_negative:
+    all2all_backend: allgather_reducescatter
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - all2all_backend
+  message_template: null
+  references:
+  - vllm/config/parallel.py:348 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_dormant_data_parallel_rank_set_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig.__post_init__: marks dormant when distributed_executor_backend == external_launcher
+    AND data_parallel_rank present True'
+  severity: dormant
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: __post_init__
+    line_at_scan: 676
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.distributed_executor_backend: external_launcher
+      vllm.engine.data_parallel_rank:
+        present: true
+  kwargs_positive:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 1
+  kwargs_negative:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 0
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - data_parallel_rank
+  message_template: null
+  references:
+  - vllm/config/parallel.py:676 (vllm.config.ParallelConfig.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_expert_placement_strategy_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig.expert_placement_strategy must be one of ['linear', 'round_robin']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.expert_placement_strategy:
+        not_in:
+        - linear
+        - round_robin
+  kwargs_positive:
+    expert_placement_strategy: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    expert_placement_strategy: linear
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_raises_api_process_rank_ge_ref_api_process_count
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when _api_process_rank >= @_api_process_count'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 337
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_rank:
+        '>=': '@_api_process_count'
+  kwargs_positive:
+    _api_process_count: 2
+    _api_process_rank: 2
+  kwargs_negative:
+    _api_process_count: 2
+    _api_process_rank: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: 'f''Invalid value of `_api_process_rank`. Expected to be `-1` or `[0, {self._api_process_count})`,
+    but found: {self._api_process_rank}'''
+  references:
+  - vllm/config/parallel.py:337 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_raises_data_parallel_external_lb_set_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when data_parallel_size <= 1 AND
+    data_parallel_external_lb present True'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 357
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_size:
+        <=: 1
+      vllm.engine.data_parallel_external_lb:
+        present: true
+  kwargs_positive:
+    data_parallel_size: 1
+    data_parallel_external_lb: 1
+  kwargs_negative:
+    data_parallel_size: 1
+    data_parallel_external_lb: false
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: data_parallel_external_lb can only be set when data_parallel_size > 1
+  references:
+  - vllm/config/parallel.py:357 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_poolerconfig_seq_pooling_type_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: PoolerConfig.seq_pooling_type must be one of ['CLS', 'LAST', 'MEAN']
+  severity: error
+  native_type: vllm.config.PoolerConfig
+  miner_source:
+    path: vllm/config/pooler.py
+    method: <pydantic_lift>
+    line_at_scan: 19
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.seq_pooling_type:
+        not_in:
+        - CLS
+        - LAST
+        - MEAN
+  kwargs_positive:
+    seq_pooling_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    seq_pooling_type: CLS
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_poolerconfig_tok_pooling_type_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: PoolerConfig.tok_pooling_type must be one of ['ALL', 'STEP']
+  severity: error
+  native_type: vllm.config.PoolerConfig
+  miner_source:
+    path: vllm/config/pooler.py
+    method: <pydantic_lift>
+    line_at_scan: 19
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.tok_pooling_type:
+        not_in:
+        - ALL
+        - STEP
+  kwargs_positive:
+    tok_pooling_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    tok_pooling_type: ALL
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_sampling_token_counts_max_tokens_lt_min_tokens
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'sampling_token_counts: error when max_tokens < min_tokens'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: <probe>
+    line_at_scan: 0
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.max_tokens:
+        <: '@min_tokens'
+  kwargs_positive:
+    max_tokens: 1
+    min_tokens: 5
+  kwargs_negative:
+    max_tokens: null
+    min_tokens: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: min_tokens must be less than or equal to max_tokens=1, got 5.
+  references:
+  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  added_by: dynamic_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_dormant_bad_words_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when bad_words absent True'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 389
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.bad_words:
+        absent: true
+  kwargs_positive:
+    bad_words: null
+  kwargs_negative:
+    bad_words: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - bad_words
+  message_template: null
+  references:
+  - vllm/sampling_params.py:389 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_dormant_seed_eq_neg1
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when seed == -1'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 378
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.seed: -1
+  kwargs_positive:
+    seed: -1
+  kwargs_negative:
+    seed: 0
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - seed
+  message_template: null
+  references:
+  - vllm/sampling_params.py:378 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when skip_reading_prefix_cache absent
+    True'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 418
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.skip_reading_prefix_cache:
+        absent: true
+  kwargs_positive:
+    skip_reading_prefix_cache: null
+  kwargs_negative:
+    skip_reading_prefix_cache: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - skip_reading_prefix_cache
+  message_template: null
+  references:
+  - vllm/sampling_params.py:418 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when max_tokens present True AND min_tokens >
+    @max_tokens'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 472
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.max_tokens:
+        present: true
+      vllm.sampling.min_tokens:
+        '>': '@max_tokens'
+  kwargs_positive:
+    max_tokens: 1
+    min_tokens: 2
+  kwargs_negative:
+    max_tokens: 1
+    min_tokens: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'min_tokens must be less than or equal to max_tokens={self.max_tokens}, got {self.min_tokens}.'
+  references:
+  - vllm/sampling_params.py:472 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_min_tokens_lt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when min_tokens < 0'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 468
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.min_tokens:
+        <: 0
+  kwargs_positive:
+    min_tokens: -1
+  kwargs_negative:
+    min_tokens: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: min_tokens must be greater than or equal to 0, got -1.
+  references:
+  - vllm/sampling_params.py:468 (vllm.SamplingParams._verify_args)
+  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  added_by: static_miner
+  cross_validated_by:
+  - dynamic_miner
+  added_at: '2026-04-27'
+  conflict_note: 'message_template: dynamic miner text overrode static_miner''s template; id: static_miner
+    -> ''vllm_samplingparams_raises_min_tokens_lt_0''; dynamic_miner -> ''vllm_sampling_token_counts_min_tokens_lt_zero'''
+- id: vllm_samplingparams_raises_n_lt_1
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when n < 1'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 424
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.n:
+        <: 1
+  kwargs_positive:
+    n: 0
+  kwargs_negative:
+    n: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'n must be at least 1, got {self.n}.'
+  references:
+  - vllm/sampling_params.py:424 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_n_not_type_int
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when n type_is_not int'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 422
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.n:
+        type_is_not: int
+  kwargs_positive:
+    n: x
+  kwargs_negative:
+    n: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'n must be an int, but is of type {type(self.n)}'
+  references:
+  - vllm/sampling_params.py:422 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_top_k_lt_neg1
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when top_k < -1'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 452
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.top_k:
+        <: -1
+  kwargs_positive:
+    top_k: -2
+  kwargs_negative:
+    top_k: -1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'top_k must be 0 (disable), or at least 1, got {self.top_k}.'
+  references:
+  - vllm/sampling_params.py:452 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_structuredoutputsconfig_backend_in_5_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: StructuredOutputsConfig.backend must be one of ['auto', 'xgrammar', 'guidance', 'outlines',
+    'lm-format-enforcer']
+  severity: error
+  native_type: vllm.config.StructuredOutputsConfig
+  miner_source:
+    path: vllm/config/structured_outputs.py
+    method: <pydantic_lift>
+    line_at_scan: 17
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.backend:
+        not_in:
+        - auto
+        - xgrammar
+        - guidance
+        - outlines
+        - lm-format-enforcer
+  kwargs_positive:
+    backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    backend: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.StructuredOutputsConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.validated.yaml
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.validated.yaml
@@ -1,0 +1,9 @@
+# Pending validation-gate operationalisation — see issue #445
+schema_version: 1.0.0
+engine: vllm
+engine_version: 0.7.3
+image_ref: vllm/vllm-openai:v0.7.3
+base_image_ref: vllm/vllm-openai:v0.7.3
+validated_at: null
+validation_commit: null
+cases: []

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/schema.discovered.json
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/schema.discovered.json
@@ -1,0 +1,566 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "vllm",
+  "engine_version": "0.7.3",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:vllm-0.7.3",
+  "base_image_ref": null,
+  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+  "discovery_limitations": [
+    {
+      "section": "sampling_params",
+      "fields": [],
+      "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative _verify_args() and are not introspectable from field metadata"
+    },
+    {
+      "section": "engine_params",
+      "fields": [],
+      "reason": "per-field descriptions unavailable (vLLM EngineArgs has only a class docstring)"
+    }
+  ],
+  "engine_params": {
+    "model": {
+      "type": "str",
+      "default": "facebook/opt-125m"
+    },
+    "served_model_name": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "tokenizer": {
+      "type": "str | None",
+      "default": null
+    },
+    "task": {
+      "type": "Literal['auto', 'generate', 'embedding', 'embed', 'classify', 'score', 'reward', 'transcription']",
+      "default": "auto"
+    },
+    "skip_tokenizer_init": {
+      "type": "bool",
+      "default": false
+    },
+    "tokenizer_mode": {
+      "type": "str",
+      "default": "auto"
+    },
+    "trust_remote_code": {
+      "type": "bool",
+      "default": false
+    },
+    "allowed_local_media_path": {
+      "type": "str",
+      "default": ""
+    },
+    "download_dir": {
+      "type": "str | None",
+      "default": null
+    },
+    "load_format": {
+      "type": "str",
+      "default": "auto"
+    },
+    "config_format": {
+      "type": "ConfigFormat",
+      "default": "auto"
+    },
+    "dtype": {
+      "type": "str",
+      "default": "auto"
+    },
+    "kv_cache_dtype": {
+      "type": "str",
+      "default": "auto"
+    },
+    "seed": {
+      "type": "int",
+      "default": 0
+    },
+    "max_model_len": {
+      "type": "int | None",
+      "default": null
+    },
+    "distributed_executor_backend": {
+      "type": "str | type[ExecutorBase] | None",
+      "default": null
+    },
+    "pipeline_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "tensor_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "max_parallel_loading_workers": {
+      "type": "int | None",
+      "default": null
+    },
+    "block_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "enable_prefix_caching": {
+      "type": "bool | None",
+      "default": null
+    },
+    "disable_sliding_window": {
+      "type": "bool",
+      "default": false
+    },
+    "use_v2_block_manager": {
+      "type": "bool",
+      "default": true
+    },
+    "swap_space": {
+      "type": "float",
+      "default": 4
+    },
+    "cpu_offload_gb": {
+      "type": "float",
+      "default": 0
+    },
+    "gpu_memory_utilization": {
+      "type": "float",
+      "default": 0.9
+    },
+    "max_num_batched_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_num_partial_prefills": {
+      "type": "int | None",
+      "default": 1
+    },
+    "max_long_partial_prefills": {
+      "type": "int | None",
+      "default": 1
+    },
+    "long_prefill_token_threshold": {
+      "type": "int | None",
+      "default": 0
+    },
+    "max_num_seqs": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_logprobs": {
+      "type": "int",
+      "default": 20
+    },
+    "disable_log_stats": {
+      "type": "bool",
+      "default": false
+    },
+    "revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "code_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "rope_scaling": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "rope_theta": {
+      "type": "float | None",
+      "default": null
+    },
+    "hf_overrides": {
+      "type": "dict[str, Any] | Callable[[<class 'transformers.configuration_utils.PretrainedConfig'>], PretrainedConfig] | None",
+      "default": null
+    },
+    "tokenizer_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "quantization": {
+      "type": "str | None",
+      "default": null
+    },
+    "enforce_eager": {
+      "type": "bool | None",
+      "default": null
+    },
+    "max_seq_len_to_capture": {
+      "type": "int",
+      "default": 8192
+    },
+    "disable_custom_all_reduce": {
+      "type": "bool",
+      "default": false
+    },
+    "tokenizer_pool_size": {
+      "type": "int",
+      "default": 0
+    },
+    "tokenizer_pool_type": {
+      "type": "str | type[ForwardRef('BaseTokenizerGroup')]",
+      "default": "ray"
+    },
+    "tokenizer_pool_extra_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "limit_mm_per_prompt": {
+      "type": "Mapping[str, int] | None",
+      "default": null
+    },
+    "mm_processor_kwargs": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "disable_mm_preprocessor_cache": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_lora": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_lora_bias": {
+      "type": "bool",
+      "default": false
+    },
+    "max_loras": {
+      "type": "int",
+      "default": 1
+    },
+    "max_lora_rank": {
+      "type": "int",
+      "default": 16
+    },
+    "enable_prompt_adapter": {
+      "type": "bool",
+      "default": false
+    },
+    "max_prompt_adapters": {
+      "type": "int",
+      "default": 1
+    },
+    "max_prompt_adapter_token": {
+      "type": "int",
+      "default": 0
+    },
+    "fully_sharded_loras": {
+      "type": "bool",
+      "default": false
+    },
+    "lora_extra_vocab_size": {
+      "type": "int",
+      "default": 256
+    },
+    "long_lora_scaling_factors": {
+      "type": "tuple[float] | None",
+      "default": null
+    },
+    "lora_dtype": {
+      "type": "str | dtype | None",
+      "default": "auto"
+    },
+    "max_cpu_loras": {
+      "type": "int | None",
+      "default": null
+    },
+    "device": {
+      "type": "str",
+      "default": "auto"
+    },
+    "num_scheduler_steps": {
+      "type": "int",
+      "default": 1
+    },
+    "multi_step_stream_outputs": {
+      "type": "bool",
+      "default": true
+    },
+    "ray_workers_use_nsight": {
+      "type": "bool",
+      "default": false
+    },
+    "num_gpu_blocks_override": {
+      "type": "int | None",
+      "default": null
+    },
+    "num_lookahead_slots": {
+      "type": "int",
+      "default": 0
+    },
+    "model_loader_extra_config": {
+      "type": "dict | None",
+      "default": null
+    },
+    "ignore_patterns": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "preemption_mode": {
+      "type": "str | None",
+      "default": null
+    },
+    "scheduler_delay_factor": {
+      "type": "float",
+      "default": 0.0
+    },
+    "enable_chunked_prefill": {
+      "type": "bool | None",
+      "default": null
+    },
+    "guided_decoding_backend": {
+      "type": "str",
+      "default": "xgrammar"
+    },
+    "logits_processor_pattern": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_model": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_model_quantization": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_draft_tensor_parallel_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "num_speculative_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "speculative_disable_mqa_scorer": {
+      "type": "bool | None",
+      "default": false
+    },
+    "speculative_max_model_len": {
+      "type": "int | None",
+      "default": null
+    },
+    "speculative_disable_by_batch_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "ngram_prompt_lookup_max": {
+      "type": "int | None",
+      "default": null
+    },
+    "ngram_prompt_lookup_min": {
+      "type": "int | None",
+      "default": null
+    },
+    "spec_decoding_acceptance_method": {
+      "type": "str",
+      "default": "rejection_sampler"
+    },
+    "typical_acceptance_sampler_posterior_threshold": {
+      "type": "float | None",
+      "default": null
+    },
+    "typical_acceptance_sampler_posterior_alpha": {
+      "type": "float | None",
+      "default": null
+    },
+    "qlora_adapter_name_or_path": {
+      "type": "str | None",
+      "default": null
+    },
+    "disable_logprobs_during_spec_decoding": {
+      "type": "bool | None",
+      "default": null
+    },
+    "otlp_traces_endpoint": {
+      "type": "str | None",
+      "default": null
+    },
+    "collect_detailed_traces": {
+      "type": "str | None",
+      "default": null
+    },
+    "disable_async_output_proc": {
+      "type": "bool",
+      "default": false
+    },
+    "scheduling_policy": {
+      "type": "Literal['fcfs', 'priority']",
+      "default": "fcfs"
+    },
+    "scheduler_cls": {
+      "type": "str | type[object]",
+      "default": "vllm.core.scheduler.Scheduler"
+    },
+    "override_neuron_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "override_pooler_config": {
+      "type": "PoolerConfig | None",
+      "default": null
+    },
+    "compilation_config": {
+      "type": "CompilationConfig | None",
+      "default": null
+    },
+    "worker_cls": {
+      "type": "str",
+      "default": "auto"
+    },
+    "kv_transfer_config": {
+      "type": "KVTransferConfig | None",
+      "default": null
+    },
+    "generation_config": {
+      "type": "str | None",
+      "default": null
+    },
+    "override_generation_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "enable_sleep_mode": {
+      "type": "bool",
+      "default": false
+    },
+    "model_impl": {
+      "type": "str",
+      "default": "auto"
+    },
+    "calculate_kv_scales": {
+      "type": "bool | None",
+      "default": null
+    },
+    "additional_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    }
+  },
+  "sampling_params": {
+    "n": {
+      "type": "integer",
+      "default": 1
+    },
+    "best_of": {
+      "type": "unknown",
+      "default": null
+    },
+    "_real_n": {
+      "type": "unknown",
+      "default": null
+    },
+    "presence_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "frequency_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "repetition_penalty": {
+      "type": "number",
+      "default": 1.0
+    },
+    "temperature": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_p": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_k": {
+      "type": "integer",
+      "default": -1
+    },
+    "min_p": {
+      "type": "number",
+      "default": 0.0
+    },
+    "seed": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop_token_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "bad_words": {
+      "type": "unknown",
+      "default": null
+    },
+    "ignore_eos": {
+      "type": "boolean",
+      "default": false
+    },
+    "max_tokens": {
+      "type": "unknown",
+      "default": 16
+    },
+    "min_tokens": {
+      "type": "integer",
+      "default": 0
+    },
+    "logprobs": {
+      "type": "unknown",
+      "default": null
+    },
+    "prompt_logprobs": {
+      "type": "unknown",
+      "default": null
+    },
+    "detokenize": {
+      "type": "boolean",
+      "default": true
+    },
+    "skip_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "spaces_between_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "logits_processors": {
+      "type": "unknown",
+      "default": null
+    },
+    "include_stop_str_in_output": {
+      "type": "boolean",
+      "default": false
+    },
+    "truncate_prompt_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "output_kind": {
+      "type": "unknown",
+      "default": 0
+    },
+    "output_text_buffer_length": {
+      "type": "integer",
+      "default": 0
+    },
+    "_all_stop_token_ids": {
+      "type": "array",
+      "default": []
+    },
+    "guided_decoding": {
+      "type": "unknown",
+      "default": null
+    },
+    "logit_bias": {
+      "type": "unknown",
+      "default": null
+    },
+    "allowed_token_ids": {
+      "type": "unknown",
+      "default": null
+    }
+  }
+}

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/ssot.yaml
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/ssot.yaml
@@ -1,0 +1,34 @@
+# Per-engine version-bundle SSOT for vllm.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, validation gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+#
+# Existing drift between `library.current_version` (Dockerfile-pinned 0.7.3)
+# and `miner_pins.*` (host-installed 0.17.x range) is intentional: the
+# miner is a CI-time tool whose host install diverges from the published
+# container image. Tracked in #378; Renovate will reconcile on the next
+# bump cycle.
+schema_version: 1
+engine: vllm
+library:
+  pep503_name: vllm
+  current_version: "0.7.3"
+  current_commit_sha: null
+image:
+  base_image_ref: "vllm/vllm-openai:v0.7.3"
+  llem_image_ref: null
+miner_pins:
+  static: ">=0.17,<0.18"
+  dynamic: ">=0.17,<0.18"
+  discovery: ">=0.17,<0.18"
+artefact_paths:
+  engine_invariants: src/llenergymeasure/engines/vllm/invariants.proposed.yaml
+  validated_invariants: src/llenergymeasure/engines/vllm/invariants.validated.yaml
+  discovered_schemas: src/llenergymeasure/engines/vllm/schema.discovered.json
+last_probe:
+  verdict: pass
+  version_inside_envelope: false
+  fingerprint: "c162e9d8bd82bd20dede4fabfc6c2a08ae2c460989c12ade558c48310b4b6c1c"
+  fingerprint_drift: []

--- a/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: transformers
 engine_version: 4.57.3
-mined_at: '2026-05-08T18:11:20+02:00'
+mined_at: '2026-05-08T04:16:13+02:00'
 invariants:
 - id: transformers_beam_search_num_beams_eq_1
   engine: transformers

--- a/src/llenergymeasure/engines/transformers/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-08T18:11:20+02:00'
-validation_commit: 216ef502375feb5295b527954f128ea6c527b746
+validated_at: '2026-05-08T04:16:13+02:00'
+validation_commit: 594affde7c1d43075018bbb61c893e875b795d7b
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-08T18:11:20+02:00",
+  "discovered_at": "2026-05-08T04:16:13+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-08T18:11:20+02:00",
+  "discovered_at": "2026-05-08T04:16:13+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {

--- a/tests/_engine_archive/test_dispatcher.py
+++ b/tests/_engine_archive/test_dispatcher.py
@@ -89,3 +89,19 @@ def test_unknown_producer_raises_loud() -> None:
     with pytest.raises(ModuleNotFoundError):
         # ``introspector`` is the user-facing name; the SSOT key is ``discovery``.
         load_machinery(engine="vllm", version="0.7.3", producer="introspector")  # type: ignore[arg-type]
+
+
+def test_dispatcher_error_message_names_file_to_create() -> None:
+    """Missing-machinery diagnostic must name the exact file path.
+
+    This is the primary signal a maintainer sees when a Renovate-driven SSOT
+    bump outpaces the per-version vendoring. The error must point them at
+    the file to create so the next chunk PR is unblocked without spelunking.
+    """
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        load_machinery(engine="vllm", version="0.16.0", producer="static")
+    msg = str(exc_info.value)
+    assert "vllm" in msg
+    assert "0.16.0" in msg
+    assert "src/llenergymeasure/_engine_archive/vllm/v0_16_0/machinery/static.py" in msg
+    assert "LANDMARKS" in msg

--- a/tests/_engine_archive/test_dispatcher.py
+++ b/tests/_engine_archive/test_dispatcher.py
@@ -1,0 +1,91 @@
+"""Unit tests for the version-aware machinery dispatcher.
+
+Exercises ``load_machinery`` for every (engine, version, producer) cell
+populated by PR-0; verifies the LANDMARKS contract; verifies the
+no-fallback rule (unknown version raises ``ModuleNotFoundError``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llenergymeasure._engine_archive._dispatcher import load_machinery
+from scripts.engine_miners._ssot import safe_version
+
+# ---------------------------------------------------------------------------
+# safe_version mangling
+# ---------------------------------------------------------------------------
+
+
+def test_safe_version_dotted_to_underscore() -> None:
+    assert safe_version("0.7.3") == "v0_7_3"
+    assert safe_version("4.57.3") == "v4_57_3"
+    assert safe_version("1.2.0") == "v1_2_0"
+
+
+def test_safe_version_handles_hyphenated_prerelease() -> None:
+    # Hyphens (e.g. PEP-440 dev / pre tags written as 1.2.0-rc1) are also
+    # mapped to underscores; the safe form remains a legal identifier.
+    assert safe_version("1.2.0-rc1") == "v1_2_0_rc1"
+
+
+def test_safe_version_rejects_non_alphanumeric() -> None:
+    with pytest.raises(ValueError):
+        safe_version("0.7.3+cuda12")  # build metadata not supported
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher resolution
+# ---------------------------------------------------------------------------
+
+
+_SUPPORTED_CELLS = [
+    ("vllm", "0.7.3", "static"),
+    ("vllm", "0.7.3", "discovery"),
+    ("tensorrt", "0.21.0", "static"),
+    ("tensorrt", "0.21.0", "discovery"),
+    ("transformers", "4.57.3", "static"),
+    ("transformers", "4.57.3", "discovery"),
+]
+
+
+@pytest.mark.parametrize("engine,version,producer", _SUPPORTED_CELLS)
+def test_load_machinery_returns_module_with_landmarks(
+    engine: str, version: str, producer: str
+) -> None:
+    """Every (engine, version, producer) cell in PR-0 exposes LANDMARKS."""
+    machinery = load_machinery(engine=engine, version=version, producer=producer)
+    landmarks = machinery.LANDMARKS
+    assert isinstance(landmarks, tuple), (
+        f"{engine}/{version}/{producer}: LANDMARKS must be a tuple, got {type(landmarks).__name__}"
+    )
+    assert all(isinstance(s, str) for s in landmarks), (
+        f"{engine}/{version}/{producer}: every LANDMARKS entry must be a str"
+    )
+    assert len(landmarks) > 0, f"{engine}/{version}/{producer}: LANDMARKS must be non-empty"
+    assert all("." in s for s in landmarks), (
+        f"{engine}/{version}/{producer}: LANDMARKS entries must be dotted attribute paths"
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-fallback contract
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_version_raises_loud() -> None:
+    """Plan's no-fallback rule: an unknown version surfaces ModuleNotFoundError."""
+    with pytest.raises(ModuleNotFoundError):
+        load_machinery(engine="vllm", version="999.999.999", producer="static")
+
+
+def test_unknown_engine_raises_loud() -> None:
+    with pytest.raises(ModuleNotFoundError):
+        load_machinery(engine="not-a-real-engine", version="0.7.3", producer="static")
+
+
+def test_unknown_producer_raises_loud() -> None:
+    """Dispatcher accepts only the three SSOT producer kinds."""
+    with pytest.raises(ModuleNotFoundError):
+        # ``introspector`` is the user-facing name; the SSOT key is ``discovery``.
+        load_machinery(engine="vllm", version="0.7.3", producer="introspector")  # type: ignore[arg-type]

--- a/tests/_engine_archive/test_producer_lazy.py
+++ b/tests/_engine_archive/test_producer_lazy.py
@@ -1,0 +1,64 @@
+"""End-to-end test of the producer module lazy LANDMARKS pattern.
+
+Each producer module (3 invariants miners + 3 schema introspectors) exposes
+``LANDMARKS`` via PEP 562 ``__getattr__`` that delegates to the dispatcher.
+This test verifies the full chain ``producer module -> __getattr__ -> dispatcher
+-> archive subpackage -> LANDMARKS`` resolves correctly at the current SSOT
+``library.current_version`` for every (engine, producer) cell.
+
+The test also asserts that the producer's exposed tuple is byte-identical to
+what the archive returns directly. Drift between the two is a refactor-time
+trap: if the producer re-export wiring drifts from the archive contents
+(e.g. someone updates the archive but forgets to flip the ``producer=`` arg
+in the producer module's dispatcher call), this test fails loud.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from llenergymeasure._engine_archive._dispatcher import load_machinery
+from scripts.engine_miners._ssot import load_ssot
+
+# (producer module path, engine, producer kind) for every probe-driving
+# producer module currently shipped. Mirrors ``_PRODUCER_MODULES`` in
+# ``scripts/_probe.py`` plus the SSOT-side ``static`` / ``discovery`` keys.
+_PRODUCERS: list[tuple[str, str, str]] = [
+    ("scripts.engine_miners.transformers_miner", "transformers", "static"),
+    ("scripts.engine_miners.vllm_static_miner", "vllm", "static"),
+    ("scripts.engine_miners.tensorrt_static_miner", "tensorrt", "static"),
+    ("scripts.engine_introspectors.transformers_introspector", "transformers", "discovery"),
+    ("scripts.engine_introspectors.vllm_introspector", "vllm", "discovery"),
+    ("scripts.engine_introspectors.tensorrt_introspector", "tensorrt", "discovery"),
+]
+
+
+@pytest.mark.parametrize("module_path,engine,producer", _PRODUCERS)
+def test_producer_lazy_landmarks_matches_archive(
+    module_path: str, engine: str, producer: str
+) -> None:
+    """Producer's exposed ``LANDMARKS`` must match the archive's tuple."""
+    producer_module = importlib.import_module(module_path)
+    landmarks_via_producer = producer_module.LANDMARKS
+
+    ssot = load_ssot(engine)
+    library = ssot["library"]
+    assert isinstance(library, dict)
+    version = str(library["current_version"])
+
+    landmarks_via_archive = load_machinery(
+        engine=engine,
+        version=version,
+        producer=producer,  # type: ignore[arg-type]
+    ).LANDMARKS
+
+    assert landmarks_via_producer == landmarks_via_archive, (
+        f"Producer {module_path} LANDMARKS drift from archive at "
+        f"{engine}=={version} ({producer}). Producer wiring may reference "
+        f"the wrong producer kind, the wrong engine, or the wrong SSOT field."
+    )
+    assert isinstance(landmarks_via_producer, tuple)
+    assert len(landmarks_via_producer) > 0
+    assert all(isinstance(s, str) for s in landmarks_via_producer)

--- a/tests/_engine_archive/test_renovate_regex.py
+++ b/tests/_engine_archive/test_renovate_regex.py
@@ -1,0 +1,68 @@
+"""Renovate regex regression test.
+
+The customManagers regex in ``renovate.json`` matches the ``pep503_name``
++ ``current_version`` pair on adjacent lines of every top-level
+``engine_versions/<engine>.yaml``. Inserting a comment, blank line, or
+new field between those two lines silently breaks Renovate detection
+(``\\s*\\n\\s*`` allows whitespace only). This test catches that drift in
+PR review by asserting the regex matches every top-level SSOT.
+
+Per the second adversarial pass on PR-0 (FM 5 mitigation).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_regex_pattern() -> str:
+    """Read the customManagers regex from renovate.json.
+
+    Renovate uses JavaScript-flavoured regex (named groups written as
+    ``(?<name>...)``); Python's ``re`` module requires ``(?P<name>...)``.
+    Translate at load time so the test exercises the same line-shape
+    requirements against the YAML, just via a Python-compatible engine.
+    """
+    cfg = json.loads((_REPO_ROOT / "renovate.json").read_text())
+    managers = cfg.get("customManagers", [])
+    for mgr in managers:
+        if mgr.get("customType") == "regex":
+            patterns = mgr.get("matchStrings", [])
+            if patterns:
+                # JS (?<name>) -> Python (?P<name>). Single regex pass since
+                # ``)`` -terminated.
+                return re.sub(r"\(\?<", "(?P<", str(patterns[0]))
+    pytest.fail("No customManagers[].matchStrings entry found in renovate.json")
+
+
+@pytest.mark.parametrize("engine", ["transformers", "vllm", "tensorrt"])
+def test_renovate_regex_matches_top_level_ssot(engine: str) -> None:
+    """Top-level engine_versions/<engine>.yaml MUST match Renovate's regex.
+
+    If this fails, Renovate has stopped detecting library bumps for
+    ``engine``. Likely cause: a comment / blank line / new field has been
+    interleaved between ``pep503_name:`` and ``current_version:``. The
+    regex requires only whitespace between them.
+    """
+    pattern = _load_regex_pattern()
+    text = (_REPO_ROOT / "engine_versions" / f"{engine}.yaml").read_text()
+    match = re.search(pattern, text)
+    assert match is not None, (
+        f"engine_versions/{engine}.yaml does not match Renovate's pep503_name+"
+        f"current_version regex. Did someone interleave a comment/blank line "
+        f"between those two fields? Renovate's regex is `\\s*\\n\\s*` between "
+        f"fields - strict whitespace only."
+    )
+    # depName + currentValue must both have been captured.
+    assert match.group("depName"), (
+        f"Renovate regex matched {engine}.yaml but did not capture depName."
+    )
+    assert match.group("currentValue"), (
+        f"Renovate regex matched {engine}.yaml but did not capture currentValue."
+    )

--- a/tests/_engine_archive/test_smoke.py
+++ b/tests/_engine_archive/test_smoke.py
@@ -1,0 +1,33 @@
+"""Smoke test for the _engine_archive package.
+
+Asserts that ``llenergymeasure._engine_archive.__file__`` resolves to a
+path under ``<repo>/src/llenergymeasure/_engine_archive/``. Catches the
+case where a stale pip-installed wheel of llenergymeasure (without the
+archive package) masks the in-tree source. This is the FM 1 mitigation
+recommended by the second adversarial pass on PR-0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import llenergymeasure._engine_archive as archive
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_engine_archive_loaded_from_source_tree() -> None:
+    """``_engine_archive.__file__`` must resolve under the repo's src/ tree.
+
+    If a stale pip-installed wheel is masking the source tree (e.g. user
+    has ``pip install llenergymeasure==0.9.0`` from before the archive
+    existed), this test fails loud rather than letting the dispatcher
+    silently load empty/missing machinery.
+    """
+    archive_file = Path(archive.__file__).resolve()
+    expected = _REPO_ROOT / "src" / "llenergymeasure" / "_engine_archive" / "__init__.py"
+    assert archive_file == expected.resolve(), (
+        f"_engine_archive.__file__ resolved to {archive_file}, expected {expected}. "
+        "A stale pip-installed wheel may be masking the in-tree archive. "
+        "Re-install in editable mode (`uv sync --dev`) or remove the cached wheel."
+    )


### PR DESCRIPTION
## Summary

Adds `src/llenergymeasure/_engine_archive/` as the importable, in-wheel home for per-engine, per-version probe machinery. Snapshots vllm 0.7.3, tensorrt 0.21.0, transformers 4.57.3 with frozen `LANDMARKS` for the static (invariants miner) and discovery (schema introspector) producers.

The 6 producer modules now expose `LANDMARKS` lazily via PEP 562 `__getattr__`, dispatching through `_engine_archive._dispatcher.load_machinery(engine, version, producer)`. The probe contract (`getattr(producer_module, "LANDMARKS")`) is unchanged.

Cell scripts gain a derivative dual-write: after canonical mining / discovery outputs land in `src/llenergymeasure/engines/<engine>/`, they are copied byte-identically to `_engine_archive/<engine>/<safe_version>/outputs/`. Future probe-blocked runs leave the archive in sync with the last successful run; the dual-tree determinism diff is 0 by construction.

## Why this shape

The earlier draft proposed top-level `engine_versions/<E>/v<V>/` for the archive. Adversarial review found two blockers: (1) the path was not Python-importable (no `__init__.py`, illegal-identifier version directories, not shipped in the wheel); (2) the dispatcher had nowhere to receive a version key from `scripts._probe`'s static `_PRODUCER_MODULES` table. Pivoting to `src/llenergymeasure/_engine_archive/` solves both — real Python package, ships in wheel, no touch on the runtime read path.

## Augmentations from second adversarial pass

- PEP 562 lazy `LANDMARKS`: defers archive load + SSOT parse to first access; pytest collection no longer drags engine machinery transitively.
- `_check_landmarks()` in `transformers_miner` iterates the LANDMARKS tuple instead of hardcoding (vllm / tensorrt orchestrators do AST-level work coupled to `_AST_TARGETS`; deferred to first version-bump PR per engine).
- `scripts/_probe.py:_read_cached_fingerprint` skips drift comparison when cached `library_version` differs from current SSOT — removes cross-bump "every landmark drifted" noise.
- `import-linter` `forbidden` contract: runtime layers (`engines`, `harness`, `api`, ...) cannot import `_engine_archive`.
- `tests/_engine_archive/test_smoke.py`: asserts `_engine_archive.__file__` is in source tree (catches stale-installed-wheel masking).
- `scripts/clean_pycache.sh`: determinism-check hygiene.

## Test plan

- [x] `tests/_engine_archive/` (16 tests: dispatcher resolution × 6 cells, no-fallback contract, renovate.json regex regression × 3 engines, source-tree smoke check, `safe_version` mangling)
- [x] `tests/unit/` full suite (2459 passed, 53 skipped — no regressions)
- [x] All 6 producer modules import cleanly + resolve `LANDMARKS` lazily via dispatcher
- [x] Both cell-script YAML files parse cleanly via `yaml.safe_load`
- [ ] **Pending CI**: full pipeline probe + mine + cp on self-hosted GPU runner
- [ ] **Pending CI**: determinism check after pipeline run (archive == canonical on re-run)

## Out of scope (deferred to follow-up PRs / first chunk per engine)

- AST_TARGETS, walker patterns, introspector targets vendoring per-version. Left in orchestrator modules; first-time vendoring happens inside each engine's first version-bump PR (the rewrite work that PR does anyway).
- `_check_landmarks()` refactor for vllm and tensorrt static miners (do AST-level work tied to `_AST_TARGETS`; refactor surfaces in chunk-1).
- Per-comment marker version-stamping, source-tarball SHA pinning, last_probe per-version cache shape.

## Review notes

- `pyproject.toml` `version` is intentionally **not** bumped — versioning policy reserves milestone bumps for milestone completion. The smoke test handles the stale-wheel concern directly.
- Local `engine_versions/transformers.compat.json` was deleted before commit to clear the pre-pivot fingerprint cache. The file is `.gitignore`d, so only the dev environment is affected; CI writes a fresh entry on first probe.
- Draft until reviewed.