### PR TITLE
docs: align engine architecture refs with vendoring + drift tool

### DIFF
--- a/docs/contributing/extending-miners.md
+++ b/docs/contributing/extending-miners.md
@@ -10,7 +10,7 @@ This document is the practitioner's guide to adding invariant miner support for 
 
 1. Read [miner-pipeline.md](/contributing/miner-pipeline) to understand the static miner / dynamic miner / lift module split.
 2. Read the [corpus format reference](/reference/invariants-corpus-format) to understand what rules look like.
-3. Review `scripts/engine_producers/transformers_static_miner.py` and `scripts/engine_producers/transformers_dynamic_miner.py` as the gold standard. The comments in those files contain important design decisions.
+3. Review `engine_versions/transformers/v4_57_3/producers/static_invariant_miner.py` and `engine_versions/transformers/v4_57_3/producers/dynamic_invariant_miner.py` as the gold standard. The comments in those files contain important design decisions. The `scripts/engine_producers/transformers_*_invariant_miner.py` modules are thin dispatcher shims that delegate to the per-version vendored producers.
 
 ---
 
@@ -30,14 +30,30 @@ Before writing any code, answer these questions:
 
 ---
 
+## The vendoring model
+
+Each producer (static invariant miner, dynamic invariant miner, schema introspector) lives at two levels:
+
+- **Per-version vendored module** at `engine_versions/<engine>/v<safe>/producers/{static_invariant_miner,dynamic_invariant_miner,schema_introspector}.py`. This is the real implementation. It pins its `LANDMARKS` tuple (the live class / method paths it expects) to the library version named in `engine_versions/<engine>/current.yaml:library.current_version`.
+
+- **Dispatcher shim** at `scripts/engine_producers/<engine>_{static_invariant_miner,dynamic_invariant_miner,schema_introspector}.py`. ~14 lines via `scripts/engine_producers/_stub_factory.py`. Module-level `__getattr__` (PEP 562) resolves to `engine_versions.<engine>.<safe_version>.producers.<producer>` at attribute-access time. The orchestrator (`build_corpus.py`) imports the shim; the shim defers to the dispatcher.
+
+When the SSOT bumps to a new library version, the dispatcher raises `ModuleNotFoundError` naming the exact file path to create. The maintainer copies the previous version's producer to the new path, adjusts `LANDMARKS` to match the new surface, and the cell re-runs green.
+
+Step 1 of this guide walks through the shim contract; subsequent steps detail the per-version producer body.
+
+---
+
 ## Step 1: Add the fail-loud import contract
 
-Create `scripts/engine_producers/{engine}_miner.py` (the orchestration entry point). The very first thing it must do:
+Create `scripts/engine_producers/{engine}_static_invariant_miner.py` (and corresponding `_dynamic_invariant_miner` / `_schema_introspector` shims) using `_stub_factory.py`'s `make_static_stub` / `make_dynamic_stub` / `make_schema_stub`. The shim's job is to defer to the per-version producer module via the dispatcher; the fail-loud contract lives inside the per-version producer.
+
+In `engine_versions/{engine}/v<safe>/producers/static_invariant_miner.py`, the first thing the module must do:
 
 ```python
 import importlib.metadata
 from scripts.engine_producers._base import check_installed_version, MinerLandmarkMissingError
-from scripts.engine_producers._ssot import load_miner_pin
+from scripts.engine_producers._current import load_miner_pin
 
 # Pin source-of-truth lives in ``engine_versions/{engine}/current.yaml`` under
 # ``miner_pins.{static|dynamic|discovery}``. Pick the producer matching this
@@ -142,7 +158,7 @@ The dataclass lift is limited to `Literal[...]` value-allowlist invariants (no n
 
 ## Step 3: Write the static miner
 
-Create `scripts/engine_producers/{engine}_static_miner.py`. The static miner walks the AST of validator methods and emits rules for conditional raises, warnings, and silent normalisations.
+Create `engine_versions/{engine}/v<safe>/producers/static_invariant_miner.py`. The static miner walks the AST of validator methods and emits rules for conditional raises, warnings, and silent normalisations.
 
 ### Pattern: walking a validator method
 
@@ -224,7 +240,7 @@ Per the transformers static miner's header, per-engine miners currently define t
 
 ## Step 4: Write the dynamic miner (if applicable)
 
-Create `scripts/engine_producers/{engine}_dynamic_miner.py` if the engine's constructors raise on invalid inputs.
+Create `engine_versions/{engine}/v<safe>/producers/dynamic_invariant_miner.py` if the engine's constructors raise on invalid inputs.
 
 **Skip this step if:** probing the engine's constructors yields zero raises. This is the case for TRT-LLM, where `TrtLlmArgs(**kwargs)` is extremely permissive at construction time; constraints are enforced in validator methods (covered by the static miner) or at build time.
 
@@ -314,22 +330,15 @@ def infer_predicates(rows: list[tuple[dict, str | None]]) -> list[InvariantCandi
 
 ## Step 5: Write the corpus orchestration entry
 
-`scripts/engine_producers/{engine}_miner.py` is the main entry point:
+`engine_versions/{engine}/v<safe>/producers/static_invariant_miner.py` houses the orchestration. Lift modules, AST walkers, and cluster probes all live in this module (or its companion `dynamic_invariant_miner.py`); the dispatcher shim under `scripts/engine_producers/` only re-exports `mine` / `LANDMARKS` symbols. The pattern:
 
 ```python
 def mine() -> list[InvariantCandidate]:
     candidates = []
     candidates.extend(mine_pydantic_invariants())
     candidates.extend(mine_dataclass_invariants())
-
-    # Static miner
-    from scripts.engine_producers.myengine_static_miner import mine as static_mine
-    candidates.extend(static_mine())
-
-    # Dynamic miner (if applicable)
-    from scripts.engine_producers.myengine_dynamic_miner import mine as dynamic_mine
-    candidates.extend(dynamic_mine())
-
+    # Combinatorial cluster probes
+    candidates.extend(mine_cluster_invariants())
     return candidates
 
 if __name__ == "__main__":
@@ -367,7 +376,7 @@ def test_cluster_probes_without_crashing(cluster):
 def test_version_envelope_resolves():
     """The miner pin loaded from the engine SSOT must be a non-empty SpecifierSet."""
     from packaging.specifiers import SpecifierSet
-    from scripts.engine_producers._ssot import load_miner_pin
+    from scripts.engine_producers._current import load_miner_pin
     envelope = load_miner_pin("myengine", "static")
     assert isinstance(envelope, SpecifierSet)
     assert str(envelope) != ""
@@ -432,8 +441,9 @@ def test_landmark_checks_raise_on_missing():
 Run the miner locally (inside the engine's Docker container if CUDA is required):
 
 ```bash
-python scripts/engine_producers/myengine_miner.py
-# Writes src/llenergymeasure/engines/_staging/myengine_miner.yaml
+python scripts/engine_producers/build_corpus.py --engine myengine --producer static
+# Runs the per-version vendored static miner via the dispatcher shim,
+# writes src/llenergymeasure/engines/_staging/myengine_static_invariant_miner.yaml
 
 python scripts/engine_producers/build_corpus.py --engine myengine
 # Merges staging files, runs validation-CI gate, writes corpus
@@ -580,6 +590,8 @@ The fail-loud envelope and the YAML diff together cover the failure modes that t
 - [invariants-corpus-format.md](/reference/invariants-corpus-format) - corpus format
 - [parameter-discovery.md](/explanation/architecture/parameter-discovery) - runtime validation
 - [architecture-overview.md](/explanation/architecture/architecture-overview) - system overview
-- `scripts/engine_producers/transformers_static_miner.py` - gold-standard static miner
-- `scripts/engine_producers/transformers_dynamic_miner.py` - gold-standard dynamic miner
+- `engine_versions/transformers/v4_57_3/producers/static_invariant_miner.py` - gold-standard static miner
+- `engine_versions/transformers/v4_57_3/producers/dynamic_invariant_miner.py` - gold-standard dynamic miner
+- `engine_versions/_dispatcher.py` and `scripts/engine_producers/_stub_factory.py` - per-version dispatch
+- `scripts/_drift.py` - the drift tool that surfaces missing-vs-extra-vs-stable landmark state at probe time
 - `scripts/engine_producers/_base.py` - shared infrastructure

--- a/docs/contributing/miner-pipeline.md
+++ b/docs/contributing/miner-pipeline.md
@@ -26,22 +26,28 @@ src/llenergymeasure/engines/{engine}/
 └── invariants.validated.yaml         CI-validated overlay, post-validate-replay
 
 src/llenergymeasure/engines/{engine}/_staging/   (gitignored, miner-only)
-├── {engine}_static_miner.yaml        Per-miner staging output (not committed)
-├── {engine}_dynamic_miner.yaml
-└── _failed_validation_{engine}.yaml  Quarantined rules
+├── {engine}_static_invariant_miner.yaml      Per-miner staging output (not committed)
+├── {engine}_dynamic_invariant_miner.yaml
+└── _failed_validation_{engine}.yaml          Quarantined rules
 
 scripts/engine_producers/
 ├── _base.py                          Shared AST primitives, detectors, filters
-├── _ssot.py                          load_miner_pin() - resolves SpecifierSet from engine SSOT
+├── _current.py                       load_current() / load_miner_pin() - resolves SpecifierSet from engine SSOT
 ├── _pydantic_lift.py                 Lift module for Pydantic models
 ├── _msgspec_lift.py                  Lift module for msgspec.Struct
 ├── _dataclass_lift.py                Lift module for stdlib @dataclass + Literal
-├── {engine}_static_miner.py          Per-engine static miner
-├── {engine}_dynamic_miner.py         Per-engine dynamic miner (when applicable)
+├── _stub_factory.py                  Producer dispatcher shims (per-engine PEP 562 hooks)
+├── {engine}_static_invariant_miner.py        Shim: dispatches to engine_versions/<engine>/v<safe>/producers/
+├── {engine}_dynamic_invariant_miner.py       Shim (when applicable)
+├── {engine}_schema_introspector.py           Shim
 ├── build_corpus.py                   Orchestration: merge + dedup + validate
 └── validate_invariants.py            Replays each rule against the live library
 
-engine_versions/{engine}/current.yaml         SSOT for library version + miner_pins envelopes
+engine_versions/{engine}/current.yaml          SSOT for library version + miner_pins envelopes
+engine_versions/{engine}/v<safe>/producers/    Per-version vendored producer modules
+├── static_invariant_miner.py
+├── dynamic_invariant_miner.py        (when applicable)
+└── schema_introspector.py
 ```
 
 The two committed YAML files form a lifecycle pair: the miners write
@@ -82,13 +88,14 @@ while `vllm/schemas` is not, or vice versa.
 
 | Symptom | Files to inspect first |
 |---|---|
-| Miner produces no rules for a new engine | `scripts/engine_producers/{engine}_*_miner.py` (does the file exist? imports succeed?); `engine_versions/{engine}/current.yaml` (is `miner_pins` populated?) |
+| Miner produces no rules for a new engine | `engine_versions/{engine}/v<safe>/producers/{static,dynamic}_invariant_miner.py` (does the file exist? imports succeed?); `engine_versions/{engine}/current.yaml` (is `miner_pins` populated?) |
 | `MinerVersionMismatchError` raised at import time | `engine_versions/{engine}/current.yaml miner_pins.{static\|dynamic\|discovery}` vs the live library version (`importlib.metadata.version("{library}")`) |
-| `MinerLandmarkMissingError` raised at import time | `scripts/engine_producers/{engine}_*_miner.py` (which `find_class` / `find_method` call returned None? compare against the live library source tree) |
+| `MinerLandmarkMissingError` raised at import time | `engine_versions/{engine}/v<safe>/producers/*.py LANDMARKS` tuple (which dotted path is missing in the live library? `scripts/_drift.py --engine {engine} --producer invariants` will surface it) |
 | Validation gate fails on a previously-passing rule | `src/llenergymeasure/engines/{engine}/invariants.proposed.yaml` (locate the rule by id) and `_staging/_failed_validation_{engine}.yaml` (which check failed: `positive_raises`, `message_template_match`, or `negative_does_not_raise`) |
 | Rule duplication or merge surprises | `scripts/engine_producers/build_corpus.py` (the merger; deduplication key is `(engine, severity, match_fields)`); look at `cross_validated_by` on the merged rule |
-| Static miner missed a predicate | `scripts/engine_producers/_base.py` (which detector should have matched? did a filter drop the candidate?) |
-| Dynamic miner inferred wrong template | `scripts/engine_producers/{engine}_dynamic_miner.py` (predicate-inference logic); the seven templates live in the same file or `_base.py` depending on engine |
+| Static miner missed a predicate | `scripts/engine_producers/_base.py` (shared detectors) and `engine_versions/{engine}/v<safe>/producers/static_invariant_miner.py` (per-version surface) |
+| Dynamic miner inferred wrong template | `engine_versions/{engine}/v<safe>/producers/dynamic_invariant_miner.py` (predicate-inference logic); the seven templates live in the per-version module or `_base.py` depending on engine |
+| Drift between dispatcher LANDMARKS and live library | `scripts/_drift.py --engine {engine} --producer {invariants,schemas}` reports `landmarks_missing` (removed) and `landmarks_added` (new surface not yet declared). Maintainer flow: patch LANDMARKS in the per-version producer module |
 
 The error classes (`MinerError`, `MinerVersionMismatchError`,
 `MinerLandmarkMissingError`) live in `scripts/engine_producers/_base.py`
@@ -140,7 +147,7 @@ diverged:
 
 Dynamic mining errs toward recall. The validation-CI gate is the
 filter, not the miner. If a noisy candidate cluster appears, look at
-`scripts/engine_producers/{engine}_dynamic_miner.py` for the cluster
+`engine_versions/{engine}/v<safe>/producers/dynamic_invariant_miner.py` for the cluster
 definition and tighten the value sets so the Cartesian product is
 smaller and more pointed.
 

--- a/docs/explanation/architecture/ci-architecture.md
+++ b/docs/explanation/architecture/ci-architecture.md
@@ -325,7 +325,7 @@ Actions tab (with their reusable's `name:` as the workflow name).
 
 A future engine (e.g. SGLang) is absorbed in three places:
 
-1. New SSOT: `engine_versions/sglang.yaml`.
+1. New SSOT: `engine_versions/sglang/current.yaml`.
 2. Either upstream image (e.g. `lmsysorg/sglang:<VER>` on Docker Hub) or
    first-party Dockerfile + extension to `build-transformers` job.
 3. Append `sglang` to the `invariants_others_cells` and

--- a/docs/explanation/architecture/engine-extensibility.md
+++ b/docs/explanation/architecture/engine-extensibility.md
@@ -114,8 +114,11 @@ generate them on the first engine-pipeline PR. See
 
 `src/llenergymeasure/engines/<engine>/schema.discovered.json` is produced by
 the schema introspector running inside the engine container. Same policy as
-invariants - generated, not authored. The introspectors live in
-`scripts/engine_producers/`.
+invariants - generated, not authored. Introspectors and miners are per-version
+vendored at `engine_versions/<engine>/v<safe>/producers/`; `scripts/engine_producers/<engine>_*.py`
+modules are thin dispatcher shims that resolve to the correct vendored module
+for the SSOT-pinned library version. When the SSOT bumps, the dispatcher
+raises `ModuleNotFoundError` naming the file path to create.
 
 ## What is automated
 
@@ -134,6 +137,14 @@ Once items 1-4 exist and a PR is opened, the engine-pipeline CI surface
   branch so they are never stale when a PR merges.
 - **Image build and cache** - builds the engine image and pushes a cached
   layer to GHCR so subsequent runs start from a warm cache.
+- **Drift detection** - `scripts/_drift.py` runs as the cell's probe step and
+  produces a `DriftReport` JSON. It catches three failure modes: declared
+  `LANDMARKS` missing from the live library (`landmarks_missing`); live surface
+  not yet in `LANDMARKS` (`landmarks_added`); per-version `EXCLUSIONS.yaml`
+  entries with expired suppressions. The `--gate {none,delta,absolute}` option
+  selects how strictly added surface gates the cell. Gate activation in cells
+  is bootstrapped against the `added_baseline` recorded in `current.yaml` on
+  green-main writeback.
 
 The weekly schedule trigger in `engine-pipeline.yml` also runs a no-cache drift
 detection rebuild every Monday, so version drift is caught even without a PR.
@@ -162,7 +173,7 @@ delivery checklist is:
    `run_warmup_prompt` to use kernel-only warmup.
 2. `docker/Dockerfile.sglang` - base image from SGLang's official release
    container; version pinned via `ARG SGLANG_VERSION`; sources version from
-   `engine_versions/sglang.yaml`.
+   `engine_versions/sglang/current.yaml`.
 3. `Engine.SGLANG = "sglang"` in `ssot.py` and a `SGLangConfig` Pydantic
    model in `engine_configs.py`.
 

--- a/docs/explanation/architecture/engine-introspection-pipelines.md
+++ b/docs/explanation/architecture/engine-introspection-pipelines.md
@@ -87,9 +87,14 @@ flowchart TD
     inspect --> limitations --> envelope
 ```
 
-The introspector is engine-specific: each engine has a module under
-`scripts/engine_producers/` that knows how to walk its own config
-surface. The shared envelope and helpers live in
+The introspector is engine-specific and per-version vendored. The real
+implementation lives at
+`engine_versions/<engine>/v<safe>/producers/schema_introspector.py`,
+where `<safe>` is the SSOT-pinned library version (e.g. `v4_57_3`).
+`scripts/engine_producers/<engine>_schema_introspector.py` is a thin
+dispatcher shim (built via `_stub_factory.make_schema_stub`) that
+resolves to the per-version module at attribute-access time via PEP 562
+`__getattr__`. The shared envelope and helpers live in
 `scripts/engine_producers/_common.py`.
 
 ### Determinism
@@ -447,8 +452,9 @@ SSOT and validate it at import time. This is a structural contract,
 not a guideline.
 
 ```python
-# Every *_miner.py must resolve its envelope from the engine's SSOT:
-from scripts.engine_producers._ssot import load_miner_pin
+# Every per-version producer (under engine_versions/{engine}/v<safe>/producers/)
+# must resolve its envelope from the engine's SSOT:
+from scripts.engine_producers._current import load_miner_pin
 
 _envelope = load_miner_pin("transformers", "static")  # SpecifierSet
 

--- a/docs/explanation/architecture/pipeline-architecture.md
+++ b/docs/explanation/architecture/pipeline-architecture.md
@@ -53,7 +53,7 @@ The diagram captures the high-level flow; per-step detail follows below.
 ```mermaid
 flowchart TD
     renovate[Renovate scans upstream releases<br/>on configured schedule]
-    bump[Custom regex manager bumps SSOT<br/>engine_versions/engine_versions/&lt;engine&gt;.yamllt;engineengine_versions/&lt;engine&gt;.yamlgt;/current.yaml + Dockerfile ARG]
+    bump[Custom regex manager bumps SSOT<br/>engine_versions/&lt;engine&gt;/current.yaml + Dockerfile ARG]
     pr[Renovate PR opens<br/>fix&#40;deps&#41;: bump vllm to 0.10.2]
 
     renovate --> bump --> pr
@@ -198,7 +198,7 @@ flowchart TD
     label --> needfollowup[Route 1 or 2 must follow before merge]
 ```
 
-**Route 1 - Patch producer code.** The dev edits `scripts/engine_producers/{engine}_*_miner.py` or `scripts/engine_producers/{engine}_introspector.py` to fix the broken landmark (e.g. follow an upstream rename). Pushing the commit re-runs the workflow; the probe re-runs; if it passes, downstream stages proceed.
+**Route 1 - Patch producer code.** The dev edits `engine_versions/{engine}/v<safe>/producers/{static_invariant_miner,dynamic_invariant_miner,schema_introspector}.py` to fix the broken landmark (e.g. follow an upstream rename). Pushing the commit re-runs the workflow; the probe re-runs; if it passes, downstream stages proceed.
 
 **Route 2 - Approve reuse via slash command.** The dev posts `@llem-ci-bot /approve-reuse <engine> <producer>` as a PR comment. Producer is one of `{invariants, schemas}` (per-producer granularity - vllm invariants might be reusable while vllm schemas are not). `approve-reuse-bot.yml` is the `issue_comment: created` listener; it validates the dev's approval rights, updates `engine_versions/{engine}/current.yaml` `miner_pins.{producer}` to widen the `SpecifierSet` to include the bumped version, and commits the SSOT change via the llem-ci-bot App token (cascades; `GITHUB_TOKEN` would not). The probe re-runs against the widened range; the verdict flips to PASS and downstream stages proceed.
 


### PR DESCRIPTION
## Summary

Hygiene pass aligning `docs/` with the post-restructure engine architecture:

- Engine producer modules are now per-version vendored under `engine_versions/<engine>/v<safe>/producers/`; `scripts/engine_producers/<engine>_*.py` are thin dispatcher shims.
- `_ssot.py` was renamed to `_current.py`; `load_ssot` → `load_current`; `engine_versions/<engine>.yaml` → `engine_versions/<engine>/current.yaml`.
- `scripts/_probe.py` was replaced by `scripts/_drift.py` (drift tool with `--gate {none,delta,absolute}` and `EXCLUSIONS.yaml`).

This PR is path-rename + dispatcher-callout work. The full extending-miners.md rewrite ("vendor a new version" as the first-class workflow) is out of scope and deferred.

## Files touched

| File | Change |
|---|---|
| `engine-extensibility.md` | Vendored producers callout; SGLang SSOT path; drift-tool bullet under automation |
| `engine-introspection-pipelines.md` | Per-version introspector path; load_miner_pin import |
| `miner-pipeline.md` | Directory tree update; investigation table; drift-tool row |
| `extending-miners.md` | New "vendoring model" section near top; per-version producer paths; "see also" updates |
| `pipeline-architecture.md` | Mermaid label fix (corrupted by an earlier multi-step rename); route-1 patch step path |
| `ci-architecture.md` | SGLang SSOT path |

## Test plan

- [ ] CI green
- [ ] No grep hits remaining for `_ssot.py`, `{engine}_static_miner.py`, `{engine}_dynamic_miner.py`, `{engine}_introspector.py` patterns in `docs/`
- [ ] Mermaid label in `pipeline-architecture.md` renders correctly