### PR TITLE
fix(infra): forward LLEM_* env vars from host into container

### DIFF
--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -781,6 +781,13 @@ class DockerRunner:
             cmd.extend(["-v", f"{hf_cache_host}:{hf_cache_container}"])
             cmd.extend(["-e", f"HF_HOME={hf_cache_container}"])
 
+        # Forward LLEM_* env vars into the container so framework defaults set
+        # on the host (e.g. LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP) reach the
+        # experiment process, which actually runs inside the container.
+        for env_key, env_val in os.environ.items():
+            if env_key.startswith("LLEM_") and env_val:
+                cmd.extend(["-e", f"{env_key}={env_val}"])
+
         # Extra volume mounts (engine cache, model cache, etc.)
         for host_path, container_path in self.extra_mounts:
             cmd.extend(["-v", f"{host_path}:{container_path}"])


### PR DESCRIPTION
## Summary
- The host CLI reads \`LLEM_*\` env vars to set framework defaults, but the experiment process actually runs inside the container, where those defaults were never visible.
- Symptom: setting \`LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto\` on the host did nothing; transformers experiments dispatched via Docker silently fell back to CPU and warmup never finished (7B model on CPU = hang).
- Forward all \`LLEM_*\` env vars with non-empty values into the container.

## Convention-locking note
This codifies \`LLEM_*\` as the framework's env-var namespace. The prefix was already in use by \`utils/env_config.py\`; this PR makes the host->container forwarding rule explicit.

## Stacking
Stacked on #620. Retarget to \`main\` after #620 merges.

## Provenance
Implementation pulled as-is from PoC branch \`poc/engine-energy-variance-2026-05-10\` (commit 0fbe15fa).

## Test plan
- [ ] CI green
- [ ] Manual: \`LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto llem run ...\` reaches the transformers plugin

Closes #606.