### PR TITLE
feat(engines): vendor transformers v4.57.3 machinery + producer refactor

### DIFF
--- a/scripts/engine_introspectors/transformers_introspector.py
+++ b/scripts/engine_introspectors/transformers_introspector.py
@@ -19,19 +19,47 @@ from scripts.engine_introspectors._common import (
     make_envelope,
     read_dockerfile_from,
 )
+from scripts.engine_miners._ssot import load_ssot
 
 # Symbols this introspector relies on inside the live ``transformers``
 # package. Read by ``scripts._probe`` before discovery runs; a missing
 # landmark flips the probe verdict to ``fail`` and skips downstream
 # discovery. Mirrors the imports inside :func:`discover`.
-LANDMARKS: tuple[str, ...] = (
-    "transformers.AutoModelForCausalLM",
-    "transformers.AutoModelForCausalLM.from_pretrained",
-    "transformers.PreTrainedModel",
-    "transformers.PreTrainedModel.from_pretrained",
-    "transformers.GenerationConfig",
-    "transformers.GenerationConfig.to_dict",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.transformers.<safe_version>.machinery.discovery``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("transformers")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/transformers.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="transformers",
+        version=str(library["current_version"]),
+        producer="discovery",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:

--- a/scripts/engine_miners/transformers_miner.py
+++ b/scripts/engine_miners/transformers_miner.py
@@ -63,7 +63,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     MinerSource,
     check_installed_version,
 )
-from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin, load_ssot  # noqa: E402
 from scripts.engine_miners.transformers_dynamic_miner import (  # noqa: E402
     walk_generation_config_invariants,
 )
@@ -72,12 +72,48 @@ from scripts.engine_miners.transformers_dynamic_miner import (  # noqa: E402
 # inside the live ``transformers`` package. Read by ``scripts._probe``
 # before mining runs; a missing landmark flips the probe verdict to
 # ``fail`` and skips the downstream stages without re-importing here.
-LANDMARKS: tuple[str, ...] = (
-    "transformers.GenerationConfig",
-    "transformers.GenerationConfig.validate",
-    "transformers.BitsAndBytesConfig",
-    "transformers.BitsAndBytesConfig.post_init",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.transformers.<safe_version>.machinery.static``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until the
+# probe (or in-module code) accesses ``LANDMARKS``; module import stays
+# cheap so unrelated test collection does not drag in the engine machinery.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``.
+
+    Caches in module ``globals()`` after first call so subsequent in-module
+    references (and the probe's ``getattr(module, "LANDMARKS")``) read
+    directly from the module dict without re-dispatching.
+    """
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("transformers")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/transformers.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="transformers",
+        version=str(library["current_version"]),
+        producer="static",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # ---------------------------------------------------------------------------
 # BitsAndBytesConfig type-check invariants (kept hand-curated - CPU-safe)
@@ -117,36 +153,26 @@ _BNB_TYPE_RULES: tuple[tuple[str, str, Any, Any], ...] = (
 
 
 def _check_landmarks() -> tuple[str, str]:
-    """Import transformers, verify the landmarks the miner relies on.
+    """Verify the archived LANDMARKS resolve under the live ``transformers`` package.
 
     Returns ``(installed_version, generation_config_source_path)``.
+
+    Iterates :data:`LANDMARKS` (lazy-loaded from
+    ``llenergymeasure._engine_archive``) and resolves each via the same
+    ``_resolve_landmark`` helper the probe uses, so the miner's runtime
+    landmark check cannot drift from the probe's static check. A missing
+    landmark raises :class:`MinerLandmarkMissingError`.
     """
-    try:
-        import transformers  # type: ignore
-    except ImportError as exc:
-        raise MinerLandmarkMissingError(
-            "transformers.__init__", detail="transformers not importable"
-        ) from exc
+    from scripts._probe import _resolve_landmark
 
-    try:
-        from transformers import GenerationConfig  # type: ignore
-    except ImportError as exc:
-        raise MinerLandmarkMissingError(
-            "transformers.GenerationConfig", detail="symbol not importable"
-        ) from exc
+    for landmark in _get_landmarks():
+        try:
+            _resolve_landmark(landmark)
+        except (AttributeError, ImportError) as exc:
+            raise MinerLandmarkMissingError(landmark, detail=str(exc)) from exc
 
-    if not hasattr(GenerationConfig, "validate"):
-        raise MinerLandmarkMissingError("GenerationConfig.validate")
-
-    try:
-        from transformers import BitsAndBytesConfig  # type: ignore
-    except ImportError as exc:
-        raise MinerLandmarkMissingError(
-            "transformers.BitsAndBytesConfig", detail="symbol not importable"
-        ) from exc
-
-    if not hasattr(BitsAndBytesConfig, "post_init"):
-        raise MinerLandmarkMissingError("BitsAndBytesConfig.post_init")
+    import transformers  # type: ignore
+    from transformers import GenerationConfig  # type: ignore
 
     source_path = inspect.getsourcefile(GenerationConfig) or "<unknown>"
     return transformers.__version__, source_path

--- a/src/llenergymeasure/_engine_archive/transformers/__init__.py
+++ b/src/llenergymeasure/_engine_archive/transformers/__init__.py
@@ -1,0 +1,7 @@
+"""Hugging Face Transformers per-version machinery archive.
+
+Subpackages here are version-pinned snapshots. LANDMARKS for the
+invariants miner reference ``GenerationConfig`` and ``BitsAndBytesConfig``
+runtime symbols; LANDMARKS for the schemas introspector reference
+``AutoModelForCausalLM``, ``PreTrainedModel``, and ``GenerationConfig``.
+"""

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/__init__.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/__init__.py
@@ -1,0 +1,7 @@
+"""Frozen Transformers 4.57.3 machinery + outputs.
+
+Initial vendored snapshot. The static-miner LANDMARKS cover the
+``GenerationConfig.validate`` and ``BitsAndBytesConfig.post_init`` seams
+the miner walks. The discovery LANDMARKS cover the ``from_pretrained``
+signatures and ``GenerationConfig.to_dict`` schema-discovery surface.
+"""

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/__init__.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``static`` (invariants), ``discovery`` (schemas)."""

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/discovery.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/discovery.py
@@ -1,0 +1,17 @@
+"""Schema-introspector LANDMARKS for Transformers 4.57.3.
+
+The introspector runs inside ``llenergymeasure:transformers-<tag>`` and
+lifts engine parameter specs via ``inspect.signature(from_pretrained)``
+and sampling parameter specs via ``GenerationConfig().to_dict()``.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "transformers.AutoModelForCausalLM",
+    "transformers.AutoModelForCausalLM.from_pretrained",
+    "transformers.PreTrainedModel",
+    "transformers.PreTrainedModel.from_pretrained",
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.to_dict",
+)

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/static.py
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/machinery/static.py
@@ -1,0 +1,16 @@
+"""Static-miner LANDMARKS for Transformers 4.57.3.
+
+Read by the probe before the invariants miner orchestrator
+(``scripts.engine_miners.transformers_miner``) runs. Covers the symbols
+the orchestrator's ``_check_landmarks()`` verifies plus the symbols the
+delegated dynamic miner (``transformers_dynamic_miner``) imports.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.validate",
+    "transformers.BitsAndBytesConfig",
+    "transformers.BitsAndBytesConfig.post_init",
+)

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.proposed.yaml
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.proposed.yaml
@@ -1,0 +1,1303 @@
+schema_version: 1.0.0
+engine: transformers
+engine_version: 4.57.3
+mined_at: '2026-05-06T22:57:22+02:00'
+invariants:
+- id: transformers_beam_search_num_beams_eq_1
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate flags `num_beams` (num beams eq 1)
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 345
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+  kwargs_positive:
+    num_beams: 1
+    num_beam_groups: 1
+    diversity_penalty: 0.0
+    early_stopping: true
+  kwargs_negative:
+    num_beams: 1
+    num_beam_groups: 1
+    diversity_penalty: 0.0
+    early_stopping: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: &id001 []
+  message_template: '`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag
+    is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.'
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+  conflict_note: 'id: dynamic_miner -> ''transformers_beam_search_num_beams_eq_1''; dynamic_miner -> ''transformers_early_stopping_type_num_beams_eq_1'''
+- id: transformers_cache_choice_cache_implementation_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `cache_implementation` (cache implementation not
+    in allowlist)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 349
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.cache_implementation:
+        present: true
+        not_in:
+        - dynamic
+        - static
+  kwargs_positive:
+    cache_implementation: nonsense
+    use_cache: true
+  kwargs_negative:
+    cache_implementation: null
+    use_cache: true
+  expected_outcome: &id002
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: 'Invalid `cache_implementation` (nonsense). Choose one of: (''static'', ''offloaded_static'',
+    ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'', ''offloaded_hybrid_chunked'',
+    ''dynamic'', ''dynamic_full'', ''offloaded'', ''quantized'')'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_cache_choice_use_cache_eq_false
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate flags `use_cache` (use cache eq false)
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 348
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.use_cache: false
+  kwargs_positive:
+    cache_implementation: static
+    use_cache: false
+  kwargs_negative:
+    cache_implementation: null
+    use_cache: false
+  expected_outcome: &id003
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: *id001
+  message_template: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation
+    will have no effect.
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_compile_config_type_compile_config_exceeds_zero
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `compile_config` (compile config exceeds zero)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 417
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.compile_config:
+        '>': 0
+  kwargs_positive:
+    compile_config: 42
+  kwargs_negative:
+    compile_config: null
+  expected_outcome: *id002
+  message_template: You provided `compile_config` as an instance of <class 'int'>, but it must be an instance
+    of `CompileConfig`.
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_compile_config_type_compile_config_type_not_in_CompileConfig
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `compile_config` (compile config type not in CompileConfig)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 417
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.compile_config:
+        present: true
+        type_is_not:
+        - CompileConfig
+  kwargs_positive:
+    compile_config: oops
+  kwargs_negative:
+    compile_config: null
+  expected_outcome: *id002
+  message_template: You provided `compile_config` as an instance of <class 'str'>, but it must be an instance
+    of `CompileConfig`.
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_dormant_early_stopping_set_true
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.minor_issues[key]_=_msg: marks dormant when num_beams == 1 AND
+    early_stopping present True (dropped: self.early_stopping is not False)'
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 606
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.early_stopping:
+        present: true
+  kwargs_positive:
+    num_beams: 1
+    early_stopping: true
+  kwargs_negative:
+    num_beams: 1
+    early_stopping: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: null
+  references:
+  - transformers/generation/configuration_utils.py:606 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.early_stopping is not False'
+- id: transformers_dormant_epsilon_cutoff_ne_0_0
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.minor_issues[key]_=_msg: marks dormant when epsilon_cutoff present
+    True AND epsilon_cutoff != 0.0 (dropped: self.do_sample is False)'
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 591
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.epsilon_cutoff:
+        '!=': 0.0
+        present: true
+  kwargs_positive:
+    epsilon_cutoff: true
+  kwargs_negative:
+    epsilon_cutoff: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: null
+  references:
+  - transformers/generation/configuration_utils.py:591 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.do_sample is False'
+- id: transformers_dormant_eta_cutoff_ne_0_0
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.minor_issues[key]_=_msg: marks dormant when eta_cutoff present
+    True AND eta_cutoff != 0.0 (dropped: self.do_sample is False)'
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 595
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.eta_cutoff:
+        '!=': 0.0
+        present: true
+  kwargs_positive:
+    eta_cutoff: true
+  kwargs_negative:
+    eta_cutoff: false
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: null
+  references:
+  - transformers/generation/configuration_utils.py:595 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.do_sample is False'
+- id: transformers_early_stopping_type_early_stopping_exceeds_zero
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `early_stopping` (early stopping exceeds zero)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.early_stopping:
+        '>': 0
+  kwargs_positive:
+    early_stopping: 1.5
+    num_beams: 1
+  kwargs_negative:
+    early_stopping: false
+    num_beams: 1
+  expected_outcome: *id002
+  message_template: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_early_stopping_type_early_stopping_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `early_stopping` (early stopping not in allowlist)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.early_stopping:
+        present: true
+        not_in:
+        - false
+        - true
+        - never
+  kwargs_positive:
+    early_stopping: sometimes
+    num_beams: 1
+  kwargs_negative:
+    early_stopping: false
+    num_beams: 1
+  expected_outcome: *id002
+  message_template: '`early_stopping` must be a boolean or ''never'', but is sometimes.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `early_stopping` (early stopping type not in bool
+    or int or str)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.early_stopping:
+        present: true
+        type_is_not:
+        - bool
+        - int
+        - str
+  kwargs_positive:
+    early_stopping: 1.5
+    num_beams: 1
+  kwargs_negative:
+    early_stopping: false
+    num_beams: 1
+  expected_outcome: *id002
+  message_template: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_epsilon_cutoff
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `epsilon_cutoff` when do_sample=False
+    and `epsilon_cutoff` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 361
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.epsilon_cutoff:
+        present: true
+        not_equal: 0.0
+  kwargs_positive:
+    do_sample: false
+    epsilon_cutoff: 0.5
+  kwargs_negative:
+    do_sample: true
+    epsilon_cutoff: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `epsilon_cutoff` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `epsilon_cutoff`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~361)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_eta_cutoff
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `eta_cutoff` when do_sample=False
+    and `eta_cutoff` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 362
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.eta_cutoff:
+        present: true
+        not_equal: 0.0
+  kwargs_positive:
+    do_sample: false
+    eta_cutoff: 0.5
+  kwargs_negative:
+    do_sample: true
+    eta_cutoff: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `eta_cutoff` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `eta_cutoff`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~362)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_min_p
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `min_p` when do_sample=False and `min_p`
+    is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 359
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.min_p:
+        present: true
+  kwargs_positive:
+    do_sample: false
+    min_p: 0.5
+  kwargs_negative:
+    do_sample: true
+    min_p: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `min_p` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `min_p`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~359)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_temperature
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `temperature` when do_sample=False
+    and `temperature` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 356
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.temperature:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    do_sample: false
+    temperature: 0.5
+  kwargs_negative:
+    do_sample: true
+    temperature: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `temperature` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `temperature`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~356)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_top_k
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `top_k` when do_sample=False and `top_k`
+    is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 357
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.top_k:
+        present: true
+        not_equal: 50
+  kwargs_positive:
+    do_sample: false
+    top_k: 51
+  kwargs_negative:
+    do_sample: true
+    top_k: 51
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `top_k` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_k`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~357)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_top_p
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `top_p` when do_sample=False and `top_p`
+    is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 358
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.top_p:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    do_sample: false
+    top_p: 0.5
+  kwargs_negative:
+    do_sample: true
+    top_p: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `top_p` is set to `{declared_value}` -- this
+    flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~358)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_greedy_strips_typical_p
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `typical_p` when do_sample=False and
+    `typical_p` is set to a non-default value
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 360
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.do_sample: false
+      transformers.sampling.typical_p:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    do_sample: false
+    typical_p: 0.5
+  kwargs_negative:
+    do_sample: true
+    typical_p: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`do_sample` is set to `False`. However, `typical_p` is set to `{declared_value}`
+    -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset
+    `typical_p`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~360)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_negative_pad_token_id
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant pad_token_id < 0
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 396
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.pad_token_id:
+        <: 0
+  kwargs_positive:
+    pad_token_id: -1
+  kwargs_negative:
+    pad_token_id: 0
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: *id001
+  message_template: '`pad_token_id` should be positive but got -1. This will cause errors when batch generating,
+    if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID`
+    to avoid errors in generation'
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+  conflict_note: 'id: dynamic_miner -> ''transformers_negative_pad_token_id''; dynamic_miner -> ''transformers_output_token_ids_pad_token_id_lt_zero'''
+- id: transformers_no_return_dict_strips_output_attentions
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `output_attentions` when return_dict_in_generate=False
+    and `output_attentions` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 389
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_attentions:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_attentions: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_attentions: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_attentions` is. When
+    `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~389)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_no_return_dict_strips_output_hidden_states
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `output_hidden_states` when return_dict_in_generate=False
+    and `output_hidden_states` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 390
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_hidden_states:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_hidden_states: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_hidden_states: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_hidden_states` is. When
+    `return_dict_in_generate` is not `True`, `output_hidden_states` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~390)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_no_return_dict_strips_output_scores
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `output_scores` when return_dict_in_generate=False
+    and `output_scores` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 391
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.return_dict_in_generate: false
+      transformers.sampling.output_scores:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    return_dict_in_generate: false
+    output_scores: true
+  kwargs_negative:
+    return_dict_in_generate: true
+    output_scores: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`return_dict_in_generate` is NOT set to `True`, but `output_scores` is. When `return_dict_in_generate`
+    is not `True`, `output_scores` is ignored.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~391)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `num_beams` (do sample eq false and num beams
+    eq 1)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 344
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.num_return_sequences:
+        '>': 1
+      transformers.sampling.do_sample: false
+  kwargs_positive:
+    num_beams: 1
+    num_return_sequences: 2
+    do_sample: false
+  kwargs_negative:
+    num_beams: 1
+    num_return_sequences: 1
+    do_sample: false
+  expected_outcome: *id002
+  message_template: Greedy methods without beam search do not support `num_return_sequences` different
+    than 1 (got 2).
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_num_return_vs_beams_num_beams_lt_num_return_sequences
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `num_beams` (num beams lt num return sequences)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 345
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams:
+        <: '@num_return_sequences'
+  kwargs_positive:
+    num_beams: 2
+    num_return_sequences: 4
+    do_sample: false
+  kwargs_negative:
+    num_beams: 1
+    num_return_sequences: 4
+    do_sample: true
+  expected_outcome: *id002
+  message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `num_beams` (num beams not divisible by num return
+    sequences)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 345
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams:
+        not_divisible_by: '@num_return_sequences'
+  kwargs_positive:
+    num_beams: 2
+    num_return_sequences: 4
+    do_sample: false
+  kwargs_negative:
+    num_beams: 1
+    num_return_sequences: 4
+    do_sample: true
+  expected_outcome: *id002
+  message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_output_token_ids_max_new_tokens_le_zero
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `max_new_tokens` (max new tokens le zero)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 335
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.max_new_tokens:
+        <=: 0
+  kwargs_positive:
+    max_new_tokens: -1
+    min_new_tokens: -1
+    pad_token_id: -1
+  kwargs_negative:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: 0
+  expected_outcome: *id002
+  message_template: '`max_new_tokens` must be greater than 0, but is -1.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_output_token_ids_max_new_tokens_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `max_new_tokens` (max new tokens not in allowlist)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 335
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.max_new_tokens:
+        present: true
+        not_in:
+        - 1
+        - 16
+  kwargs_positive:
+    max_new_tokens: -1
+    min_new_tokens: -1
+    pad_token_id: -1
+  kwargs_negative:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: 0
+  expected_outcome: *id002
+  message_template: '`max_new_tokens` must be greater than 0, but is -1.'
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_output_token_ids_pad_token_id_not_in_allowlist
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate flags `pad_token_id` (pad token id not in allowlist)
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 396
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.pad_token_id:
+        present: true
+        not_in:
+        - 0
+        - 50256
+  kwargs_positive:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: -1
+  kwargs_negative:
+    max_new_tokens: 1
+    min_new_tokens: -1
+    pad_token_id: 0
+  expected_outcome: *id003
+  message_template: '`pad_token_id` should be positive but got -1. This will cause errors when batch generating,
+    if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID`
+    to avoid errors in generation'
+  references:
+  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_raises_bnb_4bit_quant_type_not_type_str
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when bnb_4bit_quant_type type_is_not
+    str'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 563
+  match:
+    engine: transformers
+    fields:
+      transformers.bnb_4bit_quant_type:
+        type_is_not: str
+  kwargs_positive:
+    bnb_4bit_quant_type: 1
+  kwargs_negative:
+    bnb_4bit_quant_type: x
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: bnb_4bit_quant_type must be a string
+  references:
+  - transformers/utils/quantization_config.py:563 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_bnb_4bit_use_double_quant_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when bnb_4bit_use_double_quant type_is_not
+    bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 566
+  match:
+    engine: transformers
+    fields:
+      transformers.bnb_4bit_use_double_quant:
+        type_is_not: bool
+  kwargs_positive:
+    bnb_4bit_use_double_quant: 1
+  kwargs_negative:
+    bnb_4bit_use_double_quant: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: bnb_4bit_use_double_quant must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:566 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_compile_config_not_type_compileconfig
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.raise_ValueError: raises when compile_config present True AND
+    compile_config type_is_not CompileConfig'
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 561
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.compile_config:
+        type_is_not: CompileConfig
+        present: true
+  kwargs_positive:
+    compile_config: true
+  kwargs_negative:
+    compile_config: null
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: You provided `compile_config` as an instance of {type(self.compile_config)}, but it
+    must be an instance of `CompileConfig`.
+  references:
+  - transformers/generation/configuration_utils.py:561 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_enable_fp32_cpu_offload_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_enable_fp32_cpu_offload
+    type_is_not bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 554
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_enable_fp32_cpu_offload:
+        type_is_not: bool
+  kwargs_positive:
+    llm_int8_enable_fp32_cpu_offload: 1
+  kwargs_negative:
+    llm_int8_enable_fp32_cpu_offload: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_enable_fp32_cpu_offload must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:554 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_has_fp16_weight_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_has_fp16_weight type_is_not
+    bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 557
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_has_fp16_weight:
+        type_is_not: bool
+  kwargs_positive:
+    llm_int8_has_fp16_weight: 1
+  kwargs_negative:
+    llm_int8_has_fp16_weight: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_has_fp16_weight must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:557 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_skip_modules_not_type_list
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_skip_modules present
+    True AND llm_int8_skip_modules type_is_not list'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 552
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_skip_modules:
+        type_is_not: list
+        present: true
+  kwargs_positive:
+    llm_int8_skip_modules: true
+  kwargs_negative:
+    llm_int8_skip_modules: []
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_skip_modules must be a list of strings
+  references:
+  - transformers/utils/quantization_config.py:552 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_llm_int8_threshold_not_type_float
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when llm_int8_threshold type_is_not
+    float'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 549
+  match:
+    engine: transformers
+    fields:
+      transformers.llm_int8_threshold:
+        type_is_not: float
+  kwargs_positive:
+    llm_int8_threshold: x
+  kwargs_negative:
+    llm_int8_threshold: 1.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: llm_int8_threshold must be a float
+  references:
+  - transformers/utils/quantization_config.py:549 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_load_in_4bit_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when load_in_4bit type_is_not bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 543
+  match:
+    engine: transformers
+    fields:
+      transformers.load_in_4bit:
+        type_is_not: bool
+  kwargs_positive:
+    load_in_4bit: 1
+  kwargs_negative:
+    load_in_4bit: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: load_in_4bit must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:543 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_load_in_8bit_not_type_bool
+  engine: transformers
+  library: bitsandbytes
+  invariant_under_test: 'BitsAndBytesConfig.raise_TypeError: raises when load_in_8bit type_is_not bool'
+  severity: error
+  native_type: transformers.BitsAndBytesConfig
+  miner_source:
+    path: transformers/utils/quantization_config.py
+    method: post_init
+    line_at_scan: 546
+  match:
+    engine: transformers
+    fields:
+      transformers.load_in_8bit:
+        type_is_not: bool
+  kwargs_positive:
+    load_in_8bit: 1
+  kwargs_negative:
+    load_in_8bit: true
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: load_in_8bit must be a boolean
+  references:
+  - transformers/utils/quantization_config.py:546 (transformers.BitsAndBytesConfig.post_init)
+  added_by: static_miner
+  added_at: '2026-04-25'
+- id: transformers_raises_num_beams_eq_1
+  engine: transformers
+  library: transformers
+  invariant_under_test: 'GenerationConfig.raise_ValueError: raises when num_return_sequences != 1 AND
+    num_beams == 1 (dropped: self.do_sample is False)'
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 618
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_return_sequences:
+        '!=': 1
+      transformers.sampling.num_beams: 1
+  kwargs_positive:
+    num_return_sequences: 2
+    num_beams: 1
+  kwargs_negative:
+    num_return_sequences: 2
+    num_beams: 2
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Greedy methods without beam search do not support `num_return_sequences` different
+    than 1 (got {num_return_sequences}).
+  references:
+  - transformers/generation/configuration_utils.py:618 (transformers.GenerationConfig.validate)
+  added_by: static_miner
+  added_at: '2026-04-25'
+  walker_notes:
+  - 'dropped sub-clauses: self.do_sample is False'
+- id: transformers_single_beam_strips_early_stopping
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `early_stopping` when num_beams=1
+    and `early_stopping` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 339
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.early_stopping:
+        present: true
+        not_equal: false
+  kwargs_positive:
+    num_beams: 1
+    early_stopping: true
+  kwargs_negative:
+    num_beams: 4
+    early_stopping: true
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`num_beams` is set to 1. However, `early_stopping` is set to `{declared_value}` --
+    this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~339)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_single_beam_strips_length_penalty
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.validate() records dormant `length_penalty` when num_beams=1
+    and `length_penalty` is set
+  severity: dormant
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: validate
+    line_at_scan: 365
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.num_beams: 1
+      transformers.sampling.length_penalty:
+        present: true
+        not_equal: 1.0
+  kwargs_positive:
+    num_beams: 1
+    length_penalty: 0.5
+  kwargs_negative:
+    num_beams: 4
+    length_penalty: 0.5
+  expected_outcome:
+    outcome: dormant_announced
+    emission_channel: logger_warning_once
+    normalised_fields: []
+  message_template: '`num_beams` is set to 1. However, `length_penalty` is set to `{declared_value}` --
+    this flag is only used in beam-based generation modes. You should set `num_beams>1` or unset `length_penalty`.'
+  references:
+  - transformers.GenerationConfig.validate() (line ~365)
+  added_by: dynamic_miner
+  added_at: '2026-04-30'
+- id: transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig
+  engine: transformers
+  library: transformers
+  invariant_under_test: GenerationConfig.__init__ flags `watermarking_config` (watermarking config type
+    not in WatermarkingConfig)
+  severity: error
+  native_type: transformers.GenerationConfig
+  miner_source:
+    path: transformers/generation/configuration_utils.py
+    method: __init__
+    line_at_scan: 381
+  match:
+    engine: transformers
+    fields:
+      transformers.sampling.watermarking_config:
+        present: true
+        type_is_not:
+        - WatermarkingConfig
+  kwargs_positive:
+    watermarking_config: 42
+  kwargs_negative:
+    watermarking_config: null
+  expected_outcome: *id002
+  message_template: transformers.generation.configuration_utils.WatermarkingConfig() argument after **
+    must be a mapping, not int
+  references:
+  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  added_by: dynamic_miner
+  added_at: '2026-04-30'

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.validated.yaml
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/invariants.validated.yaml
@@ -1,0 +1,717 @@
+schema_version: 1.0.0
+engine: transformers
+engine_version: 4.57.3
+image_ref: llenergymeasure:transformers
+base_image_ref: llenergymeasure:transformers
+validated_at: '2026-05-06T22:57:22+02:00'
+validation_commit: b9e7af630c351227389c263573263611402e4700
+cases:
+- id: transformers_beam_search_num_beams_eq_1
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'Detected torch version: 2.5.1+cu124'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_cache_choice_cache_implementation_not_in_allowlist
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: 'Invalid `cache_implementation` (nonsense). Choose one of: (''static'',
+      ''offloaded_static'', ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'',
+      ''offloaded_hybrid_chunked'', ''dynamic'', ''dynamic_full'', ''offloaded'',
+      ''quantized'')'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_cache_choice_use_cache_eq_false
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''cache_implementation''].'
+  - 'The following generation flags are not valid and may be ignored: [''cache_implementation''].'
+  - 'The following generation flags are not valid and may be ignored: [''cache_implementation''].'
+  - '- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation
+    is set to static. cache_implementation will have no effect.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation
+    is set to static. cache_implementation will have no effect.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `cache_implementation`: You have set `use_cache` to `False`, but cache_implementation
+    is set to static. cache_implementation will have no effect.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_compile_config_type_compile_config_exceeds_zero
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: You provided `compile_config` as an instance of <class 'int'>, but it
+      must be an instance of `CompileConfig`.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_compile_config_type_compile_config_type_not_in_CompileConfig
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: You provided `compile_config` as an instance of <class 'str'>, but it
+      must be an instance of `CompileConfig`.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_dormant_early_stopping_set_true
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_dormant_epsilon_cutoff_ne_0_0
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `True` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `True` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `True` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_dormant_eta_cutoff_ne_0_0
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `True` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `True` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `True` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_early_stopping_type_early_stopping_exceeds_zero
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_early_stopping_type_early_stopping_not_in_allowlist
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`early_stopping` must be a boolean or ''never'', but is sometimes.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_epsilon_cutoff
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''epsilon_cutoff''].'
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `0.5` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `0.5` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `epsilon_cutoff`: `do_sample` is set to `False`. However, `epsilon_cutoff`
+    is set to `0.5` -- this flag is only used in sample-based generation modes. You
+    should set `do_sample=True` or unset `epsilon_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_eta_cutoff
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - 'The following generation flags are not valid and may be ignored: [''eta_cutoff''].'
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `eta_cutoff`: `do_sample` is set to `False`. However, `eta_cutoff` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `eta_cutoff`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_min_p
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''min_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''min_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''min_p''].'
+  - '- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `min_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `min_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `min_p`: `do_sample` is set to `False`. However, `min_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `min_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_temperature
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''temperature''].'
+  - 'The following generation flags are not valid and may be ignored: [''temperature''].'
+  - 'The following generation flags are not valid and may be ignored: [''temperature''].'
+  - '- `temperature`: `do_sample` is set to `False`. However, `temperature` is set
+    to `0.5` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `temperature`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `temperature`: `do_sample` is set to `False`. However, `temperature` is set
+    to `0.5` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `temperature`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `temperature`: `do_sample` is set to `False`. However, `temperature` is set
+    to `0.5` -- this flag is only used in sample-based generation modes. You should
+    set `do_sample=True` or unset `temperature`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_top_k
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''top_k''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_k''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_k''].'
+  - '- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_k`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_k`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_k`: `do_sample` is set to `False`. However, `top_k` is set to `51` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_k`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_top_p
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''top_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''top_p''].'
+  - '- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `top_p`: `do_sample` is set to `False`. However, `top_p` is set to `0.5` --
+    this flag is only used in sample-based generation modes. You should set `do_sample=True`
+    or unset `top_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_greedy_strips_typical_p
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''typical_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''typical_p''].'
+  - 'The following generation flags are not valid and may be ignored: [''typical_p''].'
+  - '- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `typical_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `typical_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `typical_p`: `do_sample` is set to `False`. However, `typical_p` is set to
+    `0.5` -- this flag is only used in sample-based generation modes. You should set
+    `do_sample=True` or unset `typical_p`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_negative_pad_token_id
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_no_return_dict_strips_output_attentions
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''output_attentions''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_attentions''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_attentions''].'
+  - '- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions`
+    is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions`
+    is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_attentions`: `return_dict_in_generate` is NOT set to `True`, but `output_attentions`
+    is. When `return_dict_in_generate` is not `True`, `output_attentions` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_no_return_dict_strips_output_hidden_states
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''output_hidden_states''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_hidden_states''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_hidden_states''].'
+  - '- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but
+    `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states`
+    is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but
+    `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states`
+    is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_hidden_states`: `return_dict_in_generate` is NOT set to `True`, but
+    `output_hidden_states` is. When `return_dict_in_generate` is not `True`, `output_hidden_states`
+    is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_no_return_dict_strips_output_scores
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''output_scores''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_scores''].'
+  - 'The following generation flags are not valid and may be ignored: [''output_scores''].'
+  - '- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores`
+    is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores`
+    is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `output_scores`: `return_dict_in_generate` is NOT set to `True`, but `output_scores`
+    is. When `return_dict_in_generate` is not `True`, `output_scores` is ignored.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_num_return_vs_beams_do_sample_eq_false_and_num_beams_eq_1
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: Greedy methods without beam search do not support `num_return_sequences`
+      different than 1 (got 2).
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_num_return_vs_beams_num_beams_lt_num_return_sequences
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`num_return_sequences` (4) has to be smaller or equal to `num_beams`
+      (2).'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`num_return_sequences` (4) has to be smaller or equal to `num_beams`
+      (2).'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_output_token_ids_max_new_tokens_le_zero
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`max_new_tokens` must be greater than 0, but is -1.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_output_token_ids_max_new_tokens_not_in_allowlist
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: '`max_new_tokens` must be greater than 0, but is -1.'
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_output_token_ids_pad_token_id_not_in_allowlist
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - 'The following generation flags are not valid and may be ignored: [''pad_token_id''].'
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `pad_token_id`: `pad_token_id` should be positive but got -1. This will cause
+    errors when batch generating, if there is padding. Please set `pad_token_id` explicitly
+    as `model.generation_config.pad_token_id=PAD_TOKEN_ID` to avoid errors in generation'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_bnb_4bit_quant_type_not_type_str
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: bnb_4bit_quant_type must be a string
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_bnb_4bit_use_double_quant_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: bnb_4bit_use_double_quant must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_compile_config_not_type_compileconfig
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: You provided `compile_config` as an instance of <class 'bool'>, but it
+      must be an instance of `CompileConfig`.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_enable_fp32_cpu_offload_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_enable_fp32_cpu_offload must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_has_fp16_weight_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_has_fp16_weight must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_skip_modules_not_type_list
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_skip_modules must be a list of strings
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_llm_int8_threshold_not_type_float
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: llm_int8_threshold must be a float
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_load_in_4bit_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: load_in_4bit must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_load_in_8bit_not_type_bool
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: load_in_8bit must be a boolean
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_raises_num_beams_eq_1
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: Greedy methods without beam search do not support `num_return_sequences`
+      different than 1 (got 2).
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_single_beam_strips_early_stopping
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - 'The following generation flags are not valid and may be ignored: [''early_stopping''].'
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `early_stopping`: `num_beams` is set to 1. However, `early_stopping` is set
+    to `True` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `early_stopping`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_single_beam_strips_length_penalty
+  outcome: dormant_announced
+  emission_channel: logger_warning_once
+  observed_messages:
+  - 'The following generation flags are not valid and may be ignored: [''length_penalty''].'
+  - 'The following generation flags are not valid and may be ignored: [''length_penalty''].'
+  - 'The following generation flags are not valid and may be ignored: [''length_penalty''].'
+  - '- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set
+    to `0.5` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `length_penalty`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set
+    to `0.5` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `length_penalty`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  - '- `length_penalty`: `num_beams` is set to 1. However, `length_penalty` is set
+    to `0.5` -- this flag is only used in beam-based generation modes. You should
+    set `num_beams>1` or unset `length_penalty`.'
+  - If you're using a pretrained model, note that some of these attributes may be
+    set through the model's `generation_config.json` file.
+  observed_silent_normalisations: {}
+  positive_confirmed: true
+  negative_confirmed: true
+- id: transformers_watermarking_type_watermarking_config_type_not_in_WatermarkingConfig
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: TypeError
+    message: transformers.generation.configuration_utils.WatermarkingConfig() argument
+      after ** must be a mapping, not int
+  positive_confirmed: true
+  negative_confirmed: true
+divergences: []

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/schema.discovered.json
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/outputs/schema.discovered.json
@@ -1,0 +1,367 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "transformers",
+  "engine_version": "4.57.3",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:transformers-4.57.3",
+  "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
+  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+  "discovery_limitations": [
+    {
+      "section": "engine_params",
+      "fields": [
+        "AutoModelForCausalLM.from_pretrained.**model_args",
+        "AutoModelForCausalLM.from_pretrained.**kwargs",
+        "PreTrainedModel.from_pretrained.**model_args",
+        "PreTrainedModel.from_pretrained.**kwargs"
+      ],
+      "reason": "from_pretrained accepts **kwargs; kwargs are not in the signature (documented kwargs live in the class docstring only)"
+    },
+    {
+      "section": "sampling_params",
+      "fields": [
+        "max_new_tokens",
+        "min_new_tokens",
+        "max_time",
+        "stop_strings",
+        "cache_implementation",
+        "cache_config",
+        "return_legacy_cache",
+        "prefill_chunk_size",
+        "min_p",
+        "bad_words_ids",
+        "forced_bos_token_id",
+        "forced_eos_token_id",
+        "exponential_decay_length_penalty",
+        "suppress_tokens",
+        "begin_suppress_tokens",
+        "sequence_bias",
+        "guidance_scale",
+        "watermarking_config",
+        "output_logits",
+        "pad_token_id",
+        "bos_token_id",
+        "eos_token_id",
+        "decoder_start_token_id",
+        "prompt_lookup_num_tokens",
+        "max_matching_ngram_size",
+        "assistant_early_exit",
+        "low_memory",
+        "penalty_alpha",
+        "dola_layers",
+        "constraints",
+        "force_words_ids"
+      ],
+      "reason": "GenerationConfig has no type annotations; None defaults yield type='unknown'"
+    }
+  ],
+  "engine_params": {
+    "config": {
+      "type": "PretrainedConfig | str | PathLike | None",
+      "default": null
+    },
+    "cache_dir": {
+      "type": "str | PathLike | None",
+      "default": null
+    },
+    "ignore_mismatched_sizes": {
+      "type": "bool",
+      "default": false
+    },
+    "force_download": {
+      "type": "bool",
+      "default": false
+    },
+    "local_files_only": {
+      "type": "bool",
+      "default": false
+    },
+    "token": {
+      "type": "str | bool | None",
+      "default": null
+    },
+    "revision": {
+      "type": "str",
+      "default": "main"
+    },
+    "use_safetensors": {
+      "type": "bool | None",
+      "default": null
+    },
+    "weights_only": {
+      "type": "bool",
+      "default": true
+    }
+  },
+  "sampling_params": {
+    "max_length": {
+      "type": "int",
+      "default": 20
+    },
+    "max_new_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "min_length": {
+      "type": "int",
+      "default": 0
+    },
+    "min_new_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "early_stopping": {
+      "type": "bool",
+      "default": false
+    },
+    "max_time": {
+      "type": "unknown",
+      "default": null
+    },
+    "stop_strings": {
+      "type": "unknown",
+      "default": null
+    },
+    "do_sample": {
+      "type": "bool",
+      "default": false
+    },
+    "num_beams": {
+      "type": "int",
+      "default": 1
+    },
+    "use_cache": {
+      "type": "bool",
+      "default": true
+    },
+    "cache_implementation": {
+      "type": "unknown",
+      "default": null
+    },
+    "cache_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "return_legacy_cache": {
+      "type": "unknown",
+      "default": null
+    },
+    "prefill_chunk_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "temperature": {
+      "type": "float",
+      "default": 1.0
+    },
+    "top_k": {
+      "type": "int",
+      "default": 50
+    },
+    "top_p": {
+      "type": "float",
+      "default": 1.0
+    },
+    "min_p": {
+      "type": "unknown",
+      "default": null
+    },
+    "typical_p": {
+      "type": "float",
+      "default": 1.0
+    },
+    "epsilon_cutoff": {
+      "type": "float",
+      "default": 0.0
+    },
+    "eta_cutoff": {
+      "type": "float",
+      "default": 0.0
+    },
+    "repetition_penalty": {
+      "type": "float",
+      "default": 1.0
+    },
+    "encoder_repetition_penalty": {
+      "type": "float",
+      "default": 1.0
+    },
+    "length_penalty": {
+      "type": "float",
+      "default": 1.0
+    },
+    "no_repeat_ngram_size": {
+      "type": "int",
+      "default": 0
+    },
+    "bad_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "renormalize_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "forced_bos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "forced_eos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "remove_invalid_values": {
+      "type": "bool",
+      "default": false
+    },
+    "exponential_decay_length_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "begin_suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "sequence_bias": {
+      "type": "unknown",
+      "default": null
+    },
+    "token_healing": {
+      "type": "bool",
+      "default": false
+    },
+    "guidance_scale": {
+      "type": "unknown",
+      "default": null
+    },
+    "watermarking_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_return_sequences": {
+      "type": "int",
+      "default": 1
+    },
+    "output_attentions": {
+      "type": "bool",
+      "default": false
+    },
+    "output_hidden_states": {
+      "type": "bool",
+      "default": false
+    },
+    "output_scores": {
+      "type": "bool",
+      "default": false
+    },
+    "output_logits": {
+      "type": "unknown",
+      "default": null
+    },
+    "return_dict_in_generate": {
+      "type": "bool",
+      "default": false
+    },
+    "pad_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "bos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "eos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "encoder_no_repeat_ngram_size": {
+      "type": "int",
+      "default": 0
+    },
+    "decoder_start_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "is_assistant": {
+      "type": "bool",
+      "default": false
+    },
+    "num_assistant_tokens": {
+      "type": "int",
+      "default": 20
+    },
+    "num_assistant_tokens_schedule": {
+      "type": "str",
+      "default": "constant"
+    },
+    "assistant_confidence_threshold": {
+      "type": "float",
+      "default": 0.4
+    },
+    "prompt_lookup_num_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "max_matching_ngram_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "assistant_early_exit": {
+      "type": "unknown",
+      "default": null
+    },
+    "assistant_lookbehind": {
+      "type": "int",
+      "default": 10
+    },
+    "target_lookbehind": {
+      "type": "int",
+      "default": 10
+    },
+    "disable_compile": {
+      "type": "bool",
+      "default": false
+    },
+    "low_memory": {
+      "type": "unknown",
+      "default": null
+    },
+    "penalty_alpha": {
+      "type": "unknown",
+      "default": null
+    },
+    "dola_layers": {
+      "type": "unknown",
+      "default": null
+    },
+    "diversity_penalty": {
+      "type": "float",
+      "default": 0.0
+    },
+    "num_beam_groups": {
+      "type": "int",
+      "default": 1
+    },
+    "constraints": {
+      "type": "unknown",
+      "default": null
+    },
+    "force_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "_from_model_config": {
+      "type": "bool",
+      "default": false
+    },
+    "transformers_version": {
+      "type": "str",
+      "default": "4.57.3"
+    }
+  }
+}

--- a/src/llenergymeasure/_engine_archive/transformers/v4_57_3/ssot.yaml
+++ b/src/llenergymeasure/_engine_archive/transformers/v4_57_3/ssot.yaml
@@ -1,0 +1,32 @@
+# Per-engine version-bundle SSOT for transformers.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, validation gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+#
+# `last_probe.verdict: unrun` is the honest seed shape for a fresh SSOT
+# that no probe has executed against yet. The probe primitive overwrites
+# this block on each per-PR run.
+schema_version: 1
+engine: transformers
+library:
+  pep503_name: transformers
+  current_version: "4.57.3"
+  current_commit_sha: null
+image:
+  base_image_ref: "llenergymeasure:transformers-4.57.3"
+  llem_image_ref: null
+miner_pins:
+  static: ">=4.56,<4.57"
+  dynamic: ">=4.56,<4.57"
+  discovery: ">=4.56,<4.57"
+artefact_paths:
+  engine_invariants: src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+  validated_invariants: src/llenergymeasure/engines/transformers/invariants.validated.yaml
+  discovered_schemas: src/llenergymeasure/engines/transformers/schema.discovered.json
+last_probe:
+  verdict: pass
+  version_inside_envelope: false
+  fingerprint: "14dc1896757dfc00a9a4e1990528ecac45394bb5f2850bfab17e87871aaa29da"
+  fingerprint_drift: []

--- a/tests/_engine_archive/test_transformers_lazy.py
+++ b/tests/_engine_archive/test_transformers_lazy.py
@@ -1,0 +1,52 @@
+"""Per-engine LANDMARKS resolution tests for transformers v4.57.3.
+
+Engine-specific complement to ``tests/_engine_archive/test_dispatcher.py``:
+asserts the two transformers producer modules expose ``LANDMARKS`` lazily
+via PEP 562 ``__getattr__`` and that the resolved tuple matches the
+machinery loaded directly through the dispatcher.
+
+Mirror style of ``test_dispatcher.py``: keep imports lazy where the assertion
+target is the module attribute, fail loud otherwise.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+_TRANSFORMERS_VERSION = "4.57.3"
+
+
+def _assert_landmark_shape(landmarks: object) -> tuple[str, ...]:
+    """Shared shape contract: non-empty tuple of dotted ``transformers.*`` paths."""
+    assert isinstance(landmarks, tuple), f"LANDMARKS must be tuple, got {type(landmarks)!r}"
+    assert len(landmarks) > 0, "LANDMARKS must be non-empty"
+    for entry in landmarks:
+        assert isinstance(entry, str), f"LANDMARKS entry must be str, got {type(entry)!r}"
+        assert entry.startswith("transformers."), (
+            f"LANDMARKS entry {entry!r} must start with 'transformers.'"
+        )
+    return landmarks  # type: ignore[return-value]
+
+
+def test_transformers_miner_landmarks_resolve_lazily() -> None:
+    """``scripts.engine_miners.transformers_miner.LANDMARKS`` resolves via PEP 562."""
+    module = importlib.import_module("scripts.engine_miners.transformers_miner")
+    landmarks = _assert_landmark_shape(module.LANDMARKS)
+
+    archived = load_machinery(
+        engine="transformers", version=_TRANSFORMERS_VERSION, producer="static"
+    ).LANDMARKS
+    assert landmarks == archived
+
+
+def test_transformers_introspector_landmarks_resolve_lazily() -> None:
+    """``scripts.engine_introspectors.transformers_introspector.LANDMARKS`` resolves via PEP 562."""
+    module = importlib.import_module("scripts.engine_introspectors.transformers_introspector")
+    landmarks = _assert_landmark_shape(module.LANDMARKS)
+
+    archived = load_machinery(
+        engine="transformers", version=_TRANSFORMERS_VERSION, producer="discovery"
+    ).LANDMARKS
+    assert landmarks == archived


### PR DESCRIPTION
## Summary

Activates the version-aware machinery dispatcher (PR #598) for **transformers**:

- Adds the per-version archive at `src/llenergymeasure/_engine_archive/transformers/v4_57_3/` (ssot, static + discovery LANDMARKS, frozen reference outputs).
- Refactors the two producer modules (`transformers_miner` orchestrator and `transformers_introspector`) to expose `LANDMARKS` lazily via PEP 562 `__getattr__` that delegates to `load_machinery(engine="transformers", version=..., producer=...)`.
- `transformers_miner._check_landmarks()` now iterates `LANDMARKS` via `scripts._probe._resolve_landmark`, removing the prior duplicate hardcoded landmark list (per the second adversarial pass FM 2 mitigation).

## Stack

Stacked on `chore/engine-archive-scaffold` (PR #598). Read-only on every other engine; no vllm or tensorrt content touched. Engine-agnostic infrastructure (`_dispatcher.py`, `_machinery_proto.py`, top-level `__init__.py`) is unchanged.

## Test plan

- [x] `pytest tests/_engine_archive/` — 13/13 pass (10 PR-A baseline + 2 new transformers + 1 smoke)
- [x] Wheel build excludes `src/llenergymeasure/_engine_archive/**` (verified via `uv build --wheel`; only runtime `engines/transformers/*` files appear in artifact)
- [x] Producer modules' `module.LANDMARKS` resolves identically to `load_machinery(...).LANDMARKS` for both `static` and `discovery` producers