### PR TITLE
feat(scripts): drift tool Phase B - coverage / added-direction

### DIFF
--- a/scripts/_drift.py
+++ b/scripts/_drift.py
@@ -9,24 +9,27 @@ drop-in replacement for the former ``_probe.py`` non-regression gate:
     fail : at least one landmark is missing, OR the producer module
            itself fails to import after one retry.
 
-Phase B (follow-up) will add the "added" direction - validators that exist
-in the live library but are not declared in the per-version archive.
-Phase C will add exclusions and CI gating.
+Phase B adds the "added" direction - validators that exist in the live library
+but are not declared in the per-version archive LANDMARKS. This is the additive
+blind spot coverage check: when Renovate bumps a library to a version with new
+validators, Phase B surfaces them so the maintainer knows to extend LANDMARKS +
+walker logic. Phase B is warning-only: ``verdict`` stays ``pass`` even when
+``landmarks_added`` is non-empty.
+
+Phase C (separate PR) will add CI gating and EXCLUSIONS.yaml.
 
 ``direction`` field semantics:
 
     "removed" : one or more declared landmarks are absent from the live library.
-    "added"   : (Phase B) one or more live validators are absent from LANDMARKS.
+    "added"   : one or more live validators are absent from LANDMARKS.
+    "mixed"   : both removed AND added gaps found simultaneously.
     "stable"  : all declared landmarks resolve; no undeclared validators found.
 
-In Phase A, each ``DriftReport`` carries ``direction`` = "removed" when
-``landmarks_missing`` is non-empty, and ``direction`` = "stable" otherwise.
-``landmarks_added`` is always empty in Phase A.
-
-Diagnostic fields (``version_inside_envelope``, ``fingerprint_drift``)
-ride along on every report and are surfaced in workflow comments. They
-NEVER affect the verdict - those signals steer the human's attention on
-``pass``-but-suspicious bumps without gating the pipeline.
+Diagnostic fields (``version_inside_envelope``, ``fingerprint_drift``,
+``landmarks_added``, ``landmarks_added_low_confidence``) ride along on every
+report. Only ``landmarks_added`` (high-confidence) is surfaced in CI output by
+default. ``landmarks_added_low_confidence`` is present in the JSON for
+completeness.
 
 Producer-module discovery uses a per-engine convention table (see
 ``_PRODUCER_MODULES``); each producer module exposes a
@@ -53,6 +56,8 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import dataclasses
+import enum
 import hashlib
 import importlib
 import inspect
@@ -79,6 +84,7 @@ from scripts.engine_producers._base import MinerLandmarkMissingError  # noqa: E4
 from scripts.engine_producers._current import current_path  # noqa: E402
 
 ProducerKind = Literal["invariants", "schemas"]
+DirectionKind = Literal["removed", "added", "mixed", "stable"]
 
 # Per-engine producer module map. The drift tool lives one layer above the
 # producers; this table is the single seam where (engine, producer) cells
@@ -110,14 +116,29 @@ class DriftReport:
     Serialised to stdout JSON and to ``engine_versions/{engine}.compat.json``
     for cross-run cache + fingerprint-drift detection.
 
-    Phase A emits ``direction`` = "removed" when ``landmarks_missing`` is
-    non-empty; "stable" otherwise. ``landmarks_added`` is always empty in
-    Phase A - Phase B will fill it by walking the live library surface.
+    Phase A fields
+    --------------
+    ``direction`` = "removed" when ``landmarks_missing`` is non-empty; "stable" otherwise.
+    ``landmarks_added`` and ``landmarks_added_low_confidence`` are empty in a Phase A run
+    (no introspection roots configured for the engine).
+
+    Phase B fields
+    --------------
+    ``landmarks_added`` : high-confidence live validators absent from LANDMARKS. Surfaced
+    in CI workflow comments. Warning-only - does NOT flip verdict to fail.
+    ``landmarks_added_low_confidence`` : medium/low-confidence candidates. Present in JSON
+    for completeness; not surfaced in CI output by default.
+    ``direction`` gains two new values: "added" (only live gaps found) and "mixed"
+    (both removed and added gaps present simultaneously).
+
+    Diagnostic fields (``version_inside_envelope``, ``fingerprint_drift``) ride along on
+    every report and steer human attention on pass-but-suspicious bumps. They NEVER
+    affect verdict.
     """
 
     engine: str
     producer: ProducerKind
-    direction: Literal["removed", "added", "stable"]
+    direction: DirectionKind
     schema_version: int
     current_version: str
     verdict: Literal["pass", "fail"]
@@ -125,6 +146,7 @@ class DriftReport:
     fingerprint_drift: list[str] = field(default_factory=list)
     landmarks_missing: list[str] = field(default_factory=list)
     landmarks_added: list[str] = field(default_factory=list)
+    landmarks_added_low_confidence: list[str] = field(default_factory=list)
     version_inside_envelope: bool = True
 
 
@@ -199,6 +221,329 @@ def _fingerprint(resolved: list[_ResolvedLandmark]) -> str:
         f"{r.landmark}|{r.qualname}|{r.filename or ''}|{r.lineno or 0}" for r in resolved
     )
     return hashlib.sha256("\n".join(parts).encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Phase B: live library introspection
+# ---------------------------------------------------------------------------
+
+# Engine-specific module roots to walk when discovering live validators.
+# Each value is either a tuple of module paths (import and walk all classes
+# found in each) or a tuple of fully-qualified class paths (import the
+# class directly - used when the module is too broad to walk exhaustively).
+#
+# "transformers" uses class-level targeting: walking all of ``transformers``
+# would pull in thousands of classes and trigger CUDA-sensitive imports
+# (e.g. BitsAndBytesConfig). Instead we enumerate only the 4 classes
+# declared in LANDMARKS.
+#
+# "vllm" and "tensorrt" use module-level targeting: their config modules are
+# narrow enough to walk fully. For tensorrt, the NGC entrypoint sets up CUDA
+# forward-compat; the drift tool is invoked inside the container so imports
+# succeed. vllm's config subpackage refactored from a flat module (0.7.x) to
+# a per-concern subpackage (0.16+); both layouts resolve via importlib.
+_ENGINE_INTROSPECTION_ROOTS: dict[str, tuple[str, ...]] = {
+    "transformers": (
+        # Class-level targets - not module-level. Avoids pulling in the full
+        # transformers import graph (CUDA-bearing BNB, flash-attn, etc.).
+        "transformers.GenerationConfig",
+        "transformers.BitsAndBytesConfig",
+        "transformers.AutoModelForCausalLM",
+        "transformers.PreTrainedModel",
+    ),
+    "vllm": (
+        "vllm.config",
+        "vllm.sampling_params",
+    ),
+    "tensorrt": (
+        "tensorrt_llm.llmapi.llm_args",
+        "tensorrt_llm.builder",
+    ),
+}
+
+# Confidence tier labels (vulture-style: kind-derived, not learned scores).
+_CONF_HIGH = "high"
+_CONF_MEDIUM = "medium"
+_CONF_LOW = "low"
+
+
+def _is_pydantic_v2_model(cls: type) -> bool:
+    """True if ``cls`` is a pydantic v2 BaseModel or pydantic-dataclass."""
+    try:
+        import pydantic  # type: ignore[import]
+
+        return isinstance(cls, type) and issubclass(cls, pydantic.BaseModel)
+    except ImportError:
+        return False
+
+
+def _is_pydantic_v1_model(cls: type) -> bool:
+    """True if ``cls`` appears to be a pydantic v1 model (pre-v2 API)."""
+    # v1 models have __fields__ and __validators__ but NOT __pydantic_decorators__.
+    return (
+        hasattr(cls, "__fields__")
+        and hasattr(cls, "__validators__")
+        and not hasattr(cls, "__pydantic_decorators__")
+        and not hasattr(cls, "model_fields")
+    )
+
+
+def _discover_pydantic_v2(cls: type, module_prefix: str) -> list[tuple[str, str]]:
+    """Discover validator methods from a pydantic v2 BaseModel / pydantic-dataclass.
+
+    Reads ``cls.__pydantic_decorators__`` (a ``DecoratorInfos`` dataclass).
+    Pydantic v2 flattens inherited validators into this attribute - do NOT
+    walk MRO manually; that would double-count.
+
+    Returns ``[(confidence, dotted_path), ...]``.
+
+    ``__pydantic_decorators__`` is documented-internal but the de-facto contract
+    consumed by autodoc-pydantic, LangChain, and others. Not wrapped in
+    try/except so callers see real bugs.
+    """
+    dec = cls.__pydantic_decorators__
+    results: list[tuple[str, str]] = []
+    qualname = _dotted_qualname(cls, module_prefix)
+
+    # Buckets that indicate genuine validator surface.
+    high_buckets = ("field_validators", "model_validators", "root_validators", "validators")
+    # Serializer/computed buckets are validator-adjacent but lower signal.
+    medium_buckets = ("field_serializers", "model_serializers", "computed_fields")
+
+    for bucket_name in high_buckets:
+        bucket = getattr(dec, bucket_name, {})
+        for method_name in bucket:
+            results.append((_CONF_HIGH, f"{qualname}.{method_name}"))
+
+    for bucket_name in medium_buckets:
+        bucket = getattr(dec, bucket_name, {})
+        for method_name in bucket:
+            results.append((_CONF_MEDIUM, f"{qualname}.{method_name}"))
+
+    # model_fields are declared fields - high confidence surface.
+    model_fields = getattr(cls, "model_fields", {})
+    for field_name in model_fields:
+        results.append((_CONF_HIGH, f"{qualname}.{field_name}"))
+
+    return results
+
+
+def _discover_pydantic_v1(cls: type, module_prefix: str) -> list[tuple[str, str]]:
+    """Discover validator methods from a pydantic v1 model."""
+    results: list[tuple[str, str]] = []
+    qualname = _dotted_qualname(cls, module_prefix)
+
+    for field_name in getattr(cls, "__fields__", {}):
+        results.append((_CONF_HIGH, f"{qualname}.{field_name}"))
+    for validator_name in getattr(cls, "__validators__", {}):
+        results.append((_CONF_HIGH, f"{qualname}.{validator_name}"))
+    for method_name in getattr(cls, "__pre_root_validators__", []):
+        results.append((_CONF_HIGH, f"{qualname}.{method_name}"))
+    for method_name in getattr(cls, "__post_root_validators__", []):
+        results.append((_CONF_HIGH, f"{qualname}.{method_name}"))
+    return results
+
+
+def _discover_dataclass(cls: type, module_prefix: str) -> list[tuple[str, str]]:
+    """Discover fields and __post_init__ from a stdlib ``@dataclass``."""
+    results: list[tuple[str, str]] = []
+    qualname = _dotted_qualname(cls, module_prefix)
+
+    try:
+        for f in dataclasses.fields(cls):
+            if not f.name.startswith("_"):
+                results.append((_CONF_HIGH, f"{qualname}.{f.name}"))
+    except TypeError:
+        # Not a dataclass (dataclasses.fields raises TypeError on non-dataclasses).
+        pass
+
+    if hasattr(cls, "__post_init__"):
+        results.append((_CONF_HIGH, f"{qualname}.__post_init__"))
+    return results
+
+
+def _discover_plain_class(cls: type, module_prefix: str) -> list[tuple[str, str]]:
+    """Discover validator-like callables on a plain class via name heuristics.
+
+    Uses ``vars(cls)`` (not ``dir(cls)`` / ``inspect.getmembers``) to avoid
+    triggering descriptors and conflating inherited members.
+
+    Confidence tiers:
+    - ``high``: none from plain classes (no decorator evidence).
+    - ``medium``: public ``validate_*`` / ``check_*`` / ``verify_*`` callables
+      in ``vars(cls)`` (might be a manual validator, might be a passthrough).
+    - ``low``: private ``_validate_*`` / ``_verify_*`` helpers.
+    """
+    results: list[tuple[str, str]] = []
+    qualname = _dotted_qualname(cls, module_prefix)
+
+    for name, obj in vars(cls).items():
+        if not callable(obj):
+            continue
+        lower = name.lower()
+        # Public validate_* / check_* / verify_* (no leading underscore)
+        if not name.startswith("_") and any(
+            lower.startswith(prefix) for prefix in ("validate", "check", "verify")
+        ):
+            results.append((_CONF_MEDIUM, f"{qualname}.{name}"))
+            continue
+        # Private _validate_* / _verify_*
+        if (
+            name.startswith("_")
+            and not name.startswith("__")
+            and any(lower.lstrip("_").startswith(prefix) for prefix in ("validate", "verify"))
+        ):
+            results.append((_CONF_LOW, f"{qualname}.{name}"))
+    return results
+
+
+def _dotted_qualname(cls: type, module_prefix: str) -> str:
+    """Canonical dotted path for ``cls`` relative to its defining module.
+
+    Prefers the module's ``__name__`` attribute for the class's own
+    ``__module__`` + ``__qualname__`` combination. Falls back to
+    ``module_prefix.cls.__qualname__`` when the class's ``__module__``
+    attribute is missing.
+    """
+    own_module = getattr(cls, "__module__", None) or module_prefix
+    qualname = getattr(cls, "__qualname__", None) or cls.__name__
+    return f"{own_module}.{qualname}"
+
+
+def _class_validator_surface(cls: type, module_prefix: str) -> list[tuple[str, str]]:
+    """Layered dispatch: discover validator surface of a single class.
+
+    Dispatch order (first match wins):
+    1. Pydantic v2 BaseModel / pydantic-dataclass - use ``__pydantic_decorators__``
+    2. Pydantic v1 - use ``__fields__`` + ``__validators__``
+    3. stdlib ``@dataclass`` - use ``dataclasses.fields`` + ``__post_init__``
+    4. Enum (StrEnum / IntEnum) - skip, no validator concept
+    5. Plain class - name-heuristic on ``vars(cls)``
+
+    Note: pydantic-dataclasses ARE pydantic v2 BaseModel subclasses after
+    decoration, so step 1 catches them before step 3.
+    """
+    if _is_pydantic_v2_model(cls):
+        return _discover_pydantic_v2(cls, module_prefix)
+    if _is_pydantic_v1_model(cls):
+        return _discover_pydantic_v1(cls, module_prefix)
+    # Enum check before dataclass: StrEnum is also a dataclass in Python 3.11+
+    # when using the functional API, but enum members have no validator surface.
+    if issubclass(cls, enum.Enum):
+        return []
+    if dataclasses.is_dataclass(cls):
+        return _discover_dataclass(cls, module_prefix)
+    return _discover_plain_class(cls, module_prefix)
+
+
+def _import_class_from_path(dotted_path: str) -> type | None:
+    """Import and return a class from a dotted path like ``transformers.GenerationConfig``.
+
+    Returns ``None`` if the import fails (engine not installed in the current
+    Python environment - expected for Docker-only engines on the host).
+    Handles partial-import failures gracefully (one broken class does not
+    abort the whole walk).
+
+    Unlike ``_resolve_landmark`` (which raises on failure and returns a
+    ``_ResolvedLandmark``), this helper returns the raw type or ``None`` - the
+    difference in return contract warrants keeping them separate.
+    """
+    parts = dotted_path.split(".")
+    module: ModuleType | None = None
+    module_idx = 0
+    for split in range(len(parts), 0, -1):
+        try:
+            candidate = importlib.import_module(".".join(parts[:split]))
+            module = candidate
+            module_idx = split
+            break
+        except ImportError:
+            continue
+    if module is None:
+        return None
+    obj: object = module
+    for attr in parts[module_idx:]:
+        try:
+            obj = getattr(obj, attr)
+        except AttributeError:
+            return None
+    if not isinstance(obj, type):
+        return None
+    return obj
+
+
+def _walk_module_classes(module_path: str) -> list[tuple[type, str]]:
+    """Import a module and return ``[(class, module_path), ...]`` for all classes defined there.
+
+    Only returns classes whose ``__module__`` matches ``module_path`` exactly
+    (avoids picking up re-exported classes from other modules). On ImportError
+    returns an empty list - engine not installed in this environment.
+    """
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError:
+        return []
+    results: list[tuple[type, str]] = []
+    for _name, obj in vars(module).items():
+        if isinstance(obj, type) and getattr(obj, "__module__", None) == module_path:
+            results.append((obj, module_path))
+    return results
+
+
+def discover_live_landmarks(engine: str) -> tuple[set[str], set[str]]:
+    """Walk the live library surface for ``engine`` and return discovered paths.
+
+    Returns ``(high_confidence, low_confidence)`` where each is a ``set[str]``
+    of canonical dotted paths like ``"vllm.config.ParallelConfig.validate_X"``.
+
+    High-confidence paths include:
+    - Pydantic v2 field_validators / model_validators / declared model_fields
+    - Pydantic v1 __fields__ + __validators__
+    - Stdlib @dataclass fields + __post_init__
+    - Plain class public ``validate_*`` / ``check_*`` / ``verify_*`` callables
+
+    Low-confidence paths include:
+    - Plain class private ``_validate_*`` / ``_verify_*`` helpers
+    - Pydantic serializer / computed_field buckets (medium tier)
+
+    Returns empty sets when the engine library is not installed in the current
+    Python environment (expected for Docker-only engines running on the host).
+
+    The function is graceful on partial failures: one broken class does not
+    abort the walk. Per-class errors are silently skipped so callers always
+    get a (possibly empty) result.
+    """
+    roots = _ENGINE_INTROSPECTION_ROOTS.get(engine, ())
+    high: set[str] = set()
+    low: set[str] = set()
+
+    def _bucket(cls: type, mod_prefix: str) -> None:
+        """Surface-discover ``cls`` and partition results into ``high`` / ``low``."""
+        try:
+            for conf, path in _class_validator_surface(cls, mod_prefix):
+                if conf == _CONF_HIGH:
+                    high.add(path)
+                else:
+                    low.add(path)
+        except Exception:  # per-class failure is non-fatal
+            pass
+
+    for root in roots:
+        # Determine whether the root is a class path or a module path.
+        # Heuristic: if the last component starts with an uppercase letter,
+        # treat it as a class; otherwise treat as a module to walk.
+        parts = root.split(".")
+        if parts[-1][0].isupper():
+            # Class-level targeting (e.g. ``transformers.GenerationConfig``).
+            cls = _import_class_from_path(root)
+            if cls is not None:
+                _bucket(cls, ".".join(parts[:-1]))
+        else:
+            # Module-level targeting (e.g. ``vllm.config``).
+            for cls, mod_path in _walk_module_classes(root):
+                _bucket(cls, mod_path)
+
+    return high, low
 
 
 # ---------------------------------------------------------------------------
@@ -343,17 +688,25 @@ def _read_landmarks(module: ModuleType) -> tuple[str, ...]:
 def run(*, engine: str, producer: ProducerKind) -> DriftReport:
     """Run the drift check for one ``(engine, producer)`` cell.
 
-    Phase A: "removed" direction only.
+    Phase A + B: "removed" and "added" directions.
 
-    Returns a :class:`DriftReport` with verdict ``pass`` iff every
-    landmark resolves; ``fail`` iff one or more landmarks raise
-    :class:`AttributeError` / :class:`ImportError` during resolution.
+    Returns a :class:`DriftReport` with verdict ``pass`` when every declared
+    landmark resolves (verdict is NOT affected by ``landmarks_added`` - Phase B
+    is warning-only). Verdict ``fail`` requires at least one declared landmark
+    to raise :class:`AttributeError` / :class:`ImportError` during resolution.
 
     Diagnostic fields (envelope check, fingerprint drift) are computed
     regardless of verdict.
 
-    ``direction`` is ``"removed"`` when ``landmarks_missing`` is non-empty;
-    ``"stable"`` otherwise. ``landmarks_added`` is always ``[]`` in Phase A.
+    Direction values:
+    - ``"removed"`` : one or more declared landmarks absent from live library.
+    - ``"added"``   : live validators absent from LANDMARKS (Phase B signal).
+    - ``"mixed"``   : both removed and added gaps found simultaneously.
+    - ``"stable"``  : all declared landmarks resolve; no undeclared validators found.
+
+    Phase B introspection is best-effort: when the engine library is not
+    installed (Docker-only engines on the host), ``discover_live_landmarks``
+    returns empty sets and ``landmarks_added`` stays empty.
     """
     current = _load_current(engine)  # FileNotFoundError -> caller handles as infra error
     library = current.get("library")
@@ -382,8 +735,33 @@ def run(*, engine: str, producer: ProducerKind) -> DriftReport:
         # landmarks, not the cause.
         drift = [r.landmark for r in resolved]
 
+    # Phase B: added-direction discovery.
+    # Only surface for "invariants" producer - schemas use a different surface.
+    # For other producer kinds, skip introspection (no false-positive noise).
+    added_high: list[str] = []
+    added_low: list[str] = []
+    if producer == "invariants":
+        live_high, live_low = discover_live_landmarks(engine)
+        declared = set(landmarks)
+        # "added" = live but not in declared LANDMARKS (the additive blind spot).
+        added_high = sorted(live_high - declared)
+        added_low = sorted(live_low - declared)
+
+    # Verdict: fail only when declared landmarks are missing (Phase A behaviour).
+    # Phase B additions are warning-only - never flip verdict.
     verdict: Literal["pass", "fail"] = "fail" if missing else "pass"
-    direction: Literal["removed", "added", "stable"] = "removed" if missing else "stable"
+
+    # Direction: reflect the combined state of both directions.
+    has_missing = bool(missing)
+    has_added = bool(added_high)
+    if has_missing and has_added:
+        direction: DirectionKind = "mixed"
+    elif has_missing:
+        direction = "removed"
+    elif has_added:
+        direction = "added"
+    else:
+        direction = "stable"
 
     return DriftReport(
         engine=engine,
@@ -395,7 +773,8 @@ def run(*, engine: str, producer: ProducerKind) -> DriftReport:
         fingerprint=fingerprint,
         fingerprint_drift=drift,
         landmarks_missing=missing,
-        landmarks_added=[],
+        landmarks_added=added_high,
+        landmarks_added_low_confidence=added_low,
         version_inside_envelope=_check_envelope(current, producer, current_version),
     )
 

--- a/tests/unit/scripts/test_drift_phase_b.py
+++ b/tests/unit/scripts/test_drift_phase_b.py
@@ -1,0 +1,788 @@
+"""Tests for :mod:`scripts._drift` Phase B (added direction / coverage check).
+
+Phase B extends the drift tool with ``discover_live_landmarks()``, which
+introspects the live library surface (Pydantic v2, Pydantic v1, stdlib
+dataclasses, enums, plain classes) and surfaces validators that exist in the
+library but are NOT declared in the per-version archive's LANDMARKS tuple.
+
+The introspection functions operate on Python types, so all tests in this
+module use stdlib / built-in types as stand-ins for engine library classes
+- no engine library installation required. The same import-via-importlib path
+exercised by the production code is preserved: tests that need to check module
+import use types registered in ``sys.modules``.
+
+Key invariants verified:
+- Layered dispatch: pydantic v2 -> pydantic v1 -> dataclass -> enum -> plain class
+- Set-diff correctness: ``landmarks_added`` = live_high - declared
+- ``landmarks_added_low_confidence`` = live_low - declared
+- Empty live surface -> no additions
+- Empty declared LANDMARKS -> all live surface surfaced as added
+- Missing engine library -> empty live surface, no error
+- Direction field: "added" / "mixed" / "stable" / "removed"
+- Verdict is always "pass" when only additions found (Phase B warning-only)
+- ``landmarks_added_low_confidence`` present in JSON output
+- ``direction = "mixed"`` when both missing and added simultaneously
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts import _drift  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Test helpers (shared with test_drift.py - duplicated to keep modules
+# independent; the helper is small enough to not warrant a conftest fixture)
+# ---------------------------------------------------------------------------
+
+
+def _install_synthetic_producer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    engine: str,
+    producer: _drift.ProducerKind,
+    landmarks: tuple[str, ...],
+    module_name: str = "scripts._drift_synthetic_producer_phase_b",
+) -> types.ModuleType:
+    """Register a fake producer module and retarget ``_PRODUCER_MODULES``."""
+    module = types.ModuleType(module_name)
+    module.LANDMARKS = landmarks  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, module)
+    monkeypatch.setitem(_drift._PRODUCER_MODULES, (engine, producer), module_name)
+    return module
+
+
+def _redirect_compat_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, engine: str = "transformers"
+) -> Path:
+    """Point current.yaml path and compat cache writes at ``tmp_path``."""
+    real_current = _PROJECT_ROOT / "engine_versions" / engine / "current.yaml"
+    fake_engine_dir = tmp_path / engine
+    fake_engine_dir.mkdir(parents=True, exist_ok=True)
+    fake_current = fake_engine_dir / "current.yaml"
+    fake_current.write_text(real_current.read_text())
+
+    def _fake_path(name: str) -> Path:
+        return tmp_path / name / "current.yaml"
+
+    monkeypatch.setattr(_drift, "current_path", _fake_path)
+    return fake_current
+
+
+# ---------------------------------------------------------------------------
+# Helpers for constructing synthetic types for introspection tests
+# ---------------------------------------------------------------------------
+
+
+def _make_pydantic_v2_model(name: str, validators: dict[str, str]) -> type:
+    """Return a pydantic v2 BaseModel subclass with the given field_validators.
+
+    ``validators`` maps method_name -> field_name. Requires pydantic installed.
+    """
+    try:
+        import pydantic
+        from pydantic import field_validator
+    except ImportError:
+        pytest.skip("pydantic not installed")
+
+    # Build a class body with field validators dynamically.
+    # Use type() to create the class; pydantic's metaclass processes it.
+    namespace: dict = {"__annotations__": {"x": int}}
+    for method_name, field_name in validators.items():
+
+        def make_validator(fn_name: str, fn_field: str) -> classmethod:
+            @field_validator(fn_field)
+            @classmethod
+            def _v(cls: type, v: int) -> int:
+                return v
+
+            _v.__name__ = fn_name
+            _v.__qualname__ = fn_name
+            return _v  # type: ignore[return-value]
+
+        namespace[method_name] = make_validator(method_name, field_name)
+    return pydantic.create_model(name, **{"x": (int, ...)})  # type: ignore[call-overload]
+
+
+# ---------------------------------------------------------------------------
+# _class_validator_surface - layered dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestLayeredDispatch:
+    """Verify that _class_validator_surface dispatches correctly by class kind."""
+
+    def test_pydantic_v2_field_validators_surfaced(self) -> None:
+        """Pydantic v2 BaseModel field_validators -> high confidence."""
+        try:
+            import pydantic
+            from pydantic import field_validator
+        except ImportError:
+            pytest.skip("pydantic not installed")
+
+        class MyModel(pydantic.BaseModel):
+            x: int
+            y: str
+
+            @field_validator("x")
+            @classmethod
+            def check_x(cls, v: int) -> int:
+                return v
+
+        results = _drift._class_validator_surface(MyModel, "mymodule")
+        paths = {path for _conf, path in results}
+        confs = {conf for conf, _path in results}
+
+        # check_x should appear as high confidence
+        assert any("check_x" in p for p in paths), f"check_x missing from {paths}"
+        assert _drift._CONF_HIGH in confs
+
+    def test_pydantic_v2_model_fields_surfaced(self) -> None:
+        """Pydantic v2 declared model_fields -> high confidence."""
+        try:
+            import pydantic
+        except ImportError:
+            pytest.skip("pydantic not installed")
+
+        class MyConfig(pydantic.BaseModel):
+            alpha: int
+            beta: str
+
+        results = _drift._class_validator_surface(MyConfig, "mymodule")
+        paths = {path for _conf, path in results}
+        assert any("alpha" in p for p in paths)
+        assert any("beta" in p for p in paths)
+
+    def test_dataclass_fields_and_post_init_surfaced(self) -> None:
+        """stdlib @dataclass: fields + __post_init__ -> high confidence."""
+
+        @dataclasses.dataclass
+        class MyDC:
+            x: int
+            y: str = "hello"
+
+            def __post_init__(self) -> None:
+                pass
+
+        results = _drift._class_validator_surface(MyDC, "mymodule")
+        paths = {path for _conf, path in results}
+        confs = {conf for conf, _path in results}
+
+        assert any("x" in p for p in paths), f"field 'x' missing from {paths}"
+        assert any("y" in p for p in paths), f"field 'y' missing from {paths}"
+        assert any("__post_init__" in p for p in paths), f"__post_init__ missing from {paths}"
+        assert confs == {_drift._CONF_HIGH}
+
+    def test_dataclass_without_post_init_no_post_init_entry(self) -> None:
+        """Dataclass without __post_init__ must not surface a post_init entry."""
+
+        @dataclasses.dataclass
+        class NakedDC:
+            a: int
+            b: float
+
+        results = _drift._class_validator_surface(NakedDC, "mymodule")
+        paths = {path for _conf, path in results}
+        assert not any("__post_init__" in p for p in paths)
+
+    def test_enum_skipped(self) -> None:
+        """Enum subclasses return empty results - no validator surface."""
+
+        class MyStrEnum(str, enum.Enum):
+            VALUE_A = "a"
+            VALUE_B = "b"
+
+        class MyIntEnum(int, enum.Enum):
+            ONE = 1
+            TWO = 2
+
+        assert _drift._class_validator_surface(MyStrEnum, "mymodule") == []
+        assert _drift._class_validator_surface(MyIntEnum, "mymodule") == []
+
+    def test_plain_class_public_validate_medium_confidence(self) -> None:
+        """Plain class with ``validate_*`` method -> medium confidence."""
+
+        class PlainConfig:
+            def validate_dtype(self) -> None:
+                pass
+
+            def check_mode(self) -> None:
+                pass
+
+        results = _drift._class_validator_surface(PlainConfig, "mymodule")
+        paths = {path for _conf, path in results}
+        confs_by_path = {path: conf for conf, path in results}
+
+        val_paths = [p for p in paths if "validate_dtype" in p or "check_mode" in p]
+        assert val_paths, f"validate_dtype / check_mode missing from {paths}"
+        for p in val_paths:
+            assert confs_by_path[p] == _drift._CONF_MEDIUM
+
+    def test_plain_class_private_validate_low_confidence(self) -> None:
+        """Plain class with ``_validate_*`` -> low confidence."""
+
+        class PlainConfig:
+            def _validate_internal(self) -> None:
+                pass
+
+        results = _drift._class_validator_surface(PlainConfig, "mymodule")
+        paths = {path for _conf, path in results}
+        confs_by_path = {path: conf for conf, path in results}
+
+        low_paths = [p for p in paths if "_validate_internal" in p]
+        assert low_paths, f"_validate_internal missing from {paths}"
+        for p in low_paths:
+            assert confs_by_path[p] == _drift._CONF_LOW
+
+    def test_plain_class_non_validator_callable_not_surfaced(self) -> None:
+        """Plain class callables that don't start with validate/check/verify are skipped."""
+
+        class PlainConfig:
+            def run(self) -> None:
+                pass
+
+            def _helper(self) -> None:
+                pass
+
+            def load_model(self) -> None:
+                pass
+
+        results = _drift._class_validator_surface(PlainConfig, "mymodule")
+        paths = {path for _conf, path in results}
+        assert not any("run" in p for p in paths)
+        assert not any("load_model" in p for p in paths)
+
+    def test_pydantic_v2_takes_precedence_over_dataclass(self) -> None:
+        """If a class is both a pydantic model and dataclass-ish, pydantic path wins."""
+        try:
+            from pydantic.dataclasses import dataclass as pydantic_dataclass
+        except ImportError:
+            pytest.skip("pydantic not installed")
+
+        # pydantic.dataclasses.dataclass wraps stdlib dataclass but creates
+        # a pydantic model; __pydantic_decorators__ is present.
+
+        @pydantic_dataclass
+        class PydDC:
+            x: int
+            y: str = "hello"
+
+        # Should go through the pydantic v2 path (has __pydantic_decorators__).
+        assert hasattr(PydDC, "__pydantic_decorators__") or hasattr(PydDC, "model_fields"), (
+            "Expected pydantic dataclass to have pydantic v2 decorator infra"
+        )
+
+        # The pydantic path returns fields from model_fields, not dataclasses.fields.
+        results = _drift._class_validator_surface(PydDC, "mymodule")
+        # Just ensure no exception and some surface surfaced.
+        assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# discover_live_landmarks - set-diff and engine wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverLiveLandmarks:
+    """Verify discover_live_landmarks() returns the expected sets."""
+
+    def test_unknown_engine_returns_empty(self) -> None:
+        """An engine with no introspection roots returns empty sets."""
+        high, low = _drift.discover_live_landmarks("ghost_engine_xyz")
+        assert high == set()
+        assert low == set()
+
+    def test_class_import_failure_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When a root class can't be imported, that root is skipped."""
+        # Patch the engine roots to point at a non-existent class.
+        monkeypatch.setitem(
+            _drift._ENGINE_INTROSPECTION_ROOTS,
+            "mock_engine",
+            ("nonexistent_module.NonExistent",),
+        )
+        high, low = _drift.discover_live_landmarks("mock_engine")
+        assert high == set()
+        assert low == set()
+
+    def test_module_import_failure_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When a root module can't be imported, that root is skipped."""
+        monkeypatch.setitem(
+            _drift._ENGINE_INTROSPECTION_ROOTS,
+            "mock_engine2",
+            ("totally_nonexistent_module_xyz",),
+        )
+        high, low = _drift.discover_live_landmarks("mock_engine2")
+        assert high == set()
+        assert low == set()
+
+    def test_class_level_root_discovered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A class-level root (uppercase last component) is imported directly."""
+
+        @dataclasses.dataclass
+        class SynthConfig:
+            alpha: int
+
+            def __post_init__(self) -> None:
+                pass
+
+        # Register a synthetic module containing SynthConfig.
+        synth_mod = types.ModuleType("synth_mod_test")
+        synth_mod.SynthConfig = SynthConfig  # type: ignore[attr-defined]
+        SynthConfig.__module__ = "synth_mod_test"
+        monkeypatch.setitem(sys.modules, "synth_mod_test", synth_mod)
+
+        monkeypatch.setitem(
+            _drift._ENGINE_INTROSPECTION_ROOTS,
+            "mock_engine3",
+            ("synth_mod_test.SynthConfig",),
+        )
+
+        high, _low = _drift.discover_live_landmarks("mock_engine3")
+        # SynthConfig has field 'alpha' and __post_init__ -> both high confidence.
+        assert any("alpha" in p for p in high), f"alpha missing from {high}"
+        assert any("__post_init__" in p for p in high), f"__post_init__ missing from {high}"
+
+    def test_module_level_root_walks_all_classes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A module-level root (lowercase last component) walks all classes in the module."""
+
+        @dataclasses.dataclass
+        class ConfigA:
+            x: int
+
+        @dataclasses.dataclass
+        class ConfigB:
+            y: str
+
+        synth_mod = types.ModuleType("synth_module_walk")
+        synth_mod.ConfigA = ConfigA  # type: ignore[attr-defined]
+        synth_mod.ConfigB = ConfigB  # type: ignore[attr-defined]
+        # Set __module__ so _walk_module_classes includes them.
+        ConfigA.__module__ = "synth_module_walk"
+        ConfigB.__module__ = "synth_module_walk"
+        monkeypatch.setitem(sys.modules, "synth_module_walk", synth_mod)
+
+        monkeypatch.setitem(
+            _drift._ENGINE_INTROSPECTION_ROOTS,
+            "mock_engine4",
+            ("synth_module_walk",),
+        )
+
+        high, _low = _drift.discover_live_landmarks("mock_engine4")
+        # Both classes should be surfaced.
+        assert any("ConfigA" in p for p in high), f"ConfigA missing from {high}"
+        assert any("ConfigB" in p for p in high), f"ConfigB missing from {high}"
+
+    def test_enum_class_in_module_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Enum classes inside a walked module are silently skipped."""
+
+        class MyEnum(str, enum.Enum):
+            VAL = "v"
+
+        synth_mod = types.ModuleType("synth_module_enum")
+        synth_mod.MyEnum = MyEnum  # type: ignore[attr-defined]
+        MyEnum.__module__ = "synth_module_enum"
+        monkeypatch.setitem(sys.modules, "synth_module_enum", synth_mod)
+
+        monkeypatch.setitem(
+            _drift._ENGINE_INTROSPECTION_ROOTS,
+            "mock_engine5",
+            ("synth_module_enum",),
+        )
+
+        high, low = _drift.discover_live_landmarks("mock_engine5")
+        # Enum members should not appear in either set.
+        assert not any("MyEnum" in p for p in high)
+        assert not any("MyEnum" in p for p in low)
+
+
+# ---------------------------------------------------------------------------
+# Set-diff correctness
+# ---------------------------------------------------------------------------
+
+
+class TestSetDiff:
+    """Verify that landmarks_added = live_high - declared."""
+
+    def _run_with_live_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        *,
+        declared_landmarks: tuple[str, ...],
+        live_high: set[str],
+        live_low: set[str],
+    ) -> _drift.DriftReport:
+        """Helper: wire a synthetic producer + fake discover_live_landmarks, run."""
+        _redirect_compat_dir(monkeypatch, tmp_path)
+        _install_synthetic_producer(
+            monkeypatch,
+            engine="transformers",
+            producer="invariants",
+            landmarks=declared_landmarks,
+        )
+        monkeypatch.setattr(_drift, "discover_live_landmarks", lambda engine: (live_high, live_low))
+        return _drift.run(engine="transformers", producer="invariants")
+
+    def test_no_additions_when_live_subset_of_declared(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Live surface fully covered by LANDMARKS -> landmarks_added empty."""
+        report = self._run_with_live_override(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError", "json.JSONEncoder"),
+            live_high={"json.JSONDecodeError", "json.JSONEncoder"},
+            live_low=set(),
+        )
+        assert report.landmarks_added == []
+        assert report.landmarks_added_low_confidence == []
+        assert report.direction == "stable"
+
+    def test_additions_when_live_superset_of_declared(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Live has more than declared -> landmarks_added non-empty."""
+        report = self._run_with_live_override(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError",),
+            live_high={"json.JSONDecodeError", "json.JSONEncoder", "json.JSONDecoder"},
+            live_low=set(),
+        )
+        assert sorted(report.landmarks_added) == sorted(["json.JSONEncoder", "json.JSONDecoder"])
+        assert report.direction == "added"
+
+    def test_low_confidence_additions_in_separate_field(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Low-confidence live paths go to landmarks_added_low_confidence, not landmarks_added."""
+        report = self._run_with_live_override(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError",),
+            live_high={"json.JSONDecodeError"},
+            live_low={"json.SomePrivateHelper"},
+        )
+        assert report.landmarks_added == []
+        assert "json.SomePrivateHelper" in report.landmarks_added_low_confidence
+
+    def test_empty_declared_all_live_surfaced(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Empty LANDMARKS -> entire live surface appears in landmarks_added."""
+        report = self._run_with_live_override(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=(),
+            live_high={"json.JSONDecodeError", "json.JSONEncoder"},
+            live_low=set(),
+        )
+        assert sorted(report.landmarks_added) == sorted(
+            ["json.JSONDecodeError", "json.JSONEncoder"]
+        )
+
+    def test_empty_live_no_additions(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Empty live surface (engine not installed) -> no additions."""
+        report = self._run_with_live_override(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError",),
+            live_high=set(),
+            live_low=set(),
+        )
+        assert report.landmarks_added == []
+        assert report.landmarks_added_low_confidence == []
+
+
+# ---------------------------------------------------------------------------
+# Direction and verdict logic
+# ---------------------------------------------------------------------------
+
+
+class TestDirectionAndVerdict:
+    """Verify direction and verdict logic across all combinations."""
+
+    def _run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        declared_landmarks: tuple[str, ...],
+        live_high: set[str],
+        live_low: set[str],
+    ) -> _drift.DriftReport:
+        _redirect_compat_dir(monkeypatch, tmp_path)
+        _install_synthetic_producer(
+            monkeypatch,
+            engine="transformers",
+            producer="invariants",
+            landmarks=declared_landmarks,
+        )
+        monkeypatch.setattr(_drift, "discover_live_landmarks", lambda engine: (live_high, live_low))
+        return _drift.run(engine="transformers", producer="invariants")
+
+    def test_direction_stable_no_gaps(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """All landmarks resolve, no additions -> stable."""
+        report = self._run(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError",),
+            live_high={"json.JSONDecodeError"},
+            live_low=set(),
+        )
+        assert report.direction == "stable"
+        assert report.verdict == "pass"
+
+    def test_direction_added_only_additions(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No missing landmarks, but live has extras -> added, verdict pass."""
+        report = self._run(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError",),
+            live_high={"json.JSONDecodeError", "json.JSONEncoder"},
+            live_low=set(),
+        )
+        assert report.direction == "added"
+        assert report.verdict == "pass"  # Phase B: warning-only
+
+    def test_direction_removed_missing_landmark(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Missing landmark, no additions -> removed, verdict fail."""
+        report = self._run(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError", "json.NonExistentXYZ"),
+            live_high=set(),
+            live_low=set(),
+        )
+        assert report.direction == "removed"
+        assert report.verdict == "fail"
+        assert "json.NonExistentXYZ" in report.landmarks_missing
+
+    def test_direction_mixed_both_missing_and_added(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Missing landmark AND live extras -> mixed, verdict still fail."""
+        report = self._run(
+            monkeypatch,
+            tmp_path,
+            declared_landmarks=("json.JSONDecodeError", "json.NonExistentXYZ"),
+            live_high={"json.JSONDecodeError", "json.JSONEncoder"},
+            live_low=set(),
+        )
+        assert report.direction == "mixed"
+        assert report.verdict == "fail"  # missing landmark overrides
+        assert "json.NonExistentXYZ" in report.landmarks_missing
+        assert "json.JSONEncoder" in report.landmarks_added
+
+    def test_added_direction_verdict_pass_not_fail(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Phase B is warning-only: additions alone NEVER flip verdict to fail."""
+        report = self._run(
+            monkeypatch,
+            tmp_path,
+            # No declared landmarks - everything in live is "added"
+            declared_landmarks=(),
+            live_high={
+                "json.JSONDecodeError",
+                "json.JSONEncoder",
+                "json.JSONDecoder",
+            },
+            live_low=set(),
+        )
+        assert report.verdict == "pass"
+        assert len(report.landmarks_added) == 3
+
+    def test_schemas_producer_skips_phase_b(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Phase B introspection is only active for the 'invariants' producer."""
+        _redirect_compat_dir(monkeypatch, tmp_path)
+        _install_synthetic_producer(
+            monkeypatch,
+            engine="transformers",
+            producer="schemas",
+            landmarks=("json.JSONDecodeError",),
+        )
+        discover_called = []
+
+        def _fake_discover(engine: str) -> tuple[set[str], set[str]]:
+            discover_called.append(engine)
+            return ({"json.JSONEncoder"}, set())
+
+        monkeypatch.setattr(_drift, "discover_live_landmarks", _fake_discover)
+        report = _drift.run(engine="transformers", producer="schemas")
+
+        # discover_live_landmarks should NOT have been called for schemas.
+        assert discover_called == [], "Phase B must not run for schemas producer"
+        assert report.landmarks_added == []
+        assert report.direction == "stable"
+
+
+# ---------------------------------------------------------------------------
+# JSON output: new Phase B fields present
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    """Verify that Phase B fields are serialised in DriftReport JSON output."""
+
+    def test_landmarks_added_in_json_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``landmarks_added`` and ``landmarks_added_low_confidence`` present in stdout JSON."""
+        real_current = _PROJECT_ROOT / "engine_versions" / "transformers" / "current.yaml"
+        fake_engine_dir = tmp_path / "transformers"
+        fake_engine_dir.mkdir(parents=True, exist_ok=True)
+        (fake_engine_dir / "current.yaml").write_text(real_current.read_text())
+        monkeypatch.setattr(_drift, "current_path", lambda name: tmp_path / name / "current.yaml")
+
+        _install_synthetic_producer(
+            monkeypatch,
+            engine="transformers",
+            producer="invariants",
+            landmarks=("json.JSONDecodeError",),
+        )
+        monkeypatch.setattr(
+            _drift,
+            "discover_live_landmarks",
+            lambda engine: ({"json.JSONEncoder"}, {"json._SomePrivate"}),
+        )
+
+        rc = _drift.main(
+            ["--engine", "transformers", "--producer", "invariants", "--no-write-cache"]
+        )
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+
+        assert "landmarks_added" in payload, "landmarks_added field must be in JSON"
+        assert "landmarks_added_low_confidence" in payload, (
+            "landmarks_added_low_confidence field must be in JSON"
+        )
+        assert "json.JSONEncoder" in payload["landmarks_added"]
+        assert "json._SomePrivate" in payload["landmarks_added_low_confidence"]
+        assert payload["direction"] == "added"
+        assert payload["verdict"] == "pass"
+
+    def test_compat_json_includes_phase_b_fields(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Phase B fields are persisted to the compat.json cache."""
+        real_current = _PROJECT_ROOT / "engine_versions" / "transformers" / "current.yaml"
+        fake_engine_dir = tmp_path / "transformers"
+        fake_engine_dir.mkdir(parents=True, exist_ok=True)
+        (fake_engine_dir / "current.yaml").write_text(real_current.read_text())
+        monkeypatch.setattr(_drift, "current_path", lambda name: tmp_path / name / "current.yaml")
+
+        _install_synthetic_producer(
+            monkeypatch,
+            engine="transformers",
+            producer="invariants",
+            landmarks=("json.JSONDecodeError",),
+        )
+        monkeypatch.setattr(
+            _drift,
+            "discover_live_landmarks",
+            lambda engine: ({"json.JSONEncoder"}, set()),
+        )
+
+        rc = _drift.main(["--engine", "transformers", "--producer", "invariants"])
+        assert rc == 0
+
+        cache_path = tmp_path / "transformers.compat.json"
+        assert cache_path.is_file()
+        cache = json.loads(cache_path.read_text())
+
+        assert "invariants" in cache
+        entry = cache["invariants"]
+        assert "landmarks_added" in entry
+        assert "landmarks_added_low_confidence" in entry
+        assert "json.JSONEncoder" in entry["landmarks_added"]
+        assert entry["direction"] == "added"
+
+
+# ---------------------------------------------------------------------------
+# _import_class_from_path helper
+# ---------------------------------------------------------------------------
+
+
+class TestImportClassFromPath:
+    """Verify _import_class_from_path handles various paths correctly."""
+
+    def test_valid_stdlib_class(self) -> None:
+        """A valid stdlib class path resolves to the class."""
+        cls = _drift._import_class_from_path("json.JSONDecodeError")
+        assert cls is not None
+        import json as _json
+
+        assert cls is _json.JSONDecodeError
+
+    def test_nonexistent_module_returns_none(self) -> None:
+        """A completely non-existent module returns None."""
+        cls = _drift._import_class_from_path("totally_fake_module_xyz.FakeClass")
+        assert cls is None
+
+    def test_nonexistent_attribute_returns_none(self) -> None:
+        """An existing module but non-existent attribute returns None."""
+        cls = _drift._import_class_from_path("json.CompletelyNonExistentClass")
+        assert cls is None
+
+    def test_non_type_object_returns_none(self) -> None:
+        """A path that resolves to a non-type object (e.g. a constant) returns None."""
+        cls = _drift._import_class_from_path("json.encoder.INFINITY")
+        assert cls is None
+
+
+# ---------------------------------------------------------------------------
+# _walk_module_classes helper
+# ---------------------------------------------------------------------------
+
+
+class TestWalkModuleClasses:
+    """Verify _walk_module_classes includes only classes defined in the module."""
+
+    def test_json_encoder_module_includes_defined_classes(self) -> None:
+        """json.encoder module returns JSONEncoder (defined there with matching __module__)."""
+        results = _drift._walk_module_classes("json.encoder")
+        class_names = {cls.__name__ for cls, _mod in results}
+        # JSONEncoder.__module__ == "json.encoder" so it should be included.
+        assert "JSONEncoder" in class_names, f"JSONEncoder missing from {class_names}"
+
+    def test_nonexistent_module_returns_empty(self) -> None:
+        """A non-existent module path returns an empty list."""
+        results = _drift._walk_module_classes("nonexistent_xyz_module")
+        assert results == []
+
+    def test_only_own_module_classes_included(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Classes with __module__ != the walked module are excluded."""
+        import json
+
+        @dataclasses.dataclass
+        class _Foreign:
+            pass
+
+        # _Foreign has __module__ = __name__ of this test module, not 'json'.
+        # Monkeypatching sys.modules['json'].Foreign ensures it's in the module
+        # namespace but its __module__ doesn't match - should be excluded.
+        monkeypatch.setattr(json, "_Foreign", _Foreign, raising=False)
+        results = _drift._walk_module_classes("json")
+        class_names = {cls.__name__ for cls, _mod in results}
+        assert "_Foreign" not in class_names


### PR DESCRIPTION
## Summary

Extends `scripts/_drift.py` (Phase A drop-in replacement for `_probe.py`) with the **added direction** - surfaces validators that exist in the live engine library but are NOT declared in the per-version archive LANDMARKS. This is the additive blind spot coverage check: when Renovate bumps a library to a version with new validators, Phase B surfaces them so the maintainer knows to extend LANDMARKS + walker logic.

**Phase B is warning-only.** `verdict` stays `pass` even when `landmarks_added` is non-empty. Phase C (separate PR) adds CI gating + EXCLUSIONS.yaml.

Key changes:

- `discover_live_landmarks(engine)` - introspects live library via layered class dispatch
  - Pydantic v2 BaseModel: reads `__pydantic_decorators__` (7 buckets) + `model_fields`
  - Pydantic v1: reads `__fields__` + `__validators__` + root validators  
  - stdlib `@dataclass`: `dataclasses.fields()` + `__post_init__`
  - Enum (StrEnum/IntEnum): skipped, no validator surface
  - Plain class: name-heuristic on `vars(cls)` for `validate_*`/`check_*`/`verify_*`
- `_ENGINE_INTROSPECTION_ROOTS` - per-engine module/class walk targets (transformers uses class-level to avoid CUDA-bearing imports; vllm/tensorrt use module-level)
- `DriftReport` gets `landmarks_added` (high confidence) + `landmarks_added_low_confidence` (medium/low)
- `direction` gains `"added"` and `"mixed"` values
- Phase B only runs for `"invariants"` producer (not `"schemas"`)
- 35 new tests in `tests/unit/scripts/test_drift_phase_b.py`

Reference: `.product/designs/coverage-probe-design-2026-05-13.md`

## Test plan

- [ ] All 48 drift tests pass (`test_drift.py` + `test_drift_phase_b.py`)
- [ ] Full suite: 2583 passed, 53 skipped (CI green)
- [ ] Docker smoke per engine (inside container): `python -m scripts._drift --engine transformers --producer invariants` emits `landmarks_added` field with reasonable signal