### PR TITLE
chore(deps): bump vllm to 0.16.0

### DIFF
--- a/engine_versions/vllm/current.yaml
+++ b/engine_versions/vllm/current.yaml
@@ -14,4 +14,4 @@ schema_version: 1
 engine: vllm
 library:
   pep503_name: vllm
-  current_version: "0.7.3"
+  current_version: "0.16.0"

--- a/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
@@ -1,8 +1,228 @@
 schema_version: 1.0.0
 engine: vllm
-engine_version: 0.7.3
-mined_at: '2026-05-14T13:25:05+02:00'
+engine_version: 0.16.0
+mined_at: '2026-05-15T14:49:43+02:00'
 invariants:
+- id: vllm_eplbconfig_raises_log_balancedness_interval_le_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'EPLBConfig._validate_eplb_config: raises when log_balancedness present True AND
+    log_balancedness_interval <= 0'
+  severity: error
+  native_type: vllm.config.EPLBConfig
+  miner_source:
+    path: parallel.py
+    method: _validate_eplb_config
+    line_at_scan: 89
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.log_balancedness:
+        present: true
+      vllm.engine.log_balancedness_interval:
+        <=: 0
+  kwargs_positive:
+    log_balancedness: 1
+    log_balancedness_interval: 0
+  kwargs_negative:
+    log_balancedness: 1
+    log_balancedness_interval: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: log_balancedness_interval must be greater than 0.
+  references:
+  - parallel.py:89 (vllm.config.EPLBConfig._validate_eplb_config)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
+- id: vllm_loraconfig_dormant_max_cpu_loras_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'LoRAConfig._validate_lora_config: marks dormant when max_cpu_loras absent True'
+  severity: dormant
+  native_type: vllm.config.LoRAConfig
+  miner_source:
+    path: lora.py
+    method: _validate_lora_config
+    line_at_scan: 94
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.max_cpu_loras:
+        absent: true
+  kwargs_positive:
+    max_cpu_loras: null
+  kwargs_negative:
+    max_cpu_loras: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - max_cpu_loras
+  message_template: null
+  references:
+  - lora.py:94 (vllm.config.LoRAConfig._validate_lora_config)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
+- id: vllm_parallelconfig_dormant_data_parallel_rank_set_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig.__post_init__: marks dormant when distributed_executor_backend
+    == external_launcher AND data_parallel_rank present True'
+  severity: dormant
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: parallel.py
+    method: __post_init__
+    line_at_scan: 564
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.distributed_executor_backend: external_launcher
+      vllm.engine.data_parallel_rank:
+        present: true
+  kwargs_positive:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 1
+  kwargs_negative:
+    distributed_executor_backend: external_launcher
+    data_parallel_rank: 0
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - data_parallel_rank
+  message_template: null
+  references:
+  - parallel.py:564 (vllm.config.ParallelConfig.__post_init__)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
+- id: vllm_parallelconfig_raises_api_process_rank_ge_ref_api_process_count
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when _api_process_rank >= @_api_process_count'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 307
+  match:
+    engine: vllm
+    fields:
+      vllm.engine._api_process_rank:
+        '>=': '@_api_process_count'
+  kwargs_positive:
+    _api_process_count: 2
+    _api_process_rank: 2
+  kwargs_negative:
+    _api_process_count: 2
+    _api_process_rank: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: 'Invalid value of `_api_process_rank`. Expected to be `-1` or `[0, {_api_process_count})`,
+    but found: {_api_process_rank}'
+  references:
+  - parallel.py:307 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
+- id: vllm_parallelconfig_raises_data_parallel_external_lb_set_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when data_parallel_size <= 1
+    AND data_parallel_external_lb present True'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 320
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_size:
+        <=: 1
+      vllm.engine.data_parallel_external_lb:
+        present: true
+  kwargs_positive:
+    data_parallel_size: 1
+    data_parallel_external_lb: 1
+  kwargs_negative:
+    data_parallel_size: 1
+    data_parallel_external_lb: false
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: data_parallel_external_lb can only be set when data_parallel_size > 1
+  references:
+  - parallel.py:320 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
+- id: vllm_parallelconfig_raises_data_parallel_size_local_gt_ref_data_parallel_size
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when data_parallel_size_local
+    > @data_parallel_size'
+  severity: error
+  native_type: vllm.config.ParallelConfig
+  miner_source:
+    path: parallel.py
+    method: _validate_parallel_config
+    line_at_scan: 314
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.data_parallel_size_local:
+        '>': '@data_parallel_size'
+  kwargs_positive:
+    data_parallel_size: 2
+    data_parallel_size_local: 3
+  kwargs_negative:
+    data_parallel_size: 2
+    data_parallel_size_local: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: data_parallel_size_local ({data_parallel_size_local}) must be <= data_parallel_size
+    ({data_parallel_size})
+  references:
+  - parallel.py:314 (vllm.config.ParallelConfig._validate_parallel_config)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
+- id: vllm_samplingparams_dormant_bad_words_unset_true
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when bad_words absent True'
+  severity: dormant
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: sampling_params.py
+    method: __post_init__
+    line_at_scan: 352
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.bad_words:
+        absent: true
+  kwargs_positive:
+    bad_words: null
+  kwargs_negative:
+    bad_words: 1
+  expected_outcome:
+    outcome: dormant_silent
+    emission_channel: none
+    normalised_fields:
+    - bad_words
+  message_template: null
+  references:
+  - sampling_params.py:352 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   engine: vllm
   library: vllm
@@ -12,7 +232,7 @@ invariants:
   miner_source:
     path: sampling_params.py
     method: __post_init__
-    line_at_scan: 311
+    line_at_scan: 341
   match:
     engine: vllm
     fields:
@@ -28,41 +248,39 @@ invariants:
     - seed
   message_template: null
   references:
-  - sampling_params.py:311 (vllm.SamplingParams.__post_init__)
+  - sampling_params.py:341 (vllm.SamplingParams.__post_init__)
   added_by: static_miner
   added_at: '2026-04-27'
-- id: vllm_samplingparams_raises_best_of_lt_ref_n
+- id: vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true
   engine: vllm
   library: vllm
-  invariant_under_test: 'SamplingParams.__post_init__: raises when best_of present True AND best_of <
-    @n'
-  severity: error
+  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when skip_reading_prefix_cache absent
+    True'
+  severity: dormant
   native_type: vllm.SamplingParams
   miner_source:
     path: sampling_params.py
     method: __post_init__
-    line_at_scan: 296
+    line_at_scan: 381
   match:
     engine: vllm
     fields:
-      vllm.sampling.best_of:
-        present: true
-        <: '@n'
+      vllm.sampling.skip_reading_prefix_cache:
+        absent: true
   kwargs_positive:
-    best_of: 1
-    n: 2
+    skip_reading_prefix_cache: null
   kwargs_negative:
-    best_of: 2
-    n: 2
+    skip_reading_prefix_cache: 1
   expected_outcome:
-    outcome: error
+    outcome: dormant_silent
     emission_channel: none
-    normalised_fields: []
-  message_template: best_of must be greater than or equal to n, got n={n} and best_of={best_of}.
+    normalised_fields:
+    - skip_reading_prefix_cache
+  message_template: null
   references:
-  - sampling_params.py:296 (vllm.SamplingParams.__post_init__)
+  - sampling_params.py:381 (vllm.SamplingParams.__post_init__)
   added_by: static_miner
-  added_at: '2026-05-13T22:55:33+02:00'
+  added_at: '2026-05-15T14:49:43+02:00'
 - id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
   engine: vllm
   library: vllm
@@ -73,7 +291,7 @@ invariants:
   miner_source:
     path: sampling_params.py
     method: _verify_args
-    line_at_scan: 388
+    line_at_scan: 435
   match:
     engine: vllm
     fields:
@@ -93,7 +311,7 @@ invariants:
     normalised_fields: []
   message_template: min_tokens must be less than or equal to max_tokens={max_tokens}, got {min_tokens}.
   references:
-  - sampling_params.py:388 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:435 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-04-27'
 - id: vllm_samplingparams_raises_min_tokens_lt_0
@@ -105,7 +323,7 @@ invariants:
   miner_source:
     path: sampling_params.py
     method: _verify_args
-    line_at_scan: 385
+    line_at_scan: 431
   match:
     engine: vllm
     fields:
@@ -121,7 +339,7 @@ invariants:
     normalised_fields: []
   message_template: min_tokens must be greater than or equal to 0, got {min_tokens}.
   references:
-  - sampling_params.py:385 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:431 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-04-27'
 - id: vllm_samplingparams_raises_n_lt_1
@@ -133,7 +351,7 @@ invariants:
   miner_source:
     path: sampling_params.py
     method: _verify_args
-    line_at_scan: 357
+    line_at_scan: 387
   match:
     engine: vllm
     fields:
@@ -149,7 +367,7 @@ invariants:
     normalised_fields: []
   message_template: n must be at least 1, got {n}.
   references:
-  - sampling_params.py:357 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:387 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-04-27'
 - id: vllm_samplingparams_raises_n_not_type_int
@@ -161,7 +379,7 @@ invariants:
   miner_source:
     path: sampling_params.py
     method: _verify_args
-    line_at_scan: 354
+    line_at_scan: 385
   match:
     engine: vllm
     fields:
@@ -177,9 +395,37 @@ invariants:
     normalised_fields: []
   message_template: n must be an int, but is of type {type(self.n)}
   references:
-  - sampling_params.py:354 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:385 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-04-27'
+- id: vllm_samplingparams_raises_repetition_penalty_le_0p0
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when repetition_penalty <= 0.0'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: sampling_params.py
+    method: _verify_args
+    line_at_scan: 397
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.repetition_penalty:
+        <=: 0.0
+  kwargs_positive:
+    repetition_penalty: 0.0
+  kwargs_negative:
+    repetition_penalty: 1.0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: repetition_penalty must be greater than zero, got {repetition_penalty}.
+  references:
+  - sampling_params.py:397 (vllm.SamplingParams._verify_args)
+  added_by: static_miner
+  added_at: '2026-05-15T14:49:43+02:00'
 - id: vllm_samplingparams_raises_temperature_lt_0p0
   engine: vllm
   library: vllm
@@ -189,7 +435,7 @@ invariants:
   miner_source:
     path: sampling_params.py
     method: _verify_args
-    line_at_scan: 368
+    line_at_scan: 402
   match:
     engine: vllm
     fields:
@@ -205,91 +451,34 @@ invariants:
     normalised_fields: []
   message_template: temperature must be non-negative, got {temperature}.
   references:
-  - sampling_params.py:368 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:402 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-05-13T22:55:33+02:00'
-- id: vllm_schedulerconfig_raises_max_num_partial_prefills_lt_1
+- id: vllm_samplingparams_raises_top_k_lt_neg1
   engine: vllm
   library: vllm
-  invariant_under_test: 'SchedulerConfig._verify_args: raises when max_num_partial_prefills < 1'
+  invariant_under_test: 'SamplingParams._verify_args: raises when top_k < -1'
   severity: error
-  native_type: vllm.config.SchedulerConfig
+  native_type: vllm.SamplingParams
   miner_source:
-    path: config.py
+    path: sampling_params.py
     method: _verify_args
-    line_at_scan: 1604
+    line_at_scan: 415
   match:
     engine: vllm
     fields:
-      vllm.engine.max_num_partial_prefills:
-        <: 1
+      vllm.sampling.top_k:
+        <: -1
   kwargs_positive:
-    max_num_partial_prefills: 0
+    top_k: -2
   kwargs_negative:
-    max_num_partial_prefills: 1
+    top_k: -1
   expected_outcome:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: max_num_partial_prefills ({max_num_partial_prefills}) must be greater than or equal
-    to 1.
+  message_template: top_k must be 0 (disable), or at least 1, got {top_k}.
   references:
-  - config.py:1604 (vllm.config.SchedulerConfig._verify_args)
+  - sampling_params.py:415 (vllm.SamplingParams._verify_args)
   added_by: static_miner
-  added_at: '2026-05-13T22:55:33+02:00'
-- id: vllm_schedulerconfig_raises_num_lookahead_slots_lt_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'SchedulerConfig._verify_args: raises when num_lookahead_slots < 0'
-  severity: error
-  native_type: vllm.config.SchedulerConfig
-  miner_source:
-    path: config.py
-    method: _verify_args
-    line_at_scan: 1592
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.num_lookahead_slots:
-        <: 0
-  kwargs_positive:
-    num_lookahead_slots: -1
-  kwargs_negative:
-    num_lookahead_slots: 0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: num_lookahead_slots ({num_lookahead_slots}) must be greater than or equal to 0.
-  references:
-  - config.py:1592 (vllm.config.SchedulerConfig._verify_args)
-  added_by: static_miner
-  added_at: '2026-05-13T22:55:33+02:00'
-- id: vllm_schedulerconfig_raises_num_scheduler_steps_lt_1
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'SchedulerConfig._verify_args: raises when num_scheduler_steps < 1'
-  severity: error
-  native_type: vllm.config.SchedulerConfig
-  miner_source:
-    path: config.py
-    method: _verify_args
-    line_at_scan: 1598
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.num_scheduler_steps:
-        <: 1
-  kwargs_positive:
-    num_scheduler_steps: 0
-  kwargs_negative:
-    num_scheduler_steps: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: num_scheduler_steps ({num_scheduler_steps}) must be greater than or equal to 1.
-  references:
-  - config.py:1598 (vllm.config.SchedulerConfig._verify_args)
-  added_by: static_miner
-  added_at: '2026-05-13T22:55:33+02:00'
+  added_at: '2026-05-15T14:49:43+02:00'

--- a/src/llenergymeasure/engines/vllm/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.validated.yaml
@@ -1,11 +1,104 @@
 schema_version: 1.0.0
 engine: vllm
-engine_version: 0.7.3
+engine_version: 0.16.0
 image_ref: llenergymeasure:vllm
 base_image_ref: llenergymeasure:vllm
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T14:49:43+02:00'
+validation_commit: 3dbe264f5785748d57f9e786260909728f1d6688
 cases:
+- id: vllm_eplbconfig_raises_log_balancedness_interval_le_0
+  outcome: error
+  emission_channel: none
+  observed_messages:
+  - No plugins for group vllm.platform_plugins found.
+  - Checking if TPU platform is available.
+  - 'TPU platform is not available because: No module named ''libtpu'''
+  - Checking if CUDA platform is available.
+  - Confirmed CUDA platform is available.
+  - Checking if ROCm platform is available.
+  - 'ROCm platform is not available because: No module named ''amdsmi'''
+  - Checking if XPU platform is available.
+  - Checking if CPU platform is available.
+  - Checking if CUDA platform is available.
+  - Confirmed CUDA platform is available.
+  - Automatically detected platform cuda.
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for EPLBConfig\n  Value error, log_balancedness_interval\
+      \ must be greater than 0. [type=value_error, input_value=ArgsKwargs((), {'log_bala...ancedness_interval':\
+      \ 0}), input_type=ArgsKwargs]\n    For further information visit https://errors.pydantic.dev/2.12/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_loraconfig_dormant_max_cpu_loras_unset_true
+  outcome: dormant_silent
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations:
+    max_cpu_loras:
+      declared: null
+      observed: 1
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_parallelconfig_dormant_data_parallel_rank_set_true
+  outcome: dormant_silent
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations:
+    data_parallel_rank:
+      declared: 1
+      observed: 0
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_parallelconfig_raises_api_process_rank_ge_ref_api_process_count
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for ParallelConfig\n  Value error, Invalid value\
+      \ of `_api_process_rank`. Expected to be `-1` or `[0, 2)`, but found: 2 [type=value_error,\
+      \ input_value=ArgsKwargs((), {'_api_pro...'_api_process_rank': 2}), input_type=ArgsKwargs]\n\
+      \    For further information visit https://errors.pydantic.dev/2.12/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_parallelconfig_raises_data_parallel_external_lb_set_true
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for ParallelConfig\n  Value error, data_parallel_external_lb\
+      \ can only be set when data_parallel_size > 1 [type=value_error, input_value=ArgsKwargs((),\
+      \ {'data_par...rallel_external_lb': 1}), input_type=ArgsKwargs]\n    For further\
+      \ information visit https://errors.pydantic.dev/2.12/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_parallelconfig_raises_data_parallel_size_local_gt_ref_data_parallel_size
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValidationError
+    message: "1 validation error for ParallelConfig\n  Value error, data_parallel_size_local\
+      \ (3) must be <= data_parallel_size (2) [type=value_error, input_value=ArgsKwargs((),\
+      \ {'data_par...arallel_size_local': 3}), input_type=ArgsKwargs]\n    For further\
+      \ information visit https://errors.pydantic.dev/2.12/v/value_error"
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_samplingparams_dormant_bad_words_unset_true
+  outcome: dormant_silent
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations:
+    bad_words:
+      declared: null
+      observed: []
+  positive_confirmed: true
+  negative_confirmed: true
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   outcome: dormant_silent
   emission_channel: none
@@ -16,14 +109,14 @@ cases:
       observed: null
   positive_confirmed: true
   negative_confirmed: true
-- id: vllm_samplingparams_raises_best_of_lt_ref_n
-  outcome: error
+- id: vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true
+  outcome: dormant_silent
   emission_channel: none
   observed_messages: []
-  observed_silent_normalisations: {}
-  observed_exception:
-    type: ValueError
-    message: best_of must be greater than or equal to n, got n=2 and best_of=1.
+  observed_silent_normalisations:
+    skip_reading_prefix_cache:
+      declared: null
+      observed: false
   positive_confirmed: true
   negative_confirmed: true
 - id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
@@ -66,44 +159,34 @@ cases:
     message: n must be an int, but is of type <class 'str'>
   positive_confirmed: true
   negative_confirmed: true
+- id: vllm_samplingparams_raises_repetition_penalty_le_0p0
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: repetition_penalty must be greater than zero, got 0.0.
+  positive_confirmed: true
+  negative_confirmed: true
 - id: vllm_samplingparams_raises_temperature_lt_0p0
   outcome: error
   emission_channel: none
   observed_messages: []
   observed_silent_normalisations: {}
   observed_exception:
-    type: ValueError
-    message: temperature must be non-negative, got -1.0.
+    type: VLLMValidationError
+    message: temperature must be non-negative, got -1.0. (parameter=temperature, value=-1.0)
   positive_confirmed: true
   negative_confirmed: true
-- id: vllm_schedulerconfig_raises_max_num_partial_prefills_lt_1
+- id: vllm_samplingparams_raises_top_k_lt_neg1
   outcome: error
   emission_channel: none
   observed_messages: []
   observed_silent_normalisations: {}
   observed_exception:
     type: ValueError
-    message: max_num_partial_prefills (0) must be greater than or equal to 1.
-  positive_confirmed: true
-  negative_confirmed: true
-- id: vllm_schedulerconfig_raises_num_lookahead_slots_lt_0
-  outcome: error
-  emission_channel: none
-  observed_messages: []
-  observed_silent_normalisations: {}
-  observed_exception:
-    type: ValueError
-    message: num_lookahead_slots (-1) must be greater than or equal to 0.
-  positive_confirmed: true
-  negative_confirmed: true
-- id: vllm_schedulerconfig_raises_num_scheduler_steps_lt_1
-  outcome: error
-  emission_channel: none
-  observed_messages: []
-  observed_silent_normalisations: {}
-  observed_exception:
-    type: ValueError
-    message: num_scheduler_steps (0) must be greater than or equal to 1.
+    message: top_k must be 0 (disable), or at least 1, got -2.
   positive_confirmed: true
   negative_confirmed: true
 divergences: []

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0.0",
   "engine": "vllm",
-  "engine_version": "0.7.3",
+  "engine_version": "0.16.0",
   "engine_commit_sha": null,
-  "image_ref": "llenergymeasure:vllm-0.7.3",
+  "image_ref": "llenergymeasure:vllm-0.16.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T20:31:21+02:00",
+  "discovered_at": "2026-05-15T14:49:43+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {
@@ -22,7 +22,15 @@
   "engine_params": {
     "model": {
       "type": "str",
-      "default": "facebook/opt-125m"
+      "default": "Qwen/Qwen3-0.6B"
+    },
+    "enable_return_routed_experts": {
+      "type": "bool",
+      "default": false
+    },
+    "model_weights": {
+      "type": "str",
+      "default": ""
     },
     "served_model_name": {
       "type": "str | list[str] | None",
@@ -32,16 +40,28 @@
       "type": "str | None",
       "default": null
     },
-    "task": {
-      "type": "Literal['auto', 'generate', 'embedding', 'embed', 'classify', 'score', 'reward', 'transcription']",
+    "hf_config_path": {
+      "type": "str | None",
+      "default": null
+    },
+    "runner": {
+      "type": "Literal['auto', 'generate', 'pooling', 'draft']",
+      "default": "auto"
+    },
+    "convert": {
+      "type": "Literal['auto', 'none', 'embed', 'classify']",
       "default": "auto"
     },
     "skip_tokenizer_init": {
       "type": "bool",
       "default": false
     },
+    "enable_prompt_embeds": {
+      "type": "bool",
+      "default": false
+    },
     "tokenizer_mode": {
-      "type": "str",
+      "type": "Literal['auto', 'hf', 'slow', 'mistral', 'deepseek_v32'] | str",
       "default": "auto"
     },
     "trust_remote_code": {
@@ -52,24 +72,32 @@
       "type": "str",
       "default": ""
     },
+    "allowed_media_domains": {
+      "type": "list[str] | None",
+      "default": null
+    },
     "download_dir": {
       "type": "str | None",
       "default": null
     },
-    "load_format": {
+    "safetensors_load_strategy": {
       "type": "str",
+      "default": "lazy"
+    },
+    "load_format": {
+      "type": "str | Any",
       "default": "auto"
     },
     "config_format": {
-      "type": "ConfigFormat",
+      "type": "str",
       "default": "auto"
     },
     "dtype": {
-      "type": "str",
+      "type": "Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32']",
       "default": "auto"
     },
     "kv_cache_dtype": {
-      "type": "str",
+      "type": "Literal['auto', 'bfloat16', 'fp8', 'fp8_e4m3', 'fp8_e5m2', 'fp8_inc', 'fp8_ds_mla']",
       "default": "auto"
     },
     "seed": {
@@ -80,37 +108,165 @@
       "type": "int | None",
       "default": null
     },
+    "cudagraph_capture_sizes": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "max_cudagraph_capture_size": {
+      "type": "int | None",
+      "default": null
+    },
     "distributed_executor_backend": {
-      "type": "str | type[ExecutorBase] | None",
+      "type": "str | Literal['ray', 'mp', 'uni', 'external_launcher'] | type[Any] | None",
       "default": null
     },
     "pipeline_parallel_size": {
       "type": "int",
       "default": 1
     },
+    "master_addr": {
+      "type": "str",
+      "default": "127.0.0.1"
+    },
+    "master_port": {
+      "type": "int",
+      "default": 29501
+    },
+    "nnodes": {
+      "type": "int",
+      "default": 1
+    },
+    "node_rank": {
+      "type": "int",
+      "default": 0
+    },
     "tensor_parallel_size": {
       "type": "int",
       "default": 1
+    },
+    "prefill_context_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "decode_context_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "dcp_kv_cache_interleave_size": {
+      "type": "int",
+      "default": 1
+    },
+    "cp_kv_cache_interleave_size": {
+      "type": "int",
+      "default": 1
+    },
+    "data_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "data_parallel_rank": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_start_rank": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_size_local": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_address": {
+      "type": "str | None",
+      "default": null
+    },
+    "data_parallel_rpc_port": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_hybrid_lb": {
+      "type": "bool",
+      "default": false
+    },
+    "data_parallel_external_lb": {
+      "type": "bool",
+      "default": false
+    },
+    "data_parallel_backend": {
+      "type": "str",
+      "default": "mp"
+    },
+    "enable_expert_parallel": {
+      "type": "bool",
+      "default": false
+    },
+    "all2all_backend": {
+      "type": "str",
+      "default": "allgather_reducescatter"
+    },
+    "enable_dbo": {
+      "type": "bool",
+      "default": false
+    },
+    "ubatch_size": {
+      "type": "int",
+      "default": 0
+    },
+    "dbo_decode_token_threshold": {
+      "type": "int",
+      "default": 32
+    },
+    "dbo_prefill_token_threshold": {
+      "type": "int",
+      "default": 512
+    },
+    "disable_nccl_for_dp_synchronization": {
+      "type": "bool | None",
+      "default": null
+    },
+    "eplb_config": {
+      "type": "EPLBConfig",
+      "default": "EPLBConfig(window_size=1000, step_interval=3000, num_redundant_experts=0, log_balancedness=False, log_balancedness_interval=1, use_async=False, policy='default')"
+    },
+    "enable_eplb": {
+      "type": "bool",
+      "default": false
+    },
+    "expert_placement_strategy": {
+      "type": "Literal['linear', 'round_robin']",
+      "default": "linear"
+    },
+    "_api_process_count": {
+      "type": "int",
+      "default": 1
+    },
+    "_api_process_rank": {
+      "type": "int",
+      "default": 0
     },
     "max_parallel_loading_workers": {
       "type": "int | None",
       "default": null
     },
     "block_size": {
-      "type": "int | None",
+      "type": "Literal[1, 8, 16, 32, 64, 128, 256] | None",
       "default": null
     },
     "enable_prefix_caching": {
       "type": "bool | None",
       "default": null
     },
+    "prefix_caching_hash_algo": {
+      "type": "Literal['sha256', 'sha256_cbor', 'xxhash', 'xxhash_cbor']",
+      "default": "sha256"
+    },
     "disable_sliding_window": {
       "type": "bool",
       "default": false
     },
-    "use_v2_block_manager": {
+    "disable_cascade_attn": {
       "type": "bool",
-      "default": true
+      "default": false
     },
     "swap_space": {
       "type": "float",
@@ -124,20 +280,24 @@
       "type": "float",
       "default": 0.9
     },
+    "kv_cache_memory_bytes": {
+      "type": "int | None",
+      "default": null
+    },
     "max_num_batched_tokens": {
       "type": "int | None",
       "default": null
     },
     "max_num_partial_prefills": {
-      "type": "int | None",
+      "type": "int",
       "default": 1
     },
     "max_long_partial_prefills": {
-      "type": "int | None",
+      "type": "int",
       "default": 1
     },
     "long_prefill_token_threshold": {
-      "type": "int | None",
+      "type": "int",
       "default": 0
     },
     "max_num_seqs": {
@@ -148,7 +308,15 @@
       "type": "int",
       "default": 20
     },
+    "logprobs_mode": {
+      "type": "Literal['raw_logits', 'raw_logprobs', 'processed_logits', 'processed_logprobs']",
+      "default": "raw_logprobs"
+    },
     "disable_log_stats": {
+      "type": "bool",
+      "default": false
+    },
+    "aggregate_engine_logging": {
       "type": "bool",
       "default": false
     },
@@ -160,67 +328,91 @@
       "type": "str | None",
       "default": null
     },
-    "rope_scaling": {
-      "type": "dict[str, Any] | None",
-      "default": null
-    },
-    "rope_theta": {
-      "type": "float | None",
+    "hf_token": {
+      "type": "bool | str | None",
       "default": null
     },
     "hf_overrides": {
-      "type": "dict[str, Any] | Callable[[<class 'transformers.configuration_utils.PretrainedConfig'>], PretrainedConfig] | None",
-      "default": null
+      "type": "dict[str, Any] | Callable[[typing.Any], Any]",
+      "default": {}
     },
     "tokenizer_revision": {
       "type": "str | None",
       "default": null
     },
     "quantization": {
-      "type": "str | None",
+      "type": "Any | None",
       "default": null
+    },
+    "allow_deprecated_quantization": {
+      "type": "bool",
+      "default": false
     },
     "enforce_eager": {
-      "type": "bool | None",
-      "default": null
-    },
-    "max_seq_len_to_capture": {
-      "type": "int",
-      "default": 8192
+      "type": "bool",
+      "default": false
     },
     "disable_custom_all_reduce": {
       "type": "bool",
       "default": false
     },
-    "tokenizer_pool_size": {
-      "type": "int",
-      "default": 0
-    },
-    "tokenizer_pool_type": {
-      "type": "str | type[ForwardRef('BaseTokenizerGroup')]",
-      "default": "ray"
-    },
-    "tokenizer_pool_extra_config": {
-      "type": "dict[str, Any] | None",
-      "default": null
-    },
     "limit_mm_per_prompt": {
-      "type": "Mapping[str, int] | None",
-      "default": null
+      "type": "dict[str, int | dict[str, int]]",
+      "default": {}
+    },
+    "enable_mm_embeds": {
+      "type": "bool",
+      "default": false
+    },
+    "interleave_mm_strings": {
+      "type": "bool",
+      "default": false
+    },
+    "media_io_kwargs": {
+      "type": "dict[str, dict[str, Any]]",
+      "default": {}
     },
     "mm_processor_kwargs": {
       "type": "dict[str, Any] | None",
       "default": null
     },
-    "disable_mm_preprocessor_cache": {
+    "mm_processor_cache_gb": {
+      "type": "float",
+      "default": 4
+    },
+    "mm_processor_cache_type": {
+      "type": "Literal['shm', 'lru'] | None",
+      "default": "lru"
+    },
+    "mm_shm_cache_max_object_size_mb": {
+      "type": "int",
+      "default": 128
+    },
+    "mm_encoder_only": {
       "type": "bool",
       "default": false
+    },
+    "mm_encoder_tp_mode": {
+      "type": "Literal['weights', 'data']",
+      "default": "weights"
+    },
+    "mm_encoder_attn_backend": {
+      "type": "AttentionBackendEnum | str | None",
+      "default": null
+    },
+    "io_processor_plugin": {
+      "type": "str | None",
+      "default": null
+    },
+    "skip_mm_profiling": {
+      "type": "bool",
+      "default": false
+    },
+    "video_pruning_rate": {
+      "type": "float",
+      "default": null
     },
     "enable_lora": {
-      "type": "bool",
-      "default": false
-    },
-    "enable_lora_bias": {
       "type": "bool",
       "default": false
     },
@@ -232,49 +424,29 @@
       "type": "int",
       "default": 16
     },
-    "enable_prompt_adapter": {
-      "type": "bool",
-      "default": false
-    },
-    "max_prompt_adapters": {
-      "type": "int",
-      "default": 1
-    },
-    "max_prompt_adapter_token": {
-      "type": "int",
-      "default": 0
+    "default_mm_loras": {
+      "type": "dict[str, str] | None",
+      "default": null
     },
     "fully_sharded_loras": {
       "type": "bool",
       "default": false
     },
-    "lora_extra_vocab_size": {
-      "type": "int",
-      "default": 256
-    },
-    "long_lora_scaling_factors": {
-      "type": "tuple[float] | None",
+    "max_cpu_loras": {
+      "type": "int | None",
       "default": null
     },
     "lora_dtype": {
       "type": "str | dtype | None",
       "default": "auto"
     },
-    "max_cpu_loras": {
-      "type": "int | None",
-      "default": null
-    },
-    "device": {
-      "type": "str",
-      "default": "auto"
-    },
-    "num_scheduler_steps": {
-      "type": "int",
-      "default": 1
-    },
-    "multi_step_stream_outputs": {
+    "enable_tower_connector_lora": {
       "type": "bool",
-      "default": true
+      "default": false
+    },
+    "specialize_active_lora": {
+      "type": "bool",
+      "default": false
     },
     "ray_workers_use_nsight": {
       "type": "bool",
@@ -284,92 +456,50 @@
       "type": "int | None",
       "default": null
     },
-    "num_lookahead_slots": {
-      "type": "int",
-      "default": 0
-    },
     "model_loader_extra_config": {
-      "type": "dict | None",
-      "default": null
+      "type": "dict",
+      "default": {}
     },
     "ignore_patterns": {
-      "type": "str | list[str] | None",
-      "default": null
-    },
-    "preemption_mode": {
-      "type": "str | None",
-      "default": null
-    },
-    "scheduler_delay_factor": {
-      "type": "float",
-      "default": 0.0
+      "type": "str | list[str]",
+      "default": [
+        "original/**/*"
+      ]
     },
     "enable_chunked_prefill": {
       "type": "bool | None",
       "default": null
     },
-    "guided_decoding_backend": {
+    "disable_chunked_mm_input": {
+      "type": "bool",
+      "default": false
+    },
+    "disable_hybrid_kv_cache_manager": {
+      "type": "bool | None",
+      "default": null
+    },
+    "structured_outputs_config": {
+      "type": "StructuredOutputsConfig",
+      "default": "StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False)"
+    },
+    "reasoning_parser": {
       "type": "str",
-      "default": "xgrammar"
+      "default": ""
+    },
+    "reasoning_parser_plugin": {
+      "type": "str | None",
+      "default": null
     },
     "logits_processor_pattern": {
       "type": "str | None",
       "default": null
     },
-    "speculative_model": {
+    "speculative_config": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "show_hidden_metrics_for_version": {
       "type": "str | None",
-      "default": null
-    },
-    "speculative_model_quantization": {
-      "type": "str | None",
-      "default": null
-    },
-    "speculative_draft_tensor_parallel_size": {
-      "type": "int | None",
-      "default": null
-    },
-    "num_speculative_tokens": {
-      "type": "int | None",
-      "default": null
-    },
-    "speculative_disable_mqa_scorer": {
-      "type": "bool | None",
-      "default": false
-    },
-    "speculative_max_model_len": {
-      "type": "int | None",
-      "default": null
-    },
-    "speculative_disable_by_batch_size": {
-      "type": "int | None",
-      "default": null
-    },
-    "ngram_prompt_lookup_max": {
-      "type": "int | None",
-      "default": null
-    },
-    "ngram_prompt_lookup_min": {
-      "type": "int | None",
-      "default": null
-    },
-    "spec_decoding_acceptance_method": {
-      "type": "str",
-      "default": "rejection_sampler"
-    },
-    "typical_acceptance_sampler_posterior_threshold": {
-      "type": "float | None",
-      "default": null
-    },
-    "typical_acceptance_sampler_posterior_alpha": {
-      "type": "float | None",
-      "default": null
-    },
-    "qlora_adapter_name_or_path": {
-      "type": "str | None",
-      "default": null
-    },
-    "disable_logprobs_during_spec_decoding": {
-      "type": "bool | None",
       "default": null
     },
     "otlp_traces_endpoint": {
@@ -377,10 +507,34 @@
       "default": null
     },
     "collect_detailed_traces": {
-      "type": "str | None",
+      "type": "list[Literal['model', 'worker', 'all']] | None",
       "default": null
     },
-    "disable_async_output_proc": {
+    "kv_cache_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "kv_cache_metrics_sample": {
+      "type": "float",
+      "default": 0.01
+    },
+    "cudagraph_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_layerwise_nvtx_tracing": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_mfu_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_logging_iteration_details": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_mm_processor_stats": {
       "type": "bool",
       "default": false
     },
@@ -389,51 +543,143 @@
       "default": "fcfs"
     },
     "scheduler_cls": {
-      "type": "str | type[object]",
-      "default": "vllm.core.scheduler.Scheduler"
-    },
-    "override_neuron_config": {
-      "type": "dict[str, Any] | None",
+      "type": "str | type[object] | None",
       "default": null
     },
-    "override_pooler_config": {
+    "pooler_config": {
       "type": "PoolerConfig | None",
       "default": null
     },
     "compilation_config": {
-      "type": "CompilationConfig | None",
+      "type": "CompilationConfig",
+      "default": "{'level': None, 'mode': None, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': [], 'splitting_ops': None, 'compile_mm_encoder': False, 'compile_sizes': None, 'compile_ranges_split_points': None, 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': None, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': None, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': None, 'static_all_moe_layers': []}"
+    },
+    "attention_config": {
+      "type": "AttentionConfig",
+      "default": "AttentionConfig(backend=None, flash_attn_version=None, use_prefill_decode_attention=False, flash_attn_max_num_splits_for_cuda_graph=32, use_cudnn_prefill=False, use_trtllm_ragged_deepseek_prefill=True, use_trtllm_attention=None, disable_flashinfer_prefill=False, disable_flashinfer_q_quantization=False)"
+    },
+    "kernel_config": {
+      "type": "KernelConfig",
+      "default": "KernelConfig(enable_flashinfer_autotune=None)"
+    },
+    "enable_flashinfer_autotune": {
+      "type": "bool",
       "default": null
     },
     "worker_cls": {
       "type": "str",
       "default": "auto"
     },
+    "worker_extension_cls": {
+      "type": "str",
+      "default": ""
+    },
+    "profiler_config": {
+      "type": "ProfilerConfig",
+      "default": "ProfilerConfig(profiler=None, torch_profiler_dir='', torch_profiler_with_stack=True, torch_profiler_with_flops=False, torch_profiler_use_gzip=True, torch_profiler_dump_cuda_time_total=True, torch_profiler_record_shapes=False, torch_profiler_with_memory=False, ignore_frontend=False, delay_iterations=0, max_iterations=0)"
+    },
     "kv_transfer_config": {
       "type": "KVTransferConfig | None",
       "default": null
     },
-    "generation_config": {
-      "type": "str | None",
+    "kv_events_config": {
+      "type": "KVEventsConfig | None",
       "default": null
     },
-    "override_generation_config": {
-      "type": "dict[str, Any] | None",
+    "ec_transfer_config": {
+      "type": "ECTransferConfig | None",
       "default": null
+    },
+    "generation_config": {
+      "type": "str",
+      "default": "auto"
     },
     "enable_sleep_mode": {
       "type": "bool",
       "default": false
     },
+    "override_generation_config": {
+      "type": "dict[str, Any]",
+      "default": {}
+    },
     "model_impl": {
       "type": "str",
       "default": "auto"
     },
+    "override_attention_dtype": {
+      "type": "str",
+      "default": null
+    },
+    "attention_backend": {
+      "type": "AttentionBackendEnum | None",
+      "default": null
+    },
     "calculate_kv_scales": {
+      "type": "bool",
+      "default": false
+    },
+    "mamba_cache_dtype": {
+      "type": "Literal['auto', 'float32', 'float16']",
+      "default": "auto"
+    },
+    "mamba_ssm_cache_dtype": {
+      "type": "Literal['auto', 'float32', 'float16']",
+      "default": "auto"
+    },
+    "mamba_block_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "mamba_cache_mode": {
+      "type": "Literal['all', 'align', 'none']",
+      "default": "none"
+    },
+    "additional_config": {
+      "type": "dict[str, Any]",
+      "default": {}
+    },
+    "use_tqdm_on_load": {
+      "type": "bool",
+      "default": true
+    },
+    "pt_load_map_location": {
+      "type": "str",
+      "default": "cpu"
+    },
+    "logits_processors": {
+      "type": "list[str | type[LogitsProcessor]] | None",
+      "default": null
+    },
+    "async_scheduling": {
       "type": "bool | None",
       "default": null
     },
-    "additional_config": {
-      "type": "dict[str, Any] | None",
+    "stream_interval": {
+      "type": "int",
+      "default": 1
+    },
+    "kv_sharing_fast_prefill": {
+      "type": "bool",
+      "default": false
+    },
+    "optimization_level": {
+      "type": "OptimizationLevel",
+      "default": 2
+    },
+    "kv_offloading_size": {
+      "type": "float | None",
+      "default": null
+    },
+    "kv_offloading_backend": {
+      "type": "Literal['native', 'lmcache']",
+      "default": "native"
+    },
+    "tokens_only": {
+      "type": "bool",
+      "default": false
+    },
+    "weight_transfer_config": {
+      "type": "WeightTransferConfig | None",
       "default": null
     }
   },
@@ -441,14 +687,6 @@
     "n": {
       "type": "integer",
       "default": 1
-    },
-    "best_of": {
-      "type": "unknown",
-      "default": null
-    },
-    "_real_n": {
-      "type": "unknown",
-      "default": null
     },
     "presence_penalty": {
       "type": "number",
@@ -472,7 +710,7 @@
     },
     "top_k": {
       "type": "integer",
-      "default": -1
+      "default": 0
     },
     "min_p": {
       "type": "number",
@@ -487,10 +725,6 @@
       "default": null
     },
     "stop_token_ids": {
-      "type": "unknown",
-      "default": null
-    },
-    "bad_words": {
       "type": "unknown",
       "default": null
     },
@@ -513,6 +747,10 @@
     "prompt_logprobs": {
       "type": "unknown",
       "default": null
+    },
+    "flat_logprobs": {
+      "type": "boolean",
+      "default": false
     },
     "detokenize": {
       "type": "boolean",
@@ -542,6 +780,10 @@
       "type": "unknown",
       "default": 0
     },
+    "skip_clone": {
+      "type": "boolean",
+      "default": false
+    },
     "output_text_buffer_length": {
       "type": "integer",
       "default": 0
@@ -550,7 +792,7 @@
       "type": "array",
       "default": []
     },
-    "guided_decoding": {
+    "structured_outputs": {
       "type": "unknown",
       "default": null
     },
@@ -559,6 +801,22 @@
       "default": null
     },
     "allowed_token_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "extra_args": {
+      "type": "unknown",
+      "default": null
+    },
+    "bad_words": {
+      "type": "unknown",
+      "default": null
+    },
+    "_bad_words_token_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "skip_reading_prefix_cache": {
       "type": "unknown",
       "default": null
     }


### PR DESCRIPTION
## Summary
- Bump `library.current_version` from `0.7.3` to `0.16.0`. Single-field diff; no other SSOT field touched post-collapse (#651, #652, #653).
- Exercises dispatcher selection of `engine_versions/vllm/v0_16_0/producers/`, cell image templating for `vllm/vllm-openai:v0.16.0`, and drift `LANDMARKS` resolution under live vllm 0.16.0.

## Test plan
- [ ] Engine-pipeline runs both invariants + schemas cells green
- [ ] Probe verdict `pass` on the PR sticky comment
- [ ] No "no exact match" stderr from dispatcher (exact `v0_16_0` archive exists)
- [ ] Mining produces updated `invariants.proposed.yaml` + `schema.discovered.json` artefacts; `current.yaml` untouched by writeback