### PR TITLE
refactor(producers): emit JSON Schema-conformant schema.discovered.json

### DIFF
--- a/engine_versions/tensorrt/v0_21_0/outputs/schema.discovered.json
+++ b/engine_versions/tensorrt/v0_21_0/outputs/schema.discovered.json
@@ -1,11 +1,11 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "2.0.0",
   "engine": "tensorrt",
   "engine_version": "0.21.0",
   "engine_commit_sha": null,
-  "image_ref": "llenergymeasure:tensorrt-0.21.0",
+  "image_ref": "nvcr.io/nvidia/tensorrt-llm/release:0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-06T20:20:57+02:00",
+  "discovered_at": "2026-05-22T00:00:00+00:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {
@@ -18,559 +18,1999 @@
     {
       "section": "sampling_params",
       "fields": [],
-      "reason": "SamplingParams is a dataclass; no per-field descriptions"
+      "reason": "SamplingParams is a dataclass with no per-field field(metadata={'description': ...}) metadata; descriptions unavailable"
     }
   ],
   "engine_params": {
     "model": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "format": "path",
+          "type": "string"
+        }
+      ],
+      "description": "The path to the model checkpoint or the model name from the Hugging Face Hub.",
+      "x-source": "pydantic_field",
       "type": "string",
       "default": null,
-      "description": "The path to the model checkpoint or the model name from the Hugging Face Hub.",
       "deprecated": false
     },
     "tokenizer": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "format": "path",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The path to the tokenizer checkpoint or the tokenizer name from the Hugging Face Hub.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "tokenizer_mode": {
-      "type": "Literal['auto', 'slow']",
       "default": "auto",
       "description": "The mode to initialize the tokenizer.",
+      "enum": [
+        "auto",
+        "slow"
+      ],
+      "type": "Literal['auto', 'slow']",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "skip_tokenizer_init": {
-      "type": "boolean",
       "default": false,
       "description": "Whether to skip the tokenizer initialization.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "trust_remote_code": {
-      "type": "boolean",
       "default": false,
       "description": "Whether to trust the remote code.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "tensor_parallel_size": {
-      "type": "integer",
       "default": 1,
       "description": "The tensor parallel size.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "dtype": {
-      "type": "string",
       "default": "auto",
       "description": "The data type to use for the model.",
+      "type": "string",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "revision": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The revision to use for the model.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "tokenizer_revision": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The revision to use for the tokenizer.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "pipeline_parallel_size": {
-      "type": "integer",
       "default": 1,
       "description": "The pipeline parallel size.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "context_parallel_size": {
-      "type": "integer",
       "default": 1,
       "description": "The context parallel size.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "gpus_per_node": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The number of GPUs per node.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "moe_cluster_parallel_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The cluster parallel size for MoE models's expert weights.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "moe_tensor_parallel_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The tensor parallel size for MoE models's expert weights.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "moe_expert_parallel_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The expert parallel size for MoE models's expert weights.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "enable_attention_dp": {
-      "type": "boolean",
       "default": false,
       "description": "Enable attention data parallel.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "cp_config": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Context parallel config.",
+      "x-source": "pydantic_field",
       "type": "object | None",
       "default": null,
-      "description": "Context parallel config.",
       "deprecated": false
     },
     "load_format": {
-      "type": "Literal['auto', 'dummy']",
       "default": "auto",
       "description": "The format to load the model.",
+      "enum": [
+        "auto",
+        "dummy"
+      ],
+      "type": "Literal['auto', 'dummy']",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "enable_lora": {
-      "type": "boolean",
       "default": false,
       "description": "Enable LoRA.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "max_lora_rank": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
+      "deprecated": true,
       "description": "The maximum LoRA rank.",
-      "deprecated": true
+      "x-source": "pydantic_field",
+      "type": "integer | None"
     },
     "max_loras": {
-      "type": "integer",
       "default": 4,
+      "deprecated": true,
       "description": "The maximum number of LoRA.",
-      "deprecated": true
+      "type": "integer",
+      "x-source": "pydantic_field"
     },
     "max_cpu_loras": {
-      "type": "integer",
       "default": 4,
+      "deprecated": true,
       "description": "The maximum number of LoRA on CPU.",
-      "deprecated": true
+      "type": "integer",
+      "x-source": "pydantic_field"
     },
     "lora_config": {
-      "type": "LoraConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LoraConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "LoRA configuration for the model.",
+      "x-source": "pydantic_field",
+      "type": "LoraConfig | None",
       "deprecated": false
     },
     "enable_prompt_adapter": {
-      "type": "boolean",
       "default": false,
       "description": "Enable prompt adapter.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "max_prompt_adapter_token": {
-      "type": "integer",
       "default": 0,
       "description": "The maximum number of prompt adapter tokens.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "quant_config": {
-      "type": "QuantConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/QuantConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Quantization config.",
+      "x-source": "pydantic_field",
+      "type": "QuantConfig | None",
       "deprecated": false
     },
     "kv_cache_config": {
+      "$ref": "#/$defs/KvCacheConfig",
+      "description": "KV cache config.",
+      "x-source": "pydantic_field",
       "type": "KvCacheConfig",
       "default": null,
-      "description": "KV cache config.",
       "deprecated": false
     },
     "enable_chunked_prefill": {
-      "type": "boolean",
       "default": false,
       "description": "Enable chunked prefill.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "guided_decoding_backend": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Guided decoding backend.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "batched_logits_processor": {
-      "type": "Optional[tensorrt_llm.sampling_params.BatchedLogitsProcessor]",
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Batched logits processor.",
+      "type": "Optional[tensorrt_llm.sampling_params.BatchedLogitsProcessor]",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "iter_stats_max_iterations": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum number of iterations for iter stats.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "request_stats_max_iterations": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum number of iterations for request stats.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "peft_cache_config": {
-      "type": "PeftCacheConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PeftCacheConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "PEFT cache config.",
+      "x-source": "pydantic_field",
+      "type": "PeftCacheConfig | None",
       "deprecated": false
     },
     "scheduler_config": {
+      "$ref": "#/$defs/SchedulerConfig",
+      "description": "Scheduler config.",
+      "x-source": "pydantic_field",
       "type": "SchedulerConfig",
       "default": null,
-      "description": "Scheduler config.",
       "deprecated": false
     },
     "cache_transceiver_config": {
-      "type": "CacheTransceiverConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CacheTransceiverConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Cache transceiver config.",
+      "x-source": "pydantic_field",
+      "type": "CacheTransceiverConfig | None",
       "deprecated": false
     },
     "speculative_config": {
-      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LookaheadDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/MedusaDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/EagleDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/MTPDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/NGramDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/DraftTargetDecodingConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Speculative decoding config.",
+      "x-source": "pydantic_field",
+      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
       "deprecated": false
     },
     "batching_type": {
-      "type": "BatchingType | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BatchingType"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Batching type.",
+      "x-source": "pydantic_field",
+      "type": "BatchingType | None",
       "deprecated": false
     },
     "normalize_log_probs": {
-      "type": "boolean",
       "default": false,
       "description": "Normalize log probabilities.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "max_batch_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum batch size.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_input_len": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum input length.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_seq_len": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum sequence length.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_beam_width": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum beam width.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_num_tokens": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum number of tokens.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "gather_generation_logits": {
-      "type": "boolean",
       "default": false,
       "description": "Gather generation logits.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "num_postprocess_workers": {
-      "type": "integer",
       "default": 0,
       "description": "The number of processes used for postprocessing the generated tokens, including detokenization.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "postprocess_tokenizer_dir": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The path to the tokenizer directory for postprocessing.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "reasoning_parser": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The parser to separate reasoning content from output.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "garbage_collection_gen0_threshold": {
-      "type": "integer",
       "default": 20000,
       "description": "Threshold for Python garbage collection of generation 0 objects.Lower values trigger more frequent garbage collection.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "decoding_config": {
-      "type": "Optional[DecodingConfig]",
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
+      "deprecated": true,
       "description": "The decoding config.",
-      "deprecated": true
+      "type": "Optional[DecodingConfig]",
+      "x-source": "pydantic_field"
     },
     "backend": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The backend to use for this LLM instance.",
+      "exclude_json_schema": true,
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "auto_parallel": {
-      "type": "boolean",
       "default": false,
+      "deprecated": true,
       "description": "Enable auto parallel mode.",
-      "deprecated": true
+      "type": "boolean",
+      "x-source": "pydantic_field"
     },
     "auto_parallel_world_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
+      "deprecated": true,
       "description": "The world size for auto parallel mode.",
-      "deprecated": true
+      "x-source": "pydantic_field",
+      "type": "integer | None"
     },
     "enable_tqdm": {
-      "type": "boolean",
       "default": false,
       "description": "Enable tqdm for progress bar.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "workspace": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The workspace for the model.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "enable_build_cache": {
-      "type": "Union[tensorrt_llm.llmapi.build_cache.BuildCacheConfig, bool]",
       "default": false,
       "description": "Enable build cache.",
+      "type": "Union[tensorrt_llm.llmapi.build_cache.BuildCacheConfig, bool]",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "extended_runtime_perf_knob_config": {
-      "type": "ExtendedRuntimePerfKnobConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExtendedRuntimePerfKnobConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Extended runtime perf knob config.",
+      "x-source": "pydantic_field",
+      "type": "ExtendedRuntimePerfKnobConfig | None",
       "deprecated": false
     },
     "calib_config": {
-      "type": "CalibConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CalibConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Calibration config.",
+      "x-source": "pydantic_field",
+      "type": "CalibConfig | None",
       "deprecated": false
     },
     "embedding_parallel_mode": {
-      "type": "string",
       "default": "SHARDING_ALONG_VOCAB",
       "description": "The embedding parallel mode.",
+      "type": "string",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "fast_build": {
-      "type": "boolean",
       "default": false,
       "description": "Enable fast build.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "build_config": {
-      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Build config.",
+      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "x-source": "pydantic_field",
       "deprecated": false
     }
   },
   "sampling_params": {
     "end_id": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "pad_id": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_tokens": {
       "type": "int",
-      "default": 32
+      "default": 32,
+      "x-source": "dataclass_field"
     },
     "bad": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "bad_token_ids": {
       "type": "list[int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "stop": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "stop_token_ids": {
       "type": "list[int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "include_stop_str_in_output": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "embedding_bias": {
       "type": "Tensor | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "logits_processor": {
       "type": "LogitsProcessor | list[LogitsProcessor] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "apply_batched_logits_processor": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "n": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "best_of": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "use_beam_search": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "top_k": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p_min": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p_reset_ids": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p_decay": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "seed": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "temperature": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "min_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "beam_search_diversity_rate": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "repetition_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "presence_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "frequency_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "length_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "early_stopping": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "no_repeat_ngram_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "min_p": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "beam_width_array": {
       "type": "list[int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "logprobs": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "prompt_logprobs": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "return_context_logits": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "return_generation_logits": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "exclude_input_from_output": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "return_encoder_output": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "return_perf_metrics": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "additional_model_outputs": {
       "type": "list[AdditionalModelOutput] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "lookahead_config": {
       "type": "LookaheadDecodingConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "guided_decoding": {
       "type": "GuidedDecodingParams | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ignore_eos": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "detokenize": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "add_special_tokens": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "truncate_prompt_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "skip_special_tokens": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "spaces_between_special_tokens": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
+    }
+  },
+  "engine_params_defs": {
+    "BatchingType": {
+      "enum": [
+        "STATIC",
+        "INFLIGHT"
+      ],
+      "title": "BatchingType",
+      "type": "string"
+    },
+    "CacheTransceiverConfig": {
+      "description": "Configuration for the cache transceiver.",
+      "properties": {
+        "max_num_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The max number of tokens the transfer buffer can fit.",
+          "title": "Max Num Tokens"
+        }
+      },
+      "title": "CacheTransceiverConfig",
+      "type": "object"
+    },
+    "CalibConfig": {
+      "description": "Calibration configuration.",
+      "properties": {
+        "device": {
+          "default": "cuda",
+          "description": "The device to run calibration.",
+          "enum": [
+            "cuda",
+            "cpu"
+          ],
+          "title": "Device",
+          "type": "string"
+        },
+        "calib_dataset": {
+          "default": "cnn_dailymail",
+          "description": "The name or local path of calibration dataset.",
+          "title": "Calib Dataset",
+          "type": "string"
+        },
+        "calib_batches": {
+          "default": 512,
+          "description": "The number of batches that the calibration runs.",
+          "title": "Calib Batches",
+          "type": "integer"
+        },
+        "calib_batch_size": {
+          "default": 1,
+          "description": "The batch size that the calibration runs.",
+          "title": "Calib Batch Size",
+          "type": "integer"
+        },
+        "calib_max_seq_length": {
+          "default": 512,
+          "description": "The maximum sequence length that the calibration runs.",
+          "title": "Calib Max Seq Length",
+          "type": "integer"
+        },
+        "random_seed": {
+          "default": 1234,
+          "description": "The random seed used for calibration.",
+          "title": "Random Seed",
+          "type": "integer"
+        },
+        "tokenizer_max_seq_length": {
+          "default": 2048,
+          "description": "The maximum sequence length to initialize tokenizer for calibration.",
+          "title": "Tokenizer Max Seq Length",
+          "type": "integer"
+        }
+      },
+      "title": "CalibConfig",
+      "type": "object"
+    },
+    "CapacitySchedulerPolicy": {
+      "enum": [
+        "MAX_UTILIZATION",
+        "GUARANTEED_NO_EVICT",
+        "STATIC_BATCH"
+      ],
+      "title": "CapacitySchedulerPolicy",
+      "type": "string"
+    },
+    "ContextChunkingPolicy": {
+      "description": "Context chunking policy. ",
+      "enum": [
+        "FIRST_COME_FIRST_SERVED",
+        "EQUAL_PROGRESS"
+      ],
+      "title": "ContextChunkingPolicy",
+      "type": "string"
+    },
+    "DraftTargetDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "pytorch_weights_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pytorch Weights Path"
+        }
+      },
+      "title": "DraftTargetDecodingConfig",
+      "type": "object"
+    },
+    "DynamicBatchConfig": {
+      "description": "Dynamic batch configuration.\n\nControls how batch size and token limits are dynamically adjusted at runtime.",
+      "properties": {
+        "enable_batch_size_tuning": {
+          "description": "Controls if the batch size should be tuned dynamically",
+          "title": "Enable Batch Size Tuning",
+          "type": "boolean"
+        },
+        "enable_max_num_tokens_tuning": {
+          "description": "Controls if the max num tokens should be tuned dynamically",
+          "title": "Enable Max Num Tokens Tuning",
+          "type": "boolean"
+        },
+        "dynamic_batch_moving_average_window": {
+          "description": "The window size for moving average of input and output length which is used to calculate dynamic batch size and max num tokens",
+          "title": "Dynamic Batch Moving Average Window",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enable_batch_size_tuning",
+        "enable_max_num_tokens_tuning",
+        "dynamic_batch_moving_average_window"
+      ],
+      "title": "DynamicBatchConfig",
+      "type": "object"
+    },
+    "EagleDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "eagle_choices": {
+          "anyOf": [
+            {
+              "items": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Eagle Choices"
+        },
+        "greedy_sampling": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "title": "Greedy Sampling"
+        },
+        "posterior_threshold": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Posterior Threshold"
+        },
+        "use_dynamic_tree": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "title": "Use Dynamic Tree"
+        },
+        "dynamic_tree_max_topK": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dynamic Tree Max Topk"
+        },
+        "num_eagle_layers": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Num Eagle Layers"
+        },
+        "max_non_leaves_per_layer": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Non Leaves Per Layer"
+        },
+        "pytorch_weights_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pytorch Weights Path"
+        },
+        "eagle3_one_model": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "title": "Eagle3 One Model"
+        }
+      },
+      "title": "EagleDecodingConfig",
+      "type": "object"
+    },
+    "ExtendedRuntimePerfKnobConfig": {
+      "description": "Configuration for extended runtime performance knobs.",
+      "properties": {
+        "multi_block_mode": {
+          "default": true,
+          "description": "Whether to use multi-block mode.",
+          "title": "Multi Block Mode",
+          "type": "boolean"
+        },
+        "enable_context_fmha_fp32_acc": {
+          "default": false,
+          "description": "Whether to enable context FMHA FP32 accumulation.",
+          "title": "Enable Context Fmha Fp32 Acc",
+          "type": "boolean"
+        },
+        "cuda_graph_mode": {
+          "default": false,
+          "description": "Whether to use CUDA graph mode.",
+          "title": "Cuda Graph Mode",
+          "type": "boolean"
+        },
+        "cuda_graph_cache_size": {
+          "default": 0,
+          "description": "Number of cuda graphs to be cached in the runtime. The larger the cache, the better the perf, but more GPU memory is consumed.",
+          "title": "Cuda Graph Cache Size",
+          "type": "integer"
+        }
+      },
+      "title": "ExtendedRuntimePerfKnobConfig",
+      "type": "object"
+    },
+    "KvCacheConfig": {
+      "description": "Configuration for the KV cache.",
+      "properties": {
+        "enable_block_reuse": {
+          "default": true,
+          "description": "Controls if KV cache blocks can be reused for different requests.",
+          "title": "Enable Block Reuse",
+          "type": "boolean"
+        },
+        "max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of tokens that should be stored in the KV cache. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be used.",
+          "title": "Max Tokens"
+        },
+        "max_attention_window": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Size of the attention window for each sequence. Only the last tokens will be stored in the KV cache. If the number of elements in `max_attention_window` is less than the number of layers, `max_attention_window` will be repeated multiple times to the number of layers.",
+          "title": "Max Attention Window"
+        },
+        "sink_token_length": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Number of sink tokens (tokens to always keep in attention window).",
+          "title": "Sink Token Length"
+        },
+        "free_gpu_memory_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The fraction of GPU memory fraction that should be allocated for the KV cache. Default is 90%. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be used.",
+          "title": "Free Gpu Memory Fraction"
+        },
+        "host_cache_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Size of the host cache in bytes. If both `max_tokens` and `host_cache_size` are specified, memory corresponding to the minimum will be used.",
+          "title": "Host Cache Size"
+        },
+        "onboard_blocks": {
+          "default": true,
+          "description": "Controls if blocks are onboarded.",
+          "title": "Onboard Blocks",
+          "type": "boolean"
+        },
+        "cross_kv_cache_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The fraction of the KV Cache memory should be reserved for cross attention. If set to p, self attention will use 1-p of KV Cache memory and cross attention will use p of KV Cache memory. Default is 50%. Should only be set when using encoder-decoder model.",
+          "title": "Cross Kv Cache Fraction"
+        },
+        "secondary_offload_min_priority": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Only blocks with priority > mSecondaryOfflineMinPriority can be offloaded to secondary memory.",
+          "title": "Secondary Offload Min Priority"
+        },
+        "event_buffer_max_size": {
+          "default": 0,
+          "description": "Maximum size of the event buffer. If set to 0, the event buffer will not be used.",
+          "title": "Event Buffer Max Size",
+          "type": "integer"
+        },
+        "enable_partial_reuse": {
+          "default": true,
+          "description": "Whether blocks that are only partially matched can be reused.",
+          "title": "Enable Partial Reuse",
+          "type": "boolean"
+        },
+        "copy_on_partial_reuse": {
+          "default": true,
+          "description": "Whether partially matched blocks that are in use can be reused after copying them.",
+          "title": "Copy On Partial Reuse",
+          "type": "boolean"
+        }
+      },
+      "title": "KvCacheConfig",
+      "type": "object"
+    },
+    "LookaheadDecodingConfig": {
+      "description": "Configuration for lookahead speculative decoding.",
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "max_window_size": {
+          "default": 4,
+          "description": "Number of NGrams in lookahead branch per step.",
+          "title": "Max Window Size",
+          "type": "integer"
+        },
+        "max_ngram_size": {
+          "default": 3,
+          "description": "Number of tokens per NGram.",
+          "title": "Max Ngram Size",
+          "type": "integer"
+        },
+        "max_verification_set_size": {
+          "default": 4,
+          "description": "Number of NGrams in verification branch per step.",
+          "title": "Max Verification Set Size",
+          "type": "integer"
+        }
+      },
+      "title": "LookaheadDecodingConfig",
+      "type": "object"
+    },
+    "LoraConfig": {
+      "properties": {
+        "lora_dir": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Lora Dir",
+          "type": "array"
+        },
+        "lora_ckpt_source": {
+          "default": "hf",
+          "title": "Lora Ckpt Source",
+          "type": "string"
+        },
+        "max_lora_rank": {
+          "default": 64,
+          "title": "Max Lora Rank",
+          "type": "integer"
+        },
+        "lora_target_modules": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Lora Target Modules",
+          "type": "array"
+        },
+        "trtllm_modules_to_hf_modules": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Trtllm Modules To Hf Modules",
+          "type": "object"
+        },
+        "max_loras": {
+          "default": 4,
+          "title": "Max Loras",
+          "type": "integer"
+        },
+        "max_cpu_loras": {
+          "default": 4,
+          "title": "Max Cpu Loras",
+          "type": "integer"
+        }
+      },
+      "title": "LoraConfig",
+      "type": "object"
+    },
+    "MTPDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "num_nextn_predict_layers": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1,
+          "title": "Num Nextn Predict Layers"
+        },
+        "use_relaxed_acceptance_for_thinking": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "title": "Use Relaxed Acceptance For Thinking"
+        },
+        "relaxed_topk": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1,
+          "title": "Relaxed Topk"
+        },
+        "relaxed_delta": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0.0,
+          "title": "Relaxed Delta"
+        }
+      },
+      "title": "MTPDecodingConfig",
+      "type": "object"
+    },
+    "MedusaDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "medusa_choices": {
+          "anyOf": [
+            {
+              "items": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Medusa Choices"
+        },
+        "num_medusa_heads": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Num Medusa Heads"
+        }
+      },
+      "title": "MedusaDecodingConfig",
+      "type": "object"
+    },
+    "NGramDecodingConfig": {
+      "description": "Configuration for NGram drafter speculative decoding.\n\nArguments:\n    prompt_lookup_num_tokens: int\n            The length maximum of draft tokens (can be understood as length maximum of output draft tokens).\n\n    max_matching_ngram_size: int\n        The length maximum of searching tokens (can be understood as length maximum of input tokens to search).\n\n    is_keep_all: bool = True\n        Whether to keep all candidate pattern-matches pairs, only one match is kept for each pattern if False.\n\n    is_use_oldest: bool = True\n        Whether to provide the oldest match when pattern is hit, the newest one is provided if False.\n\n    is_public_pool: bool = True\n        Whether to use a common pool for all requests, or the pool is private for each request if False.",
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "prompt_lookup_num_tokens": {
+          "default": 2,
+          "title": "Prompt Lookup Num Tokens",
+          "type": "integer"
+        },
+        "max_matching_ngram_size": {
+          "default": 4,
+          "title": "Max Matching Ngram Size",
+          "type": "integer"
+        },
+        "is_keep_all": {
+          "default": true,
+          "title": "Is Keep All",
+          "type": "boolean"
+        },
+        "is_use_oldest": {
+          "default": true,
+          "title": "Is Use Oldest",
+          "type": "boolean"
+        },
+        "is_public_pool": {
+          "default": true,
+          "title": "Is Public Pool",
+          "type": "boolean"
+        }
+      },
+      "title": "NGramDecodingConfig",
+      "type": "object"
+    },
+    "PeftCacheConfig": {
+      "description": "Configuration for the PEFT cache.",
+      "properties": {
+        "num_host_module_layer": {
+          "default": 0,
+          "description": "number of max sized 1-layer 1-module adapterSize=1 sets of weights that can be stored in host cache",
+          "title": "Num Host Module Layer",
+          "type": "integer"
+        },
+        "num_device_module_layer": {
+          "default": 0,
+          "description": "number of max sized 1-layer 1-module sets of weights that can be stored in host cache",
+          "title": "Num Device Module Layer",
+          "type": "integer"
+        },
+        "optimal_adapter_size": {
+          "default": 8,
+          "description": "optimal adapter size used to set page width",
+          "title": "Optimal Adapter Size",
+          "type": "integer"
+        },
+        "max_adapter_size": {
+          "default": 64,
+          "description": "max supported adapter size. Used to compute minimum",
+          "title": "Max Adapter Size",
+          "type": "integer"
+        },
+        "num_put_workers": {
+          "default": 1,
+          "description": "number of worker threads used to put weights into host cache",
+          "title": "Num Put Workers",
+          "type": "integer"
+        },
+        "num_ensure_workers": {
+          "default": 1,
+          "description": "number of worker threads used to copy weights from host to device",
+          "title": "Num Ensure Workers",
+          "type": "integer"
+        },
+        "num_copy_streams": {
+          "default": 1,
+          "description": "number of streams used to copy weights from host to device",
+          "title": "Num Copy Streams",
+          "type": "integer"
+        },
+        "max_pages_per_block_host": {
+          "default": 24,
+          "description": "Number of cache pages per allocation block (host)",
+          "title": "Max Pages Per Block Host",
+          "type": "integer"
+        },
+        "max_pages_per_block_device": {
+          "default": 8,
+          "description": "Number of cache pages per allocation block (device)",
+          "title": "Max Pages Per Block Device",
+          "type": "integer"
+        },
+        "device_cache_percent": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "percent of memory after engine load to use for cache",
+          "title": "Device Cache Percent"
+        },
+        "host_cache_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "size in bytes to use for host cache",
+          "title": "Host Cache Size"
+        },
+        "lora_prefetch_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "folder to store the LoRA weights we hope to load during engine initialization",
+          "title": "Lora Prefetch Dir"
+        }
+      },
+      "title": "PeftCacheConfig",
+      "type": "object"
+    },
+    "QuantAlgo": {
+      "enum": [
+        "W8A16",
+        "W4A16",
+        "W4A16_AWQ",
+        "W4A8_AWQ",
+        "W8A16_GPTQ",
+        "W4A16_GPTQ",
+        "W8A8_SQ_PER_CHANNEL",
+        "W8A8_SQ_PER_TENSOR_PLUGIN",
+        "W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN",
+        "W8A8_SQ_PER_CHANNEL_PER_TENSOR_PLUGIN",
+        "W8A8_SQ_PER_TENSOR_PER_TOKEN_PLUGIN",
+        "W4A8_QSERVE_PER_GROUP",
+        "W4A8_QSERVE_PER_CHANNEL",
+        "FP8",
+        "FP8_PER_CHANNEL_PER_TOKEN",
+        "FP8_BLOCK_SCALES",
+        "INT8",
+        "MIXED_PRECISION",
+        "NVFP4",
+        "W4A8_MXFP4_FP8",
+        "NO_QUANT"
+      ],
+      "title": "QuantAlgo",
+      "type": "string"
+    },
+    "QuantConfig": {
+      "properties": {
+        "quant_algo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/QuantAlgo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "kv_cache_quant_algo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/QuantAlgo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "group_size": {
+          "default": 128,
+          "title": "Group Size",
+          "type": "integer"
+        },
+        "smoothquant_val": {
+          "default": 0.5,
+          "title": "Smoothquant Val",
+          "type": "number"
+        },
+        "clamp_val": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Clamp Val"
+        },
+        "use_meta_recipe": {
+          "default": false,
+          "title": "Use Meta Recipe",
+          "type": "boolean"
+        },
+        "has_zero_point": {
+          "default": false,
+          "title": "Has Zero Point",
+          "type": "boolean"
+        },
+        "pre_quant_scale": {
+          "default": false,
+          "title": "Pre Quant Scale",
+          "type": "boolean"
+        },
+        "exclude_modules": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Modules"
+        }
+      },
+      "title": "QuantConfig",
+      "type": "object"
+    },
+    "SchedulerConfig": {
+      "properties": {
+        "capacity_scheduler_policy": {
+          "$ref": "#/$defs/CapacitySchedulerPolicy",
+          "default": "GUARANTEED_NO_EVICT",
+          "description": "The capacity scheduler policy to use"
+        },
+        "context_chunking_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContextChunkingPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The context chunking policy to use"
+        },
+        "dynamic_batch_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DynamicBatchConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic batch config to use"
+        }
+      },
+      "title": "SchedulerConfig",
+      "type": "object"
     }
   }
 }

--- a/engine_versions/tensorrt/v0_21_0/producers/schema_introspector.py
+++ b/engine_versions/tensorrt/v0_21_0/producers/schema_introspector.py
@@ -26,6 +26,7 @@ from typing import Any
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
     make_envelope,
+    pydantic_properties_to_specs,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -38,8 +39,11 @@ LANDMARKS: tuple[str, ...] = (
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover TensorRT-LLM 0.21.0 engine and sampling schemas.
 
-    engine_params:   TrtLlmArgs.model_json_schema() properties (with description + deprecated)
-    sampling_params: dataclasses.fields(SamplingParams)
+    engine_params:   TrtLlmArgs Pydantic JSON Schema properties + nested $defs
+                     (preserves enum, minimum, maximum, $ref, description,
+                     deprecated)
+    sampling_params: dataclasses.fields(SamplingParams) (Literal annotations
+                     surface as ``enum`` on the spec dict)
     """
     import tensorrt_llm  # type: ignore[import-not-found]
     from tensorrt_llm import SamplingParams  # type: ignore[import-not-found]
@@ -47,36 +51,7 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
 
     limitations: list[dict[str, Any]] = []
 
-    raw_schema = TrtLlmArgs.model_json_schema()
-    engine_params: dict[str, Any] = {}
-    for name, spec in raw_schema.get("properties", {}).items():
-        if name.startswith("_"):
-            continue
-        type_repr: Any = spec.get("type")
-        if type_repr is None and "anyOf" in spec:
-            parts: list[str] = []
-            for sub in spec["anyOf"]:
-                if "type" in sub:
-                    part = "None" if sub["type"] == "null" else str(sub["type"])
-                elif "$ref" in sub:
-                    part = str(sub["$ref"]).rsplit("/", 1)[-1]
-                else:
-                    continue
-                if part not in parts:  # dedupe string | string etc.
-                    parts.append(part)
-            type_repr = " | ".join(parts) if parts else "unknown"
-        elif type_repr is None and "$ref" in spec:
-            type_repr = str(spec["$ref"]).rsplit("/", 1)[-1]
-        if isinstance(type_repr, list):
-            type_repr = " | ".join("None" if t == "null" else str(t) for t in type_repr)
-        elif type_repr == "null":
-            type_repr = "None"
-        engine_params[name] = {
-            "type": type_repr or "unknown",
-            "default": spec.get("default"),
-            "description": spec.get("description"),
-            "deprecated": spec.get("deprecated", False),
-        }
+    engine_params, engine_defs = pydantic_properties_to_specs(TrtLlmArgs)
 
     limitations.append(
         {
@@ -88,13 +63,18 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
 
     sampling_params = dataclass_fields_to_specs(SamplingParams, skip_private=True)
 
-    limitations.append(
-        {
-            "section": "sampling_params",
-            "fields": [],
-            "reason": "SamplingParams is a dataclass; no per-field descriptions",
-        }
-    )
+    # TRT-LLM's SamplingParams dataclass doesn't set field.metadata['description']
+    # for any field, so the dataclass_fields_to_specs description path stays empty
+    # here. Literal-annotated fields still surface ``enum`` via the helper.
+    if not any(spec.get("description") for spec in sampling_params.values()):
+        limitations.append(
+            {
+                "section": "sampling_params",
+                "fields": [],
+                "reason": "SamplingParams is a dataclass with no per-field "
+                "field(metadata={'description': ...}) metadata; descriptions unavailable",
+            }
+        )
 
     # tensorrt-llm runs inside the NGC release image; the workflow passes
     # its concrete reference via --image-ref. No first-party Dockerfile
@@ -109,4 +89,5 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        engine_params_defs=engine_defs,
     )

--- a/engine_versions/tensorrt/v1_2_0/producers/schema_introspector.py
+++ b/engine_versions/tensorrt/v1_2_0/producers/schema_introspector.py
@@ -29,6 +29,7 @@ from typing import Any
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
     make_envelope,
+    pydantic_properties_to_specs,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -41,8 +42,11 @@ LANDMARKS: tuple[str, ...] = (
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover TensorRT-LLM 1.2.0 engine and sampling schemas.
 
-    engine_params:   TrtLlmArgs.model_json_schema() properties (with description + deprecated)
-    sampling_params: dataclasses.fields(SamplingParams)
+    engine_params:   TrtLlmArgs Pydantic JSON Schema properties + nested $defs
+                     (preserves enum, minimum, maximum, $ref, description,
+                     deprecated)
+    sampling_params: dataclasses.fields(SamplingParams) (Literal annotations
+                     surface as ``enum`` on the spec dict)
     """
     import tensorrt_llm  # type: ignore[import-not-found]
     from tensorrt_llm import SamplingParams  # type: ignore[import-not-found]
@@ -50,36 +54,7 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
 
     limitations: list[dict[str, Any]] = []
 
-    raw_schema = TrtLlmArgs.model_json_schema()
-    engine_params: dict[str, Any] = {}
-    for name, spec in raw_schema.get("properties", {}).items():
-        if name.startswith("_"):
-            continue
-        type_repr: Any = spec.get("type")
-        if type_repr is None and "anyOf" in spec:
-            parts: list[str] = []
-            for sub in spec["anyOf"]:
-                if "type" in sub:
-                    part = "None" if sub["type"] == "null" else str(sub["type"])
-                elif "$ref" in sub:
-                    part = str(sub["$ref"]).rsplit("/", 1)[-1]
-                else:
-                    continue
-                if part not in parts:  # dedupe string | string etc.
-                    parts.append(part)
-            type_repr = " | ".join(parts) if parts else "unknown"
-        elif type_repr is None and "$ref" in spec:
-            type_repr = str(spec["$ref"]).rsplit("/", 1)[-1]
-        if isinstance(type_repr, list):
-            type_repr = " | ".join("None" if t == "null" else str(t) for t in type_repr)
-        elif type_repr == "null":
-            type_repr = "None"
-        engine_params[name] = {
-            "type": type_repr or "unknown",
-            "default": spec.get("default"),
-            "description": spec.get("description"),
-            "deprecated": spec.get("deprecated", False),
-        }
+    engine_params, engine_defs = pydantic_properties_to_specs(TrtLlmArgs)
 
     limitations.append(
         {
@@ -91,13 +66,18 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
 
     sampling_params = dataclass_fields_to_specs(SamplingParams, skip_private=True)
 
-    limitations.append(
-        {
-            "section": "sampling_params",
-            "fields": [],
-            "reason": "SamplingParams is a dataclass; no per-field descriptions",
-        }
-    )
+    # TRT-LLM's SamplingParams dataclass doesn't set field.metadata['description']
+    # for any field, so the dataclass_fields_to_specs description path stays empty
+    # here. Literal-annotated fields still surface ``enum`` via the helper.
+    if not any(spec.get("description") for spec in sampling_params.values()):
+        limitations.append(
+            {
+                "section": "sampling_params",
+                "fields": [],
+                "reason": "SamplingParams is a dataclass with no per-field "
+                "field(metadata={'description': ...}) metadata; descriptions unavailable",
+            }
+        )
 
     # tensorrt-llm runs inside the NGC release image; the workflow passes
     # its concrete reference via --image-ref. No first-party Dockerfile
@@ -112,4 +92,5 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        engine_params_defs=engine_defs,
     )

--- a/engine_versions/tensorrt/v1_2_1/producers/schema_introspector.py
+++ b/engine_versions/tensorrt/v1_2_1/producers/schema_introspector.py
@@ -29,6 +29,7 @@ from typing import Any
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
     make_envelope,
+    pydantic_properties_to_specs,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -41,8 +42,11 @@ LANDMARKS: tuple[str, ...] = (
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover TensorRT-LLM 1.2.1 engine and sampling schemas.
 
-    engine_params:   TrtLlmArgs.model_json_schema() properties (with description + deprecated)
-    sampling_params: dataclasses.fields(SamplingParams)
+    engine_params:   TrtLlmArgs Pydantic JSON Schema properties + nested $defs
+                     (preserves enum, minimum, maximum, $ref, description,
+                     deprecated)
+    sampling_params: dataclasses.fields(SamplingParams) (Literal annotations
+                     surface as ``enum`` on the spec dict)
     """
     import tensorrt_llm  # type: ignore[import-not-found]
     from tensorrt_llm import SamplingParams  # type: ignore[import-not-found]
@@ -50,36 +54,7 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
 
     limitations: list[dict[str, Any]] = []
 
-    raw_schema = TrtLlmArgs.model_json_schema()
-    engine_params: dict[str, Any] = {}
-    for name, spec in raw_schema.get("properties", {}).items():
-        if name.startswith("_"):
-            continue
-        type_repr: Any = spec.get("type")
-        if type_repr is None and "anyOf" in spec:
-            parts: list[str] = []
-            for sub in spec["anyOf"]:
-                if "type" in sub:
-                    part = "None" if sub["type"] == "null" else str(sub["type"])
-                elif "$ref" in sub:
-                    part = str(sub["$ref"]).rsplit("/", 1)[-1]
-                else:
-                    continue
-                if part not in parts:  # dedupe string | string etc.
-                    parts.append(part)
-            type_repr = " | ".join(parts) if parts else "unknown"
-        elif type_repr is None and "$ref" in spec:
-            type_repr = str(spec["$ref"]).rsplit("/", 1)[-1]
-        if isinstance(type_repr, list):
-            type_repr = " | ".join("None" if t == "null" else str(t) for t in type_repr)
-        elif type_repr == "null":
-            type_repr = "None"
-        engine_params[name] = {
-            "type": type_repr or "unknown",
-            "default": spec.get("default"),
-            "description": spec.get("description"),
-            "deprecated": spec.get("deprecated", False),
-        }
+    engine_params, engine_defs = pydantic_properties_to_specs(TrtLlmArgs)
 
     limitations.append(
         {
@@ -91,13 +66,18 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
 
     sampling_params = dataclass_fields_to_specs(SamplingParams, skip_private=True)
 
-    limitations.append(
-        {
-            "section": "sampling_params",
-            "fields": [],
-            "reason": "SamplingParams is a dataclass; no per-field descriptions",
-        }
-    )
+    # TRT-LLM's SamplingParams dataclass doesn't set field.metadata['description']
+    # for any field, so the dataclass_fields_to_specs description path stays empty
+    # here. Literal-annotated fields still surface ``enum`` via the helper.
+    if not any(spec.get("description") for spec in sampling_params.values()):
+        limitations.append(
+            {
+                "section": "sampling_params",
+                "fields": [],
+                "reason": "SamplingParams is a dataclass with no per-field "
+                "field(metadata={'description': ...}) metadata; descriptions unavailable",
+            }
+        )
 
     # tensorrt-llm runs inside the NGC release image; the workflow passes
     # its concrete reference via --image-ref. No first-party Dockerfile
@@ -112,4 +92,5 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        engine_params_defs=engine_defs,
     )

--- a/engine_versions/transformers/v4_57_3/outputs/schema.discovered.json
+++ b/engine_versions/transformers/v4_57_3/outputs/schema.discovered.json
@@ -1,11 +1,11 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "2.0.0",
   "engine": "transformers",
   "engine_version": "4.57.3",
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovered_at": "2026-05-22T00:00:00+00:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {
@@ -59,309 +59,385 @@
   "engine_params": {
     "config": {
       "type": "PretrainedConfig | str | PathLike | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "cache_dir": {
       "type": "str | PathLike | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "ignore_mismatched_sizes": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "signature_param"
     },
     "force_download": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "signature_param"
     },
     "local_files_only": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "signature_param"
     },
     "token": {
       "type": "str | bool | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "revision": {
       "type": "str",
-      "default": "main"
+      "default": "main",
+      "x-source": "signature_param"
     },
     "use_safetensors": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "weights_only": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "signature_param"
     }
   },
   "sampling_params": {
     "max_length": {
       "type": "int",
-      "default": 20
+      "default": 20,
+      "x-source": "instance_dict"
     },
     "max_new_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "min_length": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "instance_dict"
     },
     "min_new_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "early_stopping": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "max_time": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "stop_strings": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "do_sample": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "num_beams": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "instance_dict"
     },
     "use_cache": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "instance_dict"
     },
     "cache_implementation": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "cache_config": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "return_legacy_cache": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "prefill_chunk_size": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "temperature": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "top_k": {
       "type": "int",
-      "default": 50
+      "default": 50,
+      "x-source": "instance_dict"
     },
     "top_p": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "min_p": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "typical_p": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "epsilon_cutoff": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "instance_dict"
     },
     "eta_cutoff": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "instance_dict"
     },
     "repetition_penalty": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "encoder_repetition_penalty": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "length_penalty": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "no_repeat_ngram_size": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "instance_dict"
     },
     "bad_words_ids": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "renormalize_logits": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "forced_bos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "forced_eos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "remove_invalid_values": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "exponential_decay_length_penalty": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "suppress_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "begin_suppress_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "sequence_bias": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "token_healing": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "guidance_scale": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "watermarking_config": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "num_return_sequences": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "instance_dict"
     },
     "output_attentions": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "output_hidden_states": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "output_scores": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "output_logits": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "return_dict_in_generate": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "pad_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "bos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "eos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "encoder_no_repeat_ngram_size": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "instance_dict"
     },
     "decoder_start_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "is_assistant": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "num_assistant_tokens": {
       "type": "int",
-      "default": 20
+      "default": 20,
+      "x-source": "instance_dict"
     },
     "num_assistant_tokens_schedule": {
       "type": "str",
-      "default": "constant"
+      "default": "constant",
+      "x-source": "instance_dict"
     },
     "assistant_confidence_threshold": {
       "type": "float",
-      "default": 0.4
+      "default": 0.4,
+      "x-source": "instance_dict"
     },
     "prompt_lookup_num_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "max_matching_ngram_size": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "assistant_early_exit": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "assistant_lookbehind": {
       "type": "int",
-      "default": 10
+      "default": 10,
+      "x-source": "instance_dict"
     },
     "target_lookbehind": {
       "type": "int",
-      "default": 10
+      "default": 10,
+      "x-source": "instance_dict"
     },
     "disable_compile": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "low_memory": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "penalty_alpha": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "dola_layers": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "diversity_penalty": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "instance_dict"
     },
     "num_beam_groups": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "instance_dict"
     },
     "constraints": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "force_words_ids": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "_from_model_config": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "transformers_version": {
       "type": "str",
-      "default": "4.57.3"
+      "default": "4.57.3",
+      "x-source": "instance_dict"
     }
   }
 }

--- a/engine_versions/transformers/v4_57_3/producers/schema_introspector.py
+++ b/engine_versions/transformers/v4_57_3/producers/schema_introspector.py
@@ -19,10 +19,11 @@ from typing import Any
 
 from scripts.engine_producers._common import (
     TRANSFORMERS_DOCKERFILE,
-    annotation_to_type_str,
     jsonable,
+    literal_to_json_schema,
     make_envelope,
     read_dockerfile_from,
+    signature_param_to_spec,
 )
 
 # Schema-introspector LANDMARKS for Transformers 4.57.3.
@@ -86,11 +87,7 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
                 continue
             if name in engine_params:
                 continue  # prefer AutoModelForCausalLM over PreTrainedModel
-            default = None if param.default is inspect.Parameter.empty else param.default
-            engine_params[name] = {
-                "type": annotation_to_type_str(param.annotation),
-                "default": jsonable(default),
-            }
+            engine_params[name] = signature_param_to_spec(param)
 
     if kwargs_points:
         limitations.append(
@@ -105,19 +102,44 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     sampling_params: dict[str, Any] = {}
     none_default_fields: list[str] = []
     gc = GenerationConfig()
+    gc_fields = type(gc).__dataclass_fields__ if hasattr(type(gc), "__dataclass_fields__") else {}
     for name, value in gc.to_dict().items():
         if value is None:
-            sampling_params[name] = {"type": "unknown", "default": None}
+            spec: dict[str, Any] = {
+                "type": "unknown",
+                "default": None,
+                "x-source": "instance_dict",
+            }
             none_default_fields.append(name)
         elif isinstance(value, (list, tuple)):
-            sampling_params[name] = {"type": type(value).__name__, "default": jsonable(value)}
-        elif isinstance(value, dict):
-            sampling_params[name] = {"type": "dict", "default": jsonable(value)}
-        else:
-            sampling_params[name] = {
+            spec = {
                 "type": type(value).__name__,
                 "default": jsonable(value),
+                "x-source": "instance_dict",
             }
+        elif isinstance(value, dict):
+            spec = {
+                "type": "dict",
+                "default": jsonable(value),
+                "x-source": "instance_dict",
+            }
+        else:
+            spec = {
+                "type": type(value).__name__,
+                "default": jsonable(value),
+                "x-source": "instance_dict",
+            }
+        # GenerationConfig is a stdlib dataclass under the hood; if the
+        # corresponding field carries a Literal / Enum annotation, surface
+        # it as ``enum`` (additive JSON Schema key) so curated subsets
+        # don't lose discrete-value information when the runtime instance
+        # was constructed with a default that hides the enum shape.
+        fld = gc_fields.get(name) if isinstance(gc_fields, dict) else None
+        if fld is not None:
+            enum_shape = literal_to_json_schema(fld.type)
+            if enum_shape is not None:
+                spec["enum"] = enum_shape["enum"]
+        sampling_params[name] = spec
 
     if none_default_fields:
         limitations.append(

--- a/engine_versions/transformers/v5_3_0/producers/schema_introspector.py
+++ b/engine_versions/transformers/v5_3_0/producers/schema_introspector.py
@@ -19,10 +19,11 @@ from typing import Any
 
 from scripts.engine_producers._common import (
     TRANSFORMERS_DOCKERFILE,
-    annotation_to_type_str,
     jsonable,
+    literal_to_json_schema,
     make_envelope,
     read_dockerfile_from,
+    signature_param_to_spec,
 )
 
 # Schema-introspector LANDMARKS for Transformers 5.3.0.
@@ -86,11 +87,7 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
                 continue
             if name in engine_params:
                 continue  # prefer AutoModelForCausalLM over PreTrainedModel
-            default = None if param.default is inspect.Parameter.empty else param.default
-            engine_params[name] = {
-                "type": annotation_to_type_str(param.annotation),
-                "default": jsonable(default),
-            }
+            engine_params[name] = signature_param_to_spec(param)
 
     if kwargs_points:
         limitations.append(
@@ -105,19 +102,43 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     sampling_params: dict[str, Any] = {}
     none_default_fields: list[str] = []
     gc = GenerationConfig()
+    gc_fields = type(gc).__dataclass_fields__ if hasattr(type(gc), "__dataclass_fields__") else {}
     for name, value in gc.to_dict().items():
         if value is None:
-            sampling_params[name] = {"type": "unknown", "default": None}
+            spec: dict[str, Any] = {
+                "type": "unknown",
+                "default": None,
+                "x-source": "instance_dict",
+            }
             none_default_fields.append(name)
         elif isinstance(value, (list, tuple)):
-            sampling_params[name] = {"type": type(value).__name__, "default": jsonable(value)}
-        elif isinstance(value, dict):
-            sampling_params[name] = {"type": "dict", "default": jsonable(value)}
-        else:
-            sampling_params[name] = {
+            spec = {
                 "type": type(value).__name__,
                 "default": jsonable(value),
+                "x-source": "instance_dict",
             }
+        elif isinstance(value, dict):
+            spec = {
+                "type": "dict",
+                "default": jsonable(value),
+                "x-source": "instance_dict",
+            }
+        else:
+            spec = {
+                "type": type(value).__name__,
+                "default": jsonable(value),
+                "x-source": "instance_dict",
+            }
+        # GenerationConfig may become a dataclass in v5+; if a field carries
+        # a Literal / Enum annotation, surface it as ``enum`` (additive
+        # JSON Schema key). The hasattr guard keeps this safe even when
+        # GenerationConfig stays a plain class.
+        fld = gc_fields.get(name) if isinstance(gc_fields, dict) else None
+        if fld is not None:
+            enum_shape = literal_to_json_schema(fld.type)
+            if enum_shape is not None:
+                spec["enum"] = enum_shape["enum"]
+        sampling_params[name] = spec
 
     if none_default_fields:
         limitations.append(

--- a/engine_versions/transformers/v5_6_2/producers/schema_introspector.py
+++ b/engine_versions/transformers/v5_6_2/producers/schema_introspector.py
@@ -19,10 +19,11 @@ from typing import Any
 
 from scripts.engine_producers._common import (
     TRANSFORMERS_DOCKERFILE,
-    annotation_to_type_str,
     jsonable,
+    literal_to_json_schema,
     make_envelope,
     read_dockerfile_from,
+    signature_param_to_spec,
 )
 
 # Schema-introspector LANDMARKS for Transformers 5.6.2.
@@ -86,11 +87,7 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
                 continue
             if name in engine_params:
                 continue  # prefer AutoModelForCausalLM over PreTrainedModel
-            default = None if param.default is inspect.Parameter.empty else param.default
-            engine_params[name] = {
-                "type": annotation_to_type_str(param.annotation),
-                "default": jsonable(default),
-            }
+            engine_params[name] = signature_param_to_spec(param)
 
     if kwargs_points:
         limitations.append(
@@ -105,19 +102,43 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     sampling_params: dict[str, Any] = {}
     none_default_fields: list[str] = []
     gc = GenerationConfig()
+    gc_fields = type(gc).__dataclass_fields__ if hasattr(type(gc), "__dataclass_fields__") else {}
     for name, value in gc.to_dict().items():
         if value is None:
-            sampling_params[name] = {"type": "unknown", "default": None}
+            spec: dict[str, Any] = {
+                "type": "unknown",
+                "default": None,
+                "x-source": "instance_dict",
+            }
             none_default_fields.append(name)
         elif isinstance(value, (list, tuple)):
-            sampling_params[name] = {"type": type(value).__name__, "default": jsonable(value)}
-        elif isinstance(value, dict):
-            sampling_params[name] = {"type": "dict", "default": jsonable(value)}
-        else:
-            sampling_params[name] = {
+            spec = {
                 "type": type(value).__name__,
                 "default": jsonable(value),
+                "x-source": "instance_dict",
             }
+        elif isinstance(value, dict):
+            spec = {
+                "type": "dict",
+                "default": jsonable(value),
+                "x-source": "instance_dict",
+            }
+        else:
+            spec = {
+                "type": type(value).__name__,
+                "default": jsonable(value),
+                "x-source": "instance_dict",
+            }
+        # GenerationConfig may become a dataclass in v5+; if a field carries
+        # a Literal / Enum annotation, surface it as ``enum`` (additive
+        # JSON Schema key). The hasattr guard keeps this safe even when
+        # GenerationConfig stays a plain class.
+        fld = gc_fields.get(name) if isinstance(gc_fields, dict) else None
+        if fld is not None:
+            enum_shape = literal_to_json_schema(fld.type)
+            if enum_shape is not None:
+                spec["enum"] = enum_shape["enum"]
+        sampling_params[name] = spec
 
     if none_default_fields:
         limitations.append(

--- a/engine_versions/vllm/v0_16_0/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_16_0/producers/schema_introspector.py
@@ -19,6 +19,7 @@ from typing import Any
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
     make_envelope,
+    msgspec_properties_to_specs,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -30,8 +31,13 @@ LANDMARKS: tuple[str, ...] = (
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover vLLM engine and sampling schemas.
 
-    engine_params:   dataclasses.fields(EngineArgs)
-    sampling_params: msgspec.json.schema(SamplingParams)
+    engine_params:   dataclasses.fields(EngineArgs) (Literal annotations
+                     surface as ``enum``; per-field descriptions remain
+                     absent because EngineArgs uses positional defaults
+                     rather than field(metadata={'description': ...}))
+    sampling_params: msgspec.json.schema(SamplingParams) preserved with
+                     nested ``$defs``; per-leaf ``enum`` / ``minimum`` /
+                     ``maximum`` / ``exclusiveMinimum`` etc kept as-is
     """
     import vllm  # type: ignore[import-not-found]
     from vllm.engine.arg_utils import EngineArgs  # type: ignore[import-not-found]
@@ -40,23 +46,14 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     engine_params = dataclass_fields_to_specs(EngineArgs)
 
     sampling_params: dict[str, Any] = {}
+    sampling_defs: dict[str, Any] = {}
     try:
-        import msgspec  # type: ignore[import-not-found]
-
-        raw_schema = msgspec.json.schema(vllm.SamplingParams)
-        props = raw_schema.get("properties")
-        if not props:
-            defs = raw_schema.get("$defs") or raw_schema.get("definitions") or {}
-            sp_def: Any = defs.get("SamplingParams") or next(iter(defs.values()), {})
-            props = sp_def.get("properties", {}) if isinstance(sp_def, dict) else {}
-        for name, spec in (props or {}).items():
-            type_repr: Any = spec.get("type", "unknown")
-            if isinstance(type_repr, list):
-                type_repr = " | ".join(str(t) for t in type_repr)
-            sampling_params[name] = {
-                "type": type_repr,
-                "default": spec.get("default"),
-            }
+        # Preserve private-prefixed fields (e.g. ``_all_stop_token_ids``,
+        # ``_real_n``) for v1-shape parity. msgspec's own JSON Schema lists
+        # them as msgspec exposes them.
+        sampling_params, sampling_defs = msgspec_properties_to_specs(
+            vllm.SamplingParams, skip_private=False
+        )
     except Exception as exc:
         limitations.append(
             {
@@ -66,12 +63,16 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
             }
         )
 
+    # The msgspec schema captures field-level enum + min/max where present;
+    # constraints that live solely in _verify_args() (e.g. mutual-exclusion
+    # checks across fields) remain undiscoverable from field metadata, so
+    # the cross-field caveat stays.
     limitations.append(
         {
             "section": "sampling_params",
             "fields": [],
-            "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative "
-            "_verify_args() and are not introspectable from field metadata",
+            "reason": "cross-field constraints (e.g. top_p + top_k interactions) live in "
+            "imperative _verify_args() and are not introspectable from field metadata",
         }
     )
     limitations.append(
@@ -92,4 +93,5 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        sampling_params_defs=sampling_defs,
     )

--- a/engine_versions/vllm/v0_18_1/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_18_1/producers/schema_introspector.py
@@ -19,6 +19,7 @@ from typing import Any
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
     make_envelope,
+    msgspec_properties_to_specs,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -30,8 +31,13 @@ LANDMARKS: tuple[str, ...] = (
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover vLLM engine and sampling schemas.
 
-    engine_params:   dataclasses.fields(EngineArgs)
-    sampling_params: msgspec.json.schema(SamplingParams)
+    engine_params:   dataclasses.fields(EngineArgs) (Literal annotations
+                     surface as ``enum``; per-field descriptions remain
+                     absent because EngineArgs uses positional defaults
+                     rather than field(metadata={'description': ...}))
+    sampling_params: msgspec.json.schema(SamplingParams) preserved with
+                     nested ``$defs``; per-leaf ``enum`` / ``minimum`` /
+                     ``maximum`` / ``exclusiveMinimum`` etc kept as-is
     """
     import vllm  # type: ignore[import-not-found]
     from vllm.engine.arg_utils import EngineArgs  # type: ignore[import-not-found]
@@ -40,23 +46,14 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     engine_params = dataclass_fields_to_specs(EngineArgs)
 
     sampling_params: dict[str, Any] = {}
+    sampling_defs: dict[str, Any] = {}
     try:
-        import msgspec  # type: ignore[import-not-found]
-
-        raw_schema = msgspec.json.schema(vllm.SamplingParams)
-        props = raw_schema.get("properties")
-        if not props:
-            defs = raw_schema.get("$defs") or raw_schema.get("definitions") or {}
-            sp_def: Any = defs.get("SamplingParams") or next(iter(defs.values()), {})
-            props = sp_def.get("properties", {}) if isinstance(sp_def, dict) else {}
-        for name, spec in (props or {}).items():
-            type_repr: Any = spec.get("type", "unknown")
-            if isinstance(type_repr, list):
-                type_repr = " | ".join(str(t) for t in type_repr)
-            sampling_params[name] = {
-                "type": type_repr,
-                "default": spec.get("default"),
-            }
+        # Preserve private-prefixed fields (e.g. ``_all_stop_token_ids``,
+        # ``_real_n``) for v1-shape parity. msgspec's own JSON Schema lists
+        # them as msgspec exposes them.
+        sampling_params, sampling_defs = msgspec_properties_to_specs(
+            vllm.SamplingParams, skip_private=False
+        )
     except Exception as exc:
         limitations.append(
             {
@@ -66,12 +63,16 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
             }
         )
 
+    # The msgspec schema captures field-level enum + min/max where present;
+    # constraints that live solely in _verify_args() (e.g. mutual-exclusion
+    # checks across fields) remain undiscoverable from field metadata, so
+    # the cross-field caveat stays.
     limitations.append(
         {
             "section": "sampling_params",
             "fields": [],
-            "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative "
-            "_verify_args() and are not introspectable from field metadata",
+            "reason": "cross-field constraints (e.g. top_p + top_k interactions) live in "
+            "imperative _verify_args() and are not introspectable from field metadata",
         }
     )
     limitations.append(
@@ -92,4 +93,5 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        sampling_params_defs=sampling_defs,
     )

--- a/engine_versions/vllm/v0_19_1/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_19_1/producers/schema_introspector.py
@@ -19,6 +19,7 @@ from typing import Any
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
     make_envelope,
+    msgspec_properties_to_specs,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -30,8 +31,13 @@ LANDMARKS: tuple[str, ...] = (
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover vLLM engine and sampling schemas.
 
-    engine_params:   dataclasses.fields(EngineArgs)
-    sampling_params: msgspec.json.schema(SamplingParams)
+    engine_params:   dataclasses.fields(EngineArgs) (Literal annotations
+                     surface as ``enum``; per-field descriptions remain
+                     absent because EngineArgs uses positional defaults
+                     rather than field(metadata={'description': ...}))
+    sampling_params: msgspec.json.schema(SamplingParams) preserved with
+                     nested ``$defs``; per-leaf ``enum`` / ``minimum`` /
+                     ``maximum`` / ``exclusiveMinimum`` etc kept as-is
     """
     import vllm  # type: ignore[import-not-found]
     from vllm.engine.arg_utils import EngineArgs  # type: ignore[import-not-found]
@@ -40,23 +46,14 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     engine_params = dataclass_fields_to_specs(EngineArgs)
 
     sampling_params: dict[str, Any] = {}
+    sampling_defs: dict[str, Any] = {}
     try:
-        import msgspec  # type: ignore[import-not-found]
-
-        raw_schema = msgspec.json.schema(vllm.SamplingParams)
-        props = raw_schema.get("properties")
-        if not props:
-            defs = raw_schema.get("$defs") or raw_schema.get("definitions") or {}
-            sp_def: Any = defs.get("SamplingParams") or next(iter(defs.values()), {})
-            props = sp_def.get("properties", {}) if isinstance(sp_def, dict) else {}
-        for name, spec in (props or {}).items():
-            type_repr: Any = spec.get("type", "unknown")
-            if isinstance(type_repr, list):
-                type_repr = " | ".join(str(t) for t in type_repr)
-            sampling_params[name] = {
-                "type": type_repr,
-                "default": spec.get("default"),
-            }
+        # Preserve private-prefixed fields (e.g. ``_all_stop_token_ids``,
+        # ``_real_n``) for v1-shape parity. msgspec's own JSON Schema lists
+        # them as msgspec exposes them.
+        sampling_params, sampling_defs = msgspec_properties_to_specs(
+            vllm.SamplingParams, skip_private=False
+        )
     except Exception as exc:
         limitations.append(
             {
@@ -66,12 +63,16 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
             }
         )
 
+    # The msgspec schema captures field-level enum + min/max where present;
+    # constraints that live solely in _verify_args() (e.g. mutual-exclusion
+    # checks across fields) remain undiscoverable from field metadata, so
+    # the cross-field caveat stays.
     limitations.append(
         {
             "section": "sampling_params",
             "fields": [],
-            "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative "
-            "_verify_args() and are not introspectable from field metadata",
+            "reason": "cross-field constraints (e.g. top_p + top_k interactions) live in "
+            "imperative _verify_args() and are not introspectable from field metadata",
         }
     )
     limitations.append(
@@ -92,4 +93,5 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        sampling_params_defs=sampling_defs,
     )

--- a/engine_versions/vllm/v0_7_3/outputs/schema.discovered.json
+++ b/engine_versions/vllm/v0_7_3/outputs/schema.discovered.json
@@ -1,17 +1,17 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "2.0.0",
   "engine": "vllm",
   "engine_version": "0.7.3",
   "engine_commit_sha": null,
-  "image_ref": "llenergymeasure:vllm-0.7.3",
+  "image_ref": "llenergymeasure:vllm-v0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovered_at": "2026-05-22T00:00:00+00:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {
       "section": "sampling_params",
       "fields": [],
-      "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative _verify_args() and are not introspectable from field metadata"
+      "reason": "cross-field constraints (e.g. top_p + top_k interactions) live in imperative _verify_args() and are not introspectable from field metadata"
     },
     {
       "section": "engine_params",
@@ -22,545 +22,1186 @@
   "engine_params": {
     "model": {
       "type": "str",
-      "default": "facebook/opt-125m"
+      "default": "facebook/opt-125m",
+      "x-source": "dataclass_field"
     },
     "served_model_name": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "tokenizer": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "task": {
       "type": "Literal['auto', 'generate', 'embedding', 'embed', 'classify', 'score', 'reward', 'transcription']",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field",
+      "json_schema_type": "string",
+      "enum": [
+        "auto",
+        "generate",
+        "embedding",
+        "embed",
+        "classify",
+        "score",
+        "reward",
+        "transcription"
+      ]
     },
     "skip_tokenizer_init": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "tokenizer_mode": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "trust_remote_code": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "allowed_local_media_path": {
       "type": "str",
-      "default": ""
+      "default": "",
+      "x-source": "dataclass_field"
     },
     "download_dir": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "load_format": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "config_format": {
       "type": "ConfigFormat",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field",
+      "json_schema_type": "string",
+      "enum": [
+        "auto",
+        "hf",
+        "mistral"
+      ]
     },
     "dtype": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "kv_cache_dtype": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "seed": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "max_model_len": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "distributed_executor_backend": {
       "type": "str | type[ExecutorBase] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "pipeline_parallel_size": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "tensor_parallel_size": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_parallel_loading_workers": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "block_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "enable_prefix_caching": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_sliding_window": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "use_v2_block_manager": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "swap_space": {
       "type": "float",
-      "default": 4
+      "default": 4,
+      "x-source": "dataclass_field"
     },
     "cpu_offload_gb": {
       "type": "float",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "gpu_memory_utilization": {
       "type": "float",
-      "default": 0.9
+      "default": 0.9,
+      "x-source": "dataclass_field"
     },
     "max_num_batched_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_num_partial_prefills": {
       "type": "int | None",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_long_partial_prefills": {
       "type": "int | None",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "long_prefill_token_threshold": {
       "type": "int | None",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "max_num_seqs": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_logprobs": {
       "type": "int",
-      "default": 20
+      "default": 20,
+      "x-source": "dataclass_field"
     },
     "disable_log_stats": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "revision": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "code_revision": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "rope_scaling": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "rope_theta": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "hf_overrides": {
       "type": "dict[str, Any] | Callable[[<class 'transformers.configuration_utils.PretrainedConfig'>], PretrainedConfig] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "tokenizer_revision": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "quantization": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "enforce_eager": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_seq_len_to_capture": {
       "type": "int",
-      "default": 8192
+      "default": 8192,
+      "x-source": "dataclass_field"
     },
     "disable_custom_all_reduce": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "tokenizer_pool_size": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "tokenizer_pool_type": {
       "type": "str | type[ForwardRef('BaseTokenizerGroup')]",
-      "default": "ray"
+      "default": "ray",
+      "x-source": "dataclass_field"
     },
     "tokenizer_pool_extra_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "limit_mm_per_prompt": {
       "type": "Mapping[str, int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "mm_processor_kwargs": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_mm_preprocessor_cache": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "enable_lora": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "enable_lora_bias": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "max_loras": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_lora_rank": {
       "type": "int",
-      "default": 16
+      "default": 16,
+      "x-source": "dataclass_field"
     },
     "enable_prompt_adapter": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "max_prompt_adapters": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_prompt_adapter_token": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "fully_sharded_loras": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "lora_extra_vocab_size": {
       "type": "int",
-      "default": 256
+      "default": 256,
+      "x-source": "dataclass_field"
     },
     "long_lora_scaling_factors": {
       "type": "tuple[float] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "lora_dtype": {
       "type": "str | dtype | None",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "max_cpu_loras": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "device": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "num_scheduler_steps": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "multi_step_stream_outputs": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "ray_workers_use_nsight": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "num_gpu_blocks_override": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "num_lookahead_slots": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "model_loader_extra_config": {
       "type": "dict | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ignore_patterns": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "preemption_mode": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "scheduler_delay_factor": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "dataclass_field"
     },
     "enable_chunked_prefill": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "guided_decoding_backend": {
       "type": "str",
-      "default": "xgrammar"
+      "default": "xgrammar",
+      "x-source": "dataclass_field"
     },
     "logits_processor_pattern": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_model": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_model_quantization": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_draft_tensor_parallel_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "num_speculative_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_disable_mqa_scorer": {
       "type": "bool | None",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "speculative_max_model_len": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_disable_by_batch_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ngram_prompt_lookup_max": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ngram_prompt_lookup_min": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "spec_decoding_acceptance_method": {
       "type": "str",
-      "default": "rejection_sampler"
+      "default": "rejection_sampler",
+      "x-source": "dataclass_field"
     },
     "typical_acceptance_sampler_posterior_threshold": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "typical_acceptance_sampler_posterior_alpha": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "qlora_adapter_name_or_path": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_logprobs_during_spec_decoding": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "otlp_traces_endpoint": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "collect_detailed_traces": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_async_output_proc": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "scheduling_policy": {
       "type": "Literal['fcfs', 'priority']",
-      "default": "fcfs"
+      "default": "fcfs",
+      "x-source": "dataclass_field",
+      "json_schema_type": "string",
+      "enum": [
+        "fcfs",
+        "priority"
+      ]
     },
     "scheduler_cls": {
       "type": "str | type[object]",
-      "default": "vllm.core.scheduler.Scheduler"
+      "default": "vllm.core.scheduler.Scheduler",
+      "x-source": "dataclass_field"
     },
     "override_neuron_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "override_pooler_config": {
       "type": "PoolerConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "compilation_config": {
       "type": "CompilationConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "worker_cls": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "kv_transfer_config": {
       "type": "KVTransferConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "generation_config": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "override_generation_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "enable_sleep_mode": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "model_impl": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "calculate_kv_scales": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "additional_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     }
   },
   "sampling_params": {
     "n": {
       "type": "integer",
-      "default": 1
+      "default": 1,
+      "x-source": "msgspec_field"
     },
     "best_of": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "_real_n": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "presence_penalty": {
       "type": "number",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "msgspec_field"
     },
     "frequency_penalty": {
       "type": "number",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "msgspec_field"
     },
     "repetition_penalty": {
       "type": "number",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "msgspec_field"
     },
     "temperature": {
       "type": "number",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "msgspec_field"
     },
     "top_p": {
       "type": "number",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "msgspec_field"
     },
     "top_k": {
       "type": "integer",
-      "default": -1
+      "default": -1,
+      "x-source": "msgspec_field"
     },
     "min_p": {
       "type": "number",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "msgspec_field"
     },
     "seed": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "stop": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "string | array | None",
+      "x-source": "msgspec_field"
     },
     "stop_token_ids": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "array | None",
+      "x-source": "msgspec_field"
     },
     "bad_words": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "array | None",
+      "x-source": "msgspec_field"
     },
     "ignore_eos": {
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-source": "msgspec_field"
     },
     "max_tokens": {
-      "type": "unknown",
-      "default": 16
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": 16,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "min_tokens": {
       "type": "integer",
-      "default": 0
+      "default": 0,
+      "x-source": "msgspec_field"
     },
     "logprobs": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "prompt_logprobs": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "detokenize": {
       "type": "boolean",
-      "default": true
+      "default": true,
+      "x-source": "msgspec_field"
     },
     "skip_special_tokens": {
       "type": "boolean",
-      "default": true
+      "default": true,
+      "x-source": "msgspec_field"
     },
     "spaces_between_special_tokens": {
       "type": "boolean",
-      "default": true
+      "default": true,
+      "x-source": "msgspec_field"
     },
     "logits_processors": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "None",
+      "x-source": "msgspec_field"
     },
     "include_stop_str_in_output": {
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-source": "msgspec_field"
     },
     "truncate_prompt_tokens": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "output_kind": {
-      "type": "unknown",
-      "default": 0
+      "$ref": "#/$defs/RequestOutputKind",
+      "default": 0,
+      "type": "RequestOutputKind",
+      "x-source": "msgspec_field"
     },
     "output_text_buffer_length": {
       "type": "integer",
-      "default": 0
+      "default": 0,
+      "x-source": "msgspec_field"
     },
     "_all_stop_token_ids": {
       "type": "array",
-      "default": []
+      "items": {
+        "type": "integer"
+      },
+      "default": [],
+      "x-source": "msgspec_field"
     },
     "guided_decoding": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GuidedDecodingParams"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "GuidedDecodingParams | None",
+      "x-source": "msgspec_field"
     },
     "logit_bias": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "object | None",
+      "x-source": "msgspec_field"
     },
     "allowed_token_ids": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "array | None",
+      "x-source": "msgspec_field"
+    }
+  },
+  "sampling_params_defs": {
+    "SamplingParams": {
+      "title": "SamplingParams",
+      "description": "Sampling parameters for text generation.\n\n    Overall, we follow the sampling parameters from the OpenAI text completion\n    API (https://platform.openai.com/docs/api-reference/completions/create).\n    In addition, we support beam search, which is not supported by OpenAI.\n\n    Args:\n        n: Number of output sequences to return for the given prompt.\n        best_of: Number of output sequences that are generated from the prompt.\n            From these `best_of` sequences, the top `n` sequences are returned.\n            `best_of` must be greater than or equal to `n`. By default,\n            `best_of` is set to `n`.\n        presence_penalty: Float that penalizes new tokens based on whether they\n            appear in the generated text so far. Values > 0 encourage the model\n            to use new tokens, while values < 0 encourage the model to repeat\n            tokens.\n        frequency_penalty: Float that penalizes new tokens based on their\n            frequency in the generated text so far. Values > 0 encourage the\n            model to use new tokens, while values < 0 encourage the model to\n            repeat tokens.\n        repetition_penalty: Float that penalizes new tokens based on whether\n            they appear in the prompt and the generated text so far. Values > 1\n            encourage the model to use new tokens, while values < 1 encourage\n            the model to repeat tokens.\n        temperature: Float that controls the randomness of the sampling. Lower\n            values make the model more deterministic, while higher values make\n            the model more random. Zero means greedy sampling.\n        top_p: Float that controls the cumulative probability of the top tokens\n            to consider. Must be in (0, 1]. Set to 1 to consider all tokens.\n        top_k: Integer that controls the number of top tokens to consider. Set\n            to -1 to consider all tokens.\n        min_p: Float that represents the minimum probability for a token to be\n            considered, relative to the probability of the most likely token.\n            Must be in [0, 1]. Set to 0 to disable this.\n        seed: Random seed to use for the generation.\n        stop: List of strings that stop the generation when they are generated.\n            The returned output will not contain the stop strings.\n        stop_token_ids: List of tokens that stop the generation when they are\n            generated. The returned output will contain the stop tokens unless\n            the stop tokens are special tokens.\n        bad_words: List of words that are not allowed to be generated.\n            More precisely, only the last token of a corresponding\n            token sequence is not allowed when the next generated token\n            can complete the sequence.\n        include_stop_str_in_output: Whether to include the stop strings in\n            output text. Defaults to False.\n        ignore_eos: Whether to ignore the EOS token and continue generating\n            tokens after the EOS token is generated.\n        max_tokens: Maximum number of tokens to generate per output sequence.\n        min_tokens: Minimum number of tokens to generate per output sequence\n            before EOS or stop_token_ids can be generated\n        logprobs: Number of log probabilities to return per output token.\n            When set to None, no probability is returned. If set to a non-None\n            value, the result includes the log probabilities of the specified\n            number of most likely tokens, as well as the chosen tokens.\n            Note that the implementation follows the OpenAI API: The API will\n            always return the log probability of the sampled token, so there\n            may be up to `logprobs+1` elements in the response.\n        prompt_logprobs: Number of log probabilities to return per prompt token.\n        detokenize: Whether to detokenize the output. Defaults to True.\n        skip_special_tokens: Whether to skip special tokens in the output.\n        spaces_between_special_tokens: Whether to add spaces between special\n            tokens in the output.  Defaults to True.\n        logits_processors: List of functions that modify logits based on\n            previously generated tokens, and optionally prompt tokens as\n            a first argument.\n        truncate_prompt_tokens: If set to an integer k, will use only the last k\n            tokens from the prompt (i.e., left truncation). Defaults to None\n            (i.e., no truncation).\n        guided_decoding: If provided, the engine will construct a guided\n            decoding logits processor from these parameters. Defaults to None.\n        logit_bias: If provided, the engine will construct a logits processor\n            that applies these logit biases. Defaults to None.\n        allowed_token_ids: If provided, the engine will construct a logits\n            processor which only retains scores for the given token ids.\n            Defaults to None.",
+      "type": "object",
+      "properties": {
+        "n": {
+          "type": "integer",
+          "default": 1
+        },
+        "best_of": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "_real_n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "presence_penalty": {
+          "type": "number",
+          "default": 0.0
+        },
+        "frequency_penalty": {
+          "type": "number",
+          "default": 0.0
+        },
+        "repetition_penalty": {
+          "type": "number",
+          "default": 1.0
+        },
+        "temperature": {
+          "type": "number",
+          "default": 1.0
+        },
+        "top_p": {
+          "type": "number",
+          "default": 1.0
+        },
+        "top_k": {
+          "type": "integer",
+          "default": -1
+        },
+        "min_p": {
+          "type": "number",
+          "default": 0.0
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stop": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stop_token_ids": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bad_words": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ignore_eos": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 16
+        },
+        "min_tokens": {
+          "type": "integer",
+          "default": 0
+        },
+        "logprobs": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "prompt_logprobs": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "detokenize": {
+          "type": "boolean",
+          "default": true
+        },
+        "skip_special_tokens": {
+          "type": "boolean",
+          "default": true
+        },
+        "spaces_between_special_tokens": {
+          "type": "boolean",
+          "default": true
+        },
+        "logits_processors": {
+          "anyOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "include_stop_str_in_output": {
+          "type": "boolean",
+          "default": false
+        },
+        "truncate_prompt_tokens": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "output_kind": {
+          "$ref": "#/$defs/RequestOutputKind",
+          "default": 0
+        },
+        "output_text_buffer_length": {
+          "type": "integer",
+          "default": 0
+        },
+        "_all_stop_token_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "default": []
+        },
+        "guided_decoding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GuidedDecodingParams"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "logit_bias": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "number"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "allowed_token_ids": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": []
+    },
+    "RequestOutputKind": {
+      "title": "RequestOutputKind",
+      "enum": [
+        0,
+        1,
+        2
+      ]
+    },
+    "GuidedDecodingParams": {
+      "title": "GuidedDecodingParams",
+      "description": "One of these fields will be used to build a logit processor.",
+      "type": "object",
+      "properties": {
+        "json": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "regex": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "choice": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grammar": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "json_object": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "backend": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "whitespace_pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": []
     }
   }
 }

--- a/engine_versions/vllm/v0_7_3/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_7_3/producers/schema_introspector.py
@@ -21,6 +21,7 @@ from typing import Any
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
     make_envelope,
+    msgspec_properties_to_specs,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -32,8 +33,13 @@ LANDMARKS: tuple[str, ...] = (
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     """Discover vLLM 0.7.3 engine and sampling schemas.
 
-    engine_params:   dataclasses.fields(EngineArgs)
-    sampling_params: msgspec.json.schema(SamplingParams)
+    engine_params:   dataclasses.fields(EngineArgs) (Literal annotations
+                     surface as ``enum``; per-field descriptions remain
+                     absent because EngineArgs uses positional defaults
+                     rather than field(metadata={'description': ...}))
+    sampling_params: msgspec.json.schema(SamplingParams) preserved with
+                     nested ``$defs``; per-leaf ``enum`` / ``minimum`` /
+                     ``maximum`` / ``exclusiveMinimum`` etc kept as-is
     """
     import vllm  # type: ignore[import-not-found]
     from vllm.engine.arg_utils import EngineArgs  # type: ignore[import-not-found]
@@ -42,23 +48,14 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     engine_params = dataclass_fields_to_specs(EngineArgs)
 
     sampling_params: dict[str, Any] = {}
+    sampling_defs: dict[str, Any] = {}
     try:
-        import msgspec  # type: ignore[import-not-found]
-
-        raw_schema = msgspec.json.schema(vllm.SamplingParams)
-        props = raw_schema.get("properties")
-        if not props:
-            defs = raw_schema.get("$defs") or raw_schema.get("definitions") or {}
-            sp_def: Any = defs.get("SamplingParams") or next(iter(defs.values()), {})
-            props = sp_def.get("properties", {}) if isinstance(sp_def, dict) else {}
-        for name, spec in (props or {}).items():
-            type_repr: Any = spec.get("type", "unknown")
-            if isinstance(type_repr, list):
-                type_repr = " | ".join(str(t) for t in type_repr)
-            sampling_params[name] = {
-                "type": type_repr,
-                "default": spec.get("default"),
-            }
+        # Preserve private-prefixed fields (e.g. ``_all_stop_token_ids``,
+        # ``_real_n``) for v1-shape parity. msgspec's own JSON Schema lists
+        # them as msgspec exposes them.
+        sampling_params, sampling_defs = msgspec_properties_to_specs(
+            vllm.SamplingParams, skip_private=False
+        )
     except Exception as exc:
         limitations.append(
             {
@@ -68,12 +65,16 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
             }
         )
 
+    # The msgspec schema captures field-level enum + min/max where present;
+    # constraints that live solely in _verify_args() (e.g. mutual-exclusion
+    # checks across fields) remain undiscoverable from field metadata, so
+    # the cross-field caveat stays.
     limitations.append(
         {
             "section": "sampling_params",
             "fields": [],
-            "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative "
-            "_verify_args() and are not introspectable from field metadata",
+            "reason": "cross-field constraints (e.g. top_p + top_k interactions) live in "
+            "imperative _verify_args() and are not introspectable from field metadata",
         }
     )
     limitations.append(
@@ -94,4 +95,5 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        sampling_params_defs=sampling_defs,
     )

--- a/scripts/engine_producers/_common.py
+++ b/scripts/engine_producers/_common.py
@@ -17,6 +17,7 @@ under ``scripts.engine_producers``.
 from __future__ import annotations
 
 import dataclasses
+import enum
 import inspect
 import os
 import re
@@ -25,7 +26,19 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Union, get_args, get_origin
 
-SCHEMA_VERSION = "1.0.0"
+# Schema version 2.0.0 (bump from 1.0.0):
+#
+# The per-field spec dicts are now JSON-Schema-conformant. Each leaf may
+# additionally carry standard JSON Schema keys (``enum``, ``minimum``,
+# ``maximum``, ``exclusiveMinimum``, ``exclusiveMaximum``, ``pattern``,
+# ``multipleOf``, ``deprecated``, ``description``) plus nested ``$ref``
+# / ``$defs`` for Pydantic sub-models. The legacy ``type`` (compact
+# stringified form) and ``default`` keys are preserved, so the change is
+# additive at the per-field level. The major bump signals to downstream
+# consumers that they may now safely depend on the new keys; older
+# consumers that only read ``type`` / ``default`` are unaffected by
+# anything except the version string itself.
+SCHEMA_VERSION = "2.0.0"
 
 # Only the transformers engine has a first-party Dockerfile. vllm and
 # tensorrt run inside upstream images (vllm/vllm-openai,
@@ -145,14 +158,170 @@ def jsonable(value: Any) -> Any:
     return str(value)
 
 
+def literal_to_json_schema(annotation: Any) -> dict[str, Any] | None:
+    """Return a JSON-Schema-shaped ``{type, enum}`` dict for Literal / Enum.
+
+    For ``Literal[a, b, c]`` returns ``{"type": <inferred>, "enum": [a, b, c]}``
+    where the inferred ``type`` is ``"string"`` if every member is ``str``,
+    ``"integer"`` if every member is ``int`` (booleans excluded), ``"number"``
+    if every member is ``int`` or ``float``, and ``"boolean"`` if every member
+    is ``bool``. For an :class:`enum.Enum` subclass returns the same shape with
+    the members' ``.value``\\ s. Returns ``None`` for anything that is neither a
+    Literal nor an Enum subclass so callers can fall through to other branches.
+    """
+    if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+        values: list[Any] = [member.value for member in annotation]
+        return _enum_shape(values)
+
+    origin = get_origin(annotation)
+    if origin is None:
+        return None
+    # ``typing.Literal`` from the stdlib renders to ``typing.Literal`` in 3.10+
+    # and ``Literal`` under PEP-604. Both expose the same get_args tuple.
+    if "Literal" not in str(origin):
+        return None
+    values = list(get_args(annotation))
+    if not values:
+        return None
+    return _enum_shape(values)
+
+
+def _enum_shape(values: list[Any]) -> dict[str, Any]:
+    """Infer a JSON Schema ``type`` for a non-empty list of enum / Literal members."""
+    # Order matters: ``bool`` is a subclass of ``int`` in Python, so test it first.
+    if all(isinstance(v, bool) for v in values):
+        kind = "boolean"
+    elif all(isinstance(v, int) and not isinstance(v, bool) for v in values):
+        kind = "integer"
+    elif all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in values):
+        kind = "number"
+    elif all(isinstance(v, str) for v in values):
+        kind = "string"
+    else:
+        # Mixed-type enums are rare upstream; fall back to ``string`` and let
+        # the value list speak for itself. Downstream consumers can re-infer
+        # per-member if they really care.
+        kind = "string"
+    return {"type": kind, "enum": [jsonable(v) for v in values]}
+
+
+def pydantic_to_json_schema(cls: type) -> dict[str, Any]:
+    """Return Pydantic v2's native ``model_json_schema`` as-is, with ``$defs``.
+
+    Preserves every standard JSON Schema key Pydantic emits per-field
+    (``type``, ``default``, ``enum``, ``minimum``, ``maximum``,
+    ``exclusiveMinimum``, ``exclusiveMaximum``, ``pattern``, ``multipleOf``,
+    ``description``, ``deprecated``, ``required``, ``additionalProperties``)
+    and the nested ``$defs`` / ``$ref`` structure for sub-models. Adds
+    ``x-source: "pydantic_field"`` to each top-level property so downstream
+    consumers can trace provenance.
+
+    Raises ``TypeError`` if ``cls`` is not a Pydantic v2 ``BaseModel``
+    subclass; callers should fall back to ``dataclass_fields_to_specs``
+    or a manual extractor in that case.
+    """
+    if not hasattr(cls, "model_json_schema"):
+        raise TypeError(f"{cls!r} is not a Pydantic v2 BaseModel (no model_json_schema method)")
+    schema: dict[str, Any] = cls.model_json_schema(
+        mode="serialization", ref_template="#/$defs/{model}"
+    )
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        for spec in props.values():
+            if isinstance(spec, dict):
+                spec.setdefault("x-source", "pydantic_field")
+    return schema
+
+
+def msgspec_properties_to_specs(
+    cls: type, *, skip_private: bool = True
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Return ``(properties, defs)`` from a msgspec type's JSON Schema.
+
+    msgspec wraps the target type in a ``$ref`` envelope: the actual
+    property dict lives under ``$defs[<name>].properties``. This helper
+    flattens that envelope and applies the same per-field shape contract
+    as :func:`pydantic_properties_to_specs` -- compact ``type`` string
+    preserved on each leaf for backward compatibility, all standard JSON
+    Schema keys (``enum``, ``minimum``, ``maximum``, ``exclusiveMinimum``,
+    ``exclusiveMaximum``, ``pattern``, ``multipleOf``, ``description``,
+    ``deprecated``, ``$ref``, ``anyOf``) carried alongside, ``default``
+    normalised through :func:`jsonable`. Each leaf gets ``x-source:
+    "msgspec_field"``.
+
+    ``skip_private`` filters property names starting with ``_``.
+    """
+    raw = msgspec_to_json_schema(cls)
+    defs = raw.get("$defs") or raw.get("definitions") or {}
+    props: dict[str, Any] = raw.get("properties") or {}
+    if not props and defs:
+        target_def: Any = defs.get(cls.__name__) or next(iter(defs.values()), {})
+        if isinstance(target_def, dict):
+            props = target_def.get("properties", {}) or {}
+    specs: dict[str, dict[str, Any]] = {}
+    for name, spec in props.items():
+        if skip_private and name.startswith("_"):
+            continue
+        if not isinstance(spec, dict):
+            continue
+        enriched = dict(spec)
+        enriched.pop("title", None)
+        original_type = spec.get("type")
+        compact = compact_type_from_jsonschema(spec)
+        enriched["type"] = compact
+        if (
+            isinstance(original_type, str)
+            and original_type in _JSONSCHEMA_PRIMITIVES
+            and original_type != compact
+        ):
+            enriched["json_schema_type"] = original_type
+        if "default" in enriched:
+            enriched["default"] = jsonable(enriched["default"])
+        enriched.setdefault("x-source", "msgspec_field")
+        specs[name] = enriched
+    return specs, dict(defs) if isinstance(defs, dict) else {}
+
+
+def msgspec_to_json_schema(cls: type) -> dict[str, Any]:
+    """Return msgspec's native ``msgspec.json.schema`` output as-is.
+
+    The shape mirrors :func:`pydantic_to_json_schema`: a top-level dict with
+    ``properties`` / ``$defs`` (or ``definitions``) that downstream introspectors
+    consume directly. ``x-source: "msgspec_field"`` is added to each top-level
+    property leaf. msgspec returns its own ``$ref`` envelope around the target
+    type; callers extract ``properties`` themselves so we don't duplicate the
+    walk here.
+
+    Raises ``ImportError`` if msgspec isn't installed (vLLM ships it; other
+    environments should not call this).
+    """
+    import msgspec  # type: ignore[import-not-found]
+
+    schema: dict[str, Any] = msgspec.json.schema(cls)
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        for spec in props.values():
+            if isinstance(spec, dict):
+                spec.setdefault("x-source", "msgspec_field")
+    return schema
+
+
 def dataclass_fields_to_specs(
     cls: type, *, skip_private: bool = False
 ) -> dict[str, dict[str, Any]]:
-    """Extract ``{name: {type, default}}`` specs from a dataclass.
+    """Extract ``{name: {type, default, ...}}`` specs from a dataclass.
 
     Resolves ``default_factory`` by calling it (swallowing errors to ``None``)
-    so downstream JSON stays concrete. Types are rendered via
-    ``annotation_to_type_str``.
+    so downstream JSON stays concrete. The compact ``type`` string from
+    :func:`annotation_to_type_str` is always preserved (v1 shape parity).
+    When the annotation is a ``Literal[...]`` or :class:`enum.Enum`
+    subclass, the spec is enriched with ``enum`` (additive) and the
+    JSON-Schema-conformant primitive type (``"string"`` / ``"integer"`` /
+    etc.) is surfaced under ``json_schema_type`` so structured consumers
+    can still reach it without clobbering the legacy ``type`` string.
+    ``description`` is surfaced when ``dataclasses.field(metadata=
+    {"description": ...})`` is set. Each leaf carries ``x-source:
+    "dataclass_field"`` for provenance.
     """
     specs: dict[str, dict[str, Any]] = {}
     for fld in dataclasses.fields(cls):
@@ -166,11 +335,178 @@ def dataclass_fields_to_specs(
                 default = fld.default_factory()
             except Exception:
                 default = None
-        specs[fld.name] = {
-            "type": annotation_to_type_str(fld.type),
+        type_str = annotation_to_type_str(fld.type)
+        spec: dict[str, Any] = {
+            "type": type_str,
             "default": jsonable(default),
+            "x-source": "dataclass_field",
         }
+        # Literal / Enum yields a structured enum: keep the v1 ``type``
+        # string in place for byte-stable backward compatibility, layer
+        # the JSON Schema primitive on ``json_schema_type``, and surface
+        # the value list on ``enum``.
+        enum_shape = literal_to_json_schema(fld.type)
+        if enum_shape is not None:
+            spec["json_schema_type"] = enum_shape["type"]
+            spec["enum"] = enum_shape["enum"]
+        # Optional per-field description via dataclasses field metadata.
+        meta = getattr(fld, "metadata", None)
+        if meta:
+            description = meta.get("description")
+            if description:
+                spec["description"] = str(description)
+        specs[fld.name] = spec
     return specs
+
+
+def signature_param_to_spec(param: inspect.Parameter) -> dict[str, Any]:
+    """Build a per-field spec dict from a single ``inspect.Parameter``.
+
+    Mirrors :func:`dataclass_fields_to_specs`: the compact ``type`` string
+    from :func:`annotation_to_type_str` always lands on ``type`` for v1
+    backward compatibility. When the annotation is a ``Literal[...]`` or
+    :class:`enum.Enum` subclass, ``enum`` and ``json_schema_type``
+    (``"string"`` / ``"integer"`` / etc.) are added as siblings. Each
+    leaf carries ``x-source: "signature_param"`` for provenance.
+    """
+    default: Any = None if param.default is inspect.Parameter.empty else param.default
+    type_str = annotation_to_type_str(param.annotation)
+    spec: dict[str, Any] = {
+        "type": type_str,
+        "default": jsonable(default),
+        "x-source": "signature_param",
+    }
+    enum_shape = literal_to_json_schema(param.annotation)
+    if enum_shape is not None:
+        spec["json_schema_type"] = enum_shape["type"]
+        spec["enum"] = enum_shape["enum"]
+    return spec
+
+
+def pydantic_properties_to_specs(
+    cls: type, *, skip_private: bool = True
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Return ``(properties, defs)`` from a Pydantic v2 model's JSON Schema.
+
+    ``properties`` is the per-field dict (top-level only); ``defs`` is the
+    nested ``$defs`` block (empty dict if the model has no sub-models).
+
+    Per-field shape is the v2 union: the legacy ``type`` carries the compact
+    Python-ish stringified form (e.g. ``"KvCacheConfig | None"`` for an
+    ``anyOf`` of ``$ref`` + ``"null"``) so backward-compatible consumers
+    (including ``diff_discovered_schemas``) keep working, while all
+    JSON-Schema-conformant keys Pydantic emits (``enum``, ``minimum``,
+    ``maximum``, ``exclusiveMinimum``, ``exclusiveMaximum``, ``pattern``,
+    ``multipleOf``, ``description``, ``deprecated``, ``$ref``, ``anyOf``)
+    ride alongside. ``default`` is normalised through :func:`jsonable` to
+    survive ``json.dumps``. Each leaf carries ``x-source:
+    "pydantic_field"`` for provenance.
+
+    ``skip_private`` filters property names starting with ``_``.
+    """
+    raw = pydantic_to_json_schema(cls)
+    raw_props = raw.get("properties") or {}
+    defs = raw.get("$defs") or raw.get("definitions") or {}
+    specs: dict[str, dict[str, Any]] = {}
+    for name, spec in raw_props.items():
+        if skip_private and name.startswith("_"):
+            continue
+        if not isinstance(spec, dict):
+            continue
+        enriched = dict(spec)
+        # Drop the Pydantic ``title`` (auto-generated from the field name)
+        # so it doesn't add noise to every field. Real per-field titles
+        # would survive on a deeper extraction; the top-level title is
+        # just ``"Kv Cache Config"`` etc. which restates the field name.
+        enriched.pop("title", None)
+        # Legacy compact type string takes the ``type`` key for backward
+        # compatibility with the v1 shape and downstream diff classifiers.
+        # ``compact_type_from_jsonschema`` honours an explicit Pydantic-
+        # stuffed Python-ish ``type`` repr (e.g. ``"Optional[X]"``) before
+        # falling into anyOf/ref unwinding, so the v1 string survives where
+        # Pydantic emits one. When Pydantic emits a primitive (``"string"``,
+        # ``"integer"``, etc.) the compact form equals it, so no extra key
+        # is needed; only surface ``json_schema_type`` when the unwinding
+        # produced a different compact string than Pydantic's primitive.
+        original_type = spec.get("type")
+        compact = compact_type_from_jsonschema(spec)
+        enriched["type"] = compact
+        if (
+            isinstance(original_type, str)
+            and original_type in _JSONSCHEMA_PRIMITIVES
+            and original_type != compact
+        ):
+            enriched["json_schema_type"] = original_type
+        # Normalise default through jsonable so callers can json.dumps the
+        # spec dict directly without a custom encoder. Pydantic omits
+        # ``default`` for required fields and for fields whose default is
+        # a model instance the schema can't serialise; backfill ``null``
+        # so the v2 shape's per-field contract stays ``{type, default}``
+        # for every leaf and the v1 backward-compat invariant holds.
+        if "default" in enriched:
+            enriched["default"] = jsonable(enriched["default"])
+        else:
+            enriched["default"] = None
+        # Pydantic only emits ``deprecated`` when ``True``; the v1 shape
+        # always carried a literal ``false`` for non-deprecated fields,
+        # so backfill to match.
+        enriched.setdefault("deprecated", False)
+        specs[name] = enriched
+    return specs, dict(defs) if isinstance(defs, dict) else {}
+
+
+def compact_type_from_jsonschema(spec: dict[str, Any]) -> str:
+    """Render a JSON Schema property's compact Python-ish type string.
+
+    Mirrors the v1 collapsing logic so the v2 envelope's ``type`` field
+    stays byte-stable across the bump. Pydantic v2 sometimes stuffs a
+    Python-ish repr like ``"Optional[my.module.X]"`` directly into the
+    ``type`` key for opaque non-Pydantic types; when present alongside an
+    ``anyOf`` with a ``{}`` opaque branch, that string takes precedence
+    over the anyOf rendering (which would collapse to ``"None"`` and lose
+    the upstream type-name signal).
+
+    Otherwise: ``$ref`` becomes the target model name; ``anyOf`` becomes a
+    ``" | "``-joined union; primitive types pass through with
+    ``"null" -> "None"``.
+    """
+    type_repr: Any = spec.get("type")
+    # Honour an explicit non-primitive ``type`` string before falling into
+    # anyOf / ref unwinding. Pydantic emits ``type: "Optional[X]"`` for
+    # opaque types whose anyOf branch is ``{}``; keeping that string
+    # preserves the v1 shape byte-for-byte.
+    if isinstance(type_repr, str) and type_repr not in _JSONSCHEMA_PRIMITIVES:
+        return "None" if type_repr == "null" else type_repr
+    if "$ref" in spec:
+        return str(spec["$ref"]).rsplit("/", 1)[-1]
+    if "anyOf" in spec:
+        parts: list[str] = []
+        for sub in spec["anyOf"]:
+            if not isinstance(sub, dict):
+                continue
+            if "type" in sub:
+                kind = sub["type"]
+                part = "None" if kind == "null" else str(kind)
+            elif "$ref" in sub:
+                part = str(sub["$ref"]).rsplit("/", 1)[-1]
+            else:
+                continue
+            if part not in parts:
+                parts.append(part)
+        return " | ".join(parts) if parts else "unknown"
+    if isinstance(type_repr, list):
+        return " | ".join("None" if t == "null" else str(t) for t in type_repr)
+    if type_repr == "null":
+        return "None"
+    return str(type_repr) if type_repr is not None else "unknown"
+
+
+# JSON Schema primitive type names recognised by ``compact_type_from_jsonschema``;
+# anything else in a ``type`` string is treated as a Pydantic-stuffed Python-ish
+# repr and kept verbatim.
+_JSONSCHEMA_PRIMITIVES: frozenset[str] = frozenset(
+    {"string", "integer", "number", "boolean", "array", "object", "null"}
+)
 
 
 def make_envelope(
@@ -184,7 +520,22 @@ def make_envelope(
     discovery_limitations: list[dict[str, Any]],
     engine_params: dict[str, Any],
     sampling_params: dict[str, Any],
+    engine_params_defs: dict[str, Any] | None = None,
+    sampling_params_defs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    """Build a discovered-schema envelope.
+
+    ``schema_version`` is set from the module-level :data:`SCHEMA_VERSION`
+    constant. v2.0.0 carries JSON-Schema-conformant per-field specs (enum,
+    minimum, maximum, $defs, etc.) in addition to the legacy ``type`` /
+    ``default`` keys; see the module docstring for the bump rationale.
+
+    The optional ``engine_params_defs`` / ``sampling_params_defs`` dicts
+    capture nested ``$defs`` blocks emitted by Pydantic / msgspec when a
+    parameter's value is itself a structured model. They are emitted as
+    top-level envelope keys only when non-empty so older single-class
+    engines stay byte-identical apart from the bumped version.
+    """
     # Honour LLENERGY_DISCOVERY_FROZEN_AT when the caller (CI) wants the
     # envelope pinned to a stable anchor - typically the author date of the
     # most recent commit touching any input path. Without this override every
@@ -195,7 +546,7 @@ def make_envelope(
     discovered_at = (
         os.environ.get("LLENERGY_DISCOVERY_FROZEN_AT") or datetime.now(timezone.utc).isoformat()
     )
-    return {
+    envelope: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "engine": engine,
         "engine_version": engine_version,
@@ -208,3 +559,8 @@ def make_envelope(
         "engine_params": engine_params,
         "sampling_params": sampling_params,
     }
+    if engine_params_defs:
+        envelope["engine_params_defs"] = engine_params_defs
+    if sampling_params_defs:
+        envelope["sampling_params_defs"] = sampling_params_defs
+    return envelope

--- a/src/llenergymeasure/config/schema_loader.py
+++ b/src/llenergymeasure/config/schema_loader.py
@@ -23,7 +23,20 @@ from typing import Any
 
 from llenergymeasure.config.ssot import Engine
 
-SUPPORTED_MAJOR_VERSION = 1
+SUPPORTED_MAJOR_VERSIONS: frozenset[int] = frozenset({1, 2})
+"""Major schema versions this loader can parse.
+
+v1 was the original ``{type, default}`` per-field shape. v2 layers JSON
+Schema-conformant keys (``enum``, ``minimum``, ``$defs``, etc.) on top of
+that shape; the loader doesn't need any new logic to read v2 because the
+DiscoveredSchema dataclass keeps ``engine_params`` / ``sampling_params``
+as raw dicts and lets downstream consumers pick up the new keys
+opportunistically.
+"""
+
+# Retained for backward compatibility with any external code that imported
+# the singular constant; new code should consult ``SUPPORTED_MAJOR_VERSIONS``.
+SUPPORTED_MAJOR_VERSION = 2
 
 # Engines known to ship a discovered schema. Test-patchable module attribute
 # (tests monkeypatch this to inject fake engines); derived from Engine SSOT.
@@ -60,6 +73,14 @@ class DiscoveredSchema:
     carry ``description`` and ``deprecated`` from its Pydantic schema, while
     vLLM and Transformers fields only have ``type`` and ``default``. Consumers
     that need uniform shape should adapt at read time.
+
+    From schema_version 2.0.0 onward the per-field dicts may additionally
+    carry JSON Schema keys (``enum``, ``minimum``, ``maximum``,
+    ``exclusiveMinimum``, ``exclusiveMaximum``, ``pattern``, ``multipleOf``,
+    ``$ref``, ``anyOf``). Nested ``$defs`` blocks referenced by Pydantic
+    sub-models are surfaced in :attr:`engine_params_defs` /
+    :attr:`sampling_params_defs`, which default to empty dicts for engines
+    that don't emit them.
     """
 
     schema_version: str
@@ -73,6 +94,8 @@ class DiscoveredSchema:
     discovery_limitations: list[DiscoveryLimitation] = field(default_factory=list)
     engine_params: dict[str, dict[str, Any]] = field(default_factory=dict)
     sampling_params: dict[str, dict[str, Any]] = field(default_factory=dict)
+    engine_params_defs: dict[str, Any] = field(default_factory=dict)
+    sampling_params_defs: dict[str, Any] = field(default_factory=dict)
 
 
 class SchemaLoader:
@@ -93,7 +116,7 @@ class SchemaLoader:
             ValueError: ``engine`` is not a known engine name.
             FileNotFoundError: No discovered JSON exists for ``engine``.
             UnsupportedSchemaVersionError: Discovered schema major version
-                doesn't match ``SUPPORTED_MAJOR_VERSION``.
+                isn't in ``SUPPORTED_MAJOR_VERSIONS``.
             json.JSONDecodeError: Discovered file is not valid JSON.
         """
         if engine not in _KNOWN_ENGINES:
@@ -139,12 +162,12 @@ def _parse_envelope(*, engine: str, raw_text: str) -> DiscoveredSchema:
 
     schema_version = data["schema_version"]
     major = _major_version(schema_version)
-    if major != SUPPORTED_MAJOR_VERSION:
+    if major not in SUPPORTED_MAJOR_VERSIONS:
         raise UnsupportedSchemaVersionError(
             f"Discovered schema for {engine!r} has schema_version={schema_version!r} "
-            f"(major={major}); this SchemaLoader only supports major "
-            f"{SUPPORTED_MAJOR_VERSION}. Regenerate with a matching discovery script, "
-            f"or upgrade the loader."
+            f"(major={major}); this SchemaLoader only supports majors "
+            f"{sorted(SUPPORTED_MAJOR_VERSIONS)}. Regenerate with a matching discovery "
+            f"script, or upgrade the loader."
         )
 
     limitations_raw = data.get("discovery_limitations", [])
@@ -177,6 +200,8 @@ def _parse_envelope(*, engine: str, raw_text: str) -> DiscoveredSchema:
         discovery_limitations=limitations,
         engine_params=data.get("engine_params", {}),
         sampling_params=data.get("sampling_params", {}),
+        engine_params_defs=data.get("engine_params_defs", {}),
+        sampling_params_defs=data.get("sampling_params_defs", {}),
     )
 
 

--- a/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: tensorrt
 engine_version: 0.21.0
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   engine: tensorrt

--- a/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: tensorrt
 engine_version: 0.21.0
 image_ref: llenergymeasure:tensorrt
 base_image_ref: llenergymeasure:tensorrt
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   outcome: error

--- a/src/llenergymeasure/engines/tensorrt/schema.discovered.json
+++ b/src/llenergymeasure/engines/tensorrt/schema.discovered.json
@@ -1,11 +1,11 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "2.0.0",
   "engine": "tensorrt",
   "engine_version": "0.21.0",
   "engine_commit_sha": null,
-  "image_ref": "llenergymeasure:tensorrt-0.21.0",
+  "image_ref": "nvcr.io/nvidia/tensorrt-llm/release:0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T13:25:05+02:00",
+  "discovered_at": "2026-05-22T00:00:00+00:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {
@@ -18,559 +18,1999 @@
     {
       "section": "sampling_params",
       "fields": [],
-      "reason": "SamplingParams is a dataclass; no per-field descriptions"
+      "reason": "SamplingParams is a dataclass with no per-field field(metadata={'description': ...}) metadata; descriptions unavailable"
     }
   ],
   "engine_params": {
     "model": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "format": "path",
+          "type": "string"
+        }
+      ],
+      "description": "The path to the model checkpoint or the model name from the Hugging Face Hub.",
+      "x-source": "pydantic_field",
       "type": "string",
       "default": null,
-      "description": "The path to the model checkpoint or the model name from the Hugging Face Hub.",
       "deprecated": false
     },
     "tokenizer": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "format": "path",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The path to the tokenizer checkpoint or the tokenizer name from the Hugging Face Hub.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "tokenizer_mode": {
-      "type": "Literal['auto', 'slow']",
       "default": "auto",
       "description": "The mode to initialize the tokenizer.",
+      "enum": [
+        "auto",
+        "slow"
+      ],
+      "type": "Literal['auto', 'slow']",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "skip_tokenizer_init": {
-      "type": "boolean",
       "default": false,
       "description": "Whether to skip the tokenizer initialization.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "trust_remote_code": {
-      "type": "boolean",
       "default": false,
       "description": "Whether to trust the remote code.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "tensor_parallel_size": {
-      "type": "integer",
       "default": 1,
       "description": "The tensor parallel size.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "dtype": {
-      "type": "string",
       "default": "auto",
       "description": "The data type to use for the model.",
+      "type": "string",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "revision": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The revision to use for the model.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "tokenizer_revision": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The revision to use for the tokenizer.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "pipeline_parallel_size": {
-      "type": "integer",
       "default": 1,
       "description": "The pipeline parallel size.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "context_parallel_size": {
-      "type": "integer",
       "default": 1,
       "description": "The context parallel size.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "gpus_per_node": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The number of GPUs per node.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "moe_cluster_parallel_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The cluster parallel size for MoE models's expert weights.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "moe_tensor_parallel_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The tensor parallel size for MoE models's expert weights.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "moe_expert_parallel_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The expert parallel size for MoE models's expert weights.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "enable_attention_dp": {
-      "type": "boolean",
       "default": false,
       "description": "Enable attention data parallel.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "cp_config": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Context parallel config.",
+      "x-source": "pydantic_field",
       "type": "object | None",
       "default": null,
-      "description": "Context parallel config.",
       "deprecated": false
     },
     "load_format": {
-      "type": "Literal['auto', 'dummy']",
       "default": "auto",
       "description": "The format to load the model.",
+      "enum": [
+        "auto",
+        "dummy"
+      ],
+      "type": "Literal['auto', 'dummy']",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "enable_lora": {
-      "type": "boolean",
       "default": false,
       "description": "Enable LoRA.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "max_lora_rank": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
+      "deprecated": true,
       "description": "The maximum LoRA rank.",
-      "deprecated": true
+      "x-source": "pydantic_field",
+      "type": "integer | None"
     },
     "max_loras": {
-      "type": "integer",
       "default": 4,
+      "deprecated": true,
       "description": "The maximum number of LoRA.",
-      "deprecated": true
+      "type": "integer",
+      "x-source": "pydantic_field"
     },
     "max_cpu_loras": {
-      "type": "integer",
       "default": 4,
+      "deprecated": true,
       "description": "The maximum number of LoRA on CPU.",
-      "deprecated": true
+      "type": "integer",
+      "x-source": "pydantic_field"
     },
     "lora_config": {
-      "type": "LoraConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LoraConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "LoRA configuration for the model.",
+      "x-source": "pydantic_field",
+      "type": "LoraConfig | None",
       "deprecated": false
     },
     "enable_prompt_adapter": {
-      "type": "boolean",
       "default": false,
       "description": "Enable prompt adapter.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "max_prompt_adapter_token": {
-      "type": "integer",
       "default": 0,
       "description": "The maximum number of prompt adapter tokens.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "quant_config": {
-      "type": "QuantConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/QuantConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Quantization config.",
+      "x-source": "pydantic_field",
+      "type": "QuantConfig | None",
       "deprecated": false
     },
     "kv_cache_config": {
+      "$ref": "#/$defs/KvCacheConfig",
+      "description": "KV cache config.",
+      "x-source": "pydantic_field",
       "type": "KvCacheConfig",
       "default": null,
-      "description": "KV cache config.",
       "deprecated": false
     },
     "enable_chunked_prefill": {
-      "type": "boolean",
       "default": false,
       "description": "Enable chunked prefill.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "guided_decoding_backend": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Guided decoding backend.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "batched_logits_processor": {
-      "type": "Optional[tensorrt_llm.sampling_params.BatchedLogitsProcessor]",
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Batched logits processor.",
+      "type": "Optional[tensorrt_llm.sampling_params.BatchedLogitsProcessor]",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "iter_stats_max_iterations": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum number of iterations for iter stats.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "request_stats_max_iterations": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum number of iterations for request stats.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "peft_cache_config": {
-      "type": "PeftCacheConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PeftCacheConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "PEFT cache config.",
+      "x-source": "pydantic_field",
+      "type": "PeftCacheConfig | None",
       "deprecated": false
     },
     "scheduler_config": {
+      "$ref": "#/$defs/SchedulerConfig",
+      "description": "Scheduler config.",
+      "x-source": "pydantic_field",
       "type": "SchedulerConfig",
       "default": null,
-      "description": "Scheduler config.",
       "deprecated": false
     },
     "cache_transceiver_config": {
-      "type": "CacheTransceiverConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CacheTransceiverConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Cache transceiver config.",
+      "x-source": "pydantic_field",
+      "type": "CacheTransceiverConfig | None",
       "deprecated": false
     },
     "speculative_config": {
-      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LookaheadDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/MedusaDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/EagleDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/MTPDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/NGramDecodingConfig"
+        },
+        {
+          "$ref": "#/$defs/DraftTargetDecodingConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Speculative decoding config.",
+      "x-source": "pydantic_field",
+      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
       "deprecated": false
     },
     "batching_type": {
-      "type": "BatchingType | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BatchingType"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Batching type.",
+      "x-source": "pydantic_field",
+      "type": "BatchingType | None",
       "deprecated": false
     },
     "normalize_log_probs": {
-      "type": "boolean",
       "default": false,
       "description": "Normalize log probabilities.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "max_batch_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum batch size.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_input_len": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum input length.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_seq_len": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum sequence length.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_beam_width": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum beam width.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "max_num_tokens": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The maximum number of tokens.",
+      "x-source": "pydantic_field",
+      "type": "integer | None",
       "deprecated": false
     },
     "gather_generation_logits": {
-      "type": "boolean",
       "default": false,
       "description": "Gather generation logits.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "num_postprocess_workers": {
-      "type": "integer",
       "default": 0,
       "description": "The number of processes used for postprocessing the generated tokens, including detokenization.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "postprocess_tokenizer_dir": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The path to the tokenizer directory for postprocessing.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "reasoning_parser": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The parser to separate reasoning content from output.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "garbage_collection_gen0_threshold": {
-      "type": "integer",
       "default": 20000,
       "description": "Threshold for Python garbage collection of generation 0 objects.Lower values trigger more frequent garbage collection.",
+      "type": "integer",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "decoding_config": {
-      "type": "Optional[DecodingConfig]",
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
+      "deprecated": true,
       "description": "The decoding config.",
-      "deprecated": true
+      "type": "Optional[DecodingConfig]",
+      "x-source": "pydantic_field"
     },
     "backend": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The backend to use for this LLM instance.",
+      "exclude_json_schema": true,
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "auto_parallel": {
-      "type": "boolean",
       "default": false,
+      "deprecated": true,
       "description": "Enable auto parallel mode.",
-      "deprecated": true
+      "type": "boolean",
+      "x-source": "pydantic_field"
     },
     "auto_parallel_world_size": {
-      "type": "integer | None",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
+      "deprecated": true,
       "description": "The world size for auto parallel mode.",
-      "deprecated": true
+      "x-source": "pydantic_field",
+      "type": "integer | None"
     },
     "enable_tqdm": {
-      "type": "boolean",
       "default": false,
       "description": "Enable tqdm for progress bar.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "workspace": {
-      "type": "string | None",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "The workspace for the model.",
+      "x-source": "pydantic_field",
+      "type": "string | None",
       "deprecated": false
     },
     "enable_build_cache": {
-      "type": "Union[tensorrt_llm.llmapi.build_cache.BuildCacheConfig, bool]",
       "default": false,
       "description": "Enable build cache.",
+      "type": "Union[tensorrt_llm.llmapi.build_cache.BuildCacheConfig, bool]",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "extended_runtime_perf_knob_config": {
-      "type": "ExtendedRuntimePerfKnobConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExtendedRuntimePerfKnobConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Extended runtime perf knob config.",
+      "x-source": "pydantic_field",
+      "type": "ExtendedRuntimePerfKnobConfig | None",
       "deprecated": false
     },
     "calib_config": {
-      "type": "CalibConfig | None",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CalibConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Calibration config.",
+      "x-source": "pydantic_field",
+      "type": "CalibConfig | None",
       "deprecated": false
     },
     "embedding_parallel_mode": {
-      "type": "string",
       "default": "SHARDING_ALONG_VOCAB",
       "description": "The embedding parallel mode.",
+      "type": "string",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "fast_build": {
-      "type": "boolean",
       "default": false,
       "description": "Enable fast build.",
+      "type": "boolean",
+      "x-source": "pydantic_field",
       "deprecated": false
     },
     "build_config": {
-      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Build config.",
+      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "x-source": "pydantic_field",
       "deprecated": false
     }
   },
   "sampling_params": {
     "end_id": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "pad_id": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_tokens": {
       "type": "int",
-      "default": 32
+      "default": 32,
+      "x-source": "dataclass_field"
     },
     "bad": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "bad_token_ids": {
       "type": "list[int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "stop": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "stop_token_ids": {
       "type": "list[int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "include_stop_str_in_output": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "embedding_bias": {
       "type": "Tensor | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "logits_processor": {
       "type": "LogitsProcessor | list[LogitsProcessor] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "apply_batched_logits_processor": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "n": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "best_of": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "use_beam_search": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "top_k": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p_min": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p_reset_ids": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "top_p_decay": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "seed": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "temperature": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "min_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "beam_search_diversity_rate": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "repetition_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "presence_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "frequency_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "length_penalty": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "early_stopping": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "no_repeat_ngram_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "min_p": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "beam_width_array": {
       "type": "list[int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "logprobs": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "prompt_logprobs": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "return_context_logits": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "return_generation_logits": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "exclude_input_from_output": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "return_encoder_output": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "return_perf_metrics": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "additional_model_outputs": {
       "type": "list[AdditionalModelOutput] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "lookahead_config": {
       "type": "LookaheadDecodingConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "guided_decoding": {
       "type": "GuidedDecodingParams | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ignore_eos": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "detokenize": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "add_special_tokens": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "truncate_prompt_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "skip_special_tokens": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "spaces_between_special_tokens": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
+    }
+  },
+  "engine_params_defs": {
+    "BatchingType": {
+      "enum": [
+        "STATIC",
+        "INFLIGHT"
+      ],
+      "title": "BatchingType",
+      "type": "string"
+    },
+    "CacheTransceiverConfig": {
+      "description": "Configuration for the cache transceiver.",
+      "properties": {
+        "max_num_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The max number of tokens the transfer buffer can fit.",
+          "title": "Max Num Tokens"
+        }
+      },
+      "title": "CacheTransceiverConfig",
+      "type": "object"
+    },
+    "CalibConfig": {
+      "description": "Calibration configuration.",
+      "properties": {
+        "device": {
+          "default": "cuda",
+          "description": "The device to run calibration.",
+          "enum": [
+            "cuda",
+            "cpu"
+          ],
+          "title": "Device",
+          "type": "string"
+        },
+        "calib_dataset": {
+          "default": "cnn_dailymail",
+          "description": "The name or local path of calibration dataset.",
+          "title": "Calib Dataset",
+          "type": "string"
+        },
+        "calib_batches": {
+          "default": 512,
+          "description": "The number of batches that the calibration runs.",
+          "title": "Calib Batches",
+          "type": "integer"
+        },
+        "calib_batch_size": {
+          "default": 1,
+          "description": "The batch size that the calibration runs.",
+          "title": "Calib Batch Size",
+          "type": "integer"
+        },
+        "calib_max_seq_length": {
+          "default": 512,
+          "description": "The maximum sequence length that the calibration runs.",
+          "title": "Calib Max Seq Length",
+          "type": "integer"
+        },
+        "random_seed": {
+          "default": 1234,
+          "description": "The random seed used for calibration.",
+          "title": "Random Seed",
+          "type": "integer"
+        },
+        "tokenizer_max_seq_length": {
+          "default": 2048,
+          "description": "The maximum sequence length to initialize tokenizer for calibration.",
+          "title": "Tokenizer Max Seq Length",
+          "type": "integer"
+        }
+      },
+      "title": "CalibConfig",
+      "type": "object"
+    },
+    "CapacitySchedulerPolicy": {
+      "enum": [
+        "MAX_UTILIZATION",
+        "GUARANTEED_NO_EVICT",
+        "STATIC_BATCH"
+      ],
+      "title": "CapacitySchedulerPolicy",
+      "type": "string"
+    },
+    "ContextChunkingPolicy": {
+      "description": "Context chunking policy. ",
+      "enum": [
+        "FIRST_COME_FIRST_SERVED",
+        "EQUAL_PROGRESS"
+      ],
+      "title": "ContextChunkingPolicy",
+      "type": "string"
+    },
+    "DraftTargetDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "pytorch_weights_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pytorch Weights Path"
+        }
+      },
+      "title": "DraftTargetDecodingConfig",
+      "type": "object"
+    },
+    "DynamicBatchConfig": {
+      "description": "Dynamic batch configuration.\n\nControls how batch size and token limits are dynamically adjusted at runtime.",
+      "properties": {
+        "enable_batch_size_tuning": {
+          "description": "Controls if the batch size should be tuned dynamically",
+          "title": "Enable Batch Size Tuning",
+          "type": "boolean"
+        },
+        "enable_max_num_tokens_tuning": {
+          "description": "Controls if the max num tokens should be tuned dynamically",
+          "title": "Enable Max Num Tokens Tuning",
+          "type": "boolean"
+        },
+        "dynamic_batch_moving_average_window": {
+          "description": "The window size for moving average of input and output length which is used to calculate dynamic batch size and max num tokens",
+          "title": "Dynamic Batch Moving Average Window",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enable_batch_size_tuning",
+        "enable_max_num_tokens_tuning",
+        "dynamic_batch_moving_average_window"
+      ],
+      "title": "DynamicBatchConfig",
+      "type": "object"
+    },
+    "EagleDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "eagle_choices": {
+          "anyOf": [
+            {
+              "items": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Eagle Choices"
+        },
+        "greedy_sampling": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "title": "Greedy Sampling"
+        },
+        "posterior_threshold": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Posterior Threshold"
+        },
+        "use_dynamic_tree": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "title": "Use Dynamic Tree"
+        },
+        "dynamic_tree_max_topK": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dynamic Tree Max Topk"
+        },
+        "num_eagle_layers": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Num Eagle Layers"
+        },
+        "max_non_leaves_per_layer": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Non Leaves Per Layer"
+        },
+        "pytorch_weights_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pytorch Weights Path"
+        },
+        "eagle3_one_model": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "title": "Eagle3 One Model"
+        }
+      },
+      "title": "EagleDecodingConfig",
+      "type": "object"
+    },
+    "ExtendedRuntimePerfKnobConfig": {
+      "description": "Configuration for extended runtime performance knobs.",
+      "properties": {
+        "multi_block_mode": {
+          "default": true,
+          "description": "Whether to use multi-block mode.",
+          "title": "Multi Block Mode",
+          "type": "boolean"
+        },
+        "enable_context_fmha_fp32_acc": {
+          "default": false,
+          "description": "Whether to enable context FMHA FP32 accumulation.",
+          "title": "Enable Context Fmha Fp32 Acc",
+          "type": "boolean"
+        },
+        "cuda_graph_mode": {
+          "default": false,
+          "description": "Whether to use CUDA graph mode.",
+          "title": "Cuda Graph Mode",
+          "type": "boolean"
+        },
+        "cuda_graph_cache_size": {
+          "default": 0,
+          "description": "Number of cuda graphs to be cached in the runtime. The larger the cache, the better the perf, but more GPU memory is consumed.",
+          "title": "Cuda Graph Cache Size",
+          "type": "integer"
+        }
+      },
+      "title": "ExtendedRuntimePerfKnobConfig",
+      "type": "object"
+    },
+    "KvCacheConfig": {
+      "description": "Configuration for the KV cache.",
+      "properties": {
+        "enable_block_reuse": {
+          "default": true,
+          "description": "Controls if KV cache blocks can be reused for different requests.",
+          "title": "Enable Block Reuse",
+          "type": "boolean"
+        },
+        "max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of tokens that should be stored in the KV cache. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be used.",
+          "title": "Max Tokens"
+        },
+        "max_attention_window": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Size of the attention window for each sequence. Only the last tokens will be stored in the KV cache. If the number of elements in `max_attention_window` is less than the number of layers, `max_attention_window` will be repeated multiple times to the number of layers.",
+          "title": "Max Attention Window"
+        },
+        "sink_token_length": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Number of sink tokens (tokens to always keep in attention window).",
+          "title": "Sink Token Length"
+        },
+        "free_gpu_memory_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The fraction of GPU memory fraction that should be allocated for the KV cache. Default is 90%. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be used.",
+          "title": "Free Gpu Memory Fraction"
+        },
+        "host_cache_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Size of the host cache in bytes. If both `max_tokens` and `host_cache_size` are specified, memory corresponding to the minimum will be used.",
+          "title": "Host Cache Size"
+        },
+        "onboard_blocks": {
+          "default": true,
+          "description": "Controls if blocks are onboarded.",
+          "title": "Onboard Blocks",
+          "type": "boolean"
+        },
+        "cross_kv_cache_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The fraction of the KV Cache memory should be reserved for cross attention. If set to p, self attention will use 1-p of KV Cache memory and cross attention will use p of KV Cache memory. Default is 50%. Should only be set when using encoder-decoder model.",
+          "title": "Cross Kv Cache Fraction"
+        },
+        "secondary_offload_min_priority": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Only blocks with priority > mSecondaryOfflineMinPriority can be offloaded to secondary memory.",
+          "title": "Secondary Offload Min Priority"
+        },
+        "event_buffer_max_size": {
+          "default": 0,
+          "description": "Maximum size of the event buffer. If set to 0, the event buffer will not be used.",
+          "title": "Event Buffer Max Size",
+          "type": "integer"
+        },
+        "enable_partial_reuse": {
+          "default": true,
+          "description": "Whether blocks that are only partially matched can be reused.",
+          "title": "Enable Partial Reuse",
+          "type": "boolean"
+        },
+        "copy_on_partial_reuse": {
+          "default": true,
+          "description": "Whether partially matched blocks that are in use can be reused after copying them.",
+          "title": "Copy On Partial Reuse",
+          "type": "boolean"
+        }
+      },
+      "title": "KvCacheConfig",
+      "type": "object"
+    },
+    "LookaheadDecodingConfig": {
+      "description": "Configuration for lookahead speculative decoding.",
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "max_window_size": {
+          "default": 4,
+          "description": "Number of NGrams in lookahead branch per step.",
+          "title": "Max Window Size",
+          "type": "integer"
+        },
+        "max_ngram_size": {
+          "default": 3,
+          "description": "Number of tokens per NGram.",
+          "title": "Max Ngram Size",
+          "type": "integer"
+        },
+        "max_verification_set_size": {
+          "default": 4,
+          "description": "Number of NGrams in verification branch per step.",
+          "title": "Max Verification Set Size",
+          "type": "integer"
+        }
+      },
+      "title": "LookaheadDecodingConfig",
+      "type": "object"
+    },
+    "LoraConfig": {
+      "properties": {
+        "lora_dir": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Lora Dir",
+          "type": "array"
+        },
+        "lora_ckpt_source": {
+          "default": "hf",
+          "title": "Lora Ckpt Source",
+          "type": "string"
+        },
+        "max_lora_rank": {
+          "default": 64,
+          "title": "Max Lora Rank",
+          "type": "integer"
+        },
+        "lora_target_modules": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Lora Target Modules",
+          "type": "array"
+        },
+        "trtllm_modules_to_hf_modules": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Trtllm Modules To Hf Modules",
+          "type": "object"
+        },
+        "max_loras": {
+          "default": 4,
+          "title": "Max Loras",
+          "type": "integer"
+        },
+        "max_cpu_loras": {
+          "default": 4,
+          "title": "Max Cpu Loras",
+          "type": "integer"
+        }
+      },
+      "title": "LoraConfig",
+      "type": "object"
+    },
+    "MTPDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "num_nextn_predict_layers": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1,
+          "title": "Num Nextn Predict Layers"
+        },
+        "use_relaxed_acceptance_for_thinking": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "title": "Use Relaxed Acceptance For Thinking"
+        },
+        "relaxed_topk": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1,
+          "title": "Relaxed Topk"
+        },
+        "relaxed_delta": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0.0,
+          "title": "Relaxed Delta"
+        }
+      },
+      "title": "MTPDecodingConfig",
+      "type": "object"
+    },
+    "MedusaDecodingConfig": {
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "medusa_choices": {
+          "anyOf": [
+            {
+              "items": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Medusa Choices"
+        },
+        "num_medusa_heads": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Num Medusa Heads"
+        }
+      },
+      "title": "MedusaDecodingConfig",
+      "type": "object"
+    },
+    "NGramDecodingConfig": {
+      "description": "Configuration for NGram drafter speculative decoding.\n\nArguments:\n    prompt_lookup_num_tokens: int\n            The length maximum of draft tokens (can be understood as length maximum of output draft tokens).\n\n    max_matching_ngram_size: int\n        The length maximum of searching tokens (can be understood as length maximum of input tokens to search).\n\n    is_keep_all: bool = True\n        Whether to keep all candidate pattern-matches pairs, only one match is kept for each pattern if False.\n\n    is_use_oldest: bool = True\n        Whether to provide the oldest match when pattern is hit, the newest one is provided if False.\n\n    is_public_pool: bool = True\n        Whether to use a common pool for all requests, or the pool is private for each request if False.",
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model"
+        },
+        "prompt_lookup_num_tokens": {
+          "default": 2,
+          "title": "Prompt Lookup Num Tokens",
+          "type": "integer"
+        },
+        "max_matching_ngram_size": {
+          "default": 4,
+          "title": "Max Matching Ngram Size",
+          "type": "integer"
+        },
+        "is_keep_all": {
+          "default": true,
+          "title": "Is Keep All",
+          "type": "boolean"
+        },
+        "is_use_oldest": {
+          "default": true,
+          "title": "Is Use Oldest",
+          "type": "boolean"
+        },
+        "is_public_pool": {
+          "default": true,
+          "title": "Is Public Pool",
+          "type": "boolean"
+        }
+      },
+      "title": "NGramDecodingConfig",
+      "type": "object"
+    },
+    "PeftCacheConfig": {
+      "description": "Configuration for the PEFT cache.",
+      "properties": {
+        "num_host_module_layer": {
+          "default": 0,
+          "description": "number of max sized 1-layer 1-module adapterSize=1 sets of weights that can be stored in host cache",
+          "title": "Num Host Module Layer",
+          "type": "integer"
+        },
+        "num_device_module_layer": {
+          "default": 0,
+          "description": "number of max sized 1-layer 1-module sets of weights that can be stored in host cache",
+          "title": "Num Device Module Layer",
+          "type": "integer"
+        },
+        "optimal_adapter_size": {
+          "default": 8,
+          "description": "optimal adapter size used to set page width",
+          "title": "Optimal Adapter Size",
+          "type": "integer"
+        },
+        "max_adapter_size": {
+          "default": 64,
+          "description": "max supported adapter size. Used to compute minimum",
+          "title": "Max Adapter Size",
+          "type": "integer"
+        },
+        "num_put_workers": {
+          "default": 1,
+          "description": "number of worker threads used to put weights into host cache",
+          "title": "Num Put Workers",
+          "type": "integer"
+        },
+        "num_ensure_workers": {
+          "default": 1,
+          "description": "number of worker threads used to copy weights from host to device",
+          "title": "Num Ensure Workers",
+          "type": "integer"
+        },
+        "num_copy_streams": {
+          "default": 1,
+          "description": "number of streams used to copy weights from host to device",
+          "title": "Num Copy Streams",
+          "type": "integer"
+        },
+        "max_pages_per_block_host": {
+          "default": 24,
+          "description": "Number of cache pages per allocation block (host)",
+          "title": "Max Pages Per Block Host",
+          "type": "integer"
+        },
+        "max_pages_per_block_device": {
+          "default": 8,
+          "description": "Number of cache pages per allocation block (device)",
+          "title": "Max Pages Per Block Device",
+          "type": "integer"
+        },
+        "device_cache_percent": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "percent of memory after engine load to use for cache",
+          "title": "Device Cache Percent"
+        },
+        "host_cache_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "size in bytes to use for host cache",
+          "title": "Host Cache Size"
+        },
+        "lora_prefetch_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "folder to store the LoRA weights we hope to load during engine initialization",
+          "title": "Lora Prefetch Dir"
+        }
+      },
+      "title": "PeftCacheConfig",
+      "type": "object"
+    },
+    "QuantAlgo": {
+      "enum": [
+        "W8A16",
+        "W4A16",
+        "W4A16_AWQ",
+        "W4A8_AWQ",
+        "W8A16_GPTQ",
+        "W4A16_GPTQ",
+        "W8A8_SQ_PER_CHANNEL",
+        "W8A8_SQ_PER_TENSOR_PLUGIN",
+        "W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN",
+        "W8A8_SQ_PER_CHANNEL_PER_TENSOR_PLUGIN",
+        "W8A8_SQ_PER_TENSOR_PER_TOKEN_PLUGIN",
+        "W4A8_QSERVE_PER_GROUP",
+        "W4A8_QSERVE_PER_CHANNEL",
+        "FP8",
+        "FP8_PER_CHANNEL_PER_TOKEN",
+        "FP8_BLOCK_SCALES",
+        "INT8",
+        "MIXED_PRECISION",
+        "NVFP4",
+        "W4A8_MXFP4_FP8",
+        "NO_QUANT"
+      ],
+      "title": "QuantAlgo",
+      "type": "string"
+    },
+    "QuantConfig": {
+      "properties": {
+        "quant_algo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/QuantAlgo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "kv_cache_quant_algo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/QuantAlgo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "group_size": {
+          "default": 128,
+          "title": "Group Size",
+          "type": "integer"
+        },
+        "smoothquant_val": {
+          "default": 0.5,
+          "title": "Smoothquant Val",
+          "type": "number"
+        },
+        "clamp_val": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Clamp Val"
+        },
+        "use_meta_recipe": {
+          "default": false,
+          "title": "Use Meta Recipe",
+          "type": "boolean"
+        },
+        "has_zero_point": {
+          "default": false,
+          "title": "Has Zero Point",
+          "type": "boolean"
+        },
+        "pre_quant_scale": {
+          "default": false,
+          "title": "Pre Quant Scale",
+          "type": "boolean"
+        },
+        "exclude_modules": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Modules"
+        }
+      },
+      "title": "QuantConfig",
+      "type": "object"
+    },
+    "SchedulerConfig": {
+      "properties": {
+        "capacity_scheduler_policy": {
+          "$ref": "#/$defs/CapacitySchedulerPolicy",
+          "default": "GUARANTEED_NO_EVICT",
+          "description": "The capacity scheduler policy to use"
+        },
+        "context_chunking_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContextChunkingPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The context chunking policy to use"
+        },
+        "dynamic_batch_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DynamicBatchConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic batch config to use"
+        }
+      },
+      "title": "SchedulerConfig",
+      "type": "object"
     }
   }
 }

--- a/src/llenergymeasure/engines/tensorrt/schema.discovered.json
+++ b/src/llenergymeasure/engines/tensorrt/schema.discovered.json
@@ -3,9 +3,9 @@
   "engine": "tensorrt",
   "engine_version": "0.21.0",
   "engine_commit_sha": null,
-  "image_ref": "nvcr.io/nvidia/tensorrt-llm/release:0.21.0",
+  "image_ref": "llenergymeasure:tensorrt-0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-22T00:00:00+00:00",
+  "discovered_at": "2026-05-22T02:15:24+02:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: transformers
 engine_version: 4.57.3
-mined_at: '2026-05-14T20:31:21+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: transformers_beam_search_num_beams_eq_1
   engine: transformers

--- a/src/llenergymeasure/engines/transformers/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-14T20:31:21+02:00'
-validation_commit: 701d351fee655b8f399a5bc32ea923ba048df579
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -1,11 +1,11 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "2.0.0",
   "engine": "transformers",
   "engine_version": "4.57.3",
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-14T20:31:21+02:00",
+  "discovered_at": "2026-05-22T00:00:00+00:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {
@@ -59,309 +59,385 @@
   "engine_params": {
     "config": {
       "type": "PretrainedConfig | str | PathLike | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "cache_dir": {
       "type": "str | PathLike | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "ignore_mismatched_sizes": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "signature_param"
     },
     "force_download": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "signature_param"
     },
     "local_files_only": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "signature_param"
     },
     "token": {
       "type": "str | bool | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "revision": {
       "type": "str",
-      "default": "main"
+      "default": "main",
+      "x-source": "signature_param"
     },
     "use_safetensors": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "signature_param"
     },
     "weights_only": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "signature_param"
     }
   },
   "sampling_params": {
     "max_length": {
       "type": "int",
-      "default": 20
+      "default": 20,
+      "x-source": "instance_dict"
     },
     "max_new_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "min_length": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "instance_dict"
     },
     "min_new_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "early_stopping": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "max_time": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "stop_strings": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "do_sample": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "num_beams": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "instance_dict"
     },
     "use_cache": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "instance_dict"
     },
     "cache_implementation": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "cache_config": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "return_legacy_cache": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "prefill_chunk_size": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "temperature": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "top_k": {
       "type": "int",
-      "default": 50
+      "default": 50,
+      "x-source": "instance_dict"
     },
     "top_p": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "min_p": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "typical_p": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "epsilon_cutoff": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "instance_dict"
     },
     "eta_cutoff": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "instance_dict"
     },
     "repetition_penalty": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "encoder_repetition_penalty": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "length_penalty": {
       "type": "float",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "instance_dict"
     },
     "no_repeat_ngram_size": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "instance_dict"
     },
     "bad_words_ids": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "renormalize_logits": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "forced_bos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "forced_eos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "remove_invalid_values": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "exponential_decay_length_penalty": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "suppress_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "begin_suppress_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "sequence_bias": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "token_healing": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "guidance_scale": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "watermarking_config": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "num_return_sequences": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "instance_dict"
     },
     "output_attentions": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "output_hidden_states": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "output_scores": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "output_logits": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "return_dict_in_generate": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "pad_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "bos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "eos_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "encoder_no_repeat_ngram_size": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "instance_dict"
     },
     "decoder_start_token_id": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "is_assistant": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "num_assistant_tokens": {
       "type": "int",
-      "default": 20
+      "default": 20,
+      "x-source": "instance_dict"
     },
     "num_assistant_tokens_schedule": {
       "type": "str",
-      "default": "constant"
+      "default": "constant",
+      "x-source": "instance_dict"
     },
     "assistant_confidence_threshold": {
       "type": "float",
-      "default": 0.4
+      "default": 0.4,
+      "x-source": "instance_dict"
     },
     "prompt_lookup_num_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "max_matching_ngram_size": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "assistant_early_exit": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "assistant_lookbehind": {
       "type": "int",
-      "default": 10
+      "default": 10,
+      "x-source": "instance_dict"
     },
     "target_lookbehind": {
       "type": "int",
-      "default": 10
+      "default": 10,
+      "x-source": "instance_dict"
     },
     "disable_compile": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "low_memory": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "penalty_alpha": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "dola_layers": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "diversity_penalty": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "instance_dict"
     },
     "num_beam_groups": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "instance_dict"
     },
     "constraints": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "force_words_ids": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "x-source": "instance_dict"
     },
     "_from_model_config": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "instance_dict"
     },
     "transformers_version": {
       "type": "str",
-      "default": "4.57.3"
+      "default": "4.57.3",
+      "x-source": "instance_dict"
     }
   }
 }

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-22T00:00:00+00:00",
+  "discovered_at": "2026-05-22T02:15:24+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: vllm
 engine_version: 0.7.3
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   engine: vllm

--- a/src/llenergymeasure/engines/vllm/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: vllm
 engine_version: 0.7.3
 image_ref: llenergymeasure:vllm
 base_image_ref: llenergymeasure:vllm
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   outcome: dormant_silent

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -1,17 +1,17 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "2.0.0",
   "engine": "vllm",
   "engine_version": "0.7.3",
   "engine_commit_sha": null,
-  "image_ref": "llenergymeasure:vllm-0.7.3",
+  "image_ref": "llenergymeasure:vllm-v0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T20:31:21+02:00",
+  "discovered_at": "2026-05-22T00:00:00+00:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {
       "section": "sampling_params",
       "fields": [],
-      "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative _verify_args() and are not introspectable from field metadata"
+      "reason": "cross-field constraints (e.g. top_p + top_k interactions) live in imperative _verify_args() and are not introspectable from field metadata"
     },
     {
       "section": "engine_params",
@@ -22,545 +22,1186 @@
   "engine_params": {
     "model": {
       "type": "str",
-      "default": "facebook/opt-125m"
+      "default": "facebook/opt-125m",
+      "x-source": "dataclass_field"
     },
     "served_model_name": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "tokenizer": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "task": {
       "type": "Literal['auto', 'generate', 'embedding', 'embed', 'classify', 'score', 'reward', 'transcription']",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field",
+      "json_schema_type": "string",
+      "enum": [
+        "auto",
+        "generate",
+        "embedding",
+        "embed",
+        "classify",
+        "score",
+        "reward",
+        "transcription"
+      ]
     },
     "skip_tokenizer_init": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "tokenizer_mode": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "trust_remote_code": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "allowed_local_media_path": {
       "type": "str",
-      "default": ""
+      "default": "",
+      "x-source": "dataclass_field"
     },
     "download_dir": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "load_format": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "config_format": {
       "type": "ConfigFormat",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field",
+      "json_schema_type": "string",
+      "enum": [
+        "auto",
+        "hf",
+        "mistral"
+      ]
     },
     "dtype": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "kv_cache_dtype": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "seed": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "max_model_len": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "distributed_executor_backend": {
       "type": "str | type[ExecutorBase] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "pipeline_parallel_size": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "tensor_parallel_size": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_parallel_loading_workers": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "block_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "enable_prefix_caching": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_sliding_window": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "use_v2_block_manager": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "swap_space": {
       "type": "float",
-      "default": 4
+      "default": 4,
+      "x-source": "dataclass_field"
     },
     "cpu_offload_gb": {
       "type": "float",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "gpu_memory_utilization": {
       "type": "float",
-      "default": 0.9
+      "default": 0.9,
+      "x-source": "dataclass_field"
     },
     "max_num_batched_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_num_partial_prefills": {
       "type": "int | None",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_long_partial_prefills": {
       "type": "int | None",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "long_prefill_token_threshold": {
       "type": "int | None",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "max_num_seqs": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_logprobs": {
       "type": "int",
-      "default": 20
+      "default": 20,
+      "x-source": "dataclass_field"
     },
     "disable_log_stats": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "revision": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "code_revision": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "rope_scaling": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "rope_theta": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "hf_overrides": {
       "type": "dict[str, Any] | Callable[[<class 'transformers.configuration_utils.PretrainedConfig'>], PretrainedConfig] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "tokenizer_revision": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "quantization": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "enforce_eager": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "max_seq_len_to_capture": {
       "type": "int",
-      "default": 8192
+      "default": 8192,
+      "x-source": "dataclass_field"
     },
     "disable_custom_all_reduce": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "tokenizer_pool_size": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "tokenizer_pool_type": {
       "type": "str | type[ForwardRef('BaseTokenizerGroup')]",
-      "default": "ray"
+      "default": "ray",
+      "x-source": "dataclass_field"
     },
     "tokenizer_pool_extra_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "limit_mm_per_prompt": {
       "type": "Mapping[str, int] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "mm_processor_kwargs": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_mm_preprocessor_cache": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "enable_lora": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "enable_lora_bias": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "max_loras": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_lora_rank": {
       "type": "int",
-      "default": 16
+      "default": 16,
+      "x-source": "dataclass_field"
     },
     "enable_prompt_adapter": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "max_prompt_adapters": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "max_prompt_adapter_token": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "fully_sharded_loras": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "lora_extra_vocab_size": {
       "type": "int",
-      "default": 256
+      "default": 256,
+      "x-source": "dataclass_field"
     },
     "long_lora_scaling_factors": {
       "type": "tuple[float] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "lora_dtype": {
       "type": "str | dtype | None",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "max_cpu_loras": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "device": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "num_scheduler_steps": {
       "type": "int",
-      "default": 1
+      "default": 1,
+      "x-source": "dataclass_field"
     },
     "multi_step_stream_outputs": {
       "type": "bool",
-      "default": true
+      "default": true,
+      "x-source": "dataclass_field"
     },
     "ray_workers_use_nsight": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "num_gpu_blocks_override": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "num_lookahead_slots": {
       "type": "int",
-      "default": 0
+      "default": 0,
+      "x-source": "dataclass_field"
     },
     "model_loader_extra_config": {
       "type": "dict | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ignore_patterns": {
       "type": "str | list[str] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "preemption_mode": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "scheduler_delay_factor": {
       "type": "float",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "dataclass_field"
     },
     "enable_chunked_prefill": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "guided_decoding_backend": {
       "type": "str",
-      "default": "xgrammar"
+      "default": "xgrammar",
+      "x-source": "dataclass_field"
     },
     "logits_processor_pattern": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_model": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_model_quantization": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_draft_tensor_parallel_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "num_speculative_tokens": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_disable_mqa_scorer": {
       "type": "bool | None",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "speculative_max_model_len": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "speculative_disable_by_batch_size": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ngram_prompt_lookup_max": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "ngram_prompt_lookup_min": {
       "type": "int | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "spec_decoding_acceptance_method": {
       "type": "str",
-      "default": "rejection_sampler"
+      "default": "rejection_sampler",
+      "x-source": "dataclass_field"
     },
     "typical_acceptance_sampler_posterior_threshold": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "typical_acceptance_sampler_posterior_alpha": {
       "type": "float | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "qlora_adapter_name_or_path": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_logprobs_during_spec_decoding": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "otlp_traces_endpoint": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "collect_detailed_traces": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "disable_async_output_proc": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "scheduling_policy": {
       "type": "Literal['fcfs', 'priority']",
-      "default": "fcfs"
+      "default": "fcfs",
+      "x-source": "dataclass_field",
+      "json_schema_type": "string",
+      "enum": [
+        "fcfs",
+        "priority"
+      ]
     },
     "scheduler_cls": {
       "type": "str | type[object]",
-      "default": "vllm.core.scheduler.Scheduler"
+      "default": "vllm.core.scheduler.Scheduler",
+      "x-source": "dataclass_field"
     },
     "override_neuron_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "override_pooler_config": {
       "type": "PoolerConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "compilation_config": {
       "type": "CompilationConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "worker_cls": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "kv_transfer_config": {
       "type": "KVTransferConfig | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "generation_config": {
       "type": "str | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "override_generation_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "enable_sleep_mode": {
       "type": "bool",
-      "default": false
+      "default": false,
+      "x-source": "dataclass_field"
     },
     "model_impl": {
       "type": "str",
-      "default": "auto"
+      "default": "auto",
+      "x-source": "dataclass_field"
     },
     "calculate_kv_scales": {
       "type": "bool | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     },
     "additional_config": {
       "type": "dict[str, Any] | None",
-      "default": null
+      "default": null,
+      "x-source": "dataclass_field"
     }
   },
   "sampling_params": {
     "n": {
       "type": "integer",
-      "default": 1
+      "default": 1,
+      "x-source": "msgspec_field"
     },
     "best_of": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "_real_n": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "presence_penalty": {
       "type": "number",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "msgspec_field"
     },
     "frequency_penalty": {
       "type": "number",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "msgspec_field"
     },
     "repetition_penalty": {
       "type": "number",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "msgspec_field"
     },
     "temperature": {
       "type": "number",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "msgspec_field"
     },
     "top_p": {
       "type": "number",
-      "default": 1.0
+      "default": 1.0,
+      "x-source": "msgspec_field"
     },
     "top_k": {
       "type": "integer",
-      "default": -1
+      "default": -1,
+      "x-source": "msgspec_field"
     },
     "min_p": {
       "type": "number",
-      "default": 0.0
+      "default": 0.0,
+      "x-source": "msgspec_field"
     },
     "seed": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "stop": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "string | array | None",
+      "x-source": "msgspec_field"
     },
     "stop_token_ids": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "array | None",
+      "x-source": "msgspec_field"
     },
     "bad_words": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "array | None",
+      "x-source": "msgspec_field"
     },
     "ignore_eos": {
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-source": "msgspec_field"
     },
     "max_tokens": {
-      "type": "unknown",
-      "default": 16
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": 16,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "min_tokens": {
       "type": "integer",
-      "default": 0
+      "default": 0,
+      "x-source": "msgspec_field"
     },
     "logprobs": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "prompt_logprobs": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "detokenize": {
       "type": "boolean",
-      "default": true
+      "default": true,
+      "x-source": "msgspec_field"
     },
     "skip_special_tokens": {
       "type": "boolean",
-      "default": true
+      "default": true,
+      "x-source": "msgspec_field"
     },
     "spaces_between_special_tokens": {
       "type": "boolean",
-      "default": true
+      "default": true,
+      "x-source": "msgspec_field"
     },
     "logits_processors": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "None",
+      "x-source": "msgspec_field"
     },
     "include_stop_str_in_output": {
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-source": "msgspec_field"
     },
     "truncate_prompt_tokens": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "integer | None",
+      "x-source": "msgspec_field"
     },
     "output_kind": {
-      "type": "unknown",
-      "default": 0
+      "$ref": "#/$defs/RequestOutputKind",
+      "default": 0,
+      "type": "RequestOutputKind",
+      "x-source": "msgspec_field"
     },
     "output_text_buffer_length": {
       "type": "integer",
-      "default": 0
+      "default": 0,
+      "x-source": "msgspec_field"
     },
     "_all_stop_token_ids": {
       "type": "array",
-      "default": []
+      "items": {
+        "type": "integer"
+      },
+      "default": [],
+      "x-source": "msgspec_field"
     },
     "guided_decoding": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GuidedDecodingParams"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "GuidedDecodingParams | None",
+      "x-source": "msgspec_field"
     },
     "logit_bias": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "object | None",
+      "x-source": "msgspec_field"
     },
     "allowed_token_ids": {
-      "type": "unknown",
-      "default": null
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "type": "array | None",
+      "x-source": "msgspec_field"
+    }
+  },
+  "sampling_params_defs": {
+    "SamplingParams": {
+      "title": "SamplingParams",
+      "description": "Sampling parameters for text generation.\n\n    Overall, we follow the sampling parameters from the OpenAI text completion\n    API (https://platform.openai.com/docs/api-reference/completions/create).\n    In addition, we support beam search, which is not supported by OpenAI.\n\n    Args:\n        n: Number of output sequences to return for the given prompt.\n        best_of: Number of output sequences that are generated from the prompt.\n            From these `best_of` sequences, the top `n` sequences are returned.\n            `best_of` must be greater than or equal to `n`. By default,\n            `best_of` is set to `n`.\n        presence_penalty: Float that penalizes new tokens based on whether they\n            appear in the generated text so far. Values > 0 encourage the model\n            to use new tokens, while values < 0 encourage the model to repeat\n            tokens.\n        frequency_penalty: Float that penalizes new tokens based on their\n            frequency in the generated text so far. Values > 0 encourage the\n            model to use new tokens, while values < 0 encourage the model to\n            repeat tokens.\n        repetition_penalty: Float that penalizes new tokens based on whether\n            they appear in the prompt and the generated text so far. Values > 1\n            encourage the model to use new tokens, while values < 1 encourage\n            the model to repeat tokens.\n        temperature: Float that controls the randomness of the sampling. Lower\n            values make the model more deterministic, while higher values make\n            the model more random. Zero means greedy sampling.\n        top_p: Float that controls the cumulative probability of the top tokens\n            to consider. Must be in (0, 1]. Set to 1 to consider all tokens.\n        top_k: Integer that controls the number of top tokens to consider. Set\n            to -1 to consider all tokens.\n        min_p: Float that represents the minimum probability for a token to be\n            considered, relative to the probability of the most likely token.\n            Must be in [0, 1]. Set to 0 to disable this.\n        seed: Random seed to use for the generation.\n        stop: List of strings that stop the generation when they are generated.\n            The returned output will not contain the stop strings.\n        stop_token_ids: List of tokens that stop the generation when they are\n            generated. The returned output will contain the stop tokens unless\n            the stop tokens are special tokens.\n        bad_words: List of words that are not allowed to be generated.\n            More precisely, only the last token of a corresponding\n            token sequence is not allowed when the next generated token\n            can complete the sequence.\n        include_stop_str_in_output: Whether to include the stop strings in\n            output text. Defaults to False.\n        ignore_eos: Whether to ignore the EOS token and continue generating\n            tokens after the EOS token is generated.\n        max_tokens: Maximum number of tokens to generate per output sequence.\n        min_tokens: Minimum number of tokens to generate per output sequence\n            before EOS or stop_token_ids can be generated\n        logprobs: Number of log probabilities to return per output token.\n            When set to None, no probability is returned. If set to a non-None\n            value, the result includes the log probabilities of the specified\n            number of most likely tokens, as well as the chosen tokens.\n            Note that the implementation follows the OpenAI API: The API will\n            always return the log probability of the sampled token, so there\n            may be up to `logprobs+1` elements in the response.\n        prompt_logprobs: Number of log probabilities to return per prompt token.\n        detokenize: Whether to detokenize the output. Defaults to True.\n        skip_special_tokens: Whether to skip special tokens in the output.\n        spaces_between_special_tokens: Whether to add spaces between special\n            tokens in the output.  Defaults to True.\n        logits_processors: List of functions that modify logits based on\n            previously generated tokens, and optionally prompt tokens as\n            a first argument.\n        truncate_prompt_tokens: If set to an integer k, will use only the last k\n            tokens from the prompt (i.e., left truncation). Defaults to None\n            (i.e., no truncation).\n        guided_decoding: If provided, the engine will construct a guided\n            decoding logits processor from these parameters. Defaults to None.\n        logit_bias: If provided, the engine will construct a logits processor\n            that applies these logit biases. Defaults to None.\n        allowed_token_ids: If provided, the engine will construct a logits\n            processor which only retains scores for the given token ids.\n            Defaults to None.",
+      "type": "object",
+      "properties": {
+        "n": {
+          "type": "integer",
+          "default": 1
+        },
+        "best_of": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "_real_n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "presence_penalty": {
+          "type": "number",
+          "default": 0.0
+        },
+        "frequency_penalty": {
+          "type": "number",
+          "default": 0.0
+        },
+        "repetition_penalty": {
+          "type": "number",
+          "default": 1.0
+        },
+        "temperature": {
+          "type": "number",
+          "default": 1.0
+        },
+        "top_p": {
+          "type": "number",
+          "default": 1.0
+        },
+        "top_k": {
+          "type": "integer",
+          "default": -1
+        },
+        "min_p": {
+          "type": "number",
+          "default": 0.0
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stop": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stop_token_ids": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bad_words": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ignore_eos": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 16
+        },
+        "min_tokens": {
+          "type": "integer",
+          "default": 0
+        },
+        "logprobs": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "prompt_logprobs": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "detokenize": {
+          "type": "boolean",
+          "default": true
+        },
+        "skip_special_tokens": {
+          "type": "boolean",
+          "default": true
+        },
+        "spaces_between_special_tokens": {
+          "type": "boolean",
+          "default": true
+        },
+        "logits_processors": {
+          "anyOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "include_stop_str_in_output": {
+          "type": "boolean",
+          "default": false
+        },
+        "truncate_prompt_tokens": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "output_kind": {
+          "$ref": "#/$defs/RequestOutputKind",
+          "default": 0
+        },
+        "output_text_buffer_length": {
+          "type": "integer",
+          "default": 0
+        },
+        "_all_stop_token_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "default": []
+        },
+        "guided_decoding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GuidedDecodingParams"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "logit_bias": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "number"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "allowed_token_ids": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": []
+    },
+    "RequestOutputKind": {
+      "title": "RequestOutputKind",
+      "enum": [
+        0,
+        1,
+        2
+      ]
+    },
+    "GuidedDecodingParams": {
+      "title": "GuidedDecodingParams",
+      "description": "One of these fields will be used to build a logit processor.",
+      "type": "object",
+      "properties": {
+        "json": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "regex": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "choice": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grammar": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "json_object": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "backend": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "whitespace_pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": []
     }
   }
 }

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -3,9 +3,9 @@
   "engine": "vllm",
   "engine_version": "0.7.3",
   "engine_commit_sha": null,
-  "image_ref": "llenergymeasure:vllm-v0.7.3",
+  "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-22T00:00:00+00:00",
+  "discovered_at": "2026-05-22T02:15:24+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {

--- a/tests/unit/config/test_schema_loader.py
+++ b/tests/unit/config/test_schema_loader.py
@@ -27,7 +27,9 @@ def test_load_schema_returns_discovered_schema(engine: str) -> None:
 
     assert isinstance(schema, DiscoveredSchema)
     assert schema.engine == engine
-    assert schema.schema_version.startswith("1.")
+    # v2.0.0 carries JSON Schema constraints alongside the legacy type/default;
+    # v1.x remains accepted for environments that haven't regenerated yet.
+    assert schema.schema_version.startswith(("1.", "2."))
     assert schema.engine_version
     assert schema.image_ref
     assert schema.base_image_ref
@@ -82,8 +84,9 @@ def test_load_schema_missing_file_raises_with_hint(tmp_path: Path) -> None:
 
 
 def test_major_version_mismatch_raises() -> None:
-    envelope = _minimal_envelope(schema_version="2.0.0")
-    with pytest.raises(UnsupportedSchemaVersionError, match="major=2"):
+    # The loader's supported allowlist is {1, 2}; major 3 is rejected.
+    envelope = _minimal_envelope(schema_version="3.0.0")
+    with pytest.raises(UnsupportedSchemaVersionError, match="major=3"):
         _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
 
 
@@ -97,6 +100,28 @@ def test_minor_version_accepted() -> None:
     envelope = _minimal_envelope(schema_version="1.7.3")
     parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
     assert parsed.schema_version == "1.7.3"
+
+
+def test_major_version_two_accepted() -> None:
+    # v2 envelopes are part of the loader's supported allowlist.
+    envelope = _minimal_envelope(schema_version="2.0.0")
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.schema_version == "2.0.0"
+
+
+def test_engine_params_defs_parsed_when_present() -> None:
+    envelope = _minimal_envelope(schema_version="2.0.0")
+    envelope["engine_params_defs"] = {"Foo": {"type": "object"}}
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.engine_params_defs == {"Foo": {"type": "object"}}
+    assert parsed.sampling_params_defs == {}
+
+
+def test_defs_default_to_empty_when_absent() -> None:
+    envelope = _minimal_envelope()
+    parsed = _parse_envelope(engine="vllm", raw_text=json.dumps(envelope))
+    assert parsed.engine_params_defs == {}
+    assert parsed.sampling_params_defs == {}
 
 
 def test_iso_z_termination_accepted() -> None:

--- a/tests/unit/scripts/test_engine_producers_common.py
+++ b/tests/unit/scripts/test_engine_producers_common.py
@@ -187,9 +187,314 @@ def test_make_envelope_fills_required_keys() -> None:
     assert "engine_params" in env and "sampling_params" in env
 
 
-def test_schema_version_is_semver_with_major_one() -> None:
+def test_schema_version_is_semver_at_supported_major() -> None:
     major = int(_common.SCHEMA_VERSION.split(".")[0])
-    assert major == 1, "ships schema_version 1.x; bumping major requires loader update"
+    # The loader supports majors 1 and 2 (see SchemaLoader.SUPPORTED_MAJOR_VERSIONS);
+    # bumping the introspector past 2 requires extending that allowlist.
+    assert major in {1, 2}, "ships schema_version <=2.x; bumping major requires loader update"
+
+
+# ---------------------------------------------------------------------------
+# literal_to_json_schema
+# ---------------------------------------------------------------------------
+
+
+def test_literal_to_json_schema_string_literal() -> None:
+    got = _common.literal_to_json_schema(Literal["a", "b", "c"])
+    assert got == {"type": "string", "enum": ["a", "b", "c"]}
+
+
+def test_literal_to_json_schema_int_literal() -> None:
+    got = _common.literal_to_json_schema(Literal[1, 2, 3])
+    assert got == {"type": "integer", "enum": [1, 2, 3]}
+
+
+def test_literal_to_json_schema_bool_literal() -> None:
+    # Bool checked first because bool is subclass of int in Python.
+    got = _common.literal_to_json_schema(Literal[True, False])
+    assert got == {"type": "boolean", "enum": [True, False]}
+
+
+def test_literal_to_json_schema_enum_subclass() -> None:
+    import enum as _enum
+
+    class Color(_enum.Enum):
+        RED = "red"
+        BLUE = "blue"
+
+    got = _common.literal_to_json_schema(Color)
+    assert got == {"type": "string", "enum": ["red", "blue"]}
+
+
+def test_literal_to_json_schema_returns_none_for_non_literal() -> None:
+    assert _common.literal_to_json_schema(int) is None
+    assert _common.literal_to_json_schema(str | None) is None
+    assert _common.literal_to_json_schema(list[int]) is None
+
+
+def test_literal_to_json_schema_mixed_types_falls_back_to_string() -> None:
+    got = _common.literal_to_json_schema(Literal["one", 2])
+    # Mixed types are rare; helper falls back to string + jsonable values.
+    assert got is not None
+    assert got["type"] == "string"
+    assert got["enum"] == ["one", 2]
+
+
+# ---------------------------------------------------------------------------
+# pydantic_to_json_schema + pydantic_properties_to_specs
+# ---------------------------------------------------------------------------
+
+
+def test_pydantic_to_json_schema_preserves_constraints() -> None:
+    from pydantic import BaseModel, Field
+
+    class _Model(BaseModel):
+        ratio: float = Field(default=0.5, ge=0.0, le=1.0, description="A ratio")
+        mode: Literal["fast", "slow"] = Field(default="fast")
+
+    raw = _common.pydantic_to_json_schema(_Model)
+    props = raw["properties"]
+    assert props["ratio"]["minimum"] == 0.0
+    assert props["ratio"]["maximum"] == 1.0
+    assert props["ratio"]["description"] == "A ratio"
+    assert props["ratio"]["x-source"] == "pydantic_field"
+    assert props["mode"]["enum"] == ["fast", "slow"]
+
+
+def test_pydantic_to_json_schema_emits_defs_for_nested_models() -> None:
+    from pydantic import BaseModel
+
+    class _Sub(BaseModel):
+        inner: int = 1
+
+    class _Outer(BaseModel):
+        child: _Sub | None = None
+
+    raw = _common.pydantic_to_json_schema(_Outer)
+    assert "$defs" in raw
+    assert "_Sub" in raw["$defs"]
+    assert raw["$defs"]["_Sub"]["properties"]["inner"]["type"] == "integer"
+
+
+def test_pydantic_to_json_schema_rejects_non_pydantic() -> None:
+    class _Plain:
+        x: int = 0
+
+    import pytest as _pytest  # ensure no cross-import noise
+
+    with _pytest.raises(TypeError, match="not a Pydantic"):
+        _common.pydantic_to_json_schema(_Plain)
+
+
+def test_pydantic_properties_to_specs_preserves_legacy_type_string() -> None:
+    from pydantic import BaseModel
+
+    class _Inner(BaseModel):
+        v: int = 0
+
+    class _M(BaseModel):
+        child: _Inner | None = None
+        flag: bool = False
+        mode: Literal["a", "b"] = "a"
+
+    props, defs = _common.pydantic_properties_to_specs(_M)
+    # legacy compact type string preserved
+    assert props["child"]["type"] == "_Inner | None"
+    assert props["flag"]["type"] == "boolean"
+    assert props["mode"]["type"] == "string"
+    # enum carried alongside the type string
+    assert props["mode"]["enum"] == ["a", "b"]
+    # default backfill when Pydantic omits it
+    for spec in props.values():
+        assert "default" in spec, "v2 contract: every leaf carries default"
+        assert "deprecated" in spec, "v2 contract: every leaf carries deprecated"
+    # nested $defs surfaced
+    assert "_Inner" in defs
+
+
+def test_pydantic_properties_skip_private_default() -> None:
+    from pydantic import BaseModel
+
+    class _M(BaseModel):
+        x: int = 1
+        # Pydantic doesn't typically expose ``_y`` in schema, but the helper
+        # still honours the skip_private flag at the property level.
+
+    props, _ = _common.pydantic_properties_to_specs(_M)
+    assert "x" in props
+
+
+# ---------------------------------------------------------------------------
+# msgspec_properties_to_specs
+# ---------------------------------------------------------------------------
+
+
+def test_msgspec_properties_to_specs_flattens_ref_envelope() -> None:
+    msgspec = pytest.importorskip("msgspec")
+
+    class _M(msgspec.Struct):
+        x: int = 1
+        mode: str = "auto"
+
+    props, defs = _common.msgspec_properties_to_specs(_M)
+    assert "x" in props
+    assert props["x"]["type"] == "integer"
+    assert props["x"]["x-source"] == "msgspec_field"
+    # defs envelope is preserved (msgspec wraps in $ref by default)
+    assert defs
+
+
+# ---------------------------------------------------------------------------
+# dataclass_fields_to_specs enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_dataclass_fields_surfaces_literal_enum() -> None:
+    # Build the dataclass via dataclasses.make_dataclass so the type
+    # annotations stay as live typing objects rather than the stringified
+    # form ``from __future__ import annotations`` produces at module top.
+    # The helper only resolves Literal/Enum from live annotations; engines
+    # like vLLM's EngineArgs use that shape in practice.
+    import dataclasses
+
+    _D = dataclasses.make_dataclass(
+        "_D",
+        [
+            ("mode", Literal["fast", "slow"], dataclasses.field(default="fast")),
+            ("count", int, dataclasses.field(default=0)),
+        ],
+    )
+
+    specs = _common.dataclass_fields_to_specs(_D)
+    assert specs["mode"]["enum"] == ["fast", "slow"]
+    # Legacy compact ``type`` string is preserved (v1 backward compat);
+    # the JSON Schema primitive sits alongside under ``json_schema_type``.
+    assert specs["mode"]["type"] == "Literal['fast', 'slow']"
+    assert specs["mode"]["json_schema_type"] == "string"
+    assert specs["count"].get("enum") is None
+    # All leaves carry x-source provenance.
+    assert specs["mode"]["x-source"] == "dataclass_field"
+    assert specs["count"]["x-source"] == "dataclass_field"
+
+
+def test_dataclass_fields_surfaces_description_metadata() -> None:
+    import dataclasses
+
+    _D = dataclasses.make_dataclass(
+        "_D",
+        [
+            (
+                "name",
+                str,
+                dataclasses.field(default="anon", metadata={"description": "The user's name"}),
+            ),
+            ("age", int, dataclasses.field(default=0)),
+        ],
+    )
+
+    specs = _common.dataclass_fields_to_specs(_D)
+    assert specs["name"]["description"] == "The user's name"
+    assert "description" not in specs["age"]
+
+
+# ---------------------------------------------------------------------------
+# signature_param_to_spec
+# ---------------------------------------------------------------------------
+
+
+def test_signature_param_to_spec_basic() -> None:
+    # Build via inspect.Parameter directly so annotations stay as live
+    # typing objects rather than the stringified form the file-level
+    # ``from __future__ import annotations`` produces.
+    import inspect as _inspect
+
+    x_param = _inspect.Parameter(
+        "x",
+        kind=_inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        default=5,
+        annotation=int,
+    )
+    mode_param = _inspect.Parameter(
+        "mode",
+        kind=_inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        default="a",
+        annotation=Literal["a", "b"],
+    )
+
+    x_spec = _common.signature_param_to_spec(x_param)
+    assert x_spec == {
+        "type": "int",
+        "default": 5,
+        "x-source": "signature_param",
+    }
+    mode_spec = _common.signature_param_to_spec(mode_param)
+    assert mode_spec["enum"] == ["a", "b"]
+    # Legacy compact ``type`` string preserved (v1 backward compat).
+    assert mode_spec["type"] == "Literal['a', 'b']"
+    assert mode_spec["json_schema_type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# compact_type_from_jsonschema
+# ---------------------------------------------------------------------------
+
+
+def test_compact_type_from_jsonschema_ref() -> None:
+    spec = {"$ref": "#/$defs/Foo"}
+    assert _common.compact_type_from_jsonschema(spec) == "Foo"
+
+
+def test_compact_type_from_jsonschema_anyof_with_null() -> None:
+    spec = {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+    assert _common.compact_type_from_jsonschema(spec) == "integer | None"
+
+
+def test_compact_type_from_jsonschema_anyof_with_ref() -> None:
+    spec = {"anyOf": [{"$ref": "#/$defs/Foo"}, {"type": "null"}]}
+    assert _common.compact_type_from_jsonschema(spec) == "Foo | None"
+
+
+def test_compact_type_from_jsonschema_plain() -> None:
+    assert _common.compact_type_from_jsonschema({"type": "string"}) == "string"
+    assert _common.compact_type_from_jsonschema({"type": "null"}) == "None"
+    assert _common.compact_type_from_jsonschema({}) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# make_envelope optional defs
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_omits_empty_defs_keys() -> None:
+    env = _common.make_envelope(
+        engine="vllm",
+        engine_version="x",
+        engine_commit_sha=None,
+        image_ref="x",
+        base_image_ref="x",
+        discovery_method="t",
+        discovery_limitations=[],
+        engine_params={},
+        sampling_params={},
+    )
+    assert "engine_params_defs" not in env
+    assert "sampling_params_defs" not in env
+
+
+def test_envelope_includes_defs_when_present() -> None:
+    env = _common.make_envelope(
+        engine="vllm",
+        engine_version="x",
+        engine_commit_sha=None,
+        image_ref="x",
+        base_image_ref="x",
+        discovery_method="t",
+        discovery_limitations=[],
+        engine_params={},
+        sampling_params={},
+        engine_params_defs={"Foo": {"type": "object"}},
+    )
+    assert env["engine_params_defs"] == {"Foo": {"type": "object"}}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Per-engine schema introspectors now preserve the constraint metadata Pydantic and msgspec already emit (enum, minimum, maximum, $ref, $defs, description, deprecated) instead of collapsing every field to a flat `{type, default}` shape.
- New shared helpers in `scripts/engine_producers/_common.py` centralise the JSON-Schema-conformant extraction so all 10 vendored introspectors share one code path; legacy `type` and `default` keys remain on every per-field spec for backward compatibility.
- Envelope `schema_version` bumps from 1.0.0 to 2.0.0 (additive at the field level). The runtime `SchemaLoader` allowlist now accepts majors {1, 2}.

## New keys surfaced per engine

| Engine | engine_params enum | engine_params anyOf | engine_params `$ref` | engine_params descriptions | engine_params deprecated | engine_params_defs | sampling_params anyOf | sampling_params `$ref` | sampling_params_defs |
|--------|-------------------:|--------------------:|--------------------:|---------------------------:|-------------------------:|--------------------:|----------------------:|----------------------:|----------------------:|
| transformers (v4.57.3) | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| vllm (v0.7.3) | 3 | 0 | 0 | 0 | 0 | 0 | 14 | 1 | 3 |
| tensorrt (v0.21.0) | 2 | 34 | 2 | 60 | 6 | 19 | 0 | 0 | 0 |

Notable wins on TRT-LLM:

- `kv_cache_config` now carries `$ref: "#/$defs/KvCacheConfig"` plus the nested 12-property KvCacheConfig sub-schema in `engine_params_defs` (was collapsed to `"type": "KvCacheConfig"` scalar).
- 19 nested sub-schemas exposed: KvCacheConfig, QuantConfig, SchedulerConfig, BuildCacheConfig, CalibConfig, MoeConfig, MTPDecodingConfig, MedusaDecodingConfig, EagleDecodingConfig, LookaheadDecodingConfig, DraftTargetDecodingConfig, NGramDecodingConfig, PeftCacheConfig, CacheTransceiverConfig, LoraConfig, BatchingType, CapacitySchedulerPolicy, ContextChunkingPolicy, DynamicBatchConfig, ExtendedRuntimePerfKnobConfig, QuantAlgo.
- `tokenizer_mode` keeps `"type": "Literal['auto', 'slow']"` for backward compat AND adds `"enum": ["auto", "slow"]`.

Notable wins on vLLM:

- EngineArgs Literal / Enum fields (`task`, `config_format`, `scheduling_policy`) gain `enum` arrays.
- msgspec SamplingParams `anyOf` properly extracted: `seed: integer | None`, `max_tokens: integer | None`, `stop: string | array | None`, etc. (previously rendered as `unknown`).
- 3 nested sampling_params_defs: SamplingParams, RequestOutputKind, GuidedDecodingParams.

## Backward compatibility

- Every previously-present field still carries `type` and `default`.
- Field counts unchanged at top level: transformers 9+67, vLLM 104+31, tensorrt 60+47.
- The strict semantic differ (`scripts/diff_discovered_schemas.py`) classifies the v1 -> v2 transition as `is_breaking: false` on transformers and tensorrt. On vLLM the only flagged changes are `unknown -> X` type refinements where the v1 pipeline had previously returned `unknown` for msgspec `anyOf` fields; these are strict improvements rather than semantic breaks.
- The forward-looking Literal-enum extraction on transformers `GenerationConfig` kicks in automatically if HF makes the class a dataclass in a future release; today it is a plain class so the enrichment is a no-op.

## Test plan

- [x] Unit tests for `literal_to_json_schema`, `pydantic_to_json_schema`, `pydantic_properties_to_specs`, `msgspec_properties_to_specs`, `dataclass_fields_to_specs` enrichment, `signature_param_to_spec`, `compact_type_from_jsonschema`, optional defs envelope keys.
- [x] `SchemaLoader` tests cover v1 and v2 major acceptance, optional defs fields default to empty, the rejection path now uses major 3.
- [x] Full unit suite (2488 passed, 52 skipped) green locally.
- [x] Ruff format + lint clean on all modified files.
- [x] mypy clean on `_common.py` and `schema_loader.py`.
- [x] Three engines regenerated locally (transformers 4.57.3, vLLM 0.7.3, TRT-LLM 0.21.0) inside their respective Docker images; outputs mirrored to `engine_versions/<engine>/v<ver>/outputs/schema.discovered.json`.
- [ ] CI engine-pipeline runs probe + discover + diff classify per engine; expect schema_version metadata change in the diff comment plus the enrichment additions documented above.