### PR TITLE
fix(infra): auto-mount host HuggingFace cache into containers

### DIFF
--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -773,6 +773,14 @@ class DockerRunner:
             if not any(cp == cache_container for _, cp in self.extra_mounts):
                 cmd.extend(["-v", f"{cache_host}:{cache_container}"])
 
+        # Auto-mount the host HuggingFace cache so model weights persist across
+        # ephemeral containers; otherwise each run re-downloads the full model.
+        hf_cache_host = Path.home() / ".cache" / "huggingface"
+        hf_cache_container = "/root/.cache/huggingface"
+        if not any(cp == hf_cache_container for _, cp in self.extra_mounts):
+            cmd.extend(["-v", f"{hf_cache_host}:{hf_cache_container}"])
+            cmd.extend(["-e", f"HF_HOME={hf_cache_container}"])
+
         # Extra volume mounts (engine cache, model cache, etc.)
         for host_path, container_path in self.extra_mounts:
             cmd.extend(["-v", f"{host_path}:{container_path}"])

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -883,17 +883,18 @@ class TestExtraMounts:
         assert "/host/b:/container/b" in cmd
 
     def test_no_extra_mounts_no_extra_volumes(self, tmp_path):
-        """Without extra_mounts, two -v flags are present: exchange dir + llem-src."""
+        """Without extra_mounts, three -v flags are present: exchange dir + llem-src + HF cache."""
         config = make_config()
         runner = DockerRunner(image=IMAGE)
         cmd = self._build_cmd(config, tmp_path, runner)
 
-        # Two -v flags: the exchange dir + the llem-src bind mount (all engines
-        # now use mount-based dispatch - see docker_runner._build_docker_cmd).
+        # Three -v flags: exchange dir, llem-src bind mount, and the HF cache
+        # auto-mount (all engines now use mount-based dispatch).
         v_count = cmd.count("-v")
-        assert v_count == 2
+        assert v_count == 3
         assert f"/tmp/llem-test:{CONTAINER_EXCHANGE_DIR}" in cmd
         assert any(arg.endswith(":/llem-src:ro") for arg in cmd)
+        assert any(arg.endswith(":/root/.cache/huggingface") for arg in cmd)
 
     def test_tensorrt_auto_cache_mount(self, tmp_path):
         """TRT-LLM engine auto-mounts ~/.cache/trt-llm:/root/.cache/trt-llm."""


### PR DESCRIPTION
## Summary
- Without HF cache mounted, every experiment re-downloads model weights (~16 GB for a 7B model) into the ephemeral container, then loses them when the container exits.
- Mount \`~/.cache/huggingface\` and set \`HF_HOME\` so model weights persist across runs.

## Defaults change rationale
Implicit-mount of a user cache is a defaults decision. We're landing it as opt-out rather than opt-in because the alternative (every user discovering the flag) wastes bandwidth + disk on the common path. Users with bespoke HF caches can override via existing \`extra_mounts\`.

## Provenance
Implementation pulled as-is from PoC branch \`poc/engine-energy-variance-2026-05-10\` (commit bdd7342e, runner portion only), where it ran successfully across Tier 1-4 sweeps.

## Test plan
- [ ] CI green
- [ ] Manual smoke: confirm \`~/.cache/huggingface\` is bind-mounted into a transformers container

Closes #605.