### PR TITLE
fix(infra): auto-mount host flashinfer JIT cache for TRT-LLM

### DIFF
--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -781,6 +781,14 @@ class DockerRunner:
             cmd.extend(["-v", f"{hf_cache_host}:{hf_cache_container}"])
             cmd.extend(["-e", f"HF_HOME={hf_cache_container}"])
 
+        # Auto-mount the host flashinfer JIT cache so TRT-LLM warm runs reuse
+        # already-compiled per-arch attention kernels (cold compile is minutes).
+        if config.engine == Engine.TENSORRT:
+            fi_cache_host = Path.home() / ".cache" / "flashinfer"
+            fi_cache_container = "/root/.cache/flashinfer"
+            if not any(cp == fi_cache_container for _, cp in self.extra_mounts):
+                cmd.extend(["-v", f"{fi_cache_host}:{fi_cache_container}"])
+
         # Forward LLEM_* env vars into the container so framework defaults set
         # on the host (e.g. LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP) reach the
         # experiment process, which actually runs inside the container.


### PR DESCRIPTION
## Summary
- flashinfer JIT-compiles per-arch attention kernels on first import (~30s per kernel; several kernels per engine = several minutes added to every cold start).
- Persist \`~/.cache/flashinfer\` across containers so warm runs reuse compiled kernels.
- Scoped to \`Engine.TENSORRT\` (only TRT-LLM uses flashinfer in the current backend set).

## Defaults change rationale
Same shape as #620 (HF cache). Implicit user-cache mount is opt-out; users can override via \`extra_mounts\`.

## Stacking
Stacked on #621 (which is stacked on #620). Retarget to \`main\` after both ancestors merge.

## Provenance
Implementation pulled as-is from PoC branch \`poc/engine-energy-variance-2026-05-10\` (commit b2f6b346, runner portion only).

## Test plan
- [ ] CI green
- [ ] Manual: second TRT-LLM run starts in ~1s instead of ~5 min

Closes #610.