### PR TITLE
refactor(scripts): rewrite Pydantic-vs-discovered gate to subset semantics

### DIFF
--- a/docs/explanation/architecture/parameter-curation.md
+++ b/docs/explanation/architecture/parameter-curation.md
@@ -43,7 +43,7 @@ These JSON files are the ground truth for "what parameters does this engine vers
 
 - **Field names match native engine names.** A field called `quant_config` maps directly to the engine kwarg `quant_config`. No translation layer, no llem aliases.
 - **Sub-configs group related parameters.** e.g. `TensorRTKvCacheConfig` groups all kv-cache knobs under `tensorrt.kv_cache_config.*`. The sub-config name matches the native engine kwarg name.
-- **Types may be narrowed.** A field typed `str` in discovery might become `Literal["bfloat16", "float16", "float32"]` in curation, or a `Literal[...]` may narrow further to a subset of upstream's enum - both are intentional and pass the gate's subset semantics (see below).
+- **Types may be enriched, not narrowed.** A field typed `str` in discovery may become `Literal["bfloat16", "float16", "float32"]` in curation - llem providing the concrete value set the engine accepts at runtime when the signature said only `str`. But when discovery already exposes an enumerated `Literal[...]`, llem must match it: the engine owns the value contract for fields it has enumerated. A maintainer who wants to drop values from an enumerated set should remove the field or surface the divergence explicitly, not silently shrink the accepted set.
 - **Descriptions are added.** Pydantic `Field(description=...)` docs are user-facing; discovery has none.
 
 ---
@@ -54,9 +54,9 @@ These JSON files are the ground truth for "what parameters does this engine vers
 
 | Classification | Meaning | Effect on gate |
 |---|---|---|
-| `SUBSET-COMPATIBLE` | Pydantic type is a valid restriction of discovered (Literal subset, primitive abstraction over a complex class, concrete narrowing of `any`, scalar narrowed to a Literal value set) | Pass, silent |
+| `SUBSET-COMPATIBLE` | Pydantic type is type-enriched but not narrowing (scalar enriched to a concrete Literal value set, concrete type under unconstrained `any`, primitive abstraction over a complex class) | Pass, silent |
 | `LLEM-EXTENSION` | Pydantic field absent from discovered, listed in `LLEM_NATIVE_FIELDS` (kwargs passthrough, depth below introspection, llem-orchestration, or pre-transform) | Pass, silent |
-| `CONTRADICTION` | Pydantic widens beyond discovered (e.g. discovered `Literal['a']`, Pydantic `str`) OR Pydantic field absent from discovered without a whitelist entry | Fail |
+| `CONTRADICTION` | Pydantic widens beyond discovered (e.g. discovered `Literal['a']`, Pydantic `str`), narrows an enumerated Literal (engine owns the value contract), OR Pydantic field absent from discovered without a whitelist entry | Fail |
 
 Binary exit: `0` if no contradictions, `1` otherwise. The full 3-state classification is emitted in stdout JSON for downstream consumers (e.g. the audit-bot in #655 surfacing divergence as an informational PR comment).
 

--- a/docs/explanation/architecture/parameter-curation.md
+++ b/docs/explanation/architecture/parameter-curation.md
@@ -43,19 +43,22 @@ These JSON files are the ground truth for "what parameters does this engine vers
 
 - **Field names match native engine names.** A field called `quant_config` maps directly to the engine kwarg `quant_config`. No translation layer, no llem aliases.
 - **Sub-configs group related parameters.** e.g. `TensorRTKvCacheConfig` groups all kv-cache knobs under `tensorrt.kv_cache_config.*`. The sub-config name matches the native engine kwarg name.
-- **Types may be narrowed.** A field typed `str` in discovery might become `Literal["bfloat16", "float16", "float32"]` in curation - this is intentional and allowed by the drift checker.
+- **Types may be narrowed.** A field typed `str` in discovery might become `Literal["bfloat16", "float16", "float32"]` in curation, or a `Literal[...]` may narrow further to a subset of upstream's enum - both are intentional and pass the gate's subset semantics (see below).
 - **Descriptions are added.** Pydantic `Field(description=...)` docs are user-facing; discovery has none.
 
 ---
 
-## Drift checker
+## Schema gate (subset semantics)
 
-`scripts/check_pydantic_matches_discovered.py` compares the set of leaf field names in the Pydantic models against the discovered schemas and reports two kinds of drift:
+`scripts/check_pydantic_matches_discovered.py` compares each Pydantic field against the discovered schema and emits a 3-state classification per (engine, field):
 
-| Kind | Meaning |
-|------|---------|
-| `pydantic_only` | Pydantic has a field that discovery doesn't - likely a stale field that was removed from the engine, or a kwargs-passed field invisible to signature inspection |
-| `type_mismatch` | Both sides have the field but with different types (beyond intentional narrowing) |
+| Classification | Meaning | Effect on gate |
+|---|---|---|
+| `SUBSET-COMPATIBLE` | Pydantic type is a valid restriction of discovered (Literal subset, primitive abstraction over a complex class, concrete narrowing of `any`, scalar narrowed to a Literal value set) | Pass, silent |
+| `LLEM-EXTENSION` | Pydantic field absent from discovered, listed in `LLEM_NATIVE_FIELDS` (kwargs passthrough, depth below introspection, llem-orchestration, or pre-transform) | Pass, silent |
+| `CONTRADICTION` | Pydantic widens beyond discovered (e.g. discovered `Literal['a']`, Pydantic `str`) OR Pydantic field absent from discovered without a whitelist entry | Fail |
+
+Binary exit: `0` if no contradictions, `1` otherwise. The full 3-state classification is emitted in stdout JSON for downstream consumers (e.g. the audit-bot in #655 surfacing divergence as an informational PR comment).
 
 Run it locally:
 

--- a/docs/explanation/architecture/pipeline-architecture.md
+++ b/docs/explanation/architecture/pipeline-architecture.md
@@ -153,9 +153,11 @@ The dev consumes auto-generated digests:
 The dev manually edits `engine_configs.py`:
 
 - which discovered params to expose in Pydantic;
-- which `Literal` narrowings to pin;
+- where to enrich a loose discovered scalar (e.g. `str`) into a curated `Literal[...]` value set;
 - which sub-config taxonomy to use;
 - which custom `@model_validator` decorators to add.
+
+Llem does not narrow enumerated upstream Literals - the engine owns the value contract for fields it has enumerated. If a maintainer wants to drop values, they remove the field or surface the divergence explicitly; the schema gate will hard-error on silent narrowing.
 
 A push triggers a re-run of the CI cycle; the updated summary comment supersedes the prior one (edited via comment-id key, no proliferation).
 

--- a/scripts/check_pydantic_matches_discovered.py
+++ b/scripts/check_pydantic_matches_discovered.py
@@ -2,10 +2,12 @@
 """Check Pydantic engine configs are a valid subset of discovered schemas.
 
 Detects type CONTRADICTIONS between llem's hand-authored Pydantic models
-and the machine-discovered engine parameter schemas. Pydantic is allowed
-to be narrower than discovered (curating a Literal subset, abstracting a
-complex upstream class to a primitive); only widening or unwhitelisted
-extensions fail.
+and the machine-discovered engine parameter schemas. llem curates which
+fields to expose; the value set within an exposed field is the engine's
+contract. Pydantic may provide more precise type information than the
+engine signature exposes (e.g. ``Literal[...]`` over a discovered
+``str``), but may not silently narrow an already-enumerated engine
+type.
 
 Three-state classification per (engine, field):
 - SUBSET-COMPATIBLE: pydantic type is a valid subset/restriction of discovered
@@ -187,60 +189,41 @@ def _canonicalise_pydantic_type(prop: dict[str, Any], defs: dict[str, Any]) -> s
     return _JSON_TO_PYTHON_TYPE.get(base, base)
 
 
-def _parse_literal_values(literal_str: str) -> frozenset[str] | None:
-    """Extract the value set from a canonicalised Literal[...] string.
-
-    Returns ``None`` for non-Literal inputs. The canonicaliser already
-    ``repr``-quotes values in a stable order, so we strip the surrounding
-    quotes and return the bare value strings (callers compare set inclusion).
-    """
-    if not literal_str.startswith("Literal[") or not literal_str.endswith("]"):
-        return None
-    inner = literal_str[len("Literal[") : -1]
-    if not inner:
-        return frozenset()
-    parts = [p.strip() for p in inner.split(",")]
-    return frozenset(p.strip("'\"") for p in parts)
-
-
 def _is_subset(discovered: str, pydantic: str) -> bool:
     """Return True iff ``pydantic`` is a valid restriction of ``discovered``.
 
-    The subset relation captures the curation pattern: Pydantic is allowed
-    to be narrower than the upstream-discovered type (a smaller Literal
-    value set, an abstracted primitive over a complex class, a concrete
-    type under an unconstrained ``any``); it is NOT allowed to be wider
-    (Pydantic accepts more values than upstream).
+    llem curates which fields to expose, but the value set within an
+    exposed field is the engine's contract. The subset relation accepts
+    only TYPE-ENRICHMENT cases - where llem provides more precise type
+    information than the engine's signature alone exposes - never
+    VALUE-NARROWING of an already-enumerated engine type.
 
-    Patterns recognised (each a separate clause in the if-chain):
+    Patterns recognised:
 
     1. **Equal types** - trivial pass.
     2. **T <= any** - any concrete pydantic type is a valid view of an
-       unconstrained discovered ``any``.
-    3. **Literal[A] <= Literal[B]** - subset of value set; covers the
-       intentional curation case where llem narrows an upstream enum.
-    4. **Literal[A] <= scalar** (str/int/float) - llem curates a finite
-       value set out of a broad upstream scalar (e.g. backend names).
-       Covers the legacy ``_is_intentional_narrowing`` str/int -> Literal
-       case as a special case of the subset relation.
-    5. **Literal[A] <= union containing the scalar** - covers
-       ``str | SomeClass`` discovered narrowed to ``Literal['a','b']``.
-    6. **dict|str|list <= ClassName** - llem abstracts a complex upstream
-       class to a JSON-schema-friendly primitive. Retains today's
-       "complex discovered type mapped to simple Pydantic type" case.
+       unconstrained discovered ``any`` (signature carried no type info).
+    3. **Literal[A] <= scalar** (str/int/float) - llem types the
+       concrete value set the engine accepts at runtime, where the
+       signature only said ``str`` / ``int`` / ``float``.
+    4. **Literal[A] <= union containing the scalar** - same enrichment
+       pattern for ``str | SomeClass``-style signatures.
+    5. **dict|str|list <= ClassName** - llem abstracts a complex upstream
+       class to a JSON-schema-friendly primitive for serialisation.
+
+    Literal-to-Literal narrowing is NOT accepted: when the engine
+    enumerates a value set, llem must match it. A maintainer who wants
+    to drop values should remove the field or surface the divergence
+    explicitly, not silently shrink the accepted set.
     """
     if discovered == pydantic:
         return True
     if discovered == "any":
         return True
 
-    py_values = _parse_literal_values(pydantic)
-    disc_values = _parse_literal_values(discovered)
+    pydantic_is_literal = pydantic.startswith("Literal[")
 
-    if py_values is not None and disc_values is not None:
-        return py_values <= disc_values
-
-    if py_values is not None:
+    if pydantic_is_literal:
         if discovered in ("str", "int", "float"):
             return True
         if "|" in discovered and any(

--- a/scripts/check_pydantic_matches_discovered.py
+++ b/scripts/check_pydantic_matches_discovered.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
-"""Check Pydantic engine configs align with discovered schemas.
+"""Check Pydantic engine configs are a valid subset of discovered schemas.
 
-Detects type drift between llem's hand-authored Pydantic models and the
-machine-discovered engine parameter schemas. Catches:
-- Pydantic Literal values going stale relative to engine enums
-- Type narrowing/widening between Pydantic and discovered
-- Pydantic fields with no discovered counterpart (unless whitelisted)
+Detects type CONTRADICTIONS between llem's hand-authored Pydantic models
+and the machine-discovered engine parameter schemas. Pydantic is allowed
+to be narrower than discovered (curating a Literal subset, abstracting a
+complex upstream class to a primitive); only widening or unwhitelisted
+extensions fail.
 
-Exit 0: clean alignment. Exit 1: unexplained drift detected.
-Structured JSON on stdout; human-readable details on stderr.
+Three-state classification per (engine, field):
+- SUBSET-COMPATIBLE: pydantic type is a valid subset/restriction of discovered
+- LLEM-EXTENSION:    pydantic field absent from discovered, listed in
+                     LLEM_NATIVE_FIELDS (kwargs-passthrough, depth-below-
+                     introspection, llem-orchestration, or pre-transform;
+                     see issue #655 for the planned 4-category encoding)
+- CONTRADICTION:     pydantic widens beyond discovered, OR is absent from
+                     discovered without a whitelist entry. Only this state
+                     fails the gate.
+
+Exit 0: no contradictions. Exit 1: at least one CONTRADICTION.
+Structured JSON on stdout (full 3-state classification per field).
+Human-readable contradictions on stderr.
 
 Run: python scripts/check_pydantic_matches_discovered.py
 """
@@ -176,24 +187,70 @@ def _canonicalise_pydantic_type(prop: dict[str, Any], defs: dict[str, Any]) -> s
     return _JSON_TO_PYTHON_TYPE.get(base, base)
 
 
-def _is_intentional_narrowing(discovered: str, pydantic: str) -> bool:
-    """Check if Pydantic intentionally narrows a broad engine type.
+def _parse_literal_values(literal_str: str) -> frozenset[str] | None:
+    """Extract the value set from a canonicalised Literal[...] string.
 
-    Allowed patterns:
-    - str → Literal[...] (curating valid string values)
-    - int → Literal[...] (curating valid int values)
-    - Complex class type → simpler Pydantic type (e.g. CompilationConfig → dict)
+    Returns ``None`` for non-Literal inputs. The canonicaliser already
+    ``repr``-quotes values in a stable order, so we strip the surrounding
+    quotes and return the bare value strings (callers compare set inclusion).
     """
-    if pydantic.startswith("Literal["):
-        # Simple base type → Literal (str → Literal['a', 'b'])
+    if not literal_str.startswith("Literal[") or not literal_str.endswith("]"):
+        return None
+    inner = literal_str[len("Literal[") : -1]
+    if not inner:
+        return frozenset()
+    parts = [p.strip() for p in inner.split(",")]
+    return frozenset(p.strip("'\"") for p in parts)
+
+
+def _is_subset(discovered: str, pydantic: str) -> bool:
+    """Return True iff ``pydantic`` is a valid restriction of ``discovered``.
+
+    The subset relation captures the curation pattern: Pydantic is allowed
+    to be narrower than the upstream-discovered type (a smaller Literal
+    value set, an abstracted primitive over a complex class, a concrete
+    type under an unconstrained ``any``); it is NOT allowed to be wider
+    (Pydantic accepts more values than upstream).
+
+    Patterns recognised (each a separate clause in the if-chain):
+
+    1. **Equal types** - trivial pass.
+    2. **T <= any** - any concrete pydantic type is a valid view of an
+       unconstrained discovered ``any``.
+    3. **Literal[A] <= Literal[B]** - subset of value set; covers the
+       intentional curation case where llem narrows an upstream enum.
+    4. **Literal[A] <= scalar** (str/int/float) - llem curates a finite
+       value set out of a broad upstream scalar (e.g. backend names).
+       Covers the legacy ``_is_intentional_narrowing`` str/int -> Literal
+       case as a special case of the subset relation.
+    5. **Literal[A] <= union containing the scalar** - covers
+       ``str | SomeClass`` discovered narrowed to ``Literal['a','b']``.
+    6. **dict|str|list <= ClassName** - llem abstracts a complex upstream
+       class to a JSON-schema-friendly primitive. Retains today's
+       "complex discovered type mapped to simple Pydantic type" case.
+    """
+    if discovered == pydantic:
+        return True
+    if discovered == "any":
+        return True
+
+    py_values = _parse_literal_values(pydantic)
+    disc_values = _parse_literal_values(discovered)
+
+    if py_values is not None and disc_values is not None:
+        return py_values <= disc_values
+
+    if py_values is not None:
         if discovered in ("str", "int", "float"):
             return True
-        # Compound type containing str → Literal (str | SomeClass → Literal['a', 'b'])
-        if "|" in discovered and any(p.strip() == "str" for p in discovered.split("|")):
+        if "|" in discovered and any(
+            p.strip() in ("str", "int", "float") for p in discovered.split("|")
+        ):
             return True
-    # Complex discovered type (class name) mapped to simple Pydantic type
-    return (
-        discovered[0].isupper()
+
+    return bool(
+        discovered
+        and discovered[0].isupper()
         and not discovered.startswith("Literal[")
         and pydantic in ("dict", "str", "list")
     )
@@ -252,87 +309,138 @@ def _get_pydantic_leaves(engine: str, schema: dict[str, Any]) -> dict[str, dict[
 # ---------------------------------------------------------------------------
 
 
+# Classification labels emitted in the per-field record. Only CONTRADICTION
+# fails the gate; the other two are silent passes (kept in the JSON
+# diagnostic for downstream consumers like the audit-bot in #655).
+CLASSIFICATION_SUBSET = "SUBSET-COMPATIBLE"
+CLASSIFICATION_EXTENSION = "LLEM-EXTENSION"
+CLASSIFICATION_CONTRADICTION = "CONTRADICTION"
+
+
 def check_engine(engine: str, schema: dict[str, Any]) -> list[dict[str, str]]:
-    """Check one engine for drift. Returns list of drift records."""
-    drifts: list[dict[str, str]] = []
+    """Classify each Pydantic field for ``engine`` against the discovered schema.
+
+    Returns one record per (engine, field) pair where the field appears in
+    Pydantic, regardless of classification - downstream consumers (the
+    audit-bot in #655) want the full 3-state picture, not just failures.
+    Discovered-only fields (in upstream but not curated by llem) are out
+    of scope here; they're surveyed separately by the curation doc.
+    """
+    classifications: list[dict[str, str]] = []
     defs = schema.get("$defs", {})
 
     loader = SchemaLoader()
     discovered = loader.load_schema(engine)
 
-    # Combine engine_params and sampling_params from discovered
     all_discovered: dict[str, dict[str, Any]] = {}
     all_discovered.update(discovered.engine_params)
     all_discovered.update(discovered.sampling_params)
 
-    # Get Pydantic leaves
     pydantic_leaves = _get_pydantic_leaves(engine, schema)
 
-    # Check Pydantic fields against discovered
     for leaf_name, prop in pydantic_leaves.items():
         if leaf_name in all_discovered:
-            # Both sides have it - compare types
             discovered_type = all_discovered[leaf_name].get("type", "")
             if not discovered_type or not prop or discovered_type == "unknown":
+                # Discovered type unknown -> can't classify subset relation;
+                # treat as silent pass (no information either way).
                 continue
 
             canon_discovered = _canonicalise_discovered_type(discovered_type)
             canon_pydantic = _canonicalise_pydantic_type(prop, defs)
 
-            if canon_discovered != canon_pydantic:
-                # Allow intentional narrowing: engine exposes broad type,
-                # llem curates to specific Literal values
-                if _is_intentional_narrowing(canon_discovered, canon_pydantic):
-                    continue
-                drifts.append(
+            if _is_subset(canon_discovered, canon_pydantic):
+                classifications.append(
                     {
                         "engine": engine,
                         "field": leaf_name,
-                        "kind": "type_mismatch",
+                        "classification": CLASSIFICATION_SUBSET,
+                        "discovered": canon_discovered,
+                        "pydantic": canon_pydantic,
+                    }
+                )
+            else:
+                classifications.append(
+                    {
+                        "engine": engine,
+                        "field": leaf_name,
+                        "classification": CLASSIFICATION_CONTRADICTION,
+                        "kind": "type_widens_or_disagrees",
                         "discovered": canon_discovered,
                         "pydantic": canon_pydantic,
                     }
                 )
         else:
-            # Pydantic has it, discovered doesn't
-            if (engine, leaf_name) not in LLEM_NATIVE_FIELDS:
-                drifts.append(
+            canon_pydantic = _canonicalise_pydantic_type(prop, defs) if prop else "unknown"
+            if (engine, leaf_name) in LLEM_NATIVE_FIELDS:
+                classifications.append(
                     {
                         "engine": engine,
                         "field": leaf_name,
-                        "kind": "pydantic_only",
+                        "classification": CLASSIFICATION_EXTENSION,
                         "discovered": "(not present)",
-                        "pydantic": _canonicalise_pydantic_type(prop, defs) if prop else "unknown",
+                        "pydantic": canon_pydantic,
+                    }
+                )
+            else:
+                classifications.append(
+                    {
+                        "engine": engine,
+                        "field": leaf_name,
+                        "classification": CLASSIFICATION_CONTRADICTION,
+                        "kind": "pydantic_only_unwhitelisted",
+                        "discovered": "(not present)",
+                        "pydantic": canon_pydantic,
                     }
                 )
 
-    return drifts
+    return classifications
 
 
 def main() -> None:
     schema = ExperimentConfig.model_json_schema()
-    all_drifts: list[dict[str, str]] = []
+    all_classifications: list[dict[str, str]] = []
+    contradictions_total = 0
 
     for engine in ENGINES:
-        drifts = check_engine(engine, schema)
-        all_drifts.extend(drifts)
+        records = check_engine(engine, schema)
+        all_classifications.extend(records)
 
-        if drifts:
-            print(f"\n[{engine}] {len(drifts)} drift(s) detected:", file=sys.stderr)
-            for d in drifts:
+        contradictions = [r for r in records if r["classification"] == CLASSIFICATION_CONTRADICTION]
+        contradictions_total += len(contradictions)
+
+        if contradictions:
+            print(
+                f"\n[{engine}] {len(contradictions)} contradiction(s) detected:",
+                file=sys.stderr,
+            )
+            for d in contradictions:
                 print(
                     f"  {d['field']}: {d['kind']} "
                     f"(discovered={d['discovered']}, pydantic={d['pydantic']})",
                     file=sys.stderr,
                 )
         else:
-            print(f"[{engine}] OK - no drift", file=sys.stderr)
+            subset_n = sum(1 for r in records if r["classification"] == CLASSIFICATION_SUBSET)
+            ext_n = sum(1 for r in records if r["classification"] == CLASSIFICATION_EXTENSION)
+            print(
+                f"[{engine}] OK - no contradictions "
+                f"(subset-compatible: {subset_n}, llem-extension: {ext_n})",
+                file=sys.stderr,
+            )
 
-    # Structured output on stdout
-    json.dump({"drifts": all_drifts, "total": len(all_drifts)}, sys.stdout, indent=2)
+    json.dump(
+        {
+            "classifications": all_classifications,
+            "total_contradictions": contradictions_total,
+            "total_records": len(all_classifications),
+        },
+        sys.stdout,
+        indent=2,
+    )
     print(file=sys.stdout)
 
-    sys.exit(1 if all_drifts else 0)
+    sys.exit(1 if contradictions_total else 0)
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_check_pydantic_matches_discovered.py
+++ b/tests/unit/scripts/test_check_pydantic_matches_discovered.py
@@ -11,9 +11,13 @@ sys.path.insert(0, str(Path(__file__).parents[3] / "scripts"))
 sys.path.insert(0, str(Path(__file__).parents[3] / "src"))
 
 from check_pydantic_matches_discovered import (
+    CLASSIFICATION_CONTRADICTION,
+    CLASSIFICATION_EXTENSION,
+    CLASSIFICATION_SUBSET,
     _canonicalise_discovered_type,
     _canonicalise_pydantic_type,
-    _is_intentional_narrowing,
+    _is_subset,
+    _parse_literal_values,
     check_engine,
 )
 
@@ -85,40 +89,118 @@ class TestCanonicalisePydanticType:
 
 
 # ---------------------------------------------------------------------------
-# Narrowing detection
+# Literal value parsing
 # ---------------------------------------------------------------------------
 
 
-class TestIntentionalNarrowing:
-    def test_str_to_literal(self) -> None:
-        assert _is_intentional_narrowing("str", "Literal['a', 'b']") is True
+class TestParseLiteralValues:
+    def test_single_value(self) -> None:
+        assert _parse_literal_values("Literal['a']") == frozenset({"a"})
 
-    def test_int_to_literal(self) -> None:
-        assert _is_intentional_narrowing("int", "Literal['8', '16']") is True
+    def test_multiple_values(self) -> None:
+        assert _parse_literal_values("Literal['a', 'b', 'c']") == frozenset({"a", "b", "c"})
 
-    def test_compound_str_to_literal(self) -> None:
-        assert _is_intentional_narrowing("str | type[Foo]", "Literal['mp', 'ray']") is True
+    def test_int_values_unquoted(self) -> None:
+        assert _parse_literal_values("Literal['8', '16']") == frozenset({"8", "16"})
 
-    def test_class_to_dict(self) -> None:
-        assert _is_intentional_narrowing("CompilationConfig", "dict") is True
+    def test_empty_literal(self) -> None:
+        assert _parse_literal_values("Literal[]") == frozenset()
 
-    def test_same_type_not_narrowing(self) -> None:
-        assert _is_intentional_narrowing("int", "int") is False
-
-    def test_widening_not_allowed(self) -> None:
-        assert _is_intentional_narrowing("Literal['a']", "str") is False
+    def test_non_literal_returns_none(self) -> None:
+        assert _parse_literal_values("str") is None
+        assert _parse_literal_values("int") is None
+        assert _parse_literal_values("dict[str, int]") is None
 
 
 # ---------------------------------------------------------------------------
-# Live schema alignment
+# Subset relation
+# ---------------------------------------------------------------------------
+
+
+class TestSubsetRelation:
+    def test_equal_scalars(self) -> None:
+        assert _is_subset("int", "int") is True
+        assert _is_subset("str", "str") is True
+        assert _is_subset("bool", "bool") is True
+
+    def test_concrete_subset_of_any(self) -> None:
+        assert _is_subset("any", "int") is True
+        assert _is_subset("any", "Literal['a', 'b']") is True
+        assert _is_subset("any", "ClassName") is True
+
+    def test_literal_value_set_inclusion(self) -> None:
+        # Pydantic narrows discovered Literal: subset.
+        assert _is_subset("Literal['a', 'b', 'c']", "Literal['a', 'b']") is True
+        assert _is_subset("Literal['a', 'b']", "Literal['a']") is True
+        # Equal Literals.
+        assert _is_subset("Literal['a', 'b']", "Literal['a', 'b']") is True
+
+    def test_literal_widening_fails(self) -> None:
+        # Pydantic Literal accepts MORE than discovered: not a subset.
+        assert _is_subset("Literal['a', 'b']", "Literal['a', 'b', 'c']") is False
+        # Pydantic Literal disjoint from discovered: not a subset.
+        assert _is_subset("Literal['a', 'b']", "Literal['c', 'd']") is False
+
+    def test_str_to_literal_curation(self) -> None:
+        # Existing curation pattern: str -> Literal[some-strings].
+        assert _is_subset("str", "Literal['mp', 'ray']") is True
+        assert _is_subset("int", "Literal['8', '16']") is True
+
+    def test_compound_containing_str_to_literal(self) -> None:
+        # Discovered exposes a union including str; pydantic narrows to specific values.
+        assert _is_subset("str | type[Foo]", "Literal['mp', 'ray']") is True
+
+    def test_class_to_primitive_abstraction(self) -> None:
+        # Pydantic abstracts a complex upstream class to a primitive.
+        assert _is_subset("CompilationConfig", "dict") is True
+        assert _is_subset("CompilationConfig", "str") is True
+        assert _is_subset("CompilationConfig", "list") is True
+
+    def test_widening_to_str_fails(self) -> None:
+        # Pydantic str accepts MORE than a discovered Literal: not a subset.
+        assert _is_subset("Literal['a']", "str") is False
+
+    def test_unrelated_types_fail(self) -> None:
+        assert _is_subset("int", "str") is False
+        assert _is_subset("bool", "int") is False
+        assert _is_subset("list", "dict") is False
+
+
+# ---------------------------------------------------------------------------
+# 3-state classification
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("engine", ["transformers", "vllm", "tensorrt"])
-def test_live_schemas_align(engine: str) -> None:
-    """Real repo schemas should have zero unexplained drift."""
+def test_live_schemas_have_no_contradictions(engine: str) -> None:
+    """Real repo schemas should classify with zero CONTRADICTIONs.
+
+    SUBSET-COMPATIBLE and LLEM-EXTENSION classifications are permitted
+    (they represent intentional curation + whitelisted llem-native
+    fields). Only CONTRADICTION fails the gate.
+    """
     from llenergymeasure.config.models import ExperimentConfig
 
     schema = ExperimentConfig.model_json_schema()
-    drifts = check_engine(engine, schema)
-    assert drifts == [], f"Drift detected for {engine}: {drifts}"
+    records = check_engine(engine, schema)
+    contradictions = [r for r in records if r["classification"] == CLASSIFICATION_CONTRADICTION]
+    assert contradictions == [], f"Contradictions detected for {engine}: {contradictions}"
+
+
+@pytest.mark.parametrize("engine", ["transformers", "vllm", "tensorrt"])
+def test_live_schemas_emit_full_classifications(engine: str) -> None:
+    """Each (engine, field) record carries a recognised classification.
+
+    Downstream consumers (the audit-bot in #655) walk the JSON output and
+    expect every record to be one of the three known classifications.
+    """
+    from llenergymeasure.config.models import ExperimentConfig
+
+    schema = ExperimentConfig.model_json_schema()
+    records = check_engine(engine, schema)
+    assert records, f"check_engine emitted no classifications for {engine}"
+    valid = {CLASSIFICATION_SUBSET, CLASSIFICATION_EXTENSION, CLASSIFICATION_CONTRADICTION}
+    for record in records:
+        assert record["classification"] in valid, (
+            f"Unknown classification {record['classification']!r} for {engine}.{record['field']}"
+        )

--- a/tests/unit/scripts/test_check_pydantic_matches_discovered.py
+++ b/tests/unit/scripts/test_check_pydantic_matches_discovered.py
@@ -17,9 +17,12 @@ from check_pydantic_matches_discovered import (
     _canonicalise_discovered_type,
     _canonicalise_pydantic_type,
     _is_subset,
-    _parse_literal_values,
     check_engine,
 )
+
+from llenergymeasure.config.ssot import ALL_ENGINES
+
+_ENGINES = sorted(ALL_ENGINES)
 
 # ---------------------------------------------------------------------------
 # Canonicalisation unit tests
@@ -89,30 +92,6 @@ class TestCanonicalisePydanticType:
 
 
 # ---------------------------------------------------------------------------
-# Literal value parsing
-# ---------------------------------------------------------------------------
-
-
-class TestParseLiteralValues:
-    def test_single_value(self) -> None:
-        assert _parse_literal_values("Literal['a']") == frozenset({"a"})
-
-    def test_multiple_values(self) -> None:
-        assert _parse_literal_values("Literal['a', 'b', 'c']") == frozenset({"a", "b", "c"})
-
-    def test_int_values_unquoted(self) -> None:
-        assert _parse_literal_values("Literal['8', '16']") == frozenset({"8", "16"})
-
-    def test_empty_literal(self) -> None:
-        assert _parse_literal_values("Literal[]") == frozenset()
-
-    def test_non_literal_returns_none(self) -> None:
-        assert _parse_literal_values("str") is None
-        assert _parse_literal_values("int") is None
-        assert _parse_literal_values("dict[str, int]") is None
-
-
-# ---------------------------------------------------------------------------
 # Subset relation
 # ---------------------------------------------------------------------------
 
@@ -128,11 +107,14 @@ class TestSubsetRelation:
         assert _is_subset("any", "Literal['a', 'b']") is True
         assert _is_subset("any", "ClassName") is True
 
-    def test_literal_value_set_inclusion(self) -> None:
-        # Pydantic narrows discovered Literal: subset.
-        assert _is_subset("Literal['a', 'b', 'c']", "Literal['a', 'b']") is True
-        assert _is_subset("Literal['a', 'b']", "Literal['a']") is True
-        # Equal Literals.
+    def test_literal_to_literal_narrowing_fails(self) -> None:
+        # Engine enumerated the value set; llem must match it.
+        # Narrowing is a CONTRADICTION (engine owns the value contract).
+        assert _is_subset("Literal['a', 'b', 'c']", "Literal['a', 'b']") is False
+        assert _is_subset("Literal['a', 'b']", "Literal['a']") is False
+
+    def test_literal_to_literal_equal_passes(self) -> None:
+        # Equal Literals pass via clause 1 (equal types), not via narrowing.
         assert _is_subset("Literal['a', 'b']", "Literal['a', 'b']") is True
 
     def test_literal_widening_fails(self) -> None:
@@ -141,13 +123,15 @@ class TestSubsetRelation:
         # Pydantic Literal disjoint from discovered: not a subset.
         assert _is_subset("Literal['a', 'b']", "Literal['c', 'd']") is False
 
-    def test_str_to_literal_curation(self) -> None:
-        # Existing curation pattern: str -> Literal[some-strings].
+    def test_str_to_literal_enrichment(self) -> None:
+        # Engine signature uninformative (str/int); llem enriches with the
+        # runtime-valid value set. Engine signature didn't enumerate, so
+        # this is type enrichment, not narrowing.
         assert _is_subset("str", "Literal['mp', 'ray']") is True
         assert _is_subset("int", "Literal['8', '16']") is True
 
-    def test_compound_containing_str_to_literal(self) -> None:
-        # Discovered exposes a union including str; pydantic narrows to specific values.
+    def test_compound_containing_str_to_literal_enrichment(self) -> None:
+        # Discovered exposes a union including str; pydantic enriches to specific values.
         assert _is_subset("str | type[Foo]", "Literal['mp', 'ray']") is True
 
     def test_class_to_primitive_abstraction(self) -> None:
@@ -171,13 +155,13 @@ class TestSubsetRelation:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("engine", ["transformers", "vllm", "tensorrt"])
+@pytest.mark.parametrize("engine", _ENGINES)
 def test_live_schemas_have_no_contradictions(engine: str) -> None:
     """Real repo schemas should classify with zero CONTRADICTIONs.
 
     SUBSET-COMPATIBLE and LLEM-EXTENSION classifications are permitted
-    (they represent intentional curation + whitelisted llem-native
-    fields). Only CONTRADICTION fails the gate.
+    (they represent type enrichment + whitelisted llem-native fields).
+    Only CONTRADICTION fails the gate.
     """
     from llenergymeasure.config.models import ExperimentConfig
 
@@ -187,7 +171,7 @@ def test_live_schemas_have_no_contradictions(engine: str) -> None:
     assert contradictions == [], f"Contradictions detected for {engine}: {contradictions}"
 
 
-@pytest.mark.parametrize("engine", ["transformers", "vllm", "tensorrt"])
+@pytest.mark.parametrize("engine", _ENGINES)
 def test_live_schemas_emit_full_classifications(engine: str) -> None:
     """Each (engine, field) record carries a recognised classification.
 


### PR DESCRIPTION
## Summary

The schema gate (`scripts/check_pydantic_matches_discovered.py`) used equality semantics with a small number of hardcoded "intentional narrowing" exceptions. This false-alarmed on the type-enrichment pattern where llem curates a value set out of a loosely-typed upstream field (e.g. discovered `str` -> Pydantic `Literal["bfloat16","float16"]`).

This PR rewrites the gate around a clearer architectural principle: **llem curates which fields to expose; the value set within an exposed field is the engine's contract**. Type enrichment is accepted; narrowing of an already-enumerated engine type is not.

## What this changes

- `_is_subset(discovered, pydantic)` replaces `_is_intentional_narrowing` with a positive subset relation that accepts:
  - Equal types
  - `T <= any` (engine signature carried no type info)
  - `Literal[...] <= scalar` (engine said `str`/`int`/`float`; llem enriches with the concrete runtime-valid set)
  - `Literal[...] <= union containing the scalar`
  - `dict|str|list <= ClassName` (primitive abstraction over a complex class for serialisation)
- `Literal[A] <= Literal[B]` (subset of an enumerated value set) is NOT accepted. The engine owns the value contract for fields it has enumerated; silent narrowing surfaces as `CONTRADICTION`.
- 3-state classification per `(engine, field)`: `SUBSET-COMPATIBLE`, `LLEM-EXTENSION`, `CONTRADICTION`. Binary exit derives from "any CONTRADICTION".
- Stderr lists only `CONTRADICTION`s; the other two are silent (their counts go in the per-engine OK summary line).
- `LLEM_NATIVE_FIELDS` retained verbatim. The 4-category encoding is deferred to #655.
- Tests parametrise against `ALL_ENGINES` from the config SSOT (matches the convention established in #659).

## Behaviour change worth flagging

An engine bump that drops a value from an enumerated Pydantic `Literal` (or that fails to widen Pydantic when upstream adds one) will now surface as `CONTRADICTION` instead of passing under the old "subset is fine" semantics. The maintainer must explicitly widen the Pydantic type, remove the field, or accept the divergence.

## Doc updates

- `docs/explanation/architecture/parameter-curation.md`: describes the type-enrichment principle and the updated 3-state classification.
- `docs/explanation/architecture/pipeline-architecture.md`: updates the maintainer's bump-review workflow to reflect that narrowing is no longer an option.

## Test plan

- [x] 32 tests pass: `uv run pytest tests/unit/scripts/test_check_pydantic_matches_discovered.py`
- [x] Live gate: `uv run python scripts/check_pydantic_matches_discovered.py` exits 0 (98 records classified, 0 contradictions across vllm 0.7.3 / tensorrt 0.21.0 / transformers 4.57.3)
- [x] Ruff clean