### PR TITLE
fix(cli): omit phantom Path line when no user config file exists

### DIFF
--- a/src/llenergymeasure/cli/config_cmd.py
+++ b/src/llenergymeasure/cli/config_cmd.py
@@ -144,8 +144,8 @@ def config_command(
     from llenergymeasure.config.user_config import get_user_config_path
 
     config_path = get_user_config_path()
-    print(f"  Path: {config_path}")
     if config_path.exists():
+        print(f"  Path: {config_path}")
         print("  Status: loaded")
         if verbose > 0:
             from llenergymeasure.config.user_config import (

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -85,11 +85,10 @@ def test_config_verbose_shows_python_version() -> None:
     assert short_version in result.output
 
 
-def test_config_user_config_path_shown() -> None:
+def test_config_user_config_path_shown(tmp_path: Path) -> None:
     """User config path is printed in the Config section when the file exists."""
-    fake_path = MagicMock(spec=Path)
-    fake_path.exists.return_value = True
-    fake_path.__str__ = lambda self: "/home/user/.config/llenergymeasure/config.yaml"
+    fake_path = tmp_path / "config.yaml"
+    fake_path.touch()
     with (
         patch.object(cli_config_mod, "_probe_gpu", return_value=None),
         patch("llenergymeasure.config.user_config.get_user_config_path", return_value=fake_path),
@@ -97,7 +96,7 @@ def test_config_user_config_path_shown() -> None:
         result = runner.invoke(app, ["config"])
 
     assert result.exit_code == 0
-    assert "/home/user/.config/llenergymeasure/config.yaml" in result.output
+    assert str(fake_path) in result.output
 
 
 def test_config_exits_0() -> None:
@@ -215,10 +214,8 @@ def test_config_user_config_not_found() -> None:
     assert "using defaults" in result.output
 
 
-def test_config_user_config_loaded_verbose_non_defaults() -> None:
+def test_config_user_config_loaded_verbose_non_defaults(tmp_path: Path) -> None:
     """With -v and a loaded config that has non-default values, 'Non-default values:' appears."""
-    from pathlib import Path as _Path
-
     from llenergymeasure.config.user_config import UserConfig
 
     # Build a UserConfig with a non-default value
@@ -236,9 +233,8 @@ def test_config_user_config_loaded_verbose_non_defaults() -> None:
             break
     mock_user_cfg.model_dump.return_value = modified_dump
 
-    fake_path = MagicMock(spec=_Path)
-    fake_path.exists.return_value = True
-    fake_path.__str__ = lambda self: "/fake/config.yaml"
+    fake_path = tmp_path / "config.yaml"
+    fake_path.touch()
 
     # load_user_config and UserConfig are lazy-imported inside the function body -
     # patch at the source module, not at config_cmd

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -86,8 +86,10 @@ def test_config_verbose_shows_python_version() -> None:
 
 
 def test_config_user_config_path_shown() -> None:
-    """User config path is printed in the Config section."""
-    fake_path = Path("/home/user/.config/llenergymeasure/config.yaml")
+    """User config path is printed in the Config section when the file exists."""
+    fake_path = MagicMock(spec=Path)
+    fake_path.exists.return_value = True
+    fake_path.__str__ = lambda self: "/home/user/.config/llenergymeasure/config.yaml"
     with (
         patch.object(cli_config_mod, "_probe_gpu", return_value=None),
         patch("llenergymeasure.config.user_config.get_user_config_path", return_value=fake_path),
@@ -95,7 +97,7 @@ def test_config_user_config_path_shown() -> None:
         result = runner.invoke(app, ["config"])
 
     assert result.exit_code == 0
-    assert str(fake_path) in result.output
+    assert "/home/user/.config/llenergymeasure/config.yaml" in result.output
 
 
 def test_config_exits_0() -> None:


### PR DESCRIPTION
## Summary

\`llem config\` prints a \`Path: ...\` line under the \`Config\` section even when the user has no config file. The path is meaningless in that case and sits awkwardly next to the \`Status: using defaults (no config file)\` line directly below it.

This PR moves the \`Path:\` print inside the \`if config_path.exists():\` branch. When no file exists the section now reads:

\`\`\`
Config
  Status: using defaults (no config file)
\`\`\`

When a file does exist, behaviour is unchanged.

## Test plan

- [ ] Run \`llem config\` with no user config file present - \`Path:\` line absent.
- [ ] Run \`llem config\` with a user config file present - \`Path:\` line shown as before.
- [ ] CI green.

Fixes #342