### PR TITLE
ci(engine-image): smoke-test transformers image before pushing to registry

### DIFF
--- a/.github/workflows/engine-pipeline.yml
+++ b/.github/workflows/engine-pipeline.yml
@@ -318,14 +318,19 @@ jobs:
             echo "no_cache=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build transformers image and push runtime tag for downstream cells
+      # Build is split from push so the smoke gate runs against the exact image
+      # that would be pushed: downstream invariants/schemas cells and production
+      # promotion read the cache image unchallenged, so a broken push contaminates
+      # them. Keep this split when "simplifying" the workflow.
+      - name: Build transformers image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.transformers
           target: runtime
           tags: ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}
-          push: true
+          load: true
+          push: false
           no-cache: ${{ steps.targets.outputs.no_cache }}
           build-args: |
             TRANSFORMERS_VERSION=${{ steps.version.outputs.version }}
@@ -336,6 +341,18 @@ jobs:
             type=registry,ref=ghcr.io/${{ github.repository }}/transformers:transformers-${{ steps.version.outputs.version }}
           cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache
 
+      - name: Verify transformers package imports inside built image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python3 "$IMAGE" -c "import transformers; print(f'transformers {transformers.__version__} OK')"
+
+      - name: Push validated image to cache registry
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}
+        run: docker push "$IMAGE"
+
       - name: Emit build summary
         run: |
           {
@@ -345,6 +362,7 @@ jobs:
             echo "- Transformers version: \`${{ steps.version.outputs.version }}\`"
             echo "- Buildcache ref: \`ghcr.io/${{ github.repository }}/transformers-cache:transformers-${{ steps.version.outputs.version }}-buildcache\`"
             echo "- No-cache rebuild: \`${{ steps.targets.outputs.no_cache }}\`"
+            echo "- Smoke test: \`import transformers\` passed before push"
           } >> "$GITHUB_STEP_SUMMARY"
 
   invariants-transformers:

--- a/engine_versions/transformers.yaml
+++ b/engine_versions/transformers.yaml
@@ -28,5 +28,5 @@ artefact_paths:
 last_probe:
   verdict: pass
   version_inside_envelope: false
-  fingerprint: "46664ddbff9a9c9df2974d9d5cbdbbe04ae093b874f50ee92a0cd1b0c4b83860"
+  fingerprint: "14dc1896757dfc00a9a4e1990528ecac45394bb5f2850bfab17e87871aaa29da"
   fingerprint_drift: []

--- a/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: transformers
 engine_version: 4.57.3
-mined_at: '2026-05-08T18:34:07+02:00'
+mined_at: '2026-05-08T19:37:44+02:00'
 invariants:
 - id: transformers_beam_search_num_beams_eq_1
   engine: transformers

--- a/src/llenergymeasure/engines/transformers/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-08T18:34:07+02:00'
-validation_commit: 16d36e47ecba01d2c951f3f9ac151e2bc75df1ac
+validated_at: '2026-05-08T19:37:44+02:00'
+validation_commit: 0c8d637917cba04196e91c59b79010ca2deb16fe
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-08T18:34:07+02:00",
+  "discovered_at": "2026-05-08T19:37:44+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-08T18:34:07+02:00",
+  "discovered_at": "2026-05-08T19:37:36+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {


### PR DESCRIPTION
## Summary
- Issue #603 surfaced a broken bare \`:transformers\` local image: 7.9 GB on disk, but \`python3 -c 'import transformers'\` raised \`ModuleNotFoundError\`. The publish workflow tag-copies whatever lands in the cache repo, so a broken cache image would have been promoted to canonical \`:latest\` + \`:transformers-<VER>\` tags without challenge.
- Split the \`build-transformers\` job into **build (load locally) -> smoke test -> push**. The smoke runs \`docker run --entrypoint python3 <image> -c 'import transformers; print(...)'\` against the exact image bytes that would be pushed; failure aborts the job before the cache registry receives the bad image.
- Downstream invariants/schemas cells and the production promote workflow are now safe by construction - they cannot consume a broken image.

## Design notes
- \`build-push-action\`'s \`load: true\` materialises the image in the runner's local docker daemon (already \`self-hosted\`, plenty of disk). Subsequent \`docker push\` sends the same image bytes via standard daemon-to-registry path.
- \`set -euo pipefail\` in the smoke step ensures any non-zero exit (failed import, missing package, container crash) propagates to the job.
- Smoke target is the engine package the image is named for (\`transformers\`). Framework (llenergymeasure) is bind-mounted at run time by docker_runner, so it's not a concern for the build smoke - the smoke validates only "did the build job actually produce a working engine substrate".

## Doc audit
- No user-facing CLI flags or runtime contracts changed. CI internal-only.

## Test plan
- [ ] CI green (this PR exercises the modified workflow via self-test paths filter).
- [ ] Smoke step appears in the build job's step list and runs against the loaded image.

Closes #603.