### PR TITLE
refactor(config): move study finalisation out of the config loader

### DIFF
--- a/docs/reference/library/StudyConfig.md
+++ b/docs/reference/library/StudyConfig.md
@@ -16,14 +16,20 @@ list of fully-validated [`ExperimentConfig`](./ExperimentConfig) objects (the sw
 expanded - no axes, no templates) plus two operational blocks: `output` for where to write
 results, and `study_execution` for how to sequence experiments across cycles.
 
-The key design point is that sweep resolution happens *at YAML parse time* in the loader,
-before the `StudyConfig` is constructed. By the time a `StudyConfig` exists, every item in
-`experiments` is a concrete, validated configuration ready to run. The study runner and
-harness never perform expansion - they iterate the list.
+The key design point is that sweep resolution happens *at YAML parse time* in the config
+loader, before the `StudyConfig` is constructed. By the time a `StudyConfig` exists, every
+item in `experiments` is a concrete, validated configuration ready to run. The study runner
+and harness never perform expansion - they iterate the list.
+
+Loading a `StudyConfig` from YAML is a two-step pipeline. The config loader
+(`config.loader.load_study_config`) does pure parse + sweep-expansion and returns a
+`LoadedStudyRaw`; study finalisation (`study.loading.finalise_study`) applies dedup,
+computes `study_design_hash`, and orders cycles to produce the resolved `StudyConfig`. The
+public entry that runs both steps is `api.load_study`. `run_study` calls it for you.
 
 `StudyConfig` is rarely constructed directly in userland. The normal path is to pass a YAML
-path to [`run_study`](./run_study) and let the loader produce it. Direct construction is
-useful for programmatic test generation or pipeline integration.
+path to [`run_study`](./run_study) and let it load and finalise the config. Direct
+construction is useful for programmatic test generation or pipeline integration.
 
 ---
 
@@ -37,15 +43,20 @@ from llenergymeasure import run_study
 result = run_study("study.yaml")
 ```
 
-### From YAML (via loader, for inspection)
+### From YAML (via `load_study`, for inspection)
 
 ```python
-from llenergymeasure.config.loader import load_study_config
+from llenergymeasure.api import load_study
 from pathlib import Path
 
-study = load_study_config(path=Path("study.yaml"))
+study = load_study(Path("study.yaml"))
 print(f"Expanded to {len(study.experiments)} experiments")
 ```
+
+`load_study` returns the resolved `StudyConfig`. For the raw pre-finalisation material
+(sweep-expanded but before dedup/hash/cycles), call `config.loader.load_study_config`
+directly; it returns a `LoadedStudyRaw` whose `valid_experiments` list holds the expanded
+configs.
 
 ### Programmatic construction
 
@@ -72,7 +83,7 @@ study = StudyConfig(
 |-------|------|---------|-------------|
 | `experiments` | `list[ExperimentConfig]` | _(required)_ | Resolved list of experiments to run. Minimum length 1. |
 | `study_name` | `str \| None` | `None` | Study name used in output directory naming (e.g. `gpt2-sweep_2026-05-07T14-00-00`). |
-| `study_design_hash` | `str \| None` | `None` | 16-char SHA-256 hex of the resolved experiment list (execution block excluded). Set by the loader after expansion; `None` when constructed programmatically. |
+| `study_design_hash` | `str \| None` | `None` | 16-char SHA-256 hex of the resolved experiment list (execution block excluded). Set by study finalisation after dedup; `None` when constructed programmatically. |
 
 ### `output` block (`OutputConfig`)
 
@@ -109,9 +120,9 @@ Controls sequencing, cycles, and failure handling:
 | `runners` | `dict[str, str] \| None` | `None` | Per-engine runner: `{"transformers": "local", "vllm": "docker"}`. `None` = use user config or auto-detection. |
 | `images` | `dict[str, str] \| None` | `None` | Per-engine Docker image overrides: `{"vllm": "ghcr.io/org/img:tag"}`. `None` = smart default (local build then registry fallback). |
 
-### Loader-populated metadata fields
+### Finalisation-populated metadata fields
 
-These are written by the loader and study runner; you rarely set them manually:
+These are written by study finalisation and the study runner; you rarely set them manually:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -140,10 +151,10 @@ engine-section matching and engine-invariants checking).
 ### Inspect expanded experiments before running
 
 ```python
-from llenergymeasure.config.loader import load_study_config
+from llenergymeasure.api import load_study
 from pathlib import Path
 
-study = load_study_config(path=Path("sweep.yaml"))
+study = load_study(Path("sweep.yaml"))
 print(f"{len(study.experiments)} experiments after expansion")
 for i, exp in enumerate(study.experiments, 1):
     print(f"  {i:>3}. {exp.task.model} / {exp.engine}")
@@ -152,7 +163,7 @@ for i, exp in enumerate(study.experiments, 1):
 ### Override output directory programmatically
 
 ```python
-study = load_study_config(path=Path("study.yaml"))
+study = load_study(Path("study.yaml"))
 study = study.model_copy(
     update={"output": study.output.model_copy(update={"results_dir": "/data/results"})}
 )
@@ -179,6 +190,7 @@ result = run_study(study)
 
 - [`ExperimentConfig`](./ExperimentConfig) - the per-experiment config model
 - [`run_study`](./run_study) - the function that accepts a `StudyConfig`
+- `api.load_study` - load a YAML path into a resolved `StudyConfig` (parse + finalise)
 - [`ExperimentResult`](./ExperimentResult) - result type for each experiment
 - [Study config reference](/reference/study-config) - YAML syntax (sweep, execution block)
 - [Results schema](/reference/results-schema) - on-disk layout

--- a/docs/reference/library/run_study.md
+++ b/docs/reference/library/run_study.md
@@ -211,7 +211,7 @@ distinct configurations (pre-cycle). Both are in the summary.
 ## See also
 
 - [`run_experiment`](./run_experiment) - single-experiment convenience wrapper
-- [`StudyConfig`](./StudyConfig) - the config model accepted and returned by the loader
+- [`StudyConfig`](./StudyConfig) - the config model accepted by `run_study` and returned by `api.load_study`
 - [`ExperimentResult`](./ExperimentResult) - the per-experiment result type
 - [Study config reference](/reference/study-config) - YAML syntax (sweep axes, execution block)
 - [Results schema](/reference/results-schema) - on-disk layout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,12 +152,6 @@ layers = [
     "llenergymeasure.utils",
 ]
 ignore_imports = [
-    # Phase 50 M4: config.loader.load_study_config invokes resolve_library_effective
-    # as part of the grid-expansion pipeline (between expand_grid and
-    # apply_cycles). The library-resolution mechanism lives under study/ - reviewer
-    # may decide to invert this by moving dedup into api/cli callers; for now
-    # the import is local-inside-function so there is no cycle risk.
-    "llenergymeasure.config.loader -> llenergymeasure.study.library_resolution",
     # Phase 50 M4: harness._write_config_sidecar() persists config.json
     # (needs results.persistence). Import is local-inside-method; no cycle risk.
     # H3 hashing now imports from domain.hashing (L0) - no layer breach.
@@ -208,10 +202,6 @@ forbidden_modules = [
     "llenergymeasure.infra",
     "llenergymeasure.results",
     "llenergymeasure.datasets",
-]
-ignore_imports = [
-    # Phase 50 M4: see matching ignore on main-layers contract above.
-    "llenergymeasure.config.loader -> llenergymeasure.study.library_resolution",
 ]
 
 [[tool.importlinter.contracts]]

--- a/src/llenergymeasure/api/__init__.py
+++ b/src/llenergymeasure/api/__init__.py
@@ -1,6 +1,6 @@
 """Public library API for llenergymeasure."""
 
-from llenergymeasure.api._impl import run_experiment, run_study
+from llenergymeasure.api._impl import load_study, run_experiment, run_study
 from llenergymeasure.api.report_gaps import (
     ReportGapsError,
     find_runtime_gaps,
@@ -16,6 +16,7 @@ __all__ = [
     "find_resumable_study",
     "find_runtime_gaps",
     "load_resume_state",
+    "load_study",
     "probe_energy_sampler",
     "render_yaml_fragment",
     "run_experiment",

--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -34,6 +34,43 @@ _TASK_FIELDS: frozenset[str] = frozenset(TaskConfig.model_fields) - {"model", "d
 _MEASUREMENT_FIELDS: frozenset[str] = frozenset(MeasurementConfig.model_fields)
 
 # ---------------------------------------------------------------------------
+# load_study - parse + finalise composition
+# ---------------------------------------------------------------------------
+
+
+def load_study(
+    path: str | Path,
+    cli_overrides: dict[str, Any] | None = None,
+) -> StudyConfig:
+    """Load a study YAML and finalise it into a resolved StudyConfig.
+
+    Composes the config-layer parse/expand step
+    (:func:`llenergymeasure.config.loader.load_study_config`) with the
+    study-layer finalisation
+    (:func:`llenergymeasure.study.loading.finalise_study`). This is the single
+    public entry both the CLI and ``run_study`` use, so the config layer never
+    imports upward into ``study`` and the CLI never imports ``study`` directly.
+
+    Args:
+        path: Path to study YAML file.
+        cli_overrides: Optional dict of CLI flag overrides for the execution
+            block (e.g. {"study_execution": {"n_cycles": 5}}).
+
+    Returns:
+        Resolved StudyConfig with ordered experiments, study_design_hash, dedup
+        mode, and pre-run equivalence groups.
+
+    Raises:
+        ConfigError: File not found, parse error, all configs invalid, empty study.
+        ValidationError: Pydantic structural errors pass through unchanged.
+    """
+    from llenergymeasure.config.loader import load_study_config
+    from llenergymeasure.study.loading import finalise_study
+
+    return finalise_study(load_study_config(path, cli_overrides=cli_overrides))
+
+
+# ---------------------------------------------------------------------------
 # run_experiment - three overloaded forms
 # ---------------------------------------------------------------------------
 
@@ -192,10 +229,8 @@ def run_study(
         pydantic.ValidationError: Invalid field values (passes through unchanged).
     """
     if isinstance(config, (str, Path)):
-        from llenergymeasure.config.loader import load_study_config
-
         config_path = config_path or Path(config).resolve()
-        study = load_study_config(path=config_path)
+        study = load_study(config_path)
     elif isinstance(config, StudyConfig):
         # config_path may have been passed by caller (e.g. CLI pre-loads config)
         study = config

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -418,10 +418,10 @@ def _run_study_impl(
     """Study execution path - separated for clean error handling."""
     import yaml
 
+    from llenergymeasure.api import load_study
     from llenergymeasure.cli._display import print_study_dry_run
     from llenergymeasure.cli._preflight_display import build_preflight_panel
     from llenergymeasure.config.grid import count_sweep_structure
-    from llenergymeasure.config.loader import load_study_config
 
     # Fast-fail: verify resume target exists before expensive grid expansion.
     # For resume, also load the manifest early so we can show a summary and
@@ -534,8 +534,8 @@ def _run_study_impl(
         refresh_per_second=8,
         transient=True,
     ):
-        study_config = load_study_config(
-            path=config,
+        study_config = load_study(
+            config,
             cli_overrides=study_cli_overrides if study_cli_overrides else None,
         )
     expand_elapsed = time.perf_counter() - t0_expand

--- a/src/llenergymeasure/config/loader.py
+++ b/src/llenergymeasure/config/loader.py
@@ -12,28 +12,28 @@ Priority (highest wins): cli_overrides > path YAML > user_config_defaults
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import yaml
 from pydantic import ValidationError
 
 from llenergymeasure.config._dict_utils import _unflatten, deep_merge
-from llenergymeasure.config.grid import (
-    ExperimentOrder,
-    apply_cycles,
-    compute_study_design_hash,
-    expand_grid,
-)
+from llenergymeasure.config.grid import SkippedConfig, expand_grid
 from llenergymeasure.config.models import (
     ExecutionConfig,
     ExperimentConfig,
     OutputConfig,
-    StudyConfig,
 )
 from llenergymeasure.utils.exceptions import ConfigError
 
-__all__ = ["deep_merge", "load_experiment_config", "load_study_config"]
+__all__ = [
+    "LoadedStudyRaw",
+    "deep_merge",
+    "load_experiment_config",
+    "load_study_config",
+]
 
 
 # =============================================================================
@@ -113,24 +113,59 @@ def load_experiment_config(
         raise ConfigError(f"Config construction failed{context}: {e}") from e
 
 
+@dataclass(frozen=True)
+class LoadedStudyRaw:
+    """Parsed + sweep-expanded study material, before dedup/hash/cycle finalisation.
+
+    Output of :func:`load_study_config`. Carries everything the study-layer
+    finalisation step (``llenergymeasure.study.loading.finalise_study``) needs to
+    build a resolved :class:`~llenergymeasure.config.models.StudyConfig`, without
+    the config layer reaching upward into ``study`` for the library-resolution /
+    dedup mechanism.
+
+    Attributes:
+        valid_experiments: Sweep-expanded, Pydantic-validated declared configs
+            (pre-dedup, pre-cycle). At least one entry (guards raise otherwise).
+        skipped: Grid points that failed validation during expansion.
+        study_name: Optional study name (output directory naming).
+        output: Parsed study-level output configuration.
+        execution: Parsed execution block (cycles, ordering, dedup toggle).
+        runners: Per-engine runner config, or None.
+        images: Per-engine Docker image overrides, or None.
+    """
+
+    valid_experiments: list[ExperimentConfig]
+    skipped: list[SkippedConfig]
+    study_name: str | None
+    output: OutputConfig
+    execution: ExecutionConfig
+    runners: dict[str, str] | None
+    images: dict[str, str] | None
+
+
 def load_study_config(
     path: Path | str,
     cli_overrides: dict[str, Any] | None = None,
-) -> StudyConfig:
-    """Load, expand, and validate a study YAML file.
+) -> LoadedStudyRaw:
+    """Load, expand, and validate a study YAML file (pure config-layer parse).
 
     Resolution order:
       1. Load YAML file
       2. Apply CLI overrides on execution block
-      3. Parse execution block (Pydantic validates it)
+      3. Parse output + execution blocks (Pydantic validates them)
       4. expand_grid() - Cartesian product + Pydantic validation of each ExperimentConfig
-      5. Guard: empty or all-invalid → ConfigError
-      6. compute_study_design_hash() over valid experiments
-      7. apply_cycles() for cycle ordering
-      8. Construct and return StudyConfig
+      5. Guard: empty or all-invalid -> ConfigError
 
     This is the CFG-12 contract: sweep resolution at YAML parse time, before
     Pydantic sees the individual ExperimentConfig objects.
+
+    Dedup, study_design_hash, cycle ordering, and equivalence-group serialisation
+    are deliberately NOT done here - they require the study-layer
+    library-resolution mechanism, and the config layer must not import upward.
+    Those steps live in ``llenergymeasure.study.loading.finalise_study``, which
+    consumes the :class:`LoadedStudyRaw` returned here and produces the resolved
+    :class:`~llenergymeasure.config.models.StudyConfig`. Use
+    ``llenergymeasure.api.load_study`` to run both steps in one call.
 
     Args:
         path: Path to study YAML file.
@@ -139,7 +174,8 @@ def load_study_config(
             --cycles/--order/--no-gaps flags into this dict.
 
     Returns:
-        Resolved StudyConfig with ordered experiments and study_design_hash.
+        :class:`LoadedStudyRaw` - sweep-expanded experiments plus the parsed
+        metadata the study-layer finalisation needs.
 
     Raises:
         ConfigError: File not found, parse error, base file missing, ALL configs invalid,
@@ -191,60 +227,14 @@ def load_study_config(
             "Nothing to run. Check sweep dimensions against engine constraints.\n" + skip_details
         )
 
-    # Apply library-resolution mechanism + resolved-config-hash dedup to the declared configs
-    # before running cycles. See sweep-dedup.md §2 - this collapses measurement-equivalent
-    # configs so a 6-config sweep with dormant sampling fields becomes 4 unique runs.
-    from llenergymeasure.study.library_resolution import resolve_library_effective
-
-    dedup = resolve_library_effective(
-        valid_experiments,
-        deduplicate=execution.deduplicate_equivalent,
-    )
-
-    run_experiments = dedup.canonical_configs
-    dedup_mode: Literal["resolved", "off"] = (
-        "resolved" if execution.deduplicate_equivalent else "off"
-    )
-
-    # Compute study_design_hash over the post-dedup configs - the hash
-    # identifies the *unique* measurement set, not duplicate declarations.
-    study_hash = compute_study_design_hash(run_experiments)
-
-    # Apply cycle ordering to produce execution sequence
-    ordered = apply_cycles(
-        run_experiments,
-        n_cycles=execution.n_cycles,
-        experiment_order=ExperimentOrder(execution.experiment_order),
-        study_design_hash=study_hash,
-        shuffle_seed=execution.shuffle_seed,
-    )
-
-    # Serialise pre-run equivalence groups for the sidecar writer.
-    pre_run_groups = [
-        {
-            "resolved_config_hash": g.resolved_config_hash,
-            "canonical_config_excerpt": g.canonical_excerpt,
-            "member_indices": list(g.member_indices),
-            "member_count": g.member_count,
-            "representative_index": g.representative_index,
-            "would_dedup": g.member_count > 1,
-            "deduplicated": dedup.deduplicated and g.member_count > 1,
-        }
-        for g in dedup.groups
-    ]
-
-    return StudyConfig(
-        experiments=ordered,
+    return LoadedStudyRaw(
+        valid_experiments=valid_experiments,
+        skipped=skipped,
         study_name=name,
         output=output,
-        study_execution=execution,
+        execution=execution,
         runners=runners,
         images=images,
-        study_design_hash=study_hash,
-        skipped_configs=[s.to_dict() for s in skipped],
-        dedup_mode=dedup_mode,
-        pre_run_equivalence_groups=pre_run_groups,
-        declared_resolved_config_hashes=list(dedup.declared_resolved_hashes),
     )
 
 

--- a/src/llenergymeasure/study/loading.py
+++ b/src/llenergymeasure/study/loading.py
@@ -1,0 +1,107 @@
+"""Study-layer finalisation of a parsed study config.
+
+The config layer (:mod:`llenergymeasure.config.loader`) does pure
+parse + sweep-expansion and returns a
+:class:`~llenergymeasure.config.loader.LoadedStudyRaw`. The dedup /
+study_design_hash / cycle-ordering / equivalence-group steps need the
+study-layer library-resolution mechanism, so they live here - keeping the
+config layer free of any upward import into ``study``.
+
+:func:`finalise_study` is the single composition point. The public entry that
+parses *and* finalises in one call is ``llenergymeasure.api.load_study``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from llenergymeasure.config.grid import (
+    ExperimentOrder,
+    apply_cycles,
+    compute_study_design_hash,
+)
+from llenergymeasure.config.loader import LoadedStudyRaw
+from llenergymeasure.config.models import StudyConfig
+from llenergymeasure.study.library_resolution import resolve_library_effective
+
+__all__ = ["finalise_study"]
+
+
+def finalise_study(raw: LoadedStudyRaw) -> StudyConfig:
+    """Apply library-resolution dedup, design hash, and cycle ordering.
+
+    Consumes the :class:`~llenergymeasure.config.loader.LoadedStudyRaw` produced
+    by :func:`llenergymeasure.config.loader.load_study_config` and produces the
+    resolved :class:`~llenergymeasure.config.models.StudyConfig` that the runner
+    iterates over.
+
+    Steps:
+      1. Library-resolution mechanism + resolved-config-hash dedup of the
+         declared configs (see sweep-dedup.md §2).
+      2. compute_study_design_hash() over the post-dedup configs - the hash
+         identifies the *unique* measurement set, not duplicate declarations.
+      3. apply_cycles() to produce the execution sequence.
+      4. Serialise pre-run equivalence groups for the sidecar writer.
+
+    Args:
+        raw: Parsed + sweep-expanded study material.
+
+    Returns:
+        Resolved StudyConfig with ordered experiments, study_design_hash, dedup
+        mode, and pre-run equivalence groups.
+    """
+    execution = raw.execution
+
+    # Apply library-resolution mechanism + resolved-config-hash dedup to the declared configs
+    # before running cycles. See sweep-dedup.md §2 - this collapses measurement-equivalent
+    # configs so a 6-config sweep with dormant sampling fields becomes 4 unique runs.
+    dedup = resolve_library_effective(
+        raw.valid_experiments,
+        deduplicate=execution.deduplicate_equivalent,
+    )
+
+    run_experiments = dedup.canonical_configs
+    dedup_mode: Literal["resolved", "off"] = (
+        "resolved" if execution.deduplicate_equivalent else "off"
+    )
+
+    # Compute study_design_hash over the post-dedup configs - the hash
+    # identifies the *unique* measurement set, not duplicate declarations.
+    study_hash = compute_study_design_hash(run_experiments)
+
+    # Apply cycle ordering to produce execution sequence
+    ordered = apply_cycles(
+        run_experiments,
+        n_cycles=execution.n_cycles,
+        experiment_order=ExperimentOrder(execution.experiment_order),
+        study_design_hash=study_hash,
+        shuffle_seed=execution.shuffle_seed,
+    )
+
+    # Serialise pre-run equivalence groups for the sidecar writer.
+    pre_run_groups: list[dict[str, Any]] = [
+        {
+            "resolved_config_hash": g.resolved_config_hash,
+            "canonical_config_excerpt": g.canonical_excerpt,
+            "member_indices": list(g.member_indices),
+            "member_count": g.member_count,
+            "representative_index": g.representative_index,
+            "would_dedup": g.member_count > 1,
+            "deduplicated": dedup.deduplicated and g.member_count > 1,
+        }
+        for g in dedup.groups
+    ]
+
+    return StudyConfig(
+        experiments=ordered,
+        study_name=raw.study_name,
+        output=raw.output,
+        study_execution=execution,
+        runners=raw.runners,
+        images=raw.images,
+        study_design_hash=study_hash,
+        skipped_configs=[s.to_dict() for s in raw.skipped],
+        dedup_mode=dedup_mode,
+        pre_run_equivalence_groups=pre_run_groups,
+        declared_resolved_config_hashes=list(dedup.declared_resolved_hashes),
+    )

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -164,7 +164,7 @@ class TestPipelineMultiExperimentSweep:
         (StudyRunner uses multiprocessing spawn; subprocess patching is not feasible
         for cross-process injection). Runner integration is covered by CLI E2E tests.
         """
-        from llenergymeasure.config.loader import load_study_config
+        from llenergymeasure.api import load_study
 
         yaml_content = """\
 task:
@@ -185,7 +185,7 @@ measurement:
         yaml_path = tmp_path / "study.yaml"
         yaml_path.write_text(yaml_content)
 
-        study_config = load_study_config(yaml_path)
+        study_config = load_study(yaml_path)
 
         # Sweep over 2 dtypes, n_cycles=1 → 2 experiments total
         assert len(study_config.experiments) == 2
@@ -194,7 +194,7 @@ measurement:
 
     def test_study_yaml_model_sweep(self, tmp_path: Path) -> None:
         """YAML with model sweep produces correct number of experiment configs."""
-        from llenergymeasure.config.loader import load_study_config
+        from llenergymeasure.api import load_study
 
         yaml_content = """\
 sweep:
@@ -207,7 +207,7 @@ study_execution:
         yaml_path = tmp_path / "study.yaml"
         yaml_path.write_text(yaml_content)
 
-        study_config = load_study_config(yaml_path)
+        study_config = load_study(yaml_path)
 
         assert len(study_config.experiments) == 2
         models = {exp.task.model for exp in study_config.experiments}
@@ -215,13 +215,13 @@ study_execution:
 
     def test_study_config_study_design_hash_set(self, tmp_path: Path) -> None:
         """StudyConfig.study_design_hash is populated after loading."""
-        from llenergymeasure.config.loader import load_study_config
+        from llenergymeasure.api import load_study
 
         yaml_content = "task:\n  model: gpt2\nstudy_execution:\n  n_cycles: 1\n  experiment_order: sequential\n"
         yaml_path = tmp_path / "study.yaml"
         yaml_path.write_text(yaml_content)
 
-        study_config = load_study_config(yaml_path)
+        study_config = load_study(yaml_path)
 
         assert study_config.study_design_hash
         assert len(study_config.study_design_hash) == 16

--- a/tests/integration/test_sweep_dedup_end_to_end.py
+++ b/tests/integration/test_sweep_dedup_end_to_end.py
@@ -1,9 +1,9 @@
 """End-to-end integration test for sweep canonicalisation + resolved-config dedup.
 
 Exercises the full load path: a study YAML with measurement-equivalent
-sweep configs goes through ``load_study_config`` and the resulting
-``StudyConfig`` records the pre-run equivalence groups + deduplicated
-canonical configs.
+sweep configs goes through the config-loader parse step plus the study-layer
+finalisation, and the resulting ``StudyConfig`` records the pre-run
+equivalence groups + deduplicated canonical configs.
 
 Run time: < 1s - no GPU involved, all operations are on Pydantic models
 and the engine-invariants loader.
@@ -16,12 +16,19 @@ from pathlib import Path
 import yaml
 
 from llenergymeasure.config.loader import load_study_config
+from llenergymeasure.config.models import StudyConfig
+from llenergymeasure.study.loading import finalise_study
 
 
 def _write_study(tmp_path: Path, raw: dict) -> Path:
     path = tmp_path / "study.yaml"
     path.write_text(yaml.safe_dump(raw))
     return path
+
+
+def load_study_config_finalised(path: Path, **kwargs) -> StudyConfig:
+    """Parse + finalise a study YAML into a resolved StudyConfig."""
+    return finalise_study(load_study_config(path, **kwargs))
 
 
 def test_greedy_temperature_sweep_collapses(tmp_path: Path) -> None:
@@ -36,7 +43,7 @@ def test_greedy_temperature_sweep_collapses(tmp_path: Path) -> None:
         },
     }
     path = _write_study(tmp_path, study)
-    study_config = load_study_config(path)
+    study_config = load_study_config_finalised(path)
 
     # Dedup mode default is resolved.
     assert study_config.dedup_mode == "resolved"
@@ -63,7 +70,7 @@ def test_no_dedup_preserves_all_configs(tmp_path: Path) -> None:
         "study_execution": {"deduplicate_equivalent": False},
     }
     path = _write_study(tmp_path, study)
-    study_config = load_study_config(path)
+    study_config = load_study_config_finalised(path)
 
     assert study_config.dedup_mode == "off"
     # All 6 declared configs run - library-resolution mechanism still populated the groups.
@@ -84,7 +91,7 @@ def test_cli_override_no_dedup(tmp_path: Path) -> None:
         },
     }
     path = _write_study(tmp_path, study)
-    study_config = load_study_config(
+    study_config = load_study_config_finalised(
         path,
         cli_overrides={"study_execution": {"deduplicate_equivalent": False}},
     )
@@ -106,7 +113,7 @@ def test_n_cycles_multiplies_unique_set(tmp_path: Path) -> None:
         "study_execution": {"n_cycles": 3},
     }
     path = _write_study(tmp_path, study)
-    study_config = load_study_config(path)
+    study_config = load_study_config_finalised(path)
 
     # 4 declared -> 3 unique (greedy-0.5 + greedy-0.7 collapse to greedy-1.0,
     # plus 2 sampling variants). 3 unique x 3 cycles = 9 runs.
@@ -128,7 +135,7 @@ def test_single_config_sweep_no_dedup(tmp_path: Path) -> None:
         },
     }
     path = _write_study(tmp_path, study)
-    study_config = load_study_config(path)
+    study_config = load_study_config_finalised(path)
 
     # Sampling is default-true; three temps should stay distinct.
     assert len(study_config.experiments) == 3

--- a/tests/unit/cli/test_cli_run.py
+++ b/tests/unit/cli/test_cli_run.py
@@ -79,7 +79,7 @@ def _make_mock_config() -> MagicMock:
 def _make_capture_load() -> tuple:
     """Return (capture_fn, captured_overrides) for study routing tests.
 
-    The capture function mimics load_study_config: records cli_overrides
+    The capture function mimics the api load_study facade: records cli_overrides
     and returns a MagicMock with properly configured study attributes.
     """
     captured: list = []
@@ -439,11 +439,11 @@ def test_run_study_routing_sweep_yaml(tmp_path):
     )
     mock_study_result = make_study_result()
 
-    # run_study and load_study_config are lazily imported inside _run_study_impl;
-    # patch at the source modules, not at llenergymeasure.cli.run
+    # run_study and load_study (api facade) are lazily imported inside
+    # _run_study_impl; patch at the source modules, not at llenergymeasure.cli.run
     with (
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
-        patch("llenergymeasure.config.loader.load_study_config") as mock_load,
+        patch("llenergymeasure.api.load_study") as mock_load,
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
     ):
@@ -472,7 +472,7 @@ def test_run_study_routing_experiments_yaml(tmp_path):
 
     with (
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
-        patch("llenergymeasure.config.loader.load_study_config") as mock_load,
+        patch("llenergymeasure.api.load_study") as mock_load,
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
     ):
@@ -520,10 +520,10 @@ def test_run_study_cli_defaults_applied(tmp_path):
     mock_study_result = make_study_result()
     _capture_load, captured_overrides = _make_capture_load()
 
-    # load_study_config, run_study, and build_preflight_panel are all lazily
-    # imported inside _run_study_impl - patch at source modules
+    # load_study (api facade), run_study, and build_preflight_panel are all
+    # lazily imported inside _run_study_impl - patch at source modules
     with (
-        patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
+        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
@@ -591,7 +591,7 @@ def test_fail_fast_sets_max_consecutive_failures(tmp_path):
     _capture_load, captured_overrides = _make_capture_load()
 
     with (
-        patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
+        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
@@ -612,7 +612,7 @@ def test_no_circuit_breaker_sets_max_failures_zero(tmp_path):
     _capture_load, captured_overrides = _make_capture_load()
 
     with (
-        patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
+        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
@@ -632,7 +632,7 @@ def test_timeout_flag_sets_wall_clock_timeout(tmp_path):
     _capture_load, captured_overrides = _make_capture_load()
 
     with (
-        patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
+        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
@@ -652,7 +652,7 @@ def test_timeout_flag_fractional(tmp_path):
     _capture_load, captured_overrides = _make_capture_load()
 
     with (
-        patch("llenergymeasure.config.loader.load_study_config", side_effect=_capture_load),
+        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
         patch("llenergymeasure.run_study", return_value=mock_study_result),
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
@@ -677,7 +677,7 @@ def test_resume_flag_passes_resume_to_api(tmp_path):
     mock_study_config.study_execution.n_cycles = 3
 
     with (
-        patch("llenergymeasure.config.loader.load_study_config", return_value=mock_study_config),
+        patch("llenergymeasure.api.load_study", return_value=mock_study_config),
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),
@@ -710,7 +710,7 @@ def test_resume_dir_flag_passes_path_to_api(tmp_path):
     (explicit_dir / "manifest.json").write_text("{}")
 
     with (
-        patch("llenergymeasure.config.loader.load_study_config", return_value=mock_study_config),
+        patch("llenergymeasure.api.load_study", return_value=mock_study_config),
         patch("llenergymeasure.run_study", return_value=mock_study_result) as mock_run,
         patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
         patch.object(cli_display_mod, "print_study_summary"),

--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from llenergymeasure.config.loader import deep_merge, load_experiment_config, load_study_config
 from llenergymeasure.config.models import ExperimentConfig, StudyConfig
+from llenergymeasure.study.loading import finalise_study
 from llenergymeasure.utils.exceptions import ConfigError
 
 # ---------------------------------------------------------------------------
@@ -26,6 +27,17 @@ def _write_yaml(tmp_path: Path, content: str, name: str = "config.yaml") -> Path
     path = tmp_path / name
     path.write_text(content)
     return path
+
+
+def _load_study(path: Path, cli_overrides: dict | None = None) -> StudyConfig:
+    """Parse + finalise a study YAML into a resolved StudyConfig.
+
+    The config loader now returns a LoadedStudyRaw (pure parse/expand); the
+    study-layer finalise step adds dedup, study_design_hash, cycles, and
+    equivalence groups. These tests assert on the finalised StudyConfig, so
+    compose both steps here.
+    """
+    return finalise_study(load_study_config(path, cli_overrides=cli_overrides))
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +249,7 @@ def test_load_study_config_grid_sweep(tmp_path):
             }
         )
     )
-    sc = load_study_config(study_yaml)
+    sc = _load_study(study_yaml)
     assert isinstance(sc, StudyConfig)
     # 2 dtypes x 2 n values = 4 configs, default 1 cycle
     assert len(sc.experiments) == 4
@@ -272,7 +284,7 @@ def test_load_study_config_explicit_experiments(tmp_path):
             }
         )
     )
-    sc = load_study_config(study_yaml)
+    sc = _load_study(study_yaml)
     assert len(sc.experiments) == 3
 
 
@@ -293,7 +305,7 @@ def test_load_study_config_combined_mode(tmp_path):
             }
         )
     )
-    sc = load_study_config(study_yaml)
+    sc = _load_study(study_yaml)
     # 2 sweep + 1 explicit = 3
     assert len(sc.experiments) == 3
 
@@ -316,7 +328,7 @@ def test_load_study_config_with_execution_block(tmp_path):
             }
         )
     )
-    sc = load_study_config(study_yaml)
+    sc = _load_study(study_yaml)
     assert sc.study_execution.n_cycles == 3
     assert sc.study_execution.experiment_order == "interleave"
     # 2 base configs x 3 cycles = 6 runs
@@ -336,7 +348,7 @@ def test_load_study_config_cli_overrides(tmp_path):
             }
         )
     )
-    sc = load_study_config(study_yaml, cli_overrides={"study_execution": {"n_cycles": 5}})
+    sc = _load_study(study_yaml, cli_overrides={"study_execution": {"n_cycles": 5}})
     assert sc.study_execution.n_cycles == 5
     # 2 configs x 5 cycles = 10
     assert len(sc.experiments) == 10
@@ -364,7 +376,7 @@ def test_load_study_config_with_base(tmp_path):
             }
         )
     )
-    sc = load_study_config(study_yaml)
+    sc = _load_study(study_yaml)
     assert len(sc.experiments) == 2
     # All experiments should inherit n_prompts=75 from base
     for exp in sc.experiments:
@@ -433,6 +445,37 @@ def test_load_study_config_hash_excludes_execution(tmp_path):
     study_yaml_a.write_text(yaml.dump({**sweep_content, "study_execution": {"n_cycles": 1}}))
     study_yaml_b.write_text(yaml.dump({**sweep_content, "study_execution": {"n_cycles": 5}}))
 
-    sc_a = load_study_config(study_yaml_a)
-    sc_b = load_study_config(study_yaml_b)
+    sc_a = _load_study(study_yaml_a)
+    sc_b = _load_study(study_yaml_b)
     assert sc_a.study_design_hash == sc_b.study_design_hash
+
+
+def test_load_study_config_design_hash_is_stable(tmp_path):
+    """study_design_hash for a known study must not drift across refactors.
+
+    The hash is persisted in study manifests and used for resume drift
+    detection, so its VALUE is a stable contract. This pin guards against any
+    accidental change to the resolve -> dedup -> hash pipeline (e.g. the
+    finalisation moving out of the config loader). If this assertion fails, a
+    behaviour change has slipped in - it is not safe to "just update the value".
+    """
+    study_yaml = tmp_path / "study.yaml"
+    study_yaml.write_text(
+        yaml.dump(
+            {
+                "study_name": "dedup_test",
+                "engine": "transformers",
+                "task": {"model": "gpt2", "dataset": {"source": "arc", "n_prompts": 10}},
+                "sweep": {
+                    "transformers.sampling.do_sample": [True, False],
+                    "transformers.sampling.temperature": [0.5, 1.0, 1.5],
+                },
+            }
+        )
+    )
+    sc = _load_study(study_yaml)
+    # Captured from origin/main before the loader/finalise split (PR 13).
+    assert sc.study_design_hash == "5084ea3c6b9c7b78"
+    # 6 declared configs collapse to 4 unique under resolved-config dedup.
+    assert len(sc.experiments) == 4
+    assert len(sc.declared_resolved_config_hashes) == 6

--- a/tests/unit/config/test_example_configs.py
+++ b/tests/unit/config/test_example_configs.py
@@ -22,7 +22,7 @@ import pytest
 import yaml
 from pydantic import BaseModel
 
-from llenergymeasure.config.loader import load_study_config
+from llenergymeasure.api import load_study
 from llenergymeasure.config.models import ExperimentConfig
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -85,8 +85,8 @@ def _swept_paths(raw_study: dict) -> set[str]:
 
 @pytest.mark.parametrize("config_path", STUDY_CONFIGS, ids=lambda p: p.name)
 def test_study_config_parses(config_path: Path) -> None:
-    """The config loads through load_study_config and yields >=1 experiment."""
-    study = load_study_config(config_path)
+    """The config loads through the study loader and yields >=1 experiment."""
+    study = load_study(config_path)
     assert len(study.experiments) >= 1
 
 


### PR DESCRIPTION
## Summary

Inverts the last layering IOU (D5): the foundation `config` layer no longer
imports upward into `study`. Previously `config/loader.py:load_study_config`
called `study.library_resolution.resolve_library_effective` to do dedup +
design-hash + cycle ordering, an upward edge documented as an IOU in BOTH the
`main-layers` and `foundation-independence` import-linter contracts.

The fix splits parse from finalisation:

- `config/loader.py::load_study_config` is now pure parse + validate + expand.
  It returns a new `LoadedStudyRaw` dataclass (sweep-expanded experiments +
  parsed output/execution/runners/images metadata) and does NOT import `study`.
- `study/loading.py::finalise_study(LoadedStudyRaw) -> StudyConfig` (new module)
  owns the study-layer steps: library-resolution dedup, `study_design_hash`,
  `apply_cycles`, and pre-run equivalence-group serialisation.
- `api/_impl.py::load_study(path, cli_overrides) -> StudyConfig` composes the
  two and is re-exported through `api/__init__` (precedent: `study_dir_name`).
  `run_study` and the CLI both use it, so the CLI gets finalisation via the api
  facade without importing `study` (respecting the `cli-boundary` contract).

Both `llenergymeasure.config.loader -> llenergymeasure.study.library_resolution`
`ignore_imports` entries (and their IOU comments) are removed from pyproject.toml.
Import-linter passes with them gone: 4 contracts kept, 0 broken.

Behaviour is unchanged: same `StudyConfig` contents for the same YAML. The
`study_design_hash` is a persisted manifest contract; a pin test asserts a known
study still produces `5084ea3c6b9c7b78`, and the full example study still
produces `597664338c828979` (both captured from origin/main pre-refactor).

## Test plan

- `uv run pytest tests/ -q` -> 2440 passed, 52 skipped, 0 failed
- `uv run ruff check src tests` -> all checks passed
- `uv run mypy src/` -> success, no issues (114 files)
- `uv run lint-imports` -> 4 contracts kept, 0 broken (both IOUs removed)
- `uv run llem run configs/example-study-full.yaml --dry-run` -> renders preflight
  panel + "Config valid", identical to pre-refactor; design hash 597664338c828979
- New `test_load_study_config_design_hash_is_stable` pins the hash value so any
  future drift in the resolve -> dedup -> hash pipeline fails loudly

## Doc audit

Grepped `docs/` and `src/**/README.md` for `load_study_config` and "the loader"
phrasings describing the OLD all-in-one resolver behaviour. The split changes
the public contract: `config.loader.load_study_config` now returns
`LoadedStudyRaw` (parse + expand only); `study.loading.finalise_study` does
dedup + hash + cycles; `api.load_study` is the public composition that returns a
resolved `StudyConfig`.

Stragglers fixed in this PR (commit `docs(config): align StudyConfig loader docs
with parse/finalise split`):

- `docs/reference/library/StudyConfig.md` - the concept section now describes
  the two-step parse/finalise pipeline; the "for inspection" and "common
  pattern" snippets switched from `load_study_config(path=...).experiments`
  (now a `LoadedStudyRaw`, no `.experiments`) to `api.load_study(...)` which
  returns the resolved `StudyConfig`; `study_design_hash` and the metadata-field
  table attributions changed from "set/written by the loader" to "by study
  finalisation"; added `api.load_study` to See also.
- `docs/reference/library/run_study.md` - See also line corrected: `StudyConfig`
  is accepted by `run_study` and returned by `api.load_study`, not "returned by
  the loader".

Checked and left unchanged (accurate, not describing the study-finalisation
behaviour): other "the loader" mentions in `parameter-discovery.md`,
`architecture-overview.md`, `dataset-format.md`, and `schema-discovered-format.md`
refer to the corpus/invariant validation loader; `ExperimentConfig.md` refers to
`load_experiment_config` (single-experiment, unchanged); `config/README.md`
documents the generic `load_config`/`deep_merge` surface, not `load_study_config`.
The touched docs are hand-authored (not generated by any `docs-freshness` script),
so the regenerate check is unaffected.