### PR TITLE
refactor(dispatcher): auto-fallback to prior vendored producer

### DIFF
--- a/docs/explanation/architecture/engine-introspection-pipelines.md
+++ b/docs/explanation/architecture/engine-introspection-pipelines.md
@@ -66,6 +66,66 @@ engine libraries (`import transformers`, `import vllm`, `import
 tensorrt_llm` all fail by design), so every engine's introspection must
 run in the matching container.
 
+## Per-version dispatcher
+
+Producer code (the static miner, dynamic miner, and schema introspector
+for each engine) is vendored per library version under
+`engine_versions/<engine>/v<safe>/producers/`, where `<safe>` is the
+identifier-safe form of the library version (`0.7.3` -> `v0_7_3`). Each
+vendored directory contains a frozen snapshot of the producer authored
+against that specific library API: LANDMARKS, AST targets, introspector
+class targets.
+
+`scripts/engine_producers/<engine>_<producer>.py` is a thin dispatcher
+shim (built via `_stub_factory.make_*_stub`) that resolves to the
+per-version archive at attribute-access time via PEP 562 `__getattr__`.
+The shim has no logic of its own; the version-aware resolution lives in
+`engine_versions/_dispatcher.py:load_producer`.
+
+### Dispatch with auto-fallback
+
+When the SSOT's `library.current_version` is bumped (typically by
+Renovate), the dispatcher first tries the exact-match archive at
+`engine_versions/<engine>/v<safe(current_version)>/producers/`. If that
+archive is not vendored yet, the dispatcher falls back to the most-recent
+prior vendored version, logs the choice to stderr, and the probe
+(`scripts._drift`) gates on landmark resolution under the dispatched
+producer.
+
+This makes patch-version bumps zero-touch when LANDMARKS still resolve
+under the new library: no per-version vendor PR needed for refactor-free
+upstream releases. A maintainer only vendors a fresh `vN/producers/`
+directory when the probe fails (because landmarks moved between
+versions).
+
+```mermaid
+flowchart TD
+    bump[Renovate bumps<br/>library.current_version: N-1 -> N]
+    exact{Exact-match archive at<br/>v&lt;safe&#40;N&#41;&gt;/producers/?}
+    use_exact[Use exact-match producer]
+    scan[Scan engine_versions/&lt;engine&gt;/<br/>for sibling vN_NN_NN dirs]
+    filter[Filter to dirs<br/>where version &lt;= N<br/>AND producers/&lt;producer&gt;.py exists]
+    any{Any candidates?}
+    pick[Pick highest version,<br/>log fallback to stderr]
+    raise[Raise ModuleNotFoundError<br/>with create-this-file path]
+    probe[Run probe against<br/>dispatched producer's LANDMARKS]
+    pass{Probe verdict?}
+    mine[Mine + validate proceeds]
+    fail[Red CI:<br/>maintainer patches LANDMARKS<br/>or vendors vN/producers/]
+
+    bump --> exact
+    exact -->|yes| use_exact --> probe
+    exact -->|no| scan --> filter --> any
+    any -->|yes| pick --> probe
+    any -->|no| raise
+    probe --> pass
+    pass -->|pass| mine
+    pass -->|fail| fail
+```
+
+The probe is the runtime gate: filesystem dispatch decides which code
+runs; probe decides whether that code is valid for the live library.
+
 ## Schema discovery in depth
 
 Schema discovery introspects the engine's native Python API surface to

--- a/engine_versions/_dispatcher.py
+++ b/engine_versions/_dispatcher.py
@@ -6,7 +6,7 @@ and returns it. Producer modules in ``scripts/engine_producers/`` use this
 dispatcher (via PEP 562 ``__getattr__`` on the module level) to delegate
 ``LANDMARKS`` exports to the version-pinned archive.
 
-Producer kinds match the current.yaml ``miner_pins`` keys:
+Producer kinds match the producer-archive subpackage names:
 
 - ``static_invariant_miner``: validation-invariant miners (probe contract: ``invariants``)
 - ``schema_introspector``: schema introspectors (probe contract: ``schemas``)
@@ -17,19 +17,97 @@ The version string is the dotted form from
 ``"0.7.3"``); the dispatcher converts it to a Python-identifier-safe form
 (``v0_7_3``) via :func:`scripts.engine_producers._current.safe_version`.
 
-No fallback. If the requested subpackage does not exist, the import
-raises ``ModuleNotFoundError`` and the caller (or the probe) surfaces it
-loud. The "no fallback" rule is load-bearing - it makes "missing
-versioned producer" a visible CI failure, not silent stale-data drift.
+Auto-fallback semantics
+-----------------------
+
+When the exact-match subpackage does not exist
+(``engine_versions/<engine>/v<safe(current_version)>/producers/``), the
+dispatcher scans sibling ``vN`` directories, picks the highest version
+``<= target`` that contains a ``producers/<producer>.py`` file, and imports
+it. A stderr log line names the fallback so the cell's run log surfaces
+which producer was used.
+
+This makes patch-version bumps zero-touch when LANDMARKS still resolve
+under the new library: Renovate bumps ``current_version`` to ``0.7.4``, the
+dispatcher falls back to ``v0_7_3/producers/``, and the probe (run by
+``scripts._drift``) verifies the LANDMARKS still resolve under the live
+``vllm==0.7.4``. The probe is the runtime gate; if a fallback producer's
+landmarks no longer resolve at the new library version, the probe fails
+red and the maintainer either patches LANDMARKS in the fallback producer
+or vendors a fresh ``vN/producers/`` directory.
+
+When no vendored archive exists at or below the target, the dispatcher
+raises ``ModuleNotFoundError`` with the path the maintainer needs to create.
 """
 
 from __future__ import annotations
 
 import importlib
+import re
+import sys
+from pathlib import Path
 from types import ModuleType
 from typing import Literal
 
+from packaging.version import InvalidVersion, Version
+
 ProducerKind = Literal["static_invariant_miner", "dynamic_invariant_miner", "schema_introspector"]
+
+_SAFE_VERSION_RE = re.compile(r"^v[0-9_a-zA-Z]+$")
+
+
+def _safe_to_version(safe: str) -> Version | None:
+    """Inverse of ``safe_version``: ``"v0_7_3"`` -> ``Version("0.7.3")``.
+
+    Returns ``None`` for paths that don't match the safe-version shape
+    (e.g. ``__pycache__``, ``outputs``) and for inputs whose recovered
+    dotted form isn't a valid PEP 440 version.
+    """
+    if not _SAFE_VERSION_RE.match(safe):
+        return None
+    try:
+        return Version(safe[1:].replace("_", "."))
+    except InvalidVersion:
+        return None
+
+
+def _find_fallback_safe_version(
+    *, engine_root: Path, target_version: str, producer: ProducerKind
+) -> str | None:
+    """Return ``safe`` of highest vendored archive at or below ``target_version``.
+
+    Scans ``engine_root`` for ``v[0-9_a-zA-Z]+`` directories, parses each via
+    :func:`_safe_to_version`, filters to those ``<= target`` AND that contain a
+    ``producers/<producer>.py`` file, returns the highest match. Returns
+    ``None`` when no candidate exists, when ``engine_root`` is not a directory,
+    or when ``target_version`` does not parse as PEP 440.
+
+    Engine-root path is taken as a parameter so the dispatch logic is unit-
+    testable against tmp directories. :func:`load_producer` computes the
+    real path from this module's location.
+    """
+    try:
+        target = Version(target_version)
+    except InvalidVersion:
+        return None
+    if not engine_root.is_dir():
+        return None
+
+    producer_file = f"{producer}.py"
+    candidates: list[tuple[Version, str]] = []
+    for child in engine_root.iterdir():
+        if not child.is_dir():
+            continue
+        version = _safe_to_version(child.name)
+        if version is None or version > target:
+            continue
+        if not (child / "producers" / producer_file).is_file():
+            continue
+        candidates.append((version, child.name))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda pair: pair[0])
+    return candidates[-1][1]
 
 
 def load_producer(*, engine: str, version: str, producer: ProducerKind) -> ModuleType:
@@ -42,15 +120,17 @@ def load_producer(*, engine: str, version: str, producer: ProducerKind) -> Modul
             ``"schema_introspector"``.
 
     Returns:
-        The imported ``engine_versions.<engine>.<safe>.producers.<producer>``
-        module. The caller reads ``LANDMARKS`` (and optionally ``_CLASS_TARGETS``
-        etc.) from it.
+        The imported producer module. Exact match is preferred:
+        ``engine_versions.<engine>.v<safe(version)>.producers.<producer>``.
+        On miss, falls back to the highest vendored archive ``<= version`` and
+        emits a stderr log line naming the fallback. The caller reads
+        ``LANDMARKS`` (and optionally ``_CLASS_TARGETS`` etc.) from the
+        returned module.
 
     Raises:
-        ModuleNotFoundError: if the versioned subpackage does not exist. The
-            error message names the exact file path to create - this is the
-            primary signal a maintainer sees when a Renovate-driven version bump
-            outpaces the per-version vendoring (the chunk PR hasn't landed yet).
+        ModuleNotFoundError: when no vendored archive exists at or below
+            ``version`` with a ``producers/<producer>.py`` file. The error
+            message names the exact file path to create for the next chunk PR.
     """
     # Late import: ``_current`` imports yaml/packaging which we'd rather not
     # pay at every ``__getattr__`` call site. Importing here keeps module-
@@ -61,16 +141,34 @@ def load_producer(*, engine: str, version: str, producer: ProducerKind) -> Modul
     qualified = f"engine_versions.{engine}.{safe}.producers.{producer}"
     try:
         return importlib.import_module(qualified)
-    except ModuleNotFoundError as exc:
-        # The import may fail because the engine subpackage, the version
-        # subpackage, or the producer module is missing. All three cases
-        # share the same remediation: vendor this version's producers.
+    except ModuleNotFoundError:
+        # Fall through to fallback. Distinct from "import succeeded but raised":
+        # a syntax error in an existing producer module would surface a
+        # different exception (SyntaxError / ImportError without
+        # ModuleNotFoundError), which propagates rather than triggering a
+        # silent fallback to a different version.
+        pass
+
+    engine_root = Path(__file__).resolve().parent / engine
+    fallback_safe = _find_fallback_safe_version(
+        engine_root=engine_root, target_version=version, producer=producer
+    )
+    if fallback_safe is None:
         raise ModuleNotFoundError(
-            f"No archived producer for {engine}=={version} ({producer}). "
-            f"Expected to import `{qualified}`. Create "
-            f"engine_versions/{engine}/{safe}/producers/{producer}.py "
+            f"No archived producer for {engine}=={version} ({producer}), and "
+            f"no fallback vendored archive exists at or below {version} "
+            f"with engine_versions/{engine}/v*/producers/{producer}.py. "
+            f"Create engine_versions/{engine}/{safe}/producers/{producer}.py "
             f"(with sibling __init__.py files as needed) by copying the prior "
             f"version's producers and rewriting LANDMARKS for the new library "
             f"API. See the version-bump chunk pattern in the engine archive "
             f"package docstring."
-        ) from exc
+        )
+
+    fallback_qualified = f"engine_versions.{engine}.{fallback_safe}.producers.{producer}"
+    print(
+        f"engine_versions._dispatcher: no exact match for {engine}=={version}; "
+        f"falling back to {fallback_qualified}",
+        file=sys.stderr,
+    )
+    return importlib.import_module(fallback_qualified)

--- a/tests/_engine_archive/test_dispatcher.py
+++ b/tests/_engine_archive/test_dispatcher.py
@@ -1,9 +1,14 @@
 """Unit tests for the version-aware machinery dispatcher.
 
-Engine-agnostic tests only: the ``safe_version`` mangling helper, the
-no-fallback contract (unknown engines / versions / producers raise
-``ModuleNotFoundError``), and the actionable error-message contract that
-fires when a Renovate-driven version bump outpaces the per-version vendoring.
+Covers:
+
+- ``safe_version`` mangling helper.
+- The auto-fallback contract: when no exact-match archive exists at the
+  target version, the dispatcher resolves to the highest vendored archive
+  ``<= target`` and logs the fallback to stderr.
+- The no-fallback diagnostic: when no archive exists at or below the target
+  with a ``producers/<producer>.py`` file, the dispatcher raises
+  ``ModuleNotFoundError`` with the path the maintainer needs to create.
 
 Per-engine ``load_producer`` resolution tests live in each engine's
 vendor PR alongside the engine's archive subpackage.
@@ -11,9 +16,11 @@ vendor PR alongside the engine's archive subpackage.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from engine_versions._dispatcher import load_producer
+from engine_versions._dispatcher import _find_fallback_safe_version, load_producer
 from scripts.engine_producers._current import safe_version
 
 # ---------------------------------------------------------------------------
@@ -39,41 +46,221 @@ def test_safe_version_rejects_non_alphanumeric() -> None:
 
 
 # ---------------------------------------------------------------------------
-# No-fallback contract
+# Fallback unit tests (_find_fallback_safe_version, tmp_path fixture)
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_version_raises_loud() -> None:
-    """Plan's no-fallback rule: an unknown version surfaces ModuleNotFoundError."""
+def _make_archive(root: Path, safe: str, producer: str) -> None:
+    """Create ``<root>/<safe>/producers/<producer>.py`` + __init__.py chain.
+
+    Mirrors the shape of a real engine archive enough for the dispatcher's
+    filesystem check.
+    """
+    archive_dir = root / safe / "producers"
+    archive_dir.mkdir(parents=True)
+    (root / safe / "__init__.py").write_text("")
+    (archive_dir / "__init__.py").write_text("")
+    (archive_dir / f"{producer}.py").write_text("LANDMARKS: tuple[str, ...] = ()\n")
+
+
+def test_find_fallback_picks_highest_below_target(tmp_path: Path) -> None:
+    """v0_7_3 + v0_19_1 vendored; target 0.16.0 falls back to v0_7_3."""
+    for safe in ("v0_7_3", "v0_19_1"):
+        _make_archive(tmp_path, safe, "static_invariant_miner")
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path,
+        target_version="0.16.0",
+        producer="static_invariant_miner",
+    )
+    assert result == "v0_7_3"
+
+
+def test_find_fallback_picks_exact_when_present(tmp_path: Path) -> None:
+    """When the target version is itself vendored, it is the highest <= target."""
+    for safe in ("v0_7_3", "v0_19_1"):
+        _make_archive(tmp_path, safe, "static_invariant_miner")
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path,
+        target_version="0.19.1",
+        producer="static_invariant_miner",
+    )
+    assert result == "v0_19_1"
+
+
+def test_find_fallback_returns_none_when_all_above(tmp_path: Path) -> None:
+    """All vendored versions above target -> no candidate."""
+    _make_archive(tmp_path, "v0_19_1", "static_invariant_miner")
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path,
+        target_version="0.5.0",
+        producer="static_invariant_miner",
+    )
+    assert result is None
+
+
+def test_find_fallback_skips_dirs_without_producer_file(tmp_path: Path) -> None:
+    """A version dir with only machinery/ (no producers/<producer>.py) is skipped."""
+    _make_archive(tmp_path, "v0_7_3", "static_invariant_miner")
+    # v0_18_1 has machinery/ but no producers/<producer>.py.
+    (tmp_path / "v0_18_1" / "machinery").mkdir(parents=True)
+    (tmp_path / "v0_18_1" / "__init__.py").write_text("")
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path,
+        target_version="0.18.5",
+        producer="static_invariant_miner",
+    )
+    assert result == "v0_7_3"
+
+
+def test_find_fallback_skips_non_version_dirs(tmp_path: Path) -> None:
+    """Dirs like ``__pycache__`` and ``outputs`` are silently skipped."""
+    _make_archive(tmp_path, "v0_7_3", "static_invariant_miner")
+    (tmp_path / "__pycache__").mkdir()
+    (tmp_path / "outputs").mkdir()
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path,
+        target_version="0.7.4",
+        producer="static_invariant_miner",
+    )
+    assert result == "v0_7_3"
+
+
+def test_find_fallback_handles_prerelease_ordering(tmp_path: Path) -> None:
+    """Pre-release ordering: v0_7_3rc1 < v0_7_3 < v0_7_4."""
+    for safe in ("v0_7_3rc1", "v0_7_3", "v0_7_4"):
+        _make_archive(tmp_path, safe, "static_invariant_miner")
+    # Target 0.7.3 picks v0_7_3 (rc1 ranks lower).
+    assert (
+        _find_fallback_safe_version(
+            engine_root=tmp_path,
+            target_version="0.7.3",
+            producer="static_invariant_miner",
+        )
+        == "v0_7_3"
+    )
+    # Target 0.7.3rc1 picks v0_7_3rc1 (0.7.3 > rc1, excluded).
+    assert (
+        _find_fallback_safe_version(
+            engine_root=tmp_path,
+            target_version="0.7.3rc1",
+            producer="static_invariant_miner",
+        )
+        == "v0_7_3rc1"
+    )
+
+
+def test_find_fallback_returns_none_for_missing_engine_root(tmp_path: Path) -> None:
+    """Non-existent engine_root returns None; caller raises."""
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path / "missing",
+        target_version="0.7.3",
+        producer="static_invariant_miner",
+    )
+    assert result is None
+
+
+def test_find_fallback_returns_none_for_invalid_target_version(tmp_path: Path) -> None:
+    """Garbage target_version returns None (no fallback selected)."""
+    _make_archive(tmp_path, "v0_7_3", "static_invariant_miner")
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path,
+        target_version="not-a-version",
+        producer="static_invariant_miner",
+    )
+    assert result is None
+
+
+def test_find_fallback_filters_per_producer_kind(tmp_path: Path) -> None:
+    """A dir with only ``schema_introspector.py`` isn't a fallback for ``static_invariant_miner``."""
+    _make_archive(tmp_path, "v0_7_3", "schema_introspector")
+    result = _find_fallback_safe_version(
+        engine_root=tmp_path,
+        target_version="0.7.4",
+        producer="static_invariant_miner",
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# load_producer: integration against real engine_versions/ tree
+# ---------------------------------------------------------------------------
+
+
+def test_load_producer_exact_match() -> None:
+    """When the exact version is vendored, the dispatcher returns that one."""
+    module = load_producer(engine="vllm", version="0.7.3", producer="static_invariant_miner")
+    assert module.__name__ == "engine_versions.vllm.v0_7_3.producers.static_invariant_miner"
+
+
+def test_load_producer_falls_back_when_above_all_vendored(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A target above all vendored versions falls back to the highest <= target."""
+    module = load_producer(engine="vllm", version="999.0.0", producer="static_invariant_miner")
+    assert module.__name__.startswith("engine_versions.vllm.")
+    assert module.__name__.endswith(".producers.static_invariant_miner")
+    # The fallback version comes from the live tree; just assert it's not v999.
+    assert "v999_0_0" not in module.__name__
+    # Stderr log surfaces the fallback choice.
+    captured = capsys.readouterr()
+    assert "no exact match" in captured.err
+    assert "vllm==999.0.0" in captured.err
+    assert "falling back to" in captured.err
+
+
+def test_load_producer_falls_back_to_v0_7_3_for_intermediate_target(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """vllm has v0_7_3 vendored; target 0.7.4 (unvendored) falls back to v0_7_3."""
+    module = load_producer(engine="vllm", version="0.7.4", producer="static_invariant_miner")
+    assert module.__name__ == "engine_versions.vllm.v0_7_3.producers.static_invariant_miner"
+    captured = capsys.readouterr()
+    assert "falling back to engine_versions.vllm.v0_7_3.producers.static_invariant_miner" in (
+        captured.err
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-fallback contract: raise loud when nothing exists at or below target
+# ---------------------------------------------------------------------------
+
+
+def test_below_lowest_vendored_raises_loud() -> None:
+    """All vendored vllm versions are >= 0.7.3; target 0.0.0 has no candidate."""
     with pytest.raises(ModuleNotFoundError):
-        load_producer(engine="vllm", version="999.999.999", producer="static_invariant_miner")
+        load_producer(engine="vllm", version="0.0.0", producer="static_invariant_miner")
 
 
 def test_unknown_engine_raises_loud() -> None:
+    """Non-existent engine root has no vendored archives; raises with create-this-file path."""
     with pytest.raises(ModuleNotFoundError):
         load_producer(
-            engine="not-a-real-engine", version="0.7.3", producer="static_invariant_miner"
+            engine="not-a-real-engine",
+            version="0.7.3",
+            producer="static_invariant_miner",
         )
 
 
 def test_unknown_producer_raises_loud() -> None:
-    """Dispatcher accepts only the three SSOT producer kinds."""
+    """A typo in the producer kind matches no archives; raises."""
     with pytest.raises(ModuleNotFoundError):
-        # ``introspector`` is the user-facing name; the SSOT key is ``discovery``.
+        # ``introspector`` is the user-facing probe name; the archive uses
+        # the long form ``schema_introspector``.
         load_producer(engine="vllm", version="0.7.3", producer="introspector")  # type: ignore[arg-type]
 
 
 def test_dispatcher_error_message_names_file_to_create() -> None:
-    """Missing-producer diagnostic must name the exact file path.
+    """No-fallback diagnostic names the path the maintainer needs to create.
 
-    This is the primary signal a maintainer sees when a Renovate-driven SSOT
-    bump outpaces the per-version vendoring. The error must point them at
-    the file to create so the next chunk PR is unblocked without spelunking.
+    This is the primary signal a maintainer sees when neither an exact-match
+    archive nor any earlier vendored archive can serve the bumped version.
+    The error message must point at the file to create so the next chunk PR
+    is unblocked without spelunking.
     """
     with pytest.raises(ModuleNotFoundError) as exc_info:
-        load_producer(engine="vllm", version="999.0.0", producer="static_invariant_miner")
+        load_producer(engine="vllm", version="0.0.0", producer="static_invariant_miner")
     msg = str(exc_info.value)
     assert "vllm" in msg
-    assert "999.0.0" in msg
-    assert "engine_versions/vllm/v999_0_0/producers/static_invariant_miner.py" in msg
+    assert "0.0.0" in msg
+    assert "engine_versions/vllm/v0_0_0/producers/static_invariant_miner.py" in msg
     assert "LANDMARKS" in msg


### PR DESCRIPTION
## Summary

- The per-version dispatcher (`engine_versions/_dispatcher.load_producer`) now falls back to the most-recent prior vendored archive when no exact-match `v<safe(current_version)>/producers/<producer>.py` exists, instead of raising on the spot.
- A stderr log line names the fallback so the cell's CI output surfaces which producer was actually used.
- The probe (`scripts._drift`) remains the runtime gate: it verifies the dispatched producer's `LANDMARKS` resolve under the live library. Probe-fail still blocks downstream stages and requires maintainer action (patch landmarks or vendor a fresh `vN/producers/`).

## Why

Patch-version bumps where the library API is refactor-free no longer need a maintenance touch. Renovate bumps `library.current_version` from `0.7.3` to `0.7.4`; the dispatcher falls back to `v0_7_3/producers/`; the probe verifies the landmarks still resolve under `vllm==0.7.4`; downstream mining proceeds against the bumped library with the prior version's producer code. A new `vN/producers/` directory is only vendored when the probe fails because landmarks genuinely moved between versions.

This is the first of three sequenced PRs that collapse the per-engine SSOT to an input-only file and remove the envelope-pin contract. R1 (this PR) adds the graceful-degradation path; R2 will then strip the envelope concept and the `last_probe` block from `current.yaml`; R3 cleans up the remaining vestigial fields.

## Changes

- `engine_versions/_dispatcher.py`: new `_safe_to_version` inverse helper (the package-side counterpart to `safe_version`) and `_find_fallback_safe_version` scanner that ranks sibling `vN_NN_NN` dirs by parsed version and returns the highest valid match `<= target`. `load_producer` falls through on `ModuleNotFoundError` to this scanner; on no-fallback-found, raises with the existing create-this-file diagnostic.
- `tests/_engine_archive/test_dispatcher.py`: nine new unit tests against `tmp_path` covering exact-match-when-present, fallback-to-highest-below, all-above (no candidate), missing producer file, non-version dir filtering, pre-release ordering, missing engine root, invalid target version, and per-producer-kind filtering. Three new integration tests against the real `engine_versions/` tree (exact match, fallback when target above all vendored, fallback to `v0_7_3` for `0.7.4`). Existing no-fallback tests updated to use `0.0.0` (below the lowest vendored) so they still raise.
- `docs/explanation/architecture/engine-introspection-pipelines.md`: new "Per-version dispatcher" section with a mermaid flowchart for the dispatch decision tree (exact match -> sibling scan -> filter <= target -> pick highest -> probe gate).

## Test plan

- [x] `uv run pytest tests/_engine_archive/test_dispatcher.py` - 19 tests pass.
- [x] `uv run pytest tests/_engine_archive/ tests/unit/scripts/engine_producers/` - 151 pass, 10 skipped (engine-specific tests requiring actual libs). No regressions in stub-factory or lazy-resolver suites.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy engine_versions/_dispatcher.py` clean.
- [ ] CI green on this PR.

## Follow-ups

- R2: strip envelope (`miner_pins`, `check_installed_version`, `MinerVersionMismatchError`, `load_miner_pin`, `/approve-reuse` slash command, `widen_miner_pin.py`, `approve-reuse-bot.yml`) + drop `last_probe` block from `current.yaml` (cell stops writing back to SSOT; `update_last_probe.py` deleted).
- R3: strip vestigial SSOT fields (`image.*`, `artefact_paths`, `library.current_commit_sha`, tensorrt's orphan `added_baseline`).