### PR TITLE
test: extend mypy type checking to the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           python-version: "3.12"
       - run: uv sync --dev
       - name: mypy
-        run: uv run mypy src/
+        run: uv run mypy src/ tests/
 
   test:
     needs: filter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,9 @@ repos:
     rev: v1.19.0
     hooks:
       - id: mypy
-        additional_dependencies: [pydantic>=2.0, types-PyYAML]
+        additional_dependencies: [pydantic>=2.0, types-PyYAML, pytest]
         args: [--config-file=pyproject.toml]
-        files: ^src/
+        files: ^(src|tests)/
 
   # Local hooks: Architecture import contracts + doc regeneration
   # Uses language: system to run with project venv

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ lint-fix: ## Auto-fix lint issues (ruff check --fix + format)
 	uv run ruff check src/ tests/ --fix
 	uv run ruff format src/ tests/
 
-typecheck: ## Run mypy on src/
-	uv run mypy src/
+typecheck: ## Run mypy on src/ and tests/
+	uv run mypy src/ tests/
 
 check: lint typecheck ## lint + typecheck (no tests)
 
@@ -242,7 +242,7 @@ ci-docker: ## Run ci inside a clean Ubuntu container (matches GitHub Actions env
 		uv run ruff check src/ tests/ && \
 		uv run ruff format --check src/ tests/ && \
 		uv run lint-imports && \
-		uv run mypy src/ && \
+		uv run mypy src/ tests/ && \
 		uv run pytest tests/ -m "not gpu and not docker" -x -q --tb=short && \
 		echo "=== CI-docker: all checks passed ==="'
 	@docker rmi $(CI_IMAGE) 2>/dev/null || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,44 @@ disallow_untyped_calls = false
 warn_unused_ignores = false
 exclude = []
 
+# Test suite is type-checked, but with the strict-mode rules that fight
+# established test idioms relaxed. The valuable structural checks
+# (return-value, assignment, name-defined, call-arg, index, operator,
+# var-annotated, misc, ...) still run, so a real type regression in a test
+# is caught. The relaxations below are the categories that are pure noise
+# against deliberate test patterns and would otherwise drown the signal:
+#   - no-untyped-def: thousands of `def test_*(self):` bodies are untyped by
+#     convention; annotating every one adds churn without catching bugs.
+#   - arg-type: tests pass dict / str literals into Pydantic models that coerce
+#     them at runtime (e.g. task={...}, engine="vllm"); mypy can't see the
+#     coercion, but the runtime behaviour is the point of the test.
+#   - union-attr: tests read sub-config attributes off `X | None` fields they
+#     know are populated (e.g. cfg.transformers.dtype after setting it).
+#   - attr-defined: tests introspect private / non-exported members and patch
+#     targets (e.g. module.importlib, _dormant_observations) on purpose.
+#   - type-arg: bare generics (dict, list) in throwaway test locals.
+#   - no-any-return: helper/factory returns flowing through MagicMock / Any.
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disable_error_code = [
+    "arg-type",
+    "union-attr",
+    "attr-defined",
+    "type-arg",
+    "no-any-return",
+]
+
+# scripts/ holds mining-substrate research tooling. It is not part of the
+# typed product surface (src/ never imports it) and was never in the type
+# gate. Some test modules import its helpers directly, so mypy follows those
+# imports and would otherwise gate on pre-existing untyped research code.
+# Ignore errors in scripts.* until/unless it is brought into scope on its own.
+[[tool.mypy.overrides]]
+module = "scripts.*"
+ignore_errors = true
+
 [[tool.uv.index]]
 name = "nvidia"
 url = "https://pypi.nvidia.com/"

--- a/tests/integration/test_docker_runner.py
+++ b/tests/integration/test_docker_runner.py
@@ -195,7 +195,12 @@ class TestDockerRunnerIntegration:
             "llenergymeasure.study.runner.resolve_study_runners",
             return_value={"transformers": docker_spec},
         ):
-            runner = StudyRunner(study, output_dir=tmp_path)
+            # FIXME: stale signature - StudyRunner takes
+            # (study, manifest_writer, study_dir, ...) since the runner refactor;
+            # this skipped Docker-integration test predates it and was never
+            # updated (no `output_dir` kwarg exists). Left as-is pending a GPU run
+            # to verify the corrected construction.
+            runner = StudyRunner(study, output_dir=tmp_path)  # type: ignore[call-arg]  # stale signature, see FIXME
             result = runner.run()
 
         assert len(result.experiments) == 1

--- a/tests/unit/config/engine_invariants/test_invariant_matching.py
+++ b/tests/unit/config/engine_invariants/test_invariant_matching.py
@@ -255,7 +255,7 @@ def test_resolve_field_path_pydantic_field_wins_over_method_name() -> None:
     # method on the model, the field lookup wins.
     pydantic = pytest.importorskip("pydantic")
 
-    class M(pydantic.BaseModel):
+    class M(pydantic.BaseModel):  # type: ignore[name-defined,misc]  # pydantic via importorskip
         items: list[str] = pydantic.Field(default_factory=list)
         copy_count: int = 0
 

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -247,7 +247,7 @@ def test_list_all_param_paths_unknown_engine_raises():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("dt", DTYPE_SUPPORT["transformers"])
+@pytest.mark.parametrize("dt", DTYPE_SUPPORT["transformers"])  # type: ignore[index]  # Engine is str-enum
 def test_all_pytorch_dtype_values_produce_valid_config(dt):
     """Schema-driven: each SSOT DTYPE_SUPPORT['transformers'] value creates a valid config."""
     config = make_config(dtype=dt)
@@ -256,7 +256,7 @@ def test_all_pytorch_dtype_values_produce_valid_config(dt):
 
 def test_ssot_dtype_values_match_param_test_values():
     """DTYPE_SUPPORT['transformers'] values match get_param_test_values('transformers.dtype')."""
-    from_ssot = set(DTYPE_SUPPORT["transformers"])
+    from_ssot = set(DTYPE_SUPPORT["transformers"])  # type: ignore[index]  # Engine is str-enum
     from_introspection = set(get_param_test_values("transformers.dtype"))
     # The test values from introspection should cover all SSOT dtype values
     assert from_ssot == from_introspection

--- a/tests/unit/config/test_config_schema.py
+++ b/tests/unit/config/test_config_schema.py
@@ -39,13 +39,13 @@ def test_model_only_uses_pytorch_default():
 def test_extra_fields_forbidden():
     """Unknown top-level fields are rejected with ValidationError (extra='forbid')."""
     with pytest.raises(ValidationError):
-        ExperimentConfig(task={"model": "gpt2"}, engine="transformers", unknown_field="x")
+        ExperimentConfig(task={"model": "gpt2"}, engine="transformers", unknown_field="x")  # type: ignore[call-arg]  # asserts extra rejected
 
 
 def test_multiple_extra_fields_all_rejected():
     """Multiple unknown fields are all rejected."""
     with pytest.raises(ValidationError):
-        ExperimentConfig(task={"model": "gpt2"}, engine="transformers", foo="a", bar="b")
+        ExperimentConfig(task={"model": "gpt2"}, engine="transformers", foo="a", bar="b")  # type: ignore[call-arg]  # asserts extra rejected
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +235,7 @@ def test_valid_dtype_bfloat16():
     assert config.transformers.dtype == "bfloat16"
 
 
-@pytest.mark.parametrize("dt", DTYPE_SUPPORT["transformers"])
+@pytest.mark.parametrize("dt", DTYPE_SUPPORT["transformers"])  # type: ignore[index]  # Engine is str-enum
 def test_all_pytorch_dtypes_valid(dt):
     """Schema-driven: all SSOT DTYPE_SUPPORT['transformers'] values are valid."""
     config = make_config(dtype=dt)

--- a/tests/unit/config/test_ssot.py
+++ b/tests/unit/config/test_ssot.py
@@ -13,7 +13,7 @@ def test_engine_is_str_enum() -> None:
 
 
 def test_engine_members_are_strings() -> None:
-    assert Engine.TRANSFORMERS == "transformers"
+    assert Engine.TRANSFORMERS == "transformers"  # type: ignore[comparison-overlap]  # verifies str-enum value at runtime
     assert Engine.VLLM == "vllm"
     assert Engine.TENSORRT == "tensorrt"
 

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -227,7 +227,7 @@ class TestSampling:
 
     def test_sampling_return_perf_metrics_is_extra_allow(self):
         """return_perf_metrics still accepted via extra='allow' passthrough."""
-        config = TensorRTSamplingConfig(return_perf_metrics=True)
+        config = TensorRTSamplingConfig(return_perf_metrics=True)  # type: ignore[call-arg]  # extra="allow"
         # No ValidationError - extra="allow"
         assert getattr(config, "return_perf_metrics", None) is True
 
@@ -290,14 +290,14 @@ class TestExperimentConfigIntegration:
 
     def test_tensorrt_extra_allow_forwards_unknown(self):
         """Extra fields on TensorRTConfig and sub-configs are accepted (not rejected)."""
-        config = TensorRTConfig(
+        config = TensorRTConfig(  # type: ignore[call-arg]  # extra="allow"
             tensor_parallel_size=1,
             custom_future_field="value",
         )
         # Should not raise - extra="allow"
         assert config.tensor_parallel_size == 1
 
-        quant = TensorRTQuantConfig(
+        quant = TensorRTQuantConfig(  # type: ignore[call-arg]  # extra="allow"
             quant_algo="INT8",
             custom_quant_field=42,
         )

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -1257,6 +1257,7 @@ class TestErrorJsonOnNonZeroExit:
         exc = exc_info.value
         # Structured payload attached to the exception
         assert hasattr(exc, "error_payload")
+        assert exc.error_payload is not None
         assert exc.error_payload["type"] == "RuntimeError"
         assert exc.error_payload["message"] == "CUDA out of memory inside container"
         assert "traceback" in exc.error_payload

--- a/tests/unit/docker/test_stdout_silence_watchdog.py
+++ b/tests/unit/docker/test_stdout_silence_watchdog.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import sys
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import pytest
 
@@ -75,7 +75,7 @@ def _quick_script() -> list[str]:
 
 
 @pytest.fixture
-def runner_factory() -> Iterator[callable]:
+def runner_factory() -> Iterator[Callable[..., DockerRunner]]:
     """Build a DockerRunner stub with watchdog params; yield a factory."""
     runners: list[DockerRunner] = []
 

--- a/tests/unit/domain/test_extended_metrics.py
+++ b/tests/unit/domain/test_extended_metrics.py
@@ -260,6 +260,8 @@ class TestComputeRequestLatencyMetrics:
 
     def test_ordering_p95_lte_p99(self):
         req = _compute_request_latency_metrics([10.0, 20.0, 30.0, 100.0, 200.0, 500.0])
+        assert req.e2e_latency_p95_ms is not None
+        assert req.e2e_latency_p99_ms is not None
         assert req.e2e_latency_p95_ms <= req.e2e_latency_p99_ms
 
 

--- a/tests/unit/energy/test_energy_backends_v2.py
+++ b/tests/unit/energy/test_energy_backends_v2.py
@@ -332,7 +332,7 @@ def test_nvml_trapezoidal_integration() -> None:
     assert isinstance(result, EnergyMeasurement)
     assert result.duration_sec == pytest.approx(0.2, abs=1e-9)
     assert result.total_j == pytest.approx(20.0, abs=1e-6)
-    assert result.per_gpu_j == {0: pytest.approx(20.0, abs=1e-6)}
+    assert result.per_gpu_j == {0: pytest.approx(20.0, abs=1e-6)}  # type: ignore[comparison-overlap]  # Optional dict vs approx mapping
 
 
 def test_nvml_trapezoidal_skips_none_power() -> None:

--- a/tests/unit/engines/test_check_hardware.py
+++ b/tests/unit/engines/test_check_hardware.py
@@ -187,7 +187,7 @@ class TestShortCircuitRegression:
         # _build_llm_kwargs raise ConfigError.
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(engine_path=tmp_path / "does-not-exist"),
+            tensorrt=TensorRTConfig(engine_path=tmp_path / "does-not-exist"),  # type: ignore[call-arg]  # extra="allow"
         )
 
         engine = TensorRTEngine()

--- a/tests/unit/engines/test_effective_params_capture.py
+++ b/tests/unit/engines/test_effective_params_capture.py
@@ -87,7 +87,7 @@ class _LeakyDataclass:
 
 class TestPrivateFieldStripping:
     def test_pydantic_private_fields_stripped_by_default(self):
-        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc", _from_model_config=True)
+        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc", _from_model_config=True)  # type: ignore[call-arg]  # extra="allow"
         out = extract_observed_params(obj)
         assert out == {"temperature": 0.7}
 
@@ -97,7 +97,7 @@ class TestPrivateFieldStripping:
         assert out == {"temperature": 1.0}
 
     def test_allowlist_preserves_private_field(self):
-        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc")
+        obj = _LeakyPydantic(temperature=0.7, _commit_hash="abc")  # type: ignore[call-arg]  # extra="allow"
         out = extract_observed_params(obj, private_field_allowlist={"_commit_hash"})
         assert out == {"temperature": 0.7, "_commit_hash": "abc"}
 

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -627,7 +627,7 @@ class TestValidateEngineDirectory:
 
     def test_missing_tp_size_key_skips_check(self, tmp_path):
         """config.json without mapping.tp_size skips tp_size check (non-blocking)."""
-        config = {"pretrained_config": {}, "build_config": {}}
+        config: dict[str, object] = {"pretrained_config": {}, "build_config": {}}
         (tmp_path / "config.json").write_text(json.dumps(config))
         (tmp_path / "rank0.engine").write_bytes(b"fake")
         errors = _validate_engine_directory(tmp_path, tp_size=1)
@@ -646,7 +646,7 @@ class TestBuildLlmKwargsEnginePath:
         (tmp_path / "config.json").write_text(json.dumps(config_data))
         (tmp_path / "rank0.engine").write_bytes(b"fake")
 
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(engine_path=str(tmp_path)))
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(engine_path=str(tmp_path)))  # type: ignore[call-arg]  # extra="allow"
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
@@ -661,7 +661,7 @@ class TestBuildLlmKwargsEnginePath:
 
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(engine_path=str(tmp_path), backend="trt"),
+            tensorrt=TensorRTConfig(engine_path=str(tmp_path), backend="trt"),  # type: ignore[call-arg]  # extra="allow"
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -678,7 +678,7 @@ class TestBuildLlmKwargsEnginePath:
 
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(
+            tensorrt=TensorRTConfig(  # type: ignore[call-arg]  # extra="allow"
                 engine_path=str(tmp_path), tensor_parallel_size=2, max_batch_size=16
             ),
         )
@@ -698,7 +698,7 @@ class TestBuildLlmKwargsEnginePath:
         (tmp_path / "config.json").write_text(json.dumps(config_data))
         (tmp_path / "rank0.engine").write_bytes(b"fake")
 
-        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(engine_path=str(tmp_path)))
+        config = make_config(**_TRT_DEFAULTS, tensorrt=TensorRTConfig(engine_path=str(tmp_path)))  # type: ignore[call-arg]  # extra="allow"
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
@@ -712,7 +712,7 @@ class TestBuildLlmKwargsEnginePath:
 
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt=TensorRTConfig(engine_path=str(tmp_path / "nonexistent")),
+            tensorrt=TensorRTConfig(engine_path=str(tmp_path / "nonexistent")),  # type: ignore[call-arg]  # extra="allow"
         )
         engine = TensorRTEngine()
         with pytest.raises(ConfigError, match="engine_path validation failed"):

--- a/tests/unit/engines/test_transformers_token_counting.py
+++ b/tests/unit/engines/test_transformers_token_counting.py
@@ -5,7 +5,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 
-def _count_tokens(inputs: dict, outputs: torch.Tensor) -> tuple[int, int]:
+def _count_tokens(inputs: dict, outputs: "torch.Tensor") -> tuple[int, int]:  # type: ignore[name-defined]  # torch via importorskip
     """Replicate the token counting logic from TransformersEngine._run_batch()."""
     input_token_count = int(inputs["attention_mask"].sum().item())
     input_lengths = inputs["attention_mask"].sum(dim=1)  # shape: (batch,)
@@ -15,7 +15,7 @@ def _count_tokens(inputs: dict, outputs: torch.Tensor) -> tuple[int, int]:
     return input_token_count, output_token_count
 
 
-def _old_count_tokens(inputs: dict, outputs: torch.Tensor) -> tuple[int, int]:
+def _old_count_tokens(inputs: dict, outputs: "torch.Tensor") -> tuple[int, int]:  # type: ignore[name-defined]  # torch via importorskip
     """Previous (buggy) logic for comparison."""
     input_token_count = inputs["input_ids"].shape[1] * len(inputs["input_ids"])
     tokens_per_seq = outputs.shape[1] - inputs["input_ids"].shape[1]

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -712,12 +712,12 @@ class TestBeamSearchParams:
         ):
             VLLMConfig(
                 beam_search=VLLMBeamSearchConfig(beam_width=4),
-                sampling=VLLMSamplingConfig(max_tokens=100),
+                sampling=VLLMSamplingConfig(max_tokens=100),  # type: ignore[call-arg]  # extra="allow"
             )
 
     def test_beam_search_config_accepts_all_fields(self):
         """VLLMBeamSearchConfig accepts beam_width, length_penalty, early_stopping, max_tokens."""
-        bs = VLLMBeamSearchConfig(
+        bs = VLLMBeamSearchConfig(  # type: ignore[call-arg]  # max_tokens accepted via extra="allow"
             beam_width=8, length_penalty=1.2, early_stopping=True, max_tokens=256
         )
         assert bs.beam_width == 8

--- a/tests/unit/harness/test_baseline.py
+++ b/tests/unit/harness/test_baseline.py
@@ -483,6 +483,7 @@ def test_create_energy_breakdown_with_cached_baseline():
     # adjusted = 200 - (5W * 20s) = 200 - 100 = 100J
     assert breakdown.adjusted_j == pytest.approx(100.0)
     assert breakdown.baseline_method == "cached"
+    assert breakdown.baseline_cache_age_sec is not None
     assert breakdown.baseline_cache_age_sec > 1.0
 
 

--- a/tests/unit/scripts/engine_producers/test_msgspec_lift.py
+++ b/tests/unit/scripts/engine_producers/test_msgspec_lift.py
@@ -22,14 +22,14 @@ if str(_PROJECT_ROOT) not in sys.path:
 from scripts.engine_producers._msgspec_lift import lift  # noqa: E402
 
 
-class _BoundedStruct(msgspec.Struct):
+class _BoundedStruct(msgspec.Struct):  # type: ignore[name-defined,misc]  # msgspec via importorskip
     """Fixture struct with one numeric Meta and one Literal field."""
 
     temperature: Annotated[float, msgspec.Meta(ge=0.0, le=2.0)] = 1.0
     mode: Literal["greedy", "beam"] = "greedy"
 
 
-class _PlainStruct(msgspec.Struct):
+class _PlainStruct(msgspec.Struct):  # type: ignore[name-defined,misc]  # msgspec via importorskip
     """Fixture mirroring vLLM ``SamplingParams``: no ``Meta`` annotations."""
 
     seed: int = 0

--- a/tests/unit/study/test_baseline_container.py
+++ b/tests/unit/study/test_baseline_container.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import subprocess
 import time
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -39,8 +40,8 @@ def _write_result(exchange_dir: Path, power_w: float = 42.59) -> None:
 def _make_fake_popen(
     lines: list[str],
     returncode: int = 0,
-    on_open: callable | None = None,
-) -> MagicMock:
+    on_open: Callable[[], object] | None = None,
+) -> Callable[..., MagicMock]:
     """Build a MagicMock that quacks like a Popen object for our iterator.
 
     - ``process.stdout`` iterates ``lines`` (must include trailing newlines).

--- a/tests/unit/study/test_circuit_breaker.py
+++ b/tests/unit/study/test_circuit_breaker.py
@@ -260,7 +260,7 @@ class TestFullLifecycle:
         assert cb.state == "open"
         # open -> probe -> half_open
         cb.start_probe()
-        assert cb.state == "half_open"
+        assert cb.state == "half_open"  # type: ignore[comparison-overlap]  # mypy can't model state mutation
         # half_open -> success -> closed
         cb.record_success()
         assert cb.state == "closed"
@@ -285,4 +285,4 @@ class TestFullLifecycle:
             # Recover
             cb.start_probe()
             cb.record_success()
-            assert cb.state == "closed", f"Expected closed at cycle {cycle}"
+            assert cb.state == "closed", f"Expected closed at cycle {cycle}"  # type: ignore[comparison-overlap]  # mypy can't model state mutation

--- a/tests/unit/study/test_container_lifecycle.py
+++ b/tests/unit/study/test_container_lifecycle.py
@@ -173,7 +173,7 @@ class TestInstallSigtermBridge:
             handler = signal.getsignal(signal.SIGTERM)
 
             with pytest.raises(SystemExit) as exc_info:
-                handler(signal.SIGTERM, None)  # type: ignore[call-arg]
+                handler(signal.SIGTERM, None)  # type: ignore[operator,misc]  # handler is int|Callable|None
 
             assert exc_info.value.code == 0
         finally:

--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -53,7 +53,7 @@ class TestExecutionConfig:
 
     def test_extra_fields_forbidden(self):
         with pytest.raises(ValidationError):
-            ExecutionConfig(unknown_field=42)
+            ExecutionConfig(unknown_field=42)  # type: ignore[call-arg]  # asserts extra rejected
 
     def test_valid_cycle_orders(self):
         for order in ("sequential", "interleave", "shuffle", "reverse", "latin_square"):
@@ -128,7 +128,7 @@ class TestStudyConfig:
     def test_extra_fields_forbidden(self):
         exp = ExperimentConfig(task={"model": "gpt2"})
         with pytest.raises(ValidationError):
-            StudyConfig(experiments=[exp], unknown_field="x")
+            StudyConfig(experiments=[exp], unknown_field="x")  # type: ignore[call-arg]  # asserts extra rejected
 
 
 # =============================================================================
@@ -197,6 +197,8 @@ class TestExpandGridSweep:
             assert c.vllm is None
         for c in vllm_configs:
             assert c.transformers is None
+            assert c.vllm is not None
+            assert c.vllm.engine is not None
             assert c.vllm.engine.max_num_seqs in (64, 256)
 
 

--- a/tests/unit/study/test_study_manifest.py
+++ b/tests/unit/study/test_study_manifest.py
@@ -192,7 +192,7 @@ def test_study_manifest_roundtrip_json() -> None:
 def test_study_manifest_distinct_from_study_result() -> None:
     from llenergymeasure import StudyResult
 
-    assert StudyManifest is not StudyResult
+    assert StudyManifest is not StudyResult  # type: ignore[comparison-overlap]  # runtime regression guard on distinct types
     assert not issubclass(StudyManifest, StudyResult)
     assert not issubclass(StudyResult, StudyManifest)
 

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -808,7 +808,7 @@ def test_progress_events_forwarded():
     from llenergymeasure.study.runner import _consume_progress_events
 
     mock_progress = MagicMock()
-    q = Queue()
+    q: Queue[dict[str, object]] = Queue()
     q.put({"event": "step_start", "step": "baseline", "description": "Measuring", "detail": "30s"})
     q.put({"event": "step_done", "step": "baseline", "elapsed_sec": 30.1})
     q.put({"event": "substep", "step": "model", "text": "loading weights", "elapsed_sec": 2.5})
@@ -909,7 +909,7 @@ def test_docker_runner_spec_dispatches_to_docker(
 
     fake_ctx = MagicMock()
     fake_ctx.Process.side_effect = lambda **kwargs: (
-        subprocess_process_calls.append(kwargs) or MagicMock()
+        subprocess_process_calls.append(kwargs) or MagicMock()  # type: ignore[func-returns-value]  # append-then-return idiom
     )
 
     with patch("multiprocessing.get_context", return_value=fake_ctx):

--- a/tests/unit/study/test_sweep_groups.py
+++ b/tests/unit/study/test_sweep_groups.py
@@ -228,12 +228,12 @@ class TestApplyGroupOverlay:
 
 class TestValidateSweepGroups:
     def test_no_collision_passes(self):
-        groups = {"transformers.compilation": [{}]}
+        groups: dict[str, list[dict[str, object]]] = {"transformers.compilation": [{}]}
         axis_keys = {"transformers.batch_size"}
         _validate_sweep_groups(groups, axis_keys)  # should not raise
 
     def test_collision_raises(self):
-        groups = {"transformers.batch_size": [{}]}
+        groups: dict[str, list[dict[str, object]]] = {"transformers.batch_size": [{}]}
         axis_keys = {"transformers.batch_size"}
         with pytest.raises(ConfigError, match="collide"):
             _validate_sweep_groups(groups, axis_keys)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -150,7 +150,7 @@ def test_run_experiment_no_config_no_model_raises():
     from llenergymeasure.utils.exceptions import ConfigError
 
     with pytest.raises(ConfigError):
-        run_experiment()
+        run_experiment()  # type: ignore[call-overload]  # asserts no-arg call raises ConfigError
 
 
 # =============================================================================
@@ -393,7 +393,7 @@ def test_run_skips_preflight_when_preresolved_supplied(monkeypatch, tmp_path):
     config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
     study = StudyConfig(experiments=[config])
 
-    preresolved = (
+    preresolved: tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]] = (
         {"transformers": RunnerSpec(mode="local", image=None, source="test")},
         {},
     )
@@ -412,7 +412,7 @@ def test_run_preresolved_without_skip_preflight_raises():
     config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
     study = StudyConfig(experiments=[config])
 
-    preresolved = (
+    preresolved: tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]] = (
         {"transformers": RunnerSpec(mode="local", image=None, source="test")},
         {},
     )

--- a/tests/unit/test_peak_memory.py
+++ b/tests/unit/test_peak_memory.py
@@ -111,7 +111,7 @@ def test_peak_memory_reset_precedes_measurement():
         patch("torch.cuda.reset_peak_memory_stats", side_effect=lambda: call_log.append("reset")),
         patch(
             "torch.cuda.max_memory_allocated",
-            side_effect=lambda: (call_log.append("max_alloc"), 512 * 1024 * 1024)[1],
+            side_effect=lambda: (call_log.append("max_alloc"), 512 * 1024 * 1024)[1],  # type: ignore[func-returns-value]  # append-in-tuple side-effect idiom
         ),
         patch.object(
             TransformersEngine,

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -691,7 +691,7 @@ def test_trt_checkpoint_compat_skips_when_engine_path_set(
     )
     config = make_config(
         engine="tensorrt",
-        tensorrt=TensorRTConfig(tensor_parallel_size=1, engine_path="/some/built/engine"),
+        tensorrt=TensorRTConfig(tensor_parallel_size=1, engine_path="/some/built/engine"),  # type: ignore[call-arg]  # extra="allow"
     )
     assert _check_tensorrt_checkpoint_compat(config) is None
 


### PR DESCRIPTION
## Summary

mypy (strict-with-relaxations) previously checked only `src/`; the 119 test files were unchecked. This PR brings `tests/` into the type gate in all four scope locations (pyproject, pre-commit hook, CI type-check job, Makefile).

**Baseline:** `uv run mypy src/ tests/` reported **2405 errors**, all in `tests/` (src/ was already clean). Category breakdown:

| code | count | nature |
|------|------:|--------|
| no-untyped-def | 1614 | untyped `def test_*` bodies (convention) |
| arg-type | 540 | Pydantic-coercion idiom (`task={...}`, `engine="vllm"`) |
| type-arg | 63 | bare generics in throwaway locals |
| union-attr | 61 | reading sub-config attrs off `X \| None` known-populated |
| attr-defined | 41 | private/non-exported introspection + patch targets |
| call-arg | 24 | extra-kwarg tests (`extra="allow"` configs + negative tests) |
| (smaller) | ~60 | operator/index/comparison-overlap/var-annotated/... |

**Approach: Plan B (scoped overrides).** 2405 errors massively exceeds the timebox; grinding them to zero would mean annotating 1614 test functions and adding 540+ ignores that fight intentional test idioms rather than catch bugs. Instead a `[[tool.mypy.overrides]]` block for `tests.*` relaxes only the noise categories that fight established test patterns (`no-untyped-def` via `disallow_untyped_defs=false`, plus `arg-type`, `union-attr`, `attr-defined`, `type-arg`, `no-any-return`). The structurally-valuable checks stay live repo-wide: `return-value`, `assignment`, `name-defined`, `call-arg`, `index`, `operator`, `comparison-overlap`, `var-annotated`, `misc`, `func-returns-value`, `call-overload`.

That left ~74 errors in the kept categories. Those were resolved properly:
- **Genuine improvements** (real annotations / narrowing asserts): `var-annotated` annotations on 6 locals; `assert ... is not None` narrowing in `test_extended_metrics`, `test_baseline`, `test_docker_runner`, `test_study_grid` (all pass at runtime - the values were genuinely non-None); fixed `callable` -> `Callable` annotation bugs and a wrong `-> MagicMock` return type in `test_baseline_container` / `test_stdout_silence_watchdog`.
- **Specific per-line ignores** (never bare) for deliberate idioms: `# type: ignore[call-arg]` on `extra="allow"` constructors and Pydantic-rejection negative tests; `[comparison-overlap]` on runtime str-enum / distinct-type assertions; `[index]` on str-enum-key lookups; `[func-returns-value]` on append-side-effect idioms; `[name-defined,misc]` on `importorskip`-loaded torch/msgspec/pydantic subclassing; `[call-overload]` on the no-arg negative test. Each ignore carries an inline reason.
- A `scripts.*` override (`ignore_errors = true`): `scripts/` is mining-substrate research tooling, never in the type gate, not imported by `src/`. 18 test modules import its helpers, so mypy followed those imports and surfaced 15 pre-existing untyped-script errors. Out of scope for this PR; ignored at module level.

**Real bug found (reported loudly):** `tests/integration/test_docker_runner.py:198` constructs `StudyRunner(study, output_dir=tmp_path)`, but `StudyRunner.__init__` takes `(study, manifest_writer, study_dir, ...)` and has no `output_dir` kwarg. The test predates the StudyRunner refactor and was never updated; it is gated behind `@pytest.mark.skipif` (Docker + GPU image required) so the stale signature never surfaced as a failure. Left in place with a `FIXME` comment and `# type: ignore[call-arg]` rather than guessing a correct construction for a test that cannot be run/verified in this environment without a GPU.

## Test plan

All green (re-run after rebase onto #687, which added `study/loading.py` + `api.load_study` to the type scope - both clean under this config):
- `uv run mypy src/ tests/` -> Success, 0 issues (265 source files)
- `uv run pytest tests/ -q` -> 2440 passed, 52 skipped (unchanged from main)
- `uv run ruff check src tests` -> clean
- `uv run pre-commit run mypy --all-files` -> Passed (with `pytest` added to hook `additional_dependencies`)
- `uv run lint-imports` -> 4 contracts kept, 0 broken

## Doc audit

No doc update needed. The type-check command (`mypy src/`) appears only in tooling config (Makefile, CI type-check job, pre-commit hook), all three updated to `mypy src/ tests/` in this PR. Grepped `docs/contributing` and `docs/development` for `mypy src`: no command invocation in docs (`docs/development/` does not exist; `docs/contributing/development.md` names mypy only as an installed dev tool, not a scoped command). No user-visible string or contract changed - test annotations only.
