### PR TITLE
refactor(study): split StudyRunner god module into focused collaborators

### DIFF
--- a/docs/explanation/architecture/pipeline-architecture.md
+++ b/docs/explanation/architecture/pipeline-architecture.md
@@ -213,7 +213,7 @@ Runs `scripts/_drift.py` over a curated version range (e.g. `vllm v0.9..v0.12`) 
 
 `runtime_observations.jsonl`:
 
-- **Producer:** `src/llenergymeasure/study/runtime_observations.py` (`warnings.catch_warnings` + logger handler wrapping each worker body); wired in `runner.py`.
+- **Producer:** `src/llenergymeasure/study/runtime_observations.py` (`warnings.catch_warnings` + logger handler wrapping each worker body); wired in `worker.py`.
 - **Schema:** `schema_version=1`; one record per `(study_run_id, config_hash, cycle)`; outcome in `{success, exception, subprocess_died}`.
 - **Consumer (today):** `llem report-gaps` with `--source runtime-warnings` (the only wired source). Output is a YAML fragment for manual append to the corpus, with `# TODO: human` markers on placeholder fields. Preserved as an escape-hatch.
 - **Consumer (long-term):** subsume into curation digest Section 3 ("Runtime gaps observed"). Deferred to [#475](https://github.com/henrycgbaker/llenergymeasure/issues/475); reactivate after 2-3 Renovate cycles of operational data.

--- a/src/llenergymeasure/domain/progress.py
+++ b/src/llenergymeasure/domain/progress.py
@@ -35,7 +35,7 @@ class ProgressCallback(Protocol):
     Implementors:
         - StepDisplay (cli/_step_display.py) -- Rich-based TTY rendering
         - StreamProgressCallback (entrypoints/container.py) -- JSON lines to stdout
-        - _QueueProgressCallback (study/runner.py) -- multiprocessing.Queue bridge
+        - _QueueProgressCallback (study/_progress.py) -- multiprocessing.Queue bridge
     """
 
     def on_step_start(self, step: str, description: str, detail: str = "") -> None:

--- a/src/llenergymeasure/study/README.md
+++ b/src/llenergymeasure/study/README.md
@@ -10,7 +10,12 @@ Implements the sweep runner that executes a `StudyConfig` (a list of `Experiment
 
 | Module | Description |
 |--------|-------------|
-| `runner.py` | `StudyRunner` - subprocess dispatch core |
+| `runner.py` | `StudyRunner` - study-level run loop, dispatch, and result handling |
+| `worker.py` | `_run_experiment_worker()` (child entry point), `_collect_result()`, process-group signalling |
+| `_progress.py` | `_QueueProgressCallback` + `_consume_progress_events()` - cross-process progress bridge |
+| `baseline_measure.py` | `_BaselineMixin` - baseline measurement, caching, and drift validation |
+| `image_prep.py` | `_ImageMixin` - Docker image preparation and schema-fingerprint verification |
+| `container_lifecycle.py` | Container naming/labels/cleanup, SIGTERM bridge, orphan reaper, failure artefacts |
 | `single.py` | `run_single_experiment()` - in-process / direct-DockerRunner path for a single experiment |
 | `manifest.py` | `ManifestWriter`, `StudyManifest`, `ExperimentManifestEntry` - checkpoint model |
 | `gpu_memory.py` | `check_gpu_memory_residual()` - pre-dispatch GPU memory check |

--- a/src/llenergymeasure/study/_progress.py
+++ b/src/llenergymeasure/study/_progress.py
@@ -1,0 +1,115 @@
+"""Progress plumbing for subprocess-isolated experiments.
+
+Two halves of a cross-process progress bridge:
+
+- ``_QueueProgressCallback`` lives inside the worker subprocess and serialises
+  step events onto a ``multiprocessing.Queue``.
+- ``_consume_progress_events`` runs as a daemon thread in the parent and
+  forwards those events to the study-level ``StudyProgressCallback``.
+
+Pure plumbing: neither half touches ``StudyRunner`` state.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from llenergymeasure.domain.progress import StudyProgressCallback
+
+
+class _QueueProgressCallback:
+    """ProgressCallback that serialises step events onto a multiprocessing.Queue.
+
+    Created inside the worker subprocess. Events are dicts consumed by the
+    parent's _consume_progress_events thread and forwarded to StudyStepDisplay.
+    """
+
+    def __init__(self, queue: Any) -> None:
+        self._queue = queue
+
+    def _put(self, event: dict[str, Any]) -> None:
+        with contextlib.suppress(Exception):
+            self._queue.put(event)
+
+    def on_step_start(self, step: str, description: str, detail: str = "") -> None:
+        self._put(
+            {"event": "step_start", "step": step, "description": description, "detail": detail}
+        )
+
+    def on_step_update(self, step: str, detail: str) -> None:
+        self._put({"event": "step_update", "step": step, "detail": detail})
+
+    def on_step_done(self, step: str, elapsed_sec: float) -> None:
+        self._put({"event": "step_done", "step": step, "elapsed_sec": elapsed_sec})
+
+    def on_step_skip(self, step: str, reason: str = "") -> None:
+        self._put({"event": "step_skip", "step": step, "reason": reason})
+
+    def on_substep(self, step: str, text: str, elapsed_sec: float = 0.0) -> None:
+        self._put({"event": "substep", "step": step, "text": text, "elapsed_sec": elapsed_sec})
+
+    def on_substep_start(self, step: str, text: str) -> None:
+        self._put({"event": "substep_start", "step": step, "text": text})
+
+    def on_substep_done(
+        self,
+        step: str,
+        text: str | None = None,
+        elapsed_sec: float | None = None,
+    ) -> None:
+        self._put(
+            {
+                "event": "substep_done",
+                "step": step,
+                "text": text,
+                "elapsed_sec": elapsed_sec,
+            }
+        )
+
+
+def _consume_progress_events(
+    q: Any,
+    study_progress: StudyProgressCallback | None = None,
+) -> None:
+    """Consume progress events from the queue and forward to study display.
+
+    Runs as a daemon thread in the parent process. Receives step events from
+    the child subprocess via multiprocessing.Queue and forwards them to the
+    StudyProgressCallback (typically StudyStepDisplay).
+
+    Coarse events (started/completed/failed) are ignored here - study-level
+    begin/end experiment tracking is handled directly by _run_one().
+    """
+    while True:
+        event = q.get()
+        if event is None:
+            break
+
+        if not isinstance(event, dict) or study_progress is None:
+            continue
+
+        event_type = event.get("event")
+
+        # Forward step-level events to study display
+        if event_type == "step_start":
+            study_progress.on_step_start(
+                event["step"], event.get("description", ""), event.get("detail", "")
+            )
+        elif event_type == "step_update":
+            study_progress.on_step_update(event["step"], event.get("detail", ""))
+        elif event_type == "step_done":
+            study_progress.on_step_done(event["step"], event.get("elapsed_sec", 0))
+        elif event_type == "step_skip":
+            study_progress.on_step_skip(event["step"], event.get("reason", ""))
+        elif event_type == "substep":
+            study_progress.on_substep(
+                event["step"], event.get("text", ""), event.get("elapsed_sec", 0)
+            )
+        elif event_type == "substep_start":
+            study_progress.on_substep_start(event["step"], event.get("text", ""))
+        elif event_type == "substep_done":
+            study_progress.on_substep_done(
+                event["step"], event.get("text"), event.get("elapsed_sec")
+            )

--- a/src/llenergymeasure/study/baseline_measure.py
+++ b/src/llenergymeasure/study/baseline_measure.py
@@ -1,0 +1,464 @@
+"""Study-level baseline measurement, caching, and drift validation.
+
+``_BaselineMixin`` holds the stateful baseline methods mixed into
+``StudyRunner``. Baselines are keyed per runner target ("local" or
+``image_<slug>``) so multi-engine studies don't cross-contaminate, and are
+persisted to disk so mid-study restarts reuse a still-valid measurement.
+
+For Docker targets the measurement runs inside a short-lived container of the
+same engine image, so the CUDA init footprint matches the experiment container
+(see ``.product/research/baseline-measurement-location.md``).
+
+These methods read and write ``self._baselines``, ``self._progress``,
+``self._runner_specs``, and ``self._experiments_since_validation``, which are
+initialised in ``StudyRunner.__init__``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.config.ssot import RUNNER_DOCKER
+from llenergymeasure.domain.progress import STEP_BASELINE
+from llenergymeasure.study.image_prep import _sanitize_image_for_filename
+
+if TYPE_CHECKING:
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.domain.progress import StudyProgressCallback
+    from llenergymeasure.infra.runner_resolution import RunnerSpec
+
+logger = logging.getLogger(__name__)
+
+
+class _BaselineMixin:
+    """Stateful baseline measurement/caching/validation methods for StudyRunner.
+
+    Relies on attributes set up by ``StudyRunner.__init__``:
+    ``study_dir``, ``_runner_specs``, ``_progress``, ``_baselines``, and
+    ``_experiments_since_validation``.
+    """
+
+    # Attributes provided by StudyRunner.__init__ (declared for the type checker).
+    study_dir: Path
+    _runner_specs: dict[str, RunnerSpec] | None
+    _progress: StudyProgressCallback | None
+    _baselines: dict[str, Any]
+    _experiments_since_validation: dict[str, int]
+
+    def _baseline_cache_key(self, config: ExperimentConfig) -> str:
+        """Return the cache key for this experiment's runner target.
+
+        Baselines are keyed per runner target because the container's CUDA init
+        footprint (~8.7 W/GPU on A100) is process-local and may differ between
+        engine images. See ``.product/research/baseline-measurement-location.md``.
+
+        The ``image_`` prefix uses an underscore (not ``:``) so the key is
+        safe to embed directly in both filesystem paths and Docker bind-mount
+        sources. A ``:`` in the mount source string would be parsed by Docker
+        as the mount-mode separator and fail with ``invalid mode``.
+        """
+        spec = self._runner_specs.get(config.engine) if self._runner_specs else None
+        if spec is None or spec.mode != RUNNER_DOCKER or not spec.image:
+            return "local"
+        return f"image_{_sanitize_image_for_filename(spec.image)}"
+
+    def _get_baseline(self, config: ExperimentConfig) -> Any:
+        """Return baseline power according to the configured strategy.
+
+        Strategies: ``cached`` (measure once per runner target, persist to disk,
+        reuse within TTL), ``validated`` (same, with periodic drift spot-check),
+        and ``fresh`` (returns None; harness measures in-container per experiment).
+
+        For Docker targets the measurement runs inside a short-lived container
+        of the same engine image, so the CUDA init state matches the experiment
+        container (see ``.product/research/baseline-measurement-location.md``).
+        """
+        strategy = config.measurement.baseline.strategy
+
+        if strategy == "fresh":
+            return None
+
+        cache_key = self._baseline_cache_key(config)
+        location = "host" if cache_key == "local" else "baseline container"
+        cached = self._baselines.get(cache_key)
+
+        # TTL expiry check
+        if cached is not None:
+            age = time.time() - cached.timestamp
+            if age >= config.measurement.baseline.cache_ttl_seconds:
+                logger.info(
+                    "Baseline expired (age=%.0fs > ttl=%.0fs). Re-measuring.",
+                    age,
+                    config.measurement.baseline.cache_ttl_seconds,
+                )
+                cached = None
+                self._baselines.pop(cache_key, None)
+
+        # validated: periodic spot-check for drift (only if baseline still valid)
+        if strategy == "validated" and cached is not None:
+            self._experiments_since_validation[cache_key] = (
+                self._experiments_since_validation.get(cache_key, 0) + 1
+            )
+            if (
+                self._experiments_since_validation[cache_key]
+                >= config.measurement.baseline.validation_interval
+            ):
+                self._validate_baseline(config, cache_key)
+                cached = self._baselines.get(cache_key)  # may have been re-measured
+
+        # In-memory hit → emit "Reusing" and return
+        if cached is not None:
+            if self._progress is not None:
+                self._progress.on_step_start(
+                    STEP_BASELINE,
+                    "Reusing",
+                    f"cached {cached.power_w:.1f}W · {location}",
+                )
+                self._emit_baseline_result_substeps(cached, elapsed=0.0, mode="cached")
+                self._progress.on_step_done(STEP_BASELINE, 0.0)
+            return cached
+
+        # Try loading from disk first (handles mid-study restarts)
+        disk_path = self._get_baseline_cache_path(cache_key)
+        if disk_path.exists():
+            from llenergymeasure.harness.baseline import load_baseline_cache
+
+            if self._progress is not None:
+                self._progress.on_step_start(
+                    STEP_BASELINE, "Loading", f"baseline cache · {location}"
+                )
+                t0_load = time.perf_counter()
+
+            loaded = load_baseline_cache(
+                disk_path, ttl=config.measurement.baseline.cache_ttl_seconds
+            )
+
+            if self._progress is not None:
+                load_elapsed = time.perf_counter() - t0_load
+                if loaded is not None:
+                    self._emit_baseline_result_substeps(loaded, elapsed=load_elapsed, mode="disk")
+                self._progress.on_step_done(STEP_BASELINE, load_elapsed)
+
+            if loaded is not None:
+                if loaded.method is None:
+                    loaded.method = strategy
+                self._baselines[cache_key] = loaded
+                self._experiments_since_validation.setdefault(cache_key, 0)
+                logger.debug("Loaded baseline from disk cache: %.1fW", loaded.power_w)
+                return loaded
+
+        # Measure fresh baseline (in-container for Docker targets)
+        dur = config.measurement.baseline.duration_seconds
+        # Prefer the image tag over engine name so users see which container
+        # is running in multi-engine studies.
+        spec = self._runner_specs.get(config.engine) if self._runner_specs else None
+        target_label = (spec.image if spec and spec.image else config.engine) or "baseline"
+        if self._progress is not None:
+            self._progress.on_step_start(STEP_BASELINE, "Calibrating", "sampling idle GPU draw")
+            t0_meas = time.perf_counter()
+            # Seed first substep before Popen so the docker cold-start is visible.
+            if cache_key != "local":
+                self._progress.on_substep_start(
+                    STEP_BASELINE,
+                    f"launching separate {target_label} baseline container",
+                )
+
+        on_stage = (
+            self._make_baseline_stage_callback(duration_sec=dur, target_label=target_label)
+            if self._progress is not None
+            else None
+        )
+        measured = self._measure_baseline(config, cache_key, on_stage=on_stage)
+
+        if measured is not None:
+            measured.method = strategy
+            self._baselines[cache_key] = measured
+            self._experiments_since_validation[cache_key] = 0
+
+            from llenergymeasure.harness.baseline import save_baseline_cache
+
+            save_baseline_cache(disk_path, measured)
+
+        if self._progress is not None:
+            elapsed = time.perf_counter() - t0_meas
+            if measured is None:
+                # Freeze any live substep with the failure text + accurate
+                # elapsed so users don't see a silent tick hiding a crash.
+                self._progress.on_substep_done(
+                    STEP_BASELINE,
+                    text=(
+                        f"measurement failed after {elapsed:.1f}s - see log warnings "
+                        f"(experiment container will re-measure fresh)"
+                    ),
+                    elapsed_sec=elapsed,
+                )
+            elif cache_key == "local":
+                # No container subprocess → emit a retroactive sampling substep
+                # so the local path still gets a breakdown. The Docker path
+                # already emitted substeps live via the on_stage callback.
+                self._emit_baseline_result_substeps(
+                    measured,
+                    elapsed=elapsed,
+                    mode="fresh",
+                    is_containerised=False,
+                )
+            self._progress.on_step_done(STEP_BASELINE, elapsed)
+
+        return measured
+
+    def _make_baseline_stage_callback(
+        self, *, duration_sec: float, target_label: str = "baseline"
+    ) -> Any:
+        """Build a stage-marker callback that drives live baseline sub-bullets.
+
+        Each transition ``on_substep_done``s the prior substep (freezing with
+        a tick) and ``on_substep_start``s the next one. The very first substep
+        ("launching <target_label> container") is seeded in ``_get_baseline``
+        before ``subprocess.Popen`` so the docker cold-start is visible.
+        """
+        dur_label = f"{duration_sec:.0f}s"
+
+        def on_stage(name: str, elapsed: float, kv: dict[str, str]) -> None:
+            if self._progress is None:
+                return
+            if name == "container_ready":
+                self._progress.on_substep_done(
+                    STEP_BASELINE, f"{target_label} baseline container ready"
+                )
+                self._progress.on_substep_start(
+                    STEP_BASELINE, "initialising CUDA runtime inside baseline container"
+                )
+            elif name == "cuda_primed":
+                self._progress.on_substep_done(STEP_BASELINE, "CUDA runtime primed")
+                self._progress.on_substep_start(
+                    STEP_BASELINE, f"sampling idle GPU draw ({dur_label})"
+                )
+            elif name == "sampling_done":
+                power_w = kv.get("power_w", "?")
+                samples = kv.get("samples", "?")
+                sampled = kv.get("duration", "?")
+                self._progress.on_substep_done(
+                    STEP_BASELINE,
+                    f"sampled idle GPU draw · {sampled}s ({power_w}W · {samples} samples)",
+                )
+                self._progress.on_substep_start(
+                    STEP_BASELINE,
+                    f"writing baseline result · tearing down {target_label} baseline container",
+                )
+            elif name == "result_written":
+                self._progress.on_substep_done(
+                    STEP_BASELINE,
+                    f"baseline result cached · {target_label} baseline container torn down",
+                )
+
+        return on_stage
+
+    def _emit_baseline_result_substeps(
+        self,
+        baseline: Any,  # BaselineCache
+        *,
+        elapsed: float,
+        mode: str,  # "fresh" | "cached" | "disk"
+        is_containerised: bool = False,
+    ) -> None:
+        """Emit dim-bullet substeps explaining where the baseline time went.
+
+        For a fresh Docker measurement we split the wall-clock into container
+        launch/teardown (the residual) vs the NVML sampling window (recorded
+        inside ``measure_baseline_power``). This answers "why did a 30s
+        measurement take 37.7s?" without the user having to dig through logs.
+
+        For in-memory and disk-loaded reuse we only emit the result summary -
+        there is no sampling window to describe.
+        """
+        if self._progress is None:
+            return
+        if mode == "fresh" and is_containerised:
+            # Residual captures docker run startup + CUDA prime + result write
+            # + container teardown.
+            overhead = max(0.0, elapsed - baseline.duration_sec)
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"container launch + teardown: {overhead:.1f}s",
+                overhead,
+            )
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"sampling: {baseline.duration_sec:.1f}s "
+                f"({baseline.power_w:.1f}W · {baseline.sample_count} samples)",
+                baseline.duration_sec,
+            )
+        elif mode == "fresh":
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"sampling: {baseline.duration_sec:.1f}s "
+                f"({baseline.power_w:.1f}W · {baseline.sample_count} samples)",
+                baseline.duration_sec,
+            )
+        else:
+            source = "in-memory" if mode == "cached" else "disk"
+            self._progress.on_substep(
+                STEP_BASELINE,
+                f"reused from {source} cache: "
+                f"{baseline.power_w:.1f}W ({baseline.sample_count} samples)",
+            )
+
+    def _measure_baseline(
+        self,
+        config: ExperimentConfig,
+        cache_key: str,
+        on_stage: Any = None,  # StageCallback | None
+    ) -> Any:
+        """Measure a fresh baseline on host or inside a baseline container.
+
+        Local runner targets measure on host (no process boundary, no bias).
+        Docker targets dispatch a short-lived baseline container of the engine
+        image so the CUDA init state matches the experiment container. See
+        ``.product/research/baseline-measurement-location.md`` for the
+        empirical rationale (~8.7 W/GPU bias on A100).
+
+        Args:
+            config: Experiment config with baseline settings.
+            cache_key: "local" or "image_<slug>" - chooses dispatch path.
+            on_stage: Optional callback forwarded to ``run_baseline_container``
+                for streaming stage markers. Ignored on the local path (there
+                is no subprocess to stream from).
+        """
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+
+        gpu_indices = _resolve_gpu_indices(config)
+
+        if cache_key == "local":
+            from llenergymeasure.harness.baseline import measure_baseline_power
+
+            return measure_baseline_power(
+                duration_sec=config.measurement.baseline.duration_seconds,
+                gpu_indices=gpu_indices,
+            )
+
+        # Docker: _baseline_cache_key already guaranteed a resolved image when
+        # it returned a non-"local" key.
+        assert self._runner_specs is not None
+        spec = self._runner_specs[config.engine]
+        assert spec.image is not None
+        from llenergymeasure.study.baseline_container import run_baseline_container
+
+        return run_baseline_container(
+            image=spec.image,
+            mode="measure",
+            duration_sec=config.measurement.baseline.duration_seconds,
+            gpu_indices=gpu_indices,
+            on_stage=on_stage,
+        )
+
+    def _spot_check_baseline(
+        self,
+        config: ExperimentConfig,
+        cache_key: str,
+        gpu_indices: list[int],
+    ) -> float | None:
+        """Quick drift-check measurement for the validated strategy.
+
+        Dispatches to host or baseline container matching the cache key. Returns
+        the measured power in watts, or None on failure.
+        """
+        if cache_key == "local":
+            from llenergymeasure.harness.baseline import measure_spot_check
+
+            return measure_spot_check(gpu_indices=gpu_indices, duration_sec=5.0)
+
+        spec = self._runner_specs.get(config.engine) if self._runner_specs else None
+        if spec is None or spec.image is None:
+            return None
+
+        from llenergymeasure.study.baseline_container import run_baseline_container
+
+        result = run_baseline_container(
+            image=spec.image,
+            mode="spot_check",
+            duration_sec=5.0,
+            gpu_indices=gpu_indices,
+        )
+        return result.power_w if result is not None else None
+
+    def _validate_baseline(self, config: ExperimentConfig, cache_key: str) -> None:
+        """Spot-check baseline for drift (strategy='validated' only).
+
+        Performs a short measurement and compares with the cached baseline. On
+        drift beyond the configured threshold, re-measures the full baseline and
+        updates the disk cache. Emits a single ``Validating`` step (with an
+        ``on_step_update`` mid-step when a re-measure is triggered) so the
+        display step counter stays clean.
+        """
+        cached = self._baselines.get(cache_key)
+        if cached is None:
+            return
+
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+        from llenergymeasure.harness.baseline import save_baseline_cache
+
+        gpu_indices = _resolve_gpu_indices(config)
+        location = "host" if cache_key == "local" else "baseline container"
+
+        if self._progress is not None:
+            self._progress.on_step_start(
+                STEP_BASELINE, "Validating", f"{location} · drift check (5s)"
+            )
+            t0 = time.perf_counter()
+
+        spot = self._spot_check_baseline(config, cache_key, gpu_indices)
+        self._experiments_since_validation[cache_key] = 0
+
+        if spot is None:
+            logger.warning("Baseline validation: spot-check measurement failed")
+            if self._progress is not None:
+                self._progress.on_step_done(STEP_BASELINE, time.perf_counter() - t0)
+            return
+
+        drift = abs(spot - cached.power_w) / cached.power_w
+        if drift > config.measurement.baseline.drift_threshold:
+            dur = config.measurement.baseline.duration_seconds
+            logger.info(
+                "Baseline drift detected: %.1fW -> %.1fW (%.1f%% > %.1f%% threshold). "
+                "Re-measuring full baseline.",
+                cached.power_w,
+                spot,
+                drift * 100,
+                config.measurement.baseline.drift_threshold * 100,
+            )
+            if self._progress is not None:
+                self._progress.on_step_update(
+                    STEP_BASELINE,
+                    f"{location} · drift {drift * 100:.1f}% > "
+                    f"{config.measurement.baseline.drift_threshold * 100:.0f}%, "
+                    f"re-measuring ({dur:.0f}s)",
+                )
+
+            remeasured = self._measure_baseline(config, cache_key)
+            if remeasured is not None:
+                remeasured.method = "validated"
+                self._baselines[cache_key] = remeasured
+                save_baseline_cache(self._get_baseline_cache_path(cache_key), remeasured)
+        else:
+            cached.method = "validated"
+            logger.debug(
+                "Baseline validation passed: drift=%.1f%% (threshold=%.1f%%)",
+                drift * 100,
+                config.measurement.baseline.drift_threshold * 100,
+            )
+
+        if self._progress is not None:
+            self._progress.on_step_done(STEP_BASELINE, time.perf_counter() - t0)
+
+    def _get_baseline_cache_path(self, cache_key: str) -> Path:
+        """Return the disk path for the baseline cache file keyed by runner target.
+
+        File lives at ``{study_dir}/_study-artefacts/baseline_cache_{cache_key}.json``.
+        Creates the artefacts directory if needed.
+        """
+        artefacts_dir = self.study_dir / "_study-artefacts"
+        artefacts_dir.mkdir(parents=True, exist_ok=True)
+        return artefacts_dir / f"baseline_cache_{cache_key}.json"

--- a/src/llenergymeasure/study/container_lifecycle.py
+++ b/src/llenergymeasure/study/container_lifecycle.py
@@ -17,19 +17,26 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import sys
 from datetime import datetime, timezone
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from llenergymeasure.config.ssot import TIMEOUT_DOCKER_CLI, TIMEOUT_DOCKER_STOP
 
+if TYPE_CHECKING:
+    from llenergymeasure.utils.exceptions import DockerError
+
 __all__ = [
     "cleanup_study_containers",
+    "copy_artefact",
     "generate_container_labels",
     "generate_container_name",
     "install_sigterm_bridge",
+    "persist_failure_artefacts",
     "reap_orphaned_containers",
     "register_container_cleanup",
 ]
@@ -196,3 +203,59 @@ def reap_orphaned_containers() -> int:
     except Exception:
         pass  # Never block study start
     return reaped
+
+
+def copy_artefact(src: Path, dest: Path) -> str | None:
+    """Copy a single file, returning the dest filename on success or None."""
+    if not src.exists():
+        return None
+    try:
+        shutil.copy2(src, dest)
+        logger.debug("Artefact persisted to %s", dest)
+        return dest.name
+    except Exception as copy_exc:
+        logger.warning("Failed to persist %s to %s: %s", src.name, dest, copy_exc)
+        return None
+
+
+def persist_failure_artefacts(
+    exc: DockerError,
+    study_dir: Path,
+    config_hash: str,
+    cycle: int,
+    result: dict[str, Any],
+) -> None:
+    """Copy failure artefacts from the Docker exchange dir into ``failed-runs/``.
+
+    Copies ``container.log`` and any ``*_error.json`` from the exchange
+    directory. Adds a ``log_file`` key to *result* so the manifest records
+    where the log can be found.
+    """
+    exchange_dir_str = getattr(exc, "exchange_dir", None)
+    if not exchange_dir_str:
+        return
+
+    exchange_dir = Path(exchange_dir_str)
+    failed_runs_dir = study_dir / "failed-runs"
+    prefix = f"{config_hash}_cycle{cycle}"
+
+    try:
+        failed_runs_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as mkdir_exc:
+        logger.warning("Failed to create failed-runs/: %s", mkdir_exc)
+        return
+
+    # Copy container.log (Docker stderr capture)
+    log_file = copy_artefact(
+        exchange_dir / "container.log",
+        failed_runs_dir / f"{prefix}_container.log",
+    )
+    if log_file:
+        result["log_file"] = f"failed-runs/{log_file}"
+
+    # Copy error JSON (structured traceback from container entrypoint).
+    # The error JSON uses the Docker config hash (output_dir=/run/llem),
+    # which differs from the study-level config_hash, so glob for it.
+    for src in exchange_dir.glob("*_error.json"):
+        copy_artefact(src, failed_runs_dir / f"{prefix}_error.json")
+        break  # only one expected

--- a/src/llenergymeasure/study/image_prep.py
+++ b/src/llenergymeasure/study/image_prep.py
@@ -1,0 +1,366 @@
+"""Study-level Docker image preparation and schema-fingerprint verification.
+
+``_ImageMixin`` holds the stateful image-prep methods mixed into
+``StudyRunner``: it checks (or pulls) each Docker engine's image once at study
+start, parses display metadata, and verifies the image's schema fingerprint
+against the host before any experiments run. Two pure free functions
+(``_sanitize_image_for_filename`` and ``_parse_image_metadata``) sit alongside
+the mixin.
+
+These methods read ``self._runner_specs`` and ``self._progress`` and set
+``self._images_prepared``, all initialised in ``StudyRunner.__init__``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from llenergymeasure._version import __version__ as _HOST_PKG_VERSION
+from llenergymeasure.config.ssot import (
+    DOCKER_PULL_TIMEOUT,
+    RUNNER_DOCKER,
+    TIMEOUT_DOCKER_INSPECT,
+)
+from llenergymeasure.infra.version_handshake import (
+    ENV_SKIP_IMAGE_CHECK,
+    LABEL_SCHEMA_FINGERPRINT,
+    BundledEngineVersionMismatchError,
+    ImageStamp,
+    SchemaStatus,
+    VersionMismatchError,
+    classify_engine_version,
+    classify_stamp,
+    compute_expconf_fingerprint,
+    parse_image_stamp,
+    probe_image_engine_version,
+    read_bundled_engine_version,
+    rebuild_hint,
+    skip_check_enabled,
+)
+
+if TYPE_CHECKING:
+    from llenergymeasure.domain.progress import StudyProgressCallback
+    from llenergymeasure.infra.runner_resolution import RunnerSpec
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_image_for_filename(image: str) -> str:
+    """Return a filename-safe slug for a Docker image tag.
+
+    Replaces path separators, tag markers, digest markers, and whitespace with
+    underscores. Clipped to 128 chars and stripped of trailing underscores so
+    the resulting basename stays well under typical filesystem limits.
+    """
+    sanitized = image
+    for ch in ("/", ":", "@", " ", "\t", "\n"):
+        sanitized = sanitized.replace(ch, "_")
+    sanitized = sanitized[:128].rstrip("_")
+    return sanitized or "unknown"
+
+
+def _parse_image_metadata(inspect_stdout: bytes) -> dict[str, str] | None:
+    """Extract human-readable display metadata from ``docker image inspect`` JSON.
+
+    Returns the id/size/built/layers fields the progress display renders
+    inline. Schema-handshake labels are handled separately via
+    ``parse_image_stamp`` so the raw 64-char fingerprint never leaks into
+    the display metadata.
+    """
+    try:
+        data = json.loads(inspect_stdout)
+        if not data:
+            return None
+        info = data[0]
+        meta: dict[str, str] = {}
+
+        image_id = info.get("Id", "")
+        if image_id.startswith("sha256:"):
+            image_id = image_id[7:19]
+        if image_id:
+            meta["id"] = image_id
+
+        size_bytes = info.get("Size", 0)
+        if size_bytes:
+            if size_bytes >= 1_073_741_824:
+                meta["size"] = f"{size_bytes / 1_073_741_824:.1f} GB"
+            else:
+                meta["size"] = f"{size_bytes / 1_048_576:.0f} MB"
+
+        created = info.get("Created", "")
+        if created:
+            try:
+                created_dt = datetime.fromisoformat(created[:26].rstrip("Z"))
+                created_dt = created_dt.replace(tzinfo=timezone.utc)
+                age = datetime.now(timezone.utc) - created_dt
+                if age.days > 0:
+                    meta["built"] = f"{age.days}d ago"
+                elif age.seconds >= 3600:
+                    meta["built"] = f"{age.seconds // 3600}h ago"
+                else:
+                    meta["built"] = f"{age.seconds // 60}m ago"
+            except (ValueError, TypeError):
+                pass
+
+        layers = info.get("RootFS", {}).get("Layers", [])
+        if layers:
+            meta["layers"] = str(len(layers))
+
+        return meta if meta else None
+    except (json.JSONDecodeError, KeyError, IndexError):
+        return None
+
+
+class _ImageMixin:
+    """Stateful Docker image-prep + fingerprint-verification methods for StudyRunner.
+
+    Relies on attributes set up by ``StudyRunner.__init__``: ``_runner_specs``,
+    ``_progress``, and ``_images_prepared``.
+    """
+
+    # Attributes provided by StudyRunner.__init__ (declared for the type checker).
+    _runner_specs: dict[str, RunnerSpec] | None
+    _progress: StudyProgressCallback | None
+    _images_prepared: bool
+
+    def _prepare_images(self) -> None:
+        """Check/pull Docker images for all Docker engines before experiments.
+
+        Runs once at the start of the study. Each engine's image is verified
+        (or pulled) sequentially. On failure, raises so the study aborts early.
+        Sets ``_images_prepared`` so per-experiment image_check is skipped.
+        """
+
+        if not self._runner_specs:
+            return
+
+        docker_engines = [
+            (engine_name, spec)
+            for engine_name, spec in self._runner_specs.items()
+            if spec.mode == RUNNER_DOCKER and spec.image
+        ]
+        if not docker_engines:
+            return
+
+        if self._progress:
+            self._progress.begin_image_prep([e for e, _ in docker_engines])
+
+        for engine_name, spec in docker_engines:
+            image = spec.image
+            assert image is not None  # narrowing for type checker
+            t0 = time.monotonic()
+
+            # Check if image exists locally
+            try:
+                check = subprocess.run(
+                    ["docker", "image", "inspect", image],
+                    capture_output=True,
+                    timeout=TIMEOUT_DOCKER_INSPECT,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                check = None
+
+            if check is not None and check.returncode == 0:
+                elapsed = time.monotonic() - t0
+                mismatch_error = self._finalise_image(
+                    engine_name, image, check.stdout, cached=True, elapsed=elapsed
+                )
+                if mismatch_error is not None:
+                    if self._progress:
+                        self._progress.end_image_prep()
+                    raise mismatch_error
+                continue
+
+            # Image not found locally - try to pull
+            logger.info("Image %s not found locally, pulling...", image)
+            try:
+                pull = subprocess.run(
+                    ["docker", "pull", image],
+                    capture_output=True,
+                    timeout=DOCKER_PULL_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired as exc:
+                if self._progress:
+                    self._progress.image_failed(engine_name, image, "pull timed out (30min)")
+                    self._progress.end_image_prep()
+                from llenergymeasure.infra.docker_errors import DockerImagePullError
+
+                raise DockerImagePullError(
+                    message=f"Image pull timed out: {image}",
+                    fix_suggestion=f"docker compose build {engine_name}",
+                ) from exc
+
+            if pull.returncode != 0:
+                tip = f"docker compose build {engine_name}"
+                if self._progress:
+                    self._progress.image_failed(engine_name, image, f"not found \u2014 run: {tip}")
+                    self._progress.end_image_prep()
+                from llenergymeasure.infra.docker_errors import DockerImagePullError
+
+                raise DockerImagePullError(
+                    message=f"Image not found: {image}",
+                    fix_suggestion=tip,
+                )
+
+            elapsed = time.monotonic() - t0
+            try:
+                inspect = subprocess.run(
+                    ["docker", "image", "inspect", image],
+                    capture_output=True,
+                    timeout=TIMEOUT_DOCKER_INSPECT,
+                )
+                inspect_stdout = inspect.stdout if inspect.returncode == 0 else b""
+            except Exception:
+                inspect_stdout = b""
+
+            mismatch_error = self._finalise_image(
+                engine_name, image, inspect_stdout, cached=False, elapsed=elapsed
+            )
+            if mismatch_error is not None:
+                if self._progress:
+                    self._progress.end_image_prep()
+                raise mismatch_error
+
+        if self._progress:
+            self._progress.end_image_prep()
+
+        self._images_prepared = True
+
+    def _finalise_image(
+        self,
+        engine_name: str,
+        image: str,
+        inspect_stdout: bytes,
+        *,
+        cached: bool,
+        elapsed: float,
+    ) -> Exception | None:
+        """Report an image-ready progress event and return any mismatch error.
+
+        Parses display metadata and the schema stamp from *inspect_stdout*,
+        classifies the schema status, renders it through
+        ``progress.image_ready`` so the engine row appears before any abort,
+        and returns the ``VersionMismatchError`` for the caller to raise.
+        """
+        metadata = _parse_image_metadata(inspect_stdout) or {}
+        stamp = parse_image_stamp(inspect_stdout)
+        schema_status, mismatch_error = self._verify_image_fingerprint(engine_name, image, stamp)
+        metadata["schema"] = schema_status
+
+        if self._progress:
+            self._progress.image_ready(
+                engine_name, image, cached=cached, elapsed=elapsed, metadata=metadata
+            )
+        return mismatch_error
+
+    def _verify_image_fingerprint(
+        self,
+        engine_name: str,
+        image: str,
+        stamp: ImageStamp,
+    ) -> tuple[str, Exception | None]:
+        """Compare the host schema fingerprint to *stamp* and classify the result.
+
+        Returns ``(schema_status, error)`` where ``schema_status`` is the
+        short display string and ``error`` is a ``VersionMismatchError`` to
+        raise (or ``None``). Callers raise after rendering so the offending
+        engine appears in the terminal before the study aborts.
+
+        Two-tier classification:
+
+        1. **Label-based fingerprint check** (preferred when present).
+           Definitive ``OK`` / ``MISMATCH`` answers are trusted directly.
+        2. **Bundled engine-version probe** (fallback). When the label is
+           absent or stamped ``"unknown"``, probe the engine library's
+           ``__version__`` inside the image and compare against the
+           ``engine_version`` envelope field on the bundled invariants +
+           schema artefacts (read via :func:`read_bundled_engine_version`,
+           which cross-checks both bundled artefacts agree). Closes the
+           verification gap for upstream-direct images (vllm, tensorrt)
+           which never had a llem schema-fingerprint label, and for legacy
+           local images where the fingerprint was stamped as ``"unknown"``.
+        """
+        if skip_check_enabled():
+            return "bypassed", None
+
+        host_fp = compute_expconf_fingerprint()
+        label_status = classify_stamp(stamp, host_fp)
+
+        if label_status is SchemaStatus.OK:
+            return "ok", None
+
+        if label_status is SchemaStatus.MISMATCH:
+            # Image has a real fingerprint label and it disagrees with the
+            # host. Hard-error - the label is authoritative when present.
+            assert stamp.expconf_fingerprint is not None
+            error = VersionMismatchError(
+                f"Docker image '{image}' was built from llenergymeasure "
+                f"{stamp.pkg_version or 'unknown'} (schema {stamp.expconf_fingerprint[:12]}) "
+                f"but the host is running {_HOST_PKG_VERSION} (schema {host_fp[:12]}). "
+                f"The container will reject ExperimentConfig fields added on the host "
+                f"after the image was built.\n\n"
+                f"To fix:\n"
+                f"  {rebuild_hint(engine_name)}       # rebuild locally\n"
+                f"  make docker-pull                  # or pull a newer tagged release\n\n"
+                f"If you're certain the skew is harmless, set {ENV_SKIP_IMAGE_CHECK}=1."
+            )
+            return "mismatch", error
+
+        # label_status is UNVERIFIED or UNREACHABLE: fall back to engine-
+        # version probe. The probe takes one docker-run (a few seconds)
+        # and is cached per (image, engine). The "expected" version comes
+        # from the bundled invariants/schema envelopes (the artefacts llem
+        # actually applies at experiment time), not from current.yaml -
+        # current.yaml isn't shipped in the wheel, so an SSOT-based check
+        # is silently UNREACHABLE for installed users. The bundled envelope
+        # works in both wheel and editable installs.
+        probed = probe_image_engine_version(image, engine_name)
+        try:
+            expected = read_bundled_engine_version(engine_name)
+        except BundledEngineVersionMismatchError as exc:
+            return "mismatch (bundled artefact disagreement)", exc
+        probe_status = classify_engine_version(probed, expected)
+
+        if probe_status is SchemaStatus.OK:
+            logger.debug(
+                "Image %s verified via engine-version probe: %s matches bundled envelope",
+                image,
+                probed,
+            )
+            return f"ok (engine={probed})", None
+
+        if probe_status is SchemaStatus.UNREACHABLE:
+            # Neither label nor probe yielded a definitive answer. Soft-warn
+            # and proceed - the bind-mounted framework on the host still
+            # defines the actual contract; we just can't independently
+            # verify the engine version.
+            logger.warning(
+                "Image %s has no %s label and the engine-version probe was "
+                "inconclusive (probed=%r, bundled=%r). Dispatch will proceed; "
+                "the bind-mounted framework defines the contract regardless.",
+                image,
+                LABEL_SCHEMA_FINGERPRINT,
+                probed,
+                expected,
+            )
+            return "unverified (no labels, probe inconclusive)", None
+
+        # probe_status is MISMATCH
+        error = VersionMismatchError(
+            f"Docker image '{image}' has {engine_name} library version "
+            f"{probed!r} but the bundled invariants + discovered schemas "
+            f"in this wheel were mined against {expected!r}. Applying "
+            f"version-{expected!r} validation rules to a version-{probed!r} "
+            f"substrate is not safe.\n\n"
+            f"To fix:\n"
+            f"  Pull an image matching {expected!r}, or install a wheel "
+            f"built against {probed!r}.\n\n"
+            f"If you're certain the skew is harmless, set "
+            f"{ENV_SKIP_IMAGE_CHECK}=1."
+        )
+        return f"mismatch (engine {probed} vs bundled {expected})", error

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -47,14 +47,7 @@ from llenergymeasure.config.ssot import (
     TIMEOUT_THREAD_JOIN,
 )
 from llenergymeasure.domain.progress import STEPS_LOCAL, docker_steps
-
-# ``_QueueProgressCallback`` is re-imported only to keep it reachable as
-# ``study.runner._QueueProgressCallback`` for backward-compatible imports; the
-# worker subprocess constructs it internally, so it is unused in this module.
-from llenergymeasure.study._progress import (  # noqa: F401
-    _consume_progress_events,
-    _QueueProgressCallback,
-)
+from llenergymeasure.study._progress import _consume_progress_events
 from llenergymeasure.study.baseline_measure import _BaselineMixin
 from llenergymeasure.study.gaps import run_gap
 from llenergymeasure.study.image_prep import _ImageMixin

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -1,69 +1,77 @@
-"""StudyRunner - subprocess dispatch core for experiment isolation.
+"""StudyRunner - orchestrates per-experiment subprocess/Docker dispatch.
 
-Each experiment in a study runs in a freshly spawned subprocess with a clean CUDA
-context. Results travel parent←child via multiprocessing.Pipe. The parent survives
-experiment failures, timeouts, and SIGINT without data corruption.
+``StudyRunner`` owns the study-level run loop: SIGINT handling, GPU locks,
+container lifecycle, circuit breaker, wall-clock timeout, and result handling.
+The separable concerns live in sibling modules and are mixed in or imported:
 
-Key design decisions (locked in .product/decisions/experiment-isolation.md):
-- spawn context: CUDA-safe; fork causes silent CUDA corruption (CP-1)
-- daemon=False: clean CUDA teardown if parent exits unexpectedly (CP-4)
-- Pipe-only IPC: ExperimentResult fits in Pipe buffer for typical experiment sizes
-- SIGKILL on timeout: SIGTERM may be ignored by hung CUDA operations
-- Process group kill: worker calls os.setpgrp() to become group leader so all
-  descendant processes (vLLM workers, MPI ranks, etc.) are killed together
+- ``study.worker``: subprocess-worker surface (child entry point, result
+  collection, process-group signalling).
+- ``study._progress``: cross-process progress plumbing.
+- ``study.baseline_measure`` (``_BaselineMixin``): baseline measurement,
+  caching, and drift validation.
+- ``study.image_prep`` (``_ImageMixin``): Docker image preparation and
+  schema-fingerprint verification.
+- ``study.container_lifecycle``: container naming/labels/cleanup plus failure
+  artefact persistence.
+
+Each experiment runs in a freshly spawned subprocess with a clean CUDA context
+(or in a Docker container). Results travel parent<-child via multiprocessing.Pipe
+or DockerRunner. The parent survives experiment failures, timeouts, and SIGINT
+without data corruption.
 """
 
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
 import multiprocessing
-import os
+import os  # noqa: F401 - patch target: tests patch study.runner.os.{killpg,setpgrp}
 import shutil
 import signal
-import subprocess
 import sys
 import tempfile
 import threading
 import time
-import traceback
 import uuid
 from concurrent.futures import Future
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from llenergymeasure._version import __version__ as _HOST_PKG_VERSION
 from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
-    DOCKER_PULL_TIMEOUT,
     RUNNER_DOCKER,
     TEMP_PREFIX_TIMESERIES,
-    TIMEOUT_DOCKER_INSPECT,
     TIMEOUT_ENV_SNAPSHOT,
     TIMEOUT_INTERRUPT_POLL,
     TIMEOUT_SIGTERM_GRACE,
     TIMEOUT_THREAD_JOIN,
 )
-from llenergymeasure.domain.progress import STEP_BASELINE, STEPS_LOCAL, docker_steps
-from llenergymeasure.infra.version_handshake import (
-    ENV_SKIP_IMAGE_CHECK,
-    LABEL_SCHEMA_FINGERPRINT,
-    BundledEngineVersionMismatchError,
-    ImageStamp,
-    SchemaStatus,
-    VersionMismatchError,
-    classify_engine_version,
-    classify_stamp,
-    compute_expconf_fingerprint,
-    parse_image_stamp,
-    probe_image_engine_version,
-    read_bundled_engine_version,
-    rebuild_hint,
-    skip_check_enabled,
+from llenergymeasure.domain.progress import STEPS_LOCAL, docker_steps
+
+# ``_QueueProgressCallback`` is re-imported only to keep it reachable as
+# ``study.runner._QueueProgressCallback`` for backward-compatible imports; the
+# worker subprocess constructs it internally, so it is unused in this module.
+from llenergymeasure.study._progress import (  # noqa: F401
+    _consume_progress_events,
+    _QueueProgressCallback,
 )
+from llenergymeasure.study.baseline_measure import _BaselineMixin
 from llenergymeasure.study.gaps import run_gap
+from llenergymeasure.study.image_prep import _ImageMixin
+
+# Re-imported into this module's namespace so that (a) existing
+# ``from llenergymeasure.study.runner import X`` sites keep working and
+# (b) ``patch("llenergymeasure.study.runner.<name>")`` intercepts the
+# bare-name call sites inside ``_run_one`` / ``run``.
+from llenergymeasure.study.worker import (
+    _UNSET,
+    COLLECT_RESULT_PROCESS_CRASH,
+    COLLECT_RESULT_TIMEOUT,
+    _collect_result,
+    _derive_exit_reason,
+    _kill_process_group,
+    _run_experiment_worker,
+)
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig, StudyConfig
@@ -71,7 +79,6 @@ if TYPE_CHECKING:
     from llenergymeasure.domain.progress import StudyProgressCallback
     from llenergymeasure.infra.runner_resolution import RunnerSpec
     from llenergymeasure.study.manifest import ManifestWriter
-    from llenergymeasure.utils.exceptions import DockerError
 
 __all__ = [
     "StudyRunner",
@@ -86,42 +93,6 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 # Module-level helpers
 # =============================================================================
-
-
-# Failure classifiers produced by ``_collect_result`` and consumed by
-# parent-side sentinel handling. Lifted so the producer and consumer don't
-# drift on bare strings.
-COLLECT_RESULT_PROCESS_CRASH = "ProcessCrash"
-COLLECT_RESULT_TIMEOUT = "TimeoutError"
-
-
-def _derive_exit_reason(exitcode: int | None) -> str | None:
-    """Map a negative subprocess exit code to its POSIX signal name.
-
-    Negative exit codes are signals (POSIX convention). Returns the signal
-    name (e.g. ``SIGKILL``, ``SIGSEGV``, ``SIGTERM``) for any recognised
-    signal, ``None`` otherwise. The raw code is preserved elsewhere.
-    """
-    if exitcode is None or exitcode >= 0:
-        return None
-    try:
-        return signal.Signals(-exitcode).name
-    except ValueError:
-        return None
-
-
-def _sanitize_image_for_filename(image: str) -> str:
-    """Return a filename-safe slug for a Docker image tag.
-
-    Replaces path separators, tag markers, digest markers, and whitespace with
-    underscores. Clipped to 128 chars and stripped of trailing underscores so
-    the resulting basename stays well under typical filesystem limits.
-    """
-    sanitized = image
-    for ch in ("/", ":", "@", " ", "\t", "\n"):
-        sanitized = sanitized.replace(ch, "_")
-    sanitized = sanitized[:128].rstrip("_")
-    return sanitized or "unknown"
 
 
 def _save_and_record(
@@ -233,354 +204,12 @@ def _save_and_record(
         manifest.mark_failed(config_hash, cycle, type(exc).__name__, str(exc))
 
 
-def _kill_process_group(pid: int, sig: int) -> None:
-    """Send signal to the entire process group rooted at pid.
-
-    Uses os.killpg so that all descendant processes (vLLM workers, MPI ranks, etc.)
-    receive the signal, not just the parent. Errors are suppressed because the
-    process group may already be dead by the time this is called.
-    """
-    with contextlib.suppress(ProcessLookupError, PermissionError):
-        os.killpg(pid, sig)
-
-
-# =============================================================================
-# Queue-based progress callback (runs inside child process)
-# =============================================================================
-
-
-class _QueueProgressCallback:
-    """ProgressCallback that serialises step events onto a multiprocessing.Queue.
-
-    Created inside the worker subprocess. Events are dicts consumed by the
-    parent's _consume_progress_events thread and forwarded to StudyStepDisplay.
-    """
-
-    def __init__(self, queue: Any) -> None:
-        self._queue = queue
-
-    def _put(self, event: dict[str, Any]) -> None:
-        with contextlib.suppress(Exception):
-            self._queue.put(event)
-
-    def on_step_start(self, step: str, description: str, detail: str = "") -> None:
-        self._put(
-            {"event": "step_start", "step": step, "description": description, "detail": detail}
-        )
-
-    def on_step_update(self, step: str, detail: str) -> None:
-        self._put({"event": "step_update", "step": step, "detail": detail})
-
-    def on_step_done(self, step: str, elapsed_sec: float) -> None:
-        self._put({"event": "step_done", "step": step, "elapsed_sec": elapsed_sec})
-
-    def on_step_skip(self, step: str, reason: str = "") -> None:
-        self._put({"event": "step_skip", "step": step, "reason": reason})
-
-    def on_substep(self, step: str, text: str, elapsed_sec: float = 0.0) -> None:
-        self._put({"event": "substep", "step": step, "text": text, "elapsed_sec": elapsed_sec})
-
-    def on_substep_start(self, step: str, text: str) -> None:
-        self._put({"event": "substep_start", "step": step, "text": text})
-
-    def on_substep_done(
-        self,
-        step: str,
-        text: str | None = None,
-        elapsed_sec: float | None = None,
-    ) -> None:
-        self._put(
-            {
-                "event": "substep_done",
-                "step": step,
-                "text": text,
-                "elapsed_sec": elapsed_sec,
-            }
-        )
-
-
-# =============================================================================
-# Worker function (runs inside child process)
-# =============================================================================
-
-
-def _run_experiment_worker(
-    config: ExperimentConfig,
-    conn: Any,  # multiprocessing.Connection (child end)
-    progress_queue: Any,  # multiprocessing.Queue
-    snapshot: EnvironmentSnapshot | None = None,
-    output_dir: str | None = None,
-    save_timeseries: bool = True,
-    baseline: Any = None,  # BaselineCache | None (avoids import at module level)
-    *,
-    study_dir: str,
-    study_run_id: str,
-    cycle: int,
-    config_hash: str,
-) -> None:
-    """Entry point for the child process. Runs one experiment and returns result via Pipe.
-
-    Signal handling:
-        Installs SIGINT → SIG_IGN so the child ignores Ctrl+C.
-        The parent handles SIGINT and decides whether to kill the child.
-
-    IPC protocol:
-        On success: sends ExperimentResult (or result dict) via conn.
-        On failure: sends {"type": ..., "message": ..., "traceback": ...} via conn.
-        Progress events are put to progress_queue for the consumer thread.
-
-    Args:
-        output_dir: Directory for timeseries parquet output. Passed through to harness.
-        save_timeseries: Whether to persist GPU timeseries. Passed through to harness.
-        baseline: Pre-measured baseline power from parent process (study-level cache).
-        study_dir: Study output directory. Runtime observations append to
-            ``{study_dir}/runtime_observations.jsonl``.
-        study_run_id: UUID identifying this invocation of ``StudyRunner.run()``.
-        cycle: 1-based cycle counter for this config within the study.
-        config_hash: ``compute_declared_config_hash(config)``. The parent is
-            the single SSOT for this value.
-    """
-    # Become process group leader so all descendants (vLLM workers, MPI ranks, etc.)
-    # share this PGID. The parent can then kill the whole group via os.killpg().
-    os.setpgrp()
-
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-    # Wrap the worker body BEFORE run_preflight() / get_engine() so engine
-    # import-time warnings under ``spawn`` are captured.
-    from llenergymeasure.study.runtime_observations import capture_runtime_observations
-
-    obs_ctx = capture_runtime_observations(
-        config,
-        study_dir=study_dir,
-        study_run_id=study_run_id,
-        cycle=cycle,
-        config_hash=config_hash,
-    )
-
-    try:
-        with obs_ctx:
-            progress_queue.put({"event": "started", "config_hash": config_hash})
-
-            # Create progress callback that serialises step events to queue
-            progress_cb = _QueueProgressCallback(progress_queue)
-
-            # Run the actual experiment in-process (within the spawned subprocess)
-            from llenergymeasure.engines import get_engine
-            from llenergymeasure.harness import MeasurementHarness
-            from llenergymeasure.harness.preflight import run_preflight
-
-            # Pre-flight inside subprocess: CUDA availability must be checked in the
-            # process that will use the GPU.
-            progress_cb.on_step_start("container_preflight", "Checking", "CUDA, model access")
-            t0_pf = time.perf_counter()
-            run_preflight(config)
-            progress_cb.on_step_done("container_preflight", time.perf_counter() - t0_pf)
-
-            engine = get_engine(config.engine)
-            harness = MeasurementHarness()
-            from llenergymeasure.device.gpu_info import _resolve_gpu_indices
-
-            gpu_indices = _resolve_gpu_indices(config)
-            result = harness.run(
-                engine,
-                config,
-                snapshot=snapshot,
-                gpu_indices=gpu_indices,
-                progress=progress_cb,
-                output_dir=output_dir,
-                save_timeseries=save_timeseries,
-                baseline=baseline,
-            )
-
-            # Send result back to parent via Pipe
-            conn.send(result)
-            progress_queue.put({"event": "completed", "config_hash": config_hash})
-
-    except Exception as exc:
-        error_payload = {
-            "type": type(exc).__name__,
-            "message": str(exc),
-            "traceback": traceback.format_exc(),
-        }
-        with contextlib.suppress(Exception):
-            # Pipe may be broken (e.g. parent killed). Best-effort only.
-            conn.send(error_payload)
-
-        with contextlib.suppress(Exception):
-            progress_queue.put({"event": "failed", "error": str(exc)})
-
-        raise
-
-    finally:
-        conn.close()
-
-
-# =============================================================================
-# Progress consumer (daemon thread in parent)
-# =============================================================================
-
-
-def _consume_progress_events(
-    q: Any,
-    study_progress: StudyProgressCallback | None = None,
-) -> None:
-    """Consume progress events from the queue and forward to study display.
-
-    Runs as a daemon thread in the parent process. Receives step events from
-    the child subprocess via multiprocessing.Queue and forwards them to the
-    StudyProgressCallback (typically StudyStepDisplay).
-
-    Coarse events (started/completed/failed) are ignored here - study-level
-    begin/end experiment tracking is handled directly by _run_one().
-    """
-    while True:
-        event = q.get()
-        if event is None:
-            break
-
-        if not isinstance(event, dict) or study_progress is None:
-            continue
-
-        event_type = event.get("event")
-
-        # Forward step-level events to study display
-        if event_type == "step_start":
-            study_progress.on_step_start(
-                event["step"], event.get("description", ""), event.get("detail", "")
-            )
-        elif event_type == "step_update":
-            study_progress.on_step_update(event["step"], event.get("detail", ""))
-        elif event_type == "step_done":
-            study_progress.on_step_done(event["step"], event.get("elapsed_sec", 0))
-        elif event_type == "step_skip":
-            study_progress.on_step_skip(event["step"], event.get("reason", ""))
-        elif event_type == "substep":
-            study_progress.on_substep(
-                event["step"], event.get("text", ""), event.get("elapsed_sec", 0)
-            )
-        elif event_type == "substep_start":
-            study_progress.on_substep_start(event["step"], event.get("text", ""))
-        elif event_type == "substep_done":
-            study_progress.on_substep_done(
-                event["step"], event.get("text"), event.get("elapsed_sec")
-            )
-
-
-# =============================================================================
-# Result collection (parent, after p.join)
-# =============================================================================
-
-# Sentinel object used to distinguish "no payload provided" from a None payload.
-_UNSET = object()
-
-
-def _collect_result(
-    p: Any,  # multiprocessing.Process
-    parent_conn: Any,  # multiprocessing.Connection (parent end)
-    config: ExperimentConfig,
-    timeout: float,
-    pipe_payload: Any = _UNSET,
-) -> Any:
-    """Inspect process outcome and return either a result or a failure dict.
-
-    Called after the pipe has been drained and p.join() has returned.
-
-    Args:
-        p: The child process.
-        parent_conn: Parent end of the Pipe (read-only).
-        config: Experiment configuration.
-        timeout: Timeout used for the experiment (for error messages).
-        pipe_payload: Pre-drained pipe value from the recv-before-join pattern
-            (H5 deadlock fix). When provided, skips calling recv() again.
-            Pass _UNSET (default) to fall back to reading from the pipe directly.
-
-    Returns:
-        ExperimentResult on success, dict with keys (type, message) on failure.
-    """
-    from llenergymeasure.domain.experiment import compute_declared_config_hash
-
-    config_hash = compute_declared_config_hash(config)
-
-    if p.is_alive():
-        # Timed out - kill with SIGKILL
-        # SIGKILL: SIGTERM may be ignored by hung CUDA operations
-        _kill_process_group(p.pid, signal.SIGKILL)
-        p.join()
-        return {
-            "type": COLLECT_RESULT_TIMEOUT,
-            "message": f"Experiment exceeded timeout of {timeout}s and was killed.",
-            "config_hash": config_hash,
-        }
-
-    if p.exitcode != 0:
-        # Non-zero exit - try to read error payload from pipe
-        # Use pre-drained payload if available; otherwise poll/recv
-        if pipe_payload is not _UNSET:
-            payload = pipe_payload
-            if isinstance(payload, dict) and "type" in payload and "message" in payload:
-                payload["config_hash"] = config_hash
-                return payload
-        elif parent_conn.poll():
-            try:
-                payload = parent_conn.recv()
-                if isinstance(payload, dict) and "type" in payload and "message" in payload:
-                    payload["config_hash"] = config_hash
-                    return payload
-            except Exception:
-                pass
-
-        return {
-            "type": COLLECT_RESULT_PROCESS_CRASH,
-            "message": f"Subprocess exited with code {p.exitcode} and no error data in Pipe.",
-            "config_hash": config_hash,
-        }
-
-    # Success path - use pre-drained payload if available
-    if pipe_payload is not _UNSET:
-        try:
-            payload = pipe_payload
-            # If payload is an error dict (exception in worker), treat as failure
-            if isinstance(payload, dict) and "type" in payload and "message" in payload:
-                payload["config_hash"] = config_hash
-                return payload
-            return payload
-        except Exception as exc:
-            return {
-                "type": "PipeError",
-                "message": f"Failed to process pre-drained pipe payload: {exc}",
-                "config_hash": config_hash,
-            }
-
-    # Fallback: read from pipe directly (no pre-drained payload)
-    if parent_conn.poll():
-        try:
-            payload = parent_conn.recv()
-            # If payload is an error dict (exception in worker), treat as failure
-            if isinstance(payload, dict) and "type" in payload and "message" in payload:
-                payload["config_hash"] = config_hash
-                return payload
-            return payload
-        except Exception as exc:
-            return {
-                "type": "PipeError",
-                "message": f"Failed to receive result from subprocess: {exc}",
-                "config_hash": config_hash,
-            }
-
-    return {
-        "type": COLLECT_RESULT_PROCESS_CRASH,
-        "message": "Subprocess exited 0 but sent no data through Pipe.",
-        "config_hash": config_hash,
-    }
-
-
 # =============================================================================
 # StudyRunner
 # =============================================================================
 
 
-class StudyRunner:
+class StudyRunner(_BaselineMixin, _ImageMixin):
     """Dispatcher: runs each experiment in a freshly spawned subprocess.
 
     Uses multiprocessing.get_context('spawn') - never fork.
@@ -970,710 +599,6 @@ class StudyRunner:
             self._env_snapshot_future = collect_environment_snapshot_async()
         return self._env_snapshot_future.result(timeout=TIMEOUT_ENV_SNAPSHOT)
 
-    def _baseline_cache_key(self, config: ExperimentConfig) -> str:
-        """Return the cache key for this experiment's runner target.
-
-        Baselines are keyed per runner target because the container's CUDA init
-        footprint (~8.7 W/GPU on A100) is process-local and may differ between
-        engine images. See ``.product/research/baseline-measurement-location.md``.
-
-        The ``image_`` prefix uses an underscore (not ``:``) so the key is
-        safe to embed directly in both filesystem paths and Docker bind-mount
-        sources. A ``:`` in the mount source string would be parsed by Docker
-        as the mount-mode separator and fail with ``invalid mode``.
-        """
-        spec = self._runner_specs.get(config.engine) if self._runner_specs else None
-        if spec is None or spec.mode != RUNNER_DOCKER or not spec.image:
-            return "local"
-        return f"image_{_sanitize_image_for_filename(spec.image)}"
-
-    def _get_baseline(self, config: ExperimentConfig) -> Any:
-        """Return baseline power according to the configured strategy.
-
-        Strategies: ``cached`` (measure once per runner target, persist to disk,
-        reuse within TTL), ``validated`` (same, with periodic drift spot-check),
-        and ``fresh`` (returns None; harness measures in-container per experiment).
-
-        For Docker targets the measurement runs inside a short-lived container
-        of the same engine image, so the CUDA init state matches the experiment
-        container (see ``.product/research/baseline-measurement-location.md``).
-        """
-        strategy = config.measurement.baseline.strategy
-
-        if strategy == "fresh":
-            return None
-
-        cache_key = self._baseline_cache_key(config)
-        location = "host" if cache_key == "local" else "baseline container"
-        cached = self._baselines.get(cache_key)
-
-        # TTL expiry check
-        if cached is not None:
-            age = time.time() - cached.timestamp
-            if age >= config.measurement.baseline.cache_ttl_seconds:
-                logger.info(
-                    "Baseline expired (age=%.0fs > ttl=%.0fs). Re-measuring.",
-                    age,
-                    config.measurement.baseline.cache_ttl_seconds,
-                )
-                cached = None
-                self._baselines.pop(cache_key, None)
-
-        # validated: periodic spot-check for drift (only if baseline still valid)
-        if strategy == "validated" and cached is not None:
-            self._experiments_since_validation[cache_key] = (
-                self._experiments_since_validation.get(cache_key, 0) + 1
-            )
-            if (
-                self._experiments_since_validation[cache_key]
-                >= config.measurement.baseline.validation_interval
-            ):
-                self._validate_baseline(config, cache_key)
-                cached = self._baselines.get(cache_key)  # may have been re-measured
-
-        # In-memory hit → emit "Reusing" and return
-        if cached is not None:
-            if self._progress is not None:
-                self._progress.on_step_start(
-                    STEP_BASELINE,
-                    "Reusing",
-                    f"cached {cached.power_w:.1f}W · {location}",
-                )
-                self._emit_baseline_result_substeps(cached, elapsed=0.0, mode="cached")
-                self._progress.on_step_done(STEP_BASELINE, 0.0)
-            return cached
-
-        # Try loading from disk first (handles mid-study restarts)
-        disk_path = self._get_baseline_cache_path(cache_key)
-        if disk_path.exists():
-            from llenergymeasure.harness.baseline import load_baseline_cache
-
-            if self._progress is not None:
-                self._progress.on_step_start(
-                    STEP_BASELINE, "Loading", f"baseline cache · {location}"
-                )
-                t0_load = time.perf_counter()
-
-            loaded = load_baseline_cache(
-                disk_path, ttl=config.measurement.baseline.cache_ttl_seconds
-            )
-
-            if self._progress is not None:
-                load_elapsed = time.perf_counter() - t0_load
-                if loaded is not None:
-                    self._emit_baseline_result_substeps(loaded, elapsed=load_elapsed, mode="disk")
-                self._progress.on_step_done(STEP_BASELINE, load_elapsed)
-
-            if loaded is not None:
-                if loaded.method is None:
-                    loaded.method = strategy
-                self._baselines[cache_key] = loaded
-                self._experiments_since_validation.setdefault(cache_key, 0)
-                logger.debug("Loaded baseline from disk cache: %.1fW", loaded.power_w)
-                return loaded
-
-        # Measure fresh baseline (in-container for Docker targets)
-        dur = config.measurement.baseline.duration_seconds
-        # Prefer the image tag over engine name so users see which container
-        # is running in multi-engine studies.
-        spec = self._runner_specs.get(config.engine) if self._runner_specs else None
-        target_label = (spec.image if spec and spec.image else config.engine) or "baseline"
-        if self._progress is not None:
-            self._progress.on_step_start(STEP_BASELINE, "Calibrating", "sampling idle GPU draw")
-            t0_meas = time.perf_counter()
-            # Seed first substep before Popen so the docker cold-start is visible.
-            if cache_key != "local":
-                self._progress.on_substep_start(
-                    STEP_BASELINE,
-                    f"launching separate {target_label} baseline container",
-                )
-
-        on_stage = (
-            self._make_baseline_stage_callback(duration_sec=dur, target_label=target_label)
-            if self._progress is not None
-            else None
-        )
-        measured = self._measure_baseline(config, cache_key, on_stage=on_stage)
-
-        if measured is not None:
-            measured.method = strategy
-            self._baselines[cache_key] = measured
-            self._experiments_since_validation[cache_key] = 0
-
-            from llenergymeasure.harness.baseline import save_baseline_cache
-
-            save_baseline_cache(disk_path, measured)
-
-        if self._progress is not None:
-            elapsed = time.perf_counter() - t0_meas
-            if measured is None:
-                # Freeze any live substep with the failure text + accurate
-                # elapsed so users don't see a silent tick hiding a crash.
-                self._progress.on_substep_done(
-                    STEP_BASELINE,
-                    text=(
-                        f"measurement failed after {elapsed:.1f}s - see log warnings "
-                        f"(experiment container will re-measure fresh)"
-                    ),
-                    elapsed_sec=elapsed,
-                )
-            elif cache_key == "local":
-                # No container subprocess → emit a retroactive sampling substep
-                # so the local path still gets a breakdown. The Docker path
-                # already emitted substeps live via the on_stage callback.
-                self._emit_baseline_result_substeps(
-                    measured,
-                    elapsed=elapsed,
-                    mode="fresh",
-                    is_containerised=False,
-                )
-            self._progress.on_step_done(STEP_BASELINE, elapsed)
-
-        return measured
-
-    def _make_baseline_stage_callback(
-        self, *, duration_sec: float, target_label: str = "baseline"
-    ) -> Any:
-        """Build a stage-marker callback that drives live baseline sub-bullets.
-
-        Each transition ``on_substep_done``s the prior substep (freezing with
-        a tick) and ``on_substep_start``s the next one. The very first substep
-        ("launching <target_label> container") is seeded in ``_get_baseline``
-        before ``subprocess.Popen`` so the docker cold-start is visible.
-        """
-        dur_label = f"{duration_sec:.0f}s"
-
-        def on_stage(name: str, elapsed: float, kv: dict[str, str]) -> None:
-            if self._progress is None:
-                return
-            if name == "container_ready":
-                self._progress.on_substep_done(
-                    STEP_BASELINE, f"{target_label} baseline container ready"
-                )
-                self._progress.on_substep_start(
-                    STEP_BASELINE, "initialising CUDA runtime inside baseline container"
-                )
-            elif name == "cuda_primed":
-                self._progress.on_substep_done(STEP_BASELINE, "CUDA runtime primed")
-                self._progress.on_substep_start(
-                    STEP_BASELINE, f"sampling idle GPU draw ({dur_label})"
-                )
-            elif name == "sampling_done":
-                power_w = kv.get("power_w", "?")
-                samples = kv.get("samples", "?")
-                sampled = kv.get("duration", "?")
-                self._progress.on_substep_done(
-                    STEP_BASELINE,
-                    f"sampled idle GPU draw · {sampled}s ({power_w}W · {samples} samples)",
-                )
-                self._progress.on_substep_start(
-                    STEP_BASELINE,
-                    f"writing baseline result · tearing down {target_label} baseline container",
-                )
-            elif name == "result_written":
-                self._progress.on_substep_done(
-                    STEP_BASELINE,
-                    f"baseline result cached · {target_label} baseline container torn down",
-                )
-
-        return on_stage
-
-    def _emit_baseline_result_substeps(
-        self,
-        baseline: Any,  # BaselineCache
-        *,
-        elapsed: float,
-        mode: str,  # "fresh" | "cached" | "disk"
-        is_containerised: bool = False,
-    ) -> None:
-        """Emit dim-bullet substeps explaining where the baseline time went.
-
-        For a fresh Docker measurement we split the wall-clock into container
-        launch/teardown (the residual) vs the NVML sampling window (recorded
-        inside ``measure_baseline_power``). This answers "why did a 30s
-        measurement take 37.7s?" without the user having to dig through logs.
-
-        For in-memory and disk-loaded reuse we only emit the result summary -
-        there is no sampling window to describe.
-        """
-        if self._progress is None:
-            return
-        if mode == "fresh" and is_containerised:
-            # Residual captures docker run startup + CUDA prime + result write
-            # + container teardown.
-            overhead = max(0.0, elapsed - baseline.duration_sec)
-            self._progress.on_substep(
-                STEP_BASELINE,
-                f"container launch + teardown: {overhead:.1f}s",
-                overhead,
-            )
-            self._progress.on_substep(
-                STEP_BASELINE,
-                f"sampling: {baseline.duration_sec:.1f}s "
-                f"({baseline.power_w:.1f}W · {baseline.sample_count} samples)",
-                baseline.duration_sec,
-            )
-        elif mode == "fresh":
-            self._progress.on_substep(
-                STEP_BASELINE,
-                f"sampling: {baseline.duration_sec:.1f}s "
-                f"({baseline.power_w:.1f}W · {baseline.sample_count} samples)",
-                baseline.duration_sec,
-            )
-        else:
-            source = "in-memory" if mode == "cached" else "disk"
-            self._progress.on_substep(
-                STEP_BASELINE,
-                f"reused from {source} cache: "
-                f"{baseline.power_w:.1f}W ({baseline.sample_count} samples)",
-            )
-
-    def _measure_baseline(
-        self,
-        config: ExperimentConfig,
-        cache_key: str,
-        on_stage: Any = None,  # StageCallback | None
-    ) -> Any:
-        """Measure a fresh baseline on host or inside a baseline container.
-
-        Local runner targets measure on host (no process boundary, no bias).
-        Docker targets dispatch a short-lived baseline container of the engine
-        image so the CUDA init state matches the experiment container. See
-        ``.product/research/baseline-measurement-location.md`` for the
-        empirical rationale (~8.7 W/GPU bias on A100).
-
-        Args:
-            config: Experiment config with baseline settings.
-            cache_key: "local" or "image_<slug>" - chooses dispatch path.
-            on_stage: Optional callback forwarded to ``run_baseline_container``
-                for streaming stage markers. Ignored on the local path (there
-                is no subprocess to stream from).
-        """
-        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
-
-        gpu_indices = _resolve_gpu_indices(config)
-
-        if cache_key == "local":
-            from llenergymeasure.harness.baseline import measure_baseline_power
-
-            return measure_baseline_power(
-                duration_sec=config.measurement.baseline.duration_seconds,
-                gpu_indices=gpu_indices,
-            )
-
-        # Docker: _baseline_cache_key already guaranteed a resolved image when
-        # it returned a non-"local" key.
-        assert self._runner_specs is not None
-        spec = self._runner_specs[config.engine]
-        assert spec.image is not None
-        from llenergymeasure.study.baseline_container import run_baseline_container
-
-        return run_baseline_container(
-            image=spec.image,
-            mode="measure",
-            duration_sec=config.measurement.baseline.duration_seconds,
-            gpu_indices=gpu_indices,
-            on_stage=on_stage,
-        )
-
-    def _spot_check_baseline(
-        self,
-        config: ExperimentConfig,
-        cache_key: str,
-        gpu_indices: list[int],
-    ) -> float | None:
-        """Quick drift-check measurement for the validated strategy.
-
-        Dispatches to host or baseline container matching the cache key. Returns
-        the measured power in watts, or None on failure.
-        """
-        if cache_key == "local":
-            from llenergymeasure.harness.baseline import measure_spot_check
-
-            return measure_spot_check(gpu_indices=gpu_indices, duration_sec=5.0)
-
-        spec = self._runner_specs.get(config.engine) if self._runner_specs else None
-        if spec is None or spec.image is None:
-            return None
-
-        from llenergymeasure.study.baseline_container import run_baseline_container
-
-        result = run_baseline_container(
-            image=spec.image,
-            mode="spot_check",
-            duration_sec=5.0,
-            gpu_indices=gpu_indices,
-        )
-        return result.power_w if result is not None else None
-
-    def _validate_baseline(self, config: ExperimentConfig, cache_key: str) -> None:
-        """Spot-check baseline for drift (strategy='validated' only).
-
-        Performs a short measurement and compares with the cached baseline. On
-        drift beyond the configured threshold, re-measures the full baseline and
-        updates the disk cache. Emits a single ``Validating`` step (with an
-        ``on_step_update`` mid-step when a re-measure is triggered) so the
-        display step counter stays clean.
-        """
-        cached = self._baselines.get(cache_key)
-        if cached is None:
-            return
-
-        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
-        from llenergymeasure.harness.baseline import save_baseline_cache
-
-        gpu_indices = _resolve_gpu_indices(config)
-        location = "host" if cache_key == "local" else "baseline container"
-
-        if self._progress is not None:
-            self._progress.on_step_start(
-                STEP_BASELINE, "Validating", f"{location} · drift check (5s)"
-            )
-            t0 = time.perf_counter()
-
-        spot = self._spot_check_baseline(config, cache_key, gpu_indices)
-        self._experiments_since_validation[cache_key] = 0
-
-        if spot is None:
-            logger.warning("Baseline validation: spot-check measurement failed")
-            if self._progress is not None:
-                self._progress.on_step_done(STEP_BASELINE, time.perf_counter() - t0)
-            return
-
-        drift = abs(spot - cached.power_w) / cached.power_w
-        if drift > config.measurement.baseline.drift_threshold:
-            dur = config.measurement.baseline.duration_seconds
-            logger.info(
-                "Baseline drift detected: %.1fW -> %.1fW (%.1f%% > %.1f%% threshold). "
-                "Re-measuring full baseline.",
-                cached.power_w,
-                spot,
-                drift * 100,
-                config.measurement.baseline.drift_threshold * 100,
-            )
-            if self._progress is not None:
-                self._progress.on_step_update(
-                    STEP_BASELINE,
-                    f"{location} · drift {drift * 100:.1f}% > "
-                    f"{config.measurement.baseline.drift_threshold * 100:.0f}%, "
-                    f"re-measuring ({dur:.0f}s)",
-                )
-
-            remeasured = self._measure_baseline(config, cache_key)
-            if remeasured is not None:
-                remeasured.method = "validated"
-                self._baselines[cache_key] = remeasured
-                save_baseline_cache(self._get_baseline_cache_path(cache_key), remeasured)
-        else:
-            cached.method = "validated"
-            logger.debug(
-                "Baseline validation passed: drift=%.1f%% (threshold=%.1f%%)",
-                drift * 100,
-                config.measurement.baseline.drift_threshold * 100,
-            )
-
-        if self._progress is not None:
-            self._progress.on_step_done(STEP_BASELINE, time.perf_counter() - t0)
-
-    def _get_baseline_cache_path(self, cache_key: str) -> Path:
-        """Return the disk path for the baseline cache file keyed by runner target.
-
-        File lives at ``{study_dir}/_study-artefacts/baseline_cache_{cache_key}.json``.
-        Creates the artefacts directory if needed.
-        """
-        artefacts_dir = self.study_dir / "_study-artefacts"
-        artefacts_dir.mkdir(parents=True, exist_ok=True)
-        return artefacts_dir / f"baseline_cache_{cache_key}.json"
-
-    def _prepare_images(self) -> None:
-        """Check/pull Docker images for all Docker engines before experiments.
-
-        Runs once at the start of the study. Each engine's image is verified
-        (or pulled) sequentially. On failure, raises so the study aborts early.
-        Sets ``_images_prepared`` so per-experiment image_check is skipped.
-        """
-
-        if not self._runner_specs:
-            return
-
-        docker_engines = [
-            (engine_name, spec)
-            for engine_name, spec in self._runner_specs.items()
-            if spec.mode == RUNNER_DOCKER and spec.image
-        ]
-        if not docker_engines:
-            return
-
-        if self._progress:
-            self._progress.begin_image_prep([e for e, _ in docker_engines])
-
-        for engine_name, spec in docker_engines:
-            image = spec.image
-            assert image is not None  # narrowing for type checker
-            t0 = time.monotonic()
-
-            # Check if image exists locally
-            try:
-                check = subprocess.run(
-                    ["docker", "image", "inspect", image],
-                    capture_output=True,
-                    timeout=TIMEOUT_DOCKER_INSPECT,
-                )
-            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-                check = None
-
-            if check is not None and check.returncode == 0:
-                elapsed = time.monotonic() - t0
-                mismatch_error = self._finalise_image(
-                    engine_name, image, check.stdout, cached=True, elapsed=elapsed
-                )
-                if mismatch_error is not None:
-                    if self._progress:
-                        self._progress.end_image_prep()
-                    raise mismatch_error
-                continue
-
-            # Image not found locally - try to pull
-            logger.info("Image %s not found locally, pulling...", image)
-            try:
-                pull = subprocess.run(
-                    ["docker", "pull", image],
-                    capture_output=True,
-                    timeout=DOCKER_PULL_TIMEOUT,
-                )
-            except subprocess.TimeoutExpired as exc:
-                if self._progress:
-                    self._progress.image_failed(engine_name, image, "pull timed out (30min)")
-                    self._progress.end_image_prep()
-                from llenergymeasure.infra.docker_errors import DockerImagePullError
-
-                raise DockerImagePullError(
-                    message=f"Image pull timed out: {image}",
-                    fix_suggestion=f"docker compose build {engine_name}",
-                ) from exc
-
-            if pull.returncode != 0:
-                tip = f"docker compose build {engine_name}"
-                if self._progress:
-                    self._progress.image_failed(engine_name, image, f"not found \u2014 run: {tip}")
-                    self._progress.end_image_prep()
-                from llenergymeasure.infra.docker_errors import DockerImagePullError
-
-                raise DockerImagePullError(
-                    message=f"Image not found: {image}",
-                    fix_suggestion=tip,
-                )
-
-            elapsed = time.monotonic() - t0
-            try:
-                inspect = subprocess.run(
-                    ["docker", "image", "inspect", image],
-                    capture_output=True,
-                    timeout=TIMEOUT_DOCKER_INSPECT,
-                )
-                inspect_stdout = inspect.stdout if inspect.returncode == 0 else b""
-            except Exception:
-                inspect_stdout = b""
-
-            mismatch_error = self._finalise_image(
-                engine_name, image, inspect_stdout, cached=False, elapsed=elapsed
-            )
-            if mismatch_error is not None:
-                if self._progress:
-                    self._progress.end_image_prep()
-                raise mismatch_error
-
-        if self._progress:
-            self._progress.end_image_prep()
-
-        self._images_prepared = True
-
-    @staticmethod
-    def _parse_image_metadata(inspect_stdout: bytes) -> dict[str, str] | None:
-        """Extract human-readable display metadata from ``docker image inspect`` JSON.
-
-        Returns the id/size/built/layers fields the progress display renders
-        inline. Schema-handshake labels are handled separately via
-        ``parse_image_stamp`` so the raw 64-char fingerprint never leaks into
-        the display metadata.
-        """
-        try:
-            data = json.loads(inspect_stdout)
-            if not data:
-                return None
-            info = data[0]
-            meta: dict[str, str] = {}
-
-            image_id = info.get("Id", "")
-            if image_id.startswith("sha256:"):
-                image_id = image_id[7:19]
-            if image_id:
-                meta["id"] = image_id
-
-            size_bytes = info.get("Size", 0)
-            if size_bytes:
-                if size_bytes >= 1_073_741_824:
-                    meta["size"] = f"{size_bytes / 1_073_741_824:.1f} GB"
-                else:
-                    meta["size"] = f"{size_bytes / 1_048_576:.0f} MB"
-
-            created = info.get("Created", "")
-            if created:
-                try:
-                    created_dt = datetime.fromisoformat(created[:26].rstrip("Z"))
-                    created_dt = created_dt.replace(tzinfo=timezone.utc)
-                    age = datetime.now(timezone.utc) - created_dt
-                    if age.days > 0:
-                        meta["built"] = f"{age.days}d ago"
-                    elif age.seconds >= 3600:
-                        meta["built"] = f"{age.seconds // 3600}h ago"
-                    else:
-                        meta["built"] = f"{age.seconds // 60}m ago"
-                except (ValueError, TypeError):
-                    pass
-
-            layers = info.get("RootFS", {}).get("Layers", [])
-            if layers:
-                meta["layers"] = str(len(layers))
-
-            return meta if meta else None
-        except (json.JSONDecodeError, KeyError, IndexError):
-            return None
-
-    def _finalise_image(
-        self,
-        engine_name: str,
-        image: str,
-        inspect_stdout: bytes,
-        *,
-        cached: bool,
-        elapsed: float,
-    ) -> Exception | None:
-        """Report an image-ready progress event and return any mismatch error.
-
-        Parses display metadata and the schema stamp from *inspect_stdout*,
-        classifies the schema status, renders it through
-        ``progress.image_ready`` so the engine row appears before any abort,
-        and returns the ``VersionMismatchError`` for the caller to raise.
-        """
-        metadata = self._parse_image_metadata(inspect_stdout) or {}
-        stamp = parse_image_stamp(inspect_stdout)
-        schema_status, mismatch_error = self._verify_image_fingerprint(engine_name, image, stamp)
-        metadata["schema"] = schema_status
-
-        if self._progress:
-            self._progress.image_ready(
-                engine_name, image, cached=cached, elapsed=elapsed, metadata=metadata
-            )
-        return mismatch_error
-
-    def _verify_image_fingerprint(
-        self,
-        engine_name: str,
-        image: str,
-        stamp: ImageStamp,
-    ) -> tuple[str, Exception | None]:
-        """Compare the host schema fingerprint to *stamp* and classify the result.
-
-        Returns ``(schema_status, error)`` where ``schema_status`` is the
-        short display string and ``error`` is a ``VersionMismatchError`` to
-        raise (or ``None``). Callers raise after rendering so the offending
-        engine appears in the terminal before the study aborts.
-
-        Two-tier classification:
-
-        1. **Label-based fingerprint check** (preferred when present).
-           Definitive ``OK`` / ``MISMATCH`` answers are trusted directly.
-        2. **Bundled engine-version probe** (fallback). When the label is
-           absent or stamped ``"unknown"``, probe the engine library's
-           ``__version__`` inside the image and compare against the
-           ``engine_version`` envelope field on the bundled invariants +
-           schema artefacts (read via :func:`read_bundled_engine_version`,
-           which cross-checks both bundled artefacts agree). Closes the
-           verification gap for upstream-direct images (vllm, tensorrt)
-           which never had a llem schema-fingerprint label, and for legacy
-           local images where the fingerprint was stamped as ``"unknown"``.
-        """
-        if skip_check_enabled():
-            return "bypassed", None
-
-        host_fp = compute_expconf_fingerprint()
-        label_status = classify_stamp(stamp, host_fp)
-
-        if label_status is SchemaStatus.OK:
-            return "ok", None
-
-        if label_status is SchemaStatus.MISMATCH:
-            # Image has a real fingerprint label and it disagrees with the
-            # host. Hard-error - the label is authoritative when present.
-            assert stamp.expconf_fingerprint is not None
-            error = VersionMismatchError(
-                f"Docker image '{image}' was built from llenergymeasure "
-                f"{stamp.pkg_version or 'unknown'} (schema {stamp.expconf_fingerprint[:12]}) "
-                f"but the host is running {_HOST_PKG_VERSION} (schema {host_fp[:12]}). "
-                f"The container will reject ExperimentConfig fields added on the host "
-                f"after the image was built.\n\n"
-                f"To fix:\n"
-                f"  {rebuild_hint(engine_name)}       # rebuild locally\n"
-                f"  make docker-pull                  # or pull a newer tagged release\n\n"
-                f"If you're certain the skew is harmless, set {ENV_SKIP_IMAGE_CHECK}=1."
-            )
-            return "mismatch", error
-
-        # label_status is UNVERIFIED or UNREACHABLE: fall back to engine-
-        # version probe. The probe takes one docker-run (a few seconds)
-        # and is cached per (image, engine). The "expected" version comes
-        # from the bundled invariants/schema envelopes (the artefacts llem
-        # actually applies at experiment time), not from current.yaml -
-        # current.yaml isn't shipped in the wheel, so an SSOT-based check
-        # is silently UNREACHABLE for installed users. The bundled envelope
-        # works in both wheel and editable installs.
-        probed = probe_image_engine_version(image, engine_name)
-        try:
-            expected = read_bundled_engine_version(engine_name)
-        except BundledEngineVersionMismatchError as exc:
-            return "mismatch (bundled artefact disagreement)", exc
-        probe_status = classify_engine_version(probed, expected)
-
-        if probe_status is SchemaStatus.OK:
-            logger.debug(
-                "Image %s verified via engine-version probe: %s matches bundled envelope",
-                image,
-                probed,
-            )
-            return f"ok (engine={probed})", None
-
-        if probe_status is SchemaStatus.UNREACHABLE:
-            # Neither label nor probe yielded a definitive answer. Soft-warn
-            # and proceed - the bind-mounted framework on the host still
-            # defines the actual contract; we just can't independently
-            # verify the engine version.
-            logger.warning(
-                "Image %s has no %s label and the engine-version probe was "
-                "inconclusive (probed=%r, bundled=%r). Dispatch will proceed; "
-                "the bind-mounted framework defines the contract regardless.",
-                image,
-                LABEL_SCHEMA_FINGERPRINT,
-                probed,
-                expected,
-            )
-            return "unverified (no labels, probe inconclusive)", None
-
-        # probe_status is MISMATCH
-        error = VersionMismatchError(
-            f"Docker image '{image}' has {engine_name} library version "
-            f"{probed!r} but the bundled invariants + discovered schemas "
-            f"in this wheel were mined against {expected!r}. Applying "
-            f"version-{expected!r} validation rules to a version-{probed!r} "
-            f"substrate is not safe.\n\n"
-            f"To fix:\n"
-            f"  Pull an image matching {expected!r}, or install a wheel "
-            f"built against {probed!r}.\n\n"
-            f"If you're certain the skew is harmless, set "
-            f"{ENV_SKIP_IMAGE_CHECK}=1."
-        )
-        return f"mismatch (engine {probed} vs bundled {expected})", error
-
     def _run_gap(self, seconds: float, label: str) -> None:
         """Run a thermal gap, rendering countdown in the live display or terminal."""
         if self._progress:
@@ -1957,6 +882,7 @@ class StudyRunner:
         from llenergymeasure.study.container_lifecycle import (
             generate_container_labels,
             generate_container_name,
+            persist_failure_artefacts,
         )
         from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
         from llenergymeasure.utils.exceptions import DockerError
@@ -2043,7 +969,7 @@ class StudyRunner:
                 "message": str(exc),
                 "config_hash": config_hash,
             }
-            self._persist_failure_artefacts(exc, config_hash, cycle, result)
+            persist_failure_artefacts(exc, self.study_dir, config_hash, cycle, result)
         except DockerTimeoutError as exc:
             # Normalise to "TimeoutError" so the circuit breaker sees the same
             # failure class as the subprocess path (see _collect_result).
@@ -2052,7 +978,7 @@ class StudyRunner:
                 "message": str(exc),
                 "config_hash": config_hash,
             }
-            self._persist_failure_artefacts(exc, config_hash, cycle, result)
+            persist_failure_artefacts(exc, self.study_dir, config_hash, cycle, result)
         except DockerError as exc:
             # Use structured error payload from container entrypoint when available,
             # falling back to the exception type/message for stderr-based errors.
@@ -2069,7 +995,7 @@ class StudyRunner:
                     "message": str(exc),
                     "config_hash": config_hash,
                 }
-            self._persist_failure_artefacts(exc, config_hash, cycle, result)
+            persist_failure_artefacts(exc, self.study_dir, config_hash, cycle, result)
 
         exp_elapsed = time.monotonic() - exp_start
         self._handle_result(
@@ -2087,58 +1013,3 @@ class StudyRunner:
             shutil.rmtree(docker_ts_dir, ignore_errors=True)
 
         return result
-
-    def _persist_failure_artefacts(
-        self,
-        exc: DockerError,
-        config_hash: str,
-        cycle: int,
-        result: dict[str, Any],
-    ) -> None:
-        """Copy failure artefacts from the Docker exchange dir into ``failed-runs/``.
-
-        Copies ``container.log`` and any ``*_error.json`` from the exchange
-        directory. Adds a ``log_file`` key to *result* so the manifest records
-        where the log can be found.
-        """
-        exchange_dir_str = getattr(exc, "exchange_dir", None)
-        if not exchange_dir_str:
-            return
-
-        exchange_dir = Path(exchange_dir_str)
-        failed_runs_dir = self.study_dir / "failed-runs"
-        prefix = f"{config_hash}_cycle{cycle}"
-
-        try:
-            failed_runs_dir.mkdir(parents=True, exist_ok=True)
-        except OSError as mkdir_exc:
-            logger.warning("Failed to create failed-runs/: %s", mkdir_exc)
-            return
-
-        # Copy container.log (Docker stderr capture)
-        log_file = self._copy_artefact(
-            exchange_dir / "container.log",
-            failed_runs_dir / f"{prefix}_container.log",
-        )
-        if log_file:
-            result["log_file"] = f"failed-runs/{log_file}"
-
-        # Copy error JSON (structured traceback from container entrypoint).
-        # The error JSON uses the Docker config hash (output_dir=/run/llem),
-        # which differs from the study-level config_hash, so glob for it.
-        for src in exchange_dir.glob("*_error.json"):
-            self._copy_artefact(src, failed_runs_dir / f"{prefix}_error.json")
-            break  # only one expected
-
-    @staticmethod
-    def _copy_artefact(src: Path, dest: Path) -> str | None:
-        """Copy a single file, returning the dest filename on success or None."""
-        if not src.exists():
-            return None
-        try:
-            shutil.copy2(src, dest)
-            logger.debug("Artefact persisted to %s", dest)
-            return dest.name
-        except Exception as copy_exc:
-            logger.warning("Failed to persist %s to %s: %s", src.name, dest, copy_exc)
-            return None

--- a/src/llenergymeasure/study/worker.py
+++ b/src/llenergymeasure/study/worker.py
@@ -1,0 +1,278 @@
+"""Subprocess-worker surface for experiment isolation.
+
+Each experiment runs in a freshly spawned subprocess with a clean CUDA context.
+This module holds the child-process entry point (``_run_experiment_worker``),
+the parent-side result collector (``_collect_result``), and the small helpers
+they share: process-group signalling, exit-reason derivation, and the failure
+classifier constants.
+
+Key design decisions (locked in .product/decisions/experiment-isolation.md):
+- spawn context: CUDA-safe; fork causes silent CUDA corruption (CP-1)
+- daemon=False: clean CUDA teardown if parent exits unexpectedly (CP-4)
+- Pipe-only IPC: ExperimentResult fits in Pipe buffer for typical experiment sizes
+- SIGKILL on timeout: SIGTERM may be ignored by hung CUDA operations
+- Process group kill: worker calls os.setpgrp() to become group leader so all
+  descendant processes (vLLM workers, MPI ranks, etc.) are killed together
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import time
+import traceback
+from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.study._progress import _QueueProgressCallback
+
+if TYPE_CHECKING:
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.domain.environment import EnvironmentSnapshot
+
+# Failure classifiers produced by ``_collect_result`` and consumed by
+# parent-side sentinel handling. Lifted so the producer and consumer don't
+# drift on bare strings.
+COLLECT_RESULT_PROCESS_CRASH = "ProcessCrash"
+COLLECT_RESULT_TIMEOUT = "TimeoutError"
+
+# Sentinel object used to distinguish "no payload provided" from a None payload.
+_UNSET = object()
+
+
+def _derive_exit_reason(exitcode: int | None) -> str | None:
+    """Map a negative subprocess exit code to its POSIX signal name.
+
+    Negative exit codes are signals (POSIX convention). Returns the signal
+    name (e.g. ``SIGKILL``, ``SIGSEGV``, ``SIGTERM``) for any recognised
+    signal, ``None`` otherwise. The raw code is preserved elsewhere.
+    """
+    if exitcode is None or exitcode >= 0:
+        return None
+    try:
+        return signal.Signals(-exitcode).name
+    except ValueError:
+        return None
+
+
+def _kill_process_group(pid: int, sig: int) -> None:
+    """Send signal to the entire process group rooted at pid.
+
+    Uses os.killpg so that all descendant processes (vLLM workers, MPI ranks, etc.)
+    receive the signal, not just the parent. Errors are suppressed because the
+    process group may already be dead by the time this is called.
+    """
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pid, sig)
+
+
+def _run_experiment_worker(
+    config: ExperimentConfig,
+    conn: Any,  # multiprocessing.Connection (child end)
+    progress_queue: Any,  # multiprocessing.Queue
+    snapshot: EnvironmentSnapshot | None = None,
+    output_dir: str | None = None,
+    save_timeseries: bool = True,
+    baseline: Any = None,  # BaselineCache | None (avoids import at module level)
+    *,
+    study_dir: str,
+    study_run_id: str,
+    cycle: int,
+    config_hash: str,
+) -> None:
+    """Entry point for the child process. Runs one experiment and returns result via Pipe.
+
+    Signal handling:
+        Installs SIGINT → SIG_IGN so the child ignores Ctrl+C.
+        The parent handles SIGINT and decides whether to kill the child.
+
+    IPC protocol:
+        On success: sends ExperimentResult (or result dict) via conn.
+        On failure: sends {"type": ..., "message": ..., "traceback": ...} via conn.
+        Progress events are put to progress_queue for the consumer thread.
+
+    Args:
+        output_dir: Directory for timeseries parquet output. Passed through to harness.
+        save_timeseries: Whether to persist GPU timeseries. Passed through to harness.
+        baseline: Pre-measured baseline power from parent process (study-level cache).
+        study_dir: Study output directory. Runtime observations append to
+            ``{study_dir}/runtime_observations.jsonl``.
+        study_run_id: UUID identifying this invocation of ``StudyRunner.run()``.
+        cycle: 1-based cycle counter for this config within the study.
+        config_hash: ``compute_declared_config_hash(config)``. The parent is
+            the single SSOT for this value.
+    """
+    # Become process group leader so all descendants (vLLM workers, MPI ranks, etc.)
+    # share this PGID. The parent can then kill the whole group via os.killpg().
+    os.setpgrp()
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    # Wrap the worker body BEFORE run_preflight() / get_engine() so engine
+    # import-time warnings under ``spawn`` are captured.
+    from llenergymeasure.study.runtime_observations import capture_runtime_observations
+
+    obs_ctx = capture_runtime_observations(
+        config,
+        study_dir=study_dir,
+        study_run_id=study_run_id,
+        cycle=cycle,
+        config_hash=config_hash,
+    )
+
+    try:
+        with obs_ctx:
+            progress_queue.put({"event": "started", "config_hash": config_hash})
+
+            # Create progress callback that serialises step events to queue
+            progress_cb = _QueueProgressCallback(progress_queue)
+
+            # Run the actual experiment in-process (within the spawned subprocess)
+            from llenergymeasure.engines import get_engine
+            from llenergymeasure.harness import MeasurementHarness
+            from llenergymeasure.harness.preflight import run_preflight
+
+            # Pre-flight inside subprocess: CUDA availability must be checked in the
+            # process that will use the GPU.
+            progress_cb.on_step_start("container_preflight", "Checking", "CUDA, model access")
+            t0_pf = time.perf_counter()
+            run_preflight(config)
+            progress_cb.on_step_done("container_preflight", time.perf_counter() - t0_pf)
+
+            engine = get_engine(config.engine)
+            harness = MeasurementHarness()
+            from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+
+            gpu_indices = _resolve_gpu_indices(config)
+            result = harness.run(
+                engine,
+                config,
+                snapshot=snapshot,
+                gpu_indices=gpu_indices,
+                progress=progress_cb,
+                output_dir=output_dir,
+                save_timeseries=save_timeseries,
+                baseline=baseline,
+            )
+
+            # Send result back to parent via Pipe
+            conn.send(result)
+            progress_queue.put({"event": "completed", "config_hash": config_hash})
+
+    except Exception as exc:
+        error_payload = {
+            "type": type(exc).__name__,
+            "message": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        with contextlib.suppress(Exception):
+            # Pipe may be broken (e.g. parent killed). Best-effort only.
+            conn.send(error_payload)
+
+        with contextlib.suppress(Exception):
+            progress_queue.put({"event": "failed", "error": str(exc)})
+
+        raise
+
+    finally:
+        conn.close()
+
+
+def _collect_result(
+    p: Any,  # multiprocessing.Process
+    parent_conn: Any,  # multiprocessing.Connection (parent end)
+    config: ExperimentConfig,
+    timeout: float,
+    pipe_payload: Any = _UNSET,
+) -> Any:
+    """Inspect process outcome and return either a result or a failure dict.
+
+    Called after the pipe has been drained and p.join() has returned.
+
+    Args:
+        p: The child process.
+        parent_conn: Parent end of the Pipe (read-only).
+        config: Experiment configuration.
+        timeout: Timeout used for the experiment (for error messages).
+        pipe_payload: Pre-drained pipe value from the recv-before-join pattern
+            (H5 deadlock fix). When provided, skips calling recv() again.
+            Pass _UNSET (default) to fall back to reading from the pipe directly.
+
+    Returns:
+        ExperimentResult on success, dict with keys (type, message) on failure.
+    """
+    from llenergymeasure.domain.experiment import compute_declared_config_hash
+
+    config_hash = compute_declared_config_hash(config)
+
+    if p.is_alive():
+        # Timed out - kill with SIGKILL
+        # SIGKILL: SIGTERM may be ignored by hung CUDA operations
+        _kill_process_group(p.pid, signal.SIGKILL)
+        p.join()
+        return {
+            "type": COLLECT_RESULT_TIMEOUT,
+            "message": f"Experiment exceeded timeout of {timeout}s and was killed.",
+            "config_hash": config_hash,
+        }
+
+    if p.exitcode != 0:
+        # Non-zero exit - try to read error payload from pipe
+        # Use pre-drained payload if available; otherwise poll/recv
+        if pipe_payload is not _UNSET:
+            payload = pipe_payload
+            if isinstance(payload, dict) and "type" in payload and "message" in payload:
+                payload["config_hash"] = config_hash
+                return payload
+        elif parent_conn.poll():
+            try:
+                payload = parent_conn.recv()
+                if isinstance(payload, dict) and "type" in payload and "message" in payload:
+                    payload["config_hash"] = config_hash
+                    return payload
+            except Exception:
+                pass
+
+        return {
+            "type": COLLECT_RESULT_PROCESS_CRASH,
+            "message": f"Subprocess exited with code {p.exitcode} and no error data in Pipe.",
+            "config_hash": config_hash,
+        }
+
+    # Success path - use pre-drained payload if available
+    if pipe_payload is not _UNSET:
+        try:
+            payload = pipe_payload
+            # If payload is an error dict (exception in worker), treat as failure
+            if isinstance(payload, dict) and "type" in payload and "message" in payload:
+                payload["config_hash"] = config_hash
+                return payload
+            return payload
+        except Exception as exc:
+            return {
+                "type": "PipeError",
+                "message": f"Failed to process pre-drained pipe payload: {exc}",
+                "config_hash": config_hash,
+            }
+
+    # Fallback: read from pipe directly (no pre-drained payload)
+    if parent_conn.poll():
+        try:
+            payload = parent_conn.recv()
+            # If payload is an error dict (exception in worker), treat as failure
+            if isinstance(payload, dict) and "type" in payload and "message" in payload:
+                payload["config_hash"] = config_hash
+                return payload
+            return payload
+        except Exception as exc:
+            return {
+                "type": "PipeError",
+                "message": f"Failed to receive result from subprocess: {exc}",
+                "config_hash": config_hash,
+            }
+
+    return {
+        "type": COLLECT_RESULT_PROCESS_CRASH,
+        "message": "Subprocess exited 0 but sent no data through Pipe.",
+        "config_hash": config_hash,
+    }

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -582,7 +582,7 @@ class TestDockerBaselineMount:
             patch("llenergymeasure.infra.docker_runner.DockerRunner", FakeDockerRunner),
             patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"),
             patch.object(runner, "_handle_result"),
-            patch.object(runner, "_persist_failure_artefacts"),
+            patch("llenergymeasure.study.container_lifecycle.persist_failure_artefacts"),
         ):
             runner._run_one_docker(config_cached, spec, config_hash="abc123", cycle=1, index=1)
 
@@ -1201,7 +1201,7 @@ class TestDockerPathOrdering:
             patch("llenergymeasure.infra.docker_runner.DockerRunner", FakeDockerRunner),
             patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"),
             patch.object(runner, "_handle_result"),
-            patch.object(runner, "_persist_failure_artefacts"),
+            patch("llenergymeasure.study.container_lifecycle.persist_failure_artefacts"),
         ):
             runner._run_one_docker(config_cached, spec, config_hash="abc123", cycle=1, index=1)
 

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from llenergymeasure.config.models import ExecutionConfig, ExperimentConfig, StudyConfig
+from llenergymeasure.study.image_prep import _parse_image_metadata
 from llenergymeasure.study.runner import (
     StudyRunner,
     _kill_process_group,
@@ -1571,7 +1572,7 @@ class TestPrepareImages:
 
         version_handshake.probe_image_engine_version.cache_clear()
         with patch(
-            "llenergymeasure.study.runner.probe_image_engine_version",
+            "llenergymeasure.study.image_prep.probe_image_engine_version",
             return_value=None,
         ):
             yield
@@ -1841,30 +1842,30 @@ class TestPrepareImages:
 
 
 class TestParseImageMetadata:
-    """Tests for StudyRunner._parse_image_metadata()."""
+    """Tests for study.image_prep._parse_image_metadata()."""
 
     def test_valid_inspect_output(self) -> None:
-        meta = StudyRunner._parse_image_metadata(FAKE_INSPECT_JSON)
+        meta = _parse_image_metadata(FAKE_INSPECT_JSON)
         assert meta is not None
         assert meta["id"] == "abc123def456"
         assert "GB" in meta["size"]
         assert meta["layers"] == "3"
 
     def test_empty_json_array(self) -> None:
-        assert StudyRunner._parse_image_metadata(b"[]") is None
+        assert _parse_image_metadata(b"[]") is None
 
     def test_invalid_json(self) -> None:
-        assert StudyRunner._parse_image_metadata(b"not json") is None
+        assert _parse_image_metadata(b"not json") is None
 
     def test_size_mb_format(self) -> None:
         data = b'[{"Id": "sha256:abc123", "Size": 524288000}]'
-        meta = StudyRunner._parse_image_metadata(data)
+        meta = _parse_image_metadata(data)
         assert meta is not None
         assert "MB" in meta["size"]
 
     def test_missing_fields_returns_none(self) -> None:
         data = b"[{}]"
-        assert StudyRunner._parse_image_metadata(data) is None
+        assert _parse_image_metadata(data) is None
 
     def test_handshake_labels_do_not_leak_into_display_metadata(self) -> None:
         """Display metadata never carries the raw 64-char fingerprint label."""
@@ -1875,7 +1876,7 @@ class TestParseImageMetadata:
             b'"org.opencontainers.image.version": "0.9.0"'
             b"}}}]"
         )
-        meta = StudyRunner._parse_image_metadata(data)
+        meta = _parse_image_metadata(data)
         assert meta is not None
         assert "llem_expconf_fingerprint" not in meta
         assert "llem_pkg_version" not in meta
@@ -2057,10 +2058,10 @@ class TestSchemaFingerprintHandshake:
 
         vh.probe_image_engine_version.cache_clear()
         with (
-            caplog.at_level(_logging.WARNING, logger="llenergymeasure.study.runner"),
+            caplog.at_level(_logging.WARNING, logger="llenergymeasure.study.image_prep"),
             patch("subprocess.run", return_value=ok),
             patch(
-                "llenergymeasure.study.runner.probe_image_engine_version",
+                "llenergymeasure.study.image_prep.probe_image_engine_version",
                 return_value=None,
             ),
         ):


### PR DESCRIPTION
## Summary

Decomposes the ~2,100-line `study/runner.py` god module into the `StudyRunner`
orchestrator plus four focused sibling modules inside the study package. No new
import edges: image-prep stays in study (moving it to infra would create a
forbidden infra->study edge). Zero behaviour change.

Per-module extraction:

- **`study/_progress.py`** (new): `_QueueProgressCallback` + `_consume_progress_events` - pure cross-process progress plumbing with no `StudyRunner` state.
- **`study/worker.py`** (new): the subprocess-worker surface - `_run_experiment_worker`, `_collect_result`, `_derive_exit_reason`, `_kill_process_group`, the `_UNSET` sentinel, and the `COLLECT_RESULT_PROCESS_CRASH` / `COLLECT_RESULT_TIMEOUT` constants. Engine/harness imports stay function-local (legal study->harness/engines edges).
- **`study/baseline_measure.py`** (new): `_BaselineMixin` holding the stateful baseline methods verbatim (`_get_baseline`, `_make_baseline_stage_callback`, `_emit_baseline_result_substeps`, `_measure_baseline`, `_spot_check_baseline`, `_validate_baseline`, `_get_baseline_cache_path`, `_baseline_cache_key`). Mixin (not free functions) keeps the `self._baselines` / `self._progress` / `self._runner_specs` / `self._experiments_since_validation` access intact for the smallest behaviour risk.
- **`study/image_prep.py`** (new): `_ImageMixin` with stateful `_prepare_images`, `_finalise_image`, `_verify_image_fingerprint`, plus pure free functions `_sanitize_image_for_filename` and `_parse_image_metadata`. The `version_handshake` imports moved here with them.
- **`study/container_lifecycle.py`** (existing): added free functions `persist_failure_artefacts(...)` and `copy_artefact(...)`, extracted from the former `_persist_failure_artefacts` / `_copy_artefact` methods (now taking explicit args), called from `_run_one_docker`.

`StudyRunner` becomes `class StudyRunner(_BaselineMixin, _ImageMixin)` and keeps
the orchestration surface: `__init__`, `run`, `_run_one`, `_run_one_docker`,
`_handle_result`, `_write_equivalence_groups_sidecar`, `_build_resolved_hashes`,
`_mark_remaining_skipped`, `_get_env_snapshot`, `_run_gap`, and `_save_and_record`
(stays in runner.py - `study/single.py` and tests import it from there).
runner.py drops from 2,144 to ~1,015 lines.

### Patch-target preservation strategy

runner.py re-imports the moved worker/progress symbols into its namespace
(`_run_experiment_worker`, `_collect_result`, `_kill_process_group`,
`_derive_exit_reason`, the `COLLECT_RESULT_*` constants, `_UNSET`, and
`_consume_progress_events`) and keeps `__all__`. This keeps (a) existing
`from llenergymeasure.study.runner import X` sites working and (b)
`patch("llenergymeasure.study.runner.<name>")` effective for the bare-name call
sites inside `_run_one` / `run`. `_consume_progress_events` is a genuine runtime
dependency (the consumer-thread target), not just a re-export; the unused
`_QueueProgressCallback` re-export (the worker constructs it directly from
`study._progress`) was dropped in the simplify pass.

Patch-target audit (existing test seams):

- **Preserved as-is** (call site stays in runner.py, or patches a shared stdlib
  module attribute): `study.runner._collect_result`, `study.runner.run_gap`,
  `study.runner.time.monotonic`, and `study.runner.os.killpg` /
  `study.runner.os.setpgrp` (these mutate the shared `os` module that
  `worker.py` also imports, so `import os` is retained in runner.py purely as a
  patch anchor). Tests patching the global `subprocess.run` still intercept
  `image_prep`'s `_prepare_images` unchanged.
- **Repointed** (call site moved out of runner.py):
  - `study.runner.probe_image_engine_version` -> `study.image_prep.probe_image_engine_version` (2 sites; the call now resolves in `image_prep`'s namespace).
  - `caplog.at_level(logger="llenergymeasure.study.runner")` -> `...image_prep` for the soft-warn fingerprint assertion.
  - `StudyRunner._parse_image_metadata(...)` -> `study.image_prep._parse_image_metadata(...)` (now a free function, no longer a static method).
  - `patch.object(runner, "_persist_failure_artefacts")` -> `patch("llenergymeasure.study.container_lifecycle.persist_failure_artefacts")` (2 sites; method is now a free function imported into `_run_one_docker`).

## Test plan

- `uv run pytest tests/ -q`: 2439 passed, 52 skipped, exit 0 (fail_under=80 coverage gate satisfied).
- `uv run ruff check src tests`: all checks passed.
- `uv run mypy src/`: success, no issues in 113 files.
- `uv run python -m importlinter.cli lint_imports --config pyproject.toml`: exit 0, no contract edits needed (intra-package moves).
- Orchestrator verification: 12 moved bodies confirmed AST-identical; real 2-cycle Docker study driven through the split `StudyRunner` completed both cycles.

## Doc audit

Architecture-changing refactor, so docs were swept in-branch:

- `src/llenergymeasure/study/README.md`: added the four new collaborator modules (`worker.py`, `_progress.py`, `baseline_measure.py`, `image_prep.py`) plus the previously-unlisted `container_lifecycle.py` to the module table.
- `docs/explanation/architecture/pipeline-architecture.md`: corrected the runtime-observations producer note - the capture now wraps the worker body in `worker.py`, not `runner.py`.
- Verified still-accurate (no edit needed): `StudyRunner._prepare_images` references in `troubleshoot.md` / `docker-setup.md` (method reachable via `_ImageMixin`), and the `study/runner.py` host-runner references in `methodology.md` / `infra/README.md` (`StudyRunner` still lives in `runner.py`).
