### PR TITLE
test: replace hardcoded "pytorch" engine literals with SSOT constant

### DIFF
--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -31,6 +31,7 @@ from llenergymeasure.config.models import (
     ExperimentConfig,
     StudyConfig,
 )
+from llenergymeasure.config.ssot import Engine
 from llenergymeasure.utils.exceptions import ConfigError
 
 # =============================================================================
@@ -708,14 +709,14 @@ class TestFormatPreflightSummary:
             {
                 "raw_config": {"engine": "transformers", "transformers": {"dtype": "float32"}},
                 "reason": "cross-validation failed",
-                "short_label": "pytorch, float32",
+                "short_label": f"{Engine.TRANSFORMERS}, float32",
                 "errors": [],
             }
         ]
         sc = _make_study_config(n_configs=3, n_cycles=1, skipped_configs=skipped)
         summary = format_preflight_summary(sc)
         assert "Skipping 1/" in summary
-        assert "pytorch, float32" in summary
+        assert f"{Engine.TRANSFORMERS}, float32" in summary
         assert "cross-validation failed" in summary
 
     def test_high_skip_rate_warning(self):
@@ -747,7 +748,7 @@ class TestFormatPreflightSummary:
             {
                 "raw_config": {"engine": "transformers", "transformers": {"dtype": "float32"}},
                 "reason": "validation error",
-                "short_label": "pytorch, float32",
+                "short_label": f"{Engine.TRANSFORMERS}, float32",
                 "errors": [],
             }
         ]


### PR DESCRIPTION
## Summary

PR #261 renamed the engine identifier from `pytorch` to `transformers`, but two test assertions in `test_study_grid.py` still had the old name embedded inside `short_label` strings. Those assertions were silently passing-by-mismatch (the label computed from `raw_config` already said `"transformers, float32"` but the assertion checked for `"pytorch, float32"`). This PR replaces the literals with `Engine.TRANSFORMERS` so future renames flow through automatically.

The other four files enumerated in #355 (`test_cli_run.py`, `test_study_preflight.py`, `test_cli_config.py`, `test_sweep_groups.py`) had already been fixed in a prior PR and required no changes.

## Files

- `tests/unit/study/test_study_grid.py` - import `Engine` from ssot; replace two `short_label` literals and one assertion

Pure test quality - no production-code touch.

## Test plan

- [x] All five targeted test files pass (191 tests, 0 failures).
- [ ] CI green.

Fixes #355