### PR TITLE
fix(harness): pre-flight gate for HF pre-quantised checkpoints on TRT-LLM

### DIFF
--- a/docs/how-to/run-with-tensorrt-llm.md
+++ b/docs/how-to/run-with-tensorrt-llm.md
@@ -121,6 +121,32 @@ and starts inference immediately. Changing any compile-time parameter
 triggers a new build.
 :::
 
+## HF pre-quantised checkpoints
+
+TensorRT-LLM cannot load Hugging Face AWQ or GPTQ checkpoints directly:
+the weight-key layout in HF's serialisation differs from what TensorRT-LLM
+expects, so model load raises `KeyError: 'weight'`.
+
+Pre-flight catches this and refuses the run with an actionable error. To
+benchmark a pre-quantised checkpoint, convert it once with `trtllm-build`
+and point the experiment at the build output:
+
+```bash
+trtllm-build \
+  --checkpoint_dir <path-to-converted-checkpoint> \
+  --output_dir /shared/engines/qwen2.5-7b-awq
+```
+
+```yaml
+task:
+  model: Qwen/Qwen2.5-7B-Instruct-AWQ   # original HF id, for tokenizer + metadata
+tensorrt:
+  engine_path: /shared/engines/qwen2.5-7b-awq
+```
+
+With `engine_path` set, the pre-flight gate is skipped because the engine
+is already in TensorRT-LLM's native format.
+
 ## 3. Read the results
 
 The output format matches other engines. The result file includes

--- a/src/llenergymeasure/harness/preflight.py
+++ b/src/llenergymeasure/harness/preflight.py
@@ -82,6 +82,79 @@ def _check_model_accessible(model_id: str) -> str | None:
         return None
 
 
+# TRT-LLM cannot load HF pre-quantised checkpoints directly; they require
+# trtllm-build conversion first. The detection signal is the HF-declared
+# quant_method value rather than a regex over model ids, so user-renamed
+# checkpoints (e.g. local forks without the conventional suffix) are still
+# caught - extend by adding the canonical quant_method string, not a pattern.
+_TRT_UNSUPPORTED_HF_QUANT_METHODS: tuple[str, ...] = ("awq", "gptq")
+
+
+def _read_model_quant_method(model_id: str) -> str | None:
+    """Return the HF ``quantization_config.quant_method`` for *model_id*, or None.
+
+    ``quantization_config.quant_method`` is HF's authoritative quantisation
+    declaration - every quantisation library (AutoAWQ, AutoGPTQ, bitsandbytes,
+    compressed-tensors) writes it, so it's the stable signal for "is this
+    checkpoint pre-quantised, and how?".
+
+    Returns None for both "no quantisation declared" AND "couldn't determine"
+    (network error, missing config, malformed JSON, no huggingface_hub
+    installed). Callers must treat None as "not detected, proceed" rather
+    than "definitely unquantised" - failing closed on transient errors would
+    block legitimate runs on every network hiccup.
+    """
+    import json
+
+    config_data: dict[str, object] | None = None
+
+    if model_id.startswith("/") or model_id.startswith("./") or model_id.startswith("~"):
+        config_path = Path(model_id).expanduser() / "config.json"
+        try:
+            config_data = json.loads(config_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("Could not read local config.json for %s: %s", model_id, exc)
+            return None
+    else:
+        if importlib.util.find_spec("huggingface_hub") is None:
+            return None
+        try:
+            from huggingface_hub import hf_hub_download
+
+            local = hf_hub_download(repo_id=model_id, filename="config.json")
+            config_data = json.loads(Path(local).read_text())
+        except Exception as exc:
+            logger.debug("Could not fetch HF config.json for %s: %s", model_id, exc)
+            return None
+
+    quant_block = config_data.get("quantization_config") if isinstance(config_data, dict) else None
+    if not isinstance(quant_block, dict):
+        return None
+    method = quant_block.get("quant_method")
+    return method.lower() if isinstance(method, str) else None
+
+
+def _check_tensorrt_checkpoint_compat(config: ExperimentConfig) -> str | None:
+    """Reject HF pre-quantised checkpoints on TRT-LLM unless ``engine_path`` is set."""
+    if config.engine != Engine.TENSORRT:
+        return None
+
+    trt = config.tensorrt
+    if trt is not None and getattr(trt, "engine_path", None):
+        return None
+
+    method = _read_model_quant_method(config.task.model)
+    if method is None or method not in _TRT_UNSUPPORTED_HF_QUANT_METHODS:
+        return None
+
+    return (
+        f"{config.task.model} is an HF {method.upper()} checkpoint; TRT-LLM cannot "
+        f"load it directly. Pre-build a TRT-LLM engine (`trtllm-build --checkpoint_dir "
+        f"<converted> ...`) and set `tensorrt.engine_path` to the build output. "
+        f"See docs/how-to/run-with-tensorrt-llm.md#hf-pre-quantised-checkpoints."
+    )
+
+
 def _warn_if_persistence_mode_off(gpu_indices: list[int] | None = None) -> None:
     """Log a warning if GPU persistence mode is disabled on any specified GPU.
 
@@ -156,6 +229,11 @@ def run_preflight(config: ExperimentConfig) -> None:
         failures.extend(engine_errors)
     except Exception:
         pass  # get_engine may fail if engine not installed - already caught by Check 2
+
+    # Check 5: TRT-LLM cannot consume HF pre-quantised checkpoints natively.
+    checkpoint_error = _check_tensorrt_checkpoint_compat(config)
+    if checkpoint_error is not None:
+        failures.append(checkpoint_error)
 
     if failures:
         n = len(failures)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -601,3 +601,141 @@ def test_get_compute_capability_returns_tuple_or_none() -> None:
 
     result = get_compute_capability()
     assert result is None or (isinstance(result, tuple) and len(result) == 2)
+
+
+# ---------------------------------------------------------------------------
+# Test: TRT-LLM HF pre-quantised checkpoint gate
+# ---------------------------------------------------------------------------
+
+
+def test_trt_checkpoint_compat_skips_non_tensorrt_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-tensorrt engines do not trigger the quant-checkpoint gate."""
+    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+
+    monkeypatch.setattr(
+        llenergymeasure.harness.preflight,
+        "_read_model_quant_method",
+        lambda _: "awq",
+    )
+    config = make_config(engine="transformers")
+    assert _check_tensorrt_checkpoint_compat(config) is None
+
+
+def test_trt_checkpoint_compat_passes_non_quantised(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-quantised models on TRT-LLM pass the gate."""
+    from llenergymeasure.config.engine_configs import TensorRTConfig
+    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+
+    monkeypatch.setattr(
+        llenergymeasure.harness.preflight,
+        "_read_model_quant_method",
+        lambda _: None,
+    )
+    config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
+    assert _check_tensorrt_checkpoint_compat(config) is None
+
+
+def test_trt_checkpoint_compat_rejects_awq(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HF AWQ checkpoint on TRT-LLM yields an actionable error."""
+    from llenergymeasure.config.engine_configs import TensorRTConfig
+    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+
+    monkeypatch.setattr(
+        llenergymeasure.harness.preflight,
+        "_read_model_quant_method",
+        lambda _: "awq",
+    )
+    config = make_config(
+        engine="tensorrt",
+        tensorrt=TensorRTConfig(tensor_parallel_size=1),
+        model="Qwen/Qwen2.5-7B-Instruct-AWQ",
+    )
+    err = _check_tensorrt_checkpoint_compat(config)
+    assert err is not None
+    assert "AWQ" in err
+    assert "engine_path" in err
+    assert "trtllm-build" in err
+
+
+def test_trt_checkpoint_compat_rejects_gptq(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HF GPTQ checkpoint on TRT-LLM yields an actionable error."""
+    from llenergymeasure.config.engine_configs import TensorRTConfig
+    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+
+    monkeypatch.setattr(
+        llenergymeasure.harness.preflight,
+        "_read_model_quant_method",
+        lambda _: "gptq",
+    )
+    config = make_config(
+        engine="tensorrt",
+        tensorrt=TensorRTConfig(tensor_parallel_size=1),
+        model="Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
+    )
+    err = _check_tensorrt_checkpoint_compat(config)
+    assert err is not None
+    assert "GPTQ" in err
+
+
+def test_trt_checkpoint_compat_skips_when_engine_path_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit engine_path means the user pre-built the engine; do not block."""
+    from llenergymeasure.config.engine_configs import TensorRTConfig
+    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+
+    monkeypatch.setattr(
+        llenergymeasure.harness.preflight,
+        "_read_model_quant_method",
+        lambda _: "awq",
+    )
+    config = make_config(
+        engine="tensorrt",
+        tensorrt=TensorRTConfig(tensor_parallel_size=1, engine_path="/some/built/engine"),
+    )
+    assert _check_tensorrt_checkpoint_compat(config) is None
+
+
+def test_trt_checkpoint_compat_network_failure_does_not_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transient HF Hub failures must not block dispatch."""
+    from llenergymeasure.config.engine_configs import TensorRTConfig
+    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+
+    monkeypatch.setattr(
+        llenergymeasure.harness.preflight,
+        "_read_model_quant_method",
+        lambda _: None,  # Simulates "couldn't determine"
+    )
+    config = make_config(engine="tensorrt", tensorrt=TensorRTConfig(tensor_parallel_size=1))
+    assert _check_tensorrt_checkpoint_compat(config) is None
+
+
+def test_read_quant_method_local_path(tmp_path: Path) -> None:
+    """Local model directories with an AWQ config.json are detected."""
+    import json
+
+    from llenergymeasure.harness.preflight import _read_model_quant_method
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"quantization_config": {"quant_method": "AWQ"}})
+    )
+    assert _read_model_quant_method(str(tmp_path)) == "awq"
+
+
+def test_read_quant_method_local_path_no_config(tmp_path: Path) -> None:
+    """Local directories without config.json return None (skip)."""
+    from llenergymeasure.harness.preflight import _read_model_quant_method
+
+    assert _read_model_quant_method(str(tmp_path)) is None
+
+
+def test_read_quant_method_local_path_no_quant_block(tmp_path: Path) -> None:
+    """Local config.json without quantization_config returns None."""
+    import json
+
+    from llenergymeasure.harness.preflight import _read_model_quant_method
+
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen2"}))
+    assert _read_model_quant_method(str(tmp_path)) is None


### PR DESCRIPTION
## Summary
- TensorRT-LLM 0.21 cannot load HF AWQ/GPTQ checkpoints directly. Currently the symptom is a cryptic \`KeyError: 'weight'\` deep inside \`tensorrt_llm.LLM(...)\`, raised AFTER GPU allocation and partial warmup.
- New pre-flight check reads the model's HF \`config.json[\"quantization_config\"][\"quant_method\"]\` field. If \`engine=tensorrt\` and \`quant_method in {awq, gptq}\` and no \`tensorrt.engine_path\` override is set, fail loudly with a message pointing at the \`trtllm-build\` conversion workflow.
- Detection signal is HF's authoritative metadata field, not model-id pattern matching, so it survives user-renamed checkpoints and stays robust across the HF/TRT-LLM ecosystem.

## Design notes
- Returns None on every transient failure path (no \`huggingface_hub\` installed, network error, malformed config, no \`quantization_config\` block). Treats inability-to-determine as \"not detected\" rather than blocking - same defensive pattern as the existing \`_check_model_accessible\`.
- Constant \`_TRT_UNSUPPORTED_HF_QUANT_METHODS\` so the allowlist is one-line to relax when TRT-LLM 1.x adds native support.
- Local model paths read \`<path>/config.json\` directly; Hub ids use \`hf_hub_download\` (lighter than \`AutoConfig\`, no transformers import on the preflight host).

## Test plan
- [x] 9 new unit tests in \`tests/unit/test_preflight.py\` covering: non-tensorrt skip, non-quantised pass, AWQ/GPTQ reject, engine_path override skip, network failure pass-through, local-path detection (with/without config, with/without quant block).
- [x] Existing 28 preflight tests still pass.
- [ ] CI green.

## Doc updates
- New \`## HF pre-quantised checkpoints\` section in \`docs/how-to/run-with-tensorrt-llm.md\` explaining the \`trtllm-build\` workflow.

Closes #616.