### PR TITLE
chore(transformers): bump pin to 5.9.0 (rolling-window sweep)

### DIFF
--- a/engine_versions/transformers/current.yaml
+++ b/engine_versions/transformers/current.yaml
@@ -14,4 +14,4 @@ schema_version: 1
 engine: transformers
 library:
   pep503_name: transformers
-  current_version: "5.8.1"
+  current_version: "5.9.0"


### PR DESCRIPTION
Rolling-window sweep leg 2/5 for transformers (5.7.0 -> 5.12.0). Stacked on #691 (5.8.1).

DRAFT ONLY. Not for merge. Drives the engine-pipeline E2E for a consecutive bump to validate: window-roll + prune at the 6th archive, writeback loop-guard, decay alarm across consecutive minors.

Expected pre-finding: archive/producer-cut prune is not automated; this bump should over-grow the window (6 output archives, 4 producer cuts) without pruning.