### PR TITLE
refactor(infra): runtime handshake reads engine_version from bundled envelope

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -119,11 +119,11 @@ sharing across machines on cluster storage.
   ritual; first dispatch primes automatically.
 - **Not a permanent host pollution**. The cache is a single bind-mounted
   directory; `rm -rf ~/.cache/llem/deps/` cleans it.
-- **Not an alternative to the engine-version SSOT**. The probed engine
+- **Not an alternative to the engine-version gate**. The probed engine
   library version (`vllm.__version__`, `tensorrt_llm.__version__`,
-  `transformers.__version__`) is compared at study setup against
-  `engine_versions/{engine}.yaml::library.current_version` and a
-  mismatch is a hard error (see `version_handshake.py`).
+  `transformers.__version__`) is compared at study setup against the
+  `engine_version` envelope on the wheel-bundled invariants + schema
+  artefacts, and a mismatch is a hard error (see `version_handshake.py`).
 
 ## Engine image strategy
 

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -427,16 +427,22 @@ docker image inspect llenergymeasure:transformers \
     --format '{{json .Config.Labels}}' | python3 -m json.tool
 ```
 
-> **Legacy: schema-fingerprint handshake.** Earlier versions stamped
-> `org.opencontainers.image.version` and `llem.expconf.schema.fingerprint`
-> labels at build time so `llem doctor` could detect host/container schema
-> skew via `StudyRunner._prepare_images`. Once the image stopped baking the
-> project source (the project is bind-mounted at runtime - see
-> `docs/development.md`), the bound-in source always matches the host source,
-> so the handshake became structurally redundant. The labels are no longer
-> set on any engine image; `llem doctor` reports `UNVERIFIED` for all engines
-> and does not block. Removing the dead `version_handshake.py` code is
-> tracked separately.
+> **Schema-fingerprint label is legacy; engine-version probe is live.**
+> Earlier versions stamped `org.opencontainers.image.version` and
+> `llem.expconf.schema.fingerprint` labels at build time so
+> `StudyRunner._prepare_images` could detect host/container schema skew.
+> Once the image stopped baking the project source (it is bind-mounted at
+> runtime - see `docs/development.md`), the schema-fingerprint check
+> became structurally redundant: the in-container source always equals
+> the host source. That label is no longer set on first-party images and
+> never existed on upstream-direct images (vllm, tensorrt). What
+> `version_handshake.py` does today is a different check: it probes each
+> image's engine library version (`vllm.__version__`,
+> `tensorrt_llm.__version__`, `transformers.__version__`) and compares
+> it against the engine_version envelope on the wheel-bundled invariants
+> + schema artefacts. A real library/artefact mismatch is a hard error;
+> set `LLEM_SKIP_IMAGE_CHECK=1` to bypass if you know the skew is
+> harmless.
 
 See [troubleshooting.md](/how-to/troubleshoot#schema-skew-between-host-and-docker-image)
 for the remediation flow when a mismatch is reported.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -378,15 +378,18 @@ A container stack trace full of `extra_forbidden` Pydantic errors (often with
 URLs mixing `errors.pydantic.dev/2.10/…` and `errors.pydantic.dev/2.12/…`, a
 tell for version skew).
 
-> **Legacy: the schema-fingerprint handshake no longer catches this.** Earlier
-> versions of `llem` stamped each image with an `llem.expconf.schema.fingerprint`
-> label and `StudyRunner._prepare_images` compared it to the host fingerprint
-> before any experiment ran. Once images stopped baking the project source (it
-> is bind-mounted at runtime), the handshake became structurally redundant: the
-> in-container source always equals the host source. The label is no longer
-> set on any engine image; `llem doctor` reports `UNVERIFIED` and does not
-> block. The dead `version_handshake.py` plumbing is tracked for removal in a
-> follow-up issue.
+> **What the runtime gate now catches.** The original
+> `llem.expconf.schema.fingerprint` label is gone (bind-mounted source made
+> the schema-fingerprint check structurally redundant: in-container source
+> always equals the host source). What `StudyRunner._prepare_images` does
+> today is a different check: it probes the in-container engine library
+> version and compares it against the engine_version envelope on the
+> wheel-bundled invariants + schema artefacts. The Pydantic-shape errors
+> above are exactly the symptom that probe is meant to catch ahead of
+> dispatch, so on current builds the gate should hard-error before the
+> container ever runs. If you reached this section anyway, either the image
+> shipped without engine-version visibility or `LLEM_SKIP_IMAGE_CHECK=1`
+> was set.
 
 **Cause:** all three engines now bind-mount the host project source at
 runtime, so a Pydantic-shape error here means the engine library inside the

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -44,6 +44,7 @@ __all__ = [
     "ENV_SKIP_IMAGE_CHECK",
     "LABEL_IMAGE_VERSION",
     "LABEL_SCHEMA_FINGERPRINT",
+    "BundledEngineVersionMismatchError",
     "ImageStamp",
     "SchemaStatus",
     "VersionMismatchError",
@@ -53,6 +54,7 @@ __all__ = [
     "inspect_image_stamp",
     "parse_image_stamp",
     "probe_image_engine_version",
+    "read_bundled_engine_version",
     "read_ssot_engine_version",
     "rebuild_hint",
     "skip_check_enabled",
@@ -217,8 +219,86 @@ def probe_image_engine_version(
     return None
 
 
+class BundledEngineVersionMismatchError(RuntimeError):
+    """Raised when the bundled invariants and schema artefacts disagree on engine_version.
+
+    Both artefacts are sourced from the same per-version
+    ``engine_versions/<engine>/v<safe>/outputs/`` directory at wheel build
+    time, so disagreement here indicates a build-time bundling bug
+    (mismatched force-include paths, half-applied refresh, or one artefact
+    re-mined without the other). Surfaces loud rather than picking one of
+    the two arbitrarily as the runtime expectation.
+    """
+
+
+def read_bundled_engine_version(engine: str) -> str | None:
+    """Return the engine_version field from the loaded invariants + schema artefacts.
+
+    The wheel ships per-engine machine artefacts whose envelope carries the
+    engine_version they were mined for. This function reads through
+    :class:`EngineInvariantsLoader` and :class:`SchemaLoader` (so the
+    primary read goes via the same mechanism the runtime experiment path
+    uses), cross-checks that both bundled artefacts agree on
+    engine_version, and returns the version string.
+
+    Returns ``None`` if either artefact is absent (e.g. wheel built before
+    the engine was vendored). Raises
+    :class:`BundledEngineVersionMismatchError` if the two bundled artefacts
+    disagree - that disagreement only happens via a build-time bundling
+    bug, never via a runtime configuration choice, so silent handling
+    would mask the real issue.
+
+    Preferred over :func:`read_ssot_engine_version` for the runtime
+    handshake because the bundled artefact is in the wheel (so it works
+    for installed users without an in-repo SSOT file), and because the
+    artefact's engine_version is the one llem actually applies at
+    experiment time - the SSOT version describes the build's INTENT;
+    the bundled envelope describes what shipped.
+    """
+    from llenergymeasure.config.engine_invariants.loader import EngineInvariantsLoader
+    from llenergymeasure.config.schema_loader import SchemaLoader
+
+    try:
+        invariants = EngineInvariantsLoader().load_invariants(engine)
+    except FileNotFoundError as exc:
+        logger.debug("Bundled invariants read failed for %s: %s", engine, exc)
+        return None
+    try:
+        schema = SchemaLoader().load_schema(engine)
+    except (FileNotFoundError, ValueError) as exc:
+        # ValueError covers SchemaLoader rejecting an unknown engine name.
+        logger.debug("Bundled schema read failed for %s: %s", engine, exc)
+        return None
+
+    inv_version = (invariants.engine_version or "").strip()
+    sch_version = (schema.engine_version or "").strip()
+    if not inv_version and not sch_version:
+        return None
+    if inv_version != sch_version:
+        raise BundledEngineVersionMismatchError(
+            f"Bundled artefacts for {engine!r} disagree on engine_version: "
+            f"invariants envelope says {inv_version!r}, schema envelope says "
+            f"{sch_version!r}. This indicates a build-time bundling bug - "
+            f"both artefacts must be sourced from the same per-version "
+            f"engine_versions/<engine>/v<safe>/outputs/ directory. Check "
+            f"pyproject.toml's [tool.hatch.build.targets.wheel.force-include] "
+            f"entries for the engine and rebuild the wheel."
+        )
+    return inv_version
+
+
 def read_ssot_engine_version(engine: str) -> str | None:
     """Read ``engine_versions/{engine}/current.yaml::library.current_version``.
+
+    Legacy/dev-mode helper. Use :func:`read_bundled_engine_version` for the
+    runtime handshake - it reads from the bundled wheel artefact (works
+    for installed users, no dependency on an in-repo
+    ``engine_versions/`` tree) and cross-checks invariants/schema agreement.
+
+    This SSOT-file reader returns ``None`` for wheel-installed users
+    (engine_versions/ is not in the wheel), so it can't drive the
+    runtime handshake on its own. Retained for in-repo dev tooling and
+    for the parity guard at ``scripts/ci/check_engine_bundle_pin.sh``.
 
     Returns ``None`` if the file is absent, unreadable, or the field is
     missing. The repo root is resolved via

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -270,10 +270,8 @@ def read_bundled_engine_version(engine: str) -> str | None:
         logger.debug("Bundled schema read failed for %s: %s", engine, exc)
         return None
 
-    inv_version = (invariants.engine_version or "").strip()
-    sch_version = (schema.engine_version or "").strip()
-    if not inv_version and not sch_version:
-        return None
+    inv_version = invariants.engine_version.strip()
+    sch_version = schema.engine_version.strip()
     if inv_version != sch_version:
         raise BundledEngineVersionMismatchError(
             f"Bundled artefacts for {engine!r} disagree on engine_version: "
@@ -290,15 +288,9 @@ def read_bundled_engine_version(engine: str) -> str | None:
 def read_ssot_engine_version(engine: str) -> str | None:
     """Read ``engine_versions/{engine}/current.yaml::library.current_version``.
 
-    Legacy/dev-mode helper. Use :func:`read_bundled_engine_version` for the
-    runtime handshake - it reads from the bundled wheel artefact (works
-    for installed users, no dependency on an in-repo
-    ``engine_versions/`` tree) and cross-checks invariants/schema agreement.
-
-    This SSOT-file reader returns ``None`` for wheel-installed users
-    (engine_versions/ is not in the wheel), so it can't drive the
-    runtime handshake on its own. Retained for in-repo dev tooling and
-    for the parity guard at ``scripts/ci/check_engine_bundle_pin.sh``.
+    Legacy: use :func:`read_bundled_engine_version` for the runtime handshake.
+    This helper is retained for in-repo dev tooling that needs the SSOT
+    file directly (it's not shipped in the wheel).
 
     Returns ``None`` if the file is absent, unreadable, or the field is
     missing. The repo root is resolved via

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -50,6 +50,7 @@ from llenergymeasure.domain.progress import STEP_BASELINE, STEPS_LOCAL, docker_s
 from llenergymeasure.infra.version_handshake import (
     ENV_SKIP_IMAGE_CHECK,
     LABEL_SCHEMA_FINGERPRINT,
+    BundledEngineVersionMismatchError,
     ImageStamp,
     SchemaStatus,
     VersionMismatchError,
@@ -58,7 +59,7 @@ from llenergymeasure.infra.version_handshake import (
     compute_expconf_fingerprint,
     parse_image_stamp,
     probe_image_engine_version,
-    read_ssot_engine_version,
+    read_bundled_engine_version,
     rebuild_hint,
     skip_check_enabled,
 )
@@ -1583,14 +1584,15 @@ class StudyRunner:
 
         1. **Label-based fingerprint check** (preferred when present).
            Definitive ``OK`` / ``MISMATCH`` answers are trusted directly.
-        2. **SSOT engine-version probe** (fallback). When the label is
+        2. **Bundled engine-version probe** (fallback). When the label is
            absent or stamped ``"unknown"``, probe the engine library's
-           ``__version__`` inside the image and compare against
-           ``engine_versions/{engine}.yaml::library.current_version``.
-           Closes the verification gap for upstream-direct images (vllm,
-           tensorrt) which never had a llem schema-fingerprint label,
-           and for legacy local images where the fingerprint was stamped
-           as ``"unknown"``.
+           ``__version__`` inside the image and compare against the
+           ``engine_version`` envelope field on the bundled invariants +
+           schema artefacts (read via :func:`read_bundled_engine_version`,
+           which cross-checks both bundled artefacts agree). Closes the
+           verification gap for upstream-direct images (vllm, tensorrt)
+           which never had a llem schema-fingerprint label, and for legacy
+           local images where the fingerprint was stamped as ``"unknown"``.
         """
         if skip_check_enabled():
             return "bypassed", None
@@ -1620,14 +1622,22 @@ class StudyRunner:
 
         # label_status is UNVERIFIED or UNREACHABLE: fall back to engine-
         # version probe. The probe takes one docker-run (a few seconds)
-        # and is cached per (image, engine).
+        # and is cached per (image, engine). The "expected" version comes
+        # from the bundled invariants/schema envelopes (the artefacts llem
+        # actually applies at experiment time), not from current.yaml -
+        # current.yaml isn't shipped in the wheel, so an SSOT-based check
+        # is silently UNREACHABLE for installed users. The bundled envelope
+        # works in both wheel and editable installs.
         probed = probe_image_engine_version(image, engine_name)
-        expected = read_ssot_engine_version(engine_name)
+        try:
+            expected = read_bundled_engine_version(engine_name)
+        except BundledEngineVersionMismatchError as exc:
+            return "mismatch (bundled artefact disagreement)", exc
         probe_status = classify_engine_version(probed, expected)
 
         if probe_status is SchemaStatus.OK:
             logger.debug(
-                "Image %s verified via engine-version probe: %s matches SSOT",
+                "Image %s verified via engine-version probe: %s matches bundled envelope",
                 image,
                 probed,
             )
@@ -1640,7 +1650,7 @@ class StudyRunner:
             # verify the engine version.
             logger.warning(
                 "Image %s has no %s label and the engine-version probe was "
-                "inconclusive (probed=%r, SSOT=%r). Dispatch will proceed; "
+                "inconclusive (probed=%r, bundled=%r). Dispatch will proceed; "
                 "the bind-mounted framework defines the contract regardless.",
                 image,
                 LABEL_SCHEMA_FINGERPRINT,
@@ -1652,19 +1662,17 @@ class StudyRunner:
         # probe_status is MISMATCH
         error = VersionMismatchError(
             f"Docker image '{image}' has {engine_name} library version "
-            f"{probed!r} but engine_versions/{engine_name}/current.yaml "
-            f"::library.current_version is {expected!r}. The vendored "
-            f"invariants + discovered schemas in "
-            f"src/llenergymeasure/engines/{engine_name}/ were generated "
-            f"against {expected!r} and may not be compatible with "
-            f"{probed!r}.\n\n"
+            f"{probed!r} but the bundled invariants + discovered schemas "
+            f"in this wheel were mined against {expected!r}. Applying "
+            f"version-{expected!r} validation rules to a version-{probed!r} "
+            f"substrate is not safe.\n\n"
             f"To fix:\n"
-            f"  Update engine_versions/{engine_name}/current.yaml to {probed!r}, "
-            f"or pull an image matching {expected!r}.\n\n"
+            f"  Pull an image matching {expected!r}, or install a wheel "
+            f"built against {probed!r}.\n\n"
             f"If you're certain the skew is harmless, set "
             f"{ENV_SKIP_IMAGE_CHECK}=1."
         )
-        return f"mismatch (engine {probed} vs SSOT {expected})", error
+        return f"mismatch (engine {probed} vs bundled {expected})", error
 
     def _run_gap(self, seconds: float, label: str) -> None:
         """Run a thermal gap, rendering countdown in the live display or terminal."""

--- a/tests/unit/infra/test_version_handshake.py
+++ b/tests/unit/infra/test_version_handshake.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from llenergymeasure.config.ssot import ALL_ENGINES
 from llenergymeasure.infra.version_handshake import (
     ENV_SKIP_IMAGE_CHECK,
     LABEL_IMAGE_VERSION,
@@ -247,12 +248,12 @@ class TestReadSsotEngineVersion:
 
 
 class TestReadBundledEngineVersion:
-    def test_known_engine_returns_envelope_version(self) -> None:
+    @pytest.mark.parametrize("engine", sorted(ALL_ENGINES))
+    def test_known_engine_returns_envelope_version(self, engine: str) -> None:
         """Bundled invariants + schema envelopes carry engine_version; both agree."""
-        for engine in ("vllm", "tensorrt", "transformers"):
-            version = read_bundled_engine_version(engine)
-            assert isinstance(version, str)
-            assert version  # non-empty
+        version = read_bundled_engine_version(engine)
+        assert isinstance(version, str)
+        assert version  # non-empty
 
     def test_unknown_engine_returns_none(self) -> None:
         # SchemaLoader rejects unknown engines with ValueError; helper swallows

--- a/tests/unit/infra/test_version_handshake.py
+++ b/tests/unit/infra/test_version_handshake.py
@@ -12,6 +12,7 @@ from llenergymeasure.infra.version_handshake import (
     ENV_SKIP_IMAGE_CHECK,
     LABEL_IMAGE_VERSION,
     LABEL_SCHEMA_FINGERPRINT,
+    BundledEngineVersionMismatchError,
     ImageStamp,
     SchemaStatus,
     classify_engine_version,
@@ -19,6 +20,7 @@ from llenergymeasure.infra.version_handshake import (
     compute_expconf_fingerprint,
     inspect_image_stamp,
     probe_image_engine_version,
+    read_bundled_engine_version,
     read_ssot_engine_version,
     skip_check_enabled,
 )
@@ -237,6 +239,49 @@ class TestReadSsotEngineVersion:
 
     def test_unknown_engine_returns_none(self) -> None:
         assert read_ssot_engine_version("nonexistent_engine_xyz") is None
+
+
+# ---------------------------------------------------------------------------
+# read_bundled_engine_version - reads bundled invariants + schema envelopes
+# ---------------------------------------------------------------------------
+
+
+class TestReadBundledEngineVersion:
+    def test_known_engine_returns_envelope_version(self) -> None:
+        """Bundled invariants + schema envelopes carry engine_version; both agree."""
+        for engine in ("vllm", "tensorrt", "transformers"):
+            version = read_bundled_engine_version(engine)
+            assert isinstance(version, str)
+            assert version  # non-empty
+
+    def test_unknown_engine_returns_none(self) -> None:
+        # SchemaLoader rejects unknown engines with ValueError; helper swallows
+        # to None (caller's contract: "no answer" rather than "raise").
+        assert read_bundled_engine_version("nonexistent_engine_xyz") is None
+
+    def test_invariants_schema_disagreement_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bundled artefact disagreement is a build-time bundling bug; raise loud."""
+        from dataclasses import replace
+
+        from llenergymeasure.config.engine_invariants.loader import EngineInvariantsLoader
+        from llenergymeasure.config.schema_loader import SchemaLoader
+
+        original_load_invariants = EngineInvariantsLoader.load_invariants
+        original_load_schema = SchemaLoader.load_schema
+
+        def fake_load_invariants(self, engine):  # type: ignore[no-untyped-def]
+            real = original_load_invariants(self, engine)
+            return replace(real, engine_version="1.2.3")
+
+        def fake_load_schema(self, engine):  # type: ignore[no-untyped-def]
+            real = original_load_schema(self, engine)
+            return replace(real, engine_version="9.9.9")
+
+        monkeypatch.setattr(EngineInvariantsLoader, "load_invariants", fake_load_invariants)
+        monkeypatch.setattr(SchemaLoader, "load_schema", fake_load_schema)
+
+        with pytest.raises(BundledEngineVersionMismatchError, match=r"1\.2\.3.*9\.9\.9"):
+            read_bundled_engine_version("vllm")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the consistency gap raised in #656. The two-tier image handshake's fallback (substrate vs SSOT) read \"expected\" from `engine_versions/<engine>/current.yaml` - a file that **isn't in the wheel**. For installed users, that read silently returned `None`, the gate fell through to soft-warn-and-proceed, and a substrate mismatch never surfaced. This PR pivots the \"expected\" source to the bundled invariants + schema envelopes, which are in the wheel and are the artefacts llem actually applies at experiment time.

## What this changes

- **`read_bundled_engine_version(engine)`** in `infra/version_handshake.py`: reads `engine_version` from the bundled artefacts via `EngineInvariantsLoader` and `SchemaLoader`. Cross-checks both bundled artefacts agree on `engine_version`; disagreement raises `BundledEngineVersionMismatchError` (build-time bundling bug, not a runtime configuration choice).
- **`study/runner.py:_verify_image_fingerprint`**: switches from `read_ssot_engine_version` to `read_bundled_engine_version` for the \"expected\" value. Error message rewritten to point at the bundled-vs-substrate disagreement (rather than current.yaml-vs-substrate).
- **`read_ssot_engine_version`** retained but documented as legacy/dev-mode. Used by `scripts/ci/check_engine_bundle_pin.sh` (PR-A) and other in-repo tooling that needs the SSOT explicitly.

## Behaviour change worth flagging

Previously-silent `UNREACHABLE` on installed users with mismatched substrate now surfaces as `VersionMismatchError`. This is a strict improvement in safety - applying version-X validation rules to a version-Y substrate has never been safe; the old handshake just couldn't notice. `LLEM_SKIP_IMAGE_CHECK=1` continues to bypass the gate for users who know the skew is harmless.

## Test plan

- [x] 3 new tests for `read_bundled_engine_version`: known engine returns envelope version (cross-validated against schema), unknown engine returns None, invariants/schema disagreement raises `BundledEngineVersionMismatchError` (monkeypatched).
- [x] `tests/unit/infra/test_version_handshake.py` + `tests/unit/study/test_study_runner.py`: 105 passed.
- [x] Lint clean: `ruff check src/ tests/` All checks passed!
- [x] `lint-imports`: 4 contracts kept, 0 broken (no layer violation - `infra/` importing `config/` is allowed; runtime layers continue not to import `engine_versions/`).
- [ ] Verify on PR #654 rebase: image probe vs bundled envelope disagreement should now surface as a clear VersionMismatchError instead of soft-warn.

## Relationship to other PRs

- **Independent of PR `refactor/engine-output-layout-complete` (#657)**: works against either current main (bundled artefacts in src/) or post-PR-A main (force-include from outputs/). The loaders abstract the bundling location.
- **Independent of PR `refactor/pydantic-schema-subset-gate` (#658)**: touches `infra/version_handshake.py` and `study/runner.py`, no overlap with the schema gate.

## Closes

#656.