### PR TITLE
fix(results): default transformers batch size in batch metrics + review cleanups

### DIFF
--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -345,6 +345,11 @@ def _run(
 
     _api_logger = logging.getLogger(__name__)
 
+    # Preresolved runner specs bypass preflight; demanding skip_preflight makes the
+    # contract explicit rather than silently ignoring the precomputed result.
+    if preresolved is not None and not skip_preflight:
+        raise ValueError("preresolved requires skip_preflight=True")
+
     # Load user config first so runner context can be forwarded to preflight,
     # ensuring preflight uses the same runner resolution as the actual dispatch path.
     user_config = load_user_config()

--- a/src/llenergymeasure/domain/README.md
+++ b/src/llenergymeasure/domain/README.md
@@ -104,10 +104,13 @@ Experiment result models.
 run. Holds the final metrics (energy, throughput, FLOPs, latency) directly.
 
 ### model_info.py
-Model metadata.
+Model metadata. These classes are not re-exported from the `domain` package;
+import them from `llenergymeasure.domain.model_info` directly.
 
 **ModelInfo** - Model characteristics:
 ```python
+from llenergymeasure.domain.model_info import ModelInfo
+
 ModelInfo(
     name="meta-llama/Llama-2-7b-hf",
     num_parameters=7_000_000_000,
@@ -118,6 +121,8 @@ ModelInfo(
 
 **QuantizationSpec** - Quantization details:
 ```python
+from llenergymeasure.domain.model_info import QuantizationSpec
+
 QuantizationSpec(
     enabled=True,
     bits=4,

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -716,12 +716,16 @@ class MeasurementHarness:
     def _configured_batch_size(engine_name: str, config: ExperimentConfig) -> int | None:
         """Return the configured static batch size for the engine, or None.
 
-        transformers -> config.transformers.batch_size
+        transformers -> config.transformers.batch_size, defaulting to 1 (mirrors
+                        the engine plugin, which defaults batch_size to 1 when the
+                        transformers config block or its batch_size is unset)
         tensorrt     -> config.tensorrt.max_batch_size (its analogous field)
         anything else (incl. vllm continuous batching) -> None
         """
-        if engine_name == "transformers" and config.transformers is not None:
-            return config.transformers.batch_size
+        if engine_name == "transformers":
+            if config.transformers is not None and config.transformers.batch_size is not None:
+                return config.transformers.batch_size
+            return 1
         if engine_name == "tensorrt" and config.tensorrt is not None:
             return config.tensorrt.max_batch_size
         return None

--- a/src/llenergymeasure/utils/exceptions.py
+++ b/src/llenergymeasure/utils/exceptions.py
@@ -48,7 +48,3 @@ class DockerPreFlightError(PreFlightError):
     Inherits from PreFlightError so it is caught by the existing CLI error
     handler (PreFlightError catch block in cli/run.py).
     """
-
-
-# Used by results/aggregation.py
-AggregationError = ExperimentError

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -1057,6 +1057,41 @@ def test_build_result_populates_mj_per_tok(minimal_config):
     assert result.mj_per_tok_adjusted is None
 
 
+def test_build_result_batch_utilisation_defaults_for_transformers(minimal_config):
+    """A config WITHOUT a transformers block yields batch_utilisation == 1.0.
+
+    Regression: the transformers plugin defaults batch_size to 1 when the
+    transformers config block (or its batch_size) is unset, but
+    _configured_batch_size used to return None in that case, leaving
+    batch_utilisation silently null. It must now mirror the engine default of 1.
+    """
+    # minimal_config.transformers is None - the exact unset case.
+    assert minimal_config.transformers is None
+
+    engine = FakeBackend(
+        engine_name="transformers",
+        inference_output=InferenceOutput(
+            elapsed_time_sec=1.0,
+            input_tokens=10,
+            output_tokens=20,
+            peak_memory_mb=512.0,
+            model_memory_mb=256.0,
+            batch_times=[1.0],
+            num_batches=1,
+        ),
+    )
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, minimal_config)
+
+    batch = result.extended_metrics.batch
+    # load_prompts is patched to one prompt; num_batches=1 -> effective 1.
+    assert batch.effective_batch_size == pytest.approx(1.0)
+    # configured defaults to 1 -> utilisation 1.0, not null.
+    assert batch.batch_utilisation == pytest.approx(1.0)
+
+
 def test_harness_flops_none_result_has_none_derived(minimal_config):
     """When FLOPs estimation returns None, derived fields are None."""
     engine = FakeBackend()

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -404,6 +404,23 @@ def test_run_skips_preflight_when_preresolved_supplied(monkeypatch, tmp_path):
     )
 
 
+def test_run_preresolved_without_skip_preflight_raises():
+    """Passing preresolved with skip_preflight=False is rejected, not silently honoured."""
+    import llenergymeasure.api._impl as api_module
+    from llenergymeasure.infra.runner_resolution import RunnerSpec
+
+    config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    study = StudyConfig(experiments=[config])
+
+    preresolved = (
+        {"transformers": RunnerSpec(mode="local", image=None, source="test")},
+        {},
+    )
+
+    with pytest.raises(ValueError, match="preresolved requires skip_preflight=True"):
+        api_module._run(study, skip_preflight=False, preresolved=preresolved)
+
+
 def test_run_calls_get_engine_with_correct_name(monkeypatch, tmp_path):
     """_run() calls get_engine with the experiment's engine name."""
     import llenergymeasure.api._impl as api_module

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -1,6 +1,6 @@
-"""Unit tests for ExperimentResult v3.0 schema.
+"""Unit tests for ExperimentResult v4.0 schema.
 
-Tests cover: schema_version="3.0", all RES-01..RES-11 fields, JSON round-trip,
+Tests cover: schema_version="4.0", all RES-01..RES-11 fields, JSON round-trip,
 config hash utility, MultiGPUMetrics, frozen model enforcement.
 """
 
@@ -51,7 +51,7 @@ def make_result():
 
 
 def test_schema_version_default_is_3_0(make_result):
-    """schema_version defaults to '3.0', not '3.0.0'."""
+    """schema_version defaults to '4.0', not '4.0.0'."""
     result = make_result()
     from tests.conftest import EXPERIMENT_SCHEMA_VERSION
 


### PR DESCRIPTION
## Summary

Addresses findings from an adversarial review of recent harness/results work.

### Finding 1 (major): batch_utilisation silently null on default-config transformers runs
The transformers plugin defaults `batch_size` to 1 when the `transformers`
config block (or its `batch_size`) is unset, but `_configured_batch_size` in
`harness/measurement.py` returned `None` in exactly those cases. `_compute_batch_metrics`
then left `batch_utilisation` null even though `effective_batch_size` was computed.
Empirically confirmed at the real surface: a default-config run produced
`effective_batch_size=1`, `batch_utilisation=null`.

Fix: `_configured_batch_size` now mirrors the engine's own default for
transformers - returns `config.transformers.batch_size` when set, else `1`.
The non-transformers branches are unchanged.

### Finding 2 (minor): preresolved / skip_preflight contract was advisory
`_run` in `api/_impl.py` used `preresolved` unconditionally when given, silently
ignoring `skip_preflight=False`. It now raises
`ValueError("preresolved requires skip_preflight=True")` at the top of `_run`
when `preresolved is not None and not skip_preflight`. Public signature unchanged.

### Finding 3 (minor): dead AggregationError alias
`utils/exceptions.py` defined `AggregationError = ExperimentError` with a comment
pointing at `results/aggregation.py`, a module that was deleted. Zero usages
repo-wide. Alias and comment removed.

### Nits
- `tests/unit/test_experiment_result_v2.py` docstrings updated from schema 3.0
  to 4.0 (assertions were already dynamic).
- `domain/README.md` now imports `ModelInfo` / `QuantizationSpec` from
  `llenergymeasure.domain.model_info`; they are no longer re-exported from the
  `domain` package `__all__`.

## Test plan

- New regression test `test_build_result_batch_utilisation_defaults_for_transformers`:
  a config WITHOUT a transformers block yields `batch_utilisation == 1.0` through
  `_build_result`. Verified it fails before the fix (`None`) and passes after.
- New test `test_run_preresolved_without_skip_preflight_raises`: passing
  `preresolved` with `skip_preflight=False` raises the expected `ValueError`.
- Full suite: `uv run pytest tests/ -q` -> 2439 passed, 52 skipped.
- `uv run ruff check src tests` -> clean.
- `uv run mypy src/` -> no issues in 109 source files.
- `uv run python -m importlinter.cli lint_imports --config pyproject.toml` -> exit 0.
- `AggregationError` grep -> zero hits repo-wide.