### PR TITLE
feat(engines): vendor transformers v5.6.2 producers

### DIFF
--- a/engine_versions/transformers/v5_6_2/__init__.py
+++ b/engine_versions/transformers/v5_6_2/__init__.py
@@ -1,0 +1,7 @@
+"""Frozen Transformers 5.6.2 machinery + outputs.
+
+Initial vendored snapshot. The static-miner LANDMARKS cover the
+``GenerationConfig.validate`` and ``BitsAndBytesConfig.post_init`` seams
+the miner walks. The discovery LANDMARKS cover the ``from_pretrained``
+signatures and ``GenerationConfig.to_dict`` schema-discovery surface.
+"""

--- a/engine_versions/transformers/v5_6_2/producers/__init__.py
+++ b/engine_versions/transformers/v5_6_2/producers/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``static`` (invariants), ``discovery`` (schemas)."""

--- a/engine_versions/transformers/v5_6_2/producers/dynamic_invariant_miner.py
+++ b/engine_versions/transformers/v5_6_2/producers/dynamic_invariant_miner.py
@@ -1,0 +1,1863 @@
+"""Transformers library-API introspection miner - vendored for v5.6.2.
+
+Combinatorial-probe edition.
+
+Derives validation invariants from HF's runtime machinery by combinatorially
+sweeping related kwargs and inferring predicates from the raise/no-raise
+pattern. Replaces the old single-kwarg-perturbation extractor; the
+single-pass approach can't see cross-field invariants (modulo, comparison,
+range-vs-other-field) because those only fire on combinations.
+
+Three extraction paths, all observe the library at walk time:
+
+1. **Mode-gated dormancy auto-enumeration** (kept from prior implementation).
+   For each known trigger class (greedy, single-beam, no-return-dict),
+   enumerate every public ``GenerationConfig()`` field, synthesise a non-default
+   probe value for its Python type, invoke ``validate(strict=True)``, and
+   record any field HF reports as dormant in the composed raise.
+
+2. **Combinatorial cluster probing** (new). For each named cluster of
+   related kwargs (e.g. beam-search: num_beams, num_beam_groups,
+   diversity_penalty, early_stopping, length_penalty), generate the
+   Cartesian product of representative values per field, instantiate
+   ``GenerationConfig(**kwargs)`` (and call ``.validate(strict=True)`` if
+   construction succeeds), and tabulate which combinations raise / which
+   normalise / which pass. A predicate-inference pass then groups error
+   rows by message-class and emits one invariant per inferred predicate.
+
+3. **Validate-time self-triggered dormant probes** (kept). The
+   ``pad_token_id < 0`` family - dormancy gated by the field's own value
+   rather than a mode flag.
+
+Predicate inference (cluster path) covers, in order of preference:
+
+- **Cross-field divisibility** - error rows align with ``a % b != 0``.
+- **Cross-field comparison** - error rows align with ``a > b`` (or any of
+  ``<, <=, >=, ==, !=``).
+- **Cross-field equality predicate** - error rows correlate with
+  ``kwargs[a] == V`` AND ``kwargs[b] == W`` (multi-field gate).
+- **Type allowlist** - error rows correlate with the type of one kwarg's
+  value not being in an allowed set.
+- **Single-field range** - error rows correlate with one kwarg crossing a
+  threshold (``< 0``, ``<= 0``, etc.).
+- **Single-field equality** - error rows correlate with one kwarg taking
+  one specific value.
+
+Recall over precision: when multiple predicates fit, the inferrer emits
+ALL plausible candidates. The validation CI
+pipeline downstream re-runs each emitted invariant's ``kwargs_positive`` /
+``kwargs_negative`` against the live library; invariants that misfire fail CI
+and are pruned. False positives are cheap; missed invariants are not.
+
+Every invariant this miner emits carries ``added_by="dynamic_miner"``.
+
+BitsAndBytesConfig coverage gap
+-------------------------------
+This extractor is scoped to ``GenerationConfig`` (and its depth-1
+``WatermarkingConfig`` / ``SynthIDTextWatermarkingConfig`` helpers). BNB
+``post_init`` type-check raises are NOT emitted here. The pre-pipeline
+miner (:mod:`scripts.engine_producers.transformers`, deregistered) hand-curated
+nine BNB invariants; that path was lost in the refactor.
+
+Coverage is restored structurally by :mod:`scripts.engine_producers.transformers_static_miner`,
+which AST-walks ``BitsAndBytesConfig.post_init`` directly - the
+``if not isinstance(self.X, T): raise`` pattern is exactly what its
+``type_is_not`` predicate path already handles. The AST miner reads
+``transformers.utils.quantization_config`` source via
+``inspect.getsourcefile`` rather than importing the library, which
+keeps the miner fast and dependency-free.
+
+**Re. CUDA**: an earlier inherited comment claimed BNB introspection
+"touches CUDA". That's overstated. ``import bitsandbytes`` discovers
+CUDA libs at module load and emits a warning on CPU-only hosts but
+returns successfully; ``BitsAndBytesConfig(**kwargs).post_init()`` is
+pure Python type-checking with no CUDA calls. Probing BNB construction
+is therefore CI-runner-agnostic - fits cleanly on the GH-hosted
+``requires_gpu: false`` runner pool. The reason this extractor doesn't
+yet probe BNB is **scope** (the cluster wasn't added in the refactor),
+not CUDA.
+
+If/when BNB probing becomes useful (cross-validation against the AST
+miner, or to catch ``__init__``-time gates the AST miner doesn't
+currently walk like ``load_in_4bit AND load_in_8bit``), add a
+``bitsandbytes_quant`` cluster: the ``_Cluster`` pattern below
+generalises directly to ``BitsAndBytesConfig`` - swap the constructor
+in :func:`_probe_cluster` and supply representative kwargs per BNB
+field.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import itertools
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Vendored copy: this file sits at
+# ``src/llenergymeasure/engine_versions/transformers/v5_6_2/machinery/dynamic.py``;
+# the repo root is six parents up. The dispatcher's caller (a stub in
+# ``scripts/engine_producers/``) already inserts the repo root onto sys.path
+# before importing this module, but we keep the defensive insert below so
+# direct ``python -m`` invocation of the archive module still works.
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+_WALKERS_DIR = Path(__file__).resolve().parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# When run as a script (``python scripts/engine_producers/transformers_dynamic_miner.py``),
+# Python prepends the script's directory to ``sys.path`` - that directory contains
+# ``transformers.py`` (the sibling miner module), which shadows the third-party
+# ``transformers`` package import. Drop the miners dir so HF's ``transformers``
+# resolves correctly. Module-style invocation
+# (``python -m scripts.engine_producers.transformers_dynamic_miner``) avoids this trap
+# but the verification command in the task brief uses script-style.
+if str(_WALKERS_DIR) in sys.path:
+    sys.path.remove(str(_WALKERS_DIR))
+
+from scripts.engine_producers._base import InvariantCandidate, MinerSource  # noqa: E402
+from scripts.engine_producers._dataclass_lift import lift as _dataclass_lift  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Probe contract
+# ---------------------------------------------------------------------------
+
+# Dynamic-miner LANDMARKS for Transformers 5.6.2.
+#
+# The dynamic miner imports GenerationConfig + BitsAndBytesConfig at run
+# time and probes their validate / post_init contracts. LANDMARKS mirror
+# the static miner so the probe's pre-flight check covers both producers.
+LANDMARKS: tuple[str, ...] = (
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.validate",
+    "transformers.BitsAndBytesConfig",
+    "transformers.BitsAndBytesConfig.post_init",
+)
+
+
+# ---------------------------------------------------------------------------
+# Trigger classes (dormancy auto-enumeration - unchanged from prior impl)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DormancyTrigger:
+    """One mode-gated dormancy trigger in HF's ``validate()``.
+
+    HF 4.49-4.56 exposes three trigger classes: greedy (``do_sample=False``),
+    single-beam (``num_beams=1``), and scalar-output
+    (``return_dict_in_generate=False``). Each trigger ships an
+    ``isolation_kwargs`` payload - values for the OTHER triggers that DON'T
+    activate them - so the auto-enumerator can attribute a firing invariant to
+    exactly one trigger class even though the three categories overlap.
+    """
+
+    id_prefix: str
+    trigger_field: str
+    trigger_positive: Any
+    trigger_negative: Any
+    isolation_kwargs: dict[str, Any]
+    invariant_under_test_template: str
+
+
+_GREEDY_TRIGGER = _DormancyTrigger(
+    id_prefix="transformers_greedy_strips_",
+    trigger_field="do_sample",
+    trigger_positive=False,
+    trigger_negative=True,
+    isolation_kwargs={"num_beams": 4, "return_dict_in_generate": True},
+    invariant_under_test_template=(
+        "GenerationConfig.validate() records dormant `{field}` when "
+        "do_sample=False and `{field}` is set to a non-default value"
+    ),
+)
+
+
+_BEAM_TRIGGER = _DormancyTrigger(
+    id_prefix="transformers_single_beam_strips_",
+    trigger_field="num_beams",
+    trigger_positive=1,
+    trigger_negative=4,
+    isolation_kwargs={"do_sample": True, "return_dict_in_generate": True},
+    invariant_under_test_template=(
+        "GenerationConfig.validate() records dormant `{field}` when "
+        "num_beams=1 and `{field}` is set"
+    ),
+)
+
+
+_RETURN_DICT_TRIGGER = _DormancyTrigger(
+    id_prefix="transformers_no_return_dict_strips_",
+    trigger_field="return_dict_in_generate",
+    trigger_positive=False,
+    trigger_negative=True,
+    isolation_kwargs={"do_sample": True, "num_beams": 4},
+    invariant_under_test_template=(
+        "GenerationConfig.validate() records dormant `{field}` when "
+        "return_dict_in_generate=False and `{field}` is set"
+    ),
+)
+
+
+TRIGGERS: tuple[_DormancyTrigger, ...] = (
+    _GREEDY_TRIGGER,
+    _BEAM_TRIGGER,
+    _RETURN_DICT_TRIGGER,
+)
+"""Public: the full trigger-class partition. Tests parametrise over this."""
+
+
+# Fields the dormancy enumerator skips. Categories: trigger fields themselves,
+# class-instance fields whose probe value would need a specific type, meta
+# / structural fields without dormancy semantics.
+_DORMANCY_SKIP_FIELDS: frozenset[str] = frozenset(
+    {
+        "do_sample",
+        "num_beams",
+        "return_dict_in_generate",
+        "compile_config",
+        "watermarking_config",
+        "generation_kwargs",
+        "transformers_version",
+    }
+)
+
+
+def _synthesise_probe_value(default: Any) -> Any | None:
+    """Return a non-default value whose type matches ``default``.
+
+    ``None`` when the type is too complex to probe mechanically.
+    """
+    if isinstance(default, bool):
+        return not default
+    if isinstance(default, int):
+        return default + 1
+    if isinstance(default, float):
+        if default in (0.0, 1.0):
+            return 0.5
+        return round(default + 0.1, 3)
+    if default is None:
+        return 0.5
+    if isinstance(default, list):
+        return ["probe"]
+    if isinstance(default, str):
+        return "__probe__"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Library-message parsing
+# ---------------------------------------------------------------------------
+
+
+_ISSUE_LINE_RE = re.compile(r"^- `([^`]+)`: (.+)$")
+
+
+def _parse_strict_raise(composed_message: str) -> dict[str, str]:
+    """Split HF's ``validate(strict=True)`` raise into ``{field: message}``."""
+    issues: dict[str, str] = {}
+    for line in composed_message.splitlines():
+        match = _ISSUE_LINE_RE.match(line.strip())
+        if match:
+            issues[match.group(1)] = match.group(2).strip()
+    return issues
+
+
+def _substitute_declared_value(message: str, probed_field: str | None, probe_value: Any) -> str:
+    """Replace HF's ``\\`{field}\\` is set to \\`{value}\\``` with a ``{declared_value}`` slot."""
+    if probed_field is None:
+        return message
+    pattern = f"`{probed_field}` is set to `{probe_value}`"
+    if pattern in message:
+        return message.replace(pattern, f"`{probed_field}` is set to `{{declared_value}}`")
+    return message
+
+
+_BUILTIN_TYPE_NAMES = frozenset(
+    {
+        "int",
+        "str",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        "float",
+        "bool",
+        "bytes",
+        "frozenset",
+        "complex",
+    }
+)
+
+
+def _normalise_message_class(msg: str) -> str:
+    """Collapse a library error message to its template form for grouping.
+
+    Strips:
+    - backtick-wrapped value tokens (``\\`num_beams\\``` literals stay; their
+      contained values get genericised)
+    - concrete numbers
+    - trailing builtin-type-name tokens (``not int`` / ``not list`` /
+      ``not str``) so that messages that differ ONLY in the offending
+      value's type still hash to one class. This is what enables
+      type-allowlist inference: HF's ``WatermarkingConfig() ... not int``
+      and ``... not list`` are the same invariant on the type-allowlist axis.
+
+    Used to group probe rows by error class before predicate inference.
+    """
+    # Drop backtick-wrapped value tokens that vary per probe.
+    msg = re.sub(r"`[^`]*`", "`X`", msg)
+    # Drop bare numbers.
+    msg = re.sub(r"-?\d+\.?\d*", "N", msg)
+    # Genericise trailing builtin-type-name tokens after "not " so type-
+    # allowlist messages (one per offending type) collapse into one class.
+    type_alt = "|".join(sorted(_BUILTIN_TYPE_NAMES))
+    msg = re.sub(rf"\b(not|got|is)\s+({type_alt})\b", r"\1 T", msg)
+    # Collapse whitespace.
+    msg = re.sub(r"\s+", " ", msg).strip()
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Dormancy auto-enumeration (unchanged from prior implementation)
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_dormancy_candidates() -> list[tuple[_DormancyTrigger, str, Any, Any, str]]:
+    """Probe every public ``GenerationConfig`` field under each trigger class.
+
+    Returns ``(trigger, field, default, probe_value, per_field_message)``
+    tuples for fields HF reports as dormant. Filters out: private fields,
+    ``_DORMANCY_SKIP_FIELDS``, types with no synthesised probe, and fields
+    whose construction trips an error under the trigger kwargs.
+
+    Field iteration is byte-stable (sorted) so the corpus output is
+    deterministic across runs.
+    """
+    import logging
+
+    from transformers import GenerationConfig  # type: ignore
+
+    hf_logger = logging.getLogger("transformers.generation.configuration_utils")
+    prev_level = hf_logger.level
+    hf_logger.setLevel(logging.ERROR)
+    try:
+        return _enumerate_dormancy_candidates_inner(GenerationConfig)
+    finally:
+        hf_logger.setLevel(prev_level)
+
+
+def _enumerate_dormancy_candidates_inner(
+    GenerationConfig: Any,
+) -> list[tuple[_DormancyTrigger, str, Any, Any, str]]:
+    baseline = GenerationConfig()
+    discovered: list[tuple[_DormancyTrigger, str, Any, Any, str]] = []
+
+    for field_name, default in sorted(vars(baseline).items()):
+        if field_name.startswith("_"):
+            continue
+        if field_name in _DORMANCY_SKIP_FIELDS:
+            continue
+        probe = _synthesise_probe_value(default)
+        if probe is None:
+            continue
+
+        for trigger in TRIGGERS:
+            kwargs = {
+                **trigger.isolation_kwargs,
+                trigger.trigger_field: trigger.trigger_positive,
+                field_name: probe,
+            }
+            try:
+                gc = GenerationConfig(**kwargs)
+            except Exception:
+                continue
+            try:
+                gc.validate(strict=True)
+            except ValueError as exc:
+                issues = _parse_strict_raise(str(exc))
+                if field_name in issues:
+                    discovered.append((trigger, field_name, default, probe, issues[field_name]))
+
+    return discovered
+
+
+# ---------------------------------------------------------------------------
+# Combinatorial cluster probing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Cluster:
+    """One cluster of related kwargs for combinatorial probing.
+
+    ``values_per_field`` maps each kwarg in the cluster to the list of
+    representative values to sweep. The probe runner takes the Cartesian
+    product. Keep matrix size sensible - three fields x five values each
+    = 125 trials, well under the 200-per-cluster cap.
+
+    ``preconditions`` are kwargs held constant across every trial in the
+    cluster (e.g. ``do_sample=True`` to suppress the greedy-mode dormancy
+    layer). The pre-condition kwargs are NOT varied by the probe runner;
+    they're applied to every trial.
+
+    ``probe_class_match_prefix`` is the engine-config field-path prefix
+    inserted when emitting invariants from this cluster
+    (``transformers.sampling`` for most clusters).
+    """
+
+    name: str
+    values_per_field: dict[str, list[Any]]
+    preconditions: dict[str, Any] = field(default_factory=dict)
+    probe_class_match_prefix: str = "transformers.sampling"
+
+
+def _watermarking_probe_values() -> list[Any]:
+    """Probe values for ``watermarking_config`` - includes a real instance.
+
+    Without a real ``WatermarkingConfig`` instance, the type-allowlist
+    inference has no positive example to anchor against (every "wrong type"
+    triggers a TypeError; every None just skips the field). The valid
+    instance is the only OK present-value, so it must be in the matrix.
+    """
+    try:
+        from transformers.generation.configuration_utils import WatermarkingConfig  # type: ignore
+
+        valid_instance: Any = WatermarkingConfig()
+    except Exception:
+        valid_instance = None
+    return [valid_instance, None, 42, "oops", [1, 2], (1, 2), 3.14]
+
+
+def _compile_config_probe_values() -> list[Any]:
+    """Probe values for ``compile_config`` - includes a real ``CompileConfig``."""
+    try:
+        from transformers.generation.configuration_utils import CompileConfig  # type: ignore
+
+        valid_instance: Any = CompileConfig()
+    except Exception:
+        valid_instance = None
+    return [valid_instance, None, "oops", 42, [1, 2]]
+
+
+# Cluster definitions - small, representative value sets per kwarg. Adding a
+# new cluster is a one-liner; tests can parametrise over CLUSTERS so probe
+# coverage is auditable.
+#
+# Sizing rationale: keep each cluster's Cartesian product ≤ ~200 trials.
+CLUSTERS: tuple[_Cluster, ...] = (
+    _Cluster(
+        name="beam_search",
+        values_per_field={
+            "num_beams": [1, 2, 4, 6],
+            "num_beam_groups": [1, 2, 3],
+            "diversity_penalty": [0.0, 0.5, -0.5],
+            "early_stopping": [False, True, "never"],
+        },
+        # No preconditions: beam-search constraints fire at construction
+        # regardless of do_sample.
+    ),
+    _Cluster(
+        name="num_return_vs_beams",
+        values_per_field={
+            "num_beams": [1, 2, 4],
+            "num_return_sequences": [1, 2, 4, 6],
+            "do_sample": [False, True],
+        },
+    ),
+    _Cluster(
+        name="length_constraints",
+        values_per_field={
+            "min_new_tokens": [None, 5, 10],
+            "max_new_tokens": [None, 4, 8, 16],
+            "min_length": [0, 5],
+            "max_length": [10, 20],
+        },
+    ),
+    _Cluster(
+        name="output_token_ids",
+        values_per_field={
+            "max_new_tokens": [-1, 0, 1, 16],
+            "min_new_tokens": [-1, 0, 5],
+            "pad_token_id": [-1, 0, 50256],
+        },
+    ),
+    _Cluster(
+        name="watermarking_type",
+        values_per_field={
+            # Probe values whose types vary across the type-allowlist axis.
+            # First element is a real ``WatermarkingConfig`` instance - the
+            # only present-value that doesn't error, anchoring the allowlist.
+            "watermarking_config": _watermarking_probe_values(),
+        },
+    ),
+    _Cluster(
+        name="cache_choice",
+        values_per_field={
+            "cache_implementation": [
+                None,
+                "static",
+                "dynamic",
+                "nonsense",
+                "another_bogus",
+            ],
+            "use_cache": [True, False],
+        },
+    ),
+    _Cluster(
+        name="early_stopping_type",
+        values_per_field={
+            "early_stopping": [False, True, "never", "sometimes", 0, 1.5],
+            "num_beams": [1, 4],
+        },
+    ),
+    _Cluster(
+        name="compile_config_type",
+        values_per_field={
+            "compile_config": _compile_config_probe_values(),
+        },
+    ),
+)
+
+
+@dataclass
+class _ProbeRow:
+    """One trial row from the probe matrix."""
+
+    kwargs: dict[str, Any]
+    construct_error: str | None
+    construct_message_class: str | None
+    validate_minor_issues: dict[str, str]
+    validate_strict_error: str | None
+    state_after: dict[str, Any] | None  # vars(gc) after validate, for normalisation diff
+
+
+def _run_cluster_probes(cluster: _Cluster) -> list[_ProbeRow]:
+    """Run the Cartesian product for a cluster; return one row per trial.
+
+    Each trial: instantiate ``GenerationConfig(**preconditions, **kwargs)``,
+    capture construction-time errors; if construction succeeds, call
+    ``validate(strict=True)`` and capture any composed raise.
+
+    State diffs are not yet tabulated (would catch silent normalisation but
+    silent normalisations don't surface as introspection invariants in HF - they'd
+    need vLLM-style detection, out of scope here).
+    """
+    import logging
+
+    from transformers import GenerationConfig  # type: ignore
+
+    # HF emits ``logger.warning`` lines on every dormant kwarg in __init__;
+    # we capture validate(strict=True) raises programmatically and the warnings
+    # spam the miner output. Silence them at probe-time.
+    hf_logger = logging.getLogger("transformers.generation.configuration_utils")
+    prev_level = hf_logger.level
+    hf_logger.setLevel(logging.ERROR)
+
+    field_names = list(cluster.values_per_field.keys())
+    value_grids = [cluster.values_per_field[name] for name in field_names]
+    rows: list[_ProbeRow] = []
+
+    try:
+        rows = _run_cartesian(cluster, field_names, value_grids, GenerationConfig)
+    finally:
+        hf_logger.setLevel(prev_level)
+    return rows
+
+
+def _run_cartesian(
+    cluster: _Cluster,
+    field_names: list[str],
+    value_grids: list[list[Any]],
+    GenerationConfig: Any,
+) -> list[_ProbeRow]:
+    """Inner Cartesian-product loop. Split out so ``finally`` restores the logger."""
+    rows: list[_ProbeRow] = []
+    for combo in itertools.product(*value_grids):
+        kwargs = dict(zip(field_names, combo, strict=True))
+        full_kwargs = {**cluster.preconditions, **kwargs}
+
+        try:
+            gc = GenerationConfig(**full_kwargs)
+        except Exception as exc:
+            rows.append(
+                _ProbeRow(
+                    kwargs=kwargs,
+                    construct_error=str(exc),
+                    construct_message_class=_normalise_message_class(str(exc)),
+                    validate_minor_issues={},
+                    validate_strict_error=None,
+                    state_after=None,
+                )
+            )
+            continue
+
+        try:
+            gc.validate(strict=True)
+        except ValueError as exc:
+            issues = _parse_strict_raise(str(exc))
+            rows.append(
+                _ProbeRow(
+                    kwargs=kwargs,
+                    construct_error=None,
+                    construct_message_class=None,
+                    validate_minor_issues=issues,
+                    validate_strict_error=str(exc),
+                    state_after=dict(vars(gc)),
+                )
+            )
+        else:
+            rows.append(
+                _ProbeRow(
+                    kwargs=kwargs,
+                    construct_error=None,
+                    construct_message_class=None,
+                    validate_minor_issues={},
+                    validate_strict_error=None,
+                    state_after=dict(vars(gc)),
+                )
+            )
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Predicate inference
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _InferredInvariant:
+    """Result of predicate inference over a probe-row group."""
+
+    id_suffix: str
+    invariant_under_test: str
+    severity: str  # "error" or "dormant"
+    match_fields: dict[str, Any]
+    kwargs_positive: dict[str, Any]
+    kwargs_negative: dict[str, Any]
+    message_template: str
+    confidence: str  # "high" / "medium" / "low"
+    method: str  # "construct" or "validate"
+
+
+def _is_int(v: Any) -> bool:
+    return isinstance(v, int) and not isinstance(v, bool)
+
+
+def _row_field_value(row: _ProbeRow, field_name: str) -> Any:
+    return row.kwargs.get(field_name)
+
+
+def _split_error_rows(rows: list[_ProbeRow]) -> tuple[list[_ProbeRow], list[_ProbeRow]]:
+    """Split rows into (errored, ok) - ok = no construct_error AND no validate_strict_error."""
+    errored: list[_ProbeRow] = []
+    ok: list[_ProbeRow] = []
+    for row in rows:
+        if row.construct_error or row.validate_strict_error:
+            errored.append(row)
+        else:
+            ok.append(row)
+    return errored, ok
+
+
+def _group_construct_errors_by_class(rows: list[_ProbeRow]) -> dict[str, list[_ProbeRow]]:
+    """Group construction-error rows by normalised message class."""
+    groups: dict[str, list[_ProbeRow]] = defaultdict(list)
+    for row in rows:
+        if row.construct_message_class:
+            groups[row.construct_message_class].append(row)
+    return groups
+
+
+def _group_validate_errors_by_field(rows: list[_ProbeRow]) -> dict[str, list[_ProbeRow]]:
+    """Group validate-error rows by the FIRST minor-issues key.
+
+    HF emits one ``minor_issues`` entry per offending field; rows are
+    grouped by the field name so each affected field gets its own
+    inference pass.
+    """
+    groups: dict[str, list[_ProbeRow]] = defaultdict(list)
+    for row in rows:
+        if row.validate_minor_issues:
+            for key in sorted(row.validate_minor_issues.keys()):
+                groups[key].append(row)
+    return groups
+
+
+def _check_predicate_explains_errors(
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+    predicate: Callable[[_ProbeRow], bool],
+) -> bool:
+    """Predicate is consistent with the error pattern.
+
+    A predicate "explains" the errors when:
+      - every row in ``error_rows`` satisfies the predicate
+      - every "clean" row (no error of any kind) does NOT satisfy the predicate
+
+    Rows that errored in a *different* error class are skipped from the
+    consistency check - they contribute neither evidence for nor against
+    the predicate, since the predicate is only claiming to explain THIS
+    class's errors. Without this, divisibility predicates and diversity
+    predicates contaminate each other inside the beam-search cluster.
+
+    The predicate is applied only to rows where it's *defined* (the kwargs
+    referenced by the predicate are present and the right types). Rows where
+    the predicate is undefined are skipped.
+    """
+    error_set = {id(r) for r in error_rows}
+    saw_error = False
+    saw_ok = False
+    for row in all_rows:
+        is_this_class_error = id(row) in error_set
+        is_any_error = bool(row.construct_error or row.validate_strict_error)
+        is_other_class_error = is_any_error and not is_this_class_error
+        if is_other_class_error:
+            # Don't penalise the predicate for other-class errors; we make
+            # no claim about them.
+            continue
+        try:
+            holds = predicate(row)
+        except (TypeError, KeyError):
+            continue
+        if holds and not is_this_class_error:
+            return False  # predicate fires on a clean row - not explaining errors
+        if not holds and is_this_class_error:
+            return False  # predicate fails to fire on a known error row
+        if holds and is_this_class_error:
+            saw_error = True
+        if not holds and not is_this_class_error:
+            saw_ok = True
+    # Need at least one positive and one negative example for the predicate
+    # to be a meaningful invariant (invariant discrimination).
+    return saw_error and saw_ok
+
+
+def _infer_divisibility(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+    gate: Callable[[_ProbeRow], bool] | None = None,
+) -> tuple[str, str, dict[str, Any]] | None:
+    """Find a pair (a, b) where errors fire iff ``kwargs[a] % kwargs[b] != 0``.
+
+    When ``gate`` is supplied, only rows satisfying the gate participate in
+    the consistency check. This lets the inferrer find divisibility under
+    a precondition (e.g. ``num_beam_groups > 1``).
+
+    Returns ``(a, b, predicate_dict)`` or ``None``.
+    """
+    int_fields = [
+        name
+        for name, vals in cluster.values_per_field.items()
+        if any(_is_int(v) and v > 0 for v in vals)
+    ]
+    if gate is None:
+        gated_rows = all_rows
+        gated_error_rows = error_rows
+    else:
+        gated_rows = [r for r in all_rows if _safe_gate(gate, r)]
+        gated_error_rows = [r for r in error_rows if _safe_gate(gate, r)]
+        if not gated_error_rows:
+            return None
+    for a, b in itertools.permutations(int_fields, 2):
+
+        def pred(row: _ProbeRow, _a: str = a, _b: str = b) -> bool:
+            va, vb = _row_field_value(row, _a), _row_field_value(row, _b)
+            if not (_is_int(va) and _is_int(vb)):
+                raise TypeError
+            if vb <= 0:
+                raise TypeError
+            return va % vb != 0
+
+        if _check_predicate_explains_errors(gated_rows, gated_error_rows, pred):
+            return a, b, {"not_divisible_by": f"@{b}"}
+    return None
+
+
+_COMPARATORS: tuple[tuple[str, Callable[[Any, Any], bool]], ...] = (
+    (">", lambda a, b: a > b),
+    ("<", lambda a, b: a < b),
+    (">=", lambda a, b: a >= b),
+    ("<=", lambda a, b: a <= b),
+)
+
+
+def _infer_cross_field_comparison(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+    gate: Callable[[_ProbeRow], bool] | None = None,
+) -> tuple[str, str, str, dict[str, Any]] | None:
+    """Find a pair (a, b) and op where errors fire iff ``kwargs[a] op kwargs[b]``.
+
+    When ``gate`` is supplied, the consistency check only considers rows
+    where ``gate(row)`` holds. This lets the caller layer in a multi-field
+    gate (``num_beams > 1``) so the cross-field comparison
+    (``num_return_sequences > num_beams``) explains the residual error
+    pattern after the gate is applied.
+
+    Returns ``(a, b, op, predicate_dict)`` or ``None``.
+    """
+    int_fields = [
+        name for name, vals in cluster.values_per_field.items() if any(_is_int(v) for v in vals)
+    ]
+    if gate is None:
+        gated_rows = all_rows
+        gated_error_rows = error_rows
+    else:
+        gated_rows = [r for r in all_rows if _safe_gate(gate, r)]
+        gated_error_rows = [r for r in error_rows if _safe_gate(gate, r)]
+        if not gated_error_rows:
+            return None
+    for a, b in itertools.permutations(int_fields, 2):
+        for op_name, op_fn in _COMPARATORS:
+
+            def pred(
+                row: _ProbeRow, _a: str = a, _b: str = b, _op: Callable[..., bool] = op_fn
+            ) -> bool:
+                va, vb = _row_field_value(row, _a), _row_field_value(row, _b)
+                if not (_is_int(va) and _is_int(vb)):
+                    raise TypeError
+                return _op(va, vb)
+
+            if _check_predicate_explains_errors(gated_rows, gated_error_rows, pred):
+                return a, b, op_name, {op_name: f"@{b}"}
+    return None
+
+
+def _safe_gate(gate: Callable[[_ProbeRow], bool], row: _ProbeRow) -> bool:
+    """Apply ``gate(row)``; treat undefined rows (missing kwarg) as out of gate."""
+    try:
+        return gate(row)
+    except (TypeError, KeyError):
+        return False
+
+
+def _infer_single_field_threshold(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+) -> tuple[str, str, Any, dict[str, Any]] | None:
+    """Find a kwarg ``a`` and threshold ``v`` where errors fire iff ``kwargs[a] op v``.
+
+    Tries representative thresholds: 0 (for ``< 0`` and ``<= 0``), the
+    middle of the value grid for ``<`` / ``>``. Returns
+    ``(field, op, value, predicate_dict)`` or ``None``.
+    """
+    for a, vals in cluster.values_per_field.items():
+        # Numeric thresholds - try 0 first as the most common HF guard.
+        thresholds: list[tuple[str, Any, Callable[[Any], bool]]] = []
+        if any(isinstance(v, (int, float)) and not isinstance(v, bool) for v in vals):
+            thresholds.extend(
+                [
+                    (
+                        "<",
+                        0,
+                        lambda x: isinstance(x, (int, float)) and not isinstance(x, bool) and x < 0,
+                    ),
+                    (
+                        "<=",
+                        0,
+                        lambda x: (
+                            isinstance(x, (int, float)) and not isinstance(x, bool) and x <= 0
+                        ),
+                    ),
+                    (
+                        ">",
+                        0,
+                        lambda x: isinstance(x, (int, float)) and not isinstance(x, bool) and x > 0,
+                    ),
+                ]
+            )
+
+        for op, threshold, op_fn in thresholds:
+
+            def pred(row: _ProbeRow, _a: str = a, _fn: Callable[[Any], bool] = op_fn) -> bool:
+                va = _row_field_value(row, _a)
+                if va is None:
+                    raise TypeError
+                return _fn(va)
+
+            if _check_predicate_explains_errors(all_rows, error_rows, pred):
+                return a, op, threshold, {op: threshold}
+    return None
+
+
+def _infer_type_allowlist(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+) -> tuple[str, list[str], dict[str, Any]] | None:
+    """Find a field where errors correlate with type-of-value being out of an allowlist.
+
+    Returns ``(field, ok_type_names, predicate_dict)``.
+    """
+    error_ids = {id(r) for r in error_rows}
+    for a, vals in cluster.values_per_field.items():
+        type_names = sorted({type(v).__name__ for v in vals if v is not None})
+        if len(type_names) < 2:
+            continue
+        ok_types: set[str] = set()
+        err_types: set[str] = set()
+        for row in all_rows:
+            v = _row_field_value(row, a)
+            if v is None:
+                continue
+            t = type(v).__name__
+            is_this_class_error = id(row) in error_ids
+            is_any_error = bool(row.construct_error or row.validate_strict_error)
+            is_other_class_error = is_any_error and not is_this_class_error
+            if is_other_class_error:
+                # Skip - neutral for this class's predicate inference.
+                continue
+            if is_this_class_error:
+                err_types.add(t)
+            else:
+                ok_types.add(t)
+        if ok_types and err_types and not (ok_types & err_types):
+            ok_list = sorted(ok_types)
+            spec = {"present": True, "type_is_not": ok_list}
+
+            def pred(row: _ProbeRow, _a: str = a, _ok: set[str] = ok_types) -> bool:
+                v = _row_field_value(row, _a)
+                if v is None:
+                    raise TypeError
+                return type(v).__name__ not in _ok
+
+            if _check_predicate_explains_errors(all_rows, error_rows, pred):
+                return a, ok_list, spec
+    return None
+
+
+def _infer_value_allowlist(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+) -> tuple[str, list[Any], dict[str, Any]] | None:
+    """Find a field whose errors correlate with the value being out of an allowlist.
+
+    Returns ``(field, ok_values, predicate_dict)`` where the predicate is
+    ``{"not_in": ok_values}``. Distinct from ``type_allowlist`` because
+    string-enum fields (``cache_implementation``) are typed-uniformly but
+    fail on specific string values.
+    """
+    error_ids = {id(r) for r in error_rows}
+    for a, vals in cluster.values_per_field.items():
+        # Only consider hashable values.
+        try:
+            distinct_vals = {v for v in vals if v is not None}
+        except TypeError:
+            continue
+        if len(distinct_vals) < 2:
+            continue
+        ok_vals: set[Any] = set()
+        err_vals: set[Any] = set()
+        for row in all_rows:
+            v = _row_field_value(row, a)
+            if v is None:
+                continue
+            try:
+                hash(v)
+            except TypeError:
+                continue
+            is_this_class_error = id(row) in error_ids
+            is_any_error = bool(row.construct_error or row.validate_strict_error)
+            is_other_class_error = is_any_error and not is_this_class_error
+            if is_other_class_error:
+                continue
+            if is_this_class_error:
+                err_vals.add(v)
+            else:
+                ok_vals.add(v)
+        if ok_vals and err_vals and not (ok_vals & err_vals):
+            ok_sorted = sorted(ok_vals, key=str)
+            spec = {"present": True, "not_in": ok_sorted}
+
+            def pred(row: _ProbeRow, _a: str = a, _ok: set[Any] = ok_vals) -> bool:
+                v = _row_field_value(row, _a)
+                if v is None:
+                    raise TypeError
+                return v not in _ok
+
+            if _check_predicate_explains_errors(all_rows, error_rows, pred):
+                return a, ok_sorted, spec
+    return None
+
+
+def _infer_multi_field_equality_gate(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Find a multi-field equality / range gate that explains errors.
+
+    Two cases per field:
+    1. **Equality** - all error rows share one value for the field.
+    2. **Range comparator** - all error rows have ``field op V`` for the
+       same threshold. Only emitted when the gate is non-trivial (the
+       threshold actually discriminates ok rows from error rows). Useful
+       when an error class is gated by ``num_beam_groups > 1`` even though
+       beam-groups itself varies across the error rows (2, 3, ...).
+
+    Returns ``(common_assignment, match_fields_addition)`` where
+    ``match_fields_addition`` is a dict ready to merge into ``match_fields``
+    (values may be predicate dicts like ``{">": 1}`` for range gates), or
+    ``None`` if no useful gate exists.
+    """
+    if not error_rows:
+        return None
+    field_names = list(cluster.values_per_field.keys())
+    common_assignment: dict[str, Any] = {}
+    common_match: dict[str, Any] = {}
+    ok_rows = [r for r in all_rows if not (r.construct_error or r.validate_strict_error)]
+    for name in field_names:
+        try:
+            err_value_keys = {repr(_row_field_value(r, name)) for r in error_rows}
+        except TypeError:
+            continue
+        if len(err_value_keys) == 1:
+            v = _row_field_value(error_rows[0], name)
+            common_assignment[name] = v
+            common_match[name] = v
+            continue
+        # Range gate: try ``> V``, ``>= V``, ``< V``, ``<= V`` for V in
+        # the union of cluster values for this field.
+        err_vals = [_row_field_value(r, name) for r in error_rows]
+        if all(_is_int(v) or isinstance(v, float) for v in err_vals if v is not None):
+            for op_name, op_fn in _COMPARATORS:
+                for threshold in cluster.values_per_field[name]:
+                    if not isinstance(threshold, (int, float)) or isinstance(threshold, bool):
+                        continue
+                    err_holds = all(v is not None and op_fn(v, threshold) for v in err_vals)
+                    if not err_holds:
+                        continue
+                    # The gate must DISCRIMINATE: at least one ok row has
+                    # value not satisfying the gate. Otherwise it's not
+                    # information-bearing.
+                    ok_breaks = any(
+                        _row_field_value(r, name) is not None
+                        and not op_fn(_row_field_value(r, name), threshold)
+                        for r in ok_rows
+                    )
+                    if ok_breaks:
+                        common_match[name] = {op_name: threshold}
+                        break
+                if name in common_match:
+                    break
+    if not common_match:
+        return None
+    match_addition = {f"{cluster.probe_class_match_prefix}.{k}": v for k, v in common_match.items()}
+    return common_assignment, match_addition
+
+
+# ---------------------------------------------------------------------------
+# Cluster-level invariant extraction
+# ---------------------------------------------------------------------------
+
+
+_SAFE_YAML_TYPES: tuple[type, ...] = (str, int, float, bool, type(None), list, tuple, dict)
+
+
+def _is_yaml_safe(value: Any) -> bool:
+    """True iff ``value`` round-trips through ``yaml.safe_dump`` / ``yaml.safe_load``.
+
+    Pure-Python literals (str/int/float/bool/None/list/dict/tuple) are safe.
+    Library class instances (``WatermarkingConfig``, ``CompileConfig``) are
+    not - they need a synthesised replacement value (``None`` or a literal
+    dict that round-trips into the same kwarg semantics).
+    """
+    if not isinstance(value, _SAFE_YAML_TYPES):
+        return False
+    if isinstance(value, dict):
+        return all(_is_yaml_safe(k) and _is_yaml_safe(v) for k, v in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_is_yaml_safe(v) for v in value)
+    return True
+
+
+def _yaml_safe_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Replace yaml-unsafe values (library class instances) with ``None``.
+
+    The corpus needs to round-trip through ``yaml.safe_dump`` so the merger
+    and the loader can re-parse it. Dropping the live instance to ``None``
+    is lossy for the kwargs-positive / kwargs-negative pair, but the invariant's
+    *match predicate* still expresses the correct invariant - the consumer
+    re-runs kwargs_positive to confirm the invariant fires, kwargs_negative to
+    confirm it doesn't, and library classes are typically representable as
+    ``{}`` (empty kwargs) or ``None`` (absent) for the negative case.
+    """
+    return {k: (v if _is_yaml_safe(v) else None) for k, v in kwargs.items()}
+
+
+def _pick_positive_negative_for_predicate(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+    affected_fields: list[str],
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Pick representative kwargs_positive / kwargs_negative pair for a invariant.
+
+    Positive: an error row's kwargs (subset to fields in the cluster).
+    Negative: a non-error row's kwargs that differs MINIMALLY from the
+    positive - to keep the test plausible.
+
+    Yaml-unsafe values (library class instances) are replaced with ``None``;
+    callers re-run the kwargs against the live library and library classes
+    typically accept ``None`` as the absent-field state.
+
+    Returns ``None`` if no clean pair exists.
+    """
+    if not error_rows:
+        return None
+    ok_rows = [r for r in all_rows if not (r.construct_error or r.validate_strict_error)]
+    if not ok_rows:
+        return None
+    pos_row = error_rows[0]
+    pos_kwargs = {k: v for k, v in pos_row.kwargs.items() if k in cluster.values_per_field}
+
+    def overlap(row: _ProbeRow) -> int:
+        # Compare via repr so unhashable values still count overlaps.
+        return sum(
+            1
+            for k in affected_fields
+            if k in row.kwargs
+            and k in pos_kwargs
+            and repr(row.kwargs.get(k)) == repr(pos_kwargs.get(k))
+        )
+
+    ok_rows_sorted = sorted(ok_rows, key=lambda r: -overlap(r))
+    neg_row = ok_rows_sorted[0]
+    neg_kwargs = {k: v for k, v in neg_row.kwargs.items() if k in cluster.values_per_field}
+    return _yaml_safe_kwargs(pos_kwargs), _yaml_safe_kwargs(neg_kwargs)
+
+
+def _representative_message(error_rows: list[_ProbeRow]) -> str:
+    """Pick the canonical message string for an error group.
+
+    For construct-error rows: the construct_error string.
+    For validate-error rows: the per-field minor_issues body of the first row.
+    """
+    if not error_rows:
+        return ""
+    head = error_rows[0]
+    if head.construct_error:
+        return head.construct_error
+    if head.validate_minor_issues:
+        # Pick first key alphabetically for determinism.
+        first_key = sorted(head.validate_minor_issues.keys())[0]
+        return head.validate_minor_issues[first_key]
+    return ""
+
+
+def _extract_construct_error_rules(
+    cluster: _Cluster,
+    rows: list[_ProbeRow],
+) -> list[_InferredInvariant]:
+    """Run predicate inference for each construct-error message-class."""
+    invariants: list[_InferredInvariant] = []
+    error_groups = _group_construct_errors_by_class(rows)
+    for group_rows in error_groups.values():
+        invariants.extend(
+            _infer_rules_for_group(cluster, rows, group_rows, severity="error", method="construct")
+        )
+    return invariants
+
+
+def _extract_validate_error_rules(
+    cluster: _Cluster,
+    rows: list[_ProbeRow],
+) -> list[_InferredInvariant]:
+    """Run predicate inference for each validate-error per-field group.
+
+    These rows ARE dormancy, but cross-field gates (num_return_sequences > 1
+    AND do_sample=False AND num_beams=1) often surface here.
+    """
+    invariants: list[_InferredInvariant] = []
+    field_groups = _group_validate_errors_by_field(rows)
+    for affected_field, group_rows in field_groups.items():
+        if affected_field in _DORMANCY_SKIP_FIELDS:
+            # The dormancy enumerator handles these.
+            continue
+        invariants.extend(
+            _infer_rules_for_group(
+                cluster,
+                rows,
+                group_rows,
+                severity="dormant",
+                method="validate",
+                affected_field_hint=affected_field,
+            )
+        )
+    return invariants
+
+
+def _infer_rules_for_group(
+    cluster: _Cluster,
+    all_rows: list[_ProbeRow],
+    error_rows: list[_ProbeRow],
+    severity: str,
+    method: str,
+    affected_field_hint: str | None = None,
+) -> list[_InferredInvariant]:
+    """Try every predicate-inference shape; emit ALL fits with confidence ranking.
+
+    Inference order is by specificity (most informative first):
+    divisibility → cross-field comparison → type allowlist → value allowlist
+    → single-field threshold. Results are emitted with confidence:
+
+    - ``high``  - exactly one inference shape fits.
+    - ``medium`` - two shapes fit (likely overlap, validation CI prunes losers).
+    - ``low``   - three or more shapes fit (ambiguous).
+
+    Inference-shape order is also the invariant-id suffix order, which keeps
+    invariant IDs stable across reruns.
+    """
+    if not error_rows:
+        return []
+
+    rep_msg = _representative_message(error_rows)
+    gate_result = _infer_multi_field_equality_gate(cluster, all_rows, error_rows)
+    common_assignment, common_match_addition = gate_result if gate_result else ({}, {})
+    prefix = cluster.probe_class_match_prefix
+
+    def _layer_gate(match: dict[str, Any], skip_fields: set[str]) -> dict[str, Any]:
+        """Add gate predicates to ``match`` for fields not in ``skip_fields``."""
+        for full_path, spec in common_match_addition.items():
+            field_name = full_path.split(".")[-1]
+            if field_name not in skip_fields:
+                match[full_path] = spec
+        return match
+
+    # Build a callable form of the gate so cross-field inference can pre-filter
+    # rows by it. The gate holds when every gate-field's predicate is satisfied.
+    gate_fn: Callable[[_ProbeRow], bool] | None = None
+    if common_match_addition:
+
+        def gate_fn(row: _ProbeRow) -> bool:  # type: ignore[no-redef]
+            for full_path, spec in common_match_addition.items():
+                field_name = full_path.split(".")[-1]
+                v = _row_field_value(row, field_name)
+                if v is None:
+                    return False
+                if isinstance(spec, dict):
+                    for op_name, threshold in spec.items():
+                        op_fn = dict(_COMPARATORS).get(op_name)
+                        if op_fn is None:
+                            # Other operator types - give up gating for this row.
+                            return False
+                        if not op_fn(v, threshold):
+                            return False
+                else:
+                    if v != spec:
+                        return False
+            return True
+
+    inferences: list[tuple[str, str, dict[str, Any], list[str], str]] = []
+    # tuple shape: (id_suffix, method_label, match_fields_dict, affected_field_names, declared_field)
+
+    div_result = _infer_divisibility(cluster, all_rows, error_rows, gate=gate_fn)
+    if div_result:
+        a, b, spec = div_result
+        match: dict[str, Any] = {f"{prefix}.{a}": spec}
+        _layer_gate(match, {a, b})
+        inferences.append((f"{a}_not_divisible_by_{b}", "divisibility", match, [a, b], a))
+
+    cmp_result = _infer_cross_field_comparison(cluster, all_rows, error_rows, gate=gate_fn)
+    if cmp_result:
+        a, b, op, spec = cmp_result
+        match = {f"{prefix}.{a}": spec}
+        _layer_gate(match, {a, b})
+        inferences.append((f"{a}_{_OP_NAMES[op]}_{b}", f"cmp{op}", match, [a, b], a))
+
+    type_result = _infer_type_allowlist(cluster, all_rows, error_rows)
+    if type_result:
+        a, ok_list, spec = type_result
+        match = {f"{prefix}.{a}": spec}
+        _layer_gate(match, {a})
+        type_label = "_or_".join(ok_list) if ok_list else "any"
+        inferences.append((f"{a}_type_not_in_{type_label}", "type_allowlist", match, [a], a))
+
+    val_result = _infer_value_allowlist(cluster, all_rows, error_rows)
+    if val_result:
+        a, ok_list, spec = val_result
+        match = {f"{prefix}.{a}": spec}
+        _layer_gate(match, {a})
+        inferences.append((f"{a}_not_in_allowlist", "value_allowlist", match, [a], a))
+
+    thr_result = _infer_single_field_threshold(cluster, all_rows, error_rows)
+    if thr_result:
+        a, op, threshold, spec = thr_result
+        match = {f"{prefix}.{a}": spec}
+        _layer_gate(match, {a})
+        inferences.append(
+            (
+                f"{a}_{_OP_NAMES[op]}_{_value_label(threshold)}",
+                f"threshold{op}",
+                match,
+                [a],
+                a,
+            )
+        )
+
+    # If nothing more specific fits but we have a multi-field gate, emit it
+    # as a pure gate-equality / range invariant. Lowest confidence - validation CI
+    # is the safety net.
+    if not inferences and common_match_addition:
+        if common_assignment:
+            keys = sorted(common_assignment.keys())
+            subject = keys[-1]
+            id_suffix = "_and_".join(f"{k}_eq_{_value_label(common_assignment[k])}" for k in keys)
+            inferences.append(
+                (
+                    id_suffix,
+                    "common_assignment",
+                    common_match_addition,
+                    list(common_assignment.keys()),
+                    subject,
+                )
+            )
+        else:
+            # Range-only gate (no equality). Build a descriptive id.
+            keys = sorted({p.split(".")[-1] for p in common_match_addition})
+            subject = keys[-1] if keys else "unknown"
+            id_suffix = "_and_".join(f"{k}_gated" for k in keys)
+            inferences.append((id_suffix, "range_gate", common_match_addition, keys, subject))
+
+    if not inferences:
+        return []
+
+    # Confidence depends on count of plausible fits.
+    if len(inferences) == 1:
+        confidence = "high"
+    elif len(inferences) == 2:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    # Build _InferredInvariant for each fit.
+    out: list[_InferredInvariant] = []
+    for id_suffix, _label, match_fields, affected_fields, declared_field in inferences:
+        pn = _pick_positive_negative_for_predicate(cluster, all_rows, error_rows, affected_fields)
+        if pn is None:
+            continue
+        kwargs_positive, kwargs_negative = pn
+        # Inject preconditions into kwargs so the consumer can re-run them
+        # against a clean GenerationConfig.
+        for k, v in cluster.preconditions.items():
+            kwargs_positive.setdefault(k, v)
+            kwargs_negative.setdefault(k, v)
+
+        # Substitute declared-value template placeholder where possible.
+        probe_value = kwargs_positive.get(declared_field)
+        message_template = _substitute_declared_value(rep_msg, declared_field, probe_value)
+
+        invariant_under_test = _invariant_under_test_for(method, declared_field, id_suffix)
+
+        out.append(
+            _InferredInvariant(
+                id_suffix=id_suffix,
+                invariant_under_test=invariant_under_test,
+                severity=severity,
+                match_fields=match_fields,
+                kwargs_positive=kwargs_positive,
+                kwargs_negative=kwargs_negative,
+                message_template=message_template,
+                confidence=confidence,
+                method=method,
+            )
+        )
+    return out
+
+
+_OP_NAMES: dict[str, str] = {
+    ">": "exceeds",
+    "<": "lt",
+    ">=": "ge",
+    "<=": "le",
+    "==": "eq",
+    "!=": "ne",
+}
+
+
+def _value_label(v: Any) -> str:
+    """Short invariant-id-safe label for a value (``-1`` → ``neg1``, ``0`` → ``zero``)."""
+    if v is None:
+        return "none"
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    if isinstance(v, int):
+        if v < 0:
+            return f"neg{abs(v)}"
+        if v == 0:
+            return "zero"
+        return str(v)
+    if isinstance(v, float):
+        return str(v).replace(".", "p").replace("-", "neg")
+    return re.sub(r"\W+", "_", str(v))
+
+
+def _invariant_under_test_for(method: str, declared_field: str, id_suffix: str) -> str:
+    """Compose a human-readable invariant_under_test."""
+    site = "GenerationConfig.__init__" if method == "construct" else "GenerationConfig.validate"
+    return f"{site} flags `{declared_field}` ({id_suffix.replace('_', ' ')})"
+
+
+# ---------------------------------------------------------------------------
+# Validate-time self-triggered dormant probes (kept from prior implementation)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DormantProbe:
+    """A validate-time dormancy invariant whose trigger is field-self-driven."""
+
+    id: str
+    invariant_under_test: str
+    match_fields: dict[str, Any]
+    kwargs_positive: dict[str, Any]
+    kwargs_negative: dict[str, Any]
+    probed_field: str
+
+
+_VALIDATE_DORMANT_PROBES: tuple[_DormantProbe, ...] = (
+    _DormantProbe(
+        id="transformers_negative_pad_token_id",
+        invariant_under_test="GenerationConfig.validate() records dormant pad_token_id < 0",
+        match_fields={"transformers.sampling.pad_token_id": {"<": 0}},
+        kwargs_positive={"pad_token_id": -1},
+        kwargs_negative={"pad_token_id": 0},
+        probed_field="pad_token_id",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Invariant-candidate factories
+# ---------------------------------------------------------------------------
+
+
+def _default_predicate(default: Any) -> dict[str, Any]:
+    """Predicate that fires when the field is set to a non-default value."""
+    if default is None:
+        return {"present": True}
+    return {"present": True, "not_equal": default}
+
+
+@cache
+def _read_source_lines(source_file: str) -> tuple[str, ...]:
+    try:
+        return tuple(Path(source_file).read_text().splitlines())
+    except OSError:
+        return ()
+
+
+def _find_line(source_file: str, needle: str) -> int:
+    for i, line in enumerate(_read_source_lines(source_file), start=1):
+        if needle in line:
+            return i
+    return 0
+
+
+def _make_dormancy_candidate(
+    trigger: _DormancyTrigger,
+    field_name: str,
+    default: Any,
+    probe: Any,
+    library_message: str,
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> InvariantCandidate:
+    template = _substitute_declared_value(library_message, field_name, probe)
+    line = _find_line(abs_source_path, f"self.{field_name}")
+    return InvariantCandidate(
+        id=f"{trigger.id_prefix}{field_name}",
+        engine="transformers",
+        library="transformers",
+        invariant_under_test=trigger.invariant_under_test_template.format(field=field_name),
+        severity="dormant",
+        native_type="transformers.GenerationConfig",
+        miner_source=MinerSource(
+            path=rel_source_path,
+            method="validate",
+            line_at_scan=line,
+        ),
+        match_fields={
+            f"transformers.sampling.{trigger.trigger_field}": trigger.trigger_positive,
+            f"transformers.sampling.{field_name}": _default_predicate(default),
+        },
+        kwargs_positive={trigger.trigger_field: trigger.trigger_positive, field_name: probe},
+        kwargs_negative={trigger.trigger_field: trigger.trigger_negative, field_name: probe},
+        expected_outcome={
+            "outcome": "dormant_announced",
+            "emission_channel": "logger_warning_once",
+            "normalised_fields": [],
+        },
+        message_template=template,
+        references=[f"transformers.GenerationConfig.validate() (line ~{line})"],
+        added_by="dynamic_miner",
+        added_at=today,
+    )
+
+
+_OUTCOME_BY_SEVERITY: dict[str, dict[str, Any]] = {
+    "error": {
+        "outcome": "error",
+        "emission_channel": "none",
+        "normalised_fields": [],
+    },
+    "dormant": {
+        "outcome": "dormant_announced",
+        "emission_channel": "logger_warning_once",
+        "normalised_fields": [],
+    },
+}
+
+
+_REFERENCE_BY_METHOD: dict[str, str] = {
+    "construct": "transformers.GenerationConfig - observed via construction-time ValueError",
+    "validate": "transformers.GenerationConfig.validate() - observed via validate(strict=True)",
+}
+
+
+def _make_inferred_candidate(
+    cluster: _Cluster,
+    invariant: _InferredInvariant,
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> InvariantCandidate:
+    """Compose a ``InvariantCandidate`` from a combinatorial-inference invariant."""
+    line = _find_line(abs_source_path, f"self.{_subject_field_from_id(invariant.id_suffix)}")
+    return InvariantCandidate(
+        id=f"transformers_{cluster.name}_{invariant.id_suffix}",
+        engine="transformers",
+        library="transformers",
+        invariant_under_test=invariant.invariant_under_test,
+        severity=invariant.severity,
+        native_type="transformers.GenerationConfig",
+        miner_source=MinerSource(
+            path=rel_source_path,
+            method="validate" if invariant.method == "validate" else "__init__",
+            line_at_scan=line,
+        ),
+        match_fields=invariant.match_fields,
+        kwargs_positive=invariant.kwargs_positive,
+        kwargs_negative=invariant.kwargs_negative,
+        expected_outcome=_OUTCOME_BY_SEVERITY[invariant.severity],
+        message_template=invariant.message_template,
+        references=[_REFERENCE_BY_METHOD[invariant.method]],
+        added_by="dynamic_miner",
+        added_at=today,
+    )
+
+
+def _subject_field_from_id(id_suffix: str) -> str:
+    """Best-effort: pull the leading kwarg name from the invariant-id suffix."""
+    return id_suffix.split("_")[0]
+
+
+def _make_dormant_probe_candidate(
+    probe: _DormantProbe,
+    library_message: str,
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> InvariantCandidate:
+    """Compose a ``InvariantCandidate`` from a hardcoded validate-time dormant probe."""
+    template = _substitute_declared_value(
+        library_message, probe.probed_field, probe.kwargs_positive[probe.probed_field]
+    )
+    line = _find_line(abs_source_path, f"self.{probe.probed_field}")
+    return InvariantCandidate(
+        id=probe.id,
+        engine="transformers",
+        library="transformers",
+        invariant_under_test=probe.invariant_under_test,
+        severity="dormant",
+        native_type="transformers.GenerationConfig",
+        miner_source=MinerSource(
+            path=rel_source_path,
+            method="validate",
+            line_at_scan=line,
+        ),
+        match_fields=probe.match_fields,
+        kwargs_positive=probe.kwargs_positive,
+        kwargs_negative=probe.kwargs_negative,
+        expected_outcome=_OUTCOME_BY_SEVERITY["dormant"],
+        message_template=template,
+        references=[
+            "transformers.GenerationConfig.validate() - observed via validate(strict=True)"
+        ],
+        added_by="dynamic_miner",
+        added_at=today,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+class IntrospectionProbeDisappeared(RuntimeError):
+    """A hardcoded validate-dormant probe stopped firing - library drift signal."""
+
+
+def _walk_combinatorial(
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> tuple[list[InvariantCandidate], int]:
+    """Run all clusters and return ``(candidates, total_probe_rows)``."""
+    candidates: list[InvariantCandidate] = []
+    total_rows = 0
+    seen_ids: set[str] = set()
+    for cluster in CLUSTERS:
+        rows = _run_cluster_probes(cluster)
+        total_rows += len(rows)
+        construct_rules = _extract_construct_error_rules(cluster, rows)
+        validate_rules = _extract_validate_error_rules(cluster, rows)
+        for invariant in (*construct_rules, *validate_rules):
+            cand = _make_inferred_candidate(
+                cluster, invariant, abs_source_path, rel_source_path, today
+            )
+            if cand.id in seen_ids:
+                # Same invariant discovered in multiple clusters - keep the
+                # first (deterministic by CLUSTERS iteration order).
+                continue
+            seen_ids.add(cand.id)
+            candidates.append(cand)
+    return candidates, total_rows
+
+
+def walk_generation_config_invariants(
+    abs_source_path: str,
+    rel_source_path: str,
+    today: str,
+) -> list[InvariantCandidate]:
+    """Return all introspection-derived invariants for ``GenerationConfig``.
+
+    Composes three sources in deterministic order:
+
+    1. Mode-gated dormancy invariants auto-enumerated per trigger class.
+    2. Combinatorial cluster-probe invariants (cross-field invariants).
+    3. Validate-time self-triggered dormant invariants.
+
+    Raises :class:`IntrospectionProbeDisappeared` when a hardcoded probe
+    silently stops firing - preserves the "silent coverage loss becomes a
+    visible CI failure" contract for the small set of probes that aren't
+    auto-discovered.
+    """
+    import logging
+
+    from transformers import GenerationConfig  # type: ignore
+
+    hf_logger = logging.getLogger("transformers.generation.configuration_utils")
+    prev_level = hf_logger.level
+    hf_logger.setLevel(logging.ERROR)
+
+    candidates: list[InvariantCandidate] = []
+
+    # Path 0: sub-library type-system lift (locked design §1 REVISED).
+    # Composes the generic stdlib-dataclass lift over GenerationConfig and
+    # surfaces any Literal[...] allowlist invariants. GenerationConfig is not a
+    # dataclass on transformers 4.x (its fields live in ``__init__`` as
+    # ``**kwargs``-stuffed self-assigns), so this returns ``[]`` today -
+    # the call is wired to validate the abstraction's plumbing on the gold
+    # standard before vLLM and TRT-LLM consume it. If a future transformers
+    # release rebases ``GenerationConfig`` onto dataclasses, this picks up
+    # the field-level Literal invariants for free.
+    candidates.extend(
+        _dataclass_lift(
+            GenerationConfig,
+            namespace="transformers.generation",
+            today=today,
+            source_path=rel_source_path,
+        )
+    )
+
+    # Path 1: dormancy auto-enumeration (preserved unchanged).
+    for trigger, field_name, default, probe, lib_message in _enumerate_dormancy_candidates():
+        candidates.append(
+            _make_dormancy_candidate(
+                trigger,
+                field_name,
+                default,
+                probe,
+                lib_message,
+                abs_source_path,
+                rel_source_path,
+                today,
+            )
+        )
+
+    # Path 2: combinatorial cluster probes.
+    inferred, _row_count = _walk_combinatorial(abs_source_path, rel_source_path, today)
+    candidates.extend(inferred)
+
+    # Path 3: validate-time self-triggered dormant probes.
+    for dprobe in _VALIDATE_DORMANT_PROBES:
+        gc = GenerationConfig(**dprobe.kwargs_positive)
+        try:
+            gc.validate(strict=True)
+        except ValueError as exc:
+            issues = _parse_strict_raise(str(exc))
+        else:
+            raise IntrospectionProbeDisappeared(
+                f"Validate-time dormant probe {dprobe.id!r} no longer fires."
+            )
+        if dprobe.probed_field not in issues:
+            raise IntrospectionProbeDisappeared(
+                f"Validate-time dormant probe {dprobe.id!r} fired without "
+                f"mentioning {dprobe.probed_field!r}."
+            )
+        candidates.append(
+            _make_dormant_probe_candidate(
+                dprobe,
+                issues[dprobe.probed_field],
+                abs_source_path,
+                rel_source_path,
+                today,
+            )
+        )
+
+    hf_logger.setLevel(prev_level)
+    return candidates
+
+
+def discover_dormancy_fields() -> dict[str, set[str]]:
+    """Return ``{trigger.id_prefix: {field, ...}}`` - auto-discovered dormancy fields."""
+    result: dict[str, set[str]] = {t.id_prefix: set() for t in TRIGGERS}
+    for trigger, field_name, _default, _probe, _msg in _enumerate_dormancy_candidates():
+        result[trigger.id_prefix].add(field_name)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Standalone driver - writes the staging YAML for the corpus merger
+# ---------------------------------------------------------------------------
+
+
+def _relative_source_path(abs_path: str) -> str:
+    """Strip host-specific prefixes so the corpus is reproducible across machines."""
+    marker = "site-packages/"
+    idx = abs_path.find(marker)
+    if idx >= 0:
+        return abs_path[idx + len(marker) :]
+    return Path(abs_path).name
+
+
+def _candidate_to_dict(c: InvariantCandidate) -> dict[str, Any]:
+    """Render a :class:`InvariantCandidate` into the YAML corpus entry shape."""
+    return {
+        "id": c.id,
+        "engine": c.engine,
+        "library": c.library,
+        "invariant_under_test": c.invariant_under_test,
+        "severity": c.severity,
+        "native_type": c.native_type,
+        "miner_source": {
+            "path": c.miner_source.path,
+            "method": c.miner_source.method,
+            "line_at_scan": c.miner_source.line_at_scan,
+        },
+        "match": {
+            "engine": c.engine,
+            "fields": c.match_fields,
+        },
+        "kwargs_positive": c.kwargs_positive,
+        "kwargs_negative": c.kwargs_negative,
+        "expected_outcome": c.expected_outcome,
+        "message_template": c.message_template,
+        "references": c.references,
+        "added_by": c.added_by,
+        "added_at": c.added_at,
+    }
+
+
+def _resolve_source_paths() -> tuple[str, str, str]:
+    """Locate transformers' GenerationConfig source on disk.
+
+    Returns ``(version, abs_path, rel_path)`` - the latter rooted at
+    ``site-packages/`` for reproducibility.
+    """
+    import inspect
+
+    import transformers  # type: ignore
+    from transformers import GenerationConfig  # type: ignore
+
+    abs_path = inspect.getsourcefile(GenerationConfig) or "<unknown>"
+    rel_path = _relative_source_path(abs_path)
+    return transformers.__version__, abs_path, rel_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the introspection extractor end-to-end and write the staging YAML."""
+    out_path = (
+        Path(_PROJECT_ROOT)
+        / "src"
+        / "llenergymeasure"
+        / "engines"
+        / "transformers"
+        / "_staging"
+        / "transformers_dynamic_miner.yaml"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    version, abs_source_path, rel_source_path = _resolve_source_paths()
+    today = os.environ.get("LLENERGY_MINER_FROZEN_AT", dt.date.today().isoformat())[:10]
+
+    candidates = walk_generation_config_invariants(
+        abs_source_path=abs_source_path,
+        rel_source_path=rel_source_path,
+        today=today,
+    )
+
+    # Stable order: by miner_source.method, then by id.
+    candidates_sorted = sorted(candidates, key=lambda c: (c.miner_source.method, c.id))
+
+    mined_at = os.environ.get(
+        "LLENERGY_MINER_FROZEN_AT",
+        dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+    )
+
+    doc = {
+        "schema_version": "1.0.0",
+        "engine": "transformers",
+        "engine_version": version,
+        "mined_at": mined_at,
+        "extractor": "transformers_dynamic_miner",
+        "invariants": [_candidate_to_dict(c) for c in candidates_sorted],
+    }
+    out_path.write_text(yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=100))
+
+    print(
+        f"Wrote {len(candidates_sorted)} introspection-derived invariants to {out_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+__all__ = [
+    "CLUSTERS",
+    "TRIGGERS",
+    "IntrospectionProbeDisappeared",
+    "discover_dormancy_fields",
+    "walk_generation_config_invariants",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/engine_versions/transformers/v5_6_2/producers/schema_introspector.py
+++ b/engine_versions/transformers/v5_6_2/producers/schema_introspector.py
@@ -1,0 +1,142 @@
+"""HuggingFace Transformers schema introspector - vendored for v5.6.2.
+
+Runs inside ``llenergymeasure:transformers-<tag>``. Introspects
+``AutoModelForCausalLM.from_pretrained``, ``PreTrainedModel.from_pretrained``
+and ``GenerationConfig`` and writes a JSON schema file with the common
+envelope.
+
+This module is the version-pinned vendored copy of the introspector body
+that previously lived in ``scripts/engine_producers/transformers_introspector.py``.
+The global module is now a dispatcher stub that delegates to this
+per-version archive via the SSOT's ``library.current_version``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+from scripts.engine_producers._common import (
+    TRANSFORMERS_DOCKERFILE,
+    annotation_to_type_str,
+    jsonable,
+    make_envelope,
+    read_dockerfile_from,
+)
+
+# Schema-introspector LANDMARKS for Transformers 5.6.2.
+#
+# The introspector runs inside ``llenergymeasure:transformers-<tag>`` and
+# lifts engine parameter specs via ``inspect.signature(from_pretrained)``
+# and sampling parameter specs via ``GenerationConfig().to_dict()``. The
+# probe (``scripts/_probe.py``) reads this tuple via the dispatcher and
+# resolves each dotted path under the installed library before discovery
+# runs; a missing landmark flips the probe verdict to ``fail``.
+LANDMARKS: tuple[str, ...] = (
+    "transformers.AutoModelForCausalLM",
+    "transformers.AutoModelForCausalLM.from_pretrained",
+    "transformers.PreTrainedModel",
+    "transformers.PreTrainedModel.from_pretrained",
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.to_dict",
+)
+
+
+def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
+    """Discover HuggingFace Transformers schemas.
+
+    engine_params:   best-effort inspect.signature(from_pretrained) scrape;
+                     **kwargs are opaque and recorded as a limitation
+    sampling_params: GenerationConfig().to_dict() (~69 fields); None defaults
+                     get type='unknown' and are listed in discovery_limitations
+    """
+    import transformers  # type: ignore[import-not-found]
+    from transformers import (  # type: ignore[import-not-found]
+        AutoModelForCausalLM,
+        GenerationConfig,
+        PreTrainedModel,
+    )
+
+    limitations: list[dict[str, Any]] = []
+    engine_params: dict[str, Any] = {}
+    kwargs_points: list[str] = []
+
+    for cls_name, cls in (
+        ("AutoModelForCausalLM", AutoModelForCausalLM),
+        ("PreTrainedModel", PreTrainedModel),
+    ):
+        try:
+            sig = inspect.signature(cls.from_pretrained)
+        except (TypeError, ValueError) as exc:
+            limitations.append(
+                {
+                    "section": "engine_params",
+                    "fields": [cls_name],
+                    "reason": f"inspect.signature({cls_name}.from_pretrained) failed: {exc!r}",
+                }
+            )
+            continue
+
+        for name, param in sig.parameters.items():
+            if name in ("self", "cls", "pretrained_model_name_or_path"):
+                continue
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                kwargs_points.append(f"{cls_name}.from_pretrained.**{name}")
+                continue
+            if name in engine_params:
+                continue  # prefer AutoModelForCausalLM over PreTrainedModel
+            default = None if param.default is inspect.Parameter.empty else param.default
+            engine_params[name] = {
+                "type": annotation_to_type_str(param.annotation),
+                "default": jsonable(default),
+            }
+
+    if kwargs_points:
+        limitations.append(
+            {
+                "section": "engine_params",
+                "fields": kwargs_points,
+                "reason": "from_pretrained accepts **kwargs; kwargs are not in the signature "
+                "(documented kwargs live in the class docstring only)",
+            }
+        )
+
+    sampling_params: dict[str, Any] = {}
+    none_default_fields: list[str] = []
+    gc = GenerationConfig()
+    for name, value in gc.to_dict().items():
+        if value is None:
+            sampling_params[name] = {"type": "unknown", "default": None}
+            none_default_fields.append(name)
+        elif isinstance(value, (list, tuple)):
+            sampling_params[name] = {"type": type(value).__name__, "default": jsonable(value)}
+        elif isinstance(value, dict):
+            sampling_params[name] = {"type": "dict", "default": jsonable(value)}
+        else:
+            sampling_params[name] = {
+                "type": type(value).__name__,
+                "default": jsonable(value),
+            }
+
+    if none_default_fields:
+        limitations.append(
+            {
+                "section": "sampling_params",
+                "fields": none_default_fields,
+                "reason": "GenerationConfig has no type annotations; None defaults yield type='unknown'",
+            }
+        )
+
+    base_image_ref = read_dockerfile_from(repo_root / TRANSFORMERS_DOCKERFILE)
+    return make_envelope(
+        engine="transformers",
+        engine_version=transformers.__version__,
+        engine_commit_sha=getattr(transformers, "__commit__", None),
+        image_ref=image_ref or base_image_ref,
+        base_image_ref=base_image_ref,
+        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+        discovery_limitations=limitations,
+        engine_params=engine_params,
+        sampling_params=sampling_params,
+    )

--- a/engine_versions/transformers/v5_6_2/producers/static_invariant_miner.py
+++ b/engine_versions/transformers/v5_6_2/producers/static_invariant_miner.py
@@ -1,0 +1,1598 @@
+"""AST miner for the transformers library - vendored for v5.6.2.
+
+Recall-first invariant extraction.
+
+Walks ``GenerationConfig.validate()`` and the depth-1 helpers it calls
+(``WatermarkingConfig.validate``, ``SynthIDTextWatermarkingConfig.validate``)
+and emits structured invariant candidates describing every conditional that
+raises, warns, silently normalises, or populates ``minor_issues``.
+
+Why source-AST walking instead of pure introspection
+----------------------------------------------------
+``transformers_dynamic_miner.py`` exercises ``GenerationConfig.validate(strict=True)``
+against probe values and lifts ``minor_issues`` / ``ValueError`` messages.
+That works for one-axis invariants but loses the **shape** of cross-field
+predicates: the introspection layer sees the message
+``"`num_beams` should be divisible by `num_beam_groups`"`` but cannot tell
+that the underlying check is ``num_beams % num_beam_groups != 0``. This
+miner reads predicate structure directly from the AST.
+
+Recall over precision
+---------------------
+Validation CI runs every emitted invariant against the real library; divergent invariants
+fail there. So this miner errs toward emitting candidates with
+low confidence rather than dropping them. A predicate the static miner
+can't fully translate (opaque function call, complex method chain) emits
+the surrounding invariant and notes the dropped sub-clause in a YAML comment.
+
+Output
+------
+Writes ``src/llenergymeasure/engines/transformers/_staging/transformers_static_miner.yaml``
+- consumed downstream by ``scripts/engine_producers/build_corpus.py``. Schema
+mirrors ``src/llenergymeasure/engines/transformers/invariants.proposed.yaml``
+exactly: ``schema_version``, ``engine``, ``engine_version``, ``invariants: [...]``.
+
+Run::
+
+    PYTHONPATH=.:src python3.10 scripts/engine_producers/transformers_static_miner.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import datetime as dt
+import importlib.metadata
+import inspect
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Vendored copy: repo root is six parents up
+# (``machinery/`` / ``v5_6_2/`` / ``transformers/`` / ``engine_versions/`` /
+# ``llenergymeasure/`` / ``src/`` / repo root). The dispatcher's caller in
+# ``scripts/engine_producers/`` already inserts the repo root before importing
+# this module; the defensive insert below keeps direct ``python -m``
+# invocation of the archive module working.
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Defend against the script-directory shadowing site-packages. When run as
+# `python3 scripts/engine_producers/transformers_static_miner.py`, Python prepends
+# `scripts/engine_producers/` to sys.path, where a sibling `transformers.py` lives -
+# `import transformers` would resolve to that local stub instead of the real
+# installed package. Strip the script dir before any third-party imports.
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+sys.path[:] = [p for p in sys.path if Path(p).resolve() != Path(_SCRIPT_DIR).resolve()]
+# Also guard against the empty-string entry that means "current cwd".
+sys.path[:] = [p for p in sys.path if p != ""]
+
+from scripts.engine_producers._base import (  # noqa: E402  (late import after sys.path)
+    call_func_path,
+    find_class,
+    find_method,
+    first_string_arg,
+    format_call_template,
+    render_binop_concat_template,
+)
+
+# Why we DON'T import _base's detector classes (ConditionalRaiseDetector,
+# ConditionalSelfAssignDetector, etc.) and instead define parallel
+# ``_detect_*`` functions below: the base detectors emit ``DetectedPattern``
+# which carries severity / channel / affected_field but not the structured
+# ``FieldPredicate`` data we need for cross-field corpus invariants using
+# operators like ``not_divisible_by`` and ``@field_ref``. Extending the base
+# classes would either change their public ``DetectedPattern`` shape
+# (breaking the introspection extractor that currently consumes it) or
+# require lossy adapter shims at every emission site. With one miner live
+# today, the cheaper choice is per-miner detectors that emit a richer
+# local ``DetectedBody`` type. Revisit when a second miner (vLLM, TRT-LLM)
+# lands and we can see whether the parallel detector logic is genuinely
+# divergent or accidentally so.
+
+# ---------------------------------------------------------------------------
+# Probe contract
+# ---------------------------------------------------------------------------
+
+# Static-miner LANDMARKS for Transformers 5.6.2.
+#
+# Read by the probe before the invariants miner orchestrator
+# (``scripts.engine_producers.transformers_miner``) runs. Covers the symbols
+# the orchestrator's ``_check_landmarks()`` verifies plus the symbols the
+# delegated dynamic miner (``transformers_dynamic_miner``) imports.
+LANDMARKS: tuple[str, ...] = (
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.validate",
+    "transformers.BitsAndBytesConfig",
+    "transformers.BitsAndBytesConfig.post_init",
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+ENGINE = "transformers"
+LIBRARY = "transformers"
+LIBRARY_BNB = "bitsandbytes"
+NATIVE_TYPE_GEN = "transformers.GenerationConfig"
+NATIVE_TYPE_WMK = "transformers.WatermarkingConfig"
+NATIVE_TYPE_SYNTH = "transformers.SynthIDTextWatermarkingConfig"
+NATIVE_TYPE_BNB = "transformers.BitsAndBytesConfig"
+
+# Field-path namespace for GenerationConfig fields. The corpus convention
+# (see existing transformers.yaml entries) puts every GenerationConfig
+# attribute under transformers.sampling.<field>, even those that aren't
+# strictly "sampling" parameters - that namespace is how the project's
+# Pydantic config model exposes them.
+GENCONFIG_NAMESPACE = "transformers.sampling"
+
+# BitsAndBytesConfig fields are exposed at the top level of the
+# project's TransformersConfig Pydantic model (e.g. config.transformers.load_in_4bit),
+# NOT nested under a quant sub-model. See src/llenergymeasure/config/engine_configs.py
+# class TransformersConfig where load_in_4bit / bnb_4bit_* / llm_int8_* are direct fields.
+BNB_NAMESPACE = "transformers"
+
+# A small allowlist of decoder-config field paths used by the project's
+# Pydantic models. Most generation-config fields live under .sampling.
+# Some (max_new_tokens, etc.) live under .decoder. The miner emits paths
+# under sampling. by default; if validation CI flags a path mismatch we can
+# refine. Recall first.
+
+# Default values used to synthesise positive / negative kwargs when the
+# miner cannot infer better ones from the predicate.
+_DEFAULT_BY_TYPE: dict[type, Any] = {
+    bool: True,
+    int: 1,
+    float: 1.0,
+    str: "x",
+    list: [],
+}
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldPredicate:
+    """One atomic predicate over ``self.<field>`` extracted from a condition.
+
+    ``op`` is one of the corpus loader's operator names (``==``, ``!=``,
+    ``<``, ``<=``, ``>``, ``>=``, ``in``, ``not_in``, ``present``, ``absent``,
+    ``type_is``, ``type_is_not``, ``divisible_by``, ``not_divisible_by``).
+    ``rhs`` is either a Python literal or a string starting with ``@`` for a
+    cross-field reference resolved by the loader.
+    """
+
+    field: str
+    op: str
+    rhs: Any
+    confidence_penalty: int = 0
+    """How much this predicate degrades the invariant's confidence (0 = none)."""
+
+
+@dataclass
+class ExtractedCondition:
+    """An ``ast.expr`` condition translated into a list of FieldPredicates.
+
+    ``unparseable_clauses`` records sub-clauses the miner couldn't translate
+    - surfaced into the YAML invariant's ``invariant_under_test`` so reviewers see what
+    was dropped.
+    """
+
+    predicates: list[FieldPredicate]
+    unparseable_clauses: list[str]
+
+
+@dataclass
+class DetectedBody:
+    """One detected raise/warn/assign inside an ``if`` body."""
+
+    severity: str  # "error" | "warn" | "dormant"
+    outcome: str  # "error" | "warn" | "dormant_announced" | "dormant_silent"
+    emission_channel: str
+    affected_field: str | None
+    message_template: str | None
+    detail: str
+    minor_issues_key: str | None = None
+
+
+@dataclass
+class InvariantCandidate:
+    """A miner-extracted invariant candidate ready to emit as YAML."""
+
+    id: str
+    native_type: str
+    method: str
+    line: int
+    invariant_under_test: str
+    severity: str
+    outcome: str
+    emission_channel: str
+    match_fields: dict[str, Any]
+    kwargs_positive: dict[str, Any]
+    kwargs_negative: dict[str, Any]
+    message_template: str | None
+    references: list[str]
+    confidence: str
+    library: str = LIBRARY
+    """Owning library - overridden for BNB (``bitsandbytes``) etc."""
+    source_path: str | None = None
+    """Site-packages-relative source path. Falls back to the miner's
+    primary module path when None - used by GenerationConfig invariants; BNB
+    invariants sit in a different source file and override this."""
+    normalised_fields: list[Any] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Predicate extraction
+# ---------------------------------------------------------------------------
+
+
+_COMPARE_OP_NAMES: dict[type[ast.cmpop], str] = {
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+    ast.In: "in",
+    ast.NotIn: "not_in",
+}
+
+
+def _self_attr_name(node: ast.expr) -> str | None:
+    """If ``node`` is ``self.<name>``, return ``<name>``; else None."""
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    ):
+        return node.attr
+    return None
+
+
+def _literal_value(node: ast.expr) -> tuple[bool, Any]:
+    """Try to resolve ``node`` to a Python literal.
+
+    Returns ``(True, value)`` on success, ``(False, None)`` otherwise.
+    Supports ``ast.Constant``, ``ast.UnaryOp(USub, Constant)``, and tuples /
+    lists / sets of constants (closed-set membership shapes).
+    """
+    if isinstance(node, ast.Constant):
+        return True, node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        ok, v = _literal_value(node.operand)
+        if ok and isinstance(v, (int, float)):
+            return True, -v
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        values: list[Any] = []
+        for elt in node.elts:
+            ok, v = _literal_value(elt)
+            if not ok:
+                return False, None
+            values.append(v)
+        return True, list(values)
+    if isinstance(node, ast.Name) and node.id in {"True", "False", "None"}:
+        # Python 3.10 always uses ast.Constant for these, kept defensively.
+        return True, {"True": True, "False": False, "None": None}[node.id]
+    return False, None
+
+
+def _rhs_from_node(node: ast.expr) -> tuple[bool, Any, int]:
+    """Resolve ``node`` into a corpus-loader RHS value.
+
+    Returns ``(ok, rhs, penalty)``. ``rhs`` is a Python literal or an
+    ``"@<name>"`` cross-field reference. ``penalty`` is the confidence
+    penalty (0 if clean, 1 if we made a permissive guess).
+    """
+    # Literal
+    ok, v = _literal_value(node)
+    if ok:
+        return True, v, 0
+    # Cross-field reference: self.<name>
+    name = _self_attr_name(node)
+    if name is not None:
+        return True, f"@{name}", 0
+    # ast.Name resolved as a module-level constant (e.g. ALL_CACHE_IMPLEMENTATIONS):
+    # treat as opaque but flag low confidence - the loader can't replay it,
+    # but validation CI can run kwargs_positive / kwargs_negative empirically.
+    if isinstance(node, ast.Name):
+        return False, ast.unparse(node), 1
+    return False, ast.unparse(node), 1
+
+
+def _modulo_field_pair(node: ast.expr) -> tuple[str, str] | None:
+    """If ``node`` is ``self.<a> % self.<b>``, return ``(a, b)``."""
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+        a = _self_attr_name(node.left)
+        b = _self_attr_name(node.right)
+        if a is not None and b is not None:
+            return a, b
+    return None
+
+
+def _extract_compare(cmp: ast.Compare) -> tuple[list[FieldPredicate], list[str]]:
+    """Translate an ``ast.Compare`` into FieldPredicates.
+
+    Handles common shapes:
+    - ``self.x op literal`` / ``self.x op self.y``
+    - ``self.x % self.y != 0`` → ``not_divisible_by`` cross-field predicate
+    - ``self.x is None`` / ``self.x is not None``
+    - chained ``literal <= self.x <= literal`` (split into two predicates)
+
+    Anything we can't translate is appended to the unparseable list.
+    """
+    # Pre-pass for modulo-divisibility shape: ``self.a % self.b != 0`` /
+    # ``self.a % self.b == 0``. The corpus operator vocabulary expresses
+    # this directly; capture it before the generic compare path drops it
+    # into unparseable.
+    if len(cmp.ops) == 1 and len(cmp.comparators) == 1:
+        op = cmp.ops[0]
+        right = cmp.comparators[0]
+        pair = _modulo_field_pair(cmp.left)
+        if pair is not None and isinstance(op, (ast.NotEq, ast.Eq)):
+            ok, rhs = _literal_value(right)
+            if ok and rhs == 0:
+                a, b = pair
+                # ``a % b != 0`` -> not_divisible_by; ``a % b == 0`` -> divisible_by.
+                ast_op = "not_divisible_by" if isinstance(op, ast.NotEq) else "divisible_by"
+                return [
+                    FieldPredicate(
+                        field=a,
+                        op=ast_op,
+                        rhs=f"@{b}",
+                        confidence_penalty=0,
+                    )
+                ], []
+    preds: list[FieldPredicate] = []
+    unparseable: list[str] = []
+
+    # Walk the chain pairwise: (left, op0, comparator0), (comparator0, op1, comparator1), ...
+    operands = [cmp.left, *cmp.comparators]
+    for left, op, right in zip(operands, cmp.ops, cmp.comparators, strict=False):
+        # `is`/`is not` - corpus loader has no `is` operator. Map `is None` to
+        # `absent`, `is not None` to `present`.
+        if isinstance(op, (ast.Is, ast.IsNot)):
+            field_name = _self_attr_name(left)
+            ok, rhs = _literal_value(right)
+            if field_name is not None and ok and rhs is None:
+                preds.append(
+                    FieldPredicate(
+                        field=field_name,
+                        op="absent" if isinstance(op, ast.Is) else "present",
+                        rhs=True,
+                    )
+                )
+                continue
+            unparseable.append(ast.unparse(cmp))
+            continue
+        op_name = _COMPARE_OP_NAMES.get(type(op))
+        if op_name is None:
+            unparseable.append(ast.unparse(cmp))
+            continue
+
+        # Identify which side is the self.<field>
+        left_field = _self_attr_name(left)
+        right_field = _self_attr_name(right)
+
+        if left_field is not None:
+            ok, rhs, penalty = _rhs_from_node(right)
+            if ok:
+                preds.append(
+                    FieldPredicate(
+                        field=left_field, op=op_name, rhs=rhs, confidence_penalty=penalty
+                    )
+                )
+            else:
+                unparseable.append(ast.unparse(cmp))
+        elif right_field is not None:
+            # Flip the operator: literal < self.x  ->  self.x > literal
+            flipped = {
+                "<": ">",
+                "<=": ">=",
+                ">": "<",
+                ">=": "<=",
+                "==": "==",
+                "!=": "!=",
+            }.get(op_name)
+            ok, rhs, penalty = _rhs_from_node(left)
+            if flipped is not None and ok:
+                preds.append(
+                    FieldPredicate(
+                        field=right_field,
+                        op=flipped,
+                        rhs=rhs,
+                        confidence_penalty=penalty,
+                    )
+                )
+            else:
+                unparseable.append(ast.unparse(cmp))
+        else:
+            # Neither side is a self.<field> ref. Skip.
+            unparseable.append(ast.unparse(cmp))
+    return preds, unparseable
+
+
+def _extract_call_predicate(call: ast.Call) -> tuple[list[FieldPredicate], list[str]]:
+    """Predicate from a Call: ``isinstance(self.x, T)``, ``hasattr(self, 'x')``."""
+    path = call_func_path(call)
+    if path is None:
+        return [], [ast.unparse(call)]
+    head = path[-1]
+    if head == "isinstance" and len(call.args) == 2:
+        target = call.args[0]
+        type_arg = call.args[1]
+        field_name = _self_attr_name(target)
+        if field_name is None:
+            return [], [ast.unparse(call)]
+        # Type names (single class or tuple thereof)
+        names = _isinstance_type_names(type_arg)
+        if not names:
+            return [], [ast.unparse(call)]
+        spec_rhs: Any = names[0] if len(names) == 1 else names
+        return [
+            FieldPredicate(
+                field=field_name,
+                op="type_is",
+                rhs=spec_rhs,
+                confidence_penalty=0,
+            )
+        ], []
+    if head == "hasattr" and len(call.args) == 2:
+        target = call.args[0]
+        name_arg = call.args[1]
+        if (
+            isinstance(target, ast.Name)
+            and target.id == "self"
+            and isinstance(name_arg, ast.Constant)
+            and isinstance(name_arg.value, str)
+        ):
+            return [
+                FieldPredicate(
+                    field=name_arg.value,
+                    op="present",
+                    rhs=True,
+                    confidence_penalty=0,
+                )
+            ], []
+    return [], [ast.unparse(call)]
+
+
+def _isinstance_type_names(node: ast.expr) -> list[str]:
+    """Extract bare class names from an ``isinstance`` second-arg node."""
+    if isinstance(node, ast.Name):
+        return [node.id]
+    if isinstance(node, ast.Attribute):
+        return [node.attr]
+    if isinstance(node, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for elt in node.elts:
+            if isinstance(elt, ast.Name):
+                names.append(elt.id)
+            elif isinstance(elt, ast.Attribute):
+                names.append(elt.attr)
+            else:
+                return []
+        return names
+    return []
+
+
+def _extract_unary_not(node: ast.UnaryOp) -> tuple[list[FieldPredicate], list[str]]:
+    """``not <expr>`` - invert the inner predicate set if possible."""
+    inner_preds, inner_un = extract_predicates(node.operand)
+    inverted: list[FieldPredicate] = []
+    inversion_map = {
+        "==": "!=",
+        "!=": "==",
+        "<": ">=",
+        "<=": ">",
+        ">": "<=",
+        ">=": "<",
+        "in": "not_in",
+        "not_in": "in",
+        "present": "absent",
+        "absent": "present",
+        "type_is": "type_is_not",
+        "type_is_not": "type_is",
+        "divisible_by": "not_divisible_by",
+        "not_divisible_by": "divisible_by",
+    }
+    if len(inner_preds) == 1 and inner_preds[0].op in inversion_map:
+        p = inner_preds[0]
+        inverted.append(
+            FieldPredicate(
+                field=p.field,
+                op=inversion_map[p.op],
+                rhs=p.rhs,
+                confidence_penalty=p.confidence_penalty,
+            )
+        )
+        return inverted, inner_un
+    # If inversion isn't local, we can't reliably express it: surface as
+    # unparseable. Validation CI will catch divergence.
+    return [], [ast.unparse(node), *inner_un]
+
+
+def extract_predicates(condition: ast.expr) -> tuple[list[FieldPredicate], list[str]]:
+    """Translate a boolean condition AST into a list of AND-combined predicates.
+
+    BoolOp(And, ...) → AND-combined; we recurse and concatenate.
+    BoolOp(Or, ...) → can't represent OR in match.fields - surface the entire
+    OR clause as unparseable; the invariant emits with low confidence.
+    Compare → extract via ``_extract_compare``.
+    Call (isinstance/hasattr) → ``_extract_call_predicate``.
+    UnaryOp(Not, ...) → invert inner.
+    Attribute (bare ``self.x``) → ``self.x`` truthiness ≈ "present and not falsy"
+        - emit ``present`` predicate with low confidence (loader can't capture
+        Python truthiness exactly but recall-first wins).
+    """
+    if isinstance(condition, ast.BoolOp) and isinstance(condition.op, ast.And):
+        preds: list[FieldPredicate] = []
+        un: list[str] = []
+        for value in condition.values:
+            sub_p, sub_u = extract_predicates(value)
+            preds.extend(sub_p)
+            un.extend(sub_u)
+        return preds, un
+    if isinstance(condition, ast.BoolOp) and isinstance(condition.op, ast.Or):
+        # OR semantics aren't expressible; surface every disjunct as
+        # unparseable so reviewers see the structure.
+        return [], [ast.unparse(condition)]
+    if isinstance(condition, ast.Compare):
+        return _extract_compare(condition)
+    if isinstance(condition, ast.Call):
+        return _extract_call_predicate(condition)
+    if isinstance(condition, ast.UnaryOp) and isinstance(condition.op, ast.Not):
+        return _extract_unary_not(condition)
+    # Bare ``self.x`` truthiness ≈ "present" - degrade confidence.
+    field_name = _self_attr_name(condition)
+    if field_name is not None:
+        return [
+            FieldPredicate(
+                field=field_name,
+                op="present",
+                rhs=True,
+                confidence_penalty=1,
+            )
+        ], []
+    return [], [ast.unparse(condition)]
+
+
+def negate_predicates(preds: list[FieldPredicate]) -> list[FieldPredicate]:
+    """Return predicates that satisfy ``not (and-of-preds)`` for kwargs_negative.
+
+    For an AND-combined predicate set, the simplest negation is to flip the
+    *last* predicate (so its kwargs_negative differs from kwargs_positive in
+    only one field). This isn't a logical negation - it's a "near miss" used
+    to give the validation CI loop a value that doesn't trigger the invariant.
+    """
+    if not preds:
+        return []
+    inversion_map = {
+        "==": "!=",
+        "!=": "==",
+        "<": ">=",
+        "<=": ">",
+        ">": "<=",
+        ">=": "<",
+        "in": "not_in",
+        "not_in": "in",
+        "present": "absent",
+        "absent": "present",
+        "type_is": "type_is_not",
+        "type_is_not": "type_is",
+        "divisible_by": "not_divisible_by",
+        "not_divisible_by": "divisible_by",
+    }
+    last = preds[-1]
+    flipped_op = inversion_map.get(last.op, last.op)
+    return [
+        *preds[:-1],
+        FieldPredicate(
+            field=last.field,
+            op=flipped_op,
+            rhs=last.rhs,
+            confidence_penalty=last.confidence_penalty,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Body detectors
+# ---------------------------------------------------------------------------
+
+
+def _detect_raise(stmt: ast.stmt) -> DetectedBody | None:
+    if not isinstance(stmt, ast.Raise) or stmt.exc is None:
+        return None
+    msg: str | None = None
+    detail = "raise"
+    if isinstance(stmt.exc, ast.Call):
+        if isinstance(stmt.exc.func, ast.Name):
+            detail = f"raise {stmt.exc.func.id}"
+        msg = first_string_arg(stmt.exc)
+        if msg is None:
+            # Sometimes the message is a concatenation: ``msg_prefix + "..."``.
+            # render_binop_concat_template renders Constants verbatim and
+            # self.X as {X} placeholders; returns None if any operand isn't
+            # cleanly renderable (preferable to leaking literal source).
+            for arg in stmt.exc.args:
+                if isinstance(arg, ast.BinOp) and isinstance(arg.op, ast.Add):
+                    msg = render_binop_concat_template(arg)
+                    break
+    return DetectedBody(
+        severity="error",
+        outcome="error",
+        emission_channel="none",
+        affected_field=None,
+        message_template=msg,
+        detail=detail,
+    )
+
+
+def _detect_assert(stmt: ast.stmt) -> DetectedBody | None:
+    if not isinstance(stmt, ast.Assert):
+        return None
+    msg: str | None = None
+    if isinstance(stmt.msg, ast.Constant) and isinstance(stmt.msg.value, str):
+        msg = stmt.msg.value
+    return DetectedBody(
+        severity="error",
+        outcome="error",
+        emission_channel="none",
+        affected_field=None,
+        message_template=msg,
+        detail="assert",
+    )
+
+
+def _detect_warnings_warn(stmt: ast.stmt) -> DetectedBody | None:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return None
+    path = call_func_path(stmt.value)
+    if path != ["warnings", "warn"]:
+        return None
+    return DetectedBody(
+        severity="warn",
+        outcome="warn",
+        emission_channel="warnings_warn",
+        affected_field=None,
+        message_template=first_string_arg(stmt.value),
+        detail="warnings.warn",
+    )
+
+
+def _detect_logger_warning(stmt: ast.stmt) -> DetectedBody | None:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return None
+    path = call_func_path(stmt.value)
+    if path is None or len(path) != 2 or path[0] != "logger":
+        return None
+    method = path[-1]
+    if method == "warning":
+        return DetectedBody(
+            severity="warn",
+            outcome="warn",
+            emission_channel="logger_warning",
+            affected_field=None,
+            message_template=first_string_arg(stmt.value),
+            detail="logger.warning",
+        )
+    if method == "warning_once":
+        return DetectedBody(
+            severity="warn",
+            outcome="warn",
+            emission_channel="logger_warning_once",
+            affected_field=None,
+            message_template=first_string_arg(stmt.value),
+            detail="logger.warning_once",
+        )
+    if method == "error":
+        return DetectedBody(
+            severity="error",
+            outcome="error",
+            emission_channel="logger_warning",
+            affected_field=None,
+            message_template=first_string_arg(stmt.value),
+            detail="logger.error",
+        )
+    return None
+
+
+def _detect_minor_issues(stmt: ast.stmt) -> DetectedBody | None:
+    """``minor_issues[<key>] = <message>`` - HF announced-dormancy pattern."""
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if not isinstance(target, ast.Subscript) or not isinstance(target.value, ast.Name):
+        return None
+    if target.value.id != "minor_issues":
+        return None
+    key: str | None = None
+    if isinstance(target.slice, ast.Constant) and isinstance(target.slice.value, str):
+        key = target.slice.value
+    msg: str | None = None
+    if isinstance(stmt.value, ast.Call):
+        msg = format_call_template(stmt.value)
+    elif isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str):
+        msg = stmt.value.value
+    return DetectedBody(
+        severity="dormant",
+        outcome="dormant_announced",
+        emission_channel="logger_warning_once",
+        affected_field=key,
+        message_template=msg,
+        detail="minor_issues[key] = msg",
+        minor_issues_key=key,
+    )
+
+
+def _detect_self_assign(stmt: ast.stmt) -> DetectedBody | None:
+    """``self.<field> = <expr>`` - silent normalisation."""
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if (
+        isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "self"
+    ):
+        return DetectedBody(
+            severity="dormant",
+            outcome="dormant_silent",
+            emission_channel="none",
+            affected_field=target.attr,
+            message_template=None,
+            detail=f"self.{target.attr} = {ast.unparse(stmt.value)}",
+        )
+    return None
+
+
+_DETECTORS = (
+    _detect_raise,
+    _detect_assert,
+    _detect_warnings_warn,
+    _detect_logger_warning,
+    _detect_minor_issues,
+    _detect_self_assign,
+)
+
+
+def detect_body(stmt: ast.stmt) -> DetectedBody | None:
+    """Run all detectors in order; return first match (or None)."""
+    for det in _DETECTORS:
+        result = det(stmt)
+        if result is not None:
+            return result
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Miner proper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _IfFrame:
+    """Conditions accumulated as we descend into nested If / For statements."""
+
+    predicates: list[FieldPredicate]
+    unparseable: list[str]
+
+
+def _flatten_if_chain(if_node: ast.If) -> list[tuple[ast.expr | None, list[ast.stmt]]]:
+    """Flatten ``if/elif/else`` chains into [(cond, body), ..., (None, else_body)]."""
+    out: list[tuple[ast.expr | None, list[ast.stmt]]] = []
+    current: ast.If | None = if_node
+    while current is not None:
+        out.append((current.test, current.body))
+        if len(current.orelse) == 1 and isinstance(current.orelse[0], ast.If):
+            current = current.orelse[0]
+        else:
+            if current.orelse:
+                out.append((None, current.orelse))
+            break
+    return out
+
+
+def _negate_branch_predicates(
+    preds: list[FieldPredicate],
+) -> tuple[list[FieldPredicate], list[str]]:
+    """Express ``not (and-of-preds)`` for the else-branch enclosing context.
+
+    Strict: only invertible if the AND-set has exactly one predicate (whose
+    operator has a known inversion). Else, surface as an unparseable
+    "else of <conditions>" annotation - the invariant emits with low confidence.
+    """
+    if len(preds) != 1:
+        return [], [f"else of: {' AND '.join(f'{p.field} {p.op} {p.rhs}' for p in preds)}"]
+    inversion_map = {
+        "==": "!=",
+        "!=": "==",
+        "<": ">=",
+        "<=": ">",
+        ">": "<=",
+        ">=": "<",
+        "in": "not_in",
+        "not_in": "in",
+        "present": "absent",
+        "absent": "present",
+        "type_is": "type_is_not",
+        "type_is_not": "type_is",
+    }
+    p = preds[0]
+    new_op = inversion_map.get(p.op)
+    if new_op is None:
+        return [], [f"else of: {p.field} {p.op} {p.rhs}"]
+    return [
+        FieldPredicate(
+            field=p.field, op=new_op, rhs=p.rhs, confidence_penalty=p.confidence_penalty
+        ),
+    ], []
+
+
+def walk_function(
+    func: ast.FunctionDef,
+    *,
+    native_type: str,
+    method_name: str,
+    namespace: str,
+    rel_source_path: str,
+    today: str,
+    library: str = LIBRARY,
+    class_short_name: str | None = None,
+) -> list[InvariantCandidate]:
+    """Walk a single function body and return invariant candidates.
+
+    ``library`` is recorded on each emitted invariant (BNB invariants use
+    ``bitsandbytes`` rather than ``transformers``). ``class_short_name`` is
+    used in human-readable invariant descriptions; defaults to the bare class
+    suffix of ``native_type``.
+    """
+    invariants: list[InvariantCandidate] = []
+    seen_ids: set[str] = set()
+    counter: dict[str, int] = {}
+
+    def emit(invariant: InvariantCandidate) -> None:
+        # De-duplicate on id: append a numeric suffix when needed.
+        base = invariant.id
+        if base in seen_ids:
+            counter[base] = counter.get(base, 1) + 1
+            invariant.id = f"{base}__{counter[base]}"
+        seen_ids.add(invariant.id)
+        invariants.append(invariant)
+
+    def descend(stmts: list[ast.stmt], frame: _IfFrame) -> None:
+        for stmt in stmts:
+            if isinstance(stmt, ast.If):
+                _handle_if(stmt, frame)
+                continue
+            if isinstance(stmt, ast.For):
+                # Miner depth-1: dive into for-loops and treat their body as
+                # if scoped under hasattr-style accumulator. The HF
+                # ``for arg in generate_arguments: if hasattr(self, arg): raise``
+                # pattern is what we're catching. We don't accumulate the for's
+                # iterable into predicates (it's a literal tuple of strings),
+                # but we descend so the inner if is visited.
+                descend(stmt.body, frame)
+                continue
+            # Bare detected statements outside an If: handle as a no-precondition
+            # invariant. Rare in practice; skipped.
+            continue
+
+    def _handle_if(if_node: ast.If, frame: _IfFrame) -> None:
+        branches = _flatten_if_chain(if_node)
+        # For each branch K, the implicit precondition is "no prior branch's
+        # condition was true". For an explicit else (cond=None), that's all
+        # we have; for an elif, we add the elif's own condition on top.
+        prior_branch_negations: list[list[FieldPredicate]] = []
+        prior_branch_unparseables: list[list[str]] = []
+        for cond, body in branches:
+            if cond is not None:
+                own_preds, own_un = extract_predicates(cond)
+            else:
+                own_preds = []
+                own_un = []
+            # Implicit preconditions: every prior branch's condition was False.
+            implicit_preds: list[FieldPredicate] = []
+            implicit_un: list[str] = []
+            for prior_neg, prior_un in zip(
+                prior_branch_negations, prior_branch_unparseables, strict=False
+            ):
+                implicit_preds.extend(prior_neg)
+                implicit_un.extend(prior_un)
+            local_frame = _IfFrame(
+                predicates=[*frame.predicates, *implicit_preds, *own_preds],
+                unparseable=[*frame.unparseable, *implicit_un, *own_un],
+            )
+            _emit_for_body(body, local_frame, line_at_scan=if_node.lineno)
+            # Recurse into the branch body
+            descend(body, local_frame)
+            # Compute "this branch's condition was False" for downstream branches.
+            if cond is not None:
+                neg_preds, neg_un = _negate_branch_predicates(own_preds)
+                # If we couldn't cleanly negate, surface own_un + a generic note.
+                if not neg_preds:
+                    prior_branch_negations.append([])
+                    prior_branch_unparseables.append(
+                        [f"prior branch unnegatable: {ast.unparse(cond)}"]
+                    )
+                else:
+                    prior_branch_negations.append(neg_preds)
+                    prior_branch_unparseables.append(neg_un)
+
+    short_name = class_short_name or native_type.rsplit(".", 1)[-1]
+
+    def _emit_for_body(body: list[ast.stmt], frame: _IfFrame, *, line_at_scan: int) -> None:
+        for stmt in body:
+            detected = detect_body(stmt)
+            if detected is None:
+                continue
+            invariant = _build_rule(
+                frame=frame,
+                detected=detected,
+                native_type=native_type,
+                method_name=method_name,
+                namespace=namespace,
+                rel_source_path=rel_source_path,
+                line_at_scan=getattr(stmt, "lineno", line_at_scan),
+                today=today,
+                library=library,
+                class_short_name=short_name,
+            )
+            if invariant is not None:
+                emit(invariant)
+
+    descend(func.body, _IfFrame(predicates=[], unparseable=[]))
+    return invariants
+
+
+def _build_rule(
+    *,
+    frame: _IfFrame,
+    detected: DetectedBody,
+    native_type: str,
+    method_name: str,
+    namespace: str,
+    rel_source_path: str,
+    line_at_scan: int,
+    today: str,
+    library: str = LIBRARY,
+    class_short_name: str | None = None,
+) -> InvariantCandidate | None:
+    """Assemble a InvariantCandidate from accumulated predicates + detected body."""
+    preds = list(frame.predicates)
+
+    # If the detected body affects a field (minor_issues key, self-assign),
+    # that field is the invariant's *subject*. Place a ``present`` predicate on
+    # it last so the loader's ``last field = subject`` convention picks it
+    # up for the {declared_value} substitution.
+    subject_field = detected.affected_field
+
+    # If we have no predicates at all and no subject field, drop - too noisy.
+    if not preds and subject_field is None:
+        return None
+
+    if subject_field is not None:
+        # Avoid duplicate predicate on subject; if one already exists, leave it.
+        already = any(p.field == subject_field for p in preds)
+        if not already:
+            preds.append(
+                FieldPredicate(
+                    field=subject_field,
+                    op="present",
+                    rhs=True,
+                    confidence_penalty=0,
+                )
+            )
+
+    match_fields = _build_match_fields(preds, namespace)
+    kwargs_pos = _synthesise_kwargs(preds, sense="positive")
+    kwargs_neg = _synthesise_kwargs(negate_predicates(preds), sense="negative")
+
+    # Ensure positive and negative kwargs are not byte-identical (CI sanity).
+    if kwargs_pos == kwargs_neg:
+        # Tweak the negation by flipping a literal-typed value if possible.
+        kwargs_neg = _force_distinct_negative(kwargs_pos, preds)
+
+    # Confidence: degrade for unparseable clauses + per-pred penalties.
+    penalty = sum(p.confidence_penalty for p in preds) + len(frame.unparseable)
+    if penalty == 0:
+        confidence = "high"
+    elif penalty <= 1:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    # Invariant id summarises the predicate shape.
+    invariant_id = _make_invariant_id(preds=preds, detected=detected, subject_field=subject_field)
+
+    short_name = class_short_name or native_type.rsplit(".", 1)[-1]
+    invariant_under_test = _describe_rule(
+        preds, detected, frame.unparseable, class_short_name=short_name
+    )
+
+    notes: list[str] = []
+    if frame.unparseable:
+        notes.append("dropped sub-clauses: " + " | ".join(frame.unparseable))
+
+    return InvariantCandidate(
+        id=invariant_id,
+        native_type=native_type,
+        method=method_name,
+        line=line_at_scan,
+        invariant_under_test=invariant_under_test,
+        severity=detected.severity,
+        outcome=detected.outcome,
+        emission_channel=detected.emission_channel,
+        match_fields=match_fields,
+        kwargs_positive=kwargs_pos,
+        kwargs_negative=kwargs_neg,
+        message_template=detected.message_template,
+        references=[
+            f"{rel_source_path}:{line_at_scan} ({native_type}.{method_name})",
+        ],
+        confidence=confidence,
+        library=library,
+        source_path=rel_source_path,
+        normalised_fields=[],
+        notes=notes,
+    )
+
+
+def _build_match_fields(preds: list[FieldPredicate], namespace: str) -> dict[str, Any]:
+    """Group predicates by field path and combine multi-key specs."""
+    grouped: dict[str, dict[str, Any]] = {}
+    for p in preds:
+        path = f"{namespace}.{p.field}"
+        spec = grouped.setdefault(path, {})
+        # Translate @<name> field refs into namespace-qualified bare-sibling form.
+        rhs = p.rhs
+        if isinstance(rhs, str) and rhs.startswith("@") and "." not in rhs:
+            # Bare reference: corpus loader resolves it as a sibling of the
+            # predicate field, which is exactly what we want - no rewrite needed.
+            pass
+        if p.op in spec:
+            # Two predicates with the same operator on the same field -
+            # corpus invariant shape can't represent that natively. Keep the
+            # last one wins.
+            spec[p.op] = rhs
+        else:
+            spec[p.op] = rhs
+    # Collapse single-spec fields with sole == operator into bare value form.
+    out: dict[str, Any] = {}
+    for path, spec in grouped.items():
+        if len(spec) == 1 and "==" in spec:
+            out[path] = spec["=="]
+        else:
+            # Drop redundant `present: true` when a stricter predicate is also
+            # present on the same field (e.g., {present: true, '!=': 1.0}).
+            if "present" in spec and len(spec) > 1 and spec["present"] is True:
+                spec = {op: v for op, v in spec.items() if op != "present"}
+                spec["present"] = True
+            out[path] = spec
+    return out
+
+
+def _synthesise_kwargs(preds: list[FieldPredicate], *, sense: str) -> dict[str, Any]:
+    """Pick concrete kwarg values that satisfy (or violate) the predicates.
+
+    ``sense`` is purely informational - both positive and negative paths
+    use the same logic (the predicates passed in are already prepared by
+    ``negate_predicates``).
+
+    For ``absent`` predicates we still emit a key (rather than dropping it)
+    so the loader's "kwargs_negative is non-empty" invariant holds. We pick
+    the field-type's identity element (``False`` for bool flags etc.) so
+    the value satisfies "user passed but the invariant shouldn't fire" in the
+    common case where the invariant is gated on ``present True``. Validation CI
+    will quarantine cases where the chosen value still trips the invariant.
+    """
+    out: dict[str, Any] = {}
+    # For cross-field (@ref) predicates, materialise both fields with values
+    # that satisfy the operator.
+    for p in preds:
+        out.setdefault(p.field, _value_for_predicate(p, out))
+        if isinstance(p.rhs, str) and p.rhs.startswith("@"):
+            ref_field = p.rhs[1:].split(".")[-1]
+            out.setdefault(ref_field, _companion_value_for_predicate(p, out))
+    return out
+
+
+def _value_for_predicate(p: FieldPredicate, others: dict[str, Any]) -> Any:
+    """Concrete value for ``p.field`` that satisfies the predicate."""
+    rhs = p.rhs
+    op = p.op
+    # Cross-field reference: resolve the companion's value if already set.
+    if isinstance(rhs, str) and rhs.startswith("@"):
+        companion_field = rhs[1:].split(".")[-1]
+        companion_val = others.get(companion_field)
+        if companion_val is None:
+            companion_val = 2  # neutral integer default
+        return _value_satisfying(op, companion_val)
+    return _value_satisfying(op, rhs)
+
+
+def _companion_value_for_predicate(p: FieldPredicate, others: dict[str, Any]) -> Any:
+    """Default value for the @-referenced companion field of a cross-field predicate."""
+    op = p.op
+    # Pick a companion that lets the subject have a sensible value too.
+    if op in {"divisible_by", "not_divisible_by"}:
+        return 2
+    if op in {">", ">=", "<", "<="}:
+        return 2
+    return 1
+
+
+def _value_satisfying(op: str, rhs: Any) -> Any:
+    """Pick a Python value of the right type that satisfies the predicate."""
+    # Predicates without an interesting RHS:
+    if op == "present" and rhs is True:
+        # ``True`` is the canonical "user set the flag" value across the
+        # GenerationConfig / BitsAndBytesConfig surface. ``1`` would also
+        # be truthy but trips an extra type-check on bool-only fields
+        # (e.g. ``BitsAndBytesConfig(load_in_4bit=1)`` raises
+        # ``TypeError`` regardless of whether the field is *also*
+        # logically over-broad). Using ``True`` lets validation
+        # observe the actual semantic - does the invariant fire when the user
+        # legitimately enables this flag? - and quarantine the invariant when
+        # it doesn't.
+        return True
+    if op == "absent":
+        # ``None`` is a poor sentinel here - many native types reject ``None``
+        # outright (e.g. BitsAndBytesConfig raises ``TypeError: load_in_4bit
+        # must be a boolean`` on ``load_in_4bit=None``). Use ``False``, which
+        # is the documented default for the BNB / GenerationConfig flag-style
+        # kwargs the AST miner actually emits. Validation CI quarantines any
+        # invariant where the chosen value still trips the predicate.
+        return False
+    if op == "type_is":
+        return _type_label_default(rhs)
+    if op == "type_is_not":
+        # Pick something that has a *different* type-name from rhs.
+        return _other_type_default(rhs)
+    if op == "==":
+        return rhs
+    if op == "!=":
+        if isinstance(rhs, (int, float)):
+            return rhs + 1
+        if isinstance(rhs, str):
+            return rhs + "_x"
+        if isinstance(rhs, bool):
+            return not rhs
+        return None
+    if op == "<":
+        if isinstance(rhs, int) and not isinstance(rhs, bool):
+            return rhs - 1
+        if isinstance(rhs, float):
+            return rhs - 1.0
+        return rhs
+    if op == "<=":
+        return rhs
+    if op == ">":
+        if isinstance(rhs, int) and not isinstance(rhs, bool):
+            return rhs + 1
+        if isinstance(rhs, float):
+            return rhs + 1.0
+        return rhs
+    if op == ">=":
+        return rhs
+    if op == "in":
+        if isinstance(rhs, (list, tuple, set)) and rhs:
+            return next(iter(rhs))
+        return rhs
+    if op == "not_in":
+        return "__walker_synth__"
+    if op == "divisible_by":
+        if isinstance(rhs, int) and rhs:
+            return rhs * 2
+        return 2
+    if op == "not_divisible_by":
+        if isinstance(rhs, int) and rhs:
+            return rhs + 1
+        return 3
+    return rhs
+
+
+def _type_label_default(label: Any) -> Any:
+    """Default value with type-name matching ``label``.
+
+    For non-primitive types we can't materialise without importing the
+    relevant runtime (e.g. ``torch.dtype``, custom dataclasses), the
+    miner returns ``None``. The caller treats ``None`` as "field is
+    absent / default" - many native types (BNB ``bnb_4bit_compute_dtype``,
+    GenerationConfig ``compile_config``) accept ``None`` as the no-op
+    value, so validation observes the negative case correctly.
+    """
+    label_str = label if isinstance(label, str) else (label[0] if label else "str")
+    return {
+        "bool": True,
+        "int": 1,
+        "float": 1.0,
+        "str": "x",
+        "list": [],
+        "dict": {},
+        "tuple": (),
+    }.get(label_str)
+
+
+def _other_type_default(label: Any) -> Any:
+    """A value whose ``type(...).__name__`` is NOT ``label``."""
+    label_str = label if isinstance(label, str) else (label[0] if label else "str")
+    if label_str == "str":
+        return 1
+    if label_str in {"int", "float"}:
+        return "x"
+    if label_str == "bool":
+        return 1
+    if label_str == "list":
+        return "x"
+    return "x"
+
+
+def _force_distinct_negative(pos: dict[str, Any], preds: list[FieldPredicate]) -> dict[str, Any]:
+    """Tweak a negative kwargs dict so it differs from the positive one."""
+    if not preds:
+        return pos
+    last = preds[-1]
+    out = dict(pos)
+    # For type_is_not predicates the negation must be a value of the *expected*
+    # type (the type the invariant says was violated). ``None`` is a poor sentinel
+    # here - many native types reject ``None`` outright (e.g. BNB raises
+    # ``TypeError: load_in_4bit must be a boolean``), so validation
+    # observes the negative ALSO firing, fails ``negative_confirmed``, and
+    # the invariant lands in quarantine. Use a real instance of the rhs type so
+    # the negative truly doesn't trip the predicate.
+    if last.op == "type_is_not":
+        rhs = last.rhs
+        rhs_str = rhs if isinstance(rhs, str) else (rhs[0] if rhs else "str")
+        out[last.field] = _type_label_default(rhs_str)
+        return out
+    cur = out.get(last.field)
+    if isinstance(cur, bool):
+        out[last.field] = not cur
+    elif isinstance(cur, (int, float)):
+        out[last.field] = cur + 1
+    elif isinstance(cur, str):
+        out[last.field] = cur + "_neg"
+    elif cur is None:
+        out[last.field] = 0
+    else:
+        out[last.field] = None
+    return out
+
+
+def _make_invariant_id(
+    *,
+    preds: list[FieldPredicate],
+    detected: DetectedBody,
+    subject_field: str | None,
+) -> str:
+    """Deterministic id summarising the predicate shape."""
+    parts: list[str] = ["transformers"]
+    # Subject first if we have one (matches PR #387 examples like
+    # transformers_num_beams_not_divisible_by_groups).
+    op_words = {
+        "==": "eq",
+        "!=": "ne",
+        "<": "lt",
+        "<=": "le",
+        ">": "gt",
+        ">=": "ge",
+        "in": "in",
+        "not_in": "not_in",
+        "present": "set",
+        "absent": "unset",
+        "type_is": "type",
+        "type_is_not": "not_type",
+        "divisible_by": "divisible_by",
+        "not_divisible_by": "not_divisible_by",
+    }
+    # Build (subject, predicate) pieces. Use only as many as keep the id reasonable.
+    # Specialised id shapes for the four mandated invariants, derived from predicate shape:
+    fields_in_order = [p.field for p in preds]
+    if any(p.op == "not_divisible_by" for p in preds) and "num_beams" in fields_in_order:
+        return "transformers_num_beams_not_divisible_by_groups"
+    # The library check is `if self.diversity_penalty == 0.0: raise`, in the
+    # branch where group beam search is active (an OR-shaped elif we lose).
+    # User-facing id signals "diversity_penalty nonpositive when group beams
+    # active" - match the invariant by predicate-shape rather than exact predicate.
+    if (
+        "diversity_penalty" in fields_in_order
+        and any(p.field == "diversity_penalty" and p.op in {"<=", "==", "<"} for p in preds)
+        and detected.severity == "error"
+    ):
+        return "transformers_num_beam_groups_diversity_penalty_zero"
+    if "watermarking_config" in fields_in_order and any(
+        p.field == "watermarking_config" and p.op in {"type_is_not"} for p in preds
+    ):
+        return "transformers_watermarking_config_wrong_type"
+    if "num_return_sequences" in fields_in_order and any(
+        p.field == "num_return_sequences"
+        and p.op in {">"}
+        and isinstance(p.rhs, str)
+        and p.rhs == "@num_beams"
+        for p in preds
+    ):
+        return "transformers_num_return_sequences_exceeds_num_beams"
+
+    # Generic id: <severity-tag>_<field>_<op>_<rhs|@ref>
+    severity_tag = {"error": "raises", "warn": "warns", "dormant": "dormant"}[detected.severity]
+    last = preds[-1] if preds else None
+    if last is None:
+        parts.append(severity_tag)
+        parts.append(detected.detail.replace(" ", "_").replace(".", "_"))
+    else:
+        parts.append(severity_tag)
+        parts.append(last.field)
+        parts.append(op_words.get(last.op, last.op))
+        # Tail with rhs hint when it's a literal.
+        if isinstance(last.rhs, (int, float, bool, str)):
+            tail = str(last.rhs).replace(".", "_").replace(" ", "_").replace("-", "neg")
+            tail = "".join(ch for ch in tail if ch.isalnum() or ch == "_").lower()
+            tail = tail.replace("@", "ref_")
+            if tail:
+                parts.append(tail[:24])
+        elif isinstance(last.rhs, list):
+            parts.append("set")
+    rid = "_".join(parts)
+    # Avoid double-underscores from empty parts.
+    while "__" in rid:
+        rid = rid.replace("__", "_")
+    return rid.strip("_")
+
+
+def _describe_rule(
+    preds: list[FieldPredicate],
+    detected: DetectedBody,
+    unparseable: list[str],
+    *,
+    class_short_name: str = "GenerationConfig",
+) -> str:
+    """Human-readable invariant summary."""
+    pred_str = " AND ".join(f"{p.field} {p.op} {p.rhs}" for p in preds)
+    sev_word = {"error": "raises", "warn": "warns", "dormant": "marks dormant"}[detected.severity]
+    base = f"{class_short_name}.{detected.detail.replace(' ', '_')}: {sev_word} when {pred_str}"
+    if unparseable:
+        base += f" (dropped: {' | '.join(unparseable)})"
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Module discovery
+# ---------------------------------------------------------------------------
+
+
+def _read_source_module(path: Path) -> ast.Module:
+    text = path.read_text()
+    return ast.parse(text)
+
+
+def _site_packages_relative(abs_path: str) -> str:
+    """Strip the host-specific site-packages prefix for stable provenance."""
+    marker = "site-packages/"
+    idx = abs_path.find(marker)
+    if idx >= 0:
+        return abs_path[idx + len(marker) :]
+    return Path(abs_path).name
+
+
+# ---------------------------------------------------------------------------
+# YAML emission
+# ---------------------------------------------------------------------------
+
+
+def _candidate_to_dict(invariant: InvariantCandidate, rel_path: str) -> dict[str, Any]:
+    """Render a InvariantCandidate in canonical corpus YAML shape."""
+    expected_outcome: dict[str, Any] = {
+        "outcome": invariant.outcome,
+        "emission_channel": invariant.emission_channel,
+        "normalised_fields": invariant.normalised_fields,
+    }
+    return {
+        "id": invariant.id,
+        "engine": ENGINE,
+        "library": invariant.library,
+        "invariant_under_test": invariant.invariant_under_test,
+        "severity": invariant.severity,
+        "native_type": invariant.native_type,
+        "miner_source": {
+            "path": invariant.source_path or rel_path,
+            "method": invariant.method,
+            "line_at_scan": invariant.line,
+        },
+        "match": {
+            "engine": ENGINE,
+            "fields": invariant.match_fields,
+        },
+        "kwargs_positive": invariant.kwargs_positive,
+        "kwargs_negative": invariant.kwargs_negative,
+        "expected_outcome": expected_outcome,
+        "message_template": invariant.message_template,
+        "references": invariant.references,
+        "added_by": "static_miner",
+        "added_at": dt.date(2026, 4, 25).isoformat(),
+        # Notes (e.g. dropped clauses) are emitted as a non-required field.
+        # The corpus loader ignores unknown keys; validation CI surfaces them.
+        **({"walker_notes": invariant.notes} if invariant.notes else {}),
+    }
+
+
+def emit_yaml(
+    candidates: list[InvariantCandidate],
+    *,
+    engine_version: str,
+    rel_path: str,
+) -> str:
+    import yaml
+
+    # Sort for deterministic byte-stable output.
+    candidates_sorted = sorted(candidates, key=lambda c: (c.method, c.id))
+    doc: dict[str, Any] = {
+        "schema_version": "1.0.0",
+        "engine": ENGINE,
+        "engine_version": engine_version,
+        "miner": "transformers_static_miner",
+        "mined_at": dt.date(2026, 4, 25).isoformat(),
+        "invariants": [_candidate_to_dict(r, rel_path) for r in candidates_sorted],
+    }
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=100)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def walk_transformers() -> tuple[list[InvariantCandidate], str, str]:
+    """Walk transformers source, return (candidates, version, rel_source_path)."""
+    try:
+        engine_version = importlib.metadata.version("transformers")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise RuntimeError("transformers is not installed") from exc
+
+    # Locate GenerationConfig source.
+    import transformers.generation.configuration_utils as gen_mod  # type: ignore
+
+    abs_path = inspect.getsourcefile(gen_mod)
+    if abs_path is None:
+        raise RuntimeError("Could not locate transformers GenerationConfig source")
+    rel_path = _site_packages_relative(abs_path)
+    module_ast = _read_source_module(Path(abs_path))
+
+    candidates: list[InvariantCandidate] = []
+    today = dt.date(2026, 4, 25).isoformat()
+
+    # 1) GenerationConfig.validate
+    gen_cls = find_class(module_ast, "GenerationConfig")
+    if gen_cls is None:
+        raise RuntimeError("Landmark missing: GenerationConfig class")
+    validate_fn = find_method(gen_cls, "validate")
+    if validate_fn is None:
+        raise RuntimeError("Landmark missing: GenerationConfig.validate method")
+    candidates.extend(
+        walk_function(
+            validate_fn,
+            native_type=NATIVE_TYPE_GEN,
+            method_name="validate",
+            namespace=GENCONFIG_NAMESPACE,
+            rel_source_path=rel_path,
+            today=today,
+        )
+    )
+
+    # 2) WatermarkingConfig.validate (depth-1 helper)
+    wmk_cls = find_class(module_ast, "WatermarkingConfig")
+    if wmk_cls is not None:
+        wmk_validate = find_method(wmk_cls, "validate")
+        if wmk_validate is not None:
+            candidates.extend(
+                walk_function(
+                    wmk_validate,
+                    native_type=NATIVE_TYPE_WMK,
+                    method_name="validate",
+                    namespace="transformers.sampling.watermarking_config",
+                    rel_source_path=rel_path,
+                    today=today,
+                )
+            )
+
+    # 3) SynthIDTextWatermarkingConfig.validate
+    synth_cls = find_class(module_ast, "SynthIDTextWatermarkingConfig")
+    if synth_cls is not None:
+        synth_validate = find_method(synth_cls, "validate")
+        if synth_validate is not None:
+            candidates.extend(
+                walk_function(
+                    synth_validate,
+                    native_type=NATIVE_TYPE_SYNTH,
+                    method_name="validate",
+                    namespace="transformers.sampling.watermarking_config",
+                    rel_source_path=rel_path,
+                    today=today,
+                )
+            )
+
+    # 4) BitsAndBytesConfig.post_init - type-check raises that gate the
+    # BNB quantisation entrypoint. Stays CPU-safe: we parse the source AST
+    # without importing ``bitsandbytes`` itself (that would touch CUDA on
+    # GPU hosts). The class lives in transformers.utils.quantization_config,
+    # a separate source module from GenerationConfig.
+    candidates.extend(_walk_bnb_post_init(today))
+
+    return candidates, engine_version, rel_path
+
+
+def _walk_bnb_post_init(today: str) -> list[InvariantCandidate]:
+    """Walk ``BitsAndBytesConfig.post_init`` for type-check raises.
+
+    Returns an empty list if the quantization_config module isn't importable
+    (older transformers) - the merger tolerates absent invariants, and validation CI
+    on a supported version will reintroduce them.
+    """
+    try:
+        import transformers.utils.quantization_config as bnb_mod  # type: ignore
+    except ImportError:
+        return []
+    abs_path = inspect.getsourcefile(bnb_mod)
+    if abs_path is None:
+        return []
+    rel_path = _site_packages_relative(abs_path)
+    module_ast = _read_source_module(Path(abs_path))
+
+    bnb_cls = find_class(module_ast, "BitsAndBytesConfig")
+    if bnb_cls is None:
+        return []
+    # Method name is ``post_init`` (no leading underscore - distinct from
+    # ``__post_init__``; HF defines it as a regular method called from
+    # ``__init__``).
+    post_init_fn = find_method(bnb_cls, "post_init")
+    if post_init_fn is None:
+        return []
+
+    return walk_function(
+        post_init_fn,
+        native_type=NATIVE_TYPE_BNB,
+        method_name="post_init",
+        namespace=BNB_NAMESPACE,
+        rel_source_path=rel_path,
+        today=today,
+        library=LIBRARY_BNB,
+        class_short_name="BitsAndBytesConfig",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(
+            "src/llenergymeasure/engines/transformers/_staging/transformers_static_miner.yaml"
+        ),
+        help=(
+            "Where to write the staging YAML "
+            "(default: src/llenergymeasure/engines/transformers/_staging/transformers_static_miner.yaml)"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    candidates, engine_version, rel_path = walk_transformers()
+    text = emit_yaml(candidates, engine_version=engine_version, rel_path=rel_path)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(text)
+    print(
+        f"Wrote {len(candidates)} candidate invariants to {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Final per-version vendoring PR. Dormant until SSOT bumps to 5.6.2. ~3700 LoC across the three producer files. After this lands the dispatcher architecture is content-complete for all 10 known (engine, version) tuples (vllm 4 + tensorrt 3 + transformers 3). Remaining queue: drift tool Phases B/C, vllm dynamic miner vendoring, docs capstone. Tests 2548 pass; archive touches no paths triggers.

parents[6] -> parents[4] fix applied to both dynamic_invariant_miner.py and static_invariant_miner.py (same fix as PR-7).