### PR TITLE
chore(repo): drop stale dev extras, normalise terminology, mark lockfiles generated

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "PYTHONUNBUFFERED": "1"
   },
   "initializeCommand": "docker compose build base transformers-dev 2>/dev/null || true",
-  "postCreateCommand": "pip install -e '.[transformers,dev]' && pre-commit install || true",
+  "postCreateCommand": "uv sync --dev && pre-commit install || true",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/tensorrt/devcontainer.json
+++ b/.devcontainer/tensorrt/devcontainer.json
@@ -9,7 +9,7 @@
     "PYTHONUNBUFFERED": "1"
   },
   "initializeCommand": "docker compose build base tensorrt-dev 2>/dev/null || true",
-  "postCreateCommand": "pip install -e '.[tensorrt,dev]' --no-deps && pre-commit install || true",
+  "postCreateCommand": "uv sync --dev && pre-commit install || true",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/vllm/devcontainer.json
+++ b/.devcontainer/vllm/devcontainer.json
@@ -9,7 +9,7 @@
     "PYTHONUNBUFFERED": "1"
   },
   "initializeCommand": "docker compose build base vllm-dev 2>/dev/null || true",
-  "postCreateCommand": "pip install -e '.[vllm,dev]' && pre-commit install || true",
+  "postCreateCommand": "uv sync --dev && pre-commit install || true",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Generated lockfiles - collapsed by default in PR diffs, excluded from linguist stats
+uv.lock                    linguist-generated=true
+website/package-lock.json  linguist-generated=true

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ export LLEM_EXPCONF_SCHEMA_FINGERPRINT := $(shell python3 scripts/compute_expcon
 
 # =============================================================================
 # Quick Start
-#   Local:  make setup       (pip install + pre-commit)
+#   Local:  make setup       (uv sync --dev + pre-commit)
 #   Docker: make docker-setup (above + docker compose build)
 #   Dev:    make dev          (uv sync --dev + pre-commit)
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export LLEM_EXPCONF_SCHEMA_FINGERPRINT := $(shell python3 scripts/compute_expcon
 # =============================================================================
 
 setup:
-	pip install -e ".[dev]"
+	uv sync --dev
 	pre-commit install
 	@echo "Dev environment ready. Run: lem --help"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # entries because there is no first-party image to build.
 #
 # Quick Start:
-#   pip install -e .              # Install llenergymeasure
+#   uv sync                       # Install llenergymeasure + base deps
 #   llem config                   # Check environment
 #   docker compose build transformers  # Build engine image
 #

--- a/src/llenergymeasure/energy/README.md
+++ b/src/llenergymeasure/energy/README.md
@@ -6,7 +6,7 @@ Energy measurement samplers implementing the `EnergySampler` protocol. Layer 2 i
 
 Provides pluggable GPU energy tracking via NVML (default), Zeus, or CodeCarbon. The `select_energy_sampler()` function selects the best available sampler or raises a clear error when an explicit choice is unavailable.
 
-Classes use `*Sampler` suffix to distinguish them from inference backends. The selection function is `select_energy_sampler()`.
+Classes use `*Sampler` suffix to distinguish them from inference engines. The selection function is `select_energy_sampler()`.
 
 ## Modules
 
@@ -83,7 +83,7 @@ resolved internally by the harness. See `docs/energy-measurement.md` for full ra
 
 - Layer 2 - may import from layers 0-1 only
 - Can import from: `config/`, `domain/`, `device/`, `utils/`
-- Cannot import from: `harness/`, `backends/`, `study/`, `api/`, `cli/`, `results/`
+- Cannot import from: `harness/`, `engines/`, `study/`, `api/`, `cli/`, `results/`
 
 ## Related
 

--- a/src/llenergymeasure/harness/README.md
+++ b/src/llenergymeasure/harness/README.md
@@ -95,7 +95,7 @@ from llenergymeasure.harness.state import ExperimentPhase, ExperimentState
 ## Layer constraints
 
 - Layer 3 - may import from layers 0-2
-- Can import from: `config/`, `domain/`, `device/`, `utils/`, `energy/`, `backends/`, `datasets/`, `infra/`
+- Can import from: `config/`, `domain/`, `device/`, `utils/`, `energy/`, `engines/`, `datasets/`, `infra/`
 - Cannot import from: `study/`, `api/`, `cli/`, `results/`
 
 ## Related


### PR DESCRIPTION
## Summary

Three small, orthogonal hygiene follow-ups from earlier restructure work. Each is a stale-reference / display-rendering fix; no contract changes, no engine code touched, orthogonal to the in-flight mining / introspection / CI work.

## Changes

- **`.devcontainer/*`, `Makefile`, `docker-compose.yml`**: switch local-dev install from the stale `pip install -e '.[<engine>,dev]'` pattern to the canonical `uv sync --dev`. The engine-prefixed extras were removed when engines became Docker-only; `dev` migrated from optional-dependencies to a PEP-735 dependency group.
- **`src/llenergymeasure/energy/README.md`, `src/llenergymeasure/harness/README.md`**: replace stale `backends/` module references with `engines/` per the locked terminology mapping.
- **`.gitattributes`**: mark `uv.lock` and `website/package-lock.json` as `linguist-generated=true` so they render collapsed in PR diffs and don't dominate the repo language-stats bar.

## Test plan

- [ ] `git grep -nE '\[(transformers\|vllm\|tensorrt)(,dev)?\]' .devcontainer/ Makefile docker-compose.yml` returns zero hits
- [ ] `git grep -n 'backends/' src/llenergymeasure/*/README.md` returns zero hits
- [ ] `cat .gitattributes` shows two lockfile entries
- [ ] CI green

Fixes #591
Fixes #545
Fixes #567