### PR TITLE
feat(engines): vendor tensorrt v0.21.0 machinery + producer refactor

### DIFF
--- a/scripts/engine_introspectors/tensorrt_introspector.py
+++ b/scripts/engine_introspectors/tensorrt_introspector.py
@@ -23,16 +23,47 @@ from scripts.engine_introspectors._common import (
     dataclass_fields_to_specs,
     make_envelope,
 )
+from scripts.engine_miners._ssot import load_ssot
 
 # Symbols this introspector relies on inside the live ``tensorrt_llm``
 # package. Read by ``scripts._probe`` before discovery runs; a missing
 # landmark flips the probe verdict to ``fail`` and skips downstream
 # discovery.
-LANDMARKS: tuple[str, ...] = (
-    "tensorrt_llm.SamplingParams",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.tensorrt.<safe_version>.machinery.discovery``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("tensorrt")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/tensorrt.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="tensorrt",
+        version=str(library["current_version"]),
+        producer="discovery",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:

--- a/scripts/engine_miners/tensorrt_static_miner.py
+++ b/scripts/engine_miners/tensorrt_static_miner.py
@@ -74,7 +74,7 @@ from scripts.engine_miners._base import (  # noqa: E402  (late import after sys.
     find_method,
     first_string_arg,
 )
-from scripts.engine_miners._ssot import load_miner_pin  # noqa: E402
+from scripts.engine_miners._ssot import load_miner_pin, load_ssot  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -107,27 +107,42 @@ BUILDER_REL = Path("builder.py")
 # stages. The miner itself walks /tmp source AST rather than the live
 # package (see ``_load_source``), but probe uses live-package landmarks
 # because that is the seam Renovate's library bumps shift first.
-LANDMARKS: tuple[str, ...] = (
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_dtype",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model_format_misc",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.set_runtime_knobs_from_build_config",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_with_runtime_params",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_remaining",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_speculative_config",
-    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_lora_config_consistency",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
-    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.validate_enable_build_cache",
-    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig",
-    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig.validate_positive_values",
-    "tensorrt_llm.llmapi.llm_args.CalibConfig",
-    "tensorrt_llm.llmapi.llm_args.BatchingType",
-    "tensorrt_llm.llmapi.llm_args.CapacitySchedulerPolicy",
-    "tensorrt_llm.llmapi.llm_args.ContextChunkingPolicy",
-    "tensorrt_llm.builder.Builder",
-    "tensorrt_llm.builder.Builder.build_engine",
-)
+#
+# Sourced from the version-pinned archive at
+# ``llenergymeasure._engine_archive.tensorrt.<safe_version>.machinery.static``.
+# PEP 562 ``__getattr__`` defers the archive import + SSOT parse until
+# accessed.
+
+
+def _get_landmarks() -> tuple[str, ...]:
+    """Resolve LANDMARKS for the current SSOT ``library.current_version``."""
+    cached = globals().get("LANDMARKS")
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+    ssot = load_ssot("tensorrt")
+    library = ssot.get("library")
+    if not isinstance(library, dict) or "current_version" not in library:
+        raise ValueError(
+            "engine_versions/tensorrt.yaml is missing library.current_version; "
+            "cannot resolve archived LANDMARKS."
+        )
+    landmarks = load_machinery(
+        engine="tensorrt",
+        version=str(library["current_version"]),
+        producer="static",
+    ).LANDMARKS
+    globals()["LANDMARKS"] = landmarks
+    return landmarks  # type: ignore[no-any-return]
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 hook: lazy LANDMARKS export from the per-version archive."""
+    if name == "LANDMARKS":
+        return _get_landmarks()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Class-level landmarks. Each entry is ``(class_name, file_relative_path)``.
 _CLASS_LANDMARKS: tuple[tuple[str, Path], ...] = (

--- a/src/llenergymeasure/_engine_archive/tensorrt/__init__.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/__init__.py
@@ -1,0 +1,7 @@
+"""TensorRT-LLM per-version machinery archive.
+
+Subpackages here are version-pinned snapshots. The static miner walks an
+extracted source tarball at ``/tmp/trt-llm-<V>/``; the schemas
+introspector imports the live ``tensorrt_llm`` package inside the NGC
+image. LANDMARKS are co-located here per version.
+"""

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/__init__.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/__init__.py
@@ -1,0 +1,9 @@
+"""Frozen TensorRT-LLM 0.21.0 machinery + outputs.
+
+Initial vendored snapshot. The 0.21.0 pin reflects the CUDA 12.6.x
+compatibility envelope (1.x requires CUDA 13.x, separate infrastructure
+milestone). LANDMARKS for the static miner reference symbols in the
+extracted source tree at ``/tmp/trt-llm-0.21.0/``; LANDMARKS for the
+discovery introspector reference the live ``tensorrt_llm`` package
+inside ``nvcr.io/nvidia/tensorrt-llm/release:0.21.0``.
+"""

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/__init__.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``static`` (invariants), ``discovery`` (schemas)."""

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/discovery.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/discovery.py
@@ -1,0 +1,14 @@
+"""Schema-introspector LANDMARKS for TensorRT-LLM 0.21.0.
+
+The introspector runs inside ``nvcr.io/nvidia/tensorrt-llm/release:0.21.0``
+and lifts engine parameter specs from ``TrtLlmArgs`` (Pydantic v2) and
+sampling parameter specs from ``SamplingParams`` (dataclass).
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "tensorrt_llm.SamplingParams",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
+)

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/static.py
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/machinery/static.py
@@ -1,0 +1,33 @@
+"""Static-miner LANDMARKS for TensorRT-LLM 0.21.0.
+
+The static miner walks an extracted source tree under
+``/tmp/trt-llm-0.21.0/`` rather than the installed library; LANDMARKS
+nevertheless reference the live ``tensorrt_llm`` package because that
+is the seam Renovate's library bumps shift first. A missing landmark
+under the installed library trips the probe; a divergent source tree
+trips ``MinerLandmarkMissingError`` inside the miner.
+"""
+
+from __future__ import annotations
+
+LANDMARKS: tuple[str, ...] = (
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_dtype",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_model_format_misc",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.set_runtime_knobs_from_build_config",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_with_runtime_params",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_build_config_remaining",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_speculative_config",
+    "tensorrt_llm.llmapi.llm_args.BaseLlmArgs.validate_lora_config_consistency",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.validate_enable_build_cache",
+    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig",
+    "tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig.validate_positive_values",
+    "tensorrt_llm.llmapi.llm_args.CalibConfig",
+    "tensorrt_llm.llmapi.llm_args.BatchingType",
+    "tensorrt_llm.llmapi.llm_args.CapacitySchedulerPolicy",
+    "tensorrt_llm.llmapi.llm_args.ContextChunkingPolicy",
+    "tensorrt_llm.builder.Builder",
+    "tensorrt_llm.builder.Builder.build_engine",
+)

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.proposed.yaml
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.proposed.yaml
@@ -1,0 +1,93 @@
+schema_version: 1.0.0
+engine: tensorrt
+engine_version: 0.21.0
+miner_pinned_range: <0.22.0,>=0.21.0
+mined_at: '2026-05-06T20:35:47+02:00'
+invariants:
+- id: tensorrt_raises_max_ngram_size_le_0_positive_values
+  engine: tensorrt
+  library: tensorrt_llm
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <= 0 (via
+    raise ValueError)
+  severity: error
+  native_type: tensorrt_llm.LookaheadDecodingConfig
+  miner_source:
+    path: llmapi/llm_args.py
+    method: validate_positive_values
+    line_at_scan: 577
+  match:
+    engine: tensorrt
+    fields:
+      tensorrt.max_ngram_size:
+        <=: 0
+  kwargs_positive:
+    max_ngram_size: 0
+  kwargs_negative:
+    max_ngram_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Value must be positive, got {v}
+  references:
+  - llmapi/llm_args.py:577 (tensorrt_llm.LookaheadDecodingConfig.validate_positive_values)
+  added_by: static_miner
+  added_at: '2026-05-06'
+- id: tensorrt_raises_max_verification_set_size_le_0_positive_values
+  engine: tensorrt
+  library: tensorrt_llm
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_verification_set_size
+    <= 0 (via raise ValueError)
+  severity: error
+  native_type: tensorrt_llm.LookaheadDecodingConfig
+  miner_source:
+    path: llmapi/llm_args.py
+    method: validate_positive_values
+    line_at_scan: 577
+  match:
+    engine: tensorrt
+    fields:
+      tensorrt.max_verification_set_size:
+        <=: 0
+  kwargs_positive:
+    max_verification_set_size: 0
+  kwargs_negative:
+    max_verification_set_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Value must be positive, got {v}
+  references:
+  - llmapi/llm_args.py:577 (tensorrt_llm.LookaheadDecodingConfig.validate_positive_values)
+  added_by: static_miner
+  added_at: '2026-05-06'
+- id: tensorrt_raises_max_window_size_le_0_positive_values
+  engine: tensorrt
+  library: tensorrt_llm
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <= 0 (via
+    raise ValueError)
+  severity: error
+  native_type: tensorrt_llm.LookaheadDecodingConfig
+  miner_source:
+    path: llmapi/llm_args.py
+    method: validate_positive_values
+    line_at_scan: 577
+  match:
+    engine: tensorrt
+    fields:
+      tensorrt.max_window_size:
+        <=: 0
+  kwargs_positive:
+    max_window_size: 0
+  kwargs_negative:
+    max_window_size: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: Value must be positive, got {v}
+  references:
+  - llmapi/llm_args.py:577 (tensorrt_llm.LookaheadDecodingConfig.validate_positive_values)
+  added_by: static_miner
+  added_at: '2026-05-06'

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.validated.yaml
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/invariants.validated.yaml
@@ -1,0 +1,45 @@
+schema_version: 1.0.0
+engine: tensorrt
+engine_version: 0.21.0
+image_ref: llenergymeasure:tensorrt
+base_image_ref: llenergymeasure:tensorrt
+validated_at: '2026-05-06T20:35:47+02:00'
+validation_commit: 4ad6ee7b8e43c1282751a5b76ca936c6fe6982a3
+cases:
+- id: tensorrt_raises_max_ngram_size_le_0_positive_values
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for LookaheadDecodingConfig\nmax_ngram_size\n  Value\
+      \ error, Value must be positive, got 0 [type=value_error, input_value=0, input_type=int]\n\
+      \    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: tensorrt_raises_max_verification_set_size_le_0_positive_values
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for LookaheadDecodingConfig\nmax_verification_set_size\n\
+      \  Value error, Value must be positive, got 0 [type=value_error, input_value=0,\
+      \ input_type=int]\n    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: tensorrt_raises_max_window_size_le_0_positive_values
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for LookaheadDecodingConfig\nmax_window_size\n  Value\
+      \ error, Value must be positive, got 0 [type=value_error, input_value=0, input_type=int]\n\
+      \    For further information visit https://errors.pydantic.dev/2.11/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+divergences: []

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/schema.discovered.json
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/outputs/schema.discovered.json
@@ -1,0 +1,576 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "tensorrt",
+  "engine_version": "0.21.0",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:tensorrt-0.21.0",
+  "base_image_ref": null,
+  "discovered_at": "2026-05-06T20:20:57+02:00",
+  "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+  "discovery_limitations": [
+    {
+      "section": "engine_params",
+      "fields": [
+        "build_config"
+      ],
+      "reason": "BuildConfig is not a Pydantic model; appears as Optional[object] in the schema"
+    },
+    {
+      "section": "sampling_params",
+      "fields": [],
+      "reason": "SamplingParams is a dataclass; no per-field descriptions"
+    }
+  ],
+  "engine_params": {
+    "model": {
+      "type": "string",
+      "default": null,
+      "description": "The path to the model checkpoint or the model name from the Hugging Face Hub.",
+      "deprecated": false
+    },
+    "tokenizer": {
+      "type": "string | None",
+      "default": null,
+      "description": "The path to the tokenizer checkpoint or the tokenizer name from the Hugging Face Hub.",
+      "deprecated": false
+    },
+    "tokenizer_mode": {
+      "type": "Literal['auto', 'slow']",
+      "default": "auto",
+      "description": "The mode to initialize the tokenizer.",
+      "deprecated": false
+    },
+    "skip_tokenizer_init": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to skip the tokenizer initialization.",
+      "deprecated": false
+    },
+    "trust_remote_code": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to trust the remote code.",
+      "deprecated": false
+    },
+    "tensor_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The tensor parallel size.",
+      "deprecated": false
+    },
+    "dtype": {
+      "type": "string",
+      "default": "auto",
+      "description": "The data type to use for the model.",
+      "deprecated": false
+    },
+    "revision": {
+      "type": "string | None",
+      "default": null,
+      "description": "The revision to use for the model.",
+      "deprecated": false
+    },
+    "tokenizer_revision": {
+      "type": "string | None",
+      "default": null,
+      "description": "The revision to use for the tokenizer.",
+      "deprecated": false
+    },
+    "pipeline_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The pipeline parallel size.",
+      "deprecated": false
+    },
+    "context_parallel_size": {
+      "type": "integer",
+      "default": 1,
+      "description": "The context parallel size.",
+      "deprecated": false
+    },
+    "gpus_per_node": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The number of GPUs per node.",
+      "deprecated": false
+    },
+    "moe_cluster_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The cluster parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "moe_tensor_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The tensor parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "moe_expert_parallel_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The expert parallel size for MoE models's expert weights.",
+      "deprecated": false
+    },
+    "enable_attention_dp": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable attention data parallel.",
+      "deprecated": false
+    },
+    "cp_config": {
+      "type": "object | None",
+      "default": null,
+      "description": "Context parallel config.",
+      "deprecated": false
+    },
+    "load_format": {
+      "type": "Literal['auto', 'dummy']",
+      "default": "auto",
+      "description": "The format to load the model.",
+      "deprecated": false
+    },
+    "enable_lora": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable LoRA.",
+      "deprecated": false
+    },
+    "max_lora_rank": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum LoRA rank.",
+      "deprecated": true
+    },
+    "max_loras": {
+      "type": "integer",
+      "default": 4,
+      "description": "The maximum number of LoRA.",
+      "deprecated": true
+    },
+    "max_cpu_loras": {
+      "type": "integer",
+      "default": 4,
+      "description": "The maximum number of LoRA on CPU.",
+      "deprecated": true
+    },
+    "lora_config": {
+      "type": "LoraConfig | None",
+      "default": null,
+      "description": "LoRA configuration for the model.",
+      "deprecated": false
+    },
+    "enable_prompt_adapter": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable prompt adapter.",
+      "deprecated": false
+    },
+    "max_prompt_adapter_token": {
+      "type": "integer",
+      "default": 0,
+      "description": "The maximum number of prompt adapter tokens.",
+      "deprecated": false
+    },
+    "quant_config": {
+      "type": "QuantConfig | None",
+      "default": null,
+      "description": "Quantization config.",
+      "deprecated": false
+    },
+    "kv_cache_config": {
+      "type": "KvCacheConfig",
+      "default": null,
+      "description": "KV cache config.",
+      "deprecated": false
+    },
+    "enable_chunked_prefill": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable chunked prefill.",
+      "deprecated": false
+    },
+    "guided_decoding_backend": {
+      "type": "string | None",
+      "default": null,
+      "description": "Guided decoding backend.",
+      "deprecated": false
+    },
+    "batched_logits_processor": {
+      "type": "Optional[tensorrt_llm.sampling_params.BatchedLogitsProcessor]",
+      "default": null,
+      "description": "Batched logits processor.",
+      "deprecated": false
+    },
+    "iter_stats_max_iterations": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of iterations for iter stats.",
+      "deprecated": false
+    },
+    "request_stats_max_iterations": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of iterations for request stats.",
+      "deprecated": false
+    },
+    "peft_cache_config": {
+      "type": "PeftCacheConfig | None",
+      "default": null,
+      "description": "PEFT cache config.",
+      "deprecated": false
+    },
+    "scheduler_config": {
+      "type": "SchedulerConfig",
+      "default": null,
+      "description": "Scheduler config.",
+      "deprecated": false
+    },
+    "cache_transceiver_config": {
+      "type": "CacheTransceiverConfig | None",
+      "default": null,
+      "description": "Cache transceiver config.",
+      "deprecated": false
+    },
+    "speculative_config": {
+      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
+      "default": null,
+      "description": "Speculative decoding config.",
+      "deprecated": false
+    },
+    "batching_type": {
+      "type": "BatchingType | None",
+      "default": null,
+      "description": "Batching type.",
+      "deprecated": false
+    },
+    "normalize_log_probs": {
+      "type": "boolean",
+      "default": false,
+      "description": "Normalize log probabilities.",
+      "deprecated": false
+    },
+    "max_batch_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum batch size.",
+      "deprecated": false
+    },
+    "max_input_len": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum input length.",
+      "deprecated": false
+    },
+    "max_seq_len": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum sequence length.",
+      "deprecated": false
+    },
+    "max_beam_width": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum beam width.",
+      "deprecated": false
+    },
+    "max_num_tokens": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The maximum number of tokens.",
+      "deprecated": false
+    },
+    "gather_generation_logits": {
+      "type": "boolean",
+      "default": false,
+      "description": "Gather generation logits.",
+      "deprecated": false
+    },
+    "num_postprocess_workers": {
+      "type": "integer",
+      "default": 0,
+      "description": "The number of processes used for postprocessing the generated tokens, including detokenization.",
+      "deprecated": false
+    },
+    "postprocess_tokenizer_dir": {
+      "type": "string | None",
+      "default": null,
+      "description": "The path to the tokenizer directory for postprocessing.",
+      "deprecated": false
+    },
+    "reasoning_parser": {
+      "type": "string | None",
+      "default": null,
+      "description": "The parser to separate reasoning content from output.",
+      "deprecated": false
+    },
+    "garbage_collection_gen0_threshold": {
+      "type": "integer",
+      "default": 20000,
+      "description": "Threshold for Python garbage collection of generation 0 objects.Lower values trigger more frequent garbage collection.",
+      "deprecated": false
+    },
+    "decoding_config": {
+      "type": "Optional[DecodingConfig]",
+      "default": null,
+      "description": "The decoding config.",
+      "deprecated": true
+    },
+    "backend": {
+      "type": "string | None",
+      "default": null,
+      "description": "The backend to use for this LLM instance.",
+      "deprecated": false
+    },
+    "auto_parallel": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable auto parallel mode.",
+      "deprecated": true
+    },
+    "auto_parallel_world_size": {
+      "type": "integer | None",
+      "default": null,
+      "description": "The world size for auto parallel mode.",
+      "deprecated": true
+    },
+    "enable_tqdm": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable tqdm for progress bar.",
+      "deprecated": false
+    },
+    "workspace": {
+      "type": "string | None",
+      "default": null,
+      "description": "The workspace for the model.",
+      "deprecated": false
+    },
+    "enable_build_cache": {
+      "type": "Union[tensorrt_llm.llmapi.build_cache.BuildCacheConfig, bool]",
+      "default": false,
+      "description": "Enable build cache.",
+      "deprecated": false
+    },
+    "extended_runtime_perf_knob_config": {
+      "type": "ExtendedRuntimePerfKnobConfig | None",
+      "default": null,
+      "description": "Extended runtime perf knob config.",
+      "deprecated": false
+    },
+    "calib_config": {
+      "type": "CalibConfig | None",
+      "default": null,
+      "description": "Calibration config.",
+      "deprecated": false
+    },
+    "embedding_parallel_mode": {
+      "type": "string",
+      "default": "SHARDING_ALONG_VOCAB",
+      "description": "The embedding parallel mode.",
+      "deprecated": false
+    },
+    "fast_build": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable fast build.",
+      "deprecated": false
+    },
+    "build_config": {
+      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "default": null,
+      "description": "Build config.",
+      "deprecated": false
+    }
+  },
+  "sampling_params": {
+    "end_id": {
+      "type": "int | None",
+      "default": null
+    },
+    "pad_id": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_tokens": {
+      "type": "int",
+      "default": 32
+    },
+    "bad": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "bad_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "stop": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "stop_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "include_stop_str_in_output": {
+      "type": "bool",
+      "default": false
+    },
+    "embedding_bias": {
+      "type": "Tensor | None",
+      "default": null
+    },
+    "logits_processor": {
+      "type": "LogitsProcessor | list[LogitsProcessor] | None",
+      "default": null
+    },
+    "apply_batched_logits_processor": {
+      "type": "bool",
+      "default": false
+    },
+    "n": {
+      "type": "int",
+      "default": 1
+    },
+    "best_of": {
+      "type": "int | None",
+      "default": null
+    },
+    "use_beam_search": {
+      "type": "bool",
+      "default": false
+    },
+    "top_k": {
+      "type": "int | None",
+      "default": null
+    },
+    "top_p": {
+      "type": "float | None",
+      "default": null
+    },
+    "top_p_min": {
+      "type": "float | None",
+      "default": null
+    },
+    "top_p_reset_ids": {
+      "type": "int | None",
+      "default": null
+    },
+    "top_p_decay": {
+      "type": "float | None",
+      "default": null
+    },
+    "seed": {
+      "type": "int | None",
+      "default": null
+    },
+    "temperature": {
+      "type": "float | None",
+      "default": null
+    },
+    "min_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "beam_search_diversity_rate": {
+      "type": "float | None",
+      "default": null
+    },
+    "repetition_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "presence_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "frequency_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "length_penalty": {
+      "type": "float | None",
+      "default": null
+    },
+    "early_stopping": {
+      "type": "int | None",
+      "default": null
+    },
+    "no_repeat_ngram_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "min_p": {
+      "type": "float | None",
+      "default": null
+    },
+    "beam_width_array": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "prompt_logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "return_context_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "return_generation_logits": {
+      "type": "bool",
+      "default": false
+    },
+    "exclude_input_from_output": {
+      "type": "bool",
+      "default": true
+    },
+    "return_encoder_output": {
+      "type": "bool",
+      "default": false
+    },
+    "return_perf_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "additional_model_outputs": {
+      "type": "list[AdditionalModelOutput] | None",
+      "default": null
+    },
+    "lookahead_config": {
+      "type": "LookaheadDecodingConfig | None",
+      "default": null
+    },
+    "guided_decoding": {
+      "type": "GuidedDecodingParams | None",
+      "default": null
+    },
+    "ignore_eos": {
+      "type": "bool",
+      "default": false
+    },
+    "detokenize": {
+      "type": "bool",
+      "default": true
+    },
+    "add_special_tokens": {
+      "type": "bool",
+      "default": true
+    },
+    "truncate_prompt_tokens": {
+      "type": "int | None",
+      "default": null
+    },
+    "skip_special_tokens": {
+      "type": "bool",
+      "default": true
+    },
+    "spaces_between_special_tokens": {
+      "type": "bool",
+      "default": true
+    }
+  }
+}

--- a/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/ssot.yaml
+++ b/src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/ssot.yaml
@@ -1,0 +1,34 @@
+# Per-engine version-bundle SSOT for tensorrt-llm.
+#
+# Renovate updates `library.current_version` on each upstream release;
+# every other artefact (Dockerfile ARG, miner pin reads, validation gates)
+# is derived from this file. See
+# `.product/designs/engine-coupling-architecture-2026-04-28.md` §4.
+schema_version: 1
+engine: tensorrt
+library:
+  pep503_name: tensorrt-llm
+  current_version: "0.21.0"
+  current_commit_sha: null
+image:
+  base_image_ref: "nvcr.io/nvidia/tensorrt-llm/release:0.21.0"
+  llem_image_ref: null
+source_tarball:
+  # Template for the upstream release tarball. Workflow cells that need to
+  # mine TRT-LLM source files (the static miner + introspector) read it via
+  # `yq`, then substitute `{version}` with `library.current_version`. Single
+  # locus to update if NVIDIA changes their tag scheme. See #532.
+  url_template: "https://github.com/NVIDIA/TensorRT-LLM/archive/refs/tags/v{version}.tar.gz"
+miner_pins:
+  static: ">=0.21.0,<0.22.0"
+  dynamic: ">=0.21.0,<0.22.0"
+  discovery: ">=0.21.0,<0.22.0"
+artefact_paths:
+  engine_invariants: src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
+  validated_invariants: src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
+  discovered_schemas: src/llenergymeasure/engines/tensorrt/schema.discovered.json
+last_probe:
+  verdict: pass
+  version_inside_envelope: true
+  fingerprint: "a7902bb13b595121c161edcb00516bb4e1b719c339edd70ab3e9d09802d75e6d"
+  fingerprint_drift: []

--- a/tests/_engine_archive/test_tensorrt_lazy.py
+++ b/tests/_engine_archive/test_tensorrt_lazy.py
@@ -1,0 +1,54 @@
+"""Per-engine LANDMARKS resolution tests for tensorrt-llm v0.21.0.
+
+Engine-specific complement to ``tests/_engine_archive/test_dispatcher.py``:
+asserts the two tensorrt producer modules expose ``LANDMARKS`` lazily via
+PEP 562 ``__getattr__`` and that the resolved tuple matches the machinery
+loaded directly through the dispatcher.
+
+Mirror style of ``test_dispatcher.py``: keep imports lazy where the
+assertion target is the module attribute, fail loud otherwise. Note the
+miner module name is ``tensorrt_static_miner`` (not ``tensorrt_miner``) -
+see ``scripts/_probe.py`` ``_PRODUCER_MODULES`` for the canonical mapping.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from llenergymeasure._engine_archive._dispatcher import load_machinery
+
+_TENSORRT_VERSION = "0.21.0"
+
+
+def _assert_landmark_shape(landmarks: object) -> tuple[str, ...]:
+    """Shared shape contract: non-empty tuple of dotted ``tensorrt_llm.*`` paths."""
+    assert isinstance(landmarks, tuple), f"LANDMARKS must be tuple, got {type(landmarks)!r}"
+    assert len(landmarks) > 0, "LANDMARKS must be non-empty"
+    for entry in landmarks:
+        assert isinstance(entry, str), f"LANDMARKS entry must be str, got {type(entry)!r}"
+        assert entry.startswith("tensorrt_llm."), (
+            f"LANDMARKS entry {entry!r} must start with 'tensorrt_llm.'"
+        )
+    return landmarks  # type: ignore[return-value]
+
+
+def test_tensorrt_static_miner_landmarks_resolve_lazily() -> None:
+    """``scripts.engine_miners.tensorrt_static_miner.LANDMARKS`` resolves via PEP 562."""
+    module = importlib.import_module("scripts.engine_miners.tensorrt_static_miner")
+    landmarks = _assert_landmark_shape(module.LANDMARKS)
+
+    archived = load_machinery(
+        engine="tensorrt", version=_TENSORRT_VERSION, producer="static"
+    ).LANDMARKS
+    assert landmarks == archived
+
+
+def test_tensorrt_introspector_landmarks_resolve_lazily() -> None:
+    """``scripts.engine_introspectors.tensorrt_introspector.LANDMARKS`` resolves via PEP 562."""
+    module = importlib.import_module("scripts.engine_introspectors.tensorrt_introspector")
+    landmarks = _assert_landmark_shape(module.LANDMARKS)
+
+    archived = load_machinery(
+        engine="tensorrt", version=_TENSORRT_VERSION, producer="discovery"
+    ).LANDMARKS
+    assert landmarks == archived


### PR DESCRIPTION
## Summary

Activates the per-engine archive for tensorrt-llm v0.21.0, on top of PR-A's engine-agnostic dispatcher (#598).

- Adds `src/llenergymeasure/_engine_archive/tensorrt/v0_21_0/` with static + discovery machinery modules, the per-version SSOT, and cached invariants / schema outputs.
- Refactors `scripts/engine_miners/tensorrt_static_miner.py` and `scripts/engine_introspectors/tensorrt_introspector.py` to expose `LANDMARKS` lazily via PEP 562 `__getattr__` calling `load_machinery(engine="tensorrt", version=..., producer=...)`.
- Adds `tests/_engine_archive/test_tensorrt_lazy.py` mirroring the dispatcher test style: asserts both producers expose a non-empty tuple of dotted `tensorrt_llm.*` paths and that the resolved tuple matches `load_machinery(...).LANDMARKS`.

The probe maps `("tensorrt", "invariants")` to `tensorrt_static_miner` (see `scripts/_probe.py`); the LANDMARKS hook lives in that module, not in `tensorrt_miner`. No dynamic miner exists for tensorrt - all cross-field invariants fire at engine build inside C++, out of reach for Python-side construction probing.

## Test plan

- [x] `pytest tests/_engine_archive/ -v` - 13/13 pass (7 PR-A + 2 new tensorrt + 4 unrelated parametrised renovate tests)
- [x] `uv build --wheel` - `_engine_archive` continues to be excluded from the published distribution (0 entries)
- [ ] CI green on main pipeline once base PR-A merges