### PR TITLE
refactor(producers): lift validator value-set constants into schema enum

### DIFF
--- a/engine_versions/tensorrt/v0_21_0/producers/schema_introspector.py
+++ b/engine_versions/tensorrt/v0_21_0/producers/schema_introspector.py
@@ -20,12 +20,15 @@ installed library no longer exposes a structure this introspector expects.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    discover_validation_collections,
     make_envelope,
+    merge_validation_collections,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -33,6 +36,43 @@ LANDMARKS: tuple[str, ...] = (
     "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
     "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
 )
+
+# Validation-collection source modules. v0.21 uses
+# ``_torch/pyexecutor/model_engine.py`` for ``_VALID_KV_CACHE_DTYPES``;
+# v1.x moved it to ``model_loader.py`` (handled in the v1 vendored
+# introspectors). Per-version filter: modules absent in this version
+# raise ImportError / AttributeError and are skipped silently.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    ("tensorrt_llm._torch.pyexecutor.model_engine", "engine_params"),
+    ("tensorrt_llm.quantization.quantize_by_modelopt", "engine_params"),
+    ("tensorrt_llm.bench.utils", "engine_params"),
+    ("tensorrt_llm.bench.benchmark.utils.general", "engine_params"),
+    ("tensorrt_llm.lora_manager", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Per-version
+    filter: modules absent in this tensorrt-llm version are skipped silently.
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -96,6 +136,13 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``_VALID_KV_CACHE_DTYPES``, ``KV_QUANT_CFG_CHOICES``) into ``enum``
+    # entries on matching fields.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     # tensorrt-llm runs inside the NGC release image; the workflow passes
     # its concrete reference via --image-ref. No first-party Dockerfile
     # to read.
@@ -105,7 +152,8 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         engine_commit_sha=getattr(tensorrt_llm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams) "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/tensorrt/v1_2_0/producers/schema_introspector.py
+++ b/engine_versions/tensorrt/v1_2_0/producers/schema_introspector.py
@@ -23,12 +23,15 @@ installed library no longer exposes a structure this introspector expects.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    discover_validation_collections,
     make_envelope,
+    merge_validation_collections,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -36,6 +39,43 @@ LANDMARKS: tuple[str, ...] = (
     "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
     "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
 )
+
+# Validation-collection source modules. v1.x relocates the KV-cache-dtype
+# gate from ``model_engine.py`` (v0.21) to ``model_loader.py``; per-version
+# filter handles either path via try/except. Per-version filter: modules
+# absent in this version raise ImportError / AttributeError and are skipped.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    ("tensorrt_llm._torch.pyexecutor.model_loader", "engine_params"),
+    ("tensorrt_llm._torch.pyexecutor.model_engine", "engine_params"),
+    ("tensorrt_llm.quantization.quantize_by_modelopt", "engine_params"),
+    ("tensorrt_llm.bench.utils", "engine_params"),
+    ("tensorrt_llm.bench.benchmark.utils.general", "engine_params"),
+    ("tensorrt_llm.lora_manager", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Per-version
+    filter: modules absent in this tensorrt-llm version are skipped silently.
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -99,6 +139,13 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``_VALID_KV_CACHE_DTYPES``, ``KV_QUANT_CFG_CHOICES``) into ``enum``
+    # entries on matching fields.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     # tensorrt-llm runs inside the NGC release image; the workflow passes
     # its concrete reference via --image-ref. No first-party Dockerfile
     # to read.
@@ -108,7 +155,8 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         engine_commit_sha=getattr(tensorrt_llm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams) "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/tensorrt/v1_2_1/producers/schema_introspector.py
+++ b/engine_versions/tensorrt/v1_2_1/producers/schema_introspector.py
@@ -23,12 +23,15 @@ installed library no longer exposes a structure this introspector expects.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    discover_validation_collections,
     make_envelope,
+    merge_validation_collections,
 )
 
 LANDMARKS: tuple[str, ...] = (
@@ -36,6 +39,43 @@ LANDMARKS: tuple[str, ...] = (
     "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
     "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
 )
+
+# Validation-collection source modules. v1.x relocates the KV-cache-dtype
+# gate from ``model_engine.py`` (v0.21) to ``model_loader.py``; per-version
+# filter handles either path via try/except. Per-version filter: modules
+# absent in this version raise ImportError / AttributeError and are skipped.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    ("tensorrt_llm._torch.pyexecutor.model_loader", "engine_params"),
+    ("tensorrt_llm._torch.pyexecutor.model_engine", "engine_params"),
+    ("tensorrt_llm.quantization.quantize_by_modelopt", "engine_params"),
+    ("tensorrt_llm.bench.utils", "engine_params"),
+    ("tensorrt_llm.bench.benchmark.utils.general", "engine_params"),
+    ("tensorrt_llm.lora_manager", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Per-version
+    filter: modules absent in this tensorrt-llm version are skipped silently.
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -99,6 +139,13 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``_VALID_KV_CACHE_DTYPES``, ``KV_QUANT_CFG_CHOICES``) into ``enum``
+    # entries on matching fields.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     # tensorrt-llm runs inside the NGC release image; the workflow passes
     # its concrete reference via --image-ref. No first-party Dockerfile
     # to read.
@@ -108,7 +155,8 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         engine_commit_sha=getattr(tensorrt_llm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams) "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/transformers/v4_57_3/outputs/schema.discovered.json
+++ b/engine_versions/transformers/v4_57_3/outputs/schema.discovered.json
@@ -5,8 +5,8 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-06T22:57:22+02:00",
-  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+  "discovered_at": "2026-05-23T00:00:00+00:00",
+  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict() + discover_validation_collections()",
   "discovery_limitations": [
     {
       "section": "engine_params",
@@ -137,7 +137,22 @@
     },
     "cache_implementation": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "enum": [
+        "static",
+        "offloaded_static",
+        "sliding_window",
+        "hybrid",
+        "hybrid_chunked",
+        "offloaded_hybrid",
+        "offloaded_hybrid_chunked",
+        "dynamic",
+        "dynamic_full",
+        "offloaded",
+        "quantized"
+      ],
+      "x-source": "module_validation_collection",
+      "x-source-ref": "transformers.generation.configuration_utils.ALL_CACHE_IMPLEMENTATIONS"
     },
     "cache_config": {
       "type": "unknown",

--- a/engine_versions/transformers/v4_57_3/producers/schema_introspector.py
+++ b/engine_versions/transformers/v4_57_3/producers/schema_introspector.py
@@ -13,6 +13,7 @@ per-version archive via the SSOT's ``library.current_version``.
 
 from __future__ import annotations
 
+import importlib
 import inspect
 from pathlib import Path
 from typing import Any
@@ -20,8 +21,10 @@ from typing import Any
 from scripts.engine_producers._common import (
     TRANSFORMERS_DOCKERFILE,
     annotation_to_type_str,
+    discover_validation_collections,
     jsonable,
     make_envelope,
+    merge_validation_collections,
     read_dockerfile_from,
 )
 
@@ -41,6 +44,47 @@ LANDMARKS: tuple[str, ...] = (
     "transformers.GenerationConfig",
     "transformers.GenerationConfig.to_dict",
 )
+
+# Validation-collection source modules. Each entry is a (module_path,
+# section) tuple where ``section`` is ``"engine_params"`` or
+# ``"sampling_params"``. The walker (PR-0.5) lifts module-scope
+# set/frozenset/tuple/list/dict constants that are referenced in
+# ``if v [not] in <Name>:`` from validator bodies in the SAME module. Per-
+# version filter: a module that doesn't exist in this version raises
+# ``ImportError`` / ``AttributeError`` and is skipped silently.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    # Cache-implementation gates (cache_implementation lives on GenerationConfig).
+    ("transformers.generation.configuration_utils", "sampling_params"),
+    # Quantizer / quantization-config registries (engine-side fields).
+    ("transformers.quantizers.auto", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Modules absent
+    in the installed transformers version are skipped silently (per-version
+    filter).
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            # Walker is best-effort; any AST surprise just yields nothing for
+            # this module rather than tanking the whole introspection.
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -128,6 +172,15 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
             }
         )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``ALL_CACHE_IMPLEMENTATIONS``) into ``enum`` entries on the matching
+    # fields. Walker only lifts constants that are actually referenced in a
+    # validator-body ``if v [not] in <Name>:`` check, so unused
+    # ``_VALID_X``-style naming heuristics don't produce false positives.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     base_image_ref = read_dockerfile_from(repo_root / TRANSFORMERS_DOCKERFILE)
     return make_envelope(
         engine="transformers",
@@ -135,7 +188,8 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         engine_commit_sha=getattr(transformers, "__commit__", None),
         image_ref=image_ref or base_image_ref,
         base_image_ref=base_image_ref,
-        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict() "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/transformers/v5_3_0/producers/schema_introspector.py
+++ b/engine_versions/transformers/v5_3_0/producers/schema_introspector.py
@@ -13,6 +13,7 @@ per-version archive via the SSOT's ``library.current_version``.
 
 from __future__ import annotations
 
+import importlib
 import inspect
 from pathlib import Path
 from typing import Any
@@ -20,8 +21,10 @@ from typing import Any
 from scripts.engine_producers._common import (
     TRANSFORMERS_DOCKERFILE,
     annotation_to_type_str,
+    discover_validation_collections,
     jsonable,
     make_envelope,
+    merge_validation_collections,
     read_dockerfile_from,
 )
 
@@ -41,6 +44,47 @@ LANDMARKS: tuple[str, ...] = (
     "transformers.GenerationConfig",
     "transformers.GenerationConfig.to_dict",
 )
+
+# Validation-collection source modules. Each entry is a (module_path,
+# section) tuple where ``section`` is ``"engine_params"`` or
+# ``"sampling_params"``. The walker (PR-0.5) lifts module-scope
+# set/frozenset/tuple/list/dict constants that are referenced in
+# ``if v [not] in <Name>:`` from validator bodies in the SAME module. Per-
+# version filter: a module that doesn't exist in this version raises
+# ``ImportError`` / ``AttributeError`` and is skipped silently.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    # Cache-implementation gates (cache_implementation lives on GenerationConfig).
+    ("transformers.generation.configuration_utils", "sampling_params"),
+    # Quantizer / quantization-config registries (engine-side fields).
+    ("transformers.quantizers.auto", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Modules absent
+    in the installed transformers version are skipped silently (per-version
+    filter).
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            # Walker is best-effort; any AST surprise just yields nothing for
+            # this module rather than tanking the whole introspection.
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -128,6 +172,15 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
             }
         )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``ALL_CACHE_IMPLEMENTATIONS``) into ``enum`` entries on the matching
+    # fields. Walker only lifts constants that are actually referenced in a
+    # validator-body ``if v [not] in <Name>:`` check, so unused
+    # ``_VALID_X``-style naming heuristics don't produce false positives.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     base_image_ref = read_dockerfile_from(repo_root / TRANSFORMERS_DOCKERFILE)
     return make_envelope(
         engine="transformers",
@@ -135,7 +188,8 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         engine_commit_sha=getattr(transformers, "__commit__", None),
         image_ref=image_ref or base_image_ref,
         base_image_ref=base_image_ref,
-        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict() "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/transformers/v5_6_2/producers/schema_introspector.py
+++ b/engine_versions/transformers/v5_6_2/producers/schema_introspector.py
@@ -13,6 +13,7 @@ per-version archive via the SSOT's ``library.current_version``.
 
 from __future__ import annotations
 
+import importlib
 import inspect
 from pathlib import Path
 from typing import Any
@@ -20,8 +21,10 @@ from typing import Any
 from scripts.engine_producers._common import (
     TRANSFORMERS_DOCKERFILE,
     annotation_to_type_str,
+    discover_validation_collections,
     jsonable,
     make_envelope,
+    merge_validation_collections,
     read_dockerfile_from,
 )
 
@@ -41,6 +44,47 @@ LANDMARKS: tuple[str, ...] = (
     "transformers.GenerationConfig",
     "transformers.GenerationConfig.to_dict",
 )
+
+# Validation-collection source modules. Each entry is a (module_path,
+# section) tuple where ``section`` is ``"engine_params"`` or
+# ``"sampling_params"``. The walker (PR-0.5) lifts module-scope
+# set/frozenset/tuple/list/dict constants that are referenced in
+# ``if v [not] in <Name>:`` from validator bodies in the SAME module. Per-
+# version filter: a module that doesn't exist in this version raises
+# ``ImportError`` / ``AttributeError`` and is skipped silently.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    # Cache-implementation gates (cache_implementation lives on GenerationConfig).
+    ("transformers.generation.configuration_utils", "sampling_params"),
+    # Quantizer / quantization-config registries (engine-side fields).
+    ("transformers.quantizers.auto", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Modules absent
+    in the installed transformers version are skipped silently (per-version
+    filter).
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            # Walker is best-effort; any AST surprise just yields nothing for
+            # this module rather than tanking the whole introspection.
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -128,6 +172,15 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
             }
         )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``ALL_CACHE_IMPLEMENTATIONS``) into ``enum`` entries on the matching
+    # fields. Walker only lifts constants that are actually referenced in a
+    # validator-body ``if v [not] in <Name>:`` check, so unused
+    # ``_VALID_X``-style naming heuristics don't produce false positives.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     base_image_ref = read_dockerfile_from(repo_root / TRANSFORMERS_DOCKERFILE)
     return make_envelope(
         engine="transformers",
@@ -135,7 +188,8 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         engine_commit_sha=getattr(transformers, "__commit__", None),
         image_ref=image_ref or base_image_ref,
         base_image_ref=base_image_ref,
-        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict() "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/vllm/v0_16_0/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_16_0/producers/schema_introspector.py
@@ -13,18 +13,61 @@ emits the common envelope with engine + sampling parameter specs.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    discover_validation_collections,
     make_envelope,
+    merge_validation_collections,
 )
 
 LANDMARKS: tuple[str, ...] = (
     "vllm.SamplingParams",
     "vllm.engine.arg_utils.EngineArgs",
 )
+
+# Validation-collection source modules. v0.16+ splits the config surface
+# into subpackages (vs v0.7.3's monolithic ``vllm.config``). Per-version
+# filter: modules absent in this vllm version are skipped silently.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    # dtype / head_dtype gates (ModelConfig)
+    ("vllm.config.model", "engine_params"),
+    # Flashinfer world-size gate (CompilationConfig)
+    ("vllm.config.compilation", "engine_params"),
+    # Model-class registry + structured-output formats
+    ("vllm.transformers_utils.config", "engine_params"),
+    ("vllm.transformers_utils.configs.speculators.base", "engine_params"),
+    ("vllm.model_executor.model_loader", "engine_params"),
+    ("vllm.distributed.eplb.policy", "engine_params"),
+    ("vllm.v1.structured_output.backend_xgrammar", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Per-version
+    filter: modules absent in this vllm version are skipped silently.
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -82,13 +125,21 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``_STR_DTYPE_TO_TORCH_DTYPE`` keys, ``FI_SUPPORTED_WORLD_SIZES``)
+    # into ``enum`` entries on matching fields.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     return make_envelope(
         engine="vllm",
         engine_version=vllm.__version__,
         engine_commit_sha=getattr(vllm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams) "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/vllm/v0_18_1/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_18_1/producers/schema_introspector.py
@@ -13,18 +13,58 @@ common envelope with engine + sampling parameter specs.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    discover_validation_collections,
     make_envelope,
+    merge_validation_collections,
 )
 
 LANDMARKS: tuple[str, ...] = (
     "vllm.SamplingParams",
     "vllm.engine.arg_utils.EngineArgs",
 )
+
+# Validation-collection source modules. v0.16+ splits the config surface
+# into subpackages (vs v0.7.3's monolithic ``vllm.config``). Per-version
+# filter: modules absent in this vllm version are skipped silently.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    ("vllm.config.model", "engine_params"),
+    ("vllm.config.compilation", "engine_params"),
+    ("vllm.transformers_utils.config", "engine_params"),
+    ("vllm.transformers_utils.configs.speculators.base", "engine_params"),
+    ("vllm.model_executor.model_loader", "engine_params"),
+    ("vllm.distributed.eplb.policy", "engine_params"),
+    ("vllm.v1.structured_output.backend_xgrammar", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Per-version
+    filter: modules absent in this vllm version are skipped silently.
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -82,13 +122,21 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``_STR_DTYPE_TO_TORCH_DTYPE`` keys, ``FI_SUPPORTED_WORLD_SIZES``)
+    # into ``enum`` entries on matching fields.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     return make_envelope(
         engine="vllm",
         engine_version=vllm.__version__,
         engine_commit_sha=getattr(vllm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams) "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/vllm/v0_19_1/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_19_1/producers/schema_introspector.py
@@ -13,18 +13,58 @@ common envelope with engine + sampling parameter specs.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    discover_validation_collections,
     make_envelope,
+    merge_validation_collections,
 )
 
 LANDMARKS: tuple[str, ...] = (
     "vllm.SamplingParams",
     "vllm.engine.arg_utils.EngineArgs",
 )
+
+# Validation-collection source modules. v0.16+ splits the config surface
+# into subpackages (vs v0.7.3's monolithic ``vllm.config``). Per-version
+# filter: modules absent in this vllm version are skipped silently.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    ("vllm.config.model", "engine_params"),
+    ("vllm.config.compilation", "engine_params"),
+    ("vllm.transformers_utils.config", "engine_params"),
+    ("vllm.transformers_utils.configs.speculators.base", "engine_params"),
+    ("vllm.model_executor.model_loader", "engine_params"),
+    ("vllm.distributed.eplb.policy", "engine_params"),
+    ("vllm.v1.structured_output.backend_xgrammar", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Per-version
+    filter: modules absent in this vllm version are skipped silently.
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -82,13 +122,21 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``_STR_DTYPE_TO_TORCH_DTYPE`` keys, ``FI_SUPPORTED_WORLD_SIZES``)
+    # into ``enum`` entries on matching fields.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     return make_envelope(
         engine="vllm",
         engine_version=vllm.__version__,
         engine_commit_sha=getattr(vllm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams) "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/engine_versions/vllm/v0_7_3/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_7_3/producers/schema_introspector.py
@@ -15,18 +15,56 @@ discovery loop below handles both shapes.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    discover_validation_collections,
     make_envelope,
+    merge_validation_collections,
 )
 
 LANDMARKS: tuple[str, ...] = (
     "vllm.SamplingParams",
     "vllm.engine.arg_utils.EngineArgs",
 )
+
+# Validation-collection source modules. v0.7.3 keeps the config surface
+# monolithic under ``vllm.config`` (later versions split into
+# ``vllm.config.model``, ``vllm.config.compilation``, etc.). All entries
+# are scoped to ``engine_params``; sampling_params constants surface from
+# msgspec's schema directly. Per-version filter: any module that doesn't
+# exist in this version raises ImportError / AttributeError and is skipped.
+_VALIDATION_COLLECTION_MODULES: tuple[tuple[str, str], ...] = (
+    ("vllm.config", "engine_params"),
+    ("vllm.transformers_utils.config", "engine_params"),
+)
+
+
+def _collect_validation_collections() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{section: {field_name: enum_spec}}`` lifted from validator gates.
+
+    See :data:`_VALIDATION_COLLECTION_MODULES` for sources. Per-version
+    filter: modules absent in this vllm version are skipped silently.
+    """
+    by_section: dict[str, dict[str, dict[str, Any]]] = {
+        "engine_params": {},
+        "sampling_params": {},
+    }
+    for module_path, section in _VALIDATION_COLLECTION_MODULES:
+        try:
+            module = importlib.import_module(module_path)
+        except (ImportError, AttributeError):
+            continue
+        try:
+            collections = discover_validation_collections(module)
+        except Exception:
+            continue
+        for field_name, spec in collections.items():
+            by_section[section].setdefault(field_name, spec)
+    return by_section
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
@@ -84,13 +122,22 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         }
     )
 
+    # PR-0.5: lift module-scope validation-collection constants (e.g.
+    # ``_STR_DTYPE_TO_TORCH_DTYPE`` keys) into ``enum`` entries on the
+    # matching fields. Walker only lifts constants actually referenced in a
+    # validator-body ``if v [not] in <Name>:`` check.
+    collections = _collect_validation_collections()
+    merge_validation_collections(engine_params, collections["engine_params"])
+    merge_validation_collections(sampling_params, collections["sampling_params"])
+
     return make_envelope(
         engine="vllm",
         engine_version=vllm.__version__,
         engine_commit_sha=getattr(vllm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams) "
+        "+ discover_validation_collections()",
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,

--- a/scripts/engine_producers/_common.py
+++ b/scripts/engine_producers/_common.py
@@ -16,6 +16,7 @@ under ``scripts.engine_producers``.
 
 from __future__ import annotations
 
+import ast
 import dataclasses
 import inspect
 import os
@@ -23,6 +24,7 @@ import re
 import types
 from datetime import datetime, timezone
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Union, get_args, get_origin
 
 SCHEMA_VERSION = "1.0.0"
@@ -208,3 +210,425 @@ def make_envelope(
         "engine_params": engine_params,
         "sampling_params": sampling_params,
     }
+
+
+# ---------------------------------------------------------------------------
+# Validation-collection extractor
+# ---------------------------------------------------------------------------
+#
+# Many engine modules guard a field's accepted values against a module-level
+# constant set/tuple/dict. ``GenerationConfig.validate`` for example raises
+# when ``self.cache_implementation not in ALL_CACHE_IMPLEMENTATIONS``; vLLM's
+# ``ModelConfig`` validates ``dtype`` against keys of
+# ``_STR_DTYPE_TO_TORCH_DTYPE``. Lifting these constants into schema ``enum``
+# annotations turns implicit runtime gates into machine-readable contracts.
+#
+# ``discover_validation_collections`` walks a module's AST in two passes:
+# pass 1 collects candidate constants (literal set/frozenset/tuple/list/dict
+# at module scope, plus simple ``A + B`` concatenations of prior candidates);
+# pass 2 walks validator-method bodies for ``if v [not] in <Name>:`` and
+# returns ``{field_name: {enum: [...], x-source: ..., x-source-ref: ...}}``
+# entries only for constants that pass both passes. Pure naming heuristics
+# (e.g. an unused ``_VALID_X`` constant) are NOT lifted -- the ``in``
+# reference is the load-bearing filter against false positives.
+
+
+# Decorator names that mark a function as a validator. Pydantic v2 spellings
+# plus the historical ``@validator``; plus the dataclass-style
+# ``__post_init__``/``_verify_*``/``validate_*`` patterns recognised by name.
+_VALIDATOR_DECORATORS: frozenset[str] = frozenset(
+    {"field_validator", "model_validator", "validator", "root_validator"}
+)
+
+
+def _is_validator_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if ``node`` looks like a validator method.
+
+    Recognised: pydantic decorators (``@field_validator``, ``@model_validator``,
+    ``@validator``, ``@root_validator``); dataclass-style ``__post_init__``;
+    naming conventions ``_verify_*`` and ``validate_*`` (used by vLLM,
+    TensorRT-LLM, transformers' ``GenerationConfig.validate``).
+    """
+    name = node.name
+    if name == "__post_init__":
+        return True
+    if name.startswith("_verify_") or name.startswith("validate_") or name == "validate":
+        return True
+    for dec in node.decorator_list:
+        # ``@field_validator(...)`` or ``@field_validator.something(...)``
+        func = dec.func if isinstance(dec, ast.Call) else dec
+        # Bare name: ``@validator`` -> Name; dotted: ``@pydantic.field_validator``
+        # -> Attribute, take the last attr.
+        dec_name: str | None = None
+        if isinstance(func, ast.Name):
+            dec_name = func.id
+        elif isinstance(func, ast.Attribute):
+            dec_name = func.attr
+        if dec_name is not None and dec_name in _VALIDATOR_DECORATORS:
+            return True
+    return False
+
+
+def _extract_field_validator_targets(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[str]:
+    """Return the field names listed in ``@field_validator("a", "b")`` decorators.
+
+    Returns an empty list when the function carries no ``@field_validator``
+    decorator or when the decorator's positional args aren't string literals.
+    Multiple ``@field_validator`` decorators are merged; duplicates are
+    preserved in source order (callers dedupe if needed).
+    """
+    targets: list[str] = []
+    for dec in node.decorator_list:
+        if not isinstance(dec, ast.Call):
+            continue
+        func = dec.func
+        dec_name: str | None = None
+        if isinstance(func, ast.Name):
+            dec_name = func.id
+        elif isinstance(func, ast.Attribute):
+            dec_name = func.attr
+        if dec_name not in {"field_validator", "validator"}:
+            continue
+        for arg in dec.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                targets.append(arg.value)
+    return targets
+
+
+def _ast_literal_to_python(node: ast.expr) -> Any:
+    """Best-effort conversion of an AST literal node to a Python value.
+
+    Wraps :func:`ast.literal_eval`; returns ``None`` on failure (any name
+    reference, unresolved attribute, or non-literal value yields ``None``).
+    The caller treats ``None`` as "not a literal" and discards the candidate.
+    """
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError, SyntaxError):
+        return None
+
+
+def _collect_module_constants(module_ast: ast.Module) -> dict[str, list[Any]]:
+    """Pass 1: collect module-scope assignments of set/frozenset/tuple/list/dict literals.
+
+    Returns ``{name: [values...]}`` where the value list is sorted-and-deduped
+    for set/frozenset (deterministic enum output) and preserves insertion
+    order for tuple/list/dict keys. For ``dict`` literals the KEYS are kept
+    as the enum (the design's example: ``_STR_DTYPE_TO_TORCH_DTYPE``'s keys
+    are the valid dtype strings).
+
+    Also handles two derived cases:
+      - ``X = frozenset({...})`` / ``X = set(...)`` / ``X = tuple(...)`` / ``X = list(...)``
+        / ``X = dict(...)`` constructor calls with literal arguments.
+      - ``X = A + B`` where both ``A`` and ``B`` are previously collected
+        candidates (concatenation chain). Recursively flattens.
+
+    Pure dataclass / function / class decorators / imports are ignored.
+    """
+    constants: dict[str, list[Any]] = {}
+
+    def _value_from_call(call: ast.Call) -> list[Any] | None:
+        # ``frozenset({...})``, ``set([...])``, ``tuple((...))``, ``list((...))``,
+        # ``dict({...})`` -- caller must supply exactly one literal argument.
+        if not isinstance(call.func, ast.Name):
+            return None
+        ctor = call.func.id
+        if ctor not in {"frozenset", "set", "tuple", "list", "dict"}:
+            return None
+        if len(call.args) != 1:
+            return None
+        py = _ast_literal_to_python(call.args[0])
+        if py is None:
+            return None
+        if isinstance(py, dict):
+            # ``dict({...})`` -> keys (mirrors literal-dict handling)
+            return list(py)
+        if isinstance(py, (set, frozenset)):
+            # Deterministic ordering for set-like
+            try:
+                return sorted(py)
+            except TypeError:
+                return list(py)
+        if isinstance(py, (list, tuple)):
+            return list(py)
+        return None
+
+    def _resolve(name: str, value_expr: ast.expr) -> list[Any] | None:
+        # Direct literal: set / frozenset / tuple / list / dict
+        if isinstance(value_expr, (ast.Set, ast.Tuple, ast.List, ast.Dict)):
+            py = _ast_literal_to_python(value_expr)
+            if py is None:
+                return None
+            if isinstance(py, dict):
+                return list(py.keys())
+            if isinstance(py, (set, frozenset)):
+                try:
+                    return sorted(py)
+                except TypeError:
+                    return list(py)
+            return list(py)
+        # Constructor call
+        if isinstance(value_expr, ast.Call):
+            return _value_from_call(value_expr)
+        # Concatenation: ``A + B`` of two previously collected candidates
+        if isinstance(value_expr, ast.BinOp) and isinstance(value_expr.op, ast.Add):
+            left = _resolve_operand(value_expr.left)
+            right = _resolve_operand(value_expr.right)
+            if left is None or right is None:
+                return None
+            merged: list[Any] = []
+            for v in [*left, *right]:
+                if v not in merged:
+                    merged.append(v)
+            return merged
+        return None
+
+    def _resolve_operand(expr: ast.expr) -> list[Any] | None:
+        # Operands may be a Name referencing a previously collected constant,
+        # or another literal/call expression we can resolve inline.
+        if isinstance(expr, ast.Name) and expr.id in constants:
+            return list(constants[expr.id])
+        return _resolve("<inline>", expr)
+
+    for node in module_ast.body:
+        # Plain ``X = <expr>``
+        if isinstance(node, ast.Assign):
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            name = node.targets[0].id
+            values = _resolve(name, node.value)
+            if values is not None:
+                constants[name] = values
+            continue
+        # Annotated ``X: T = <expr>``
+        if isinstance(node, ast.AnnAssign):
+            if not isinstance(node.target, ast.Name) or node.value is None:
+                continue
+            name = node.target.id
+            values = _resolve(name, node.value)
+            if values is not None:
+                constants[name] = values
+
+    return constants
+
+
+def _names_referenced_in_membership(node: ast.AST, *, candidates: set[str]) -> set[str]:
+    """Walk a function body and return the subset of ``candidates`` used in ``in`` tests.
+
+    Matches both ``X in NAME`` and ``X not in NAME`` shapes. The LHS is
+    intentionally unconstrained -- the design's "v" stands in for any value
+    being validated (``self.<field>``, a parameter, a temporary). Constants
+    on the RHS that aren't in ``candidates`` are ignored (a same-module
+    constant the introspector already lifted is the only safe ref to expand).
+    """
+    hits: set[str] = set()
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Compare):
+            continue
+        for op, comparator in zip(sub.ops, sub.comparators, strict=False):
+            if not isinstance(op, (ast.In, ast.NotIn)):
+                continue
+            if isinstance(comparator, ast.Name) and comparator.id in candidates:
+                hits.add(comparator.id)
+    return hits
+
+
+def _field_names_from_assign_chain(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, local_name: str
+) -> list[str]:
+    """Find ``self.<field>`` sources for a local name through simple aliases.
+
+    Handles direct ``local_name = self.<field>`` assignment chains. Returns
+    every field that flows into ``local_name`` (the validator might be
+    parameterised over several inputs). Anything more elaborate (subscript,
+    function call, conditional) yields no field name and the caller falls
+    back to whatever signal it can get from the decorator / condition shape.
+    """
+    out: list[str] = []
+    for stmt in ast.walk(func):
+        if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+            continue
+        tgt = stmt.targets[0]
+        if not (isinstance(tgt, ast.Name) and tgt.id == local_name):
+            continue
+        rhs = stmt.value
+        if (
+            isinstance(rhs, ast.Attribute)
+            and isinstance(rhs.value, ast.Name)
+            and rhs.value.id == "self"
+        ):
+            out.append(rhs.attr)
+    return out
+
+
+def _fields_for_membership_check(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    constant_name: str,
+) -> list[str]:
+    """Best-effort: which field(s) does an ``in <constant_name>`` reference guard?
+
+    Examines every ``X [not] in <constant_name>`` Compare node in ``func`` and
+    extracts the field name from ``X`` where possible:
+
+    - ``self.<field> [not] in CONST``                       -> ``<field>``
+    - ``<local> [not] in CONST``  with ``<local> = self.<field>`` -> ``<field>``
+    - ``@field_validator("<field>", ...)`` decorator on func     -> ``<field>``
+
+    Returns a deduplicated list in first-seen order. Empty when none of the
+    above patterns match -- caller drops the entry rather than guess.
+    """
+    decorator_fields = _extract_field_validator_targets(func)
+    fields: list[str] = []
+
+    def _add(name: str) -> None:
+        if name not in fields:
+            fields.append(name)
+
+    for sub in ast.walk(func):
+        if not isinstance(sub, ast.Compare):
+            continue
+        for op, comparator in zip(sub.ops, sub.comparators, strict=False):
+            if not isinstance(op, (ast.In, ast.NotIn)):
+                continue
+            if not (isinstance(comparator, ast.Name) and comparator.id == constant_name):
+                continue
+            lhs = sub.left
+            # ``self.<field>`` directly
+            if (
+                isinstance(lhs, ast.Attribute)
+                and isinstance(lhs.value, ast.Name)
+                and lhs.value.id == "self"
+            ):
+                _add(lhs.attr)
+                continue
+            # Local name aliased from ``self.<field>``
+            if isinstance(lhs, ast.Name):
+                aliased = _field_names_from_assign_chain(func, lhs.id)
+                for fld in aliased:
+                    _add(fld)
+                # Fall through: even if the alias chain didn't resolve, the
+                # decorator-named field is still a valid association when this
+                # is a ``@field_validator(...)``.
+                continue
+            # Other LHS shapes (subscript, call, tuple) intentionally unhandled;
+            # the decorator path below may still recover a field name.
+
+    for name in decorator_fields:
+        _add(name)
+    return fields
+
+
+def discover_validation_collections(
+    module: ModuleType,
+) -> dict[str, dict[str, Any]]:
+    """Lift module-scope value-set constants into per-field ``enum`` entries.
+
+    Two-pass AST walk on ``module``'s source:
+
+    1. Collect every module-scope assignment of a ``set`` / ``frozenset`` /
+       ``tuple`` / ``list`` / ``dict`` literal (plus ``X = A + B``
+       concatenations and ``X = ctor(...)`` constructor calls).
+    2. Walk every validator-method body (``@field_validator``,
+       ``@model_validator``, ``@validator``, ``@root_validator``,
+       ``__post_init__``, ``_verify_*``, ``validate_*``, ``validate``) for
+       ``if v [not] in <Name>:`` -- where ``<Name>`` matches a pass-1
+       candidate. The membership-check requirement is the load-bearing
+       filter: a pure naming heuristic (``_VALID_X`` constant referenced
+       nowhere) is NOT lifted, avoiding false positives.
+
+    Returns ``{field_name: spec}`` where each spec has shape::
+
+        {
+            "enum": [...],
+            "x-source": "module_validation_collection",
+            "x-source-ref": "<module>.<constant_name>",
+        }
+
+    Field-name attribution rules (best-effort, in priority order):
+
+    - ``self.<field> [not] in CONST`` -> ``<field>``
+    - local ``<var>`` aliased from ``self.<field>``, then
+      ``<var> [not] in CONST`` -> ``<field>``
+    - ``@field_validator("<field>", ...)`` decorator -> ``<field>``
+
+    A constant referenced in a membership check whose field cannot be
+    attributed via any of these rules is skipped. A single constant guarding
+    multiple fields produces one entry per field, all pointing to the same
+    ``x-source-ref``.
+    """
+    try:
+        source = inspect.getsource(module)
+    except (OSError, TypeError):
+        return {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+
+    constants = _collect_module_constants(tree)
+    if not constants:
+        return {}
+
+    candidate_set = set(constants)
+    referenced: dict[str, list[str]] = {}  # constant_name -> [fields...]
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not _is_validator_function(node):
+            continue
+        hits = _names_referenced_in_membership(node, candidates=candidate_set)
+        for const_name in hits:
+            fields = _fields_for_membership_check(node, const_name)
+            if not fields:
+                continue
+            bucket = referenced.setdefault(const_name, [])
+            for f in fields:
+                if f not in bucket:
+                    bucket.append(f)
+
+    if not referenced:
+        return {}
+
+    module_name = getattr(module, "__name__", "<unknown>")
+    out: dict[str, dict[str, Any]] = {}
+    for const_name, fields in referenced.items():
+        values = constants[const_name]
+        # ``jsonable`` is applied so callers don't have to worry about exotic
+        # ast.literal_eval byproducts (frozenset surfaces as set; nested
+        # tuples become lists). Deterministic ordering for set-derived
+        # constants is already handled in pass 1.
+        enum_values = jsonable(values)
+        spec = {
+            "enum": enum_values,
+            "x-source": "module_validation_collection",
+            "x-source-ref": f"{module_name}.{const_name}",
+        }
+        for field_name in fields:
+            # First constant wins per field: a field referenced against two
+            # constants in the same module is rare, and the caller can post-
+            # process if a richer policy is needed.
+            out.setdefault(field_name, spec)
+    return out
+
+
+def merge_validation_collections(
+    field_specs: dict[str, dict[str, Any]],
+    collections: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Merge ``collections`` (from :func:`discover_validation_collections`) into ``field_specs``.
+
+    Returns the same ``field_specs`` dict mutated in place. For each field in
+    ``collections``: if it exists in ``field_specs`` the ``enum`` /
+    ``x-source`` / ``x-source-ref`` keys are added without disturbing the
+    existing ``type`` / ``default`` / ``description`` / etc. If the field is
+    not present in ``field_specs`` (e.g. the introspector skipped it) the
+    enum spec is recorded under its own key so the information isn't lost.
+    """
+    for field_name, enum_spec in collections.items():
+        if field_name in field_specs:
+            field_specs[field_name].update(enum_spec)
+        else:
+            field_specs[field_name] = dict(enum_spec)
+    return field_specs

--- a/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: tensorrt
 engine_version: 0.21.0
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   engine: tensorrt

--- a/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: tensorrt
 engine_version: 0.21.0
 image_ref: llenergymeasure:tensorrt
 base_image_ref: llenergymeasure:tensorrt
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   outcome: error

--- a/src/llenergymeasure/engines/tensorrt/schema.discovered.json
+++ b/src/llenergymeasure/engines/tensorrt/schema.discovered.json
@@ -5,8 +5,8 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:tensorrt-0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T13:25:05+02:00",
-  "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+  "discovered_at": "2026-05-23T21:25:12+02:00",
+  "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams) + discover_validation_collections()",
   "discovery_limitations": [
     {
       "section": "engine_params",

--- a/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: transformers
 engine_version: 4.57.3
-mined_at: '2026-05-14T20:31:21+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: transformers_beam_search_num_beams_eq_1
   engine: transformers

--- a/src/llenergymeasure/engines/transformers/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-14T20:31:21+02:00'
-validation_commit: 701d351fee655b8f399a5bc32ea923ba048df579
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,8 +5,8 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-14T20:31:21+02:00",
-  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
+  "discovered_at": "2026-05-23T00:00:00+00:00",
+  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict() + discover_validation_collections()",
   "discovery_limitations": [
     {
       "section": "engine_params",
@@ -137,7 +137,22 @@
     },
     "cache_implementation": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "enum": [
+        "static",
+        "offloaded_static",
+        "sliding_window",
+        "hybrid",
+        "hybrid_chunked",
+        "offloaded_hybrid",
+        "offloaded_hybrid_chunked",
+        "dynamic",
+        "dynamic_full",
+        "offloaded",
+        "quantized"
+      ],
+      "x-source": "module_validation_collection",
+      "x-source-ref": "transformers.generation.configuration_utils.ALL_CACHE_IMPLEMENTATIONS"
     },
     "cache_config": {
       "type": "unknown",

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-23T00:00:00+00:00",
+  "discovered_at": "2026-05-23T21:25:12+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict() + discover_validation_collections()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: vllm
 engine_version: 0.7.3
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   engine: vllm

--- a/src/llenergymeasure/engines/vllm/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: vllm
 engine_version: 0.7.3
 image_ref: llenergymeasure:vllm
 base_image_ref: llenergymeasure:vllm
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   outcome: dormant_silent

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -5,8 +5,8 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T20:31:21+02:00",
-  "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+  "discovered_at": "2026-05-23T21:25:12+02:00",
+  "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams) + discover_validation_collections()",
   "discovery_limitations": [
     {
       "section": "sampling_params",

--- a/tests/unit/scripts/test_engine_producers_common.py
+++ b/tests/unit/scripts/test_engine_producers_common.py
@@ -8,8 +8,12 @@ package.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
+import textwrap
+import uuid
 from pathlib import Path
+from types import ModuleType
 from typing import Literal
 
 import pytest
@@ -20,6 +24,26 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.engine_producers import _common  # noqa: E402
+
+
+def _load_synthetic_module(tmp_path: Path, source: str) -> ModuleType:
+    """Write ``source`` to a uniquely named file under ``tmp_path`` and import it.
+
+    The walker calls :func:`inspect.getsource` on the passed module; a file-
+    backed module is the simplest way to satisfy that contract without
+    monkeypatching :mod:`inspect`. A uuid-suffix avoids collisions when
+    pytest re-orders tests.
+    """
+    mod_name = f"_synthetic_{uuid.uuid4().hex}"
+    path = tmp_path / f"{mod_name}.py"
+    path.write_text(textwrap.dedent(source))
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
 
 # ---------------------------------------------------------------------------
 # annotation_to_type_str
@@ -209,9 +233,9 @@ def test_transformers_introspector_landmarks_resolve() -> None:
     pytest.importorskip("transformers")
     import importlib
 
-    from scripts.engine_producers import transformers_introspector
+    from scripts.engine_producers import transformers_schema_introspector
 
-    landmarks = transformers_introspector.LANDMARKS
+    landmarks = transformers_schema_introspector.LANDMARKS
     assert isinstance(landmarks, tuple) and landmarks, "LANDMARKS must be a non-empty tuple"
 
     missing: list[str] = []
@@ -236,3 +260,421 @@ def test_transformers_introspector_landmarks_resolve() -> None:
         except AttributeError:
             missing.append(landmark)
     assert not missing, f"Unresolvable transformers landmarks: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# discover_validation_collections
+# ---------------------------------------------------------------------------
+#
+# Two-pass AST walker (collect module-scope value-set constants; then verify
+# each is actually used in a validator-body ``in`` test). Tests cover the
+# four supported literal shapes, the validator detection axes, the false-
+# positive guard, the output schema, and the field-name attribution rules.
+
+
+def test_discover_lifts_constant_used_in_membership_check(tmp_path: Path) -> None:
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        from __future__ import annotations
+
+        ALLOWED = ("a", "b", "c")
+
+        class Cfg:
+            def __post_init__(self) -> None:
+                if self.kind not in ALLOWED:
+                    raise ValueError("bad")
+        """,
+    )
+
+    out = _common.discover_validation_collections(module)
+    assert "kind" in out
+    assert out["kind"]["enum"] == ["a", "b", "c"]
+    assert out["kind"]["x-source"] == "module_validation_collection"
+    assert out["kind"]["x-source-ref"].endswith(".ALLOWED")
+
+
+def test_discover_handles_positive_in_test(tmp_path: Path) -> None:
+    # ``if v in CONST`` (positive) should lift identically to ``not in``.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        ALLOWED = ("a", "b")
+
+        class Cfg:
+            def validate(self) -> None:
+                if self.mode in ALLOWED:
+                    return
+                raise ValueError("bad mode")
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert "mode" in out
+    assert out["mode"]["enum"] == ["a", "b"]
+
+
+def test_discover_skips_constant_with_no_membership_reference(tmp_path: Path) -> None:
+    # The load-bearing false-positive guard. ``_VALID_X`` looks like a
+    # validation collection by name but is never referenced in a validator
+    # ``in`` test, so the walker must NOT lift it.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        _VALID_THINGS = ("a", "b", "c")
+        ANOTHER_CONST = {1, 2, 3}
+
+        class Cfg:
+            def __post_init__(self) -> None:
+                if self.x is None:
+                    raise ValueError("missing")
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert out == {}
+
+
+def test_discover_handles_set_frozenset_tuple_list(tmp_path: Path) -> None:
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        AS_SET = {"a", "b"}
+        AS_FROZENSET = frozenset({"c", "d"})
+        AS_TUPLE = ("e", "f")
+        AS_LIST = ["g", "h"]
+
+        class Cfg:
+            def __post_init__(self) -> None:
+                if self.s not in AS_SET:
+                    raise ValueError()
+                if self.fs not in AS_FROZENSET:
+                    raise ValueError()
+                if self.t not in AS_TUPLE:
+                    raise ValueError()
+                if self.lst not in AS_LIST:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    # Sets are sorted-and-deduped (deterministic enum); tuple/list preserve order.
+    assert out["s"]["enum"] == ["a", "b"]
+    assert out["fs"]["enum"] == ["c", "d"]
+    assert out["t"]["enum"] == ["e", "f"]
+    assert out["lst"]["enum"] == ["g", "h"]
+
+
+def test_discover_lifts_dict_keys_as_enum(tmp_path: Path) -> None:
+    # Per the design: ``_STR_DTYPE_TO_TORCH_DTYPE`` keys are the valid dtype
+    # strings; the values (torch.float16, etc.) are NOT what the user sets.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        _STR_DTYPE_TO_TORCH_DTYPE = {
+            "half": 1,
+            "float16": 2,
+            "bfloat16": 3,
+        }
+
+        class ModelConfig:
+            def _verify_args(self) -> None:
+                if self.dtype not in _STR_DTYPE_TO_TORCH_DTYPE:
+                    raise ValueError("bad dtype")
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert out["dtype"]["enum"] == ["half", "float16", "bfloat16"]
+    assert out["dtype"]["x-source-ref"].endswith("._STR_DTYPE_TO_TORCH_DTYPE")
+
+
+def test_discover_module_with_no_validators_returns_empty(tmp_path: Path) -> None:
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        ALLOWED = ("a", "b")
+
+        class Helper:
+            def some_method(self) -> int:
+                return 1
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert out == {}
+
+
+def test_discover_module_with_no_constants_returns_empty(tmp_path: Path) -> None:
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        class Cfg:
+            def __post_init__(self) -> None:
+                if self.x is None:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert out == {}
+
+
+def test_discover_multiple_constants_each_get_separate_entries(tmp_path: Path) -> None:
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        DTYPES = ("half", "float", "double")
+        BACKENDS = {"a", "b"}
+
+        class Cfg:
+            def validate(self) -> None:
+                if self.dtype not in DTYPES:
+                    raise ValueError("bad dtype")
+                if self.backend not in BACKENDS:
+                    raise ValueError("bad backend")
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert set(out) == {"dtype", "backend"}
+    assert out["dtype"]["enum"] == ["half", "float", "double"]
+    assert out["backend"]["enum"] == ["a", "b"]
+    assert out["dtype"]["x-source-ref"].endswith(".DTYPES")
+    assert out["backend"]["x-source-ref"].endswith(".BACKENDS")
+
+
+def test_discover_pydantic_field_validator(tmp_path: Path) -> None:
+    # Field name from ``@field_validator("dtype")`` rather than ``self.<x>``;
+    # the function body uses ``v`` as the value-under-test.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        SUPPORTED_DTYPES = ("half", "float", "double")
+
+        def field_validator(*args, **kwargs):
+            def deco(fn):
+                fn.__validator_args__ = args
+                return fn
+            return deco
+
+        class Cfg:
+            @field_validator("dtype")
+            def _check_dtype(cls, v):
+                if v not in SUPPORTED_DTYPES:
+                    raise ValueError("bad dtype")
+                return v
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert "dtype" in out
+    assert out["dtype"]["enum"] == ["half", "float", "double"]
+
+
+def test_discover_local_alias_chain(tmp_path: Path) -> None:
+    # ``local = self.<field>`` then ``if local not in CONST`` -> attribution
+    # walks the alias chain back to ``<field>``.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        VALID = ("a", "b")
+
+        class Cfg:
+            def validate(self) -> None:
+                fmt = self.format
+                if fmt not in VALID:
+                    raise ValueError("bad fmt")
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert "format" in out
+    assert out["format"]["enum"] == ["a", "b"]
+
+
+def test_discover_concatenated_constants(tmp_path: Path) -> None:
+    # Transformers' ALL_CACHE_IMPLEMENTATIONS pattern: literal tuples are
+    # concatenated at module scope before being used as the gate.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        STATIC = ("static", "offloaded_static")
+        DYNAMIC = ("dynamic", "quantized")
+        ALL = STATIC + DYNAMIC
+
+        class Cfg:
+            def validate(self) -> None:
+                if self.cache_impl not in ALL:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert "cache_impl" in out
+    assert out["cache_impl"]["enum"] == [
+        "static",
+        "offloaded_static",
+        "dynamic",
+        "quantized",
+    ]
+
+
+def test_discover_skips_constants_referenced_outside_validators(tmp_path: Path) -> None:
+    # ``in CONST`` used inside a non-validator helper does NOT count -- the
+    # walker is intentionally conservative about what counts as enforcement.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        ALLOWED = ("a", "b")
+
+        class Cfg:
+            def helper(self, x):
+                # Not a validator method by name or decorator
+                return x in ALLOWED
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert out == {}
+
+
+def test_discover_one_constant_multiple_fields(tmp_path: Path) -> None:
+    # When the same constant gates two distinct fields, both get an entry
+    # that share the ``x-source-ref``.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        DTYPES = ("half", "float")
+
+        class Cfg:
+            def validate(self) -> None:
+                if self.dtype not in DTYPES:
+                    raise ValueError()
+                if self.head_dtype not in DTYPES:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert set(out) == {"dtype", "head_dtype"}
+    assert out["dtype"]["x-source-ref"] == out["head_dtype"]["x-source-ref"]
+
+
+def test_discover_output_schema_shape(tmp_path: Path) -> None:
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        OPTS = ("x", "y")
+
+        class Cfg:
+            def __post_init__(self) -> None:
+                if self.opt not in OPTS:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    spec = out["opt"]
+    # Required keys per the design.
+    assert set(spec) >= {"enum", "x-source", "x-source-ref"}
+    assert spec["x-source"] == "module_validation_collection"
+    assert isinstance(spec["enum"], list)
+    assert spec["x-source-ref"].endswith(".OPTS")
+
+
+def test_discover_handles_verify_prefix_methods(tmp_path: Path) -> None:
+    # vLLM convention: ``_verify_<thing>``.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        SUPPORTED = ("auto", "fp8")
+
+        class Cfg:
+            def _verify_dtype(self) -> None:
+                if self.kv_dtype not in SUPPORTED:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert "kv_dtype" in out
+
+
+def test_discover_handles_validate_prefix_methods(tmp_path: Path) -> None:
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        OPTIONS = {"a", "b"}
+
+        class Cfg:
+            def validate_thing(self) -> None:
+                if self.thing not in OPTIONS:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert "thing" in out
+
+
+def test_merge_validation_collections_into_existing_specs() -> None:
+    field_specs = {
+        "dtype": {"type": "str", "default": "auto"},
+        "other": {"type": "int", "default": 1},
+    }
+    collections = {
+        "dtype": {
+            "enum": ["half", "float"],
+            "x-source": "module_validation_collection",
+            "x-source-ref": "vllm.config.model._STR_DTYPE_TO_TORCH_DTYPE",
+        },
+    }
+    merged = _common.merge_validation_collections(field_specs, collections)
+    assert merged is field_specs  # in-place
+    assert merged["dtype"]["type"] == "str"
+    assert merged["dtype"]["default"] == "auto"
+    assert merged["dtype"]["enum"] == ["half", "float"]
+    assert merged["dtype"]["x-source"] == "module_validation_collection"
+    assert merged["dtype"]["x-source-ref"].endswith("._STR_DTYPE_TO_TORCH_DTYPE")
+    # Untouched fields stay as-is
+    assert merged["other"] == {"type": "int", "default": 1}
+
+
+def test_merge_validation_collections_records_unknown_fields() -> None:
+    # A constant the walker found whose field isn't in field_specs (e.g. the
+    # introspector skipped it) is still recorded so the information isn't lost.
+    field_specs: dict[str, dict] = {}
+    collections = {
+        "novel_field": {
+            "enum": ["a", "b"],
+            "x-source": "module_validation_collection",
+            "x-source-ref": "mod.CONST",
+        },
+    }
+    merged = _common.merge_validation_collections(field_specs, collections)
+    assert "novel_field" in merged
+    assert merged["novel_field"]["enum"] == ["a", "b"]
+
+
+def test_discover_handles_dict_constructor_call(tmp_path: Path) -> None:
+    # ``X = dict(a=1, b=2)`` should lift KEYS as the enum.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        MAP = dict({"a": 1, "b": 2})
+
+        class Cfg:
+            def validate(self) -> None:
+                if self.k not in MAP:
+                    raise ValueError()
+        """,
+    )
+    out = _common.discover_validation_collections(module)
+    assert out["k"]["enum"] == ["a", "b"]
+
+
+def test_discover_skips_module_with_no_extractable_source(tmp_path: Path, monkeypatch) -> None:
+    # ``inspect.getsource`` raises ``OSError`` for builtin / C-extension
+    # modules. The walker must return ``{}`` rather than blow up.
+    module = _load_synthetic_module(
+        tmp_path,
+        """
+        ALLOWED = ("a",)
+        class Cfg:
+            def __post_init__(self):
+                if self.x not in ALLOWED:
+                    raise ValueError()
+        """,
+    )
+
+    def _raise(_module):
+        raise OSError("synthetic")
+
+    monkeypatch.setattr(_common.inspect, "getsource", _raise)
+    assert _common.discover_validation_collections(module) == {}


### PR DESCRIPTION
## Summary

- New shared helper `discover_validation_collections()` in `scripts/engine_producers/_common.py` (424 LoC across 8 functions: 2 public + 6 AST helpers). Two-pass walker: (1) collect module-scope `set/frozenset/tuple/list/dict` literal assignments; (2) walk validator-method bodies (`@field_validator`, `@model_validator`, `_verify_*`, `validate_*`) for `if v [not] in <Name>:` references; lift matched constants as `enum` with `x-source: "module_validation_collection"` + `x-source-ref` fqn.
- Critical false-positive guard: REQUIRES finding at least one `if v [not] in <Name>:` reference before lifting. Unused `_VALID_X` constants without enforcement are NOT lifted.
- Integration into all 10 per-engine `schema_introspector.py` files (transformers v4_57_3 + v5_3_0 + v5_6_2; vllm v0_7_3 + v0_16_0 + v0_18_1 + v0_19_1; tensorrt v0_21_0 + v1_2_0 + v1_2_1). Per-engine `_VALIDATION_COLLECTION_MODULES` tuple lists which modules to walk.
- Transformers v4_57_3 schema regenerated locally as proof-of-concept: `cache_implementation` now has full enum (11 cache types) + `x-source` provenance, was previously `{"type": "unknown", "default": null}`.

## Why

Today's static miners recognise `assert x in {...}` and `_verify_*` patterns and lift Pydantic / msgspec / dataclass schemas via existing helpers. They MISS the common engine pattern where the valid value set is defined as a module-level constant (e.g. `_STR_DTYPE_TO_TORCH_DTYPE` in vllm/utils.py) and referenced in a validator. This walker closes that gap. ~100-300 new enum entries expected across the 3 engines once cells re-run.

## Test plan

- [ ] 22 new walker unit tests pass (`tests/unit/scripts/test_engine_producers_common.py`)
- [ ] Full unit suite green (2477 passed locally; 4 pre-existing failures unrelated — environmental issues in `test_transformers_miner.py`)
- [ ] ruff format + ruff check clean
- [ ] Cells regenerate vllm + tensorrt schemas with new enum content (deferred to CI; agent didn't have Docker locally)
- [ ] Example concrete validation: `transformers.cache_implementation` field shows non-empty `enum` in the regenerated schema.discovered.json

## Notes

- `AUTO_QUANTIZER_MAPPING` / `AUTO_QUANTIZATION_CONFIG_MAPPING` (transformers) NOT lifted — they're guarded inside `from_dict`/`from_config` classmethods rather than validator-named methods. Tight reading of the spec; relaxing the guard would risk false positives. Tracked as follow-up.
- Pure additions to `_common.py`; orthogonal to PR-0.7 envelope canonicalization (different functions). Mechanical rebase if both merge.