### PR TITLE
feat(latency): opt-in streaming latency profiling

### DIFF
--- a/docs/reference/engines/configuration.md
+++ b/docs/reference/engines/configuration.md
@@ -107,6 +107,7 @@ across engines.
 | `baseline.validation_interval` | int >= 1 | `5` | Re-validate every N experiments (validated only) | `models.py:165-171` |
 | `baseline.drift_threshold` | float [0.01, 0.50] | `0.10` | Drift fraction that triggers re-measurement (validated only) | `models.py:172-180` |
 | `energy_sampler` | `auto` \| `nvml` \| `zeus` \| `codecarbon` \| null | `auto` | Energy sampler; null disables energy measurement | `models.py:320-327` |
+| `latency_profiling` | bool | `false` | Opt-in per-token latency profiling. Captures TTFT/ITL (transformers via a streamer forced to `batch_size=1`; vLLM via decode-average ITL). Overhead may perturb energy and latency, so profiled runs are tagged in `measurement_warnings` and energy is emitted as-is. Unsupported on tensorrt. | `models.py:296-307` |
 
 ### Top-level optional fields
 

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -109,7 +109,7 @@ live at the top level of `result.json`.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `extended_metrics.tpot_ms` | float &#124; null | Time per output token (ITL mean). Always `null` today - requires streaming inter-token capture, not yet wired for any engine. |
+| `extended_metrics.tpot_ms` | float &#124; null | Time per output token (ITL mean). Populated only when `measurement.latency_profiling=true` (transformers via streamer; vLLM via decode-average ITL); `null` otherwise. |
 | `extended_metrics.token_efficiency_index` | float &#124; null | Composite `throughput x tokens_per_joule x precision_factor`. |
 | `extended_metrics.memory.model_memory_utilisation` | float &#124; null | Model weights / total VRAM (0-1). |
 | `extended_metrics.memory.tokens_per_gb_vram` | float &#124; null | Output tokens per GB of peak VRAM. |
@@ -119,7 +119,8 @@ live at the top level of `result.json`.
 | `extended_metrics.batch.num_batches` / `effective_batch_size` / `batch_utilisation` / `padding_overhead` | int/float &#124; null | Static-batching efficiency. `null` for vLLM (continuous batching). |
 | `extended_metrics.kv_cache.*` | float/int &#124; null | Prefix-cache hit rate and block occupancy (vLLM only). |
 | `extended_metrics.request_latency.e2e_latency_{mean,median,p95,p99}_ms` | float &#124; null | Per-request end-to-end latency distribution. |
-| `latency_stats` | object &#124; null | TTFT/ITL statistics from streaming capture (vLLM only). |
+| `latency_stats` | object &#124; null | TTFT/ITL statistics. vLLM populates TTFT-only stats on every run (engine-recorded first-token timestamps); ITL stats are added only when `measurement.latency_profiling=true`. transformers populates `latency_stats` (TTFT + ITL) only under profiling. Always `null` for tensorrt. |
+| `latency_stats.measurement_mode` | str | Provenance of the latency capture: `true_streaming` (real per-token / first-token timestamps), `proportional` (decode-average ITL estimate, vLLM under profiling), or `per_request_batch`. The mode reflects the weakest signal present. |
 | `steady_state_window` | [float, float] &#124; null | `(0.0, inference_time_sec)` - the measured window relative to inference start. |
 
 #### Per-engine support matrix
@@ -130,22 +131,39 @@ means it stays `null` for that engine.
 | Metric group | vLLM | transformers | tensorrt |
 |--------------|:----:|:------------:|:--------:|
 | `request_latency.*` (per-request E2E) | yes (from RequestOutput metrics) | yes (per-batch approximation) | dash (metrics usually absent in 0.21.0) |
-| `latency_stats` (TTFT/ITL) | yes | dash (non-streaming) | dash |
+| `latency_stats` TTFT | yes (always-on) | profiling only | dash |
+| `latency_stats` ITL / `tpot_ms` | profiling only (`proportional`) | profiling only (`true_streaming`) | dash (unsupported) |
 | `kv_cache.*` | yes (best-effort) | dash | dash |
 | `gpu_utilisation.*` (SM + mem-bw) | yes | yes | yes |
 | `memory.*` ratios | yes | yes | yes |
 | `batch.*` (num_batches/padding/utilisation) | dash (continuous batching) | yes | `num_batches=1` only; padding/utilisation dash |
-| `tpot_ms` | dash | dash | dash |
 
-**transformers latency is approximated.** A non-streaming `generate()` only
-exposes per-batch wall time, so each prompt in a batch is attributed
-`batch_time / batch_size` (the `PER_REQUEST_BATCH` mode). This is an estimate,
-not a true per-request timestamp - treat transformers `request_latency` as
-batch-level granularity. vLLM `request_latency`/`latency_stats` come from real
-per-request arrival/first-token/finish timestamps.
+**Latency profiling is opt-in.** Set `measurement.latency_profiling: true` to
+capture inter-token latency (and hence `tpot_ms`). Per-engine semantics:
 
-`tpot_ms` is `null` for every engine pending streaming inter-token-latency
-capture; it is intentionally not derived from totals.
+- **transformers**: a custom generation streamer records true per-token arrival
+  times. Profiling forces `batch_size=1` (one streamed token maps to one
+  request) and is incompatible with beam search (`num_beams > 1` falls back to
+  the non-profiled path). Mode = `true_streaming`. With profiling off,
+  `latency_stats` is `null`.
+- **vLLM**: TTFT comes from engine-recorded first-token timestamps and is
+  populated on every run (mode `true_streaming` when only TTFT is present).
+  Under profiling, a decode-average ITL is derived per request
+  (`(finished - first_token) / (n_out - 1)`); because that averages over the
+  decode phase rather than timing each token, the mode becomes `proportional`.
+- **tensorrt**: latency profiling is unsupported; the fields stay `null` and a
+  warning is recorded in `measurement_warnings`.
+
+**Energy caveat.** Per-token timing capture adds overhead that can perturb both
+energy and latency. Energy figures from a profiled run are emitted as-is and are
+**not** directly comparable to non-profiled runs; every profiled run records a
+disclaimer in `measurement_warnings` (the flag is also part of the config hash,
+so profiled and non-profiled runs are distinct experiments).
+
+**transformers non-profiled latency is approximated.** Without profiling, a
+non-streaming `generate()` only exposes per-batch wall time, so each prompt in a
+batch is attributed `batch_time / batch_size` (the `PER_REQUEST_BATCH` mode in
+`request_latency`). This is an estimate, not a true per-request timestamp.
 
 ### Sidecar reference
 

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -293,6 +293,17 @@ class MeasurementConfig(BaseModel):
         ),
         json_schema_extra={"display_label": "Sampler"},
     )
+    latency_profiling: bool = Field(
+        default=False,
+        description=(
+            "Opt-in per-token latency profiling. Default off. When enabled, the "
+            "engine captures per-token timing (transformers via a streamer forced "
+            "to batch_size=1; vLLM via decode-average inter-token latency); this "
+            "overhead may perturb energy and latency, so profiled runs are tagged "
+            "in measurement_warnings and energy figures are emitted as-is."
+        ),
+        json_schema_extra={"display_label": "Latency Profiling"},
+    )
 
 
 # =============================================================================

--- a/src/llenergymeasure/domain/metrics.py
+++ b/src/llenergymeasure/domain/metrics.py
@@ -602,11 +602,15 @@ class LatencyStatistics:
     itl_full_mean_ms: float | None = None
     itl_full_p99_ms: float | None = None
 
+    # Provenance: how these latency measurements were obtained.
+    measurement_mode: LatencyMeasurementMode = LatencyMeasurementMode.TRUE_STREAMING
+
 
 def compute_latency_statistics(
     ttft_ms: list[float],
     itl_trimmed_ms: list[float] | None = None,
     itl_full_ms: list[float] | None = None,
+    measurement_mode: LatencyMeasurementMode = LatencyMeasurementMode.TRUE_STREAMING,
 ) -> LatencyStatistics | None:
     """Compute TTFT/ITL statistics from flat sample lists.
 
@@ -618,6 +622,8 @@ def compute_latency_statistics(
         ttft_ms: Per-request time-to-first-token samples in ms.
         itl_trimmed_ms: Trimmed inter-token latency samples (first/last excluded).
         itl_full_ms: All inter-token latency samples.
+        measurement_mode: How these measurements were obtained (provenance).
+            Defaults to TRUE_STREAMING.
 
     Returns:
         LatencyStatistics, or None when ttft_ms is empty.
@@ -668,6 +674,7 @@ def compute_latency_statistics(
         itl_samples=itl_samples,
         itl_full_mean_ms=itl_full_mean_ms,
         itl_full_p99_ms=itl_full_p99_ms,
+        measurement_mode=measurement_mode,
     )
 
 

--- a/src/llenergymeasure/engines/_observed.py
+++ b/src/llenergymeasure/engines/_observed.py
@@ -161,3 +161,43 @@ def extract_request_metrics(outputs: Any) -> tuple[list[float], list[float]]:
         if arrival is not None and first_token is not None:
             ttft_ms.append((first_token - arrival) * 1000.0)
     return latencies_ms, ttft_ms
+
+
+def extract_decode_itl(outputs: Any) -> list[float]:
+    """Extract a decode-average inter-token latency (ms) per request from RequestOutputs.
+
+    The engine does not expose a true per-token timestamp stream, so this derives
+    one average ITL per request from the decode phase: the wall time between the
+    first generated token and request completion, divided by the number of decode
+    intervals (``n_out - 1``). This is a PROPORTIONAL_ESTIMATE, not a true
+    per-token measurement - it assumes uniform spacing across decode steps.
+
+    Best-effort: a request is skipped (no sample produced) unless
+    ``first_token_time`` and ``finished_time`` are both present and the request
+    produced more than one output token (``n_out > 1``). The ``SimpleNamespace``
+    shape of ``o.metrics`` / ``o.outputs[*].token_ids`` makes this testable
+    without a live engine.
+
+    Args:
+        outputs: Iterable of ``RequestOutput`` objects.
+
+    Returns:
+        List of per-request decode-average ITL samples in ms (possibly empty).
+    """
+    itl_ms: list[float] = []
+    for o in outputs:
+        metrics = getattr(o, "metrics", None)
+        if metrics is None:
+            continue
+        first_token = getattr(metrics, "first_token_time", None)
+        finished = getattr(metrics, "finished_time", None)
+        if first_token is None or finished is None:
+            continue
+        request_outputs = getattr(o, "outputs", None)
+        if not request_outputs:
+            continue
+        n_out = sum(len(getattr(out, "token_ids", ()) or ()) for out in request_outputs)
+        if n_out <= 1:
+            continue
+        itl_ms.append((finished - first_token) * 1000.0 / (n_out - 1))
+    return itl_ms

--- a/src/llenergymeasure/engines/protocol.py
+++ b/src/llenergymeasure/engines/protocol.py
@@ -39,6 +39,12 @@ class InferenceOutput:
     """Per-request time-to-first-token in ms. Empty for non-streaming engines."""
     itl_ms: list[float] = field(default_factory=list)
     """Inter-token latency samples in ms. Empty for non-streaming engines."""
+    latency_measurement_mode: str | None = None
+    """Engine-declared capture mode for ttft_ms/itl_ms (a
+    ``LatencyMeasurementMode`` value string, e.g. ``"true_streaming"`` or
+    ``"proportional"``). Plain string to keep the protocol dependency-free; the
+    harness maps it to the enum. None when the engine performed no streaming/ITL
+    capture for this run."""
     num_batches: int | None = None
     """Number of static batches processed. None for continuous batching (vLLM)."""
     padding_tokens: int | None = None

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -331,6 +331,12 @@ class TensorRTEngine:
         if self._build_metadata is not None:
             extras["build_metadata"] = self._build_metadata
 
+        # TRT-LLM does not expose a per-token timing stream here, so latency
+        # profiling is unsupported: signal it so the harness can warn. Latency
+        # fields stay empty/None.
+        if config.measurement.latency_profiling:
+            extras["latency_profiling_unsupported"] = True
+
         # Defensive per-request metric capture - RequestOutput.metrics is usually
         # absent in TRT-LLM 0.21.0, so these lists typically come back empty.
         from llenergymeasure.engines._observed import extract_request_metrics

--- a/src/llenergymeasure/engines/transformers/plugin.py
+++ b/src/llenergymeasure/engines/transformers/plugin.py
@@ -15,9 +15,38 @@ from collections.abc import Callable
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.domain.metrics import LatencyMeasurementMode
 from llenergymeasure.engines.protocol import InferenceOutput
 
 logger = logging.getLogger(__name__)
+
+
+class _TimingStreamer:
+    """A minimal ``transformers.BaseStreamer`` that records token-arrival times.
+
+    ``model.generate(streamer=...)`` calls ``put()`` once per decode step (and
+    once for the prompt tensor, which we drop). Each call records
+    ``time.perf_counter() * 1000.0`` (ms). ``end()`` is a no-op. Used only under
+    latency profiling, which forces ``batch_size=1`` so each ``put()`` maps to a
+    single request's token.
+    """
+
+    def __init__(self) -> None:
+        self.token_times_ms: list[float] = []
+        self._prompt_seen = False
+
+    def put(self, value: Any) -> None:
+        import time
+
+        # The first put() carries the prompt input_ids (a 2-D tensor); drop it so
+        # only generated-token arrivals are timed.
+        if not self._prompt_seen:
+            self._prompt_seen = True
+            return
+        self.token_times_ms.append(time.perf_counter() * 1000.0)
+
+    def end(self) -> None:
+        """No-op: nothing to flush."""
 
 
 class TransformersEngine:
@@ -165,6 +194,35 @@ class TransformersEngine:
         else:
             logger.debug("Transformers batch_size not set, defaulting to 1")
 
+        # Latency profiling: per-token timing capture via a custom streamer. The
+        # streamer requires batch_size=1 (one put() per decode step maps to a
+        # single request), and beam search is incompatible with streaming, so we
+        # fall back to the non-profiled path when num_beams > 1.
+        profiling = config.measurement.latency_profiling
+        profiling_forced_batch_size = False
+        num_beams = (
+            config.transformers.num_beams
+            if config.transformers is not None and config.transformers.num_beams is not None
+            else 1
+        )
+        if profiling and num_beams > 1:
+            logger.warning(
+                "latency_profiling requested but num_beams=%d > 1; beam search is "
+                "incompatible with a generation streamer. Falling back to the "
+                "non-profiled inference path.",
+                num_beams,
+            )
+            profiling = False
+        if profiling and batch_size != 1:
+            logger.warning(
+                "latency_profiling requested with batch_size=%d; forcing "
+                "batch_size=1 so per-token timestamps map to a single request. "
+                "This perturbs throughput relative to non-profiled runs.",
+                batch_size,
+            )
+            batch_size = 1
+            profiling_forced_batch_size = True
+
         # Reset peak stats BEFORE the measurement loop so max_memory_allocated()
         # captures inference-window-only peak (KV cache + activations + batch buffers),
         # NOT model weights already allocated by load_model().
@@ -189,20 +247,38 @@ class TransformersEngine:
         # batch is attributed batch_time / len(batch). This is an approximation, NOT a
         # true per-request timestamp.
         per_request_latencies_ms: list[float] = []
+        # Under profiling, per-request cumulative token-arrival timestamps (ms),
+        # starting with t0 (pre-generate) so the first interval is TTFT.
+        token_timestamps_per_request: list[list[float]] = []
+        ttft_ms_per_request: list[float] = []
 
         logger.info(
-            "Starting measurement: %d prompts, batch_size=%d, max_new_tokens=%s",
+            "Starting measurement: %d prompts, batch_size=%d, max_new_tokens=%s%s",
             len(prompts),
             batch_size,
             config.task.max_output_tokens or "unlimited",
+            " (latency profiling)" if profiling else "",
         )
 
         for batch_start in range(0, len(prompts), batch_size):
             batch = prompts[batch_start : batch_start + batch_size]
             try:
-                batch_input, batch_output, batch_time, batch_padding = self._run_batch(
-                    hf_model, tokenizer, config, batch, generate_kwargs
-                )
+                if profiling:
+                    import time as _time
+
+                    streamer = _TimingStreamer()
+                    t0_ms = _time.perf_counter() * 1000.0
+                    batch_input, batch_output, batch_time, batch_padding = self._run_batch(
+                        hf_model, tokenizer, config, batch, generate_kwargs, streamer=streamer
+                    )
+                    put_times = streamer.token_times_ms
+                    token_timestamps_per_request.append([t0_ms, *put_times])
+                    if put_times:
+                        ttft_ms_per_request.append(put_times[0] - t0_ms)
+                else:
+                    batch_input, batch_output, batch_time, batch_padding = self._run_batch(
+                        hf_model, tokenizer, config, batch, generate_kwargs
+                    )
                 total_input_tokens += batch_input
                 total_output_tokens += batch_output
                 total_time_sec += batch_time
@@ -241,6 +317,31 @@ class TransformersEngine:
             total_time_sec,
         )
 
+        extras: dict[str, Any] = {
+            "hf_model": hf_model,  # For FLOPs estimation in harness
+            # generate_kwargs stashed so capture_observed_params can read
+            # GenerationConfig state post-window without recomputing.
+            "generate_kwargs": generate_kwargs,
+        }
+        if profiling_forced_batch_size:
+            extras["profiling_forced_batch_size"] = True
+
+        # Latency profiling capture: trimmed ITL from per-token timestamps + TTFT.
+        # The streamer gives true per-token arrivals (batch_size=1 forced), so this
+        # is TRUE_STREAMING provenance.
+        ttft_ms: list[float] = []
+        itl_ms: list[float] = []
+        latency_measurement_mode: str | None = None
+        if profiling:
+            from llenergymeasure.domain.metrics import collect_itl_measurements
+
+            _itl_full, itl_trimmed, _excluded = collect_itl_measurements(
+                token_timestamps_per_request
+            )
+            itl_ms = itl_trimmed
+            ttft_ms = ttft_ms_per_request
+            latency_measurement_mode = LatencyMeasurementMode.TRUE_STREAMING.value
+
         return InferenceOutput(
             elapsed_time_sec=total_time_sec,
             input_tokens=total_input_tokens,
@@ -248,16 +349,13 @@ class TransformersEngine:
             peak_memory_mb=peak_memory_mb,
             model_memory_mb=0.0,  # Captured by harness before run_inference
             batch_times=batch_times,
-            extras={
-                "hf_model": hf_model,  # For FLOPs estimation in harness
-                # generate_kwargs stashed so capture_observed_params can read
-                # GenerationConfig state post-window without recomputing.
-                "generate_kwargs": generate_kwargs,
-            },
+            extras=extras,
             # PER_REQUEST_BATCH approximation - each request gets batch_time/len(batch).
+            # Under profiling batch_size=1, so this is the true per-request wall time.
             per_request_latencies_ms=per_request_latencies_ms,
-            ttft_ms=[],  # Non-streaming - no time-to-first-token
-            itl_ms=[],  # Non-streaming - no inter-token latency
+            ttft_ms=ttft_ms,  # Populated only under latency profiling
+            itl_ms=itl_ms,  # Populated only under latency profiling
+            latency_measurement_mode=latency_measurement_mode,
             num_batches=len(batch_times),
             padding_tokens=total_padding_tokens,
             kv_cache_stats=None,  # Transformers has no paged KV cache
@@ -518,12 +616,16 @@ class TransformersEngine:
         config: ExperimentConfig,
         batch: list[str],
         generate_kwargs: dict[str, Any],
+        streamer: Any | None = None,
     ) -> tuple[int, int, float, int]:
         """Run a single batch through model.generate().
 
         Returns (input_tokens, output_tokens, time_sec, padding_tokens) where
         padding_tokens = total padded positions in the input
         (``input_ids.numel() - attention_mask.sum()``).
+
+        When ``streamer`` is provided (latency profiling), it is forwarded to
+        ``generate(streamer=...)`` so per-token arrival times are recorded.
         """
         import time
 
@@ -560,6 +662,8 @@ class TransformersEngine:
             gen_kwargs = {**generate_kwargs}
             if config.task.max_output_tokens is not None:
                 gen_kwargs["max_new_tokens"] = config.task.max_output_tokens
+            if streamer is not None:
+                gen_kwargs["streamer"] = streamer
             outputs = model.generate(**inputs, **gen_kwargs)
         elapsed = time.perf_counter() - t0
 

--- a/src/llenergymeasure/engines/vllm/plugin.py
+++ b/src/llenergymeasure/engines/vllm/plugin.py
@@ -320,10 +320,24 @@ class VLLMEngine:
             extras["hf_model"] = hf_model
 
         # Best-effort extended-metrics capture (continuous batching: no static batches).
-        from llenergymeasure.engines._observed import extract_request_metrics
+        from llenergymeasure.domain.metrics import LatencyMeasurementMode
+        from llenergymeasure.engines._observed import extract_decode_itl, extract_request_metrics
 
         per_request_latencies_ms, ttft_ms = extract_request_metrics(outputs)
         kv_cache_stats = _capture_kv_cache_stats(llm)
+
+        # TTFT timestamps are engine-recorded (real per-request first_token_time),
+        # so on their own they are TRUE_STREAMING. Under latency profiling we
+        # additionally derive a decode-average ITL, which is only a
+        # PROPORTIONAL_ESTIMATE - the mode then describes that weakest signal.
+        itl_ms: list[float] = []
+        latency_measurement_mode: str | None = None
+        if config.measurement.latency_profiling:
+            itl_ms = extract_decode_itl(outputs)
+            if ttft_ms:
+                latency_measurement_mode = LatencyMeasurementMode.PROPORTIONAL_ESTIMATE.value
+        elif ttft_ms:
+            latency_measurement_mode = LatencyMeasurementMode.TRUE_STREAMING.value
 
         return InferenceOutput(
             elapsed_time_sec=elapsed,
@@ -335,6 +349,8 @@ class VLLMEngine:
             extras=extras,
             per_request_latencies_ms=per_request_latencies_ms,
             ttft_ms=ttft_ms,
+            itl_ms=itl_ms,
+            latency_measurement_mode=latency_measurement_mode,
             num_batches=None,  # Continuous batching - no static batch count
             padding_tokens=None,  # Continuous batching - no padding
             kv_cache_stats=kv_cache_stats,

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -730,6 +730,63 @@ class MeasurementHarness:
             return config.tensorrt.max_batch_size
         return None
 
+    @staticmethod
+    def _resolve_measurement_mode(
+        declared_mode: str | None,
+        measurement_warnings: list[str],
+    ) -> Any:
+        """Map an engine-declared latency mode string to LatencyMeasurementMode.
+
+        The engine sets ``output.latency_measurement_mode`` explicitly whenever it
+        emits TTFT. If it is missing while TTFT is present, that is an engine bug:
+        log a warning and fall back to the field's default (TRUE_STREAMING),
+        noting it in measurement_warnings.
+        """
+        from llenergymeasure.domain.metrics import LatencyMeasurementMode
+
+        if declared_mode is None:
+            logger.warning(
+                "Engine emitted TTFT samples but no latency_measurement_mode; "
+                "defaulting provenance to TRUE_STREAMING."
+            )
+            measurement_warnings.append(
+                "latency_measurement_mode missing despite TTFT capture; "
+                "provenance defaulted to true_streaming (engine should set it explicitly)."
+            )
+            return LatencyMeasurementMode.TRUE_STREAMING
+        return LatencyMeasurementMode(declared_mode)
+
+    @staticmethod
+    def _append_latency_profiling_warnings(
+        config: ExperimentConfig,
+        output: InferenceOutput,
+        engine_name: str,
+        measurement_warnings: list[str],
+    ) -> None:
+        """Append latency-profiling provenance warnings to measurement_warnings.
+
+        Only fires when ``config.measurement.latency_profiling`` is enabled. Adds
+        the fixed provenance note plus, when relevant, the batch-size-forcing note
+        (transformers) and the unsupported-engine note (tensorrt).
+        """
+        if not config.measurement.latency_profiling:
+            return
+        measurement_warnings.append(
+            "latency_profiling enabled: per-token timing capture (streamer/decode-average "
+            "ITL) may perturb energy and latency; energy figures emitted as-is and are not "
+            "directly comparable to non-profiled runs."
+        )
+        if output.extras.get("profiling_forced_batch_size"):
+            measurement_warnings.append(
+                "latency_profiling forced batch_size=1 for per-token timing capture; "
+                "throughput is not comparable to the configured batch size."
+            )
+        if output.extras.get("latency_profiling_unsupported"):
+            measurement_warnings.append(
+                f"latency_profiling is not supported by the {engine_name} engine; "
+                "no per-token timing was captured."
+            )
+
     def _build_result(
         self,
         engine_name: str,
@@ -912,12 +969,29 @@ class MeasurementHarness:
                 "padding_overhead": padding_overhead,
             }
 
+        # Latency stats from streaming TTFT/ITL. Computed BEFORE extended metrics
+        # so the ITL mean can feed tpot_ms. measurement_mode is mapped from the
+        # engine-declared capture mode (provenance). vLLM populates TTFT-only stats
+        # even without profiling; ITL (and thus tpot_ms) needs profiling.
+        latency_stats = None
+        if output.ttft_ms:
+            measurement_mode = self._resolve_measurement_mode(
+                output.latency_measurement_mode, measurement_warnings
+            )
+            latency_stats = compute_latency_statistics(
+                output.ttft_ms,
+                itl_trimmed_ms=output.itl_ms or None,
+                measurement_mode=measurement_mode,
+            )
+
+        itl_mean_ms = latency_stats.itl_mean_ms if latency_stats is not None else None
+
         extended_metrics = compute_extended_metrics(
             output_tokens=output.output_tokens,
             total_energy_j=total_energy_j,
             tokens_per_second=avg_tokens_per_second,
             precision_factor=1.0,  # No precision-scaling applied (default)
-            itl_mean_ms=None,  # tpot_ms stays null - needs streaming ITL capture
+            itl_mean_ms=itl_mean_ms,  # populates tpot_ms when ITL was captured
             per_request_latencies_ms=output.per_request_latencies_ms or None,
             gpu_utilisation_samples=gpu_utilisation_samples or None,
             memory_bandwidth_samples=memory_bandwidth_samples or None,
@@ -929,12 +1003,8 @@ class MeasurementHarness:
         # know the model baseline split).
         extended_metrics.memory.inference_memory_mb = inference_memory_mb
 
-        # Latency stats from streaming TTFT/ITL (vLLM only; null otherwise).
-        latency_stats = (
-            compute_latency_statistics(output.ttft_ms, itl_trimmed_ms=output.itl_ms or None)
-            if output.ttft_ms
-            else None
-        )
+        # Latency profiling provenance warnings (appended to measurement_warnings).
+        self._append_latency_profiling_warnings(config, output, engine_name, measurement_warnings)
 
         steady_state_window = (0.0, output.inference_time_sec)
         warmup_excluded_samples = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def make_config(**overrides) -> ExperimentConfig:
     (dtype now lives per-engine on TransformersConfig/VLLMConfig/TensorRTConfig).
     """
     _TASK_FIELDS = {"model", "dataset", "max_input_tokens", "max_output_tokens", "random_seed"}
-    _MEASUREMENT_FIELDS = {"warmup", "baseline", "energy_sampler"}
+    _MEASUREMENT_FIELDS = {"warmup", "baseline", "energy_sampler", "latency_profiling"}
 
     dtype = overrides.pop("dtype", None)
 

--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -474,8 +474,13 @@ def test_load_study_config_design_hash_is_stable(tmp_path):
         )
     )
     sc = _load_study(study_yaml)
-    # Captured from origin/main before the loader/finalise split (PR 13).
-    assert sc.study_design_hash == "5084ea3c6b9c7b78"
+    # Pinned over the full resolved-config surface (config.model_dump). Re-pinned
+    # when MeasurementConfig gained the opt-in latency_profiling field: a new
+    # defaulted field shifts the canonical JSON, so the fingerprint moves while
+    # the resolve -> dedup -> hash pipeline is unchanged (6 declared -> 4 unique
+    # below still holds). A value change with those structural assertions intact
+    # is a benign schema-surface shift; a change to the dedup counts is not.
+    assert sc.study_design_hash == "f6c89398e2a344dd"
     # 6 declared configs collapse to 4 unique under resolved-config dedup.
     assert len(sc.experiments) == 4
     assert len(sc.declared_resolved_config_hashes) == 6

--- a/tests/unit/domain/test_experiment.py
+++ b/tests/unit/domain/test_experiment.py
@@ -133,3 +133,13 @@ class TestMeasurementConfigHash:
     def test_hash_is_string(self):
         h = compute_declared_config_hash(make_config())
         assert isinstance(h, str)
+
+    def test_latency_profiling_default_off(self):
+        config = make_config()
+        assert config.measurement.latency_profiling is False
+
+    def test_latency_profiling_distinct_hash(self):
+        """Toggling latency_profiling must change the declared config hash."""
+        h_off = compute_declared_config_hash(make_config(latency_profiling=False))
+        h_on = compute_declared_config_hash(make_config(latency_profiling=True))
+        assert h_off != h_on

--- a/tests/unit/domain/test_metrics.py
+++ b/tests/unit/domain/test_metrics.py
@@ -215,6 +215,24 @@ class TestComputeLatencyStatistics:
         assert stats.itl_full_mean_ms == pytest.approx(5.0)
         assert stats.itl_full_p99_ms is not None
 
+    def test_measurement_mode_defaults_to_true_streaming(self):
+        from llenergymeasure.domain.metrics import LatencyMeasurementMode
+
+        stats = compute_latency_statistics([10.0])
+        assert stats is not None
+        assert stats.measurement_mode is LatencyMeasurementMode.TRUE_STREAMING
+
+    def test_measurement_mode_round_trips(self):
+        from llenergymeasure.domain.metrics import LatencyMeasurementMode
+
+        stats = compute_latency_statistics(
+            [10.0],
+            itl_trimmed_ms=[5.0],
+            measurement_mode=LatencyMeasurementMode.PROPORTIONAL_ESTIMATE,
+        )
+        assert stats is not None
+        assert stats.measurement_mode is LatencyMeasurementMode.PROPORTIONAL_ESTIMATE
+
 
 # ---------------------------------------------------------------------------
 # TestCollectItlMeasurements

--- a/tests/unit/engines/test_extended_capture.py
+++ b/tests/unit/engines/test_extended_capture.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from llenergymeasure.engines._observed import extract_request_metrics
+from llenergymeasure.engines._observed import extract_decode_itl, extract_request_metrics
 from llenergymeasure.engines.vllm.plugin import _capture_kv_cache_stats
 
 # ---------------------------------------------------------------------------
@@ -59,6 +59,65 @@ class TestExtractRequestMetrics:
         latencies, ttft = extract_request_metrics([])
         assert latencies == []
         assert ttft == []
+
+
+# ---------------------------------------------------------------------------
+# extract_decode_itl
+# ---------------------------------------------------------------------------
+
+
+def _req_decode(first_token=None, finished=None, n_out=0, with_metrics=True):
+    """Build a fake RequestOutput for extract_decode_itl.
+
+    ``n_out`` controls the total generated-token count across outputs (a single
+    CompletionOutput whose ``token_ids`` has length ``n_out``).
+    """
+    if not with_metrics:
+        return SimpleNamespace(metrics=None, outputs=[SimpleNamespace(token_ids=[0] * n_out)])
+    metrics = SimpleNamespace(first_token_time=first_token, finished_time=finished)
+    return SimpleNamespace(
+        metrics=metrics,
+        outputs=[SimpleNamespace(token_ids=list(range(n_out)))],
+    )
+
+
+class TestExtractDecodeItl:
+    def test_decode_average_math(self):
+        # finished-first_token = 0.9s over n_out-1 = 9 intervals -> 100 ms each.
+        outputs = [_req_decode(first_token=1.0, finished=1.9, n_out=10)]
+        itl = extract_decode_itl(outputs)
+        assert itl == pytest.approx([100.0])
+
+    def test_multi_request(self):
+        outputs = [
+            _req_decode(first_token=1.0, finished=1.9, n_out=10),  # 100 ms
+            _req_decode(first_token=0.0, finished=0.2, n_out=3),  # 0.2s / 2 = 100 ms
+        ]
+        itl = extract_decode_itl(outputs)
+        assert itl == pytest.approx([100.0, 100.0])
+
+    def test_n_out_one_skipped(self):
+        outputs = [_req_decode(first_token=1.0, finished=2.0, n_out=1)]
+        assert extract_decode_itl(outputs) == []
+
+    def test_n_out_zero_skipped(self):
+        outputs = [_req_decode(first_token=1.0, finished=2.0, n_out=0)]
+        assert extract_decode_itl(outputs) == []
+
+    def test_missing_first_token_skipped(self):
+        outputs = [_req_decode(first_token=None, finished=2.0, n_out=5)]
+        assert extract_decode_itl(outputs) == []
+
+    def test_missing_finished_skipped(self):
+        outputs = [_req_decode(first_token=1.0, finished=None, n_out=5)]
+        assert extract_decode_itl(outputs) == []
+
+    def test_metrics_none_skipped(self):
+        outputs = [_req_decode(with_metrics=False, n_out=5)]
+        assert extract_decode_itl(outputs) == []
+
+    def test_empty_outputs(self):
+        assert extract_decode_itl([]) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/engines/test_latency_profiling.py
+++ b/tests/unit/engines/test_latency_profiling.py
@@ -1,0 +1,220 @@
+"""Unit tests for opt-in streaming latency profiling capture.
+
+All host-safe: no GPU, no torch, no engine library import. The transformers
+``run_inference`` profiling path is exercised by monkeypatching ``_run_batch``
+(which would otherwise need torch tensors) so it drives the streamer's ``put()``
+and returns synthetic token counts.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from llenergymeasure.domain.metrics import LatencyMeasurementMode
+from llenergymeasure.engines.transformers.plugin import TransformersEngine, _TimingStreamer
+from tests.conftest import make_config
+
+# ---------------------------------------------------------------------------
+# _TimingStreamer
+# ---------------------------------------------------------------------------
+
+
+class TestTimingStreamer:
+    def test_first_put_is_prompt_and_dropped(self):
+        s = _TimingStreamer()
+        s.put("prompt_tensor")  # dropped (input_ids)
+        assert s.token_times_ms == []
+
+    def test_records_monotonic_token_times(self):
+        s = _TimingStreamer()
+        s.put("prompt")  # dropped
+        s.put("tok1")
+        s.put("tok2")
+        s.put("tok3")
+        assert len(s.token_times_ms) == 3
+        # perf_counter is monotonic non-decreasing
+        assert s.token_times_ms == sorted(s.token_times_ms)
+        assert all(isinstance(t, float) for t in s.token_times_ms)
+
+    def test_end_is_noop(self):
+        s = _TimingStreamer()
+        s.put("prompt")
+        s.put("tok")
+        s.end()
+        assert len(s.token_times_ms) == 1
+
+
+# ---------------------------------------------------------------------------
+# Transformers run_inference profiling path (mocked _run_batch)
+# ---------------------------------------------------------------------------
+
+
+def _patch_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the cuda helpers + torch.manual_seed used by run_inference."""
+    import llenergymeasure.engines._cuda as cuda_mod
+
+    monkeypatch.setattr(cuda_mod, "reset_cuda_peak_memory", lambda: None)
+    monkeypatch.setattr(cuda_mod, "get_cuda_peak_memory_mb", lambda: 0.0)
+
+    # run_inference does `import torch as _torch; _torch.manual_seed(...)`.
+    fake_torch = SimpleNamespace(manual_seed=lambda _seed: None)
+    monkeypatch.setitem(__import__("sys").modules, "torch", fake_torch)
+
+
+def _make_run_batch(n_tokens: int, batch_size_seen: list[int]):
+    """Return a fake _run_batch that drives the streamer with n_tokens puts."""
+
+    def _fake_run_batch(
+        self: Any,
+        model: Any,
+        tokenizer: Any,
+        config: Any,
+        batch: list[str],
+        generate_kwargs: dict[str, Any],
+        streamer: Any | None = None,
+    ) -> tuple[int, int, float, int]:
+        batch_size_seen.append(len(batch))
+        if streamer is not None:
+            streamer.put("prompt")  # dropped
+            for _ in range(n_tokens):
+                streamer.put("tok")
+        # (input_tokens, output_tokens, time_sec, padding_tokens)
+        return 5, n_tokens, 0.1, 0
+
+    return _fake_run_batch
+
+
+class TestTransformersProfilingPath:
+    def test_profiling_sets_mode_and_captures_itl(self, monkeypatch):
+        _patch_cuda(monkeypatch)
+        batch_sizes: list[int] = []
+        monkeypatch.setattr(TransformersEngine, "_run_batch", _make_run_batch(6, batch_sizes))
+
+        config = make_config(engine="transformers", latency_profiling=True)
+        engine = TransformersEngine()
+        out = engine.run_inference(config, (object(), object()), ["p1", "p2"])
+
+        assert out.latency_measurement_mode == LatencyMeasurementMode.TRUE_STREAMING.value
+        # 6 tokens -> 5 intervals + t0 boundary; trimmed ITL drops first/last.
+        assert out.itl_ms  # non-empty
+        assert len(out.ttft_ms) == 2  # one TTFT per request
+        # batch forced to 1 (default batch unset -> already 1)
+        assert all(b == 1 for b in batch_sizes)
+
+    def test_profiling_forces_batch_size_one(self, monkeypatch):
+        _patch_cuda(monkeypatch)
+        batch_sizes: list[int] = []
+        monkeypatch.setattr(TransformersEngine, "_run_batch", _make_run_batch(4, batch_sizes))
+
+        # batch_size=4 should be forced to 1 under profiling.
+        config = make_config(
+            engine="transformers",
+            latency_profiling=True,
+            transformers={"batch_size": 4},
+        )
+        engine = TransformersEngine()
+        out = engine.run_inference(config, (object(), object()), ["p1", "p2", "p3"])
+
+        assert all(b == 1 for b in batch_sizes)
+        assert out.extras.get("profiling_forced_batch_size") is True
+
+    def test_beam_guard_falls_back_to_non_profiled(self, monkeypatch):
+        _patch_cuda(monkeypatch)
+        batch_sizes: list[int] = []
+        # _run_batch must be called WITHOUT a streamer when falling back.
+        seen_streamer: list[bool] = []
+
+        def _fake_run_batch(self, model, tokenizer, config, batch, generate_kwargs, streamer=None):
+            batch_sizes.append(len(batch))
+            seen_streamer.append(streamer is not None)
+            return 5, 4, 0.1, 0
+
+        monkeypatch.setattr(TransformersEngine, "_run_batch", _fake_run_batch)
+
+        config = make_config(
+            engine="transformers",
+            latency_profiling=True,
+            transformers={"num_beams": 4},
+        )
+        engine = TransformersEngine()
+        out = engine.run_inference(config, (object(), object()), ["p1", "p2"])
+
+        # Beam guard -> profiling disabled: no streamer, no mode, no ITL/TTFT.
+        assert out.latency_measurement_mode is None
+        assert out.itl_ms == []
+        assert out.ttft_ms == []
+        assert not any(seen_streamer)
+
+    def test_profiling_off_is_non_streaming(self, monkeypatch):
+        _patch_cuda(monkeypatch)
+        batch_sizes: list[int] = []
+        monkeypatch.setattr(TransformersEngine, "_run_batch", _make_run_batch(4, batch_sizes))
+
+        config = make_config(engine="transformers", latency_profiling=False)
+        engine = TransformersEngine()
+        out = engine.run_inference(config, (object(), object()), ["p1"])
+
+        assert out.latency_measurement_mode is None
+        assert out.itl_ms == []
+        assert out.ttft_ms == []
+        assert "profiling_forced_batch_size" not in out.extras
+
+
+# ---------------------------------------------------------------------------
+# vLLM mode-setting (logic exercised via extract_decode_itl + mode rules)
+# ---------------------------------------------------------------------------
+
+
+def _vllm_req(first_token, finished, n_out):
+    metrics = SimpleNamespace(
+        arrival_time=0.0,
+        finished_time=finished,
+        first_token_time=first_token,
+    )
+    return SimpleNamespace(
+        metrics=metrics,
+        outputs=[SimpleNamespace(token_ids=list(range(n_out)))],
+    )
+
+
+class TestVllmModeSelection:
+    """Replicates the vLLM plugin's mode-selection branch (host-safe)."""
+
+    @staticmethod
+    def _select_mode(profiling: bool, outputs: list) -> tuple[list[float], str | None]:
+        from llenergymeasure.engines._observed import (
+            extract_decode_itl,
+            extract_request_metrics,
+        )
+
+        _lat, ttft = extract_request_metrics(outputs)
+        itl: list[float] = []
+        mode: str | None = None
+        if profiling:
+            itl = extract_decode_itl(outputs)
+            if ttft:
+                mode = LatencyMeasurementMode.PROPORTIONAL_ESTIMATE.value
+        elif ttft:
+            mode = LatencyMeasurementMode.TRUE_STREAMING.value
+        return itl, mode
+
+    def test_profiling_on_is_proportional(self):
+        outputs = [_vllm_req(first_token=0.1, finished=1.0, n_out=10)]
+        itl, mode = self._select_mode(True, outputs)
+        assert itl  # decode ITL captured
+        assert mode == LatencyMeasurementMode.PROPORTIONAL_ESTIMATE.value
+
+    def test_profiling_off_with_ttft_is_true_streaming(self):
+        outputs = [_vllm_req(first_token=0.1, finished=1.0, n_out=10)]
+        itl, mode = self._select_mode(False, outputs)
+        assert itl == []  # no ITL without profiling
+        assert mode == LatencyMeasurementMode.TRUE_STREAMING.value
+
+    def test_no_ttft_no_mode(self):
+        outputs = [SimpleNamespace(metrics=None, outputs=[])]
+        itl, mode = self._select_mode(True, outputs)
+        assert itl == []
+        assert mode is None

--- a/tests/unit/harness/test_latency_profiling_harness.py
+++ b/tests/unit/harness/test_latency_profiling_harness.py
@@ -1,0 +1,166 @@
+"""Harness-level tests for latency profiling provenance and wiring.
+
+Uses the same FakeBackend/_apply_patches pattern as test_harness.py but drives a
+controllable InferenceOutput so the harness's latency_stats/tpot_ms/provenance
+logic can be asserted without GPU or engine libraries.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
+from llenergymeasure.domain.metrics import LatencyMeasurementMode
+from llenergymeasure.engines.protocol import InferenceOutput
+from llenergymeasure.harness import MeasurementHarness
+from tests.unit.harness.test_harness import FakeBackend, _make_mock_pts
+
+
+def _config(latency_profiling: bool) -> ExperimentConfig:
+    return ExperimentConfig(
+        task={
+            "model": "fake/model",
+            "dataset": DatasetConfig(n_prompts=1),
+            "max_input_tokens": 32,
+            "max_output_tokens": 32,
+        },
+        engine="transformers",
+        measurement={"latency_profiling": latency_profiling},
+    )
+
+
+def _apply_patches():
+    import contextlib
+
+    stack = contextlib.ExitStack()
+    patches = [
+        patch(
+            "llenergymeasure.harness.measurement.collect_environment_snapshot", return_value=None
+        ),
+        patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
+        patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
+        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
+        patch(
+            "llenergymeasure.harness.measurement.estimate_flops_palm",
+            return_value=MagicMock(value=1e9),
+        ),
+        patch("llenergymeasure.harness.measurement._cuda_sync"),
+        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch(
+            "llenergymeasure.harness.measurement.write_timeseries_parquet",
+            return_value=MagicMock(name="timeseries.parquet"),
+        ),
+        patch("llenergymeasure.harness.measurement.collect_measurement_warnings", return_value=[]),
+    ]
+    for p in patches:
+        stack.enter_context(p)
+    return stack
+
+
+def _profiled_output() -> InferenceOutput:
+    """An InferenceOutput as a profiling-enabled streaming engine would emit."""
+    return InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=20,
+        peak_memory_mb=512.0,
+        model_memory_mb=256.0,
+        batch_times=[1.0],
+        ttft_ms=[100.0, 110.0],
+        itl_ms=[5.0, 6.0, 7.0, 8.0],
+        latency_measurement_mode=LatencyMeasurementMode.PROPORTIONAL_ESTIMATE.value,
+    )
+
+
+def test_profiling_on_populates_latency_stats_mode_and_tpot():
+    engine = FakeBackend(inference_output=_profiled_output())
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, _config(True))
+
+    assert result.latency_stats is not None
+    assert result.latency_stats.measurement_mode is LatencyMeasurementMode.PROPORTIONAL_ESTIMATE
+    # tpot_ms is the ITL mean (5,6,7,8 -> 6.5)
+    assert result.extended_metrics.tpot_ms == pytest.approx(6.5)
+    # Provenance warning present
+    assert any("latency_profiling enabled" in w for w in result.measurement_warnings)
+
+
+def test_profiling_on_forced_batch_warning():
+    out = _profiled_output()
+    out.extras["profiling_forced_batch_size"] = True
+    engine = FakeBackend(inference_output=out)
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, _config(True))
+
+    assert any("forced batch_size=1" in w for w in result.measurement_warnings)
+
+
+def test_profiling_on_unsupported_engine_warning():
+    out = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=20,
+        peak_memory_mb=512.0,
+        model_memory_mb=256.0,
+        batch_times=[1.0],
+    )
+    out.extras["latency_profiling_unsupported"] = True
+    engine = FakeBackend(inference_output=out)
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, _config(True))
+
+    assert any("not supported" in w for w in result.measurement_warnings)
+    # No streaming signal -> no latency_stats
+    assert result.latency_stats is None
+
+
+def test_profiling_off_no_warning_and_nulls():
+    out = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=20,
+        peak_memory_mb=512.0,
+        model_memory_mb=256.0,
+        batch_times=[1.0],
+    )
+    engine = FakeBackend(inference_output=out)
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, _config(False))
+
+    assert result.latency_stats is None
+    assert result.extended_metrics.tpot_ms is None
+    assert not any("latency_profiling" in w for w in result.measurement_warnings)
+
+
+def test_ttft_without_mode_defaults_and_warns():
+    """Defensive path: ttft present but mode None -> default + warning (should be rare)."""
+    out = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=20,
+        peak_memory_mb=512.0,
+        model_memory_mb=256.0,
+        batch_times=[1.0],
+        ttft_ms=[100.0, 110.0],
+        latency_measurement_mode=None,
+    )
+    engine = FakeBackend(inference_output=out)
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, _config(False))
+
+    assert result.latency_stats is not None
+    assert result.latency_stats.measurement_mode is LatencyMeasurementMode.TRUE_STREAMING
+    assert any("latency_measurement_mode missing" in w for w in result.measurement_warnings)

--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -155,6 +155,25 @@ class TestExpandGridSweep:
         assert dtypes_set == {"float16", "bfloat16"}
         assert ns == {50, 100}
 
+    def test_latency_profiling_sweep_two_distinct_hashes(self):
+        """Sweeping measurement.latency_profiling yields 2 configs with distinct hashes."""
+        from llenergymeasure.domain.experiment import compute_declared_config_hash
+
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "sweep": {
+                "measurement.latency_profiling": [False, True],
+            },
+        }
+        valid, skipped = expand_grid(raw)
+        assert len(valid) == 2
+        assert len(skipped) == 0
+        flags = {c.measurement.latency_profiling for c in valid}
+        assert flags == {False, True}
+        hashes = {compute_declared_config_hash(c) for c in valid}
+        assert len(hashes) == 2
+
     def test_engine_scoped_sweep_routes_to_section(self):
         """transformers.batch_size routes to the transformers section, not top-level."""
         raw = {


### PR DESCRIPTION
## Summary

Adds opt-in streaming latency profiling. A new `measurement.latency_profiling`
flag (default OFF) makes engines capture per-token timing so `tpot_ms` and ITL
statistics populate, with explicit provenance recorded per run. The flag is part
of the declared config hash (sweepable; profiled and non-profiled runs are
distinct experiments), and overhead is disclosed because per-token capture can
perturb energy and latency.

## Provenance semantics (modes per engine)

The `LatencyMeasurementMode` enum values used: `true_streaming`,
`per_request_batch`, `proportional`. `LatencyStatistics` gains a
`measurement_mode` field; the mode always describes the weakest signal present.

- **transformers**: a module-level `_TimingStreamer` (a 2-method
  `BaseStreamer`) records true per-token arrival times. Profiling forces
  `batch_size=1` (one streamed token maps to one request) and is incompatible
  with beam search, so `num_beams > 1` falls back to the non-profiled path.
  Mode = `true_streaming`. Profiling off is byte-identical to before (TTFT/ITL
  empty, mode `None`).
- **vLLM**: TTFT comes from engine-recorded `first_token_time` and is populated
  on every run (mode `true_streaming` whenever TTFT is present). Under profiling
  a decode-average ITL is derived per request via new
  `extract_decode_itl` (`(finished - first_token) / (n_out - 1)`); because that
  averages the decode phase rather than timing each token, the mode becomes
  `proportional`.
- **tensorrt**: latency profiling is unsupported; latency fields stay
  empty/`None` and a warning is recorded.

The harness computes `latency_stats` before extended metrics so the trimmed ITL
mean feeds `tpot_ms`, maps the engine-declared mode string to the enum (with a
defensive default + warning if an engine emits TTFT without a mode), and appends
provenance warnings to `measurement_warnings`: a fixed disclaimer that energy is
emitted as-is and not comparable to non-profiled runs, plus the
batch-size-forcing note (transformers) and the unsupported-engine note
(tensorrt).

## Test plan

All host-safe (no GPU, mocked):

- domain: `measurement_mode` round-trip; `tpot_ms` from ITL mean (existing);
  flag default off; hash distinctness; a sweep over
  `measurement.latency_profiling` yields two distinct hashes.
- engines: `_TimingStreamer` timestamp recording; `extract_decode_itl` math incl.
  `n_out<=1` and missing timestamps; transformers profiling path (mocked
  `generate` driving `put()` N times: batch forced to 1, mode set, beam guard
  falls back); vLLM mode selection.
- harness: a fake engine returning ttft/itl/mode yields `latency_stats` with the
  mode + `tpot_ms` + provenance warning; profiling off yields nulls and no
  warning; forced-batch, unsupported-engine, and missing-mode paths.

Full suite (post-rebase onto #687 + #688): 2468 passed, 52 skipped. `ruff`,
`mypy src/ tests/` (test suite now in the type gate per #688; the two new
latency test modules pass clean under the `tests.*` overrides), import-linter
(4 contracts kept), and `make docs-check` all green. CLI dry-run of
`configs/example-study-full.yaml` remains valid.

The rebase re-pinned one golden value: `test_load_study_config_design_hash_is_stable`
asserts a fixed `study_design_hash`. The new `latency_profiling` field enters
`ExperimentConfig.model_dump()`, so the canonical-JSON fingerprint shifts
(`5084ea3c6b9c7b78` -> `f6c89398e2a344dd`) while the resolve -> dedup -> hash
pipeline is unchanged (the 6-declared -> 4-unique structural assertions still
hold). Re-pinned with an explanatory comment.

## Schema fingerprint

Adding `latency_profiling` to `MeasurementConfig` changes the expconf schema
fingerprint. Already-published engine images embed the previous fingerprint, so
the version handshake will report MISMATCH until images are rebuilt. This is
expected.

## Doc audit

PASS. The PR updates `docs/reference/engines/configuration.md` (new
`latency_profiling` row) and `docs/reference/results-schema.md` (per-engine
support matrix, `latency_stats`/`tpot_ms` semantics, `measurement_mode`
provenance, and the opt-in/energy-caveat prose). Both verified consistent with
the shipped code post-rebase: the `LatencyMeasurementMode` enum string values
(`true_streaming`, `proportional`, `per_request_batch`), the transformers
`batch_size=1` forcing + `num_beams > 1` fallback, the vLLM decode-average ITL
derivation, the tensorrt unsupported path, and the harness-emitted
energy-as-is disclaimer all match what the docs describe. No further doc update
needed.

