### PR TITLE
feat(drift): surface re-export aliases as informational signal

### DIFF
--- a/docs/explanation/architecture/engine-extensibility.md
+++ b/docs/explanation/architecture/engine-extensibility.md
@@ -142,8 +142,18 @@ Once items 1-4 exist and a PR is opened, the engine-pipeline CI surface
   `LANDMARKS` symbols that no longer resolve under the live library
   (`landmarks_missing`). A non-empty `landmarks_missing` flips the verdict
   to `fail` and blocks the downstream mining step. Diagnostic fields
-  (`fingerprint`, `fingerprint_drift`, `version_inside_envelope`) ride along
-  on every report for human attention but never affect the verdict.
+  (`fingerprint`, `fingerprint_drift`, `version_inside_envelope`,
+  `landmarks_aliased`) ride along on every report for human attention but
+  never affect the verdict.
+
+  `landmarks_aliased` surfaces landmarks whose declared path resolves through
+  a package re-export shim - i.e. the upstream library moved the symbol's
+  canonical home (e.g. `vllm.config.CacheConfig` -> `vllm.config.cache.CacheConfig`)
+  but kept the old import path working via `from .cache import CacheConfig` in
+  `vllm/config/__init__.py`. The landmark still resolves, so verdict stays
+  `pass`, but the signal is a maintainer hint that the next producer cut
+  should declare against the canonical path (in case upstream drops the
+  re-export in a future major version).
 
 The weekly schedule trigger in `engine-pipeline.yml` also runs a no-cache drift
 detection rebuild every Monday, so version drift is caught even without a PR.

--- a/scripts/_drift.py
+++ b/scripts/_drift.py
@@ -15,6 +15,15 @@ every report and are informational - they NEVER affect verdict:
                                   tuples; shifts on real refactors.
     ``fingerprint_drift``       : landmarks whose coordinates moved since
                                   the cached fingerprint was written.
+    ``landmarks_aliased``       : landmarks whose declared path resolves
+                                  through a package re-export rather than
+                                  at the canonical home (e.g. upstream
+                                  refactored a flat module into a subpackage
+                                  and kept the old import paths working
+                                  via ``from X.Y import Z`` in ``__init__``).
+                                  A maintainer-facing hint that the canonical
+                                  module path has moved; future producer cuts
+                                  should declare against the canonical path.
 
 Producer-module discovery uses a per-engine convention table (see
 ``_PRODUCER_MODULES``); each producer module exposes a
@@ -118,6 +127,7 @@ class DriftReport:
     fingerprint: str
     fingerprint_drift: list[str] = field(default_factory=list)
     landmarks_missing: list[str] = field(default_factory=list)
+    landmarks_aliased: list[str] = field(default_factory=list)
     version_inside_envelope: bool = True
 
 
@@ -130,15 +140,24 @@ class DriftReport:
 class _ResolvedLandmark:
     """One successfully-resolved landmark and its source coordinates.
 
-    The fingerprint is a sorted hash of these tuples; ``filename`` +
-    ``lineno`` are advisory but track real refactors (a method moving
-    from line 142 to 187 across a patch release).
+    The fingerprint is a sorted hash of (landmark, qualname, filename, lineno);
+    ``filename`` + ``lineno`` are advisory but track real refactors (a method
+    moving from line 142 to 187 across a patch release).
+
+    ``declared_module`` is the longest importable prefix of ``landmark``
+    (i.e. what we imported to start the getattr chain). ``resolved_module``
+    is ``obj.__module__`` if defined, or ``None`` for objects without one
+    (modules themselves, some C extension types). When the two differ, the
+    landmark resolved through a package re-export shim and joins
+    ``landmarks_aliased`` on the report.
     """
 
     landmark: str
     qualname: str
     filename: str | None
     lineno: int | None
+    declared_module: str
+    resolved_module: str | None
 
 
 def _resolve_landmark(landmark: str) -> _ResolvedLandmark:
@@ -164,6 +183,7 @@ def _resolve_landmark(landmark: str) -> _ResolvedLandmark:
     if module is None:
         raise ImportError(f"No importable prefix in landmark {landmark!r}")
 
+    declared_module = ".".join(parts[:module_idx])
     obj: object = module
     for attr in parts[module_idx:]:
         obj = getattr(obj, attr)
@@ -178,11 +198,14 @@ def _resolve_landmark(landmark: str) -> _ResolvedLandmark:
         lineno = None
 
     qualname = getattr(obj, "__qualname__", None) or getattr(obj, "__name__", landmark)
+    resolved_module = getattr(obj, "__module__", None)
     return _ResolvedLandmark(
         landmark=landmark,
         qualname=str(qualname),
         filename=filename,
         lineno=lineno,
+        declared_module=declared_module,
+        resolved_module=str(resolved_module) if resolved_module is not None else None,
     )
 
 
@@ -372,6 +395,12 @@ def run(*, engine: str, producer: ProducerKind) -> DriftReport:
         # landmarks, not the cause.
         drift = [r.landmark for r in resolved]
 
+    aliased = [
+        r.landmark
+        for r in resolved
+        if r.resolved_module is not None and r.resolved_module != r.declared_module
+    ]
+
     verdict: Literal["pass", "fail"] = "fail" if missing else "pass"
 
     return DriftReport(
@@ -383,6 +412,7 @@ def run(*, engine: str, producer: ProducerKind) -> DriftReport:
         fingerprint=fingerprint,
         fingerprint_drift=drift,
         landmarks_missing=missing,
+        landmarks_aliased=aliased,
         version_inside_envelope=_check_envelope(current, producer, current_version),
     )
 

--- a/scripts/_drift.py
+++ b/scripts/_drift.py
@@ -114,9 +114,9 @@ class DriftReport:
 
     ``verdict`` is ``fail`` iff ``landmarks_missing`` is non-empty.
 
-    Diagnostic fields (``version_inside_envelope``, ``fingerprint_drift``)
-    ride along on every report and steer human attention on pass-but-
-    suspicious bumps. They NEVER affect verdict.
+    Diagnostic fields (``version_inside_envelope``, ``fingerprint_drift``,
+    ``landmarks_aliased``) ride along on every report and steer human
+    attention on pass-but-suspicious bumps. They NEVER affect verdict.
     """
 
     engine: str
@@ -144,20 +144,18 @@ class _ResolvedLandmark:
     ``filename`` + ``lineno`` are advisory but track real refactors (a method
     moving from line 142 to 187 across a patch release).
 
-    ``declared_module`` is the longest importable prefix of ``landmark``
-    (i.e. what we imported to start the getattr chain). ``resolved_module``
-    is ``obj.__module__`` if defined, or ``None`` for objects without one
-    (modules themselves, some C extension types). When the two differ, the
-    landmark resolved through a package re-export shim and joins
-    ``landmarks_aliased`` on the report.
+    ``aliased`` is True when ``obj.__module__`` differs from the longest
+    importable prefix of ``landmark`` - i.e. the landmark resolved through a
+    package re-export shim (the upstream library moved the symbol's canonical
+    home but kept the old import path working). Objects without ``__module__``
+    (modules themselves, certain C extension types) are not aliased.
     """
 
     landmark: str
     qualname: str
     filename: str | None
     lineno: int | None
-    declared_module: str
-    resolved_module: str | None
+    aliased: bool
 
 
 def _resolve_landmark(landmark: str) -> _ResolvedLandmark:
@@ -199,13 +197,13 @@ def _resolve_landmark(landmark: str) -> _ResolvedLandmark:
 
     qualname = getattr(obj, "__qualname__", None) or getattr(obj, "__name__", landmark)
     resolved_module = getattr(obj, "__module__", None)
+    aliased = resolved_module is not None and resolved_module != declared_module
     return _ResolvedLandmark(
         landmark=landmark,
         qualname=str(qualname),
         filename=filename,
         lineno=lineno,
-        declared_module=declared_module,
-        resolved_module=str(resolved_module) if resolved_module is not None else None,
+        aliased=aliased,
     )
 
 
@@ -395,11 +393,7 @@ def run(*, engine: str, producer: ProducerKind) -> DriftReport:
         # landmarks, not the cause.
         drift = [r.landmark for r in resolved]
 
-    aliased = [
-        r.landmark
-        for r in resolved
-        if r.resolved_module is not None and r.resolved_module != r.declared_module
-    ]
+    aliased = [r.landmark for r in resolved if r.aliased]
 
     verdict: Literal["pass", "fail"] = "fail" if missing else "pass"
 

--- a/tests/unit/scripts/test_drift.py
+++ b/tests/unit/scripts/test_drift.py
@@ -394,19 +394,26 @@ def _install_class_module(
     return cls
 
 
-def test_resolved_landmark_carries_resolved_module(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``_resolve_landmark`` captures both declared and resolved module paths."""
+def test_resolved_landmark_carries_aliased_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_resolve_landmark`` sets ``aliased`` from declared vs resolved module comparison."""
     _install_class_module(
         monkeypatch,
-        canonical_module="t2_canonical_test_pkg",
+        canonical_module="t2_resolver_canonical_pkg",
         alias_parent=None,
         class_name="Bar",
     )
+    _install_class_module(
+        monkeypatch,
+        canonical_module="t2_resolver_alias_pkg.canonical",
+        alias_parent="t2_resolver_alias_pkg",
+        class_name="Baz",
+    )
 
-    resolved = _drift._resolve_landmark("t2_canonical_test_pkg.Bar")
+    canonical = _drift._resolve_landmark("t2_resolver_canonical_pkg.Bar")
+    aliased = _drift._resolve_landmark("t2_resolver_alias_pkg.Baz")
 
-    assert resolved.declared_module == "t2_canonical_test_pkg"
-    assert resolved.resolved_module == "t2_canonical_test_pkg"
+    assert canonical.aliased is False
+    assert aliased.aliased is True
 
 
 def test_aliased_landmark_surfaces_in_report(

--- a/tests/unit/scripts/test_drift.py
+++ b/tests/unit/scripts/test_drift.py
@@ -359,3 +359,121 @@ def test_drift_unsupported_engine_producer_pair_returns_infra_error(
     monkeypatch.setattr(_drift, "_PRODUCER_MODULES", {})  # empty map
     rc = _drift.main(["--engine", "transformers", "--producer", "invariants"])
     assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# T2 alias detection
+# ---------------------------------------------------------------------------
+
+
+def _install_class_module(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    canonical_module: str,
+    alias_parent: str | None,
+    class_name: str = "Foo",
+) -> type:
+    """Install a synthetic class in ``canonical_module`` with optional re-export.
+
+    When ``alias_parent`` is set, also installs a parent-level module that
+    re-exports the class (sets ``alias_parent.<class_name> = cls``). The
+    class's ``__module__`` always points at the canonical module, so an
+    alias-path resolution will surface as aliased.
+    """
+    canonical = types.ModuleType(canonical_module)
+    cls = type(class_name, (), {})
+    cls.__module__ = canonical_module
+    setattr(canonical, class_name, cls)
+    monkeypatch.setitem(sys.modules, canonical_module, canonical)
+
+    if alias_parent is not None:
+        alias = types.ModuleType(alias_parent)
+        setattr(alias, class_name, cls)  # re-export
+        monkeypatch.setitem(sys.modules, alias_parent, alias)
+
+    return cls
+
+
+def test_resolved_landmark_carries_resolved_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_resolve_landmark`` captures both declared and resolved module paths."""
+    _install_class_module(
+        monkeypatch,
+        canonical_module="t2_canonical_test_pkg",
+        alias_parent=None,
+        class_name="Bar",
+    )
+
+    resolved = _drift._resolve_landmark("t2_canonical_test_pkg.Bar")
+
+    assert resolved.declared_module == "t2_canonical_test_pkg"
+    assert resolved.resolved_module == "t2_canonical_test_pkg"
+
+
+def test_aliased_landmark_surfaces_in_report(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A landmark whose declared path goes through a re-export surfaces in ``landmarks_aliased``."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_class_module(
+        monkeypatch,
+        canonical_module="t2_alias_test_pkg.canonical",
+        alias_parent="t2_alias_test_pkg",
+        class_name="Foo",
+    )
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("t2_alias_test_pkg.Foo",),  # aliased: parent re-exports from .canonical
+    )
+
+    report = _drift.run(engine="transformers", producer="invariants")
+
+    assert report.verdict == "pass"
+    assert report.landmarks_aliased == ["t2_alias_test_pkg.Foo"]
+    assert report.landmarks_missing == []
+
+
+def test_canonical_landmark_does_not_alias(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A landmark resolving at its canonical home is NOT flagged as aliased."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_class_module(
+        monkeypatch,
+        canonical_module="t2_canonical_landmark_pkg",
+        alias_parent=None,
+        class_name="Foo",
+    )
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("t2_canonical_landmark_pkg.Foo",),
+    )
+
+    report = _drift.run(engine="transformers", producer="invariants")
+
+    assert report.verdict == "pass"
+    assert report.landmarks_aliased == []
+
+
+def test_aliased_never_affects_verdict(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``landmarks_aliased`` is informational; verdict stays ``pass`` while ``landmarks_missing`` is empty."""
+    _redirect_compat_dir(monkeypatch, tmp_path)
+    _install_class_module(
+        monkeypatch,
+        canonical_module="t2_verdict_pkg.canonical",
+        alias_parent="t2_verdict_pkg",
+        class_name="Foo",
+    )
+    _install_synthetic_producer(
+        monkeypatch,
+        engine="transformers",
+        producer="invariants",
+        landmarks=("t2_verdict_pkg.Foo",),
+    )
+
+    report = _drift.run(engine="transformers", producer="invariants")
+
+    assert report.verdict == "pass"  # not flipped by alias
+    assert report.landmarks_aliased  # but informational signal present
+    assert report.landmarks_missing == []


### PR DESCRIPTION
## Summary

Adds a `landmarks_aliased: list[str]` field to `DriftReport` that captures landmarks whose declared path resolves through an upstream package re-export shim. Informational signal only — never affects verdict.

## What's an aliased landmark?

When the resolver hits `landmark = "vllm.config.CacheConfig"`:

1. Finds the longest importable prefix (`vllm.config` is importable).
2. Walks attribute access from there (`getattr(vllm.config, "CacheConfig")` returns the class).
3. Resolves successfully — the landmark is reachable.

But the class's canonical home is `vllm.config.cache.CacheConfig`. It only appears in `vllm.config` because `vllm/config/__init__.py` does `from .cache import CacheConfig`. The two names refer to the same class object (identity test confirms `is True`), but `CacheConfig.__module__ == "vllm.config.cache"`.

Empirical context: the PoC validity check (`probe-validity-check-2026-05-14.md`) measured this exactly. vllm 0.16 refactored `vllm/config.py` from a flat module into a per-concern subpackage and kept old import paths working via package re-exports. 13 of the 23 producer landmarks that a naive LANDMARKS-tuple diff would call "removed" actually still resolve through these aliases.

## How it surfaces

`_resolve_landmark` now captures two new fields on `_ResolvedLandmark`:

- `declared_module: str` — the longest importable prefix of the landmark (what `importlib.import_module` succeeded on).
- `resolved_module: str | None` — `obj.__module__` after the getattr chain, or `None` for objects without one (modules themselves, some C extension types).

In `run()`, aliased landmarks are computed as those where `resolved_module is not None and resolved_module != declared_module`, then surfaced on the report.

## Why it's informational only

Aliases are usually intentional and stable. Failing CI on them would generate noise on every routine refactor upstream ships. The signal earns its keep two ways:

- **Stability warning**: if upstream eventually drops the re-export in a major version, every landmark in the aliased list flips to `landmarks_missing` simultaneously. Knowing the alias surface ahead of time lets the maintainer pre-empt the breakage at the next producer cut.
- **Canonical-path hint**: when cutting a new producer, the aliased list tells the maintainer "your declared paths still work but they're going through aliases; update `_CLASS_TARGETS` to use the canonical path."

## Diff stats

- `scripts/_drift.py`: +36 LoC (new field + capture + compute)
- `tests/unit/scripts/test_drift.py`: +122 LoC (4 new tests + synthetic-fixture helper)
- `docs/explanation/architecture/engine-extensibility.md`: +9 LoC (paragraph explaining T2)

Net: +163 / -5.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_drift.py -v` → 15 passed locally (11 existing + 4 new T2)
- [x] `uv run pytest tests/unit/scripts/ -q` → 314 passed locally
- [x] `python3 -m scripts._drift --engine transformers --producer invariants --no-write-cache` → JSON now includes `landmarks_aliased: []`
- [ ] CI green on this PR
- [ ] Inside an engine container where the engine is installed, verify the field populates correctly (test running in CI handles this when the cell workflow runs)

## Doc audit outcome

`docs/explanation/architecture/engine-extensibility.md` paragraph added in the same PR explaining what an aliased landmark is and why it's informational. No other docs reference the drift-detection bullet today.