### PR TITLE
feat(engines): vendor vllm v0.7.3 machinery + producer refactor

### DIFF
--- a/scripts/engine_introspectors/vllm_introspector.py
+++ b/scripts/engine_introspectors/vllm_introspector.py
@@ -13,14 +13,46 @@ from scripts.engine_introspectors._common import (
     dataclass_fields_to_specs,
     make_envelope,
 )
+from scripts.engine_miners._ssot import load_ssot
 
 # Symbols this introspector relies on inside the live ``vllm`` package.
 # Read by ``scripts._probe`` before discovery runs; a missing landmark
 # flips the probe verdict to ``fail`` and skips downstream discovery.
-LANDMARKS: tuple[str, ...] = (
-    "vllm.SamplingParams",
-    "vllm.engine.arg_utils.EngineArgs",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.vllm.<safe_version>.machinery.discovery``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("vllm")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/vllm.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="vllm",
+        version=str(library["current_version"]),
+        producer="discovery",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:

--- a/scripts/engine_miners/vllm_static_miner.py
+++ b/scripts/engine_miners/vllm_static_miner.py
@@ -66,7 +66,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     find_method,
     first_string_arg,
 )
-from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin, load_ssot  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Engine + namespace conventions
@@ -88,37 +88,52 @@ NS_ENGINE = "vllm.engine"
 
 # Symbols this miner relies on resolving inside the live ``vllm`` package.
 # Read by ``scripts._probe`` before mining runs; a missing landmark flips
-# the probe verdict to ``fail`` and skips downstream stages. Mirrors the
-# ``_AST_TARGETS`` rows below at the dotted-path level so the probe can
-# detect upstream class / method renames without re-parsing the AST.
-LANDMARKS: tuple[str, ...] = (
-    "vllm.sampling_params.SamplingParams",
-    "vllm.sampling_params.SamplingParams._verify_args",
-    "vllm.sampling_params.SamplingParams.__post_init__",
-    "vllm.sampling_params.SamplingParams._verify_greedy_sampling",
-    "vllm.sampling_params.StructuredOutputsParams",
-    "vllm.sampling_params.StructuredOutputsParams.__post_init__",
-    "vllm.config.parallel.ParallelConfig",
-    "vllm.config.parallel.ParallelConfig._validate_parallel_config",
-    "vllm.config.parallel.ParallelConfig._verify_args",
-    "vllm.config.parallel.ParallelConfig.__post_init__",
-    "vllm.config.parallel.EPLBConfig",
-    "vllm.config.parallel.EPLBConfig._validate_eplb_config",
-    "vllm.config.lora.LoRAConfig",
-    "vllm.config.lora.LoRAConfig._validate_lora_config",
-    "vllm.config.multimodal.MultiModalConfig",
-    "vllm.config.multimodal.MultiModalConfig._validate_multimodal_config",
-    "vllm.config.structured_outputs.StructuredOutputsConfig",
-    "vllm.config.structured_outputs.StructuredOutputsConfig._validate_structured_output_config",
-    "vllm.config.cache.CacheConfig",
-    "vllm.config.cache.CacheConfig._validate_cache_dtype",
-    "vllm.config.model.ModelConfig",
-    "vllm.config.model.ModelConfig.__post_init__",
-    "vllm.config.compilation.CompilationConfig",
-    "vllm.config.compilation.CompilationConfig.__post_init__",
-    "vllm.config.scheduler.SchedulerConfig",
-    "vllm.config.scheduler.SchedulerConfig.__post_init__",
-)
+# the probe verdict to ``fail`` and skips downstream stages.
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.vllm.<safe_version>.machinery.static``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until the
+# probe (or in-module code) accesses ``LANDMARKS``.
+#
+# NOTE: ``_AST_TARGETS`` below remains hardcoded in this module for now.
+# Vendoring it into the per-version archive is deferred to chunk-1 (the
+# vllm 0.7.3 -> 0.16.0 PR), where the AST_TARGETS rewrite is the heart of
+# the work anyway. Until then, ``_check_landmarks()`` continues to do
+# AST-level verification against this in-module ``_AST_TARGETS`` registry.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``.
+
+    Caches in module ``globals()`` after first call so subsequent in-module
+    references read directly from the module dict without re-dispatching.
+    """
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("vllm")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/vllm.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="vllm",
+        version=str(library["current_version"]),
+        producer="static",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/_engine_archive/vllm/__init__.py
+++ b/src/llenergymeasure/_engine_archive/vllm/__init__.py
@@ -1,0 +1,7 @@
+"""vLLM per-version machinery archive.
+
+Subpackages here are version-pinned snapshots, one per shipped pipeline
+state. The active version is the one named in ``engine_versions/vllm.yaml``
+``library.current_version``; the dispatcher maps that to the matching
+subpackage via :func:`scripts.engine_miners._ssot.safe_version`.
+"""

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/__init__.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/__init__.py
@@ -1,0 +1,7 @@
+"""Frozen vLLM 0.7.3 machinery + outputs.
+
+Initial vendored snapshot. Holds LANDMARKS for the static miner and
+schema introspector. AST_TARGETS / walker patterns are deferred to a
+follow-up scaffold PR; until then those data structures live in their
+respective producer modules under ``scripts/engine_miners/``.
+"""

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/__init__.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``static`` (invariants), ``discovery`` (schemas)."""

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/discovery.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/discovery.py
@@ -1,0 +1,14 @@
+"""Schema-introspector LANDMARKS for vLLM 0.7.3.
+
+Read by the probe before the introspector runs inside the
+``vllm/vllm-openai:v0.7.3`` image. The introspector extracts engine
+parameter specs from ``EngineArgs`` (dataclass) and sampling parameter
+specs from ``SamplingParams`` (msgspec-typed).
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "vllm.SamplingParams",
+    "vllm.engine.arg_utils.EngineArgs",
+)

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/static.py
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/machinery/static.py
@@ -1,0 +1,42 @@
+"""Static-miner LANDMARKS for vLLM 0.7.3.
+
+These are the dotted attribute paths the probe verifies under the
+installed ``vllm`` package before the static miner runs. Mirrors the
+``_AST_TARGETS`` registry in ``scripts/engine_miners/vllm_static_miner.py``
+at the dotted-path level, plus class targets needed for AST walking.
+
+Frozen at vllm 0.7.3. Subsequent versions live alongside this file as
+sibling subpackages (``v0_16_0``, ``v0_18_1``, ...) populated by the
+chunk PRs that bump ``current_version`` in the SSOT.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "vllm.sampling_params.SamplingParams",
+    "vllm.sampling_params.SamplingParams._verify_args",
+    "vllm.sampling_params.SamplingParams.__post_init__",
+    "vllm.sampling_params.SamplingParams._verify_greedy_sampling",
+    "vllm.sampling_params.StructuredOutputsParams",
+    "vllm.sampling_params.StructuredOutputsParams.__post_init__",
+    "vllm.config.parallel.ParallelConfig",
+    "vllm.config.parallel.ParallelConfig._validate_parallel_config",
+    "vllm.config.parallel.ParallelConfig._verify_args",
+    "vllm.config.parallel.ParallelConfig.__post_init__",
+    "vllm.config.parallel.EPLBConfig",
+    "vllm.config.parallel.EPLBConfig._validate_eplb_config",
+    "vllm.config.lora.LoRAConfig",
+    "vllm.config.lora.LoRAConfig._validate_lora_config",
+    "vllm.config.multimodal.MultiModalConfig",
+    "vllm.config.multimodal.MultiModalConfig._validate_multimodal_config",
+    "vllm.config.structured_outputs.StructuredOutputsConfig",
+    "vllm.config.structured_outputs.StructuredOutputsConfig._validate_structured_output_config",
+    "vllm.config.cache.CacheConfig",
+    "vllm.config.cache.CacheConfig._validate_cache_dtype",
+    "vllm.config.model.ModelConfig",
+    "vllm.config.model.ModelConfig.__post_init__",
+    "vllm.config.compilation.CompilationConfig",
+    "vllm.config.compilation.CompilationConfig.__post_init__",
+    "vllm.config.scheduler.SchedulerConfig",
+    "vllm.config.scheduler.SchedulerConfig.__post_init__",
+)

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.proposed.yaml
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.proposed.yaml
@@ -1,0 +1,1497 @@
+schema_version: 1.0.0
+engine: vllm
+engine_version: 0.17.1
+miner_pinned_range: <0.18,>=0.17
+mined_at: '2026-04-27'
+invariants:
+- id: vllm_cacheconfig_cache_dtype_in_7_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.cache_dtype must be one of ['auto', 'bfloat16', 'fp8', 'fp8_e4m3', 'fp8_e5m2',
+    'fp8_inc', 'fp8_ds_mla']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.cache_dtype:
+        not_in:
+        - auto
+        - bfloat16
+        - fp8
+        - fp8_e4m3
+        - fp8_e5m2
+        - fp8_inc
+        - fp8_ds_mla
+  kwargs_positive:
+    cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_cpu_offload_gb_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.cpu_offload_gb requires >= 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.cpu_offload_gb:
+        <: 0
+  kwargs_positive:
+    cpu_offload_gb: -1
+  kwargs_negative:
+    cpu_offload_gb: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_gpu_memory_utilization_gt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.gpu_memory_utilization requires > 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.gpu_memory_utilization:
+        <=: 0
+  kwargs_positive:
+    gpu_memory_utilization: 0
+  kwargs_negative:
+    gpu_memory_utilization: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_gpu_memory_utilization_le_1
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.gpu_memory_utilization requires <= 1
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.gpu_memory_utilization:
+        '>': 1
+  kwargs_positive:
+    gpu_memory_utilization: 2
+  kwargs_negative:
+    gpu_memory_utilization: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_kv_offloading_backend_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.kv_offloading_backend must be one of ['native', 'lmcache']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.kv_offloading_backend:
+        not_in:
+        - native
+        - lmcache
+  kwargs_positive:
+    kv_offloading_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    kv_offloading_backend: native
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_block_size_gt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_block_size requires > 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_block_size:
+        <=: 0
+  kwargs_positive:
+    mamba_block_size: 0
+  kwargs_negative:
+    mamba_block_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_cache_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_cache_dtype must be one of ['auto', 'float32', 'float16']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_cache_dtype:
+        not_in:
+        - auto
+        - float32
+        - float16
+  kwargs_positive:
+    mamba_cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_cache_mode_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_cache_mode must be one of ['all', 'align', 'none']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_cache_mode:
+        not_in:
+        - all
+        - align
+        - none
+  kwargs_positive:
+    mamba_cache_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_cache_mode: all
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_mamba_ssm_cache_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.mamba_ssm_cache_dtype must be one of ['auto', 'float32', 'float16']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mamba_ssm_cache_dtype:
+        not_in:
+        - auto
+        - float32
+        - float16
+  kwargs_positive:
+    mamba_ssm_cache_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mamba_ssm_cache_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_prefix_caching_hash_algo_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.prefix_caching_hash_algo must be one of ['sha256', 'sha256_cbor', 'xxhash',
+    'xxhash_cbor']
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.prefix_caching_hash_algo:
+        not_in:
+        - sha256
+        - sha256_cbor
+        - xxhash
+        - xxhash_cbor
+  kwargs_positive:
+    prefix_caching_hash_algo: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    prefix_caching_hash_algo: sha256
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_cacheconfig_swap_space_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: CacheConfig.swap_space requires >= 0
+  severity: error
+  native_type: vllm.config.CacheConfig
+  miner_source:
+    path: vllm/config/cache.py
+    method: <pydantic_lift>
+    line_at_scan: 38
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.swap_space:
+        <: 0
+  kwargs_positive:
+    swap_space: -1
+  kwargs_negative:
+    swap_space: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_compilationconfig_compile_cache_save_format_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: CompilationConfig.compile_cache_save_format must be one of ['binary', 'unpacked']
+  severity: error
+  native_type: vllm.config.CompilationConfig
+  miner_source:
+    path: vllm/config/compilation.py
+    method: <pydantic_lift>
+    line_at_scan: 336
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.compile_cache_save_format:
+        not_in:
+        - binary
+        - unpacked
+  kwargs_positive:
+    compile_cache_save_format: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    compile_cache_save_format: binary
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.CompilationConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_compilationconfig_dormant_backend_eq
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'CompilationConfig.__post_init__: marks dormant when backend == '
+  severity: dormant
+  native_type: vllm.config.CompilationConfig
+  miner_source:
+    path: vllm/config/compilation.py
+    method: __post_init__
+    line_at_scan: 905
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.backend: ''
+  kwargs_positive:
+    backend: ''
+  kwargs_negative:
+    backend: _x
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - backend
+  message_template: null
+  references:
+  - vllm/config/compilation.py:905 (vllm.config.CompilationConfig.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_eplbconfig_num_redundant_experts_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: EPLBConfig.num_redundant_experts requires >= 0
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 50
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.num_redundant_experts:
+        <: 0
+  kwargs_positive:
+    num_redundant_experts: -1
+  kwargs_negative:
+    num_redundant_experts: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_eplbconfig_policy_in_1_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: EPLBConfig.policy must be one of ['default']
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 50
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.policy:
+        not_in:
+        - default
+  kwargs_positive:
+    policy: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    policy: default
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_eplbconfig_raises_log_balancedness_interval_le_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'EPLBConfig._validate_eplb_config: raises when log_balancedness present True AND log_balancedness_interval
+    <= 0'
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_eplb_config
+    line_at_scan: 89
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.log_balancedness:
+        present: true
+      vllm.engine.log_balancedness_interval:
+        <=: 0
+  kwargs_positive:
+    log_balancedness: 1
+    log_balancedness_interval: 0
+  kwargs_negative:
+    log_balancedness: 1
+    log_balancedness_interval: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: log_balancedness_interval must be greater than 0.
+  references:
+  - vllm/config/parallel.py:89 (vllm.config.EPLBConfig._validate_eplb_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_dormant_max_cpu_loras_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'LoRAConfig._validate_lora_config: marks dormant when max_cpu_loras absent True'
+  severity: dormant
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: _validate_lora_config
+    line_at_scan: 94
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_cpu_loras:
+        absent: true
+  kwargs_positive:
+    max_cpu_loras: null
+  kwargs_negative:
+    max_cpu_loras: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - max_cpu_loras
+  message_template: null
+  references:
+  - vllm/config/lora.py:94 (vllm.config.LoRAConfig._validate_lora_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_lora_dtype_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: LoRAConfig.lora_dtype must be one of ['auto', 'float16', 'bfloat16']
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.lora_dtype:
+        not_in:
+        - auto
+        - float16
+        - bfloat16
+  kwargs_positive:
+    lora_dtype: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    lora_dtype: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_max_lora_rank_in_9_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: LoRAConfig.max_lora_rank must be one of [1, 8, 16, 32, 64, 128, 256, 320, 512]
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_lora_rank:
+        not_in:
+        - 1
+        - 8
+        - 16
+        - 32
+        - 64
+        - 128
+        - 256
+        - 320
+        - 512
+  kwargs_positive:
+    max_lora_rank: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    max_lora_rank: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_loraconfig_max_loras_ge_1
+  engine: vllm
+  library: vllm
+  invariant_under_test: LoRAConfig.max_loras requires >= 1
+  severity: error
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: vllm/config/lora.py
+    method: <pydantic_lift>
+    line_at_scan: 28
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_loras:
+        <: 1
+  kwargs_positive:
+    max_loras: 0
+  kwargs_negative:
+    max_loras: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_modelconfig_convert_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.convert must be one of ['auto', 'none', 'embed', 'classify']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.convert:
+        not_in:
+        - auto
+        - none
+        - embed
+        - classify
+  kwargs_positive:
+    convert: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    convert: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_modelconfig_logprobs_mode_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.logprobs_mode must be one of ['raw_logits', 'raw_logprobs', 'processed_logits',
+    'processed_logprobs']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.logprobs_mode:
+        not_in:
+        - raw_logits
+        - raw_logprobs
+        - processed_logits
+        - processed_logprobs
+  kwargs_positive:
+    logprobs_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    logprobs_mode: raw_logits
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_modelconfig_mm_encoder_tp_mode_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.mm_encoder_tp_mode must be one of ['weights', 'data']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_encoder_tp_mode:
+        not_in:
+        - weights
+        - data
+  kwargs_positive:
+    mm_encoder_tp_mode: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mm_encoder_tp_mode: weights
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_encoder_tp_mode_in_2_values''; pydantic_lift
+    -> ''vllm_multimodalconfig_mm_encoder_tp_mode_in_2_values'''
+- id: vllm_modelconfig_mm_processor_cache_type_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.mm_processor_cache_type must be one of ['shm', 'lru']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_processor_cache_type:
+        not_in:
+        - shm
+        - lru
+  kwargs_positive:
+    mm_processor_cache_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    mm_processor_cache_type: shm
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_processor_cache_type_in_2_values''; pydantic_lift
+    -> ''vllm_multimodalconfig_mm_processor_cache_type_in_2_values'''
+- id: vllm_modelconfig_runner_in_4_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ModelConfig.runner must be one of ['auto', 'generate', 'pooling', 'draft']
+  severity: error
+  native_type: vllm.config.ModelConfig
+  miner_source:
+    path: vllm/config/model.py
+    method: <pydantic_lift>
+    line_at_scan: 99
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.runner:
+        not_in:
+        - auto
+        - generate
+        - pooling
+        - draft
+  kwargs_positive:
+    runner: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    runner: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_multimodalconfig_mm_processor_cache_gb_ge_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: MultiModalConfig.mm_processor_cache_gb requires >= 0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.mm_processor_cache_gb:
+        <: 0
+  kwargs_positive:
+    mm_processor_cache_gb: -1
+  kwargs_negative:
+    mm_processor_cache_gb: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_multimodalconfig_video_pruning_rate_ge_0p0
+  engine: vllm
+  library: vllm
+  invariant_under_test: MultiModalConfig.video_pruning_rate requires >= 0.0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.video_pruning_rate:
+        <: 0.0
+  kwargs_positive:
+    video_pruning_rate: -1.0
+  kwargs_negative:
+    video_pruning_rate: 0.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_multimodalconfig_video_pruning_rate_lt_1p0
+  engine: vllm
+  library: vllm
+  invariant_under_test: MultiModalConfig.video_pruning_rate requires < 1.0
+  severity: error
+  native_type: vllm.config.MultiModalConfig
+  miner_source:
+    path: vllm/config/multimodal.py
+    method: <pydantic_lift>
+    line_at_scan: 71
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.video_pruning_rate:
+        '>=': 1.0
+  kwargs_positive:
+    video_pruning_rate: 1.0
+  kwargs_negative:
+    video_pruning_rate: 0.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig__api_process_count_gt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig._api_process_count requires > 0
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_count:
+        <=: 0
+  kwargs_positive:
+    _api_process_count: 0
+  kwargs_negative:
+    _api_process_count: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig__api_process_rank_ge_neg1
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig._api_process_rank requires >= -1
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_rank:
+        <: -1
+  kwargs_positive:
+    _api_process_rank: -2
+  kwargs_negative:
+    _api_process_rank: -1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_all2all_backend_in_7_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig.all2all_backend must be one of ['naive', 'pplx', 'deepep_high_throughput',
+    'deepep_low_latency', 'mori', 'allgather_reducescatter', 'flashinfer_all2allv']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.all2all_backend:
+        not_in:
+        - naive
+        - pplx
+        - deepep_high_throughput
+        - deepep_low_latency
+        - mori
+        - allgather_reducescatter
+        - flashinfer_all2allv
+  kwargs_positive:
+    all2all_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    all2all_backend: naive
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_data_parallel_backend_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig.data_parallel_backend must be one of ['ray', 'mp']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_backend:
+        not_in:
+        - ray
+        - mp
+  kwargs_positive:
+    data_parallel_backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    data_parallel_backend: ray
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_dormant_all2all_backend_eq_pplx
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: marks dormant when all2all_backend == pplx'
+  severity: dormant
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 348
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.all2all_backend: pplx
+  kwargs_positive:
+    all2all_backend: pplx
+  kwargs_negative:
+    all2all_backend: allgather_reducescatter
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - all2all_backend
+  message_template: null
+  references:
+  - vllm/config/parallel.py:348 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_dormant_data_parallel_rank_set_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig.__post_init__: marks dormant when distributed_executor_backend == external_launcher
+    AND data_parallel_rank present True'
+  severity: dormant
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: __post_init__
+    line_at_scan: 676
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.distributed_executor_backend: external_launcher
+      vllm.engine.data_parallel_rank:
+        present: true
+  kwargs_positive:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 1
+  kwargs_negative:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 0
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - data_parallel_rank
+  message_template: null
+  references:
+  - vllm/config/parallel.py:676 (vllm.config.ParallelConfig.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_expert_placement_strategy_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: ParallelConfig.expert_placement_strategy must be one of ['linear', 'round_robin']
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: <pydantic_lift>
+    line_at_scan: 93
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.expert_placement_strategy:
+        not_in:
+        - linear
+        - round_robin
+  kwargs_positive:
+    expert_placement_strategy: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    expert_placement_strategy: linear
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_raises_api_process_rank_ge_ref_api_process_count
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when _api_process_rank >= @_api_process_count'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 337
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_rank:
+        '>=': '@_api_process_count'
+  kwargs_positive:
+    _api_process_count: 2
+    _api_process_rank: 2
+  kwargs_negative:
+    _api_process_count: 2
+    _api_process_rank: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: 'f''Invalid value of `_api_process_rank`. Expected to be `-1` or `[0, {self._api_process_count})`,
+    but found: {self._api_process_rank}'''
+  references:
+  - vllm/config/parallel.py:337 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_parallelconfig_raises_data_parallel_external_lb_set_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when data_parallel_size <= 1 AND
+    data_parallel_external_lb present True'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: vllm/config/parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 357
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_size:
+        <=: 1
+      vllm.engine.data_parallel_external_lb:
+        present: true
+  kwargs_positive:
+    data_parallel_size: 1
+    data_parallel_external_lb: 1
+  kwargs_negative:
+    data_parallel_size: 1
+    data_parallel_external_lb: false
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: data_parallel_external_lb can only be set when data_parallel_size > 1
+  references:
+  - vllm/config/parallel.py:357 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_poolerconfig_seq_pooling_type_in_3_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: PoolerConfig.seq_pooling_type must be one of ['CLS', 'LAST', 'MEAN']
+  severity: error
+  native_type: vllm.config.PoolerConfig
+  miner_source:
+    path: vllm/config/pooler.py
+    method: <pydantic_lift>
+    line_at_scan: 19
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.seq_pooling_type:
+        not_in:
+        - CLS
+        - LAST
+        - MEAN
+  kwargs_positive:
+    seq_pooling_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    seq_pooling_type: CLS
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_poolerconfig_tok_pooling_type_in_2_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: PoolerConfig.tok_pooling_type must be one of ['ALL', 'STEP']
+  severity: error
+  native_type: vllm.config.PoolerConfig
+  miner_source:
+    path: vllm/config/pooler.py
+    method: <pydantic_lift>
+    line_at_scan: 19
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.tok_pooling_type:
+        not_in:
+        - ALL
+        - STEP
+  kwargs_positive:
+    tok_pooling_type: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    tok_pooling_type: ALL
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'
+- id: vllm_sampling_token_counts_max_tokens_lt_min_tokens
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'sampling_token_counts: error when max_tokens < min_tokens'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: <probe>
+    line_at_scan: 0
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.max_tokens:
+        <: '@min_tokens'
+  kwargs_positive:
+    max_tokens: 1
+    min_tokens: 5
+  kwargs_negative:
+    max_tokens: null
+    min_tokens: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: min_tokens must be less than or equal to max_tokens=1, got 5.
+  references:
+  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  added_by: dynamic_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_dormant_bad_words_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when bad_words absent True'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 389
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.bad_words:
+        absent: true
+  kwargs_positive:
+    bad_words: null
+  kwargs_negative:
+    bad_words: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - bad_words
+  message_template: null
+  references:
+  - vllm/sampling_params.py:389 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_dormant_seed_eq_neg1
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when seed == -1'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 378
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.seed: -1
+  kwargs_positive:
+    seed: -1
+  kwargs_negative:
+    seed: 0
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - seed
+  message_template: null
+  references:
+  - vllm/sampling_params.py:378 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when skip_reading_prefix_cache absent
+    True'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: __post_init__
+    line_at_scan: 418
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.skip_reading_prefix_cache:
+        absent: true
+  kwargs_positive:
+    skip_reading_prefix_cache: null
+  kwargs_negative:
+    skip_reading_prefix_cache: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - skip_reading_prefix_cache
+  message_template: null
+  references:
+  - vllm/sampling_params.py:418 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when max_tokens present True AND min_tokens >
+    @max_tokens'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 472
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.max_tokens:
+        present: true
+      vllm.sampling.min_tokens:
+        '>': '@max_tokens'
+  kwargs_positive:
+    max_tokens: 1
+    min_tokens: 2
+  kwargs_negative:
+    max_tokens: 1
+    min_tokens: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'min_tokens must be less than or equal to max_tokens={self.max_tokens}, got {self.min_tokens}.'
+  references:
+  - vllm/sampling_params.py:472 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_min_tokens_lt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when min_tokens < 0'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 468
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.min_tokens:
+        <: 0
+  kwargs_positive:
+    min_tokens: -1
+  kwargs_negative:
+    min_tokens: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: min_tokens must be greater than or equal to 0, got -1.
+  references:
+  - vllm/sampling_params.py:468 (vllm.SamplingParams._verify_args)
+  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  added_by: static_miner
+  cross_validated_by:
+  - dynamic_miner
+  added_at: '2026-04-27'
+  conflict_note: 'message_template: dynamic miner text overrode static_miner''s template; id: static_miner
+    -> ''vllm_samplingparams_raises_min_tokens_lt_0''; dynamic_miner -> ''vllm_sampling_token_counts_min_tokens_lt_zero'''
+- id: vllm_samplingparams_raises_n_lt_1
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when n < 1'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 424
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.n:
+        <: 1
+  kwargs_positive:
+    n: 0
+  kwargs_negative:
+    n: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'n must be at least 1, got {self.n}.'
+  references:
+  - vllm/sampling_params.py:424 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_n_not_type_int
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when n type_is_not int'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 422
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.n:
+        type_is_not: int
+  kwargs_positive:
+    n: x
+  kwargs_negative:
+    n: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'n must be an int, but is of type {type(self.n)}'
+  references:
+  - vllm/sampling_params.py:422 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_top_k_lt_neg1
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when top_k < -1'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: vllm/sampling_params.py
+    method: _verify_args
+    line_at_scan: 452
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.top_k:
+        <: -1
+  kwargs_positive:
+    top_k: -2
+  kwargs_negative:
+    top_k: -1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: f'top_k must be 0 (disable), or at least 1, got {self.top_k}.'
+  references:
+  - vllm/sampling_params.py:452 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-04-27'
+- id: vllm_structuredoutputsconfig_backend_in_5_values
+  engine: vllm
+  library: vllm
+  invariant_under_test: StructuredOutputsConfig.backend must be one of ['auto', 'xgrammar', 'guidance', 'outlines',
+    'lm-format-enforcer']
+  severity: error
+  native_type: vllm.config.StructuredOutputsConfig
+  miner_source:
+    path: vllm/config/structured_outputs.py
+    method: <pydantic_lift>
+    line_at_scan: 17
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.backend:
+        not_in:
+        - auto
+        - xgrammar
+        - guidance
+        - outlines
+        - lm-format-enforcer
+  kwargs_positive:
+    backend: <invalid_pydantic_lift_probe>
+  kwargs_negative:
+    backend: auto
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: null
+  references:
+  - "vllm.StructuredOutputsConfig \u2014 Pydantic FieldInfo metadata"
+  added_by: pydantic_lift
+  added_at: '2026-04-27'

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.validated.yaml
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/invariants.validated.yaml
@@ -1,0 +1,9 @@
+# Pending validation-gate operationalisation — see issue #445
+schema_version: 1.0.0
+engine: vllm
+engine_version: 0.7.3
+image_ref: vllm/vllm-openai:v0.7.3
+base_image_ref: vllm/vllm-openai:v0.7.3
+validated_at: null
+validation_commit: null
+cases: []

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/schema.discovered.json
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/outputs/schema.discovered.json
@@ -1,0 +1,566 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "vllm",
+  "engine_version": "0.7.3",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:vllm-0.7.3",
+  "base_image_ref": null,
+  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+  "discovery_limitations": [
+    {
+      "section": "sampling_params",
+      "fields": [],
+      "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative _verify_args() and are not introspectable from field metadata"
+    },
+    {
+      "section": "engine_params",
+      "fields": [],
+      "reason": "per-field descriptions unavailable (vLLM EngineArgs has only a class docstring)"
+    }
+  ],
+  "engine_params": {
+    "model": {
+      "type": "str",
+      "default": "facebook/opt-125m"
+    },
+    "served_model_name": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "tokenizer": {
+      "type": "str | None",
+      "default": null
+    },
+    "task": {
+      "type": "Literal['auto', 'generate', 'embedding', 'embed', 'classify', 'score', 'reward', 'transcription']",
+      "default": "auto"
+    },
+    "skip_tokenizer_init": {
+      "type": "bool",
+      "default": false
+    },
+    "tokenizer_mode": {
+      "type": "str",
+      "default": "auto"
+    },
+    "trust_remote_code": {
+      "type": "bool",
+      "default": false
+    },
+    "allowed_local_media_path": {
+      "type": "str",
+      "default": ""
+    },
+    "download_dir": {
+      "type": "str | None",
+      "default": null
+    },
+    "load_format": {
+      "type": "str",
+      "default": "auto"
+    },
+    "config_format": {
+      "type": "ConfigFormat",
+      "default": "auto"
+    },
+    "dtype": {
+      "type": "str",
+      "default": "auto"
+    },
+    "kv_cache_dtype": {
+      "type": "str",
+      "default": "auto"
+    },
+    "seed": {
+      "type": "int",
+      "default": 0
+    },
+    "max_model_len": {
+      "type": "int | None",
+      "default": null
+    },
+    "distributed_executor_backend": {
+      "type": "str | type[ExecutorBase] | None",
+      "default": null
+    },
+    "pipeline_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "tensor_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "max_parallel_loading_workers": {
+      "type": "int | None",
+      "default": null
+    },
+    "block_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "enable_prefix_caching": {
+      "type": "bool | None",
+      "default": null
+    },
+    "disable_sliding_window": {
+      "type": "bool",
+      "default": false
+    },
+    "use_v2_block_manager": {
+      "type": "bool",
+      "default": true
+    },
+    "swap_space": {
+      "type": "float",
+      "default": 4
+    },
+    "cpu_offload_gb": {
+      "type": "float",
+      "default": 0
+    },
+    "gpu_memory_utilization": {
+      "type": "float",
+      "default": 0.9
+    },
+    "max_num_batched_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_num_partial_prefills": {
+      "type": "int | None",
+      "default": 1
+    },
+    "max_long_partial_prefills": {
+      "type": "int | None",
+      "default": 1
+    },
+    "long_prefill_token_threshold": {
+      "type": "int | None",
+      "default": 0
+    },
+    "max_num_seqs": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_logprobs": {
+      "type": "int",
+      "default": 20
+    },
+    "disable_log_stats": {
+      "type": "bool",
+      "default": false
+    },
+    "revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "code_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "rope_scaling": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "rope_theta": {
+      "type": "float | None",
+      "default": null
+    },
+    "hf_overrides": {
+      "type": "dict[str, Any] | Callable[[<class 'transformers.configuration_utils.PretrainedConfig'>], PretrainedConfig] | None",
+      "default": null
+    },
+    "tokenizer_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "quantization": {
+      "type": "str | None",
+      "default": null
+    },
+    "enforce_eager": {
+      "type": "bool | None",
+      "default": null
+    },
+    "max_seq_len_to_capture": {
+      "type": "int",
+      "default": 8192
+    },
+    "disable_custom_all_reduce": {
+      "type": "bool",
+      "default": false
+    },
+    "tokenizer_pool_size": {
+      "type": "int",
+      "default": 0
+    },
+    "tokenizer_pool_type": {
+      "type": "str | type[ForwardRef('BaseTokenizerGroup')]",
+      "default": "ray"
+    },
+    "tokenizer_pool_extra_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "limit_mm_per_prompt": {
+      "type": "Mapping[str, int] | None",
+      "default": null
+    },
+    "mm_processor_kwargs": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "disable_mm_preprocessor_cache": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_lora": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_lora_bias": {
+      "type": "bool",
+      "default": false
+    },
+    "max_loras": {
+      "type": "int",
+      "default": 1
+    },
+    "max_lora_rank": {
+      "type": "int",
+      "default": 16
+    },
+    "enable_prompt_adapter": {
+      "type": "bool",
+      "default": false
+    },
+    "max_prompt_adapters": {
+      "type": "int",
+      "default": 1
+    },
+    "max_prompt_adapter_token": {
+      "type": "int",
+      "default": 0
+    },
+    "fully_sharded_loras": {
+      "type": "bool",
+      "default": false
+    },
+    "lora_extra_vocab_size": {
+      "type": "int",
+      "default": 256
+    },
+    "long_lora_scaling_factors": {
+      "type": "tuple[float] | None",
+      "default": null
+    },
+    "lora_dtype": {
+      "type": "str | dtype | None",
+      "default": "auto"
+    },
+    "max_cpu_loras": {
+      "type": "int | None",
+      "default": null
+    },
+    "device": {
+      "type": "str",
+      "default": "auto"
+    },
+    "num_scheduler_steps": {
+      "type": "int",
+      "default": 1
+    },
+    "multi_step_stream_outputs": {
+      "type": "bool",
+      "default": true
+    },
+    "ray_workers_use_nsight": {
+      "type": "bool",
+      "default": false
+    },
+    "num_gpu_blocks_override": {
+      "type": "int | None",
+      "default": null
+    },
+    "num_lookahead_slots": {
+      "type": "int",
+      "default": 0
+    },
+    "model_loader_extra_config": {
+      "type": "dict | None",
+      "default": null
+    },
+    "ignore_patterns": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "preemption_mode": {
+      "type": "str | None",
+      "default": null
+    },
+    "scheduler_delay_factor": {
+      "type": "float",
+      "default": 0.0
+    },
+    "enable_chunked_prefill": {
+      "type": "bool | None",
+      "default": null
+    },
+    "guided_decoding_backend": {
+      "type": "str",
+      "default": "xgrammar"
+    },
+    "logits_processor_pattern": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_model": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_model_quantization": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_draft_tensor_parallel_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "num_speculative_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "speculative_disable_mqa_scorer": {
+      "type": "bool | None",
+      "default": false
+    },
+    "speculative_max_model_len": {
+      "type": "int | None",
+      "default": null
+    },
+    "speculative_disable_by_batch_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "ngram_prompt_lookup_max": {
+      "type": "int | None",
+      "default": null
+    },
+    "ngram_prompt_lookup_min": {
+      "type": "int | None",
+      "default": null
+    },
+    "spec_decoding_acceptance_method": {
+      "type": "str",
+      "default": "rejection_sampler"
+    },
+    "typical_acceptance_sampler_posterior_threshold": {
+      "type": "float | None",
+      "default": null
+    },
+    "typical_acceptance_sampler_posterior_alpha": {
+      "type": "float | None",
+      "default": null
+    },
+    "qlora_adapter_name_or_path": {
+      "type": "str | None",
+      "default": null
+    },
+    "disable_logprobs_during_spec_decoding": {
+      "type": "bool | None",
+      "default": null
+    },
+    "otlp_traces_endpoint": {
+      "type": "str | None",
+      "default": null
+    },
+    "collect_detailed_traces": {
+      "type": "str | None",
+      "default": null
+    },
+    "disable_async_output_proc": {
+      "type": "bool",
+      "default": false
+    },
+    "scheduling_policy": {
+      "type": "Literal['fcfs', 'priority']",
+      "default": "fcfs"
+    },
+    "scheduler_cls": {
+      "type": "str | type[object]",
+      "default": "vllm.core.scheduler.Scheduler"
+    },
+    "override_neuron_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "override_pooler_config": {
+      "type": "PoolerConfig | None",
+      "default": null
+    },
+    "compilation_config": {
+      "type": "CompilationConfig | None",
+      "default": null
+    },
+    "worker_cls": {
+      "type": "str",
+      "default": "auto"
+    },
+    "kv_transfer_config": {
+      "type": "KVTransferConfig | None",
+      "default": null
+    },
+    "generation_config": {
+      "type": "str | None",
+      "default": null
+    },
+    "override_generation_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "enable_sleep_mode": {
+      "type": "bool",
+      "default": false
+    },
+    "model_impl": {
+      "type": "str",
+      "default": "auto"
+    },
+    "calculate_kv_scales": {
+      "type": "bool | None",
+      "default": null
+    },
+    "additional_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    }
+  },
+  "sampling_params": {
+    "n": {
+      "type": "integer",
+      "default": 1
+    },
+    "best_of": {
+      "type": "unknown",
+      "default": null
+    },
+    "_real_n": {
+      "type": "unknown",
+      "default": null
+    },
+    "presence_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "frequency_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "repetition_penalty": {
+      "type": "number",
+      "default": 1.0
+    },
+    "temperature": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_p": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_k": {
+      "type": "integer",
+      "default": -1
+    },
+    "min_p": {
+      "type": "number",
+      "default": 0.0
+    },
+    "seed": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop_token_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "bad_words": {
+      "type": "unknown",
+      "default": null
+    },
+    "ignore_eos": {
+      "type": "boolean",
+      "default": false
+    },
+    "max_tokens": {
+      "type": "unknown",
+      "default": 16
+    },
+    "min_tokens": {
+      "type": "integer",
+      "default": 0
+    },
+    "logprobs": {
+      "type": "unknown",
+      "default": null
+    },
+    "prompt_logprobs": {
+      "type": "unknown",
+      "default": null
+    },
+    "detokenize": {
+      "type": "boolean",
+      "default": true
+    },
+    "skip_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "spaces_between_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "logits_processors": {
+      "type": "unknown",
+      "default": null
+    },
+    "include_stop_str_in_output": {
+      "type": "boolean",
+      "default": false
+    },
+    "truncate_prompt_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "output_kind": {
+      "type": "unknown",
+      "default": 0
+    },
+    "output_text_buffer_length": {
+      "type": "integer",
+      "default": 0
+    },
+    "_all_stop_token_ids": {
+      "type": "array",
+      "default": []
+    },
+    "guided_decoding": {
+      "type": "unknown",
+      "default": null
+    },
+    "logit_bias": {
+      "type": "unknown",
+      "default": null
+    },
+    "allowed_token_ids": {
+      "type": "unknown",
+      "default": null
+    }
+  }
+}

--- a/src/llenergymeasure/_engine_archive/vllm/v0_7_3/ssot.yaml
+++ b/src/llenergymeasure/_engine_archive/vllm/v0_7_3/ssot.yaml
@@ -1,0 +1,34 @@
+# Per-engine version-bundle SSOT for vllm.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, validation gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+#
+# Existing drift between `library.current_version` (Dockerfile-pinned 0.7.3)
+# and `miner_pins.*` (host-installed 0.17.x range) is intentional: the
+# miner is a CI-time tool whose host install diverges from the published
+# container image. Tracked in #378; Renovate will reconcile on the next
+# bump cycle.
+schema_version: 1
+engine: vllm
+library:
+  pep503_name: vllm
+  current_version: "0.7.3"
+  current_commit_sha: null
+image:
+  base_image_ref: "vllm/vllm-openai:v0.7.3"
+  llem_image_ref: null
+miner_pins:
+  static: ">=0.17,<0.18"
+  dynamic: ">=0.17,<0.18"
+  discovery: ">=0.17,<0.18"
+artefact_paths:
+  engine_invariants: src/llenergymeasure/engines/vllm/invariants.proposed.yaml
+  validated_invariants: src/llenergymeasure/engines/vllm/invariants.validated.yaml
+  discovered_schemas: src/llenergymeasure/engines/vllm/schema.discovered.json
+last_probe:
+  verdict: pass
+  version_inside_envelope: false
+  fingerprint: "c162e9d8bd82bd20dede4fabfc6c2a08ae2c460989c12ade558c48310b4b6c1c"
+  fingerprint_drift: []

--- a/tests/_engine_archive/test_vllm_lazy.py
+++ b/tests/_engine_archive/test_vllm_lazy.py
@@ -1,0 +1,64 @@
+"""Per-engine lazy-LANDMARKS tests for vLLM at v0.7.3.
+
+Asserts that the producer modules' PEP 562 ``__getattr__`` hooks resolve
+``LANDMARKS`` to the same tuple that ``load_machinery`` returns directly
+from the per-version archive subpackage. This catches drift between the
+producer-side wiring (script ``_get_landmarks`` + dispatcher call) and
+the archive contents (``_engine_archive/vllm/v0_7_3/machinery/*.py``).
+
+Mirror of ``tests/_engine_archive/test_dispatcher.py`` style: pytest,
+parametrize across producer kinds, no fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+
+from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+# (producer_module_path, producer_kind) pairs. The producer kind is the
+# SSOT-side name (``static`` / ``discovery``) the dispatcher routes on.
+_PRODUCERS: tuple[tuple[str, str], ...] = (
+    ("scripts.engine_miners.vllm_static_miner", "static"),
+    ("scripts.engine_introspectors.vllm_introspector", "discovery"),
+)
+
+
+def _import_producer(module_path: str) -> ModuleType:
+    """Import (or re-import) the producer module fresh.
+
+    Re-import avoids cross-test contamination of the module-global
+    ``LANDMARKS`` cache populated by ``_get_landmarks()``.
+    """
+    return importlib.import_module(module_path)
+
+
+@pytest.mark.parametrize("module_path,producer", _PRODUCERS)
+def test_producer_landmarks_is_non_empty_tuple_of_dotted_paths(
+    module_path: str, producer: str
+) -> None:
+    """The lazy LANDMARKS export must be a non-empty tuple of dotted paths."""
+    module = _import_producer(module_path)
+    landmarks = module.LANDMARKS  # triggers PEP 562 __getattr__
+    assert isinstance(landmarks, tuple), f"{module_path}.LANDMARKS must be a tuple"
+    assert len(landmarks) > 0, f"{module_path}.LANDMARKS must be non-empty"
+    for entry in landmarks:
+        assert isinstance(entry, str), f"LANDMARKS entry {entry!r} must be a string"
+        assert "." in entry, f"LANDMARKS entry {entry!r} must be a dotted path"
+
+
+@pytest.mark.parametrize("module_path,producer", _PRODUCERS)
+def test_producer_landmarks_matches_dispatcher(module_path: str, producer: str) -> None:
+    """Producer-side LANDMARKS must equal what the dispatcher returns directly.
+
+    Drift between these two means the producer module's ``_get_landmarks``
+    is resolving a different version (or wiring) than the per-version
+    archive at v0.7.3 actually contains - exactly the failure mode the
+    archive subpackage is meant to prevent.
+    """
+    module = _import_producer(module_path)
+    direct = load_machinery(engine="vllm", version="0.7.3", producer=producer).LANDMARKS
+    assert direct == module.LANDMARKS


### PR DESCRIPTION
## Summary

Chunk-0 for vllm in the engine-archive vendoring rollout. Activates the version-aware machinery dispatcher (landed in PR #598) for vllm at v0.7.3 (current SSOT pinned version).

Stacked on top of PR #598 (`chore/engine-archive-scaffold`). Until #598 merges to main, this PR's diff appears layered on top of it; once #598 lands, only the vllm-scoped changes remain.

- Adds `src/llenergymeasure/_engine_archive/vllm/v0_7_3/` with machinery modules (`static.py`, `discovery.py`), vendored output snapshots (invariants.proposed/validated, schema.discovered), and the v0.7.3 SSOT slice.
- Refactors `scripts/engine_miners/vllm_static_miner.py` and `scripts/engine_introspectors/vllm_introspector.py` to expose `LANDMARKS` lazily via PEP 562 `__getattr__` that delegates to `load_machinery(engine="vllm", version=<SSOT current>, producer=...)`. Module imports stay cheap; the archive load + SSOT parse defer until the probe (or in-module code) accesses `LANDMARKS`.
- The probe contract is unchanged - it still reads `getattr(producer, "LANDMARKS")`. Engine-pipeline behaviour for vllm changes from "hardcoded LANDMARKS in producer module" to "dispatcher-resolved LANDMARKS at v0_7_3" - same tuple contents, lazy load path.

Subsequent Renovate-driven vllm bumps create sibling `v0_16_0/`, `v0_18_1/`, `v0_19_1/` subpackages alongside `v0_7_3/`, each rewriting LANDMARKS for the new library API. The producer modules themselves do not change between bumps.

## Test plan

- [x] `tests/_engine_archive/test_vllm_lazy.py` (new) - parametrized across (static, discovery) producers; asserts the lazy LANDMARKS export is a non-empty tuple of dotted paths AND equals what `load_machinery` returns directly. Catches drift between producer wiring and archive contents.
- [x] All 11 PR-A tests still pass (dispatcher, smoke, renovate-regex).
- [x] `uv build --wheel` succeeds and the resulting wheel still excludes `_engine_archive/` (zero entries).
- [x] Pre-commit + pre-push hooks green.

15 tests pass total in `tests/_engine_archive/`.

## Boundary

Read-only on every other engine - no tensorrt or transformers content touched. No modifications to engine-agnostic infrastructure (dispatcher, Protocol, _ssot.py, _probe.py, cell scripts, pyproject.toml) - those remain PR-A's domain.