### PR TITLE
refactor(engines): drop vestigial fields from current.yaml SSOT

### DIFF
--- a/engine_versions/tensorrt/current.yaml
+++ b/engine_versions/tensorrt/current.yaml
@@ -15,17 +15,9 @@ engine: tensorrt
 library:
   pep503_name: tensorrt-llm
   current_version: "0.21.0"
-  current_commit_sha: null
-image:
-  base_image_ref: "nvcr.io/nvidia/tensorrt-llm/release:0.21.0"
-  llem_image_ref: null
 source_tarball:
   # Template for the upstream release tarball. Workflow cells that need to
   # mine TRT-LLM source files (the static miner + introspector) read it via
   # `yq`, then substitute `{version}` with `library.current_version`. Single
   # locus to update if NVIDIA changes their tag scheme. See #532.
   url_template: "https://github.com/NVIDIA/TensorRT-LLM/archive/refs/tags/v{version}.tar.gz"
-artefact_paths:
-  engine_invariants: src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
-  validated_invariants: src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
-  discovered_schemas: src/llenergymeasure/engines/tensorrt/schema.discovered.json

--- a/engine_versions/transformers/current.yaml
+++ b/engine_versions/transformers/current.yaml
@@ -15,11 +15,3 @@ engine: transformers
 library:
   pep503_name: transformers
   current_version: "4.57.3"
-  current_commit_sha: null
-image:
-  base_image_ref: "llenergymeasure:transformers-4.57.3"
-  llem_image_ref: null
-artefact_paths:
-  engine_invariants: src/llenergymeasure/engines/transformers/invariants.proposed.yaml
-  validated_invariants: src/llenergymeasure/engines/transformers/invariants.validated.yaml
-  discovered_schemas: src/llenergymeasure/engines/transformers/schema.discovered.json

--- a/engine_versions/vllm/current.yaml
+++ b/engine_versions/vllm/current.yaml
@@ -15,11 +15,3 @@ engine: vllm
 library:
   pep503_name: vllm
   current_version: "0.7.3"
-  current_commit_sha: null
-image:
-  base_image_ref: "vllm/vllm-openai:v0.7.3"
-  llem_image_ref: null
-artefact_paths:
-  engine_invariants: src/llenergymeasure/engines/vllm/invariants.proposed.yaml
-  validated_invariants: src/llenergymeasure/engines/vllm/invariants.validated.yaml
-  discovered_schemas: src/llenergymeasure/engines/vllm/schema.discovered.json


### PR DESCRIPTION
> Stacked on #652. Will retarget to `main` after #652 squash-merges (which in turn waits for #651).

## Summary

Removes four unused fields from `engine_versions/<engine>/current.yaml`. Pure cosmetic tidy; safe-by-construction (grep-confirmed no consumers).

| Field | Why it goes |
|---|---|
| `image.base_image_ref` | Cells derive image tag from `library.current_version` via case statement in `_engine-invariants-cell.yml` + `_engine-schemas-cell.yml`. The `base_image_ref` field in `schema.discovered.json` is a separate runtime concept and stays. |
| `image.llem_image_ref` | Always null. Unread. |
| `artefact_paths.{engine_invariants, validated_invariants, discovered_schemas}` | Cells hard-code paths via `${ENGINES_DIR}`. Unread. |
| `library.current_commit_sha` | Always null. Unread. |

## Final SSOT shape

After this PR:

```yaml
# engine_versions/{transformers,vllm}/current.yaml (3 top-level keys)
schema_version: 1
engine: vllm
library:
  pep503_name: vllm
  current_version: "0.7.3"
```

```yaml
# engine_versions/tensorrt/current.yaml (4 top-level keys)
schema_version: 1
engine: tensorrt
library:
  pep503_name: tensorrt-llm
  current_version: "0.21.0"
source_tarball:
  url_template: "https://github.com/NVIDIA/TensorRT-LLM/archive/refs/tags/v{version}.tar.gz"
```

The SSOT is now fully collapsed to Renovate-writable input only.

## Why this is safe

`grep` audit on `image.base_image_ref`, `image.llem_image_ref`, `artefact_paths`, and `library.current_commit_sha` shows zero consumers in scripts, src, tests, docs, or workflows that read these fields from `current.yaml`. The same field names appear in `schema.discovered.json` envelopes (written by the schema introspectors), but those are a separate runtime concept consumed by `src/llenergymeasure/config/schema_loader.py` from the JSON files, not from `current.yaml`.

## Test plan

- [x] `uv run pytest tests/_engine_archive/ tests/unit/scripts/engine_producers/ tests/unit/scripts/test_drift.py tests/unit/scripts/test_generate_curation_doc.py` - 168 pass, 9 skipped.
- [x] `ruff check src/ tests/` - clean.
- [x] YAML round-trip: each SSOT parses to a dict; key set matches the planned shape.
- [ ] CI green on this PR.

## Diff stats

3 files changed, -24 lines (LoC stays roughly the same; the comments on what remains expand slightly).