### PR TITLE
feat(scripts): drift tool Phase A - replaces _probe.py

### DIFF
--- a/.github/workflows/_engine-invariants-cell.yml
+++ b/.github/workflows/_engine-invariants-cell.yml
@@ -266,7 +266,7 @@ jobs:
             -e PYTHONDONTWRITEBYTECODE \
             "${ENTRYPOINT_FLAG[@]}" \
             "$IMAGE" \
-            "${CMD_PREFIX[@]}" -m scripts._probe --engine "$ENGINE" --producer invariants \
+            "${CMD_PREFIX[@]}" -m scripts._drift --engine "$ENGINE" --producer invariants \
               --output "/llem-probe-out/probe-${ENGINE}.json"
           VERDICT=$(jq -r '.verdict' "/tmp/llem-probe-out/probe-${ENGINE}.json")
           echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_engine-schemas-cell.yml
+++ b/.github/workflows/_engine-schemas-cell.yml
@@ -228,7 +228,7 @@ jobs:
             -e PYTHONDONTWRITEBYTECODE \
             "${ENTRYPOINT_FLAG[@]}" \
             "$IMAGE" \
-            "${CMD_PREFIX[@]}" -m scripts._probe --engine "$ENGINE" --producer schemas \
+            "${CMD_PREFIX[@]}" -m scripts._drift --engine "$ENGINE" --producer schemas \
               --output "/llem-probe-out/probe-${ENGINE}.json"
           VERDICT=$(jq -r '.verdict' "/tmp/llem-probe-out/probe-${ENGINE}.json")
           echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/engine-pipeline.yml
+++ b/.github/workflows/engine-pipeline.yml
@@ -40,7 +40,7 @@ on:
       - 'scripts/validate_invariants.py'
       - 'scripts/_invariant_validation_common.py'
       - 'scripts/refresh_invariant_rules.sh'
-      - 'scripts/_probe.py'
+      - 'scripts/_drift.py'
       - 'scripts/update_last_probe.py'
       - 'scripts/diff_engine_invariants.py'
       - 'scripts/diff_discovered_schemas.py'

--- a/docs/contributing/miner-pipeline.md
+++ b/docs/contributing/miner-pipeline.md
@@ -115,7 +115,7 @@ Run inside the container:
 ```bash
 docker run --rm -v "$PWD":/workspace -w /workspace \
   llenergymeasure:{engine}-{version} \
-  python -m scripts._probe --producer invariants
+  python -m scripts._drift --producer invariants
 ```
 
 ### Validation gate flips a previously-passing rule

--- a/docs/explanation/architecture/architecture-overview.md
+++ b/docs/explanation/architecture/architecture-overview.md
@@ -114,7 +114,7 @@ flowchart TB
     pipeline --> vllm["vLLM:<br/>engine-pipeline.yml runs inside llem:vllm-VER<br/>on self-hosted GPU runner (Docker isolates uv.lock)"]
     pipeline --> trt["TRT-LLM:<br/>engine-pipeline.yml runs inside llem:tensorrt-VER<br/>on self-hosted GPU runner (CUDA-aware import)"]
 
-    tf & vllm & trt --> steps["Per-engine step sequence:<br/>1. Probe - scripts._probe checks landmarks<br/>2. Mine - build_corpus.py writes proposed.yaml<br/>3. Validate-replay - validate_invariants.py replays every rule<br/>4. Doc-gen - generate_invariants_doc.py refreshes docs/reference/engines/invariants-&lt;engine&gt;.md<br/>5. Atomic writeback - one bot commit covers all artefacts"]
+    tf & vllm & trt --> steps["Per-engine step sequence:<br/>1. Probe - scripts._drift checks landmarks<br/>2. Mine - build_corpus.py writes proposed.yaml<br/>3. Validate-replay - validate_invariants.py replays every rule<br/>4. Doc-gen - generate_invariants_doc.py refreshes docs/reference/engines/invariants-&lt;engine&gt;.md<br/>5. Atomic writeback - one bot commit covers all artefacts"]
 
     steps --> green[CI must be green before merge]
     green --> ship[Package ships with updated corpus]

--- a/docs/explanation/architecture/auto-refresh-pipeline.md
+++ b/docs/explanation/architecture/auto-refresh-pipeline.md
@@ -60,7 +60,7 @@ workflow cells:
   (`scripts/engine_producers/`) inside the new engine container. The
   introspector imports the live library and walks its Pydantic models to
   produce a JSON schema of all configurable parameters.
-- `_engine-invariants-cell.yml` - runs the `_probe.py` entry point
+- `_engine-invariants-cell.yml` - runs the `_drift.py` entry point
   (`Mine + validate inside container` step) inside the container. The probe
   dispatches to the engine-specific miner (`scripts/engine_producers/`) which
   extracts validator functions, default values, and invalid-combination rules.

--- a/docs/explanation/architecture/pipeline-architecture.md
+++ b/docs/explanation/architecture/pipeline-architecture.md
@@ -84,7 +84,7 @@ flowchart TD
 
 Layers over: invariant-miner + invalidity-miner + lift modules + validation-CI gate.
 
-1. **PROBE** - inline `python -m scripts._probe --producer invariants`; verdict `pass` or `fail`.
+1. **PROBE** - inline `python -m scripts._drift --producer invariants`; verdict `pass` or `fail`.
 2. **MINE** (only if probe passes) - `build_corpus.py` writes `src/llenergymeasure/engines/{engine}/invariants.proposed.yaml`.
 3. **VALIDATE-REPLAY** - `validate_invariants.py` plus the `compare_expected_vs_observed` contract from `_invariant_validation_common.py`. Replays `kwargs_positive` + `kwargs_negative` against the live library; classifies outcomes (`positive_confirmed`, `negative_confirmed`, `divergence`). Writes `src/llenergymeasure/engines/{engine}/invariants.validated.yaml`.
 4. **DIFF vs HEAD** for both `proposed.yaml` and `validated.yaml` artefacts.
@@ -96,7 +96,7 @@ Layers over: invariant-miner + invalidity-miner + lift modules + validation-CI g
 
 Layers over: parameter-discovery + typed-schema-discovery.
 
-1. **PROBE** - inline `python -m scripts._probe --producer schemas`; verdict `pass` or `fail`.
+1. **PROBE** - inline `python -m scripts._drift --producer schemas`; verdict `pass` or `fail`.
 2. **DISCOVER** (only if probe passes) - `engine_producers` writes `src/llenergymeasure/config/discovered_schemas/{engine}/schema.discovered.json`.
 3. **DIFF vs HEAD**.
 4. **REGENERATE** `docs/reference/engines/curation-{engine}.md` (Parameters section - fact base for the human curator; pre-existing behaviour preserved).
@@ -214,7 +214,7 @@ These pipelines run independent of the per-PR Renovate cycle.
 
 #### `engine-versions-sweep.yml` (scheduled, advisory)
 
-Runs `scripts/_probe.py` over a curated version range (e.g. `vllm v0.9..v0.12`) on a weekly schedule. Updates `engine_versions/{engine}.compat.json` (probe cache + compat-matrix in one file; closes [#470](https://github.com/henrycgbaker/llenergymeasure/issues/470)). Populates the probe-result cache so per-PR probes hit a warm cache.
+Runs `scripts/_drift.py` over a curated version range (e.g. `vllm v0.9..v0.12`) on a weekly schedule. Updates `engine_versions/{engine}.compat.json` (probe cache + compat-matrix in one file; closes [#470](https://github.com/henrycgbaker/llenergymeasure/issues/470)). Populates the probe-result cache so per-PR probes hit a warm cache.
 
 #### Runtime side-products (study-local, not CI)
 

--- a/engine_versions/_machinery_proto.py
+++ b/engine_versions/_machinery_proto.py
@@ -10,7 +10,7 @@ attributes are typed ``Any`` because per-engine shapes diverge:
   miner and a BNB-focused static miner, so its ``AST_TARGETS`` shape is
   not directly comparable.
 
-The probe (``scripts/_probe.py``) only reads ``LANDMARKS`` from the
+The drift tool (``scripts/_drift.py``) only reads ``LANDMARKS`` from the
 producer module via ``getattr``; the other attributes are consumed by
 the per-engine miners themselves. PR-0 vendors LANDMARKS only;
 AST_TARGETS / WALKER_PATTERNS / INTROSPECTOR_TARGETS are deferred to a

--- a/engine_versions/transformers/v4_57_3/producers/schema_introspector.py
+++ b/engine_versions/transformers/v4_57_3/producers/schema_introspector.py
@@ -30,9 +30,9 @@ from scripts.engine_producers._common import (
 # The introspector runs inside ``llenergymeasure:transformers-<tag>`` and
 # lifts engine parameter specs via ``inspect.signature(from_pretrained)``
 # and sampling parameter specs via ``GenerationConfig().to_dict()``. The
-# probe (``scripts/_probe.py``) reads this tuple via the dispatcher and
-# resolves each dotted path under the installed library before discovery
-# runs; a missing landmark flips the probe verdict to ``fail``.
+# drift tool (``scripts/_drift.py``) reads this tuple via the dispatcher
+# and resolves each dotted path under the installed library before
+# discovery runs; a missing landmark flips the probe verdict to ``fail``.
 LANDMARKS: tuple[str, ...] = (
     "transformers.AutoModelForCausalLM",
     "transformers.AutoModelForCausalLM.from_pretrained",

--- a/engine_versions/vllm/v0_7_3/producers/static_invariant_miner.py
+++ b/engine_versions/vllm/v0_7_3/producers/static_invariant_miner.py
@@ -53,8 +53,8 @@ NS_GUIDED = "vllm.sampling.guided_decoding"
 NS_ENGINE = "vllm.engine"
 
 
-# Probe-contract landmarks. Read by ``scripts._probe`` before the miner
-# runs; a missing landmark flips the probe verdict to ``fail``.
+# Drift-tool contract landmarks. Read by ``scripts._drift`` before the
+# miner runs; a missing landmark flips the probe verdict to ``fail``.
 LANDMARKS: tuple[str, ...] = (
     "vllm.sampling_params.SamplingParams",
     "vllm.sampling_params.SamplingParams._verify_args",

--- a/scripts/_drift.py
+++ b/scripts/_drift.py
@@ -1,15 +1,27 @@
-"""Probe primitive - binary reusability check for per-engine producers.
+"""Drift tool - bidirectional landmark drift detection for per-engine producers.
 
-The probe is the first step of each per-concern workflow (engine-invariants
-+ engine-schemas). It answers one question: do the landmarks the producer
-relies on still resolve under the currently-installed library?
-
-Verdict semantics (binary, per the engine-coupling design doc §3):
+The drift tool is the first step of each per-concern workflow (engine-invariants
++ engine-schemas). Phase A covers the "removed" direction only, which is a
+drop-in replacement for the former ``_probe.py`` non-regression gate:
 
     pass : every landmark in ``producer.LANDMARKS`` resolves to a live
            class / method / module attribute under ``import {library}``.
     fail : at least one landmark is missing, OR the producer module
            itself fails to import after one retry.
+
+Phase B (follow-up) will add the "added" direction - validators that exist
+in the live library but are not declared in the per-version archive.
+Phase C will add exclusions and CI gating.
+
+``direction`` field semantics:
+
+    "removed" : one or more declared landmarks are absent from the live library.
+    "added"   : (Phase B) one or more live validators are absent from LANDMARKS.
+    "stable"  : all declared landmarks resolve; no undeclared validators found.
+
+In Phase A, each ``DriftReport`` carries ``direction`` = "removed" when
+``landmarks_missing`` is non-empty, and ``direction`` = "stable" otherwise.
+``landmarks_added`` is always empty in Phase A.
 
 Diagnostic fields (``version_inside_envelope``, ``fingerprint_drift``)
 ride along on every report and are surfaced in workflow comments. They
@@ -22,11 +34,16 @@ Producer-module discovery uses a per-engine convention table (see
 (e.g. ``"transformers.GenerationConfig"``,
 ``"vllm.config.parallel.ParallelConfig.__post_init__"``).
 
+The CLI producer kind tokens ("invariants", "schemas") are the probe-contract
+names, NOT the producer-file names. The ``_PRODUCER_MODULES`` map translates
+them to the underlying module paths. CLI callers keep the same interface as the
+former ``_probe.py``.
+
 Usage::
 
-    python -m scripts._probe --engine transformers --producer invariants
+    python -m scripts._drift --engine transformers --producer invariants
 
-Emits a JSON ``ProbeReport`` to stdout. Exit 0 on either verdict - the
+Emits a JSON ``DriftReport`` to stdout. Exit 0 on either verdict - the
 binary verdict travels in the JSON, and downstream workflow steps gate
 on it. Exit 2 only on infrastructure failure (current.yaml missing, producer
 module unimportable, current.yaml malformed).
@@ -52,8 +69,8 @@ import yaml
 from packaging.specifiers import SpecifierSet
 
 # Make the top-level ``scripts`` package importable when invoked as a
-# plain script (``python scripts/_probe.py``) as well as via
-# ``python -m scripts._probe``.
+# plain script (``python scripts/_drift.py``) as well as via
+# ``python -m scripts._drift``.
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
@@ -63,7 +80,7 @@ from scripts.engine_producers._current import current_path  # noqa: E402
 
 ProducerKind = Literal["invariants", "schemas"]
 
-# Per-engine producer module map. The probe lives one layer above the
+# Per-engine producer module map. The drift tool lives one layer above the
 # producers; this table is the single seam where (engine, producer) cells
 # resolve to a Python module path. Keep it exhaustive - adding a new
 # engine means adding a row here.
@@ -77,7 +94,7 @@ _PRODUCER_MODULES: dict[tuple[str, ProducerKind], str] = {
 }
 
 # current.yaml ``miner_pins.*`` keys are typed by extraction strategy
-# (``static | dynamic | discovery``); the probe's user-facing producer
+# (``static | dynamic | discovery``); the drift tool's user-facing producer
 # kinds are typed by concern (``invariants | schemas``). One layer of
 # translation lives here.
 _SSOT_PIN_FOR_PRODUCER: dict[ProducerKind, str] = {
@@ -87,21 +104,28 @@ _SSOT_PIN_FOR_PRODUCER: dict[ProducerKind, str] = {
 
 
 @dataclass(frozen=True)
-class ProbeReport:
-    """Structured report of one probe run.
+class DriftReport:
+    """Structured report of one drift-tool run.
 
     Serialised to stdout JSON and to ``engine_versions/{engine}.compat.json``
     for cross-run cache + fingerprint-drift detection.
+
+    Phase A emits ``direction`` = "removed" when ``landmarks_missing`` is
+    non-empty; "stable" otherwise. ``landmarks_added`` is always empty in
+    Phase A - Phase B will fill it by walking the live library surface.
     """
 
     engine: str
     producer: ProducerKind
+    direction: Literal["removed", "added", "stable"]
+    schema_version: int
+    current_version: str
     verdict: Literal["pass", "fail"]
-    library_version: str
-    version_inside_envelope: bool
     fingerprint: str
     fingerprint_drift: list[str] = field(default_factory=list)
     landmarks_missing: list[str] = field(default_factory=list)
+    landmarks_added: list[str] = field(default_factory=list)
+    version_inside_envelope: bool = True
 
 
 # ---------------------------------------------------------------------------
@@ -183,11 +207,11 @@ def _fingerprint(resolved: list[_ResolvedLandmark]) -> str:
 
 
 def _load_current(engine: str) -> dict[str, object]:
-    """Read + parse ``engine_versions/{engine}.yaml``.
+    """Read + parse ``engine_versions/{engine}/current.yaml``.
 
-    Raises :class:`FileNotFoundError` if missing. The probe treats current.yaml
-    absence as an infrastructure error (exit code 2) - every supported
-    engine must have a current.yaml before the probe is wired up for it.
+    Raises :class:`FileNotFoundError` if missing. The drift tool treats
+    current.yaml absence as an infrastructure error (exit code 2) - every
+    supported engine must have a current.yaml before the tool is wired up.
     """
     path = current_path(engine)
     text = path.read_text()  # FileNotFoundError surfaces here
@@ -197,8 +221,8 @@ def _load_current(engine: str) -> dict[str, object]:
     return data
 
 
-def _check_envelope(ssot: dict[str, object], producer: ProducerKind, library_version: str) -> bool:
-    """True iff ``library_version`` falls inside ``miner_pins.{ssot_key}``."""
+def _check_envelope(ssot: dict[str, object], producer: ProducerKind, current_version: str) -> bool:
+    """True iff ``current_version`` falls inside ``miner_pins.{ssot_key}``."""
     pins = ssot.get("miner_pins") or {}
     if not isinstance(pins, dict):
         return False
@@ -206,7 +230,7 @@ def _check_envelope(ssot: dict[str, object], producer: ProducerKind, library_ver
     if raw is None:
         return False
     spec = SpecifierSet(str(raw))
-    return spec.contains(library_version, prereleases=True)
+    return spec.contains(current_version, prereleases=True)
 
 
 def _compat_path(engine: str) -> Path:
@@ -216,27 +240,27 @@ def _compat_path(engine: str) -> Path:
     sibling of the per-engine sub-directory (not inside it). Resolved via
     ``current_path`` parent so tests can monkeypatch the location.
     """
-    # current_path(engine) → engine_versions/{engine}/current.yaml
-    # .parent          → engine_versions/{engine}/
-    # .parent          → engine_versions/
+    # current_path(engine) -> engine_versions/{engine}/current.yaml
+    # .parent          -> engine_versions/{engine}/
+    # .parent          -> engine_versions/
     return current_path(engine).parent.parent / f"{engine}.compat.json"
 
 
 def _read_cached_fingerprint(
-    engine: str, producer: ProducerKind, library_version: str
+    engine: str, producer: ProducerKind, current_version: str
 ) -> str | None:
     """Return the previous-run fingerprint for this (engine, producer), or ``None``.
 
     Returns ``None`` when:
 
     - The cache file does not exist or is malformed.
-    - The cached entry is missing a ``library_version`` field.
-    - The cached entry's ``library_version`` differs from the *current*
+    - The cached entry is missing a ``current_version`` field.
+    - The cached entry's ``current_version`` differs from the current
       library version. This is the cross-version skip: bumping
       ``library.current_version`` invalidates the prior fingerprint by
       definition (it was computed against a different installed library),
       so reporting "every landmark drifted" would be noise. Returning
-      ``None`` here causes ``probe()`` to treat this as a first-run
+      ``None`` here causes ``run()`` to treat this as a first-run
       fingerprint and emit empty ``fingerprint_drift``; the next run at
       the bumped version writes a fresh cache entry.
     """
@@ -252,15 +276,17 @@ def _read_cached_fingerprint(
     entry = (cache.get(producer) if isinstance(cache, dict) else None) or {}
     if not isinstance(entry, dict):
         return None
-    cached_library_version = entry.get("library_version")
-    if cached_library_version != library_version:
+    # Accept both the new field name ("current_version") and the legacy
+    # "library_version" written by older cache entries from _probe.py.
+    cached_version = entry.get("current_version") or entry.get("library_version")
+    if cached_version != current_version:
         # Cache was written against a different library version; treat as miss.
         return None
     fp = entry.get("fingerprint")
     return str(fp) if isinstance(fp, str) else None
 
 
-def _write_cached_report(engine: str, report: ProbeReport) -> None:
+def _write_cached_report(engine: str, report: DriftReport) -> None:
     """Atomically merge ``report`` into ``engine_versions/{engine}.compat.json``."""
     path = _compat_path(engine)
     cache: dict[str, object] = {}
@@ -314,21 +340,26 @@ def _read_landmarks(module: ModuleType) -> tuple[str, ...]:
 # ---------------------------------------------------------------------------
 
 
-def probe(*, engine: str, producer: ProducerKind) -> ProbeReport:
-    """Run the probe for one ``(engine, producer)`` cell.
+def run(*, engine: str, producer: ProducerKind) -> DriftReport:
+    """Run the drift check for one ``(engine, producer)`` cell.
 
-    Returns a :class:`ProbeReport` with verdict ``pass`` iff every
+    Phase A: "removed" direction only.
+
+    Returns a :class:`DriftReport` with verdict ``pass`` iff every
     landmark resolves; ``fail`` iff one or more landmarks raise
     :class:`AttributeError` / :class:`ImportError` during resolution.
 
     Diagnostic fields (envelope check, fingerprint drift) are computed
     regardless of verdict.
+
+    ``direction`` is ``"removed"`` when ``landmarks_missing`` is non-empty;
+    ``"stable"`` otherwise. ``landmarks_added`` is always ``[]`` in Phase A.
     """
     current = _load_current(engine)  # FileNotFoundError -> caller handles as infra error
     library = current.get("library")
     if not isinstance(library, dict) or "current_version" not in library:
         raise ValueError(f"current.yaml for {engine} missing library.current_version.")
-    library_version = str(library["current_version"])
+    current_version = str(library["current_version"])
 
     producer_module = _import_producer(engine, producer)
     landmarks = _read_landmarks(producer_module)
@@ -342,7 +373,7 @@ def probe(*, engine: str, producer: ProducerKind) -> ProbeReport:
             missing.append(landmark)
 
     fingerprint = _fingerprint(resolved)
-    cached = _read_cached_fingerprint(engine, producer, library_version)
+    cached = _read_cached_fingerprint(engine, producer, current_version)
     drift: list[str] = []
     if cached is not None and cached != fingerprint:
         # Per-landmark drift would require caching per-landmark hashes;
@@ -352,16 +383,20 @@ def probe(*, engine: str, producer: ProducerKind) -> ProbeReport:
         drift = [r.landmark for r in resolved]
 
     verdict: Literal["pass", "fail"] = "fail" if missing else "pass"
+    direction: Literal["removed", "added", "stable"] = "removed" if missing else "stable"
 
-    return ProbeReport(
+    return DriftReport(
         engine=engine,
         producer=producer,
+        direction=direction,
+        schema_version=1,
+        current_version=current_version,
         verdict=verdict,
-        library_version=library_version,
-        version_inside_envelope=_check_envelope(current, producer, library_version),
         fingerprint=fingerprint,
         fingerprint_drift=drift,
         landmarks_missing=missing,
+        landmarks_added=[],
+        version_inside_envelope=_check_envelope(current, producer, current_version),
     )
 
 
@@ -371,7 +406,7 @@ def probe(*, engine: str, producer: ProducerKind) -> ProbeReport:
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="scripts._probe", description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(prog="scripts._drift", description=__doc__.splitlines()[0])
     parser.add_argument(
         "--engine", required=True, help="Engine name (transformers / vllm / tensorrt)."
     )
@@ -391,7 +426,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         default=None,
         help=(
-            "Path to write the ProbeReport JSON. When set, JSON goes to this file "
+            "Path to write the DriftReport JSON. When set, JSON goes to this file "
             "atomically (write to .tmp, fsync, rename) and stdout stays clean. When "
             "absent, JSON is written to stdout (legacy behaviour). Use --output in "
             "CI when the engine library may write to stdout at import time (e.g. "
@@ -401,7 +436,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _write_report_to_file(path: Path, report: ProbeReport) -> None:
+def _write_report_to_file(path: Path, report: DriftReport) -> None:
     """Atomically write *report* as JSON to *path*.
 
     Uses ``tempfile.mkstemp`` for a collision-free temp file in the parent
@@ -411,11 +446,10 @@ def _write_report_to_file(path: Path, report: ProbeReport) -> None:
     files. Parent directory is created if missing.
 
     The output is chmod'd to 0644. ``tempfile.mkstemp`` defaults to 0600
-    (owner-only) for security, but CI invokes the probe inside a Docker
+    (owner-only) for security, but CI invokes the drift tool inside a Docker
     container running as root and reads the result on the host via a bind
     mount. Without 0644 the non-root host runner user gets ``Permission
-    denied`` when opening the JSON. PoC reproduces the bug with mkstemp's
-    default mode and verifies the fix; see local-engine-build-test.sh.
+    denied`` when opening the JSON.
     """
     payload = json.dumps(asdict(report), indent=2, sort_keys=True)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -436,7 +470,7 @@ def _write_report_to_file(path: Path, report: ProbeReport) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
-        report = probe(engine=args.engine, producer=args.producer)
+        report = run(engine=args.engine, producer=args.producer)
     except (FileNotFoundError, KeyError, ImportError, AttributeError, TypeError, ValueError) as exc:
         # Infrastructure failure: current.yaml missing / malformed / producer
         # module unimportable / LANDMARKS missing or malformed. Distinct

--- a/scripts/engine_producers/transformers_miner.py
+++ b/scripts/engine_producers/transformers_miner.py
@@ -69,7 +69,7 @@ from scripts.engine_producers.transformers_dynamic_invariant_miner import (  # n
 )
 
 # Symbols this orchestrator (and its delegated dynamic miner) relies on
-# inside the live ``transformers`` package. Read by ``scripts._probe``
+# inside the live ``transformers`` package. Read by ``scripts._drift``
 # before mining runs; a missing landmark flips the probe verdict to
 # ``fail`` and skips the downstream stages without re-importing here.
 #
@@ -163,7 +163,7 @@ def _check_landmarks() -> tuple[str, str]:
     landmark check cannot drift from the probe's static check. A missing
     landmark raises :class:`MinerLandmarkMissingError`.
     """
-    from scripts._probe import _resolve_landmark
+    from scripts._drift import _resolve_landmark
 
     for landmark in _get_landmarks():
         try:

--- a/scripts/update_last_probe.py
+++ b/scripts/update_last_probe.py
@@ -246,6 +246,12 @@ def update(*, engine: str, report: dict[str, Any]) -> int:
     write failure the current.yaml update is preserved (no rollback). Both paths
     are idempotent so subsequent runs converge.
     """
+    # Accept both the new field name ("current_version", from DriftReport) and
+    # the legacy name ("library_version", from the old ProbeReport) so that any
+    # cached compat.json entries written before the rename still parse cleanly.
+    if "current_version" in report and "library_version" not in report:
+        report = dict(report)
+        report["library_version"] = report["current_version"]
     required = {
         "verdict",
         "version_inside_envelope",
@@ -256,7 +262,7 @@ def update(*, engine: str, report: dict[str, Any]) -> int:
     missing = required - report.keys()
     if missing:
         print(
-            f"ProbeReport JSON missing required fields: {sorted(missing)}.",
+            f"DriftReport JSON missing required fields: {sorted(missing)}.",
             file=sys.stderr,
         )
         return 2

--- a/scripts/widen_miner_pin.py
+++ b/scripts/widen_miner_pin.py
@@ -61,7 +61,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from scripts._probe import _SSOT_PIN_FOR_PRODUCER, ProducerKind  # noqa: E402
+from scripts._drift import _SSOT_PIN_FOR_PRODUCER, ProducerKind  # noqa: E402
 from scripts.engine_producers._current import current_path  # noqa: E402
 
 

--- a/tests/_engine_archive/test_tensorrt_lazy.py
+++ b/tests/_engine_archive/test_tensorrt_lazy.py
@@ -8,7 +8,7 @@ loaded directly through the dispatcher.
 Mirror style of ``test_dispatcher.py``: keep imports lazy where the
 assertion target is the module attribute, fail loud otherwise. Note the
 miner module name is ``tensorrt_static_invariant_miner`` (not ``tensorrt_miner``) -
-see ``scripts/_probe.py`` ``_PRODUCER_MODULES`` for the canonical mapping.
+see ``scripts/_drift.py`` ``_PRODUCER_MODULES`` for the canonical mapping.
 """
 
 from __future__ import annotations

--- a/tests/unit/scripts/test_drift.py
+++ b/tests/unit/scripts/test_drift.py
@@ -1,16 +1,19 @@
-"""Tests for :mod:`scripts._probe` - the probe primitive.
+"""Tests for :mod:`scripts._drift` - the drift tool Phase A (removed direction).
 
-The probe primitive answers a binary question ("do all landmarks resolve
-under the live library?") and emits a richly-diagnosed report. These
-tests verify pass/fail verdict derivation, fingerprint stability + drift,
+The drift tool answers the same binary question as the former ``_probe.py``
+("do all landmarks resolve under the live library?") and emits a richly-
+diagnosed :class:`DriftReport`. Phase A covers the "removed" direction only;
+Phase B will add "added" (live validators not in LANDMARKS).
+
+These tests verify pass/fail verdict derivation, fingerprint stability + drift,
 current.yaml envelope checks, and round-tripping through the cache file.
 
 LANDMARKS are stdlib symbols (``json.JSONDecodeError`` etc.) rather than
-real engine symbols: the probe imports modules via ``importlib`` and
+real engine symbols: the drift tool imports modules via ``importlib`` and
 introspects with ``getattr``, so any module path works. Engine libraries
 are not installed on host (engines run only inside their Docker images
-- see ``docs/development.md``); using stdlib symbols keeps the probe's
-resolution logic exercised host-side without an engine dependency.
+- see ``docs/development.md``); using stdlib symbols keeps the resolution
+logic exercised host-side without an engine dependency.
 """
 
 from __future__ import annotations
@@ -26,7 +29,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from scripts import _probe  # noqa: E402
+from scripts import _drift  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -37,13 +40,13 @@ def _install_synthetic_producer(
     monkeypatch: pytest.MonkeyPatch,
     *,
     engine: str,
-    producer: _probe.ProducerKind,
+    producer: _drift.ProducerKind,
     landmarks: tuple[str, ...],
-    module_name: str = "scripts._probe_synthetic_producer",
+    module_name: str = "scripts._drift_synthetic_producer",
 ) -> types.ModuleType:
     """Register a fake producer module + retarget the ``_PRODUCER_MODULES`` map.
 
-    The probe loads producer modules by ``importlib.import_module``;
+    The drift tool loads producer modules by ``importlib.import_module``;
     placing one in ``sys.modules`` is sufficient. Tests use this to
     decouple LANDMARKS contents from the real miner / introspector
     bodies, which live elsewhere on the repo's release cadence.
@@ -51,7 +54,7 @@ def _install_synthetic_producer(
     module = types.ModuleType(module_name)
     module.LANDMARKS = landmarks  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, module_name, module)
-    monkeypatch.setitem(_probe._PRODUCER_MODULES, (engine, producer), module_name)
+    monkeypatch.setitem(_drift._PRODUCER_MODULES, (engine, producer), module_name)
     return module
 
 
@@ -66,7 +69,7 @@ def _redirect_compat_dir(
 
     The compat.json cache ends up at ``tmp_path/{engine}.compat.json``
     because ``_compat_path`` walks two parents up from the fake current.yaml
-    (``tmp_path/{engine}/current.yaml`` → ``.parent.parent`` = ``tmp_path``).
+    (``tmp_path/{engine}/current.yaml`` -> ``.parent.parent`` = ``tmp_path``).
     """
     real_current = _PROJECT_ROOT / "engine_versions" / engine / "current.yaml"
     fake_engine_dir = tmp_path / engine
@@ -77,7 +80,7 @@ def _redirect_compat_dir(
     def _fake_path(name: str) -> Path:
         return tmp_path / name / "current.yaml"
 
-    monkeypatch.setattr(_probe, "current_path", _fake_path)
+    monkeypatch.setattr(_drift, "current_path", _fake_path)
     return fake_current
 
 
@@ -86,10 +89,10 @@ def _redirect_compat_dir(
 # ---------------------------------------------------------------------------
 
 
-def test_probe_pass_when_all_landmarks_resolve(
+def test_drift_pass_when_all_landmarks_resolve(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """All landmarks resolve → verdict ``pass``, ``landmarks_missing`` empty."""
+    """All landmarks resolve -> verdict ``pass``, ``landmarks_missing`` empty."""
     _redirect_compat_dir(monkeypatch, tmp_path)
     _install_synthetic_producer(
         monkeypatch,
@@ -101,7 +104,7 @@ def test_probe_pass_when_all_landmarks_resolve(
         ),
     )
 
-    report = _probe.probe(engine="transformers", producer="invariants")
+    report = _drift.run(engine="transformers", producer="invariants")
 
     assert report.verdict == "pass"
     assert report.landmarks_missing == []
@@ -110,8 +113,8 @@ def test_probe_pass_when_all_landmarks_resolve(
     assert report.fingerprint  # non-empty hex digest
 
 
-def test_probe_fail_when_landmark_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """One missing landmark → verdict ``fail`` with the offender enumerated."""
+def test_drift_fail_when_landmark_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """One missing landmark -> verdict ``fail`` with the offender enumerated."""
     _redirect_compat_dir(monkeypatch, tmp_path)
     _install_synthetic_producer(
         monkeypatch,
@@ -123,21 +126,19 @@ def test_probe_fail_when_landmark_missing(monkeypatch: pytest.MonkeyPatch, tmp_p
         ),
     )
 
-    report = _probe.probe(engine="transformers", producer="invariants")
+    report = _drift.run(engine="transformers", producer="invariants")
 
     assert report.verdict == "fail"
     assert report.landmarks_missing == ["json.NonExistentSymbolXYZ"]
 
 
 # ---------------------------------------------------------------------------
-# Fingerprint behaviour
+# Direction field (Phase A)
 # ---------------------------------------------------------------------------
 
 
-def test_probe_fingerprint_stable_across_runs(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Same library, same landmarks → identical fingerprint across runs."""
+def test_drift_direction_stable_on_pass(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """All landmarks resolve -> direction is ``stable``."""
     _redirect_compat_dir(monkeypatch, tmp_path)
     _install_synthetic_producer(
         monkeypatch,
@@ -146,13 +147,67 @@ def test_probe_fingerprint_stable_across_runs(
         landmarks=("json.JSONDecodeError",),
     )
 
-    first = _probe.probe(engine="transformers", producer="invariants")
-    second = _probe.probe(engine="transformers", producer="invariants")
+    report = _drift.run(engine="transformers", producer="invariants")
+
+    assert report.direction == "stable"
+    assert report.landmarks_added == []
+
+
+def test_drift_direction_removed_on_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Missing landmark -> direction is ``removed``."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("json.NonExistentSymbolXYZ",),
+    )
+
+    report = _drift.run(engine="transformers", producer="invariants")
+
+    assert report.direction == "removed"
+    assert report.landmarks_added == []  # Phase A always empty
+
+
+def test_drift_schema_version_is_one(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``schema_version`` is always 1 in Phase A."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("json.JSONDecodeError",),
+    )
+
+    report = _drift.run(engine="transformers", producer="invariants")
+
+    assert report.schema_version == 1
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_drift_fingerprint_stable_across_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same library, same landmarks -> identical fingerprint across runs."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("json.JSONDecodeError",),
+    )
+
+    first = _drift.run(engine="transformers", producer="invariants")
+    second = _drift.run(engine="transformers", producer="invariants")
 
     assert first.fingerprint == second.fingerprint
 
 
-def test_probe_fingerprint_drift_listed_on_change(
+def test_drift_fingerprint_drift_listed_on_change(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Fingerprint shift across runs surfaces in ``fingerprint_drift``."""
@@ -164,9 +219,9 @@ def test_probe_fingerprint_drift_listed_on_change(
         landmarks=("json.JSONDecodeError",),
     )
 
-    first = _probe.probe(engine="transformers", producer="invariants")
+    first = _drift.run(engine="transformers", producer="invariants")
     assert first.fingerprint_drift == []  # no cache yet
-    _probe._write_cached_report("transformers", first)
+    _drift._write_cached_report("transformers", first)
 
     # Swap the LANDMARKS so the fingerprint shifts; the cached value is
     # the previous one. Drift should be reported.
@@ -176,7 +231,7 @@ def test_probe_fingerprint_drift_listed_on_change(
         producer="invariants",
         landmarks=("json.JSONEncoder",),
     )
-    second = _probe.probe(engine="transformers", producer="invariants")
+    second = _drift.run(engine="transformers", producer="invariants")
 
     assert second.fingerprint != first.fingerprint
     assert second.fingerprint_drift  # non-empty
@@ -187,7 +242,7 @@ def test_probe_fingerprint_drift_listed_on_change(
 # ---------------------------------------------------------------------------
 
 
-def test_probe_version_inside_envelope_matches_ssot(
+def test_drift_version_inside_envelope_matches_ssot(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """``version_inside_envelope`` reflects the current.yaml ``miner_pins.static`` range."""
@@ -213,14 +268,14 @@ def test_probe_version_inside_envelope_matches_ssot(
         '  discovery: ">=99.0,<100.0"\n'
     )
 
-    report = _probe.probe(engine="transformers", producer="invariants")
+    report = _drift.run(engine="transformers", producer="invariants")
 
     assert report.verdict == "pass"  # landmarks still resolve
     assert report.version_inside_envelope is False
-    assert report.library_version == "0.0.1"
+    assert report.current_version == "0.0.1"
 
 
-def test_probe_writes_compat_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_drift_writes_compat_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """``main`` writes a round-trippable ``{engine}.compat.json`` cache file."""
     _redirect_compat_dir(monkeypatch, tmp_path)
     _install_synthetic_producer(
@@ -230,7 +285,7 @@ def test_probe_writes_compat_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
         landmarks=("json.JSONDecodeError",),
     )
 
-    rc = _probe.main(["--engine", "transformers", "--producer", "invariants"])
+    rc = _drift.main(["--engine", "transformers", "--producer", "invariants"])
     assert rc == 0
 
     cache_path = tmp_path / "transformers.compat.json"
@@ -239,9 +294,13 @@ def test_probe_writes_compat_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     assert "invariants" in cache
     assert cache["invariants"]["verdict"] == "pass"
     assert cache["invariants"]["fingerprint"]
+    # New fields present in compat cache
+    assert cache["invariants"]["direction"] == "stable"
+    assert cache["invariants"]["schema_version"] == 1
+    assert cache["invariants"]["current_version"]
 
 
-def test_probe_output_flag_writes_to_file_keeps_stdout_clean(
+def test_drift_output_flag_writes_to_file_keeps_stdout_clean(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """``--output PATH`` writes the JSON to a file and prints nothing to stdout.
@@ -258,25 +317,29 @@ def test_probe_output_flag_writes_to_file_keeps_stdout_clean(
         landmarks=("json.JSONDecodeError",),
     )
 
-    out = tmp_path / "probe-out" / "report.json"
-    rc = _probe.main(["--engine", "transformers", "--producer", "invariants", "--output", str(out)])
+    out = tmp_path / "drift-out" / "report.json"
+    rc = _drift.main(["--engine", "transformers", "--producer", "invariants", "--output", str(out)])
     assert rc == 0
 
-    assert out.is_file(), "Probe should write JSON to --output path"
+    assert out.is_file(), "Drift tool should write JSON to --output path"
     captured = capsys.readouterr()
     assert captured.out == "", "stdout should be empty when --output is set"
 
-    # Mode 0644 - readable by the host runner user when the probe is invoked
+    # Mode 0644 - readable by the host runner user when the tool is invoked
     # from inside a Docker container running as root via a bind mount.
-    # `tempfile.mkstemp` defaults to 0600 which would block host reads.
+    # ``tempfile.mkstemp`` defaults to 0600 which would block host reads.
     assert out.stat().st_mode & 0o777 == 0o644, "output must be 0644 for host bind-mount reads"
 
     payload = json.loads(out.read_text())
     assert payload["engine"] == "transformers"
     assert payload["verdict"] == "pass"
+    assert payload["direction"] == "stable"
+    assert payload["schema_version"] == 1
+    assert "current_version" in payload
+    assert "landmarks_added" in payload
 
 
-def test_probe_atomic_output_rename_failure_leaves_destination_intact(
+def test_drift_atomic_output_rename_failure_leaves_destination_intact(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A crash at the ``os.replace`` step must NOT leave a partial JSON at
@@ -286,26 +349,26 @@ def test_probe_atomic_output_rename_failure_leaves_destination_intact(
     out = tmp_path / "report.json"
     out.write_text("STALE", encoding="utf-8")  # pre-existing content
 
-    # Force the rename step to fail. The temp file should still be cleaned
-    # up (no orphan ``.tmp`` left in the directory) and the destination
-    # should still contain its original content.
     def boom(src: str, dst: str) -> None:
         raise OSError("simulated rename failure")
 
     monkeypatch.setattr(_os, "replace", boom)
 
-    report = _probe.ProbeReport(
+    report = _drift.DriftReport(
         engine="transformers",
         producer="invariants",
+        direction="stable",
+        schema_version=1,
+        current_version="9.9.9",
         verdict="pass",
-        library_version="9.9.9",
         version_inside_envelope=True,
         fingerprint="deadbeef",
         fingerprint_drift=[],
         landmarks_missing=[],
+        landmarks_added=[],
     )
     with pytest.raises(OSError, match="simulated rename failure"):
-        _probe._write_report_to_file(out, report)
+        _drift._write_report_to_file(out, report)
 
     # Destination unchanged (the rename never happened)
     assert out.read_text() == "STALE"
@@ -313,11 +376,11 @@ def test_probe_atomic_output_rename_failure_leaves_destination_intact(
     assert not list(tmp_path.glob("*.tmp")), "tempfile cleanup must remove .tmp on failure"
 
 
-def test_probe_ssot_missing_returns_infra_error(
+def test_drift_ssot_missing_returns_infra_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """No current.yaml for the engine → CLI exits 2 with a stderr error envelope."""
-    monkeypatch.setattr(_probe, "current_path", lambda name: tmp_path / f"{name}.yaml")
+    """No current.yaml for the engine -> CLI exits 2 with a stderr error envelope."""
+    monkeypatch.setattr(_drift, "current_path", lambda name: tmp_path / f"{name}.yaml")
     _install_synthetic_producer(
         monkeypatch,
         engine="ghost_engine",
@@ -325,15 +388,15 @@ def test_probe_ssot_missing_returns_infra_error(
         landmarks=("json.JSONDecodeError",),
     )
 
-    rc = _probe.main(["--engine", "ghost_engine", "--producer", "invariants"])
+    rc = _drift.main(["--engine", "ghost_engine", "--producer", "invariants"])
     assert rc == 2
 
 
-def test_probe_unsupported_engine_producer_pair_returns_infra_error(
+def test_drift_unsupported_engine_producer_pair_returns_infra_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Unknown ``(engine, producer)`` mapping → exit 2, no JSON on stdout."""
+    """Unknown ``(engine, producer)`` mapping -> exit 2, no JSON on stdout."""
     _redirect_compat_dir(monkeypatch, tmp_path)
-    monkeypatch.setattr(_probe, "_PRODUCER_MODULES", {})  # empty map
-    rc = _probe.main(["--engine", "transformers", "--producer", "invariants"])
+    monkeypatch.setattr(_drift, "_PRODUCER_MODULES", {})  # empty map
+    rc = _drift.main(["--engine", "transformers", "--producer", "invariants"])
     assert rc == 2

--- a/tests/unit/scripts/test_engine_producers_common.py
+++ b/tests/unit/scripts/test_engine_producers_common.py
@@ -196,13 +196,13 @@ def test_schema_version_is_semver_with_major_one() -> None:
 # Per-engine LANDMARKS contracts
 # ---------------------------------------------------------------------------
 #
-# The probe primitive (``scripts._probe``) reads ``LANDMARKS`` from each
+# The drift tool (``scripts._drift``) reads ``LANDMARKS`` from each
 # producer module and resolves every dotted path against the installed
 # library; a single missing landmark flips the probe verdict to ``fail``
 # and skips downstream discovery. These tests exercise the same
 # resolution logic for the transformers introspector so a landmark-name
 # drift in upstream transformers is caught at unit-test time rather than
-# only on the next probe run.
+# only on the next drift-tool run.
 
 
 def test_transformers_introspector_landmarks_resolve() -> None:


### PR DESCRIPTION
## Summary

- Replaces `scripts/_probe.py` with `scripts/_drift.py` as a drop-in that extends the JSON shape for forward compatibility with Phase B (added direction) and Phase C (CI gating).
- Probe logic is preserved verbatim - same algorithm, same CLI interface, same exit codes. CI cell workflows gate on `.verdict` and render `.landmarks_missing` unchanged.
- Three new JSON fields: `direction` ("stable"/"removed" in Phase A), `schema_version` (always 1), `landmarks_added` (always `[]` in Phase A). `library_version` renamed to `current_version` to match terminology established in engine-coupling redesign.
- `update_last_probe.py` accepts both `current_version` (new) and `library_version` (legacy compat.json cache entries).

## Files changed

| File | Change |
|---|---|
| `scripts/_drift.py` | New file (replaces `_probe.py`); `DriftReport` dataclass; `run()` function |
| `scripts/_probe.py` | Removed |
| `tests/unit/scripts/test_drift.py` | Renamed + extended with 3 new direction/schema_version tests (13 total, up from 10) |
| `tests/unit/scripts/test_probe.py` | Removed |
| `.github/workflows/_engine-invariants-cell.yml` | `-m scripts._probe` -> `-m scripts._drift` |
| `.github/workflows/_engine-schemas-cell.yml` | `-m scripts._probe` -> `-m scripts._drift` |
| `.github/workflows/engine-pipeline.yml` | `paths:` filter updated |
| `scripts/widen_miner_pin.py` | Import from `_drift` instead of `_probe` |
| `scripts/update_last_probe.py` | Accept `current_version` or `library_version` from JSON |
| `scripts/engine_producers/transformers_miner.py` | Import `_resolve_landmark` from `_drift` |
| `engine_versions/`, `docs/`, `tests/` | Comment/doc references updated |

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_drift.py -x -q` - 13 passed
- [x] `uv run pytest -x -q` - 2548 passed, 53 skipped (net +3 for new direction tests)
- [x] `uv run ruff check` + `ruff format --check` - clean
- [ ] CI green (all 23 checks)
- [ ] Local Docker verification: `docker run ... -m scripts._drift --engine transformers --producer invariants --output ...` yields `verdict: pass`, `direction: stable`, `landmarks_added: []`

## Out of scope

Phase B (added direction, live introspection) and Phase C (exclusions, CI gating) are tracked in the follow-up issue.