### PR TITLE
refactor(engines): codegen + commit engine corpus shadow infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,13 @@ jobs:
             echo "::error::docker/Dockerfile.tensorrt is gone for a reason - see version_handshake.py + scripts/container_entrypoint.sh"
             exit 1
           fi
+      - name: Engine corpus shadow parity check
+        # The loader reads from src/llenergymeasure/engines/<engine>/ (the
+        # data shadow), but the SSOT lives at
+        # engine_versions/<engine>/v<safe>/outputs/. Cells writeback both
+        # locations atomically; this gate fails CI if a human edits one
+        # without re-syncing the other.
+        run: uv run python scripts/engine_producers/regen_engine_corpus.py --check
 
   type-check:
     needs: filter

--- a/.github/workflows/engine-pipeline.yml
+++ b/.github/workflows/engine-pipeline.yml
@@ -461,6 +461,19 @@ jobs:
           merge-multiple: true
           path: /tmp/writeback-staging
 
+      - name: Set up Python for codegen sync
+        # Provisions the Python used by regen_engine_corpus.py. Lightweight:
+        # the script only depends on PyYAML, which is in this project's
+        # base runtime deps so uv resolves it from uv.lock.
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: writeback-3.12
+          python-version: "3.12"
+
+      - name: Install sync-script deps (PyYAML)
+        run: uv sync
+
       - name: Apply artefacts and emit single commit
         env:
           APP_ID: ${{ secrets.APP_ID }}
@@ -494,14 +507,26 @@ jobs:
           # Apply staging onto the working tree, preserving relative paths.
           rsync -a /tmp/writeback-staging/ ./
 
+          # Re-derive the data shadow (src/llenergymeasure/engines/<e>/*)
+          # from the per-version SSOT (engine_versions/<e>/v<current>/outputs/*).
+          # Belt-and-braces: per-cell Mirror steps already write both copies,
+          # but this guarantees the commit is internally consistent even if a
+          # cell's mirror gate (engine vendored at this version) skipped.
+          uv run python scripts/engine_producers/regen_engine_corpus.py --write
+
           git config user.name  "llem-ci-bot[bot]"
           git config user.email "${APP_ID}+llem-ci-bot[bot]@users.noreply.github.com"
 
-          # Stage only the paths writeback artefacts may produce.
+          # Stage only the paths writeback artefacts may produce. Both the
+          # SSOT (engine_versions/<e>/v<safe>/outputs/*) and the shadow
+          # (src/llenergymeasure/engines/<e>/*) land atomically in one commit.
           git add \
             'src/llenergymeasure/engines/*/invariants.proposed.yaml' \
             'src/llenergymeasure/engines/*/invariants.validated.yaml' \
             'src/llenergymeasure/engines/*/schema.discovered.json' \
+            'engine_versions/*/*/outputs/invariants.proposed.yaml' \
+            'engine_versions/*/*/outputs/invariants.validated.yaml' \
+            'engine_versions/*/*/outputs/schema.discovered.json' \
             'engine_versions/*/current.yaml' \
             'docs/reference/engines/invariants-*.md' \
             'docs/reference/engines/curation-*.md' \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,14 @@ repos:
         language: system
         pass_filenames: false
         files: ^(src/llenergymeasure/config/.*\.py|scripts/generate_config_docs\.py)$
+
+      - id: engine-corpus-shadow-parity
+        name: Engine corpus shadow parity check
+        # Verifies src/llenergymeasure/engines/<engine>/ matches the
+        # per-version SSOT under engine_versions/<engine>/v<current>/outputs/.
+        # Blocks commits that edit one location without re-syncing the other;
+        # to fix, run: python scripts/engine_producers/regen_engine_corpus.py --write
+        entry: python scripts/engine_producers/regen_engine_corpus.py --check
+        language: system
+        pass_filenames: false
+        files: ^(engine_versions/.*/outputs/.*|src/llenergymeasure/engines/.*\.(yaml|json)|scripts/engine_producers/regen_engine_corpus\.py|scripts/engine_producers/_current\.py)$

--- a/engine_versions/tensorrt/v0_21_0/outputs/invariants.proposed.yaml
+++ b/engine_versions/tensorrt/v0_21_0/outputs/invariants.proposed.yaml
@@ -1,13 +1,13 @@
 schema_version: 1.0.0
 engine: tensorrt
 engine_version: 0.21.0
-mined_at: '2026-05-06T20:35:47+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   engine: tensorrt
   library: tensorrt_llm
-  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <= 0 (via
-    raise ValueError)
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <=
+    0 (via raise ValueError)
   severity: error
   native_type: tensorrt_llm.LookaheadDecodingConfig
   miner_source:
@@ -64,8 +64,8 @@ invariants:
 - id: tensorrt_raises_max_window_size_le_0_positive_values
   engine: tensorrt
   library: tensorrt_llm
-  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <= 0 (via
-    raise ValueError)
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <=
+    0 (via raise ValueError)
   severity: error
   native_type: tensorrt_llm.LookaheadDecodingConfig
   miner_source:

--- a/engine_versions/tensorrt/v0_21_0/outputs/invariants.validated.yaml
+++ b/engine_versions/tensorrt/v0_21_0/outputs/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: tensorrt
 engine_version: 0.21.0
 image_ref: llenergymeasure:tensorrt
 base_image_ref: llenergymeasure:tensorrt
-validated_at: '2026-05-06T20:35:47+02:00'
-validation_commit: 4ad6ee7b8e43c1282751a5b76ca936c6fe6982a3
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   outcome: error

--- a/engine_versions/tensorrt/v0_21_0/outputs/schema.discovered.json
+++ b/engine_versions/tensorrt/v0_21_0/outputs/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:tensorrt-0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-06T20:20:57+02:00",
+  "discovered_at": "2026-05-15T12:49:19+02:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {

--- a/engine_versions/transformers/v4_57_3/outputs/invariants.proposed.yaml
+++ b/engine_versions/transformers/v4_57_3/outputs/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: transformers
 engine_version: 4.57.3
-mined_at: '2026-05-06T22:57:22+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: transformers_beam_search_num_beams_eq_1
   engine: transformers
@@ -34,7 +34,7 @@ invariants:
   message_template: '`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag
     is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  - transformers.GenerationConfig.validate() - observed via validate(strict=True)
   added_by: dynamic_miner
   added_at: '2026-04-30'
   conflict_note: 'id: dynamic_miner -> ''transformers_beam_search_num_beams_eq_1''; dynamic_miner -> ''transformers_early_stopping_type_num_beams_eq_1'''
@@ -71,7 +71,7 @@ invariants:
     ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'', ''offloaded_hybrid_chunked'',
     ''dynamic'', ''dynamic_full'', ''offloaded'', ''quantized'')'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_cache_choice_use_cache_eq_false
@@ -101,7 +101,7 @@ invariants:
   message_template: You have set `use_cache` to `False`, but cache_implementation is set to static. cache_implementation
     will have no effect.
   references:
-  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  - transformers.GenerationConfig.validate() - observed via validate(strict=True)
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_compile_config_type_compile_config_exceeds_zero
@@ -127,7 +127,7 @@ invariants:
   message_template: You provided `compile_config` as an instance of <class 'int'>, but it must be an instance
     of `CompileConfig`.
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_compile_config_type_compile_config_type_not_in_CompileConfig
@@ -155,7 +155,7 @@ invariants:
   message_template: You provided `compile_config` as an instance of <class 'str'>, but it must be an instance
     of `CompileConfig`.
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_dormant_early_stopping_set_true
@@ -280,7 +280,7 @@ invariants:
   expected_outcome: *id002
   message_template: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_early_stopping_type_early_stopping_not_in_allowlist
@@ -311,7 +311,7 @@ invariants:
   expected_outcome: *id002
   message_template: '`early_stopping` must be a boolean or ''never'', but is sometimes.'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_early_stopping_type_early_stopping_type_not_in_bool_or_int_or_str
@@ -343,7 +343,7 @@ invariants:
   expected_outcome: *id002
   message_template: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_greedy_strips_epsilon_cutoff
@@ -614,7 +614,7 @@ invariants:
     if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID`
     to avoid errors in generation'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  - transformers.GenerationConfig.validate() - observed via validate(strict=True)
   added_by: dynamic_miner
   added_at: '2026-04-30'
   conflict_note: 'id: dynamic_miner -> ''transformers_negative_pad_token_id''; dynamic_miner -> ''transformers_output_token_ids_pad_token_id_lt_zero'''
@@ -750,7 +750,7 @@ invariants:
   message_template: Greedy methods without beam search do not support `num_return_sequences` different
     than 1 (got 2).
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_num_return_vs_beams_num_beams_lt_num_return_sequences
@@ -779,7 +779,7 @@ invariants:
   expected_outcome: *id002
   message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences
@@ -809,7 +809,7 @@ invariants:
   expected_outcome: *id002
   message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_output_token_ids_max_new_tokens_le_zero
@@ -838,7 +838,7 @@ invariants:
   expected_outcome: *id002
   message_template: '`max_new_tokens` must be greater than 0, but is -1.'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_output_token_ids_max_new_tokens_not_in_allowlist
@@ -870,7 +870,7 @@ invariants:
   expected_outcome: *id002
   message_template: '`max_new_tokens` must be greater than 0, but is -1.'
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_output_token_ids_pad_token_id_not_in_allowlist
@@ -904,7 +904,7 @@ invariants:
     if there is padding. Please set `pad_token_id` explicitly as `model.generation_config.pad_token_id=PAD_TOKEN_ID`
     to avoid errors in generation'
   references:
-  - "transformers.GenerationConfig.validate() \u2014 observed via validate(strict=True)"
+  - transformers.GenerationConfig.validate() - observed via validate(strict=True)
   added_by: dynamic_miner
   added_at: '2026-04-30'
 - id: transformers_raises_bnb_4bit_quant_type_not_type_str
@@ -1298,6 +1298,6 @@ invariants:
   message_template: transformers.generation.configuration_utils.WatermarkingConfig() argument after **
     must be a mapping, not int
   references:
-  - "transformers.GenerationConfig \u2014 observed via construction-time ValueError"
+  - transformers.GenerationConfig - observed via construction-time ValueError
   added_by: dynamic_miner
   added_at: '2026-04-30'

--- a/engine_versions/transformers/v4_57_3/outputs/invariants.validated.yaml
+++ b/engine_versions/transformers/v4_57_3/outputs/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-06T22:57:22+02:00'
-validation_commit: b9e7af630c351227389c263573263611402e4700
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/engine_versions/transformers/v4_57_3/outputs/schema.discovered.json
+++ b/engine_versions/transformers/v4_57_3/outputs/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovered_at": "2026-05-15T12:49:19+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/engine_versions/vllm/v0_7_3/outputs/invariants.proposed.yaml
+++ b/engine_versions/vllm/v0_7_3/outputs/invariants.proposed.yaml
@@ -1,1257 +1,8 @@
 schema_version: 1.0.0
 engine: vllm
-engine_version: 0.17.1
-mined_at: '2026-04-27'
+engine_version: 0.7.3
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
-- id: vllm_cacheconfig_cache_dtype_in_7_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.cache_dtype must be one of ['auto', 'bfloat16', 'fp8', 'fp8_e4m3', 'fp8_e5m2',
-    'fp8_inc', 'fp8_ds_mla']
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.cache_dtype:
-        not_in:
-        - auto
-        - bfloat16
-        - fp8
-        - fp8_e4m3
-        - fp8_e5m2
-        - fp8_inc
-        - fp8_ds_mla
-  kwargs_positive:
-    cache_dtype: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    cache_dtype: auto
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_cpu_offload_gb_ge_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.cpu_offload_gb requires >= 0
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.cpu_offload_gb:
-        <: 0
-  kwargs_positive:
-    cpu_offload_gb: -1
-  kwargs_negative:
-    cpu_offload_gb: 0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_gpu_memory_utilization_gt_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.gpu_memory_utilization requires > 0
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.gpu_memory_utilization:
-        <=: 0
-  kwargs_positive:
-    gpu_memory_utilization: 0
-  kwargs_negative:
-    gpu_memory_utilization: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_gpu_memory_utilization_le_1
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.gpu_memory_utilization requires <= 1
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.gpu_memory_utilization:
-        '>': 1
-  kwargs_positive:
-    gpu_memory_utilization: 2
-  kwargs_negative:
-    gpu_memory_utilization: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_kv_offloading_backend_in_2_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.kv_offloading_backend must be one of ['native', 'lmcache']
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.kv_offloading_backend:
-        not_in:
-        - native
-        - lmcache
-  kwargs_positive:
-    kv_offloading_backend: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    kv_offloading_backend: native
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_mamba_block_size_gt_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.mamba_block_size requires > 0
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.mamba_block_size:
-        <=: 0
-  kwargs_positive:
-    mamba_block_size: 0
-  kwargs_negative:
-    mamba_block_size: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_mamba_cache_dtype_in_3_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.mamba_cache_dtype must be one of ['auto', 'float32', 'float16']
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.mamba_cache_dtype:
-        not_in:
-        - auto
-        - float32
-        - float16
-  kwargs_positive:
-    mamba_cache_dtype: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    mamba_cache_dtype: auto
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_mamba_cache_mode_in_3_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.mamba_cache_mode must be one of ['all', 'align', 'none']
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.mamba_cache_mode:
-        not_in:
-        - all
-        - align
-        - none
-  kwargs_positive:
-    mamba_cache_mode: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    mamba_cache_mode: all
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_mamba_ssm_cache_dtype_in_3_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.mamba_ssm_cache_dtype must be one of ['auto', 'float32', 'float16']
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.mamba_ssm_cache_dtype:
-        not_in:
-        - auto
-        - float32
-        - float16
-  kwargs_positive:
-    mamba_ssm_cache_dtype: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    mamba_ssm_cache_dtype: auto
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_prefix_caching_hash_algo_in_4_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.prefix_caching_hash_algo must be one of ['sha256', 'sha256_cbor', 'xxhash',
-    'xxhash_cbor']
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.prefix_caching_hash_algo:
-        not_in:
-        - sha256
-        - sha256_cbor
-        - xxhash
-        - xxhash_cbor
-  kwargs_positive:
-    prefix_caching_hash_algo: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    prefix_caching_hash_algo: sha256
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_cacheconfig_swap_space_ge_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: CacheConfig.swap_space requires >= 0
-  severity: error
-  native_type: vllm.config.CacheConfig
-  miner_source:
-    path: vllm/config/cache.py
-    method: <pydantic_lift>
-    line_at_scan: 38
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.swap_space:
-        <: 0
-  kwargs_positive:
-    swap_space: -1
-  kwargs_negative:
-    swap_space: 0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CacheConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_compilationconfig_compile_cache_save_format_in_2_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: CompilationConfig.compile_cache_save_format must be one of ['binary', 'unpacked']
-  severity: error
-  native_type: vllm.config.CompilationConfig
-  miner_source:
-    path: vllm/config/compilation.py
-    method: <pydantic_lift>
-    line_at_scan: 336
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.compile_cache_save_format:
-        not_in:
-        - binary
-        - unpacked
-  kwargs_positive:
-    compile_cache_save_format: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    compile_cache_save_format: binary
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.CompilationConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_compilationconfig_dormant_backend_eq
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'CompilationConfig.__post_init__: marks dormant when backend == '
-  severity: dormant
-  native_type: vllm.config.CompilationConfig
-  miner_source:
-    path: vllm/config/compilation.py
-    method: __post_init__
-    line_at_scan: 905
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.backend: ''
-  kwargs_positive:
-    backend: ''
-  kwargs_negative:
-    backend: _x
-  expected_outcome:
-    outcome: dormant_silent
-    emission_channel: none
-    normalised_fields:
-    - backend
-  message_template: null
-  references:
-  - vllm/config/compilation.py:905 (vllm.config.CompilationConfig.__post_init__)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_eplbconfig_num_redundant_experts_ge_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: EPLBConfig.num_redundant_experts requires >= 0
-  severity: error
-  native_type: vllm.config.EPLBConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: <pydantic_lift>
-    line_at_scan: 50
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.num_redundant_experts:
-        <: 0
-  kwargs_positive:
-    num_redundant_experts: -1
-  kwargs_negative:
-    num_redundant_experts: 0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_eplbconfig_policy_in_1_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: EPLBConfig.policy must be one of ['default']
-  severity: error
-  native_type: vllm.config.EPLBConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: <pydantic_lift>
-    line_at_scan: 50
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.policy:
-        not_in:
-        - default
-  kwargs_positive:
-    policy: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    policy: default
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.EPLBConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_eplbconfig_raises_log_balancedness_interval_le_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'EPLBConfig._validate_eplb_config: raises when log_balancedness present True AND log_balancedness_interval
-    <= 0'
-  severity: error
-  native_type: vllm.config.EPLBConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: _validate_eplb_config
-    line_at_scan: 89
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.log_balancedness:
-        present: true
-      vllm.engine.log_balancedness_interval:
-        <=: 0
-  kwargs_positive:
-    log_balancedness: 1
-    log_balancedness_interval: 0
-  kwargs_negative:
-    log_balancedness: 1
-    log_balancedness_interval: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: log_balancedness_interval must be greater than 0.
-  references:
-  - vllm/config/parallel.py:89 (vllm.config.EPLBConfig._validate_eplb_config)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_loraconfig_dormant_max_cpu_loras_unset_true
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'LoRAConfig._validate_lora_config: marks dormant when max_cpu_loras absent True'
-  severity: dormant
-  native_type: vllm.config.LoRAConfig
-  miner_source:
-    path: vllm/config/lora.py
-    method: _validate_lora_config
-    line_at_scan: 94
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.max_cpu_loras:
-        absent: true
-  kwargs_positive:
-    max_cpu_loras: null
-  kwargs_negative:
-    max_cpu_loras: 1
-  expected_outcome:
-    outcome: dormant_silent
-    emission_channel: none
-    normalised_fields:
-    - max_cpu_loras
-  message_template: null
-  references:
-  - vllm/config/lora.py:94 (vllm.config.LoRAConfig._validate_lora_config)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_loraconfig_lora_dtype_in_3_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: LoRAConfig.lora_dtype must be one of ['auto', 'float16', 'bfloat16']
-  severity: error
-  native_type: vllm.config.LoRAConfig
-  miner_source:
-    path: vllm/config/lora.py
-    method: <pydantic_lift>
-    line_at_scan: 28
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.lora_dtype:
-        not_in:
-        - auto
-        - float16
-        - bfloat16
-  kwargs_positive:
-    lora_dtype: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    lora_dtype: auto
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_loraconfig_max_lora_rank_in_9_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: LoRAConfig.max_lora_rank must be one of [1, 8, 16, 32, 64, 128, 256, 320, 512]
-  severity: error
-  native_type: vllm.config.LoRAConfig
-  miner_source:
-    path: vllm/config/lora.py
-    method: <pydantic_lift>
-    line_at_scan: 28
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.max_lora_rank:
-        not_in:
-        - 1
-        - 8
-        - 16
-        - 32
-        - 64
-        - 128
-        - 256
-        - 320
-        - 512
-  kwargs_positive:
-    max_lora_rank: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    max_lora_rank: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_loraconfig_max_loras_ge_1
-  engine: vllm
-  library: vllm
-  invariant_under_test: LoRAConfig.max_loras requires >= 1
-  severity: error
-  native_type: vllm.config.LoRAConfig
-  miner_source:
-    path: vllm/config/lora.py
-    method: <pydantic_lift>
-    line_at_scan: 28
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.max_loras:
-        <: 1
-  kwargs_positive:
-    max_loras: 0
-  kwargs_negative:
-    max_loras: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.LoRAConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_modelconfig_convert_in_4_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ModelConfig.convert must be one of ['auto', 'none', 'embed', 'classify']
-  severity: error
-  native_type: vllm.config.ModelConfig
-  miner_source:
-    path: vllm/config/model.py
-    method: <pydantic_lift>
-    line_at_scan: 99
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.convert:
-        not_in:
-        - auto
-        - none
-        - embed
-        - classify
-  kwargs_positive:
-    convert: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    convert: auto
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_modelconfig_logprobs_mode_in_4_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ModelConfig.logprobs_mode must be one of ['raw_logits', 'raw_logprobs', 'processed_logits',
-    'processed_logprobs']
-  severity: error
-  native_type: vllm.config.ModelConfig
-  miner_source:
-    path: vllm/config/model.py
-    method: <pydantic_lift>
-    line_at_scan: 99
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.logprobs_mode:
-        not_in:
-        - raw_logits
-        - raw_logprobs
-        - processed_logits
-        - processed_logprobs
-  kwargs_positive:
-    logprobs_mode: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    logprobs_mode: raw_logits
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_modelconfig_mm_encoder_tp_mode_in_2_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ModelConfig.mm_encoder_tp_mode must be one of ['weights', 'data']
-  severity: error
-  native_type: vllm.config.ModelConfig
-  miner_source:
-    path: vllm/config/model.py
-    method: <pydantic_lift>
-    line_at_scan: 99
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.mm_encoder_tp_mode:
-        not_in:
-        - weights
-        - data
-  kwargs_positive:
-    mm_encoder_tp_mode: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    mm_encoder_tp_mode: weights
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
-  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_encoder_tp_mode_in_2_values''; pydantic_lift
-    -> ''vllm_multimodalconfig_mm_encoder_tp_mode_in_2_values'''
-- id: vllm_modelconfig_mm_processor_cache_type_in_2_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ModelConfig.mm_processor_cache_type must be one of ['shm', 'lru']
-  severity: error
-  native_type: vllm.config.ModelConfig
-  miner_source:
-    path: vllm/config/model.py
-    method: <pydantic_lift>
-    line_at_scan: 99
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.mm_processor_cache_type:
-        not_in:
-        - shm
-        - lru
-  kwargs_positive:
-    mm_processor_cache_type: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    mm_processor_cache_type: shm
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
-  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-  conflict_note: 'id: pydantic_lift -> ''vllm_modelconfig_mm_processor_cache_type_in_2_values''; pydantic_lift
-    -> ''vllm_multimodalconfig_mm_processor_cache_type_in_2_values'''
-- id: vllm_modelconfig_runner_in_4_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ModelConfig.runner must be one of ['auto', 'generate', 'pooling', 'draft']
-  severity: error
-  native_type: vllm.config.ModelConfig
-  miner_source:
-    path: vllm/config/model.py
-    method: <pydantic_lift>
-    line_at_scan: 99
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.runner:
-        not_in:
-        - auto
-        - generate
-        - pooling
-        - draft
-  kwargs_positive:
-    runner: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    runner: auto
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ModelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_multimodalconfig_mm_processor_cache_gb_ge_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: MultiModalConfig.mm_processor_cache_gb requires >= 0
-  severity: error
-  native_type: vllm.config.MultiModalConfig
-  miner_source:
-    path: vllm/config/multimodal.py
-    method: <pydantic_lift>
-    line_at_scan: 71
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.mm_processor_cache_gb:
-        <: 0
-  kwargs_positive:
-    mm_processor_cache_gb: -1
-  kwargs_negative:
-    mm_processor_cache_gb: 0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_multimodalconfig_video_pruning_rate_ge_0p0
-  engine: vllm
-  library: vllm
-  invariant_under_test: MultiModalConfig.video_pruning_rate requires >= 0.0
-  severity: error
-  native_type: vllm.config.MultiModalConfig
-  miner_source:
-    path: vllm/config/multimodal.py
-    method: <pydantic_lift>
-    line_at_scan: 71
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.video_pruning_rate:
-        <: 0.0
-  kwargs_positive:
-    video_pruning_rate: -1.0
-  kwargs_negative:
-    video_pruning_rate: 0.0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_multimodalconfig_video_pruning_rate_lt_1p0
-  engine: vllm
-  library: vllm
-  invariant_under_test: MultiModalConfig.video_pruning_rate requires < 1.0
-  severity: error
-  native_type: vllm.config.MultiModalConfig
-  miner_source:
-    path: vllm/config/multimodal.py
-    method: <pydantic_lift>
-    line_at_scan: 71
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.video_pruning_rate:
-        '>=': 1.0
-  kwargs_positive:
-    video_pruning_rate: 1.0
-  kwargs_negative:
-    video_pruning_rate: 0.0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.MultiModalConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig__api_process_count_gt_0
-  engine: vllm
-  library: vllm
-  invariant_under_test: ParallelConfig._api_process_count requires > 0
-  severity: error
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: <pydantic_lift>
-    line_at_scan: 93
-  match:
-    engine: vllm
-    fields:
-      vllm.engine._api_process_count:
-        <=: 0
-  kwargs_positive:
-    _api_process_count: 0
-  kwargs_negative:
-    _api_process_count: 1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig__api_process_rank_ge_neg1
-  engine: vllm
-  library: vllm
-  invariant_under_test: ParallelConfig._api_process_rank requires >= -1
-  severity: error
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: <pydantic_lift>
-    line_at_scan: 93
-  match:
-    engine: vllm
-    fields:
-      vllm.engine._api_process_rank:
-        <: -1
-  kwargs_positive:
-    _api_process_rank: -2
-  kwargs_negative:
-    _api_process_rank: -1
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig_all2all_backend_in_7_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ParallelConfig.all2all_backend must be one of ['naive', 'pplx', 'deepep_high_throughput',
-    'deepep_low_latency', 'mori', 'allgather_reducescatter', 'flashinfer_all2allv']
-  severity: error
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: <pydantic_lift>
-    line_at_scan: 93
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.all2all_backend:
-        not_in:
-        - naive
-        - pplx
-        - deepep_high_throughput
-        - deepep_low_latency
-        - mori
-        - allgather_reducescatter
-        - flashinfer_all2allv
-  kwargs_positive:
-    all2all_backend: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    all2all_backend: naive
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig_data_parallel_backend_in_2_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ParallelConfig.data_parallel_backend must be one of ['ray', 'mp']
-  severity: error
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: <pydantic_lift>
-    line_at_scan: 93
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.data_parallel_backend:
-        not_in:
-        - ray
-        - mp
-  kwargs_positive:
-    data_parallel_backend: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    data_parallel_backend: ray
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig_dormant_all2all_backend_eq_pplx
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'ParallelConfig._validate_parallel_config: marks dormant when all2all_backend == pplx'
-  severity: dormant
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: _validate_parallel_config
-    line_at_scan: 348
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.all2all_backend: pplx
-  kwargs_positive:
-    all2all_backend: pplx
-  kwargs_negative:
-    all2all_backend: allgather_reducescatter
-  expected_outcome:
-    outcome: dormant_silent
-    emission_channel: none
-    normalised_fields:
-    - all2all_backend
-  message_template: null
-  references:
-  - vllm/config/parallel.py:348 (vllm.config.ParallelConfig._validate_parallel_config)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig_dormant_data_parallel_rank_set_true
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'ParallelConfig.__post_init__: marks dormant when distributed_executor_backend == external_launcher
-    AND data_parallel_rank present True'
-  severity: dormant
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: __post_init__
-    line_at_scan: 676
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.distributed_executor_backend: external_launcher
-      vllm.engine.data_parallel_rank:
-        present: true
-  kwargs_positive:
-    distributed_executor_backend: external_launcher
-    data_parallel_rank: 1
-  kwargs_negative:
-    distributed_executor_backend: external_launcher
-    data_parallel_rank: 0
-  expected_outcome:
-    outcome: dormant_silent
-    emission_channel: none
-    normalised_fields:
-    - data_parallel_rank
-  message_template: null
-  references:
-  - vllm/config/parallel.py:676 (vllm.config.ParallelConfig.__post_init__)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig_expert_placement_strategy_in_2_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: ParallelConfig.expert_placement_strategy must be one of ['linear', 'round_robin']
-  severity: error
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: <pydantic_lift>
-    line_at_scan: 93
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.expert_placement_strategy:
-        not_in:
-        - linear
-        - round_robin
-  kwargs_positive:
-    expert_placement_strategy: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    expert_placement_strategy: linear
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.ParallelConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig_raises_api_process_rank_ge_ref_api_process_count
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when _api_process_rank >= @_api_process_count'
-  severity: error
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: _validate_parallel_config
-    line_at_scan: 337
-  match:
-    engine: vllm
-    fields:
-      vllm.engine._api_process_rank:
-        '>=': '@_api_process_count'
-  kwargs_positive:
-    _api_process_count: 2
-    _api_process_rank: 2
-  kwargs_negative:
-    _api_process_count: 2
-    _api_process_rank: 0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: 'f''Invalid value of `_api_process_rank`. Expected to be `-1` or `[0, {self._api_process_count})`,
-    but found: {self._api_process_rank}'''
-  references:
-  - vllm/config/parallel.py:337 (vllm.config.ParallelConfig._validate_parallel_config)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_parallelconfig_raises_data_parallel_external_lb_set_true
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'ParallelConfig._validate_parallel_config: raises when data_parallel_size <= 1 AND
-    data_parallel_external_lb present True'
-  severity: error
-  native_type: vllm.config.ParallelConfig
-  miner_source:
-    path: vllm/config/parallel.py
-    method: _validate_parallel_config
-    line_at_scan: 357
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.data_parallel_size:
-        <=: 1
-      vllm.engine.data_parallel_external_lb:
-        present: true
-  kwargs_positive:
-    data_parallel_size: 1
-    data_parallel_external_lb: 1
-  kwargs_negative:
-    data_parallel_size: 1
-    data_parallel_external_lb: false
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: data_parallel_external_lb can only be set when data_parallel_size > 1
-  references:
-  - vllm/config/parallel.py:357 (vllm.config.ParallelConfig._validate_parallel_config)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_poolerconfig_seq_pooling_type_in_3_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: PoolerConfig.seq_pooling_type must be one of ['CLS', 'LAST', 'MEAN']
-  severity: error
-  native_type: vllm.config.PoolerConfig
-  miner_source:
-    path: vllm/config/pooler.py
-    method: <pydantic_lift>
-    line_at_scan: 19
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.seq_pooling_type:
-        not_in:
-        - CLS
-        - LAST
-        - MEAN
-  kwargs_positive:
-    seq_pooling_type: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    seq_pooling_type: CLS
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_poolerconfig_tok_pooling_type_in_2_values
-  engine: vllm
-  library: vllm
-  invariant_under_test: PoolerConfig.tok_pooling_type must be one of ['ALL', 'STEP']
-  severity: error
-  native_type: vllm.config.PoolerConfig
-  miner_source:
-    path: vllm/config/pooler.py
-    method: <pydantic_lift>
-    line_at_scan: 19
-  match:
-    engine: vllm
-    fields:
-      vllm.engine.tok_pooling_type:
-        not_in:
-        - ALL
-        - STEP
-  kwargs_positive:
-    tok_pooling_type: <invalid_pydantic_lift_probe>
-  kwargs_negative:
-    tok_pooling_type: ALL
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: null
-  references:
-  - "vllm.PoolerConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
-- id: vllm_sampling_token_counts_max_tokens_lt_min_tokens
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'sampling_token_counts: error when max_tokens < min_tokens'
-  severity: error
-  native_type: vllm.SamplingParams
-  miner_source:
-    path: vllm/sampling_params.py
-    method: <probe>
-    line_at_scan: 0
-  match:
-    engine: vllm
-    fields:
-      vllm.sampling.max_tokens:
-        <: '@min_tokens'
-  kwargs_positive:
-    max_tokens: 1
-    min_tokens: 5
-  kwargs_negative:
-    max_tokens: null
-    min_tokens: 0
-  expected_outcome:
-    outcome: error
-    emission_channel: none
-    normalised_fields: []
-  message_template: min_tokens must be less than or equal to max_tokens=1, got 5.
-  references:
-  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
-  added_by: dynamic_miner
-  added_at: '2026-04-27'
-- id: vllm_samplingparams_dormant_bad_words_unset_true
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when bad_words absent True'
-  severity: dormant
-  native_type: vllm.SamplingParams
-  miner_source:
-    path: vllm/sampling_params.py
-    method: __post_init__
-    line_at_scan: 389
-  match:
-    engine: vllm
-    fields:
-      vllm.sampling.bad_words:
-        absent: true
-  kwargs_positive:
-    bad_words: null
-  kwargs_negative:
-    bad_words: 1
-  expected_outcome:
-    outcome: dormant_silent
-    emission_channel: none
-    normalised_fields:
-    - bad_words
-  message_template: null
-  references:
-  - vllm/sampling_params.py:389 (vllm.SamplingParams.__post_init__)
-  added_by: static_miner
-  added_at: '2026-04-27'
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   engine: vllm
   library: vllm
@@ -1259,9 +10,9 @@ invariants:
   severity: dormant
   native_type: vllm.SamplingParams
   miner_source:
-    path: vllm/sampling_params.py
+    path: sampling_params.py
     method: __post_init__
-    line_at_scan: 378
+    line_at_scan: 311
   match:
     engine: vllm
     fields:
@@ -1277,50 +28,52 @@ invariants:
     - seed
   message_template: null
   references:
-  - vllm/sampling_params.py:378 (vllm.SamplingParams.__post_init__)
+  - sampling_params.py:311 (vllm.SamplingParams.__post_init__)
   added_by: static_miner
   added_at: '2026-04-27'
-- id: vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true
+- id: vllm_samplingparams_raises_best_of_lt_ref_n
   engine: vllm
   library: vllm
-  invariant_under_test: 'SamplingParams.__post_init__: marks dormant when skip_reading_prefix_cache absent
-    True'
-  severity: dormant
-  native_type: vllm.SamplingParams
-  miner_source:
-    path: vllm/sampling_params.py
-    method: __post_init__
-    line_at_scan: 418
-  match:
-    engine: vllm
-    fields:
-      vllm.sampling.skip_reading_prefix_cache:
-        absent: true
-  kwargs_positive:
-    skip_reading_prefix_cache: null
-  kwargs_negative:
-    skip_reading_prefix_cache: 1
-  expected_outcome:
-    outcome: dormant_silent
-    emission_channel: none
-    normalised_fields:
-    - skip_reading_prefix_cache
-  message_template: null
-  references:
-  - vllm/sampling_params.py:418 (vllm.SamplingParams.__post_init__)
-  added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
-  engine: vllm
-  library: vllm
-  invariant_under_test: 'SamplingParams._verify_args: raises when max_tokens present True AND min_tokens >
-    @max_tokens'
+  invariant_under_test: 'SamplingParams.__post_init__: raises when best_of present True AND best_of <
+    @n'
   severity: error
   native_type: vllm.SamplingParams
   miner_source:
-    path: vllm/sampling_params.py
+    path: sampling_params.py
+    method: __post_init__
+    line_at_scan: 296
+  match:
+    engine: vllm
+    fields:
+      vllm.sampling.best_of:
+        present: true
+        <: '@n'
+  kwargs_positive:
+    best_of: 1
+    n: 2
+  kwargs_negative:
+    best_of: 2
+    n: 2
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: best_of must be greater than or equal to n, got n={n} and best_of={best_of}.
+  references:
+  - sampling_params.py:296 (vllm.SamplingParams.__post_init__)
+  added_by: static_miner
+  added_at: '2026-05-13T22:55:33+02:00'
+- id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SamplingParams._verify_args: raises when max_tokens present True AND min_tokens
+    > @max_tokens'
+  severity: error
+  native_type: vllm.SamplingParams
+  miner_source:
+    path: sampling_params.py
     method: _verify_args
-    line_at_scan: 472
+    line_at_scan: 388
   match:
     engine: vllm
     fields:
@@ -1338,9 +91,9 @@ invariants:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: f'min_tokens must be less than or equal to max_tokens={self.max_tokens}, got {self.min_tokens}.'
+  message_template: min_tokens must be less than or equal to max_tokens={max_tokens}, got {min_tokens}.
   references:
-  - vllm/sampling_params.py:472 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:388 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-04-27'
 - id: vllm_samplingparams_raises_min_tokens_lt_0
@@ -1350,9 +103,9 @@ invariants:
   severity: error
   native_type: vllm.SamplingParams
   miner_source:
-    path: vllm/sampling_params.py
+    path: sampling_params.py
     method: _verify_args
-    line_at_scan: 468
+    line_at_scan: 385
   match:
     engine: vllm
     fields:
@@ -1366,16 +119,11 @@ invariants:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: min_tokens must be greater than or equal to 0, got -1.
+  message_template: min_tokens must be greater than or equal to 0, got {min_tokens}.
   references:
-  - vllm/sampling_params.py:468 (vllm.SamplingParams._verify_args)
-  - "vllm.SamplingParams \u2014 observed via combinatorial probing"
+  - sampling_params.py:385 (vllm.SamplingParams._verify_args)
   added_by: static_miner
-  cross_validated_by:
-  - dynamic_miner
   added_at: '2026-04-27'
-  conflict_note: 'message_template: dynamic miner text overrode static_miner''s template; id: static_miner
-    -> ''vllm_samplingparams_raises_min_tokens_lt_0''; dynamic_miner -> ''vllm_sampling_token_counts_min_tokens_lt_zero'''
 - id: vllm_samplingparams_raises_n_lt_1
   engine: vllm
   library: vllm
@@ -1383,9 +131,9 @@ invariants:
   severity: error
   native_type: vllm.SamplingParams
   miner_source:
-    path: vllm/sampling_params.py
+    path: sampling_params.py
     method: _verify_args
-    line_at_scan: 424
+    line_at_scan: 357
   match:
     engine: vllm
     fields:
@@ -1399,9 +147,9 @@ invariants:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: f'n must be at least 1, got {self.n}.'
+  message_template: n must be at least 1, got {n}.
   references:
-  - vllm/sampling_params.py:424 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:357 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-04-27'
 - id: vllm_samplingparams_raises_n_not_type_int
@@ -1411,9 +159,9 @@ invariants:
   severity: error
   native_type: vllm.SamplingParams
   miner_source:
-    path: vllm/sampling_params.py
+    path: sampling_params.py
     method: _verify_args
-    line_at_scan: 422
+    line_at_scan: 354
   match:
     engine: vllm
     fields:
@@ -1427,70 +175,121 @@ invariants:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: f'n must be an int, but is of type {type(self.n)}'
+  message_template: n must be an int, but is of type {type(self.n)}
   references:
-  - vllm/sampling_params.py:422 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:354 (vllm.SamplingParams._verify_args)
   added_by: static_miner
   added_at: '2026-04-27'
-- id: vllm_samplingparams_raises_top_k_lt_neg1
+- id: vllm_samplingparams_raises_temperature_lt_0p0
   engine: vllm
   library: vllm
-  invariant_under_test: 'SamplingParams._verify_args: raises when top_k < -1'
+  invariant_under_test: 'SamplingParams._verify_args: raises when temperature < 0.0'
   severity: error
   native_type: vllm.SamplingParams
   miner_source:
-    path: vllm/sampling_params.py
+    path: sampling_params.py
     method: _verify_args
-    line_at_scan: 452
+    line_at_scan: 368
   match:
     engine: vllm
     fields:
-      vllm.sampling.top_k:
-        <: -1
+      vllm.sampling.temperature:
+        <: 0.0
   kwargs_positive:
-    top_k: -2
+    temperature: -1.0
   kwargs_negative:
-    top_k: -1
+    temperature: 0.0
   expected_outcome:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: f'top_k must be 0 (disable), or at least 1, got {self.top_k}.'
+  message_template: temperature must be non-negative, got {temperature}.
   references:
-  - vllm/sampling_params.py:452 (vllm.SamplingParams._verify_args)
+  - sampling_params.py:368 (vllm.SamplingParams._verify_args)
   added_by: static_miner
-  added_at: '2026-04-27'
-- id: vllm_structuredoutputsconfig_backend_in_5_values
+  added_at: '2026-05-13T22:55:33+02:00'
+- id: vllm_schedulerconfig_raises_max_num_partial_prefills_lt_1
   engine: vllm
   library: vllm
-  invariant_under_test: StructuredOutputsConfig.backend must be one of ['auto', 'xgrammar', 'guidance', 'outlines',
-    'lm-format-enforcer']
+  invariant_under_test: 'SchedulerConfig._verify_args: raises when max_num_partial_prefills < 1'
   severity: error
-  native_type: vllm.config.StructuredOutputsConfig
+  native_type: vllm.config.SchedulerConfig
   miner_source:
-    path: vllm/config/structured_outputs.py
-    method: <pydantic_lift>
-    line_at_scan: 17
+    path: config.py
+    method: _verify_args
+    line_at_scan: 1604
   match:
     engine: vllm
     fields:
-      vllm.engine.backend:
-        not_in:
-        - auto
-        - xgrammar
-        - guidance
-        - outlines
-        - lm-format-enforcer
+      vllm.engine.max_num_partial_prefills:
+        <: 1
   kwargs_positive:
-    backend: <invalid_pydantic_lift_probe>
+    max_num_partial_prefills: 0
   kwargs_negative:
-    backend: auto
+    max_num_partial_prefills: 1
   expected_outcome:
     outcome: error
     emission_channel: none
     normalised_fields: []
-  message_template: null
+  message_template: max_num_partial_prefills ({max_num_partial_prefills}) must be greater than or equal
+    to 1.
   references:
-  - "vllm.StructuredOutputsConfig \u2014 Pydantic FieldInfo metadata"
-  added_by: pydantic_lift
-  added_at: '2026-04-27'
+  - config.py:1604 (vllm.config.SchedulerConfig._verify_args)
+  added_by: static_miner
+  added_at: '2026-05-13T22:55:33+02:00'
+- id: vllm_schedulerconfig_raises_num_lookahead_slots_lt_0
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SchedulerConfig._verify_args: raises when num_lookahead_slots < 0'
+  severity: error
+  native_type: vllm.config.SchedulerConfig
+  miner_source:
+    path: config.py
+    method: _verify_args
+    line_at_scan: 1592
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.num_lookahead_slots:
+        <: 0
+  kwargs_positive:
+    num_lookahead_slots: -1
+  kwargs_negative:
+    num_lookahead_slots: 0
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: num_lookahead_slots ({num_lookahead_slots}) must be greater than or equal to 0.
+  references:
+  - config.py:1592 (vllm.config.SchedulerConfig._verify_args)
+  added_by: static_miner
+  added_at: '2026-05-13T22:55:33+02:00'
+- id: vllm_schedulerconfig_raises_num_scheduler_steps_lt_1
+  engine: vllm
+  library: vllm
+  invariant_under_test: 'SchedulerConfig._verify_args: raises when num_scheduler_steps < 1'
+  severity: error
+  native_type: vllm.config.SchedulerConfig
+  miner_source:
+    path: config.py
+    method: _verify_args
+    line_at_scan: 1598
+  match:
+    engine: vllm
+    fields:
+      vllm.engine.num_scheduler_steps:
+        <: 1
+  kwargs_positive:
+    num_scheduler_steps: 0
+  kwargs_negative:
+    num_scheduler_steps: 1
+  expected_outcome:
+    outcome: error
+    emission_channel: none
+    normalised_fields: []
+  message_template: num_scheduler_steps ({num_scheduler_steps}) must be greater than or equal to 1.
+  references:
+  - config.py:1598 (vllm.config.SchedulerConfig._verify_args)
+  added_by: static_miner
+  added_at: '2026-05-13T22:55:33+02:00'

--- a/engine_versions/vllm/v0_7_3/outputs/invariants.validated.yaml
+++ b/engine_versions/vllm/v0_7_3/outputs/invariants.validated.yaml
@@ -1,9 +1,109 @@
-# Pending validation-gate operationalisation — see issue #445
 schema_version: 1.0.0
 engine: vllm
 engine_version: 0.7.3
-image_ref: vllm/vllm-openai:v0.7.3
-base_image_ref: vllm/vllm-openai:v0.7.3
-validated_at: null
-validation_commit: null
-cases: []
+image_ref: llenergymeasure:vllm
+base_image_ref: llenergymeasure:vllm
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
+cases:
+- id: vllm_samplingparams_dormant_seed_eq_neg1
+  outcome: dormant_silent
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations:
+    seed:
+      declared: -1
+      observed: null
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_samplingparams_raises_best_of_lt_ref_n
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: best_of must be greater than or equal to n, got n=2 and best_of=1.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_samplingparams_raises_min_tokens_gt_ref_max_tokens
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: min_tokens must be less than or equal to max_tokens=1, got 2.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_samplingparams_raises_min_tokens_lt_0
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: min_tokens must be greater than or equal to 0, got -1.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_samplingparams_raises_n_lt_1
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: n must be at least 1, got 0.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_samplingparams_raises_n_not_type_int
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: n must be an int, but is of type <class 'str'>
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_samplingparams_raises_temperature_lt_0p0
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: temperature must be non-negative, got -1.0.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_schedulerconfig_raises_max_num_partial_prefills_lt_1
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: max_num_partial_prefills (0) must be greater than or equal to 1.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_schedulerconfig_raises_num_lookahead_slots_lt_0
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: num_lookahead_slots (-1) must be greater than or equal to 0.
+  positive_confirmed: true
+  negative_confirmed: true
+- id: vllm_schedulerconfig_raises_num_scheduler_steps_lt_1
+  outcome: error
+  emission_channel: none
+  observed_messages: []
+  observed_silent_normalisations: {}
+  observed_exception:
+    type: ValueError
+    message: num_scheduler_steps (0) must be greater than or equal to 1.
+  positive_confirmed: true
+  negative_confirmed: true
+divergences: []

--- a/engine_versions/vllm/v0_7_3/outputs/schema.discovered.json
+++ b/engine_versions/vllm/v0_7_3/outputs/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovered_at": "2026-05-15T12:49:19+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {

--- a/scripts/engine_producers/_current.py
+++ b/scripts/engine_producers/_current.py
@@ -6,6 +6,8 @@ This module exposes the lookup helpers that read it:
 - :func:`current_path` - absolute path to the engine's current.yaml.
 - :func:`load_current` - parse the YAML to a dict.
 - :func:`safe_version` - identifier-safe mangling of a PEP 440 version.
+- :func:`current_outputs_dir` - directory holding the engine's per-version
+  mined outputs (``engine_versions/{engine}/v{safe}/outputs/``).
 
 The current-state path is resolved by walking up from this file until a
 ``pyproject.toml`` marker is found - the canonical project-root marker
@@ -67,3 +69,32 @@ def safe_version(version: str) -> str:
             f"resulting candidate {safe!r} contains non-alphanumeric chars."
         )
     return safe
+
+
+def current_outputs_dir(engine: str) -> Path:
+    """Return ``engine_versions/{engine}/v{safe}/outputs/`` for the current pin.
+
+    Resolves ``library.current_version`` from the engine's ``current.yaml``,
+    mangles it via :func:`safe_version`, and joins under the engine's
+    version-bundle root. The returned path is the SSOT directory holding the
+    per-version mined corpus artefacts (``invariants.proposed.yaml``,
+    ``invariants.validated.yaml``, ``schema.discovered.json``).
+
+    Used by sync scripts that mirror the per-version archive into the loader's
+    expected location under ``src/llenergymeasure/engines/<engine>/`` (the
+    "data shadow" the wheel ships).
+    """
+    data = load_current(engine)
+    library = data.get("library")
+    if not isinstance(library, dict):
+        raise ValueError(f"current.yaml for {engine!r} missing required 'library' mapping.")
+    version = library.get("current_version")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"current.yaml for {engine!r} missing 'library.current_version' string.")
+    return (
+        _find_repo_root(Path(__file__).resolve())
+        / "engine_versions"
+        / engine
+        / safe_version(version)
+        / "outputs"
+    )

--- a/scripts/engine_producers/regen_engine_corpus.py
+++ b/scripts/engine_producers/regen_engine_corpus.py
@@ -1,0 +1,151 @@
+"""Sync per-version engine corpus (SSOT) into the loader's shadow location.
+
+The mined-corpus SSOT lives at
+``engine_versions/<engine>/v<safe>/outputs/{invariants.proposed.yaml,
+invariants.validated.yaml, schema.discovered.json}``. The loader reads from
+``src/llenergymeasure/engines/<engine>/{same-files}`` (the "data shadow" that
+ships in the wheel). This script copies SSOT -> shadow.
+
+Two modes:
+
+- ``--write`` (default): ``shutil.copy2`` each source onto its destination.
+  Idempotent; preserves mtime.
+- ``--check``: read both files, exit 1 with a unified diff per drifted file.
+  No writes. CI parity gate.
+
+Single source of truth for path derivation: :func:`_current.current_outputs_dir`
+and :func:`_current.safe_version`. The script is intentionally tiny - the
+heavy lifting lives in the per-engine miners that produce the SSOT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import shutil
+import sys
+from pathlib import Path
+
+# Project root on sys.path so this script works both as ``python -m
+# scripts.engine_producers.regen_engine_corpus`` and as a direct
+# ``python scripts/engine_producers/regen_engine_corpus.py``.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_producers._current import (  # noqa: E402
+    _find_repo_root,
+    current_outputs_dir,
+)
+
+ENGINES: tuple[str, ...] = ("vllm", "tensorrt", "transformers")
+CORPUS_FILES: tuple[str, ...] = (
+    "invariants.proposed.yaml",
+    "invariants.validated.yaml",
+    "schema.discovered.json",
+)
+
+
+def _shadow_dir(engine: str) -> Path:
+    """Return ``src/llenergymeasure/engines/<engine>/`` for the given engine."""
+    return (
+        _find_repo_root(Path(__file__).resolve()) / "src" / "llenergymeasure" / "engines" / engine
+    )
+
+
+def _file_diff(src: Path, dst: Path) -> str:
+    """Return a unified diff string (src vs dst); empty if byte-identical."""
+    src_text = src.read_text().splitlines(keepends=True)
+    dst_text = dst.read_text().splitlines(keepends=True) if dst.exists() else []
+    return "".join(
+        difflib.unified_diff(
+            dst_text,
+            src_text,
+            fromfile=str(dst),
+            tofile=str(src),
+        )
+    )
+
+
+def sync_engine(engine: str, *, write: bool) -> list[str]:
+    """Sync (or check) one engine. Return list of human-readable drift messages.
+
+    Empty list = no drift detected (or write succeeded). Non-empty list under
+    ``write=False`` indicates the caller should exit non-zero. Missing source
+    files raise ``FileNotFoundError`` loud - the SSOT path is computed from
+    ``current.yaml``; a missing source means the per-version archive hasn't
+    been produced yet and the caller must surface that as a real error, not
+    silently skip.
+    """
+    outputs = current_outputs_dir(engine)
+    shadow = _shadow_dir(engine)
+    drift: list[str] = []
+    for filename in CORPUS_FILES:
+        src = outputs / filename
+        dst = shadow / filename
+        if not src.exists():
+            raise FileNotFoundError(
+                f"Source file missing for {engine}: {src}. "
+                f"Check engine_versions/{engine}/current.yaml points at a "
+                f"version whose outputs/ directory has been populated by the "
+                f"cells workflow."
+            )
+        if write:
+            shadow.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            continue
+        # --check mode: compare bytes and accumulate diff per file.
+        src_bytes = src.read_bytes()
+        dst_bytes = dst.read_bytes() if dst.exists() else b""
+        if src_bytes == dst_bytes:
+            continue
+        diff = _file_diff(src, dst)
+        drift.append(f"{engine}/{filename} drift:\n{diff}")
+    return drift
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sync per-version engine corpus artefacts from engine_versions/ "
+            "(SSOT) to src/llenergymeasure/engines/ (data shadow)."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Don't write; exit 1 with a unified diff per drifted file. Used as the CI parity gate."
+        ),
+    )
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help="Sync SSOT -> shadow via shutil.copy2 (default).",
+    )
+    args = parser.parse_args(argv)
+
+    # Default to --write when neither flag is passed; --check is opt-in.
+    write = not args.check
+
+    all_drift: list[str] = []
+    for engine in ENGINES:
+        all_drift.extend(sync_engine(engine, write=write))
+
+    if not write and all_drift:
+        for entry in all_drift:
+            print(entry, file=sys.stderr)
+        print(
+            "\nDrift detected between engine_versions/<engine>/v<current>/outputs/ "
+            "and src/llenergymeasure/engines/<engine>/. Run:\n"
+            "    python scripts/engine_producers/regen_engine_corpus.py --write\n"
+            "to sync.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
@@ -1,13 +1,13 @@
 schema_version: 1.0.0
 engine: tensorrt
 engine_version: 0.21.0
-mined_at: '2026-05-06T20:35:47+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   engine: tensorrt
   library: tensorrt_llm
-  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <= 0 (via
-    raise ValueError)
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <=
+    0 (via raise ValueError)
   severity: error
   native_type: tensorrt_llm.LookaheadDecodingConfig
   miner_source:
@@ -64,8 +64,8 @@ invariants:
 - id: tensorrt_raises_max_window_size_le_0_positive_values
   engine: tensorrt
   library: tensorrt_llm
-  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <= 0 (via
-    raise ValueError)
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <=
+    0 (via raise ValueError)
   severity: error
   native_type: tensorrt_llm.LookaheadDecodingConfig
   miner_source:

--- a/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
@@ -1,13 +1,13 @@
 schema_version: 1.0.0
 engine: tensorrt
 engine_version: 0.21.0
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-06T20:35:47+02:00'
 invariants:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   engine: tensorrt
   library: tensorrt_llm
-  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <=
-    0 (via raise ValueError)
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_ngram_size <= 0 (via
+    raise ValueError)
   severity: error
   native_type: tensorrt_llm.LookaheadDecodingConfig
   miner_source:
@@ -64,8 +64,8 @@ invariants:
 - id: tensorrt_raises_max_window_size_le_0_positive_values
   engine: tensorrt
   library: tensorrt_llm
-  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <=
-    0 (via raise ValueError)
+  invariant_under_test: LookaheadDecodingConfig.validate_positive_values raises when max_window_size <= 0 (via
+    raise ValueError)
   severity: error
   native_type: tensorrt_llm.LookaheadDecodingConfig
   miner_source:

--- a/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: tensorrt
 engine_version: 0.21.0
 image_ref: llenergymeasure:tensorrt
 base_image_ref: llenergymeasure:tensorrt
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-06T20:35:47+02:00'
+validation_commit: 4ad6ee7b8e43c1282751a5b76ca936c6fe6982a3
 cases:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   outcome: error

--- a/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: tensorrt
 engine_version: 0.21.0
 image_ref: llenergymeasure:tensorrt
 base_image_ref: llenergymeasure:tensorrt
-validated_at: '2026-05-06T20:35:47+02:00'
-validation_commit: 4ad6ee7b8e43c1282751a5b76ca936c6fe6982a3
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   outcome: error

--- a/src/llenergymeasure/engines/tensorrt/schema.discovered.json
+++ b/src/llenergymeasure/engines/tensorrt/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:tensorrt-0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-06T20:20:57+02:00",
+  "discovered_at": "2026-05-15T12:49:19+02:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/tensorrt/schema.discovered.json
+++ b/src/llenergymeasure/engines/tensorrt/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:tensorrt-0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T13:25:05+02:00",
+  "discovered_at": "2026-05-06T20:20:57+02:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: transformers
 engine_version: 4.57.3
-mined_at: '2026-05-14T20:31:21+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: transformers_beam_search_num_beams_eq_1
   engine: transformers

--- a/src/llenergymeasure/engines/transformers/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-14T20:31:21+02:00'
-validation_commit: 701d351fee655b8f399a5bc32ea923ba048df579
+validated_at: '2026-05-06T22:57:22+02:00'
+validation_commit: b9e7af630c351227389c263573263611402e4700
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/src/llenergymeasure/engines/transformers/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-06T22:57:22+02:00'
-validation_commit: b9e7af630c351227389c263573263611402e4700
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovered_at": "2026-05-15T12:49:19+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-14T20:31:21+02:00",
+  "discovered_at": "2026-05-06T22:57:22+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: vllm
 engine_version: 0.7.3
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   engine: vllm

--- a/src/llenergymeasure/engines/vllm/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: vllm
 engine_version: 0.7.3
 image_ref: llenergymeasure:vllm
 base_image_ref: llenergymeasure:vllm
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   outcome: dormant_silent

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T20:31:21+02:00",
+  "discovered_at": "2026-05-06T22:57:22+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovered_at": "2026-05-15T12:49:19+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {

--- a/tests/unit/engine_producers/test_current.py
+++ b/tests/unit/engine_producers/test_current.py
@@ -1,0 +1,161 @@
+"""Unit tests for ``scripts/engine_producers/_current.py``.
+
+Covers the lookup helpers used across the corpus pipeline:
+
+- :func:`current_path` / :func:`load_current` / :func:`safe_version` -
+  small helpers exercised end-to-end via the live ``engine_versions/`` tree.
+- :func:`current_outputs_dir` - the per-version archive path that
+  ``regen_engine_corpus.py`` (and future Move 3 callers) compose into the
+  SSOT-to-shadow sync. Exercised with monkeypatching so a synthetic
+  ``current.yaml`` can stand in for the real one.
+
+``safe_version`` already has fast unit coverage in
+``tests/_engine_archive/test_dispatcher.py``; the tests here cover the
+remaining helpers without duplicating that.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Make scripts/ importable for direct module access in tests.
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_producers import _current  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# current_path / load_current (sanity against the live tree)
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentPath:
+    def test_returns_absolute_path_under_engine_versions(self) -> None:
+        path = _current.current_path("vllm")
+        assert path.is_absolute()
+        assert path.name == "current.yaml"
+        assert path.parent.name == "vllm"
+        assert path.parent.parent.name == "engine_versions"
+
+    def test_live_current_yaml_exists_for_each_engine(self) -> None:
+        for engine in ("vllm", "tensorrt", "transformers"):
+            assert _current.current_path(engine).is_file()
+
+
+class TestLoadCurrent:
+    def test_loads_real_engine_current_yaml_to_dict(self) -> None:
+        data = _current.load_current("vllm")
+        assert isinstance(data, dict)
+        assert data["engine"] == "vllm"
+        assert isinstance(data["library"], dict)
+        assert data["library"]["pep503_name"] == "vllm"
+
+    def test_raises_on_missing_yaml(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Point ``current_path`` at a non-existent file to verify the error.
+        monkeypatch.setattr(_current, "current_path", lambda engine: tmp_path / "nope.yaml")
+        with pytest.raises(FileNotFoundError):
+            _current.load_current("vllm")
+
+    def test_raises_on_non_mapping_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bad = tmp_path / "current.yaml"
+        bad.write_text("- this\n- is\n- a\n- list\n")
+        monkeypatch.setattr(_current, "current_path", lambda engine: bad)
+        with pytest.raises(ValueError, match="did not parse to a mapping"):
+            _current.load_current("vllm")
+
+
+# ---------------------------------------------------------------------------
+# current_outputs_dir
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentOutputsDir:
+    def test_resolves_live_engine_to_engine_versions_outputs(self) -> None:
+        # Live tree: vllm pins 0.7.3 -> v0_7_3/outputs/.
+        path = _current.current_outputs_dir("vllm")
+        assert path.is_absolute()
+        assert path.name == "outputs"
+        assert path.parent.name.startswith("v")  # safe_version form
+        assert path.parent.parent.name == "vllm"
+        assert path.parent.parent.parent.name == "engine_versions"
+        # Sanity: the resolved version matches what ``load_current`` returns.
+        data = _current.load_current("vllm")
+        expected_safe = _current.safe_version(data["library"]["current_version"])
+        assert path.parent.name == expected_safe
+
+    def test_uses_safe_version_mangling(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Synthetic current.yaml at version 4.57.3 -> v4_57_3/outputs/.
+        synth = tmp_path / "current.yaml"
+        synth.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "engine": "transformers",
+                    "library": {
+                        "pep503_name": "transformers",
+                        "current_version": "4.57.3",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(_current, "current_path", lambda engine: synth)
+        path = _current.current_outputs_dir("transformers")
+        # ``_find_repo_root`` walks up from _current.py, not from the
+        # synthetic dir, so the returned path is rooted at the live repo;
+        # we assert the version-safe suffix shape only.
+        assert path.parts[-3:] == ("transformers", "v4_57_3", "outputs")
+
+    def test_raises_when_library_block_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        synth = tmp_path / "current.yaml"
+        synth.write_text(yaml.safe_dump({"schema_version": 1, "engine": "vllm"}))
+        monkeypatch.setattr(_current, "current_path", lambda engine: synth)
+        with pytest.raises(ValueError, match="missing required 'library' mapping"):
+            _current.current_outputs_dir("vllm")
+
+    def test_raises_when_current_version_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        synth = tmp_path / "current.yaml"
+        synth.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "engine": "vllm",
+                    "library": {"pep503_name": "vllm"},
+                }
+            )
+        )
+        monkeypatch.setattr(_current, "current_path", lambda engine: synth)
+        with pytest.raises(ValueError, match=r"missing 'library\.current_version'"):
+            _current.current_outputs_dir("vllm")
+
+    def test_raises_when_current_version_non_string(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # YAML happily parses bare numbers; the guard must reject them so
+        # ``safe_version`` never receives a non-string and accidentally
+        # produces ``v473`` for ``4.73``.
+        synth = tmp_path / "current.yaml"
+        synth.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "engine": "vllm",
+                    "library": {"pep503_name": "vllm", "current_version": 4.73},
+                }
+            )
+        )
+        monkeypatch.setattr(_current, "current_path", lambda engine: synth)
+        with pytest.raises(ValueError, match=r"missing 'library\.current_version'"):
+            _current.current_outputs_dir("vllm")

--- a/tests/unit/engine_producers/test_regen_engine_corpus.py
+++ b/tests/unit/engine_producers/test_regen_engine_corpus.py
@@ -1,0 +1,317 @@
+"""Unit tests for ``scripts/engine_producers/regen_engine_corpus.py``.
+
+The script copies per-version corpus artefacts from
+``engine_versions/<engine>/v<safe>/outputs/`` (SSOT) into
+``src/llenergymeasure/engines/<engine>/`` (data shadow the loader reads).
+Two modes:
+
+- ``--check``: exit 1 with a unified diff per drifted file. No writes.
+- ``--write`` (default): ``shutil.copy2`` each source onto its destination.
+
+Tests use ``tmp_path`` and monkeypatch the path-derivation helpers so the
+real ``engine_versions/`` and ``src/llenergymeasure/engines/`` trees stay
+untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable for direct module access in tests.
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_producers import regen_engine_corpus  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers: spin up a synthetic SSOT / shadow tree per test
+# ---------------------------------------------------------------------------
+
+
+_PROPOSED = "schema_version: 1.0.0\nengine: {engine}\ninvariants: []\n"
+_VALIDATED = "schema_version: 1.0.0\nengine: {engine}\ncases: []\n"
+_DISCOVERED = '{{"schema_version": "1.0.0", "engine": "{engine}"}}\n'
+
+
+def _write_outputs(outputs_dir: Path, engine: str) -> None:
+    """Populate ``outputs_dir`` with the three SSOT artefacts."""
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    (outputs_dir / "invariants.proposed.yaml").write_text(_PROPOSED.format(engine=engine))
+    (outputs_dir / "invariants.validated.yaml").write_text(_VALIDATED.format(engine=engine))
+    (outputs_dir / "schema.discovered.json").write_text(_DISCOVERED.format(engine=engine))
+
+
+def _install_engine(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    engines: tuple[str, ...] = ("vllm",),
+    populate_shadow: bool = False,
+) -> tuple[dict[str, Path], dict[str, Path]]:
+    """Wire monkeypatched per-engine paths and return ``(outputs, shadow)`` maps.
+
+    Each engine gets its own SSOT outputs directory (always populated) and a
+    shadow directory (populated only when ``populate_shadow`` is True).
+    """
+    outputs_map: dict[str, Path] = {}
+    shadow_map: dict[str, Path] = {}
+    for engine in engines:
+        outputs_map[engine] = tmp_path / "engine_versions" / engine / "v0_0_0" / "outputs"
+        shadow_map[engine] = tmp_path / "src" / "llenergymeasure" / "engines" / engine
+        _write_outputs(outputs_map[engine], engine)
+        if populate_shadow:
+            _write_outputs(shadow_map[engine], engine)
+
+    monkeypatch.setattr(
+        regen_engine_corpus, "current_outputs_dir", lambda engine: outputs_map[engine]
+    )
+    monkeypatch.setattr(regen_engine_corpus, "_shadow_dir", lambda engine: shadow_map[engine])
+    monkeypatch.setattr(regen_engine_corpus, "ENGINES", tuple(engines))
+    return outputs_map, shadow_map
+
+
+# ---------------------------------------------------------------------------
+# --check mode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMode:
+    def test_exits_zero_when_shadow_matches_ssot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_engine(tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=True)
+        rc = regen_engine_corpus.main(["--check"])
+        assert rc == 0
+
+    def test_exits_one_with_diff_on_drift(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _outputs, shadow = _install_engine(
+            tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=True
+        )
+        # Hand-edit the shadow to introduce drift in one file.
+        (shadow["vllm"] / "invariants.proposed.yaml").write_text(
+            "schema_version: 1.0.0\nengine: vllm\ninvariants: [DRIFTED]\n"
+        )
+        rc = regen_engine_corpus.main(["--check"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "vllm/invariants.proposed.yaml drift" in captured.err
+        assert "DRIFTED" in captured.err
+        # Resolution hint is present.
+        assert "regen_engine_corpus.py --write" in captured.err
+
+    def test_exits_one_when_shadow_missing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Shadow dir not populated -> every file shows as drift (dst missing).
+        _install_engine(tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False)
+        rc = regen_engine_corpus.main(["--check"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        # All three files surface as drift entries.
+        assert captured.err.count("vllm/") >= 3
+
+    def test_writes_nothing_in_check_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # populate_shadow=False -> shadow dir doesn't exist before --check.
+        _install_engine(tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False)
+        shadow_dir = tmp_path / "src" / "llenergymeasure" / "engines" / "vllm"
+        assert not shadow_dir.exists()
+        regen_engine_corpus.main(["--check"])
+        # --check must not have created the shadow dir.
+        assert not shadow_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# --write mode
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMode:
+    def test_default_mode_is_write(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No flag -> writes. Shadow starts empty; after main() it has all three.
+        _install_engine(tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False)
+        rc = regen_engine_corpus.main([])
+        assert rc == 0
+        shadow = tmp_path / "src" / "llenergymeasure" / "engines" / "vllm"
+        assert (shadow / "invariants.proposed.yaml").is_file()
+        assert (shadow / "invariants.validated.yaml").is_file()
+        assert (shadow / "schema.discovered.json").is_file()
+
+    def test_explicit_write_flag_works(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_engine(tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False)
+        rc = regen_engine_corpus.main(["--write"])
+        assert rc == 0
+        shadow = tmp_path / "src" / "llenergymeasure" / "engines" / "vllm"
+        assert (shadow / "invariants.proposed.yaml").read_text() == _PROPOSED.format(engine="vllm")
+
+    def test_write_overwrites_existing_shadow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _outputs, shadow = _install_engine(
+            tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=True
+        )
+        # Hand-edit the shadow; --write should restore the SSOT byte content.
+        (shadow["vllm"] / "invariants.proposed.yaml").write_text("DRIFTED")
+        rc = regen_engine_corpus.main(["--write"])
+        assert rc == 0
+        assert (shadow["vllm"] / "invariants.proposed.yaml").read_text() == _PROPOSED.format(
+            engine="vllm"
+        )
+
+    def test_write_creates_shadow_dir_if_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Shadow dir doesn't exist (e.g. a freshly-vendored engine).
+        _install_engine(tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False)
+        shadow = tmp_path / "src" / "llenergymeasure" / "engines" / "vllm"
+        assert not shadow.exists()
+        regen_engine_corpus.main(["--write"])
+        assert shadow.is_dir()
+
+    def test_write_preserves_mtime_via_copy2(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        outputs, _shadow = _install_engine(
+            tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False
+        )
+        # Set a known mtime on the SSOT file.
+        import os
+
+        target = outputs["vllm"] / "invariants.proposed.yaml"
+        target_mtime = 1_700_000_000  # arbitrary fixed epoch
+        os.utime(target, (target_mtime, target_mtime))
+        regen_engine_corpus.main(["--write"])
+        shadow_file = (
+            tmp_path / "src" / "llenergymeasure" / "engines" / "vllm" / "invariants.proposed.yaml"
+        )
+        # ``copy2`` preserves mtime to the second; allow 1s slop for FS rounding.
+        assert abs(shadow_file.stat().st_mtime - target_mtime) < 2
+
+
+# ---------------------------------------------------------------------------
+# Per-engine iteration
+# ---------------------------------------------------------------------------
+
+
+class TestPerEngineIteration:
+    def test_iterates_all_configured_engines(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Three engines, all populated -> --write fills all three shadow dirs.
+        _install_engine(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            engines=("vllm", "tensorrt", "transformers"),
+            populate_shadow=False,
+        )
+        rc = regen_engine_corpus.main(["--write"])
+        assert rc == 0
+        for engine in ("vllm", "tensorrt", "transformers"):
+            shadow = tmp_path / "src" / "llenergymeasure" / "engines" / engine
+            assert (shadow / "invariants.proposed.yaml").is_file()
+            assert (shadow / "invariants.validated.yaml").is_file()
+            assert (shadow / "schema.discovered.json").is_file()
+
+    def test_check_accumulates_drift_across_engines(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _outputs, shadow = _install_engine(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            engines=("vllm", "tensorrt"),
+            populate_shadow=True,
+        )
+        # Drift in two different engines surfaces both in the report.
+        (shadow["vllm"] / "invariants.proposed.yaml").write_text("DRIFTED-vllm")
+        (shadow["tensorrt"] / "schema.discovered.json").write_text('{"DRIFTED-tensorrt": true}')
+        rc = regen_engine_corpus.main(["--check"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "vllm/invariants.proposed.yaml drift" in captured.err
+        assert "tensorrt/schema.discovered.json drift" in captured.err
+
+    def test_first_engine_clean_still_reports_second_engine_drift(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Regression guard: --check must not short-circuit on the first clean
+        # engine; it must surface drift in any engine.
+        _outputs, shadow = _install_engine(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            engines=("vllm", "tensorrt", "transformers"),
+            populate_shadow=True,
+        )
+        (shadow["transformers"] / "invariants.validated.yaml").write_text("DRIFTED")
+        rc = regen_engine_corpus.main(["--check"])
+        assert rc == 1
+        assert "transformers/invariants.validated.yaml drift" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Error handling: missing source files
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSource:
+    def test_missing_source_file_raises_with_clear_message(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        outputs, _shadow = _install_engine(
+            tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False
+        )
+        # Delete one SSOT artefact to simulate a freshly-renovated current.yaml
+        # whose cells workflow hasn't populated outputs/ yet.
+        (outputs["vllm"] / "schema.discovered.json").unlink()
+        with pytest.raises(FileNotFoundError) as exc_info:
+            regen_engine_corpus.main(["--check"])
+        message = str(exc_info.value)
+        assert "vllm" in message
+        assert "schema.discovered.json" in message
+        assert "current.yaml" in message  # Resolution hint mentions cause.
+
+    def test_missing_source_in_write_mode_also_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        outputs, _shadow = _install_engine(
+            tmp_path=tmp_path, monkeypatch=monkeypatch, populate_shadow=False
+        )
+        (outputs["vllm"] / "invariants.proposed.yaml").unlink()
+        with pytest.raises(FileNotFoundError):
+            regen_engine_corpus.main(["--write"])
+
+
+# ---------------------------------------------------------------------------
+# CLI argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestCliFlags:
+    def test_check_and_write_mutually_exclusive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # argparse exits the process with code 2 on bad usage.
+        _install_engine(tmp_path=tmp_path, monkeypatch=monkeypatch)
+        with pytest.raises(SystemExit) as exc_info:
+            regen_engine_corpus.main(["--check", "--write"])
+        assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

- New `scripts/engine_producers/regen_engine_corpus.py` (~150 LoC) syncs the per-version engine corpus SSOT (`engine_versions/<engine>/v<safe>/outputs/*.{yaml,json}`) into the loader's shadow location (`src/llenergymeasure/engines/<engine>/`). Two modes: `--write` (default, `shutil.copy2` SSOT -> shadow) and `--check` (CI parity gate; exits 1 with unified diff per drifted file).
- Helper `current_outputs_dir()` added to `scripts/engine_producers/_current.py` (single source of truth for the per-engine current-version outputs path; reused by the sync script and by future codegen scripts).
- CI lint job (`.github/workflows/ci.yml`) gets `python scripts/engine_producers/regen_engine_corpus.py --check` step.
- Pre-commit hook entry `engine-corpus-shadow-parity` added to `.pre-commit-config.yaml`, gated on edits to the affected paths.
- Writeback bot (`engine-pipeline.yml`) provisions `uv` and runs `--write` after cells produce outputs/, and the writeback `git add` list is extended to include `engine_versions/*/*/outputs/*` paths (these were being uploaded as artefacts but never staged; the bot commit didn't actually contain them). Result: bot commit atomically includes BOTH SSOT and shadow with the SAME timestamps.

## Why

Today the writeback bot writes mined corpus to `src/<engine>/` directly; the per-version archive under `engine_versions/<engine>/v<safe>/outputs/` is only mirrored by the cells (separate code paths). Two locations, one truth: drifts silently. Vllm v_7_3 demonstrates this: the archive's envelope says `engine_version: 0.17.1` (historical safe-version bug) while src/ has the correct 0.7.3 content from a later mine.

This PR introduces a single mechanism (`regen_engine_corpus.py`) that keeps the shadow in sync with the SSOT via codegen + commit. Matches the SOTA pattern verified by `.product/research/pr657-bundling-strategy-2026-05-22.md` (tzdata, certifi, protobuf, charset-normalizer, unicodedata2 all use this pattern; none use build hooks).

## Drift on current main is expected

The `--check` job will FAIL on initial CI run. All 9 SSOT/shadow file pairs drift today:
- vllm v_7_3: substantive (envelope 0.17.1, ~1447 lines vs correct ~230 lines)
- transformers v4_57_3 + tensorrt v0_21_0: metadata-only (timestamps + `validation_commit` SHA differ by one cells cycle)

Resolution per the rework plan B5 (post-merge sequence):
1. After PR merges, trigger cells via `gh workflow run engine-pipeline.yml` per engine.
2. The new writeback bot commits BOTH locations atomically with the SAME timestamps.
3. After all 3 engines have run cells once post-merge: all 9 pairs in sync; `--check` passes.

DO NOT merge this PR until the resolution sequence above is staged. The check failure on this PR's CI is the gate working as designed against existing drift.

## Test plan

- [ ] 25 new unit tests pass (`tests/unit/engine_producers/test_regen_engine_corpus.py` + `test_current.py`)
- [ ] Full unit suite green
- [ ] `ruff format` + `ruff check` clean on changed files
- [ ] `regen_engine_corpus.py --check` correctly identifies all 9 drifted pairs on main (verified locally; expected to fail on this PR's CI)
- [ ] After merge + 3 cells triggers: `--check` passes