### PR TITLE
feat(results): wire extended metrics in the single-process path

### DIFF
--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -48,7 +48,7 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 | Field | Type | Description |
 |-------|------|-------------|
 | `measurement_methodology` | `"total" \| "steady_state" \| "windowed"` | What was measured: the full run, the steady-state window after warmup, or an explicit time window. |
-| `steady_state_window` | `tuple[float, float] \| None` | `(start_sec, end_sec)` relative to experiment start. `None` when `methodology="total"`. |
+| `steady_state_window` | `tuple[float, float] \| None` | `(start_sec, end_sec)` relative to inference start. The single-process path sets `(0.0, inference_time_sec)`. `None` only when no inference window was recorded. |
 
 ### Core metrics
 
@@ -92,7 +92,7 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 | Field | Type | Description |
 |-------|------|-------------|
 | `measurement_warnings` | `list[str]` | Quality warnings (e.g. short duration, thermal drift detected). |
-| `warmup_excluded_samples` | `int \| None` | Prompts excluded during warmup. `None` when `methodology="total"`. |
+| `warmup_excluded_samples` | `int \| None` | Warmup iterations run before the measurement window (from `warmup_result.iterations_completed`). `None` when no warmup result is available. |
 | `reproducibility_notes` | `str` | Fixed disclaimer about NVML measurement accuracy (+/- 5%). |
 | `thermal_throttle` | `ThermalThrottleInfo \| None` | GPU thermal and power throttle events during the run. |
 | `warmup_result` | `WarmupResult \| None` | Warmup convergence result (populated when CV convergence detection is enabled). |

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -51,7 +51,7 @@ The scientific record. One JSON file per experiment cell. Schema version `4.0`.
 | Field | Type | Description |
 |-------|------|-------------|
 | `measurement_methodology` | `"total"` &#124; `"steady_state"` &#124; `"windowed"` | Which slice of the run produced the headline metrics |
-| `warmup_excluded_samples` | int &#124; null | Prompts excluded during warmup; `null` when `methodology = "total"` |
+| `warmup_excluded_samples` | int &#124; null | Number of warmup iterations run before the measurement window (from `warmup_result.iterations_completed`); `null` when no warmup result is available |
 | `reproducibility_notes` | str | Free-text caveats (default mentions NVML accuracy +/-5 %, thermal drift) |
 
 ### Aggregate metrics
@@ -97,6 +97,55 @@ These are the run totals (post-warmup-exclusion when applicable).
 | `energy_per_device_j` | list[float] &#124; null | Per-GPU energy breakdown (length = `num_processes`) |
 
 For the methodology that motivates baseline subtraction, see [Methodology &gt; Baseline power](/explanation/methodology/methodology#baseline-power).
+
+### Extended efficiency metrics
+
+`extended_metrics` is a nested object with five always-present sub-objects
+(`memory`, `gpu_utilisation`, `batch`, `kv_cache`, `request_latency`) plus two
+scalars (`tpot_ms`, `token_efficiency_index`). Every leaf is `null` when it
+cannot be computed for the engine/run; the harness fills what each engine can
+provide. `latency_stats`, `steady_state_window`, and `warmup_excluded_samples`
+live at the top level of `result.json`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `extended_metrics.tpot_ms` | float &#124; null | Time per output token (ITL mean). Always `null` today - requires streaming inter-token capture, not yet wired for any engine. |
+| `extended_metrics.token_efficiency_index` | float &#124; null | Composite `throughput x tokens_per_joule x precision_factor`. |
+| `extended_metrics.memory.model_memory_utilisation` | float &#124; null | Model weights / total VRAM (0-1). |
+| `extended_metrics.memory.tokens_per_gb_vram` | float &#124; null | Output tokens per GB of peak VRAM. |
+| `extended_metrics.memory.kv_cache_mb` / `kv_cache_memory_ratio` | float &#124; null | KV-cache size and its share of peak memory (vLLM only, when exposed). |
+| `extended_metrics.gpu_utilisation.sm_utilisation_mean` | float &#124; null | Mean SM utilisation (0-100) over NVML samples. |
+| `extended_metrics.gpu_utilisation.memory_bandwidth_utilisation` | float &#124; null | Mean memory-controller activity (0-100). NVML proxy: percent of time a read/write was issued, **not** achieved bandwidth. |
+| `extended_metrics.batch.num_batches` / `effective_batch_size` / `batch_utilisation` / `padding_overhead` | int/float &#124; null | Static-batching efficiency. `null` for vLLM (continuous batching). |
+| `extended_metrics.kv_cache.*` | float/int &#124; null | Prefix-cache hit rate and block occupancy (vLLM only). |
+| `extended_metrics.request_latency.e2e_latency_{mean,median,p95,p99}_ms` | float &#124; null | Per-request end-to-end latency distribution. |
+| `latency_stats` | object &#124; null | TTFT/ITL statistics from streaming capture (vLLM only). |
+| `steady_state_window` | [float, float] &#124; null | `(0.0, inference_time_sec)` - the measured window relative to inference start. |
+
+#### Per-engine support matrix
+
+A check means the engine populates the field in the single-process path; a dash
+means it stays `null` for that engine.
+
+| Metric group | vLLM | transformers | tensorrt |
+|--------------|:----:|:------------:|:--------:|
+| `request_latency.*` (per-request E2E) | yes (from RequestOutput metrics) | yes (per-batch approximation) | dash (metrics usually absent in 0.21.0) |
+| `latency_stats` (TTFT/ITL) | yes | dash (non-streaming) | dash |
+| `kv_cache.*` | yes (best-effort) | dash | dash |
+| `gpu_utilisation.*` (SM + mem-bw) | yes | yes | yes |
+| `memory.*` ratios | yes | yes | yes |
+| `batch.*` (num_batches/padding/utilisation) | dash (continuous batching) | yes | `num_batches=1` only; padding/utilisation dash |
+| `tpot_ms` | dash | dash | dash |
+
+**transformers latency is approximated.** A non-streaming `generate()` only
+exposes per-batch wall time, so each prompt in a batch is attributed
+`batch_time / batch_size` (the `PER_REQUEST_BATCH` mode). This is an estimate,
+not a true per-request timestamp - treat transformers `request_latency` as
+batch-level granularity. vLLM `request_latency`/`latency_stats` come from real
+per-request arrival/first-token/finish timestamps.
+
+`tpot_ms` is `null` for every engine pending streaming inter-token-latency
+capture; it is intentionally not derived from totals.
 
 ### Sidecar reference
 

--- a/src/llenergymeasure/cli/_display.py
+++ b/src/llenergymeasure/cli/_display.py
@@ -61,10 +61,10 @@ def print_result_summary(result: ExperimentResult) -> None:
 
     if result.latency_stats is not None:
         ls = result.latency_stats
-        if hasattr(ls, "ttft_ms") and ls.ttft_ms is not None:
-            print(f"  Latency TTFT   {_sig3(ls.ttft_ms)} ms")
-        if hasattr(ls, "itl_ms") and ls.itl_ms is not None:
-            print(f"  Latency ITL    {_sig3(ls.itl_ms)} ms")
+        if ls.ttft_mean_ms is not None:
+            print(f"  Latency TTFT   {_sig3(ls.ttft_mean_ms)} ms")
+        if ls.itl_mean_ms is not None:
+            print(f"  Latency ITL    {_sig3(ls.itl_mean_ms)} ms")
     print()
 
     # --- Timing ---

--- a/src/llenergymeasure/device/power_thermal.py
+++ b/src/llenergymeasure/device/power_thermal.py
@@ -31,6 +31,10 @@ class PowerThermalSample:
     memory_total_mb: float | None = None
     temperature_c: float | None = None
     sm_utilisation: float | None = None
+    memory_bandwidth_utilisation: float | None = None
+    """Percent of time the memory controller was active during the sample
+    interval (NVML ``utilization.memory`` proxy). This is NOT true achieved
+    memory bandwidth - it is the fraction of time any read/write was issued."""
     thermal_throttle: bool = False
     throttle_reasons: int = 0
     gpu_index: int = 0
@@ -186,10 +190,11 @@ class PowerThermalSampler:
                             except pynvml.NVMLError:
                                 pass
 
-                            # Utilisation
+                            # Utilisation (SM + memory-controller activity proxy)
                             try:
                                 util = pynvml.nvmlDeviceGetUtilizationRates(handle)
                                 sample.sm_utilisation = float(util.gpu)
+                                sample.memory_bandwidth_utilisation = float(util.memory)
                             except pynvml.NVMLError:
                                 pass
 

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -152,7 +152,8 @@ class ExperimentResult(BaseModel):
     )
     warmup_excluded_samples: int | None = Field(
         default=None,
-        description="Number of prompts excluded during warmup. None when methodology=total.",
+        description="Warmup iterations run before the measurement window "
+        "(from WarmupResult.iterations_completed). None when no warmup result.",
     )
     reproducibility_notes: str = Field(
         default=(

--- a/src/llenergymeasure/domain/extended_metrics.py
+++ b/src/llenergymeasure/domain/extended_metrics.py
@@ -1,7 +1,10 @@
-"""Extended efficiency metrics computation.
+"""Extended efficiency metrics computation (pure math, Layer 0).
 
 Computes extended metrics from raw inference data. All metrics use graceful
 degradation - null values when data is unavailable, never errors.
+
+This module is pure: it depends only on ``domain.metrics`` and numpy, so it sits
+at the bottom of the architectural layering and can be called from the harness.
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ def compute_extended_metrics(
     itl_mean_ms: float | None = None,
     per_request_latencies_ms: list[float] | None = None,
     gpu_utilisation_samples: list[float] | None = None,
+    memory_bandwidth_samples: list[float] | None = None,
     memory_stats: dict[str, float] | None = None,
     batch_stats: dict[str, Any] | None = None,
     kv_cache_stats: dict[str, Any] | None = None,
@@ -47,6 +51,7 @@ def compute_extended_metrics(
         itl_mean_ms: Mean inter-token latency in ms (for TPOT).
         per_request_latencies_ms: Per-request E2E latencies in ms.
         gpu_utilisation_samples: GPU SM utilisation samples (0-100).
+        memory_bandwidth_samples: GPU memory-bandwidth utilisation samples (0-100).
         memory_stats: Dict with peak_mb, total_vram_mb, model_mb, kv_cache_mb.
         batch_stats: Dict with effective_batch_size, padding_overhead, num_batches.
         kv_cache_stats: Dict with hit_rate, blocks_used, blocks_total (vLLM).
@@ -73,7 +78,9 @@ def compute_extended_metrics(
     metrics.memory = _compute_memory_metrics(output_tokens, memory_stats)
 
     # GPU utilisation
-    metrics.gpu_utilisation = _compute_gpu_utilisation_metrics(gpu_utilisation_samples)
+    metrics.gpu_utilisation = _compute_gpu_utilisation_metrics(
+        gpu_utilisation_samples, memory_bandwidth_samples
+    )
 
     # Batch efficiency
     metrics.batch = _compute_batch_metrics(batch_stats)
@@ -121,15 +128,23 @@ def _compute_memory_metrics(
 
 def _compute_gpu_utilisation_metrics(
     samples: list[float] | None,
+    memory_bandwidth_samples: list[float] | None = None,
 ) -> GPUUtilisationMetrics:
-    """Compute GPU utilisation metrics from samples."""
+    """Compute GPU utilisation metrics from samples.
+
+    Args:
+        samples: SM utilisation samples (0-100), one per NVML poll tick.
+        memory_bandwidth_samples: Memory-bandwidth utilisation samples (0-100).
+            NVML proxy: percent of time the memory controller was active.
+    """
     gpu = GPUUtilisationMetrics()
 
-    if not samples:
-        return gpu
+    if samples:
+        gpu.sm_utilisation_mean = float(np.mean(samples))
+        gpu.sm_utilisation_samples = len(samples)
 
-    gpu.sm_utilisation_mean = float(np.mean(samples))
-    gpu.sm_utilisation_samples = len(samples)
+    if memory_bandwidth_samples:
+        gpu.memory_bandwidth_utilisation = float(np.mean(memory_bandwidth_samples))
 
     return gpu
 

--- a/src/llenergymeasure/engines/_helpers.py
+++ b/src/llenergymeasure/engines/_helpers.py
@@ -239,6 +239,44 @@ def compute_cv(values: list[float]) -> float:
     return float(np.std(values)) / mean
 
 
+# ---------------------------------------------------------------------------
+# Per-request metrics extraction (shared by vLLM and TRT-LLM RequestOutputs)
+# ---------------------------------------------------------------------------
+
+
+def extract_request_metrics(outputs: Any) -> tuple[list[float], list[float]]:
+    """Extract per-request E2E latency and TTFT (ms) from RequestOutputs.
+
+    vLLM and TRT-LLM both surface a ``RequestOutput.metrics`` namespace with
+    ``arrival_time`` / ``finished_time`` / ``first_token_time`` timestamps.
+
+    Best-effort: ``o.metrics`` may be None, and individual timestamp attrs may be
+    missing depending on the library version / config. Any sample that cannot be
+    fully computed is skipped (rather than producing a partial/garbage value).
+
+    Args:
+        outputs: Iterable of ``RequestOutput`` objects.
+
+    Returns:
+        Tuple of (per_request_latencies_ms, ttft_ms). Either list may be empty
+        when no request exposed usable timestamps.
+    """
+    latencies_ms: list[float] = []
+    ttft_ms: list[float] = []
+    for o in outputs:
+        metrics = getattr(o, "metrics", None)
+        if metrics is None:
+            continue
+        arrival = getattr(metrics, "arrival_time", None)
+        finished = getattr(metrics, "finished_time", None)
+        first_token = getattr(metrics, "first_token_time", None)
+        if arrival is not None and finished is not None:
+            latencies_ms.append((finished - arrival) * 1000.0)
+        if arrival is not None and first_token is not None:
+            ttft_ms.append((first_token - arrival) * 1000.0)
+    return latencies_ms, ttft_ms
+
+
 def cleanup_model(model_obj: Any, *, use_gc: bool = True) -> None:
     """Release a model object from GPU memory and clear CUDA cache.
 

--- a/src/llenergymeasure/engines/protocol.py
+++ b/src/llenergymeasure/engines/protocol.py
@@ -15,6 +15,11 @@ class InferenceOutput:
 
     Engine-specific data (e.g. vLLM RequestOutput objects) goes in extras.
     The harness uses these fields to assemble the full ExperimentResult.
+
+    The extended-metrics fields below are best-effort: an empty list or ``None``
+    means the engine could not provide that signal for this run (the harness
+    leaves the corresponding result field null). Engine-internal opaque objects
+    (model handles, RequestOutput lists) stay in ``extras``.
     """
 
     elapsed_time_sec: float
@@ -25,6 +30,23 @@ class InferenceOutput:
     batch_times: list[float] = field(default_factory=list)
     extras: dict[str, Any] = field(default_factory=dict)
     inference_time_sec: float = 0.0  # Set by harness after perf_counter brackets
+
+    # Extended-metrics capture (best-effort; empty/None = engine cannot provide)
+    per_request_latencies_ms: list[float] = field(default_factory=list)
+    """Per-request end-to-end latency in ms. Empty when the engine cannot
+    attribute timing per request (e.g. a single batched call)."""
+    ttft_ms: list[float] = field(default_factory=list)
+    """Per-request time-to-first-token in ms. Empty for non-streaming engines."""
+    itl_ms: list[float] = field(default_factory=list)
+    """Inter-token latency samples in ms. Empty for non-streaming engines."""
+    num_batches: int | None = None
+    """Number of static batches processed. None for continuous batching (vLLM)."""
+    padding_tokens: int | None = None
+    """Total padding tokens added across batches. None when not measurable
+    (continuous batching, or engines that do not pad)."""
+    kv_cache_stats: dict[str, Any] | None = None
+    """KV-cache stats dict (hit_rate/blocks_used/blocks_total/kv_cache_mb).
+    None for engines that do not expose a paged KV cache (Transformers/TRT-LLM)."""
 
     @property
     def total_tokens(self) -> int:

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.engines.protocol import InferenceOutput
+from llenergymeasure.engines.vllm.plugin import _extract_request_metrics
 from llenergymeasure.utils.exceptions import ConfigError, EngineError
 
 logger = logging.getLogger(__name__)
@@ -331,6 +332,10 @@ class TensorRTEngine:
         if self._build_metadata is not None:
             extras["build_metadata"] = self._build_metadata
 
+        # Defensive per-request metric capture - RequestOutput.metrics is usually
+        # absent in TRT-LLM 0.21.0, so these lists typically come back empty.
+        per_request_latencies_ms, ttft_ms = _extract_request_metrics(outputs)
+
         return InferenceOutput(
             elapsed_time_sec=elapsed,
             input_tokens=input_token_count,
@@ -339,6 +344,11 @@ class TensorRTEngine:
             model_memory_mb=0.0,  # Captured by harness before run_inference
             batch_times=[elapsed],
             extras=extras,
+            per_request_latencies_ms=per_request_latencies_ms,
+            ttft_ms=ttft_ms,
+            num_batches=1,  # Single batched generate() call
+            padding_tokens=None,  # Not measurable from TRT-LLM RequestOutputs
+            kv_cache_stats=None,  # TRT-LLM does not expose paged KV-cache stats here
         )
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -28,7 +28,6 @@ from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.engines.protocol import InferenceOutput
-from llenergymeasure.engines.vllm.plugin import _extract_request_metrics
 from llenergymeasure.utils.exceptions import ConfigError, EngineError
 
 logger = logging.getLogger(__name__)
@@ -334,7 +333,9 @@ class TensorRTEngine:
 
         # Defensive per-request metric capture - RequestOutput.metrics is usually
         # absent in TRT-LLM 0.21.0, so these lists typically come back empty.
-        per_request_latencies_ms, ttft_ms = _extract_request_metrics(outputs)
+        from llenergymeasure.engines._helpers import extract_request_metrics
+
+        per_request_latencies_ms, ttft_ms = extract_request_metrics(outputs)
 
         return InferenceOutput(
             elapsed_time_sec=elapsed,

--- a/src/llenergymeasure/engines/transformers/plugin.py
+++ b/src/llenergymeasure/engines/transformers/plugin.py
@@ -182,7 +182,13 @@ class TransformersEngine:
         total_input_tokens = 0
         total_output_tokens = 0
         total_time_sec = 0.0
+        total_padding_tokens = 0
         batch_times: list[float] = []
+        # PER_REQUEST_BATCH approximation (see LatencyMeasurementMode.PER_REQUEST_BATCH):
+        # non-streaming generate() gives only per-batch wall time, so each prompt in a
+        # batch is attributed batch_time / len(batch). This is an approximation, NOT a
+        # true per-request timestamp.
+        per_request_latencies_ms: list[float] = []
 
         logger.info(
             "Starting measurement: %d prompts, batch_size=%d, max_new_tokens=%s",
@@ -194,13 +200,16 @@ class TransformersEngine:
         for batch_start in range(0, len(prompts), batch_size):
             batch = prompts[batch_start : batch_start + batch_size]
             try:
-                batch_input, batch_output, batch_time = self._run_batch(
+                batch_input, batch_output, batch_time, batch_padding = self._run_batch(
                     hf_model, tokenizer, config, batch, generate_kwargs
                 )
                 total_input_tokens += batch_input
                 total_output_tokens += batch_output
                 total_time_sec += batch_time
+                total_padding_tokens += batch_padding
                 batch_times.append(batch_time)
+                per_request_ms = (batch_time * 1000.0) / len(batch)
+                per_request_latencies_ms.extend([per_request_ms] * len(batch))
 
                 logger.debug(
                     "Batch %d-%d: in=%d out=%d tokens in %.2fs",
@@ -245,6 +254,13 @@ class TransformersEngine:
                 # GenerationConfig state post-window without recomputing.
                 "generate_kwargs": generate_kwargs,
             },
+            # PER_REQUEST_BATCH approximation - each request gets batch_time/len(batch).
+            per_request_latencies_ms=per_request_latencies_ms,
+            ttft_ms=[],  # Non-streaming - no time-to-first-token
+            itl_ms=[],  # Non-streaming - no inter-token latency
+            num_batches=len(batch_times),
+            padding_tokens=total_padding_tokens,
+            kv_cache_stats=None,  # Transformers has no paged KV cache
         )
 
     # -------------------------------------------------------------------------
@@ -502,8 +518,13 @@ class TransformersEngine:
         config: ExperimentConfig,
         batch: list[str],
         generate_kwargs: dict[str, Any],
-    ) -> tuple[int, int, float]:
-        """Run a single batch through model.generate() and return (input_tokens, output_tokens, time_sec)."""
+    ) -> tuple[int, int, float, int]:
+        """Run a single batch through model.generate().
+
+        Returns (input_tokens, output_tokens, time_sec, padding_tokens) where
+        padding_tokens = total padded positions in the input
+        (``input_ids.numel() - attention_mask.sum()``).
+        """
         import time
 
         import torch
@@ -519,6 +540,8 @@ class TransformersEngine:
         inputs = tokenizer(batch, **tokenizer_kwargs)
         inputs = {k: v.to(model.device) for k, v in inputs.items()}
         input_token_count = int(inputs["attention_mask"].sum().item())
+        # Padding tokens: total tensor positions minus real (attended) tokens.
+        padding_tokens = int(inputs["input_ids"].numel()) - input_token_count
 
         # Determine autocast settings
         from contextlib import nullcontext
@@ -545,7 +568,7 @@ class TransformersEngine:
         output_token_count = int(
             sum(max(0, outputs.shape[1] - int(inp_len.item())) for inp_len in input_lengths)
         )
-        return input_token_count, output_token_count, elapsed
+        return input_token_count, output_token_count, elapsed, padding_tokens
 
     def _build_generate_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
         """Build generation kwargs from TransformersSamplingConfig and TransformersConfig.

--- a/src/llenergymeasure/engines/vllm/plugin.py
+++ b/src/llenergymeasure/engines/vllm/plugin.py
@@ -26,6 +26,100 @@ from llenergymeasure.utils.exceptions import EngineError
 logger = logging.getLogger(__name__)
 
 
+def _extract_request_metrics(outputs: Any) -> tuple[list[float], list[float]]:
+    """Extract per-request E2E latency and TTFT (ms) from vLLM RequestOutputs.
+
+    Best-effort: ``o.metrics`` may be None, and individual timestamp attrs may be
+    missing depending on the vLLM version / config. Any sample that cannot be
+    fully computed is skipped (rather than producing a partial/garbage value).
+
+    Args:
+        outputs: Iterable of vLLM ``RequestOutput`` objects.
+
+    Returns:
+        Tuple of (per_request_latencies_ms, ttft_ms). Either list may be empty
+        when no request exposed usable timestamps.
+    """
+    latencies_ms: list[float] = []
+    ttft_ms: list[float] = []
+    for o in outputs:
+        metrics = getattr(o, "metrics", None)
+        if metrics is None:
+            continue
+        arrival = getattr(metrics, "arrival_time", None)
+        finished = getattr(metrics, "finished_time", None)
+        first_token = getattr(metrics, "first_token_time", None)
+        if arrival is not None and finished is not None:
+            latencies_ms.append((finished - arrival) * 1000.0)
+        if arrival is not None and first_token is not None:
+            ttft_ms.append((first_token - arrival) * 1000.0)
+    return latencies_ms, ttft_ms
+
+
+def _capture_kv_cache_stats(llm: Any) -> dict[str, Any] | None:
+    """Capture KV-cache stats from a vLLM (V0-era) LLM engine, best-effort.
+
+    Reads:
+      - ``blocks_total`` from ``cache_config.num_gpu_blocks`` (reliable in 0.7.3).
+      - ``usage`` / ``hit_rate`` from the V0 Stats surface
+        (``gpu_cache_usage_sys`` / ``gpu_prefix_cache_hit_rate``) via the engine's
+        stat loggers, each guarded independently.
+      - ``kv_cache_mb`` derived from ``usage * num_gpu_blocks * block_size_bytes``
+        when block size is cheaply exposed; omitted otherwise.
+
+    Any unreadable value is left out of the dict. Returns None only when nothing
+    at all could be read.
+    """
+    stats: dict[str, Any] = {}
+
+    engine = getattr(llm, "llm_engine", None)
+    if engine is None:
+        return None
+
+    cache_config = getattr(engine, "cache_config", None)
+    num_gpu_blocks: int | None = None
+    block_size: int | None = None
+    if cache_config is not None:
+        num_gpu_blocks = getattr(cache_config, "num_gpu_blocks", None)
+        if isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0:
+            stats["blocks_total"] = num_gpu_blocks
+        bs = getattr(cache_config, "block_size", None)
+        if isinstance(bs, int) and bs > 0:
+            block_size = bs
+
+    # V0 Stats surface via stat loggers: gpu_cache_usage_sys, gpu_prefix_cache_hit_rate.
+    usage: float | None = None
+    try:
+        stat_loggers = getattr(engine, "stat_loggers", None)
+        if stat_loggers:
+            for logger_obj in stat_loggers.values():
+                last = getattr(logger_obj, "last_local_log", None)
+                if last is None:
+                    continue
+                u = getattr(last, "gpu_cache_usage_sys", None)
+                if u is not None and usage is None:
+                    usage = float(u)
+                    stats["usage"] = usage
+                hr = getattr(last, "gpu_prefix_cache_hit_rate", None)
+                if hr is not None and "hit_rate" not in stats:
+                    stats["hit_rate"] = float(hr)
+    except Exception as exc:  # pragma: no cover - best-effort capture
+        logger.debug("vLLM KV-cache stats capture failed: %s", exc)
+
+    # Derive blocks_used and kv_cache_mb when both usage and block geometry known.
+    if usage is not None and num_gpu_blocks is not None and num_gpu_blocks > 0:
+        stats["blocks_used"] = round(usage * num_gpu_blocks)
+        if block_size is not None:
+            # block size in bytes is not directly exposed; only derive kv_cache_mb
+            # when cache_config carries a precomputed per-block byte size.
+            block_bytes = getattr(cache_config, "block_size_bytes", None)
+            if isinstance(block_bytes, int) and block_bytes > 0:
+                kv_bytes = usage * num_gpu_blocks * block_bytes
+                stats["kv_cache_mb"] = kv_bytes / (1024 * 1024)
+
+    return stats or None
+
+
 class VLLMEngine:
     """vLLM inference engine - offline batch mode, thin plugin.
 
@@ -255,6 +349,10 @@ class VLLMEngine:
         if hf_model is not None:
             extras["hf_model"] = hf_model
 
+        # Best-effort extended-metrics capture (continuous batching: no static batches).
+        per_request_latencies_ms, ttft_ms = _extract_request_metrics(outputs)
+        kv_cache_stats = _capture_kv_cache_stats(llm)
+
         return InferenceOutput(
             elapsed_time_sec=elapsed,
             input_tokens=input_token_count,
@@ -263,6 +361,11 @@ class VLLMEngine:
             model_memory_mb=0.0,  # Captured by harness before run_inference
             batch_times=[elapsed],
             extras=extras,
+            per_request_latencies_ms=per_request_latencies_ms,
+            ttft_ms=ttft_ms,
+            num_batches=None,  # Continuous batching - no static batch count
+            padding_tokens=None,  # Continuous batching - no padding
+            kv_cache_stats=kv_cache_stats,
         )
 
     # -------------------------------------------------------------------------

--- a/src/llenergymeasure/engines/vllm/plugin.py
+++ b/src/llenergymeasure/engines/vllm/plugin.py
@@ -26,36 +26,6 @@ from llenergymeasure.utils.exceptions import EngineError
 logger = logging.getLogger(__name__)
 
 
-def _extract_request_metrics(outputs: Any) -> tuple[list[float], list[float]]:
-    """Extract per-request E2E latency and TTFT (ms) from vLLM RequestOutputs.
-
-    Best-effort: ``o.metrics`` may be None, and individual timestamp attrs may be
-    missing depending on the vLLM version / config. Any sample that cannot be
-    fully computed is skipped (rather than producing a partial/garbage value).
-
-    Args:
-        outputs: Iterable of vLLM ``RequestOutput`` objects.
-
-    Returns:
-        Tuple of (per_request_latencies_ms, ttft_ms). Either list may be empty
-        when no request exposed usable timestamps.
-    """
-    latencies_ms: list[float] = []
-    ttft_ms: list[float] = []
-    for o in outputs:
-        metrics = getattr(o, "metrics", None)
-        if metrics is None:
-            continue
-        arrival = getattr(metrics, "arrival_time", None)
-        finished = getattr(metrics, "finished_time", None)
-        first_token = getattr(metrics, "first_token_time", None)
-        if arrival is not None and finished is not None:
-            latencies_ms.append((finished - arrival) * 1000.0)
-        if arrival is not None and first_token is not None:
-            ttft_ms.append((first_token - arrival) * 1000.0)
-    return latencies_ms, ttft_ms
-
-
 def _capture_kv_cache_stats(llm: Any) -> dict[str, Any] | None:
     """Capture KV-cache stats from a vLLM (V0-era) LLM engine, best-effort.
 
@@ -350,7 +320,9 @@ class VLLMEngine:
             extras["hf_model"] = hf_model
 
         # Best-effort extended-metrics capture (continuous batching: no static batches).
-        per_request_latencies_ms, ttft_ms = _extract_request_metrics(outputs)
+        from llenergymeasure.engines._helpers import extract_request_metrics
+
+        per_request_latencies_ms, ttft_ms = extract_request_metrics(outputs)
         kv_cache_stats = _capture_kv_cache_stats(llm)
 
         return InferenceOutput(

--- a/src/llenergymeasure/harness/__init__.py
+++ b/src/llenergymeasure/harness/__init__.py
@@ -540,8 +540,10 @@ class MeasurementHarness:
             baseline=baseline,
             flops_result=flops_result,
             timeseries_path=timeseries_path,
+            timeseries_samples=timeseries_samples,
             measurement_warnings=measurement_warnings,
             warmup_result=warmup_result,
+            prompt_count=len(prompts),
         )
         _substep("save", "result assembled")
 
@@ -707,6 +709,20 @@ class MeasurementHarness:
             nvml_sample_count=nvml_count,
         )
 
+    @staticmethod
+    def _configured_batch_size(engine_name: str, config: ExperimentConfig) -> int | None:
+        """Return the configured static batch size for the engine, or None.
+
+        transformers -> config.transformers.batch_size
+        tensorrt     -> config.tensorrt.max_batch_size (its analogous field)
+        anything else (incl. vllm continuous batching) -> None
+        """
+        if engine_name == "transformers" and config.transformers is not None:
+            return config.transformers.batch_size
+        if engine_name == "tensorrt" and config.tensorrt is not None:
+            return config.tensorrt.max_batch_size
+        return None
+
     def _build_result(
         self,
         engine_name: str,
@@ -725,6 +741,8 @@ class MeasurementHarness:
         timeseries_path: str | None,
         measurement_warnings: list[str],
         warmup_result: Any = None,
+        timeseries_samples: list[PowerThermalSample] | None = None,
+        prompt_count: int = 0,
     ) -> ExperimentResult:
         """Assemble ExperimentResult from measurement data.
 
@@ -748,14 +766,17 @@ class MeasurementHarness:
             timeseries_path: Relative path to Parquet sidecar, or None.
             measurement_warnings: List of quality warning strings.
             warmup_result: WarmupResult from warmup phase, or None.
+            timeseries_samples: Raw PowerThermalSample list for GPU-utilisation /
+                memory-bandwidth / total-VRAM extraction. None = no samples.
+            prompt_count: Number of prompts in the run (for batch effective size).
 
         Returns:
             Fully assembled ExperimentResult.
         """
+        from llenergymeasure.domain.extended_metrics import compute_extended_metrics
         from llenergymeasure.domain.metrics import (
-            ExtendedEfficiencyMetrics,
-            MemoryEfficiencyMetrics,
             MultiGPUMetrics,
+            compute_latency_statistics,
         )
         from llenergymeasure.harness.baseline import create_energy_breakdown
 
@@ -838,12 +859,79 @@ class MeasurementHarness:
             output.peak_memory_mb,
             inference_memory_mb,
         )
-        extended_metrics = ExtendedEfficiencyMetrics(
-            memory=MemoryEfficiencyMetrics(
-                model_memory_mb=model_memory_mb,
-                peak_memory_mb=output.peak_memory_mb,
-                inference_memory_mb=inference_memory_mb,
-            )
+
+        # --- Extended efficiency metrics ---
+        samples = timeseries_samples or []
+        gpu_utilisation_samples = [
+            s.sm_utilisation for s in samples if s.sm_utilisation is not None
+        ]
+        memory_bandwidth_samples = [
+            s.memory_bandwidth_utilisation
+            for s in samples
+            if s.memory_bandwidth_utilisation is not None
+        ]
+        total_vram_mb = max(
+            (s.memory_total_mb for s in samples if s.memory_total_mb is not None),
+            default=0.0,
+        )
+
+        kv_cache_stats = output.kv_cache_stats
+        kv_cache_mb = kv_cache_stats.get("kv_cache_mb") if kv_cache_stats else None
+        memory_stats: dict[str, float] = {
+            "peak_mb": output.peak_memory_mb,
+            "model_mb": model_memory_mb,
+            "total_vram_mb": total_vram_mb,
+        }
+        if kv_cache_mb is not None:
+            memory_stats["kv_cache_mb"] = kv_cache_mb
+
+        # Batch stats: None for vLLM (continuous batching). Static-batching engines
+        # report num_batches + padding; effective batch size derives from prompt count.
+        batch_stats: dict[str, Any] | None = None
+        if engine_name != "vllm" and output.num_batches:
+            configured_batch_size = self._configured_batch_size(engine_name, config)
+            effective_batch_size: float | None = None
+            if output.num_batches > 0:
+                effective_batch_size = prompt_count / output.num_batches
+            padding_overhead: float | None = None
+            if output.padding_tokens is not None and output.input_tokens > 0:
+                total_positions = output.input_tokens + output.padding_tokens
+                if total_positions > 0:
+                    padding_overhead = output.padding_tokens / total_positions
+            batch_stats = {
+                "num_batches": output.num_batches,
+                "effective_batch_size": effective_batch_size,
+                "configured_batch_size": configured_batch_size,
+                "padding_overhead": padding_overhead,
+            }
+
+        extended_metrics = compute_extended_metrics(
+            output_tokens=output.output_tokens,
+            total_energy_j=total_energy_j,
+            tokens_per_second=avg_tokens_per_second,
+            precision_factor=1.0,  # No precision-scaling applied (default)
+            itl_mean_ms=None,  # tpot_ms stays null - needs streaming ITL capture
+            per_request_latencies_ms=output.per_request_latencies_ms or None,
+            gpu_utilisation_samples=gpu_utilisation_samples or None,
+            memory_bandwidth_samples=memory_bandwidth_samples or None,
+            memory_stats=memory_stats,
+            batch_stats=batch_stats,
+            kv_cache_stats=kv_cache_stats,
+        )
+        # Preserve inference-only memory delta (compute_extended_metrics does not
+        # know the model baseline split).
+        extended_metrics.memory.inference_memory_mb = inference_memory_mb
+
+        # Latency stats from streaming TTFT/ITL (vLLM only; null otherwise).
+        latency_stats = (
+            compute_latency_statistics(output.ttft_ms, itl_trimmed_ms=output.itl_ms or None)
+            if output.ttft_ms
+            else None
+        )
+
+        steady_state_window = (0.0, output.inference_time_sec)
+        warmup_excluded_samples = (
+            warmup_result.iterations_completed if warmup_result is not None else None
         )
 
         return ExperimentResult(
@@ -881,4 +969,7 @@ class MeasurementHarness:
             warmup_result=warmup_result,
             measurement_warnings=measurement_warnings,
             extended_metrics=extended_metrics,
+            latency_stats=latency_stats,
+            steady_state_window=steady_state_window,
+            warmup_excluded_samples=warmup_excluded_samples,
         )

--- a/tests/unit/cli/test_cli_display.py
+++ b/tests/unit/cli/test_cli_display.py
@@ -312,23 +312,26 @@ def test_print_result_summary_with_flops(capsys):
 
 
 def test_print_result_summary_with_latency_stats(capsys):
-    """Result with latency_stats that has ttft_ms/itl_ms shows Latency lines.
+    """Result with latency_stats (real LatencyStatistics) shows TTFT/ITL lines.
 
-    The _display.py code checks hasattr(ls, "ttft_ms") - uses duck typing
-    so any object with those attributes will trigger the print.
+    The display reads the concrete field names ttft_mean_ms / itl_mean_ms.
     """
-    from unittest.mock import MagicMock
-
+    from llenergymeasure.domain.metrics import LatencyStatistics
     from tests.conftest import make_result
 
-    # Use MagicMock to create an object with ttft_ms and itl_ms attributes
-    # (the display code uses hasattr duck typing, not a concrete LatencyStatistics)
-    latency = MagicMock()
-    latency.ttft_ms = 12.5
-    latency.itl_ms = 3.2
+    latency = LatencyStatistics(
+        ttft_mean_ms=12.5,
+        ttft_median_ms=12.0,
+        ttft_p95_ms=14.0,
+        ttft_p99_ms=15.0,
+        ttft_min_ms=10.0,
+        ttft_max_ms=16.0,
+        ttft_samples=3,
+        itl_mean_ms=3.2,
+        itl_samples=10,
+    )
 
     result = make_result()
-    # Inject latency via model_construct to bypass validation
     result = result.model_copy(update={"latency_stats": latency})
     print_result_summary(result)
     out = capsys.readouterr().out

--- a/tests/unit/device/test_power_thermal.py
+++ b/tests/unit/device/test_power_thermal.py
@@ -231,7 +231,7 @@ def _make_full_pynvml_mock() -> MagicMock:
         total=80 * 1024**3,
     )
     mock.nvmlDeviceGetTemperature.return_value = 75
-    mock.nvmlDeviceGetUtilizationRates.return_value = MagicMock(gpu=90)
+    mock.nvmlDeviceGetUtilizationRates.return_value = MagicMock(gpu=90, memory=45)
     mock.nvmlClocksEventReasonSwThermalSlowdown = 0x20
     mock.nvmlClocksEventReasonHwThermalSlowdown = 0x40
     mock.nvmlClocksEventReasonSwPowerCap = 0x04
@@ -261,6 +261,23 @@ def test_sampler_lifecycle_pynvml_available():
     mean = sampler.get_mean_power()
     assert mean is not None
     assert mean == pytest.approx(200.0, rel=0.01)
+
+
+def test_sampler_captures_memory_bandwidth_utilisation():
+    """memory_bandwidth_utilisation is read from nvmlDeviceGetUtilizationRates().memory."""
+    mock_pynvml = _make_full_pynvml_mock()
+
+    with patch.dict(sys.modules, {"pynvml": mock_pynvml}):
+        sampler = PowerThermalSampler(gpu_indices=[0], sample_interval_ms=10)
+        with sampler:
+            time.sleep(0.07)
+
+    samples = sampler.get_samples()
+    assert samples, "expected at least one sample"
+    mem_bw = [s.memory_bandwidth_utilisation for s in samples]
+    assert all(v == pytest.approx(45.0) for v in mem_bw)
+    # SM utilisation still captured from the same call
+    assert all(s.sm_utilisation == pytest.approx(90.0) for s in samples)
 
 
 # =============================================================================

--- a/tests/unit/domain/test_extended_metrics.py
+++ b/tests/unit/domain/test_extended_metrics.py
@@ -1,11 +1,10 @@
-"""Unit tests for results/extended_metrics.py - compute_extended_metrics and helpers."""
+"""Unit tests for domain/extended_metrics.py - compute_extended_metrics and helpers."""
 
 from __future__ import annotations
 
 import pytest
 
-from llenergymeasure.domain.metrics import ExtendedEfficiencyMetrics
-from llenergymeasure.results.extended_metrics import (
+from llenergymeasure.domain.extended_metrics import (
     _compute_batch_metrics,
     _compute_gpu_utilisation_metrics,
     _compute_kv_cache_metrics,
@@ -13,6 +12,7 @@ from llenergymeasure.results.extended_metrics import (
     _compute_request_latency_metrics,
     compute_extended_metrics,
 )
+from llenergymeasure.domain.metrics import ExtendedEfficiencyMetrics
 
 # ---------------------------------------------------------------------------
 # TestComputeExtendedMetrics
@@ -159,6 +159,20 @@ class TestComputeGPUUtilisationMetrics:
         assert gpu.sm_utilisation_mean == pytest.approx(42.0)
         assert gpu.sm_utilisation_samples == 1
 
+    def test_memory_bandwidth_mean(self):
+        gpu = _compute_gpu_utilisation_metrics([50.0, 60.0], [30.0, 50.0])
+        assert gpu.sm_utilisation_mean == pytest.approx(55.0)
+        assert gpu.memory_bandwidth_utilisation == pytest.approx(40.0)
+
+    def test_memory_bandwidth_none_when_absent(self):
+        gpu = _compute_gpu_utilisation_metrics([50.0, 60.0], None)
+        assert gpu.memory_bandwidth_utilisation is None
+
+    def test_memory_bandwidth_without_sm(self):
+        gpu = _compute_gpu_utilisation_metrics(None, [10.0, 20.0])
+        assert gpu.sm_utilisation_mean is None
+        assert gpu.memory_bandwidth_utilisation == pytest.approx(15.0)
+
 
 # ---------------------------------------------------------------------------
 # TestComputeBatchMetrics
@@ -247,3 +261,52 @@ class TestComputeRequestLatencyMetrics:
     def test_ordering_p95_lte_p99(self):
         req = _compute_request_latency_metrics([10.0, 20.0, 30.0, 100.0, 200.0, 500.0])
         assert req.e2e_latency_p95_ms <= req.e2e_latency_p99_ms
+
+
+# ---------------------------------------------------------------------------
+# TestComputeExtendedMetricsIntegrated - full wiring through grouped sub-metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeExtendedMetricsIntegrated:
+    """compute_extended_metrics() wiring memory/batch/gpu/kv-cache together."""
+
+    def test_full_population(self):
+        result = compute_extended_metrics(
+            output_tokens=1000,
+            total_energy_j=20.0,
+            tokens_per_second=200.0,
+            per_request_latencies_ms=[100.0, 120.0, 110.0],
+            gpu_utilisation_samples=[80.0, 90.0],
+            memory_bandwidth_samples=[40.0, 60.0],
+            memory_stats={
+                "peak_mb": 4096.0,
+                "model_mb": 8192.0,
+                "total_vram_mb": 40960.0,
+                "kv_cache_mb": 1024.0,
+            },
+            batch_stats={
+                "num_batches": 4,
+                "effective_batch_size": 8.0,
+                "configured_batch_size": 16,
+                "padding_overhead": 0.2,
+            },
+            kv_cache_stats={"hit_rate": 0.5, "blocks_used": 100, "blocks_total": 200},
+        )
+        # Memory ratios
+        assert result.memory.model_memory_utilisation == pytest.approx(8192.0 / 40960.0)
+        assert result.memory.kv_cache_memory_ratio == pytest.approx(1024.0 / 4096.0)
+        assert result.memory.tokens_per_gb_vram == pytest.approx(1000 / (4096.0 / 1024))
+        # GPU utilisation incl mem-bw
+        assert result.gpu_utilisation.sm_utilisation_mean == pytest.approx(85.0)
+        assert result.gpu_utilisation.memory_bandwidth_utilisation == pytest.approx(50.0)
+        # Batch
+        assert result.batch.num_batches == 4
+        assert result.batch.batch_utilisation == pytest.approx(0.5)
+        assert result.batch.padding_overhead == pytest.approx(0.2)
+        # KV cache
+        assert result.kv_cache.kv_cache_hit_rate == pytest.approx(0.5)
+        assert result.kv_cache.kv_cache_blocks_used == 100
+        # Request latency
+        assert result.request_latency.e2e_latency_samples == 3
+        assert result.request_latency.e2e_latency_mean_ms == pytest.approx(110.0)

--- a/tests/unit/engines/test_extended_capture.py
+++ b/tests/unit/engines/test_extended_capture.py
@@ -1,0 +1,120 @@
+"""Unit tests for per-engine extended-metrics capture helpers.
+
+All host-safe: vLLM/TRT-LLM RequestOutputs are MagicMocks, the transformers
+padding math is exercised through the real ``_run_batch`` with mocked tensors.
+No GPU or engine library import occurs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from llenergymeasure.engines.vllm.plugin import (
+    _capture_kv_cache_stats,
+    _extract_request_metrics,
+)
+
+# ---------------------------------------------------------------------------
+# _extract_request_metrics
+# ---------------------------------------------------------------------------
+
+
+def _req(arrival=None, finished=None, first_token=None, with_metrics=True):
+    """Build a fake RequestOutput with a .metrics namespace (or metrics=None)."""
+    if not with_metrics:
+        return SimpleNamespace(metrics=None)
+    metrics = SimpleNamespace(
+        arrival_time=arrival,
+        finished_time=finished,
+        first_token_time=first_token,
+    )
+    return SimpleNamespace(metrics=metrics)
+
+
+class TestExtractRequestMetrics:
+    def test_full_metrics(self):
+        outputs = [
+            _req(arrival=1.0, finished=2.0, first_token=1.2),
+            _req(arrival=10.0, finished=10.5, first_token=10.1),
+        ]
+        latencies, ttft = _extract_request_metrics(outputs)
+        assert latencies == pytest.approx([1000.0, 500.0])
+        assert ttft == pytest.approx([200.0, 100.0])
+
+    def test_metrics_none_skipped(self):
+        outputs = [_req(with_metrics=False), _req(arrival=0.0, finished=1.0, first_token=0.1)]
+        latencies, ttft = _extract_request_metrics(outputs)
+        assert latencies == pytest.approx([1000.0])
+        assert ttft == pytest.approx([100.0])
+
+    def test_partial_attrs(self):
+        # arrival+finished present but no first_token -> latency captured, ttft skipped
+        outputs = [_req(arrival=0.0, finished=2.0, first_token=None)]
+        latencies, ttft = _extract_request_metrics(outputs)
+        assert latencies == pytest.approx([2000.0])
+        assert ttft == []
+
+    def test_empty_outputs(self):
+        latencies, ttft = _extract_request_metrics([])
+        assert latencies == []
+        assert ttft == []
+
+
+# ---------------------------------------------------------------------------
+# _capture_kv_cache_stats
+# ---------------------------------------------------------------------------
+
+
+def _make_llm(num_gpu_blocks=None, usage=None, hit_rate=None, block_size=None):
+    """Build a MagicMock vLLM with controllable cache_config + stat_loggers."""
+    llm = MagicMock()
+    engine = llm.llm_engine
+    if num_gpu_blocks is None and block_size is None:
+        engine.cache_config = None
+    else:
+        engine.cache_config = SimpleNamespace(
+            num_gpu_blocks=num_gpu_blocks,
+            block_size=block_size,
+        )
+    if usage is None and hit_rate is None:
+        engine.stat_loggers = None
+    else:
+        last = SimpleNamespace(
+            gpu_cache_usage_sys=usage,
+            gpu_prefix_cache_hit_rate=hit_rate,
+        )
+        engine.stat_loggers = {"prometheus": SimpleNamespace(last_local_log=last)}
+    return llm
+
+
+class TestCaptureKVCacheStats:
+    def test_fully_readable(self):
+        llm = _make_llm(num_gpu_blocks=200, usage=0.5, hit_rate=0.8, block_size=16)
+        stats = _capture_kv_cache_stats(llm)
+        assert stats is not None
+        assert stats["blocks_total"] == 200
+        assert stats["usage"] == pytest.approx(0.5)
+        assert stats["hit_rate"] == pytest.approx(0.8)
+        assert stats["blocks_used"] == 100
+
+    def test_partially_readable_blocks_only(self):
+        # cache_config present (blocks_total) but no stat loggers -> usage/hit_rate absent
+        llm = _make_llm(num_gpu_blocks=128)
+        stats = _capture_kv_cache_stats(llm)
+        assert stats is not None
+        assert stats["blocks_total"] == 128
+        assert "usage" not in stats
+        assert "hit_rate" not in stats
+        assert "blocks_used" not in stats
+
+    def test_unreadable_returns_none(self):
+        llm = _make_llm()  # cache_config None, stat_loggers None
+        assert _capture_kv_cache_stats(llm) is None
+
+    def test_no_engine_returns_none(self):
+        llm = MagicMock()
+        llm.llm_engine = None
+        assert _capture_kv_cache_stats(llm) is None

--- a/tests/unit/engines/test_extended_capture.py
+++ b/tests/unit/engines/test_extended_capture.py
@@ -12,13 +12,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from llenergymeasure.engines.vllm.plugin import (
-    _capture_kv_cache_stats,
-    _extract_request_metrics,
-)
+from llenergymeasure.engines._helpers import extract_request_metrics
+from llenergymeasure.engines.vllm.plugin import _capture_kv_cache_stats
 
 # ---------------------------------------------------------------------------
-# _extract_request_metrics
+# extract_request_metrics
 # ---------------------------------------------------------------------------
 
 
@@ -40,25 +38,25 @@ class TestExtractRequestMetrics:
             _req(arrival=1.0, finished=2.0, first_token=1.2),
             _req(arrival=10.0, finished=10.5, first_token=10.1),
         ]
-        latencies, ttft = _extract_request_metrics(outputs)
+        latencies, ttft = extract_request_metrics(outputs)
         assert latencies == pytest.approx([1000.0, 500.0])
         assert ttft == pytest.approx([200.0, 100.0])
 
     def test_metrics_none_skipped(self):
         outputs = [_req(with_metrics=False), _req(arrival=0.0, finished=1.0, first_token=0.1)]
-        latencies, ttft = _extract_request_metrics(outputs)
+        latencies, ttft = extract_request_metrics(outputs)
         assert latencies == pytest.approx([1000.0])
         assert ttft == pytest.approx([100.0])
 
     def test_partial_attrs(self):
         # arrival+finished present but no first_token -> latency captured, ttft skipped
         outputs = [_req(arrival=0.0, finished=2.0, first_token=None)]
-        latencies, ttft = _extract_request_metrics(outputs)
+        latencies, ttft = extract_request_metrics(outputs)
         assert latencies == pytest.approx([2000.0])
         assert ttft == []
 
     def test_empty_outputs(self):
-        latencies, ttft = _extract_request_metrics([])
+        latencies, ttft = extract_request_metrics([])
         assert latencies == []
         assert ttft == []
 

--- a/tests/unit/engines/test_transformers_token_counting.py
+++ b/tests/unit/engines/test_transformers_token_counting.py
@@ -103,3 +103,29 @@ class TestPaddedBatch:
         _, new_out = _count_tokens(inputs, outputs)
 
         assert new_out == 0, f"Expected 0 output tokens when no generation, got {new_out}"
+
+
+def _count_padding(inputs: dict) -> int:
+    """Replicate the padding-token math from TransformersEngine._run_batch()."""
+    input_token_count = int(inputs["attention_mask"].sum().item())
+    return int(inputs["input_ids"].numel()) - input_token_count
+
+
+class TestPaddingTokenCount:
+    """Padding tokens = input_ids.numel() - attention_mask.sum()."""
+
+    def test_no_padding_uniform(self) -> None:
+        input_ids = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        attention_mask = torch.ones_like(input_ids)
+        assert _count_padding({"input_ids": input_ids, "attention_mask": attention_mask}) == 0
+
+    def test_padded_batch(self) -> None:
+        # 2x5 = 10 positions, 8 real tokens -> 2 padding tokens
+        input_ids = torch.tensor([[1, 2, 3, 0, 0], [4, 5, 6, 7, 8]])
+        attention_mask = torch.tensor([[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]])
+        assert _count_padding({"input_ids": input_ids, "attention_mask": attention_mask}) == 2
+
+    def test_single_sequence_no_padding(self) -> None:
+        input_ids = torch.tensor([[1, 2, 3]])
+        attention_mask = torch.ones_like(input_ids)
+        assert _count_padding({"input_ids": input_ids, "attention_mask": attention_mask}) == 0

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -284,6 +284,15 @@ def test_harness_sets_warmup_result_thermal_floor(minimal_config):
 # ---------------------------------------------------------------------------
 
 
+def _real_sample(**overrides):
+    """Build a minimal real PowerThermalSample (numeric fields, not MagicMock)."""
+    from llenergymeasure.device.power_thermal import PowerThermalSample
+
+    defaults = dict(timestamp=0.0, sm_utilisation=50.0, memory_total_mb=40960.0)
+    defaults.update(overrides)
+    return PowerThermalSample(**defaults)
+
+
 def _make_mock_pts(*, samples: list | None = None):
     """Build a PowerThermalSampler mock that satisfies the harness's usage."""
     from llenergymeasure.domain.metrics import ThermalThrottleInfo
@@ -1081,6 +1090,122 @@ def test_harness_save_timeseries_false_skips_parquet(tmp_path):
     assert result.timeseries is None
 
 
+def test_harness_populates_extended_metrics(minimal_config):
+    """A run with GPU samples + per-request latencies populates previously-null fields.
+
+    Verifies extended_metrics.gpu_utilisation / memory ratios / request_latency,
+    plus latency_stats, steady_state_window, and warmup_excluded_samples.
+    """
+    from llenergymeasure.device.power_thermal import PowerThermalSample
+
+    samples = [
+        PowerThermalSample(
+            timestamp=0.0,
+            sm_utilisation=80.0,
+            memory_bandwidth_utilisation=40.0,
+            memory_total_mb=40960.0,
+            memory_used_mb=10000.0,
+        ),
+        PowerThermalSample(
+            timestamp=0.1,
+            sm_utilisation=90.0,
+            memory_bandwidth_utilisation=60.0,
+            memory_total_mb=40960.0,
+            memory_used_mb=11000.0,
+        ),
+    ]
+
+    output = InferenceOutput(
+        elapsed_time_sec=2.0,
+        input_tokens=40,
+        output_tokens=200,
+        peak_memory_mb=4096.0,
+        model_memory_mb=0.0,
+        batch_times=[1.0, 1.0],
+        per_request_latencies_ms=[100.0, 120.0, 110.0],
+        ttft_ms=[10.0, 12.0, 11.0],
+        itl_ms=[2.0, 3.0],
+        num_batches=2,
+        padding_tokens=8,
+    )
+    engine = FakeBackend(inference_output=output)
+    harness = MeasurementHarness()
+
+    # model_memory_mb is captured by the harness (mocked here to a real value so
+    # model_memory_utilisation is computable).
+    with (
+        _apply_patches(),
+        patch(
+            "llenergymeasure.harness.PowerThermalSampler",
+            new=_make_mock_pts(samples=samples),
+        ),
+        patch.object(MeasurementHarness, "_capture_model_memory_mb", return_value=8192.0),
+    ):
+        result = harness.run(engine, minimal_config)
+
+    em = result.extended_metrics
+    assert em is not None
+    # GPU utilisation incl mem-bw
+    assert em.gpu_utilisation.sm_utilisation_mean == pytest.approx(85.0)
+    assert em.gpu_utilisation.memory_bandwidth_utilisation == pytest.approx(50.0)
+    assert em.gpu_utilisation.sm_utilisation_samples == 2
+    # Memory ratios (total_vram_mb from samples, model from _capture_model_memory_mb)
+    assert em.memory.model_memory_utilisation == pytest.approx(8192.0 / 40960.0)
+    assert em.memory.tokens_per_gb_vram is not None
+    # Request latency
+    assert em.request_latency.e2e_latency_mean_ms == pytest.approx(110.0)
+    assert em.request_latency.e2e_latency_samples == 3
+    # Batch metrics (transformers engine name "fake" != vllm, num_batches truthy)
+    assert em.batch.num_batches == 2
+    # Latency stats from TTFT/ITL
+    assert result.latency_stats is not None
+    assert result.latency_stats.ttft_mean_ms == pytest.approx(11.0)
+    assert result.latency_stats.itl_mean_ms == pytest.approx(2.5)
+    # Steady-state window + warmup exclusion
+    assert result.steady_state_window is not None
+    assert result.steady_state_window[0] == pytest.approx(0.0)
+    assert result.steady_state_window[1] > 0.0
+    assert result.warmup_excluded_samples == 1
+
+
+def test_harness_vllm_batch_metrics_none(minimal_config):
+    """vLLM engine (continuous batching) leaves batch metrics null even with num_batches set."""
+    from llenergymeasure.device.power_thermal import PowerThermalSample
+
+    samples = [PowerThermalSample(timestamp=0.0, sm_utilisation=70.0, memory_total_mb=40960.0)]
+    output = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=20,
+        peak_memory_mb=512.0,
+        model_memory_mb=0.0,
+        per_request_latencies_ms=[50.0],
+        num_batches=None,
+        padding_tokens=None,
+        kv_cache_stats={"hit_rate": 0.9, "blocks_used": 10, "blocks_total": 100},
+    )
+    engine = FakeBackend(engine_name="vllm", inference_output=output)
+    harness = MeasurementHarness()
+
+    with (
+        _apply_patches(),
+        patch(
+            "llenergymeasure.harness.PowerThermalSampler",
+            new=_make_mock_pts(samples=samples),
+        ),
+    ):
+        result = harness.run(engine, minimal_config)
+
+    em = result.extended_metrics
+    assert em is not None
+    # vLLM: batch metrics remain null
+    assert em.batch.num_batches is None
+    assert em.batch.effective_batch_size is None
+    # KV cache populated from output.kv_cache_stats
+    assert em.kv_cache.kv_cache_hit_rate == pytest.approx(0.9)
+    assert em.kv_cache.kv_cache_blocks_used == 10
+
+
 def test_harness_save_timeseries_true_writes_parquet(tmp_path):
     """save_timeseries=True (default) writes timeseries parquet when output_dir is set."""
     from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
@@ -1107,7 +1232,8 @@ def test_harness_save_timeseries_true_writes_parquet(tmp_path):
         patch("llenergymeasure.harness.estimate_flops_palm", return_value=MagicMock(value=0)),
         patch("llenergymeasure.harness._cuda_sync"),
         patch(
-            "llenergymeasure.harness.PowerThermalSampler", new=_make_mock_pts(samples=[MagicMock()])
+            "llenergymeasure.harness.PowerThermalSampler",
+            new=_make_mock_pts(samples=[_real_sample()]),
         ),
         patch(
             "llenergymeasure.harness.write_timeseries_parquet",


### PR DESCRIPTION
## Summary

`result.json` had a block of permanently-null extended-metrics fields because
nothing computed them in the live single-process path. This PR wires them up.

- **Layering move**: `compute_extended_metrics` + helpers move from `results/`
  to a new pure `domain/extended_metrics.py` (Layer 0, imports only
  `domain.metrics` + numpy) so the harness can call them without a layering
  breach. `results/extended_metrics.py` is deleted; the only importer was its
  test, which moves to `tests/unit/domain/`. Import-linter: 4 contracts kept.
- **Per-engine capture**: `InferenceOutput` gains typed best-effort fields
  (`per_request_latencies_ms`, `ttft_ms`, `itl_ms`, `num_batches`,
  `padding_tokens`, `kv_cache_stats`; empty/None = engine cannot provide).
  Each plugin fills what it can (see matrix). The shared per-request extractor
  `extract_request_metrics` lives in `engines/_helpers.py` (used by both the
  vLLM and TRT-LLM plugins; no cross-plugin import edge).
- **Sampler**: `PowerThermalSample` gains `memory_bandwidth_utilisation`, read
  from the existing `nvmlDeviceGetUtilizationRates().memory` NVML proxy
  (percent of time the memory controller was active, not true bandwidth).
- **Harness wiring**: `_build_result` now calls `compute_extended_metrics(...)`
  with GPU/mem-bw samples, per-request latencies, batch stats, and KV-cache
  stats, and sets `latency_stats` (vLLM only), `steady_state_window`, and
  `warmup_excluded_samples`. `tpot_ms` stays null (needs streaming ITL; not
  faked from totals).
- **Display fix**: `cli/_display` read `ls.ttft_ms`/`ls.itl_ms` behind `hasattr`
  guards, but `LatencyStatistics` exposes `ttft_mean_ms`/`itl_mean_ms`, so the
  latency block silently printed nothing. Fixed to the real field names.

Schema version is unchanged (4.0) - these are always-null optional fields.

## Engine support matrix

| Metric group | vLLM | transformers | tensorrt |
|--------------|:----:|:------------:|:--------:|
| `request_latency.*` (per-request E2E) | yes (RequestOutput metrics) | yes (per-batch approximation) | no (metrics usually absent in 0.21.0) |
| `latency_stats` (TTFT/ITL) | yes | no (non-streaming) | no |
| `kv_cache.*` | yes (best-effort) | no | no |
| `gpu_utilisation.*` (SM + mem-bw) | yes | yes | yes |
| `memory.*` ratios | yes | yes | yes |
| `batch.*` | no (continuous batching) | yes | `num_batches=1` only |
| `tpot_ms` | no | no | no |

transformers `request_latency` is the `PER_REQUEST_BATCH` approximation
(`batch_time / batch_size`), documented as such - non-streaming `generate()`
gives only per-batch wall time. vLLM uses real per-request timestamps.

## Doc audit

- `docs/reference/results-schema.md`: adds the extended-metrics field table and
  the per-engine support matrix (in this PR).
- `docs/reference/library/ExperimentResult.md`: corrected two field docs whose
  semantics this PR changed - `warmup_excluded_samples` now counts warmup
  iterations (from `warmup_result.iterations_completed`, populated whenever a
  warmup result exists) and `steady_state_window` is now always set on the
  single-process path (`(0.0, inference_time_sec)`), so it is no longer null for
  total runs. Both now agree with the corrected pydantic field descriptions.
- No other doc surface contradicts the change.

## Test plan

- `uv run pytest tests/ -q`: 2436 passed, 52 skipped, 0 failed.
- `uv run ruff check src tests`: clean.
- `uv run mypy src/`: clean (104 files).
- Import-linter (module form): 4 contracts kept, 0 broken.
- New/extended unit tests: domain extended-metrics (memory ratios, batch,
  gpu+mem-bw, kv-cache, integrated), engine capture helpers
  (`extract_request_metrics`, `_capture_kv_cache_stats` with MagicMocks;
  transformers padding math), harness produces non-null extended_metrics +
  latency_stats + steady_state_window + warmup_excluded_samples, sampler
  reads memory-bandwidth from mocked NVML.
- GPU verification (orchestrator, real runs in Docker on the shared GPU host):
  transformers and vLLM live runs both populated the matrix-promised fields -
  vLLM TTFT/latency_stats work, KV `blocks_total=16475` with `hit_rate`
  gracefully null. The TRT-LLM live run was skipped; its wired paths are shared
  with vLLM (`extract_request_metrics`) and covered by the mock-based unit
  tests. Verdict: PASS.
