### PR TITLE
fix(engines): TRT-LLM 0.21 SamplingParams kwargs (seed, max_tokens)

### DIFF
--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -598,9 +598,9 @@ class TensorRTEngine:
         kwargs: dict[str, Any] = (
             sampling.model_dump(exclude_none=True) if sampling is not None else {}
         )
-        kwargs["random_seed"] = config.task.random_seed
+        kwargs["seed"] = config.task.random_seed
         if config.task.max_output_tokens is not None:
-            kwargs["max_new_tokens"] = config.task.max_output_tokens
+            kwargs["max_tokens"] = config.task.max_output_tokens
         return kwargs
 
     def _build_sampling_params(self, config: ExperimentConfig) -> Any:

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -412,7 +412,7 @@ class TestBuildLlmKwargs:
 
 class TestBuildSamplingParams:
     def test_build_sampling_params_defaults(self, monkeypatch):
-        """Default config produces SamplingParams with max_new_tokens and no temperature."""
+        """Default config produces SamplingParams with max_tokens and no temperature."""
         mock_trt = _make_fake_tensorrt_llm_module()
         monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
         monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
@@ -422,10 +422,10 @@ class TestBuildSamplingParams:
         params = engine._build_sampling_params(config)
 
         assert isinstance(params, _FakeSamplingParams)
-        assert params._kwargs["max_new_tokens"] == config.task.max_output_tokens
+        assert params._kwargs["max_tokens"] == config.task.max_output_tokens
 
     def test_build_sampling_params_passes_random_seed(self, monkeypatch):
-        """random_seed from ExperimentConfig is forwarded to SamplingParams."""
+        """random_seed from ExperimentConfig is forwarded to SamplingParams as `seed`."""
         mock_trt = _make_fake_tensorrt_llm_module()
         monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
         monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
@@ -434,7 +434,7 @@ class TestBuildSamplingParams:
         engine = TensorRTEngine()
         params = engine._build_sampling_params(config)
 
-        assert params._kwargs["random_seed"] == 123
+        assert params._kwargs["seed"] == 123
 
     def test_build_sampling_params_default_no_temperature(self, monkeypatch):
         """Unset sampling -> no temperature in kwargs (TRT-LLM uses its own default)."""


### PR DESCRIPTION
## Summary
- TRT-LLM 0.21.0 renamed two `SamplingParams` kwargs (`random_seed` -> `seed`, `max_new_tokens` -> `max_tokens`). The plugin still wrote the older names, so every TRT-LLM generate call failed with an invalid-argument error.
- Two-line API match. No behaviour change beyond making TRT-LLM experiments work.

## Provenance
Implementation pulled as-is from PoC branch \`poc/engine-energy-variance-2026-05-10\` (commits b2f6b346 + 61972002), where it ran successfully across Tier 1-4 sweeps.

## Test plan
- [ ] CI green
- [ ] Manual TRT-LLM smoke (already validated on PoC branch)

Closes #609.