### PR TITLE
fix(workflows): schemas cell stops writing engine current.yaml

### DIFF
--- a/.github/workflows/_engine-schemas-cell.yml
+++ b/.github/workflows/_engine-schemas-cell.yml
@@ -251,8 +251,9 @@ jobs:
           echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
           exit "$DRIFT_RC"
 
-      # last_probe is the invariants cell's: schemas' landmarks_added is empty
-      # and its fingerprint tuple differs. Two writers race the aggregator rsync.
+      # The canonical last_probe writer is in _engine-invariants-cell.yml.
+      # Removed from this cell because schemas' landmarks_added is unconditionally
+      # empty and its fingerprint tuple differs - two writers raced the aggregator rsync.
 
       - name: Save current schema for diffing
         if: steps.probe.outputs.verdict == 'pass'

--- a/.github/workflows/_engine-schemas-cell.yml
+++ b/.github/workflows/_engine-schemas-cell.yml
@@ -251,36 +251,8 @@ jobs:
           echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
           exit "$DRIFT_RC"
 
-      - name: Update last_probe in current.yaml
-        if: always() && steps.probe.outcome == 'success'
-        env:
-          IMAGE: ${{ steps.version.outputs.image }}
-          ENGINE: ${{ inputs.engine }}
-          RUNNER: ${{ inputs.runner }}
-        run: |
-          DOCKER_FLAGS=()
-          if [[ "$RUNNER" == "self-hosted" ]]; then
-            DOCKER_FLAGS+=(
-              --user "$(id -u):$(id -g)"
-              -v /tmp/llem-passwd-synth:/etc/passwd:ro
-              -v /tmp/llem-group-synth:/etc/group:ro
-              -e LD_LIBRARY_PATH
-            )
-          fi
-          ENTRYPOINT_FLAG=(--entrypoint bash)
-          CMD_PREFIX=()
-          if [[ "$ENGINE" == "tensorrt" ]]; then
-            ENTRYPOINT_FLAG=(--entrypoint /opt/nvidia/nvidia_entrypoint.sh)
-            CMD_PREFIX=(bash)
-          fi
-          docker run --rm "${DOCKER_FLAGS[@]}" \
-            -v "${GITHUB_WORKSPACE}:/repo" \
-            -v /tmp/llem-probe-out:/llem-probe-out:ro \
-            -w /repo \
-            -e PYTHONPATH \
-            "${ENTRYPOINT_FLAG[@]}" \
-            "$IMAGE" \
-            "${CMD_PREFIX[@]}" -c "python3 scripts/update_last_probe.py --engine ${ENGINE} < /llem-probe-out/probe-${ENGINE}.json"
+      # last_probe is the invariants cell's: schemas' landmarks_added is empty
+      # and its fingerprint tuple differs. Two writers race the aggregator rsync.
 
       - name: Save current schema for diffing
         if: steps.probe.outputs.verdict == 'pass'
@@ -473,7 +445,6 @@ jobs:
           path: |
             ${{ env.ENGINES_DIR }}/${{ inputs.engine }}/schema.discovered.json
             engine_versions/${{ inputs.engine }}/${{ steps.version.outputs.safe_version }}/outputs/schema.discovered.json
-            engine_versions/${{ inputs.engine }}/current.yaml
             docs/user/generated/curation-${{ inputs.engine }}.md
             docs/user/generated/schema-${{ inputs.engine }}.md
           # See invariants cell for rationale (archive path gated on engine

--- a/src/llenergymeasure/engines/tensorrt/schema.discovered.json
+++ b/src/llenergymeasure/engines/tensorrt/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:tensorrt-0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T00:45:13+02:00",
+  "discovered_at": "2026-05-14T13:25:05+02:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-14T00:45:13+02:00",
+  "discovered_at": "2026-05-14T13:25:05+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T00:45:13+02:00",
+  "discovered_at": "2026-05-14T13:25:05+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {


### PR DESCRIPTION
## Summary

The schemas cell was racing the invariants cell over `engine_versions/<engine>/current.yaml`. Both cells wrote the file (via `scripts/update_last_probe.py`) and both uploaded it as a writeback artefact. The aggregator's `actions/download-artifact@v4` with `merge-multiple: true` does not guarantee ordering across artefacts that contain colliding paths, so the schemas-vs-invariants rsync was a coin-flip per pipeline run.

Symptom traced through PR #644's writeback history:
| Bot commit | Cells that ran | Race outcome |
|---|---|---|
| `a2ac50f3` | both | populated baseline won |
| `1200a459` | both | empty baseline won (race flipped) |
| `c094f62a` | schemas only | empty baseline overwrote |
| `b261e005` | invariants only | populated baseline trivially won |

## Why the schemas cell had no business writing `last_probe`

`landmarks_added` is unconditionally empty for `producer == "schemas"` (`scripts/_drift.py:922-931` only walks live discovery for invariants), and the fingerprint is computed over a different `LANDMARKS` tuple. Owning `last_probe` is the invariants cell's job.

## Changes

- Remove the `Update last_probe in current.yaml` docker-run step from `_engine-schemas-cell.yml`.
- Remove `engine_versions/<engine>/current.yaml` from the schemas cell's `upload-artifact` path list, so the aggregator no longer sees a stale checkout copy from the schemas cell.

## Test plan

- [ ] CI green on this PR (engine-pipeline + cells)
- [ ] After merge: workflow_dispatch on main, verify `engine_versions/<engine>/current.yaml:last_probe.added_baseline` is populated and deterministic across consecutive runs
- [ ] Unblocks #24 (activate --gate delta in cell workflows)

Root cause investigation: subagent report appended to session log; full transcript shows 6 byte-identical drift outputs across varied PYTHONHASHSEED values inside the transformers container, ruling out drift-tool non-determinism. Race is purely in the aggregator merge.