### PR TITLE
refactor(study): move single-experiment execution into the study layer

### DIFF
--- a/src/llenergymeasure/api/README.md
+++ b/src/llenergymeasure/api/README.md
@@ -89,8 +89,8 @@ run_study(...)
         ├─ run_study_preflight()
         ├─ resolve_study_runners()
         ├─ create_study_dir() + ManifestWriter
-        ├─ _run_in_process()  # single experiment: harness or DockerRunner directly
-        └─ _run_via_runner()  # multi-experiment: StudyRunner subprocess loop
+        ├─ run_single_experiment()  # single experiment (study layer): harness or DockerRunner directly
+        └─ _run_via_runner()        # multi-experiment: StudyRunner subprocess loop
 ```
 
 ## Layer constraints

--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -6,7 +6,6 @@ This module is internal (underscore prefix). Import via llenergymeasure.__init__
 from __future__ import annotations
 
 import json
-import shutil
 import time
 from pathlib import Path
 from typing import Any, overload
@@ -19,11 +18,11 @@ from llenergymeasure.config.models import (
     StudyConfig,
     TaskConfig,
 )
-from llenergymeasure.config.ssot import RUNNER_DOCKER, TEMP_PREFIX_TIMESERIES
-from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+from llenergymeasure.config.ssot import RUNNER_DOCKER
 from llenergymeasure.domain.experiment import ExperimentResult, StudyResult, StudySummary
 from llenergymeasure.domain.progress import ProgressCallback
 from llenergymeasure.infra.runner_resolution import RunnerSpec
+from llenergymeasure.study.single import run_single_experiment
 from llenergymeasure.utils.exceptions import ConfigError
 
 # Single source of truth for n_prompts default - derived from DatasetConfig field default
@@ -513,7 +512,7 @@ def _run(
             )
 
         exp_start = time.monotonic()
-        result_files, experiment_results, warnings = _run_in_process(
+        result_files, experiment_results, warnings = run_single_experiment(
             study,
             manifest,
             study_dir,
@@ -598,174 +597,6 @@ def _run(
         summary=summary,
         skipped_experiments=study.skipped_configs,
     )
-
-
-def _run_in_process(
-    study: StudyConfig,
-    manifest: Any,
-    study_dir: Path,
-    runner_specs: Any = None,
-    progress: ProgressCallback | None = None,
-    resolution_logs: dict[str, dict[str, Any]] | None = None,
-) -> tuple[list[str], list[ExperimentResult | None], list[str]]:
-    """Run a single experiment in-process or via DockerRunner directly.
-
-    When runner_specs resolves the engine to "docker", uses DockerRunner directly
-    (no subprocess spawning). Otherwise runs in-process via the engine.
-
-    Errors from run_preflight() and harness.run(engine, config) propagate unchanged (PreFlightError,
-    EngineError). Only result-saving errors are caught so a save failure does not
-    discard a completed measurement.
-    """
-    from llenergymeasure.domain.experiment import compute_declared_config_hash
-    from llenergymeasure.study.runner import _save_and_record
-
-    config = study.experiments[0]
-    config_hash = compute_declared_config_hash(config)
-    cycle = 1
-
-    # Pre-dispatch GPU memory residual check (MEAS-01, MEAS-02)
-    # Mirrors the pattern used in StudyRunner._run_one() and _run_one_docker().
-    from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
-
-    check_gpu_memory_residual()
-
-    # Collect environment snapshot once - used for both harness and environment.json sidecar
-    from llenergymeasure.harness.environment import collect_environment_snapshot
-
-    snapshot = collect_environment_snapshot()
-
-    # Check runner spec for this engine
-    spec = runner_specs.get(config.engine) if runner_specs else None
-
-    manifest.mark_running(config_hash, cycle)
-
-    save_ts = study.output.save_timeseries
-    ts_tmpdir: Path | None = None  # Only set for local path
-
-    if spec is not None and spec.mode == RUNNER_DOCKER:
-        # Docker path: dispatch to container directly (no subprocess)
-        from llenergymeasure.infra.docker_errors import (
-            DockerStdoutSilenceError,
-            DockerTimeoutError,
-        )
-        from llenergymeasure.infra.docker_runner import DockerRunner
-        from llenergymeasure.infra.image_registry import get_default_image
-        from llenergymeasure.utils.exceptions import DockerError
-
-        image = spec.image if spec.image is not None else get_default_image(config.engine)
-
-        docker_runner = DockerRunner(
-            image=image,
-            timeout=study.study_execution.experiment_timeout_seconds,
-            silence_timeout=study.study_execution.stdout_silence_timeout_seconds,
-            source=spec.source,
-            extra_mounts=spec.extra_mounts,
-        )
-        docker_ts_dir: Path | None = None
-        try:
-            result, docker_ts_dir = docker_runner.run(
-                config, progress=progress, save_timeseries=save_ts
-            )
-        except DockerStdoutSilenceError as exc:
-            # Distinct error type so users can tell stuck-process kills
-            # from wall-clock timeouts when reading the manifest.
-            error_payload: dict[str, Any] = {
-                "type": "StdoutSilenceTimeoutError",
-                "message": str(exc),
-                "config_hash": config_hash,
-            }
-            manifest.mark_failed(
-                config_hash, cycle, error_payload["type"], error_payload["message"]
-            )
-            return [], [None], [error_payload["message"]]
-        except DockerTimeoutError as exc:
-            # Normalise to "TimeoutError" so the circuit breaker sees the same
-            # failure class as the subprocess path.
-            error_payload = {
-                "type": "TimeoutError",
-                "message": str(exc),
-                "config_hash": config_hash,
-            }
-            manifest.mark_failed(
-                config_hash, cycle, error_payload["type"], error_payload["message"]
-            )
-            return [], [None], [error_payload["message"]]
-        except DockerError as exc:
-            # Convert to failure dict - manifest marks failed, study continues
-            error_payload = {
-                "type": type(exc).__name__,
-                "message": str(exc),
-                "config_hash": config_hash,
-            }
-            manifest.mark_failed(
-                config_hash, cycle, error_payload["type"], error_payload["message"]
-            )
-            return [], [None], [error_payload["message"]]
-        # Docker path: ts_tmpdir comes from DockerRunner
-        ts_tmpdir = docker_ts_dir
-    else:
-        # Local in-process path - errors propagate naturally (PreFlightError, EngineError)
-        import tempfile
-
-        from llenergymeasure.engines import get_engine
-        from llenergymeasure.harness import MeasurementHarness
-        from llenergymeasure.harness.preflight import run_preflight
-
-        if progress:
-            progress.on_step_start("container_preflight", "Checking", "CUDA, model access")
-        t0 = time.perf_counter()
-        run_preflight(config)
-        if progress:
-            progress.on_step_done("container_preflight", time.perf_counter() - t0)
-
-        # Create temp dir for timeseries parquet (if enabled)
-        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES)) if save_ts else None
-
-        try:
-            engine = get_engine(config.engine)
-            harness = MeasurementHarness()
-            gpu_indices = _resolve_gpu_indices(config)
-            result = harness.run(
-                engine,
-                config,
-                snapshot=snapshot,
-                gpu_indices=gpu_indices,
-                progress=progress,
-                output_dir=str(ts_tmpdir) if ts_tmpdir else None,
-                save_timeseries=save_ts,
-            )
-        except Exception:
-            if ts_tmpdir is not None:
-                shutil.rmtree(ts_tmpdir, ignore_errors=True)
-            raise
-
-    # Handle error payload returned from Docker container (exit 0 but wrote error JSON)
-    if isinstance(result, dict) and "type" in result:
-        error_type = result.get("type", "UnknownError")
-        error_message = result.get("message", "")
-        manifest.mark_failed(config_hash, cycle, error_type, error_message)
-        return [], [None], [error_message]
-
-    result_files: list[str] = []
-    warnings: list[str] = []
-    _save_and_record(
-        result,
-        study_dir,
-        manifest,
-        config_hash,
-        cycle,
-        result_files,
-        ts_source_dir=ts_tmpdir,
-        environment_snapshot=snapshot,
-        resolution_log=(resolution_logs or {}).get(config_hash),
-    )
-
-    # Clean up temp dirs
-    if ts_tmpdir is not None and ts_tmpdir.exists():
-        shutil.rmtree(ts_tmpdir, ignore_errors=True)
-
-    return result_files, [result], warnings
 
 
 def _run_via_runner(

--- a/src/llenergymeasure/study/README.md
+++ b/src/llenergymeasure/study/README.md
@@ -11,6 +11,7 @@ Implements the sweep runner that executes a `StudyConfig` (a list of `Experiment
 | Module | Description |
 |--------|-------------|
 | `runner.py` | `StudyRunner` - subprocess dispatch core |
+| `single.py` | `run_single_experiment()` - in-process / direct-DockerRunner path for a single experiment |
 | `manifest.py` | `ManifestWriter`, `StudyManifest`, `ExperimentManifestEntry` - checkpoint model |
 | `gpu_memory.py` | `check_gpu_memory_residual()` - pre-dispatch GPU memory check |
 | `gaps.py` | `run_gap()` - thermal gap between experiments |

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import shutil
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from llenergymeasure.config.models import StudyConfig
 from llenergymeasure.config.ssot import RUNNER_DOCKER, TEMP_PREFIX_TIMESERIES
@@ -24,13 +24,17 @@ from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 from llenergymeasure.domain.experiment import ExperimentResult
 from llenergymeasure.domain.progress import ProgressCallback
 
+if TYPE_CHECKING:
+    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.study.manifest import ManifestWriter
+
 
 def run_single_experiment(
     study: StudyConfig,
-    manifest: Any,
+    manifest: ManifestWriter,
     study_dir: Path,
     *,
-    runner_specs: Any = None,
+    runner_specs: dict[str, RunnerSpec] | None = None,
     progress: ProgressCallback | None = None,
     resolution_logs: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[str], list[ExperimentResult | None], list[str]]:

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -1,0 +1,194 @@
+"""Single-experiment in-process execution path - shared seam in the study layer.
+
+A study with exactly one experiment and ``n_cycles == 1`` runs in-process (or
+dispatches to a DockerRunner directly) rather than spawning a subprocess via
+StudyRunner. This module is that path. It lives in the study layer so the
+result-saving helper (``_save_and_record``) is an intra-package call rather than
+an api-layer reach into a study-layer private symbol.
+
+The api layer (``api/_impl._run``) keeps the single-experiment dispatch decision
+and the study-level progress begin/end block; it delegates the actual execution
+body to ``run_single_experiment`` here.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from llenergymeasure.config.models import StudyConfig
+from llenergymeasure.config.ssot import RUNNER_DOCKER, TEMP_PREFIX_TIMESERIES
+from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+from llenergymeasure.domain.experiment import ExperimentResult
+from llenergymeasure.domain.progress import ProgressCallback
+
+
+def run_single_experiment(
+    study: StudyConfig,
+    manifest: Any,
+    study_dir: Path,
+    *,
+    runner_specs: Any = None,
+    progress: ProgressCallback | None = None,
+    resolution_logs: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[str], list[ExperimentResult | None], list[str]]:
+    """Run a single experiment in-process or via DockerRunner directly.
+
+    When runner_specs resolves the engine to "docker", uses DockerRunner directly
+    (no subprocess spawning). Otherwise runs in-process via the engine.
+
+    Errors from run_preflight() and harness.run(engine, config) propagate unchanged (PreFlightError,
+    EngineError). Only result-saving errors are caught so a save failure does not
+    discard a completed measurement.
+    """
+    from llenergymeasure.domain.experiment import compute_declared_config_hash
+    from llenergymeasure.study.runner import _save_and_record
+
+    config = study.experiments[0]
+    config_hash = compute_declared_config_hash(config)
+    cycle = 1
+
+    # Pre-dispatch GPU memory residual check (MEAS-01, MEAS-02)
+    # Mirrors the pattern used in StudyRunner._run_one() and _run_one_docker().
+    from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
+
+    check_gpu_memory_residual()
+
+    # Collect environment snapshot once - used for both harness and environment.json sidecar
+    from llenergymeasure.harness.environment import collect_environment_snapshot
+
+    snapshot = collect_environment_snapshot()
+
+    # Check runner spec for this engine
+    spec = runner_specs.get(config.engine) if runner_specs else None
+
+    manifest.mark_running(config_hash, cycle)
+
+    save_ts = study.output.save_timeseries
+    ts_tmpdir: Path | None = None  # Only set for local path
+
+    if spec is not None and spec.mode == RUNNER_DOCKER:
+        # Docker path: dispatch to container directly (no subprocess)
+        from llenergymeasure.infra.docker_errors import (
+            DockerStdoutSilenceError,
+            DockerTimeoutError,
+        )
+        from llenergymeasure.infra.docker_runner import DockerRunner
+        from llenergymeasure.infra.image_registry import get_default_image
+        from llenergymeasure.utils.exceptions import DockerError
+
+        image = spec.image if spec.image is not None else get_default_image(config.engine)
+
+        docker_runner = DockerRunner(
+            image=image,
+            timeout=study.study_execution.experiment_timeout_seconds,
+            silence_timeout=study.study_execution.stdout_silence_timeout_seconds,
+            source=spec.source,
+            extra_mounts=spec.extra_mounts,
+        )
+        docker_ts_dir: Path | None = None
+        try:
+            result, docker_ts_dir = docker_runner.run(
+                config, progress=progress, save_timeseries=save_ts
+            )
+        except DockerStdoutSilenceError as exc:
+            # Distinct error type so users can tell stuck-process kills
+            # from wall-clock timeouts when reading the manifest.
+            error_payload: dict[str, Any] = {
+                "type": "StdoutSilenceTimeoutError",
+                "message": str(exc),
+                "config_hash": config_hash,
+            }
+            manifest.mark_failed(
+                config_hash, cycle, error_payload["type"], error_payload["message"]
+            )
+            return [], [None], [error_payload["message"]]
+        except DockerTimeoutError as exc:
+            # Normalise to "TimeoutError" so the circuit breaker sees the same
+            # failure class as the subprocess path.
+            error_payload = {
+                "type": "TimeoutError",
+                "message": str(exc),
+                "config_hash": config_hash,
+            }
+            manifest.mark_failed(
+                config_hash, cycle, error_payload["type"], error_payload["message"]
+            )
+            return [], [None], [error_payload["message"]]
+        except DockerError as exc:
+            # Convert to failure dict - manifest marks failed, study continues
+            error_payload = {
+                "type": type(exc).__name__,
+                "message": str(exc),
+                "config_hash": config_hash,
+            }
+            manifest.mark_failed(
+                config_hash, cycle, error_payload["type"], error_payload["message"]
+            )
+            return [], [None], [error_payload["message"]]
+        # Docker path: ts_tmpdir comes from DockerRunner
+        ts_tmpdir = docker_ts_dir
+    else:
+        # Local in-process path - errors propagate naturally (PreFlightError, EngineError)
+        import tempfile
+
+        from llenergymeasure.engines import get_engine
+        from llenergymeasure.harness import MeasurementHarness
+        from llenergymeasure.harness.preflight import run_preflight
+
+        if progress:
+            progress.on_step_start("container_preflight", "Checking", "CUDA, model access")
+        t0 = time.perf_counter()
+        run_preflight(config)
+        if progress:
+            progress.on_step_done("container_preflight", time.perf_counter() - t0)
+
+        # Create temp dir for timeseries parquet (if enabled)
+        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES)) if save_ts else None
+
+        try:
+            engine = get_engine(config.engine)
+            harness = MeasurementHarness()
+            gpu_indices = _resolve_gpu_indices(config)
+            result = harness.run(
+                engine,
+                config,
+                snapshot=snapshot,
+                gpu_indices=gpu_indices,
+                progress=progress,
+                output_dir=str(ts_tmpdir) if ts_tmpdir else None,
+                save_timeseries=save_ts,
+            )
+        except Exception:
+            if ts_tmpdir is not None:
+                shutil.rmtree(ts_tmpdir, ignore_errors=True)
+            raise
+
+    # Handle error payload returned from Docker container (exit 0 but wrote error JSON)
+    if isinstance(result, dict) and "type" in result:
+        error_type = result.get("type", "UnknownError")
+        error_message = result.get("message", "")
+        manifest.mark_failed(config_hash, cycle, error_type, error_message)
+        return [], [None], [error_message]
+
+    result_files: list[str] = []
+    warnings: list[str] = []
+    _save_and_record(
+        result,
+        study_dir,
+        manifest,
+        config_hash,
+        cycle,
+        result_files,
+        ts_source_dir=ts_tmpdir,
+        environment_snapshot=snapshot,
+        resolution_log=(resolution_logs or {}).get(config_hash),
+    )
+
+    # Clean up temp dirs
+    if ts_tmpdir is not None and ts_tmpdir.exists():
+        shutil.rmtree(ts_tmpdir, ignore_errors=True)
+
+    return result_files, [result], warnings

--- a/tests/unit/study/test_single.py
+++ b/tests/unit/study/test_single.py
@@ -1,0 +1,107 @@
+"""Unit tests for the single-experiment in-process execution seam.
+
+run_single_experiment() is the shared body for single-experiment / n_cycles=1
+studies. These tests verify it without GPU hardware (uses monkeypatching).
+"""
+
+from __future__ import annotations
+
+from llenergymeasure import ExperimentConfig, ExperimentResult, StudyConfig
+from llenergymeasure.study.single import run_single_experiment
+from tests.conftest import make_result
+
+
+class _MockBackend:
+    """Minimal EnginePlugin for run_single_experiment() tests.
+
+    Implements the 4-method EnginePlugin protocol. Tests that use this mock
+    also patch MeasurementHarness.run to return the pre-built result directly,
+    so only load_model/warmup/run_inference/cleanup stubs are needed here.
+    """
+
+    def __init__(self, result: ExperimentResult) -> None:
+        self._result = result
+        self.run_inference_calls: list[ExperimentConfig] = []
+
+    @property
+    def name(self) -> str:
+        return "transformers"
+
+    def load_model(self, config: ExperimentConfig, **kwargs):
+        return object()  # Opaque model object
+
+    def warmup(self, config: ExperimentConfig, model, prompts: list[str] | None = None):
+        from llenergymeasure.domain.metrics import WarmupResult
+
+        return WarmupResult(
+            converged=True, final_cv=0.0, iterations_completed=0, target_cv=0.01, max_prompts=1
+        )
+
+    def run_inference(self, config: ExperimentConfig, model, prompts: list[str] | None = None):
+        from llenergymeasure.engines.protocol import InferenceOutput
+
+        self.run_inference_calls.append(config)
+        return InferenceOutput(
+            elapsed_time_sec=1.0,
+            input_tokens=10,
+            output_tokens=20,
+            peak_memory_mb=0.0,
+            model_memory_mb=0.0,
+        )
+
+    def cleanup(self, model) -> None:
+        pass
+
+
+def _patch_harness(monkeypatch, result: ExperimentResult) -> None:
+    """Patch MeasurementHarness.run to return a pre-built result.
+
+    Used by tests that verify execution wiring (preflight, get_engine) without
+    running the actual measurement lifecycle.
+    """
+    import llenergymeasure.harness as harness_module
+
+    monkeypatch.setattr(
+        harness_module.MeasurementHarness, "run", lambda self, engine, config, **kw: result
+    )
+
+
+def test_run_single_experiment_calls_gpu_memory_check(monkeypatch, tmp_path):
+    """run_single_experiment() calls check_gpu_memory_residual before running the experiment."""
+    import llenergymeasure.engines as engines_module
+    import llenergymeasure.harness.preflight as pf_module
+
+    gpu_check_calls: list[int] = []
+
+    def mock_gpu_check(device_index=0, threshold_mb=1024.0):
+        gpu_check_calls.append(device_index)
+
+    mock_result = make_result(experiment_id="gpu-check-test")
+    mock_engine = _MockBackend(mock_result)
+
+    monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
+    monkeypatch.setattr(engines_module, "get_engine", lambda name: mock_engine)
+    _patch_harness(monkeypatch, mock_result)
+    monkeypatch.setattr(
+        "llenergymeasure.study.gpu_memory.check_gpu_memory_residual",
+        mock_gpu_check,
+    )
+    monkeypatch.setattr(
+        "llenergymeasure.results.persistence.save_result",
+        lambda result, output_dir, **kw: tmp_path / "result.json",
+    )
+
+    from unittest.mock import MagicMock
+
+    from llenergymeasure.study.manifest import ManifestWriter
+
+    mock_manifest = MagicMock(spec=ManifestWriter)
+
+    config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    study = StudyConfig(experiments=[config])
+
+    run_single_experiment(study, mock_manifest, tmp_path, runner_specs=None)
+
+    assert len(gpu_check_calls) == 1, (
+        f"Expected check_gpu_memory_residual to be called once, got {len(gpu_check_calls)}"
+    )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -756,7 +756,7 @@ def test_run_resolves_runners_and_passes_to_study_runner(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(api_module, "_run_via_runner", mock_run_via_runner)
 
-    # Use a 2-experiment study to force _run_via_runner path (not _run_in_process)
+    # Use a 2-experiment study to force _run_via_runner path (not run_single_experiment)
     import llenergymeasure.engines as engines_module
 
     mock_engine = _MockBackend(mock_result)
@@ -779,53 +779,6 @@ def test_run_resolves_runners_and_passes_to_study_runner(monkeypatch, tmp_path):
 
     assert len(captured_runner_specs) == 1, "_run_via_runner not called or called multiple times"
     assert captured_runner_specs[0] == resolved_specs
-
-
-# =============================================================================
-# Plan 24-01: GPU memory check in _run_in_process
-# =============================================================================
-
-
-def test_run_in_process_calls_gpu_memory_check(monkeypatch, tmp_path):
-    """_run_in_process() calls check_gpu_memory_residual before running the experiment."""
-    import llenergymeasure.api._impl as api_module
-    import llenergymeasure.engines as engines_module
-    import llenergymeasure.harness.preflight as pf_module
-
-    gpu_check_calls: list[int] = []
-
-    def mock_gpu_check(device_index=0, threshold_mb=1024.0):
-        gpu_check_calls.append(device_index)
-
-    mock_result = make_result(experiment_id="gpu-check-test")
-    mock_engine = _MockBackend(mock_result)
-
-    monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
-    monkeypatch.setattr(engines_module, "get_engine", lambda name: mock_engine)
-    _patch_harness(monkeypatch, mock_result)
-    monkeypatch.setattr(
-        "llenergymeasure.study.gpu_memory.check_gpu_memory_residual",
-        mock_gpu_check,
-    )
-    monkeypatch.setattr(
-        "llenergymeasure.results.persistence.save_result",
-        lambda result, output_dir, **kw: tmp_path / "result.json",
-    )
-
-    from unittest.mock import MagicMock
-
-    from llenergymeasure.study.manifest import ManifestWriter
-
-    mock_manifest = MagicMock(spec=ManifestWriter)
-
-    config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
-    study = StudyConfig(experiments=[config])
-
-    api_module._run_in_process(study, mock_manifest, tmp_path, runner_specs=None)
-
-    assert len(gpu_check_calls) == 1, (
-        f"Expected check_gpu_memory_residual to be called once, got {len(gpu_check_calls)}"
-    )
 
 
 def test_run_mixed_runner_warning_logged(monkeypatch, tmp_path, caplog):
@@ -977,7 +930,7 @@ class TestResolveGpuIndices:
 
     def test_pytorch_no_device_map_returns_zero(self):
         """PyTorch engine with device_map=None always returns [0]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = self._make_pytorch_config(device_map=None)
         assert _resolve_gpu_indices(config) == [0]
@@ -986,7 +939,7 @@ class TestResolveGpuIndices:
         """PyTorch with device_map='auto' and 4 visible GPUs returns [0, 1, 2, 3]."""
         import sys
 
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         mock_pynvml = self._make_mock_pynvml(device_count=4)
         monkeypatch.setitem(sys.modules, "pynvml", mock_pynvml)
@@ -998,7 +951,7 @@ class TestResolveGpuIndices:
         """PyTorch with device_map='auto' and only 1 GPU returns [0] (no-op multi-GPU)."""
         import sys
 
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         mock_pynvml = self._make_mock_pynvml(device_count=1)
         monkeypatch.setitem(sys.modules, "pynvml", mock_pynvml)
@@ -1010,7 +963,7 @@ class TestResolveGpuIndices:
         """PyTorch with device_map='auto' but pynvml absent falls through to [0]."""
         import sys
 
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         # Remove pynvml from sys.modules so the local import raises ImportError
         monkeypatch.setitem(sys.modules, "pynvml", None)  # type: ignore[arg-type]
@@ -1020,14 +973,14 @@ class TestResolveGpuIndices:
 
     def test_non_pytorch_non_vllm_engine_returns_zero(self):
         """Unknown engines return [0]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = ExperimentConfig.model_construct(task={"model": "gpt2"}, engine="tensorrt")
         assert _resolve_gpu_indices(config) == [0]
 
     def test_pytorch_engine_no_pytorch_block_returns_zero(self):
         """PyTorch engine with transformers=None (no pytorch block) returns [0]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = ExperimentConfig.model_construct(
             task={"model": "gpt2"}, engine="transformers", transformers=None
@@ -1049,43 +1002,43 @@ class TestResolveGpuIndices:
 
     def test_vllm_tp2_returns_two_gpus(self):
         """vLLM with tensor_parallel_size=2 returns [0, 1]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = self._make_vllm_config(tp=2)
         assert _resolve_gpu_indices(config) == [0, 1]
 
     def test_vllm_tp4_returns_four_gpus(self):
         """vLLM with tensor_parallel_size=4 returns [0, 1, 2, 3]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = self._make_vllm_config(tp=4)
         assert _resolve_gpu_indices(config) == [0, 1, 2, 3]
 
     def test_vllm_tp2_pp2_returns_four_gpus(self):
         """vLLM with tp=2, pp=2 returns [0, 1, 2, 3]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = self._make_vllm_config(tp=2, pp=2)
         assert _resolve_gpu_indices(config) == [0, 1, 2, 3]
 
     def test_vllm_tp1_returns_single_gpu(self):
         """vLLM with tensor_parallel_size=1 (default) returns [0]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = self._make_vllm_config(tp=1)
         assert _resolve_gpu_indices(config) == [0]
 
     def test_vllm_no_engine_block_returns_single_gpu(self):
         """vLLM with no engine config returns [0]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
         from llenergymeasure.config.engine_configs import VLLMConfig
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = ExperimentConfig(task={"model": "gpt2"}, engine="vllm", vllm=VLLMConfig())
         assert _resolve_gpu_indices(config) == [0]
 
     def test_vllm_no_vllm_block_returns_single_gpu(self):
         """vLLM engine with vllm=None returns [0]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = ExperimentConfig(task={"model": "gpt2"}, engine="vllm")
         assert _resolve_gpu_indices(config) == [0]
@@ -1108,35 +1061,35 @@ class TestResolveGpuIndicesTensorrt:
 
     def test_tensorrt_tp1_returns_single_index(self):
         """tensor_parallel_size=1 -> [0] (single GPU)."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 1})
         assert _resolve_gpu_indices(config) == [0]
 
     def test_tensorrt_tp2_returns_two_indices(self):
         """tensor_parallel_size=2 -> [0, 1] (two GPUs for energy monitoring)."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 2})
         assert _resolve_gpu_indices(config) == [0, 1]
 
     def test_tensorrt_tp4_returns_four_indices(self):
         """tensor_parallel_size=4 -> [0, 1, 2, 3]."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = make_config(engine="tensorrt", tensorrt={"tensor_parallel_size": 4})
         assert _resolve_gpu_indices(config) == [0, 1, 2, 3]
 
     def test_tensorrt_tp_none_returns_single_index(self):
         """tensor_parallel_size=None (default) -> [0] (single GPU)."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = make_config(engine="tensorrt", tensorrt={})
         assert _resolve_gpu_indices(config) == [0]
 
     def test_tensorrt_no_config_returns_single_index(self):
         """engine=tensorrt but tensorrt=None -> [0] (fallback)."""
-        from llenergymeasure.api._impl import _resolve_gpu_indices
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 
         config = make_config(engine="tensorrt")
         assert _resolve_gpu_indices(config) == [0]


### PR DESCRIPTION
## Summary

`api/_impl.py` had two parallel execution paths. The single-experiment
path (`_run_in_process`) ran the harness / DockerRunner directly but also
reached into a study-layer private symbol:
`from llenergymeasure.study.runner import _save_and_record` - the api layer
importing a study underscore.

This moves that single-experiment execution body into a new
`src/llenergymeasure/study/single.py` (`run_single_experiment`). Inside the
study package the `_save_and_record` call is a legal intra-package call, so
the api->study-private import is gone. There is one execution seam, owned by
the layer that also owns multi-experiment execution (`StudyRunner`).

No behavior change: a single experiment with `n_cycles == 1` still runs
in-process. It is NOT routed through `StudyRunner` (that would switch it to
subprocess isolation). `_run` keeps the dispatch decision and the
single-experiment progress begin/end block; it now delegates the body to
`run_single_experiment`.

Knock-on: `_impl` no longer re-exported `_resolve_gpu_indices`, so the
`_resolve_gpu_indices` unit tests now import it from its canonical home
(`llenergymeasure.device.gpu_info`).

Closer follow-ups: tightened `run_single_experiment`'s `manifest` and
`runner_specs` parameters from `Any` to `ManifestWriter` and
`dict[str, RunnerSpec] | None` (TYPE_CHECKING imports, no layer change);
added a `single.py` row to the study module table.

## Test plan

- `uv run pytest tests/ -q` - 2437 passed, 52 skipped (coverage gate clean).
- `uv run ruff check src tests` - all checks pass.
- `uv run mypy src/` - no issues in 108 files.
- `uv run lint-imports` - 4 contracts kept, 0 broken (no contract edits;
  api->study public import was already legal).
- `uv run llem run configs/example-study-full.yaml --dry-run` - prints panel
  + "Config valid".
- New `tests/unit/study/test_single.py` covers the moved
  `run_single_experiment` GPU-memory-check path;
  `test_run_dispatches_single_in_process` still asserts `StudyRunner` is not
  constructed for N=1.
- `grep -rn "_run_in_process\|study.runner import _save_and_record"
  src/llenergymeasure/api/` returns nothing.

## Doc audit

- `api/README.md` ASCII dataflow diagram updated by the implementer:
  `_run_in_process()` -> `run_single_experiment()` (study layer).
- `grep -rn "_run_in_process" docs/ README.md src/` returns nothing: no
  stragglers.
- `study/README.md` module table now lists the new `single.py` entry seam
  (added in this PR).
- Remaining "single experiment" doc hits are the user-facing concept, not
  the internal dispatch symbol; no change needed.