### PR TITLE
refactor: decompose CLI and API orchestrator functions

### DIFF
--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -372,13 +372,8 @@ def _run(
     Single-experiment / n_cycles=1:  runs in-process or via DockerRunner directly.
     Otherwise:                         delegates to StudyRunner.
     """
-    import logging
-
     from llenergymeasure.config.user_config import load_user_config
     from llenergymeasure.study.manifest import ManifestWriter, create_study_dir
-    from llenergymeasure.study.preflight import run_study_preflight
-
-    _api_logger = logging.getLogger(__name__)
 
     # Preresolved runner specs bypass preflight; demanding skip_preflight makes the
     # contract explicit rather than silently ignoring the precomputed result.
@@ -389,41 +384,9 @@ def _run(
     # ensuring preflight uses the same runner resolution as the actual dispatch path.
     user_config = load_user_config()
 
-    # Multi-engine guard - raises PreFlightError for multi-engine studies without
-    # Docker, or auto-elevates to Docker when available. Also runs Docker pre-flight
-    # checks when any engine resolves to a Docker runner.
-    # Preflight returns resolved runner specs so we don't resolve them twice.
-    # When the caller already ran preflight (e.g. the CLI, to render its panel),
-    # reuse that result instead of resolving runners a second time.
-    if preresolved is not None:
-        runner_specs, system_overrides = preresolved
-    else:
-        if progress:
-            progress.on_step_start("preflight", "Checking", "environment and Docker")
-            t0_pf = time.perf_counter()
-        try:
-            runner_specs, system_overrides = run_study_preflight(
-                study,
-                skip_preflight=skip_preflight,
-                yaml_runners=study.runners,
-                user_config=user_config.runners,
-                yaml_images=study.images,
-                user_config_images=user_config.images or None,
-            )
-        except Exception:
-            if progress:
-                progress.on_step_done("preflight", time.perf_counter() - t0_pf)
-            raise
-        if progress:
-            progress.on_step_done("preflight", time.perf_counter() - t0_pf)
-
-    # Warn on mixed runners (some local, some docker)
-    modes = {spec.mode for spec in runner_specs.values()}
-    if len(modes) > 1:
-        _api_logger.warning(
-            "Mixed runners detected. For consistent measurements, "
-            "consider running all engines in Docker."
-        )
+    runner_specs, system_overrides = _resolve_runner_specs(
+        study, user_config, preresolved, skip_preflight, progress
+    )
 
     # Resolve results_dir: resume_dir takes priority, then YAML > user config > built-in default
     if resume_dir is not None:
@@ -442,144 +405,17 @@ def _run(
     # Create _study-artefacts/ once for config copy, skipped log, and study-level env.
     artefacts_dir = _ensure_study_artefacts_dir(study_dir)
 
-    # Identity fields for all study-level artefacts
-    _study_hash = study.study_design_hash or ""
-    _study_name = study.study_name or ""
+    _write_study_artefacts(study, artefacts_dir, system_overrides, config_path)
 
-    # Copy original YAML config to _study-artefacts/ with identity header.
-    if config_path is not None:
-        dest = artefacts_dir / "study_config.yaml"
-        try:
-            original = Path(config_path).read_text(encoding="utf-8")
-            header = f"# study_design_hash: {_study_hash} | study_name: {_study_name}\n"
-            dest.write_text(header + original, encoding="utf-8")
-            _api_logger.info("Config YAML copied to %s", dest)
-        except FileNotFoundError:
-            _api_logger.warning("Config YAML %s not found, skipping copy", config_path)
-
-    # Persist skipped config details to _study-artefacts/.
-    if study.skipped_configs:
-        _write_skipped_configs_log(study.skipped_configs, artefacts_dir, _study_hash, _study_name)
-
-    # Persist system overrides to _study-artefacts/ (runner auto-elevation, etc.)
-    if system_overrides:
-        overrides_with_identity = {
-            "study_design_hash": _study_hash,
-            "study_name": _study_name,
-            **system_overrides,
-        }
-        overrides_path = artefacts_dir / "system_overrides.json"
-        try:
-            overrides_path.write_text(
-                json.dumps(overrides_with_identity, indent=2), encoding="utf-8"
-            )
-            _api_logger.info("System overrides written to %s", overrides_path)
-        except OSError as exc:
-            _api_logger.warning("Failed to write system_overrides.json: %s", exc)
-
-    # Write study-level environment.json (installed_packages + software constants).
-    try:
-        from llenergymeasure.harness.environment import collect_software_environment
-
-        sw_env = collect_software_environment()
-        study_env = {
-            "study_design_hash": _study_hash,
-            "study_name": _study_name,
-            **sw_env,
-        }
-        env_path = artefacts_dir / "environment.json"
-        env_path.write_text(json.dumps(study_env, indent=2), encoding="utf-8")
-        _api_logger.info("Study-level environment written to %s", env_path)
-    except Exception as exc:
-        _api_logger.warning("Failed to write study-level environment.json: %s", exc)
-
-    # Build per-experiment resolution logs (config_hash -> resolution dict).
-    # Computed once here so runners don't need to know about resolution logic.
-    resolution_logs: dict[str, dict[str, Any]] = {}
-    try:
-        from llenergymeasure.config.introspection import get_swept_field_paths
-        from llenergymeasure.config.resolution import build_resolution_log
-        from llenergymeasure.domain.experiment import compute_declared_config_hash
-
-        swept_fields = get_swept_field_paths(study.experiments)
-        seen_hashes: set[str] = set()
-        for exp in study.experiments:
-            h = compute_declared_config_hash(exp)
-            if h in seen_hashes:
-                continue
-            seen_hashes.add(h)
-            resolution_logs[h] = build_resolution_log(
-                exp.model_dump(),
-                cli_overrides=cli_overrides,
-                swept_fields=swept_fields,
-            )
-    except Exception as exc:
-        _api_logger.debug("Failed to build resolution logs: %s", exc)
+    resolution_logs = _build_resolution_logs(study, cli_overrides)
 
     wall_start = time.monotonic()
     is_single = len(study.experiments) == 1 and study.study_execution.n_cycles == 1
 
     if is_single:
-        # For single-experiment studies with a StudyProgressCallback, emit
-        # begin/end experiment events so the study display shows the table row.
-        from llenergymeasure.domain.progress import STEPS_LOCAL, StudyProgressCallback, docker_steps
-
-        study_cb: StudyProgressCallback | None = (
-            progress if isinstance(progress, StudyProgressCallback) else None
+        result_files, experiment_results, warnings = _run_single_experiment_dispatch(
+            study, manifest, study_dir, runner_specs, progress, resolution_logs
         )
-        if study_cb is not None:
-            from llenergymeasure.utils.formatting import format_experiment_header
-
-            config = study.experiments[0]
-            spec = runner_specs.get(config.engine) if runner_specs else None
-            is_docker = spec and spec.mode == RUNNER_DOCKER
-            if is_docker:
-                host_baseline = (
-                    config.measurement.baseline.enabled
-                    and config.measurement.baseline.strategy != "fresh"
-                )
-                steps = docker_steps(images_prepared=False, host_baseline=host_baseline)
-            else:
-                steps = list(STEPS_LOCAL)
-            study_cb.begin_experiment(
-                1,
-                format_experiment_header(config),
-                steps,
-                runner_info=spec.to_runner_info() if spec else None,
-            )
-
-        exp_start = time.monotonic()
-        result_files, experiment_results, warnings = run_single_experiment(
-            study,
-            manifest,
-            study_dir,
-            runner_specs=runner_specs,
-            progress=progress,
-            resolution_logs=resolution_logs,
-        )
-        exp_elapsed = time.monotonic() - exp_start
-
-        if study_cb is not None:
-            r = experiment_results[0] if experiment_results else None
-            if r is not None:
-                energy = r.total_energy_j if r.total_energy_j > 0 else None
-                tp = r.avg_tokens_per_second if r.avg_tokens_per_second > 0 else None
-                infer = r.total_inference_time_sec if r.total_inference_time_sec > 0 else None
-                adj_e = (
-                    r.energy_adjusted_j if r.energy_adjusted_j and r.energy_adjusted_j > 0 else None
-                )
-                study_cb.end_experiment_ok(
-                    1,
-                    exp_elapsed,
-                    energy_j=energy,
-                    throughput_tok_s=tp,
-                    inference_time_sec=infer,
-                    adj_energy_j=adj_e,
-                    mj_per_tok_adjusted=r.mj_per_tok_adjusted,
-                    mj_per_tok_total=r.mj_per_tok_total,
-                )
-            else:
-                study_cb.end_experiment_fail(1, exp_elapsed)
     else:
         result_files, experiment_results, warnings = _run_via_runner(
             study,
@@ -634,6 +470,233 @@ def _run(
         summary=summary,
         skipped_experiments=study.skipped_configs,
     )
+
+
+def _resolve_runner_specs(
+    study: StudyConfig,
+    user_config: Any,
+    preresolved: tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]] | None,
+    skip_preflight: bool,
+    progress: ProgressCallback | None,
+) -> tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]]:
+    """Resolve runner specs via preflight, or reuse a caller-provided preresolved result.
+
+    Runs the multi-engine guard + Docker preflight (raising PreFlightError for
+    multi-engine studies without Docker, or auto-elevating when available), emits
+    preflight progress, and warns when the study mixes local and Docker runners.
+    """
+    import logging
+
+    from llenergymeasure.study.preflight import run_study_preflight
+
+    _api_logger = logging.getLogger(__name__)
+
+    if preresolved is not None:
+        runner_specs, system_overrides = preresolved
+    else:
+        if progress:
+            progress.on_step_start("preflight", "Checking", "environment and Docker")
+            t0_pf = time.perf_counter()
+        try:
+            runner_specs, system_overrides = run_study_preflight(
+                study,
+                skip_preflight=skip_preflight,
+                yaml_runners=study.runners,
+                user_config=user_config.runners,
+                yaml_images=study.images,
+                user_config_images=user_config.images or None,
+            )
+        except Exception:
+            if progress:
+                progress.on_step_done("preflight", time.perf_counter() - t0_pf)
+            raise
+        if progress:
+            progress.on_step_done("preflight", time.perf_counter() - t0_pf)
+
+    # Warn on mixed runners (some local, some docker)
+    modes = {spec.mode for spec in runner_specs.values()}
+    if len(modes) > 1:
+        _api_logger.warning(
+            "Mixed runners detected. For consistent measurements, "
+            "consider running all engines in Docker."
+        )
+    return runner_specs, system_overrides
+
+
+def _write_study_artefacts(
+    study: StudyConfig,
+    artefacts_dir: Path,
+    system_overrides: dict[str, dict[str, str]],
+    config_path: Path | None,
+) -> None:
+    """Persist study-level artefacts to ``_study-artefacts/``.
+
+    Writes the original YAML copy (with an identity header), the skipped-config log,
+    the system-overrides record, and the software environment snapshot. Each write is
+    best-effort and logs on failure rather than aborting the run.
+    """
+    import logging
+
+    _api_logger = logging.getLogger(__name__)
+
+    # Identity fields for all study-level artefacts
+    _study_hash = study.study_design_hash or ""
+    _study_name = study.study_name or ""
+
+    # Copy original YAML config to _study-artefacts/ with identity header.
+    if config_path is not None:
+        dest = artefacts_dir / "study_config.yaml"
+        try:
+            original = Path(config_path).read_text(encoding="utf-8")
+            header = f"# study_design_hash: {_study_hash} | study_name: {_study_name}\n"
+            dest.write_text(header + original, encoding="utf-8")
+            _api_logger.info("Config YAML copied to %s", dest)
+        except FileNotFoundError:
+            _api_logger.warning("Config YAML %s not found, skipping copy", config_path)
+
+    # Persist skipped config details to _study-artefacts/.
+    if study.skipped_configs:
+        _write_skipped_configs_log(study.skipped_configs, artefacts_dir, _study_hash, _study_name)
+
+    # Persist system overrides to _study-artefacts/ (runner auto-elevation, etc.)
+    if system_overrides:
+        overrides_with_identity = {
+            "study_design_hash": _study_hash,
+            "study_name": _study_name,
+            **system_overrides,
+        }
+        overrides_path = artefacts_dir / "system_overrides.json"
+        try:
+            overrides_path.write_text(
+                json.dumps(overrides_with_identity, indent=2), encoding="utf-8"
+            )
+            _api_logger.info("System overrides written to %s", overrides_path)
+        except OSError as exc:
+            _api_logger.warning("Failed to write system_overrides.json: %s", exc)
+
+    # Write study-level environment.json (installed_packages + software constants).
+    try:
+        from llenergymeasure.harness.environment import collect_software_environment
+
+        sw_env = collect_software_environment()
+        study_env = {
+            "study_design_hash": _study_hash,
+            "study_name": _study_name,
+            **sw_env,
+        }
+        env_path = artefacts_dir / "environment.json"
+        env_path.write_text(json.dumps(study_env, indent=2), encoding="utf-8")
+        _api_logger.info("Study-level environment written to %s", env_path)
+    except Exception as exc:
+        _api_logger.warning("Failed to write study-level environment.json: %s", exc)
+
+
+def _build_resolution_logs(
+    study: StudyConfig, cli_overrides: dict[str, Any] | None
+) -> dict[str, dict[str, Any]]:
+    """Build per-experiment resolution logs keyed by declared-config hash.
+
+    Computed once here so runners don't need to know about resolution logic.
+    Best-effort: returns whatever was built before any failure.
+    """
+    import logging
+
+    _api_logger = logging.getLogger(__name__)
+
+    resolution_logs: dict[str, dict[str, Any]] = {}
+    try:
+        from llenergymeasure.config.introspection import get_swept_field_paths
+        from llenergymeasure.config.resolution import build_resolution_log
+        from llenergymeasure.domain.experiment import compute_declared_config_hash
+
+        swept_fields = get_swept_field_paths(study.experiments)
+        seen_hashes: set[str] = set()
+        for exp in study.experiments:
+            h = compute_declared_config_hash(exp)
+            if h in seen_hashes:
+                continue
+            seen_hashes.add(h)
+            resolution_logs[h] = build_resolution_log(
+                exp.model_dump(),
+                cli_overrides=cli_overrides,
+                swept_fields=swept_fields,
+            )
+    except Exception as exc:
+        _api_logger.debug("Failed to build resolution logs: %s", exc)
+    return resolution_logs
+
+
+def _run_single_experiment_dispatch(
+    study: StudyConfig,
+    manifest: Any,
+    study_dir: Path,
+    runner_specs: Any,
+    progress: ProgressCallback | None,
+    resolution_logs: dict[str, dict[str, Any]],
+) -> tuple[list[str], list[ExperimentResult | None], list[str]]:
+    """Run a single-experiment study in-process, emitting study-table begin/end events.
+
+    For a StudyProgressCallback, emits begin_experiment / end_experiment_(ok|fail) so
+    the study display shows the single experiment's table row.
+    """
+    from llenergymeasure.domain.progress import STEPS_LOCAL, StudyProgressCallback, docker_steps
+
+    study_cb: StudyProgressCallback | None = (
+        progress if isinstance(progress, StudyProgressCallback) else None
+    )
+    if study_cb is not None:
+        from llenergymeasure.utils.formatting import format_experiment_header
+
+        config = study.experiments[0]
+        spec = runner_specs.get(config.engine) if runner_specs else None
+        is_docker = spec and spec.mode == RUNNER_DOCKER
+        if is_docker:
+            host_baseline = (
+                config.measurement.baseline.enabled
+                and config.measurement.baseline.strategy != "fresh"
+            )
+            steps = docker_steps(images_prepared=False, host_baseline=host_baseline)
+        else:
+            steps = list(STEPS_LOCAL)
+        study_cb.begin_experiment(
+            1,
+            format_experiment_header(config),
+            steps,
+            runner_info=spec.to_runner_info() if spec else None,
+        )
+
+    exp_start = time.monotonic()
+    result_files, experiment_results, warnings = run_single_experiment(
+        study,
+        manifest,
+        study_dir,
+        runner_specs=runner_specs,
+        progress=progress,
+        resolution_logs=resolution_logs,
+    )
+    exp_elapsed = time.monotonic() - exp_start
+
+    if study_cb is not None:
+        r = experiment_results[0] if experiment_results else None
+        if r is not None:
+            energy = r.total_energy_j if r.total_energy_j > 0 else None
+            tp = r.avg_tokens_per_second if r.avg_tokens_per_second > 0 else None
+            infer = r.total_inference_time_sec if r.total_inference_time_sec > 0 else None
+            adj_e = r.energy_adjusted_j if r.energy_adjusted_j and r.energy_adjusted_j > 0 else None
+            study_cb.end_experiment_ok(
+                1,
+                exp_elapsed,
+                energy_j=energy,
+                throughput_tok_s=tp,
+                inference_time_sec=infer,
+                adj_energy_j=adj_e,
+                mj_per_tok_adjusted=r.mj_per_tok_adjusted,
+                mj_per_tok_total=r.mj_per_tok_total,
+            )
+        else:
+            study_cb.end_experiment_fail(1, exp_elapsed)
+
+    return result_files, experiment_results, warnings
 
 
 def _run_via_runner(

--- a/src/llenergymeasure/cli/config_cmd.py
+++ b/src/llenergymeasure/cli/config_cmd.py
@@ -82,7 +82,18 @@ def config_command(
     from llenergymeasure.cli import _setup_logging
 
     _setup_logging(verbose)
-    # --- GPU ---
+    _print_gpu_status(verbose)
+    _print_engine_status(verbose)
+    _print_energy_status()
+    _print_config_status(verbose)
+
+    # --- Python ---
+    print("Python")
+    print(f"  {sys.version.split()[0]}")
+
+
+def _print_gpu_status(verbose: int) -> None:
+    """Print the GPU section: detected devices and (verbose) the driver version."""
     print("GPU")
     gpus = _probe_gpu()
     if gpus:
@@ -105,7 +116,9 @@ def config_command(
     else:
         print("  No GPU detected")
 
-    # --- Inference engines ---
+
+def _print_engine_status(verbose: int) -> None:
+    """Print the inference-engine section: install state and (verbose) versions."""
     print("Engines")
     for engine, package in ENGINE_PACKAGES.items():
         installed = importlib.util.find_spec(package) is not None
@@ -119,7 +132,9 @@ def config_command(
         else:
             print(f"  {engine}: not installed  (runs in Docker - see docs/development.md)")
 
-    # --- Energy backends ---
+
+def _print_energy_status() -> None:
+    """Print the energy-backend section: which sampler would be selected."""
     print("Energy")
     has_nvml = importlib.util.find_spec("pynvml") is not None
     has_zeus = importlib.util.find_spec("zeus") is not None
@@ -139,49 +154,50 @@ def config_command(
     else:
         print("  Sampler: none (install nvidia-ml-py for NVML)")
 
-    # --- User config ---
+
+def _print_config_status(verbose: int) -> None:
+    """Print the user-config section: path, load status, and (verbose) non-defaults."""
     print("Config")
     from llenergymeasure.config.user_config import get_user_config_path
 
     config_path = get_user_config_path()
-    if config_path.exists():
-        print(f"  Path: {config_path}")
-        print("  Status: loaded")
-        if verbose > 0:
-            from llenergymeasure.config.user_config import (
-                UserConfig,
-                load_user_config,
-            )
-
-            try:
-                user_cfg = load_user_config()
-                defaults = UserConfig()
-                cfg_dump = user_cfg.model_dump()
-                default_dump = defaults.model_dump()
-                non_defaults: dict[str, Any] = {}
-                for section, values in cfg_dump.items():
-                    section_defaults = default_dump.get(section, {})
-                    if isinstance(values, dict) and isinstance(section_defaults, dict):
-                        diff = {k: v for k, v in values.items() if v != section_defaults.get(k)}
-                        if diff:
-                            non_defaults[section] = diff
-                    elif values != section_defaults:
-                        non_defaults[section] = values
-                if non_defaults:
-                    print("  Non-default values:")
-                    for section, values in non_defaults.items():
-                        if isinstance(values, dict):
-                            for k, v in values.items():
-                                print(f"    {section}.{k}: {v}")
-                        else:
-                            print(f"    {section}: {values}")
-                else:
-                    print("  (all values are defaults)")
-            except Exception as e:
-                print(f"  (could not load config: {e})")
-    else:
+    if not config_path.exists():
         print("  Status: using defaults (no config file)")
+        return
 
-    # --- Python ---
-    print("Python")
-    print(f"  {sys.version.split()[0]}")
+    print(f"  Path: {config_path}")
+    print("  Status: loaded")
+    if verbose == 0:
+        return
+
+    from llenergymeasure.config.user_config import (
+        UserConfig,
+        load_user_config,
+    )
+
+    try:
+        user_cfg = load_user_config()
+        defaults = UserConfig()
+        cfg_dump = user_cfg.model_dump()
+        default_dump = defaults.model_dump()
+        non_defaults: dict[str, Any] = {}
+        for section, values in cfg_dump.items():
+            section_defaults = default_dump.get(section, {})
+            if isinstance(values, dict) and isinstance(section_defaults, dict):
+                diff = {k: v for k, v in values.items() if v != section_defaults.get(k)}
+                if diff:
+                    non_defaults[section] = diff
+            elif values != section_defaults:
+                non_defaults[section] = values
+        if non_defaults:
+            print("  Non-default values:")
+            for section, values in non_defaults.items():
+                if isinstance(values, dict):
+                    for k, v in values.items():
+                        print(f"    {section}.{k}: {v}")
+                else:
+                    print(f"    {section}: {values}")
+        else:
+            print("  (all values are defaults)")
+    except Exception as e:
+        print(f"  (could not load config: {e})")

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -396,6 +396,190 @@ def _build_header(config: Any, runner_tag: str = RUNNER_LOCAL) -> str:
 # ---------------------------------------------------------------------------
 
 
+_HistoricalRow = tuple[
+    int, str, str, float, float | None, float | None, float | None, float | None, float | None
+]
+
+
+def _resolve_resume_target(
+    resume: bool, resume_dir: Path | None, output: str | None
+) -> tuple[Path | None, Any, bool]:
+    """Resolve the resume target directory and load its manifest (best-effort).
+
+    Returns ``(resume_dir, resume_manifest, is_resume)``. Raises typer.BadParameter
+    when an explicit --resume-dir is not a study directory, or --resume finds nothing.
+    """
+    resume_manifest = None
+    is_resume = resume or resume_dir is not None
+    if resume_dir is not None:
+        if not (resume_dir / "manifest.json").exists():
+            raise typer.BadParameter(
+                f"No manifest.json in {resume_dir} - not a valid study directory.",
+                param_hint="--resume-dir",
+            )
+        try:
+            from llenergymeasure.api import load_resume_state
+
+            resume_manifest, _ = load_resume_state(resume_dir)
+        except Exception:
+            pass  # Best-effort: display will work without manifest data
+    elif resume:
+        from llenergymeasure.api import find_resumable_study
+
+        _output = Path(output or "./results")
+        resume_dir = find_resumable_study(_output)
+        if resume_dir is None:
+            raise typer.BadParameter(
+                f"No resumable study found in {_output}. Run a study first or use --resume-dir.",
+                param_hint="--resume",
+            )
+        try:
+            from llenergymeasure.api import load_resume_state
+
+            resume_manifest, _ = load_resume_state(resume_dir)
+        except Exception:
+            pass  # Best-effort: display will work without manifest data
+    return resume_dir, resume_manifest, is_resume
+
+
+def _build_study_cli_overrides(
+    cli_overrides: dict[str, Any],
+    cycles: int | None,
+    order: str | None,
+    no_gaps: bool,
+    fail_fast: bool,
+    no_circuit_breaker: bool,
+    timeout: float | None,
+    no_dedup: bool,
+    yaml_execution: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge CLI flags into the study override dict passed to load_study.
+
+    Applies the CLI-layer effective defaults (n_cycles=3, experiment_order="shuffle")
+    only when neither the YAML study_execution block nor a CLI flag sets them; the
+    Pydantic defaults are intentionally more conservative (n_cycles=1).
+    """
+    exec_overrides: dict[str, Any] = {}
+
+    if cycles is not None:
+        exec_overrides["n_cycles"] = cycles
+    elif "n_cycles" not in yaml_execution:
+        exec_overrides["n_cycles"] = 3  # CLI effective default
+
+    if order is not None:
+        exec_overrides["experiment_order"] = order
+    elif "experiment_order" not in yaml_execution:
+        exec_overrides["experiment_order"] = "shuffle"  # CLI effective default
+
+    if no_gaps:
+        exec_overrides["experiment_gap_seconds"] = 0
+        exec_overrides["cycle_gap_seconds"] = 0
+
+    # Robustness overrides: circuit breaker, timeout
+    if fail_fast:
+        exec_overrides["max_consecutive_failures"] = 1
+        exec_overrides["circuit_breaker_cooldown_seconds"] = 0
+    if no_circuit_breaker:
+        exec_overrides["max_consecutive_failures"] = 0
+    if timeout is not None:
+        exec_overrides["wall_clock_timeout_hours"] = timeout
+
+    # --no-dedup disables library-resolution mechanism sweep dedup (runs every declared config)
+    if no_dedup:
+        exec_overrides["deduplicate_equivalent"] = False
+
+    study_cli_overrides: dict[str, Any] = {}
+    if cli_overrides:
+        study_cli_overrides.update(cli_overrides)
+    if exec_overrides:
+        study_cli_overrides["study_execution"] = exec_overrides
+    return study_cli_overrides
+
+
+def _print_config_summary(
+    console: Any,
+    study_config: Any,
+    is_resume: bool,
+    resume_manifest: Any,
+    expand_elapsed: float,
+) -> None:
+    """Print the config-expansion summary lines (valid configs, skipped, resume status)."""
+    from llenergymeasure.utils.formatting import format_elapsed as _fmt_elapsed
+    from llenergymeasure.utils.formatting import truncate_detail as _trunc_detail
+
+    n_valid = len(study_config.experiments) // max(study_config.study_execution.n_cycles, 1)
+    n_skipped = len(study_config.skipped_configs) if study_config.skipped_configs else 0
+    _step_n = 1
+    _step_total = 1 + (1 if n_skipped else 0) + (1 if is_resume else 0)
+
+    detail_done = _trunc_detail(f"{n_valid} valid configs")
+    console.print(
+        f"   {f'[{_step_n}/{_step_total}]':>7s}  {'Config':<16s} {detail_done:<34s}"
+        f"  [bold green]✓[/]  {_fmt_elapsed(expand_elapsed)}"
+    )
+    _step_n += 1
+
+    if n_skipped:
+        detail_skip = _trunc_detail(f"skipped {n_skipped} invalid config(s)")
+        console.print(
+            f"   {f'[{_step_n}/{_step_total}]':>7s}  {'Config':<16s} {detail_skip:<34s}"
+            f"  [bold green]✓[/]  {_fmt_elapsed(expand_elapsed)}"
+        )
+        _step_n += 1
+
+    # Resume summary: show status counts from manifest
+    if is_resume and resume_manifest is not None:
+        m = resume_manifest
+        parts = []
+        if m.completed > 0:
+            parts.append(f"{m.completed} completed")
+        if m.failed > 0:
+            parts.append(f"{m.failed} failed")
+        if m.interrupted > 0:
+            parts.append(f"{m.interrupted} interrupted")
+        if m.skipped > 0:
+            parts.append(f"{m.skipped} skipped")
+        n_to_run = m.total_experiments - m.completed
+        parts.append(f"{n_to_run} to run")
+        resume_detail = _trunc_detail(", ".join(parts))
+        console.print(
+            f"   {f'[{_step_n}/{_step_total}]':>7s}  {'Resume':<16s} {resume_detail:<34s}"
+            f"  [bold green]✓[/]  {_fmt_elapsed(0.0)}"
+        )
+
+
+def _build_historical_rows(resume_manifest: Any) -> list[_HistoricalRow]:
+    """Build completed/failed experiment rows from a resume manifest for pre-population.
+
+    Uses a sequential display index (1, 2, 3...) for historical rows and derives
+    elapsed from started/completed timestamps when the stored value is missing.
+    """
+    historical: list[_HistoricalRow] = []
+    hist_idx = 0
+    for entry in resume_manifest.experiments:
+        if entry.status not in ("completed", "failed"):
+            continue
+        hist_idx += 1
+        elapsed = entry.elapsed_seconds or 0.0
+        if elapsed == 0.0 and entry.started_at and entry.completed_at:
+            elapsed = (entry.completed_at - entry.started_at).total_seconds()
+        status = "OK" if entry.status == "completed" else "FAIL"
+        historical.append(
+            (
+                hist_idx,
+                status,
+                entry.config_summary,
+                elapsed,
+                entry.inference_seconds,
+                entry.energy_joules,
+                entry.adj_energy_joules,
+                entry.throughput_tok_s,
+                entry.mj_per_tok,
+            )
+        )
+    return historical
+
+
 def _run_study_impl(
     config: Path,
     cli_overrides: dict[str, Any],
@@ -426,79 +610,24 @@ def _run_study_impl(
     # Fast-fail: verify resume target exists before expensive grid expansion.
     # For resume, also load the manifest early so we can show a summary and
     # pre-populate the completed experiments table.
-    _resume_manifest = None
-    is_resume = resume or resume_dir is not None
-    if resume_dir is not None:
-        if not (resume_dir / "manifest.json").exists():
-            raise typer.BadParameter(
-                f"No manifest.json in {resume_dir} - not a valid study directory.",
-                param_hint="--resume-dir",
-            )
-        try:
-            from llenergymeasure.api import load_resume_state
-
-            _resume_manifest, _ = load_resume_state(resume_dir)
-        except Exception:
-            pass  # Best-effort: display will work without manifest data
-    elif resume:
-        from llenergymeasure.api import find_resumable_study
-
-        _output = Path(output or "./results")
-        resume_dir = find_resumable_study(_output)
-        if resume_dir is None:
-            raise typer.BadParameter(
-                f"No resumable study found in {_output}. Run a study first or use --resume-dir.",
-                param_hint="--resume",
-            )
-        try:
-            from llenergymeasure.api import load_resume_state
-
-            _resume_manifest, _ = load_resume_state(resume_dir)
-        except Exception:
-            pass  # Best-effort: display will work without manifest data
+    resume_dir, _resume_manifest, is_resume = _resolve_resume_target(resume, resume_dir, output)
 
     # Check what the YAML execution block specifies (to apply CLI effective defaults)
     raw = yaml.safe_load(config.read_text()) or {}
     yaml_execution = raw.get("study_execution", {}) or {}
 
-    # Build execution overrides from CLI flags
-    exec_overrides: dict[str, Any] = {}
-
-    # CLI effective defaults: n_cycles=3, experiment_order="shuffle" when neither YAML nor CLI specifies
-    # These are applied at CLI layer; Pydantic defaults are conservative (n_cycles=1)
-    if cycles is not None:
-        exec_overrides["n_cycles"] = cycles
-    elif "n_cycles" not in yaml_execution:
-        exec_overrides["n_cycles"] = 3  # CLI effective default
-
-    if order is not None:
-        exec_overrides["experiment_order"] = order
-    elif "experiment_order" not in yaml_execution:
-        exec_overrides["experiment_order"] = "shuffle"  # CLI effective default
-
-    if no_gaps:
-        exec_overrides["experiment_gap_seconds"] = 0
-        exec_overrides["cycle_gap_seconds"] = 0
-
-    # Robustness overrides: circuit breaker, timeout
-    if fail_fast:
-        exec_overrides["max_consecutive_failures"] = 1
-        exec_overrides["circuit_breaker_cooldown_seconds"] = 0
-    if no_circuit_breaker:
-        exec_overrides["max_consecutive_failures"] = 0
-    if timeout is not None:
-        exec_overrides["wall_clock_timeout_hours"] = timeout
-
-    # --no-dedup disables library-resolution mechanism sweep dedup (runs every declared config)
-    if no_dedup:
-        exec_overrides["deduplicate_equivalent"] = False
-
-    # Build full CLI overrides dict
-    study_cli_overrides: dict[str, Any] = {}
-    if cli_overrides:
-        study_cli_overrides.update(cli_overrides)
-    if exec_overrides:
-        study_cli_overrides["study_execution"] = exec_overrides
+    # Merge CLI flags (with CLI-layer effective defaults) into the load_study overrides
+    study_cli_overrides = _build_study_cli_overrides(
+        cli_overrides,
+        cycles,
+        order,
+        no_gaps,
+        fail_fast,
+        no_circuit_breaker,
+        timeout,
+        no_dedup,
+        yaml_execution,
+    )
 
     # Load study config with overrides - show step-format spinner during expansion
     from rich.console import Console as _ExpandConsole
@@ -541,45 +670,9 @@ def _run_study_impl(
     expand_elapsed = time.perf_counter() - t0_expand
 
     # Print completed lines with green ticks (same format as step display)
-    n_valid = len(study_config.experiments) // max(study_config.study_execution.n_cycles, 1)
-    n_skipped = len(study_config.skipped_configs) if study_config.skipped_configs else 0
-    _step_n = 1
-    _step_total = 1 + (1 if n_skipped else 0) + (1 if is_resume else 0)
-
-    detail_done = _trunc_detail(f"{n_valid} valid configs")
-    _expand_console.print(
-        f"   {f'[{_step_n}/{_step_total}]':>7s}  {'Config':<16s} {detail_done:<34s}"
-        f"  [bold green]✓[/]  {_fmt_elapsed(expand_elapsed)}"
+    _print_config_summary(
+        _expand_console, study_config, is_resume, _resume_manifest, expand_elapsed
     )
-    _step_n += 1
-
-    if n_skipped:
-        detail_skip = _trunc_detail(f"skipped {n_skipped} invalid config(s)")
-        _expand_console.print(
-            f"   {f'[{_step_n}/{_step_total}]':>7s}  {'Config':<16s} {detail_skip:<34s}"
-            f"  [bold green]✓[/]  {_fmt_elapsed(expand_elapsed)}"
-        )
-        _step_n += 1
-
-    # Resume summary: show status counts from manifest
-    if is_resume and _resume_manifest is not None:
-        m = _resume_manifest
-        parts = []
-        if m.completed > 0:
-            parts.append(f"{m.completed} completed")
-        if m.failed > 0:
-            parts.append(f"{m.failed} failed")
-        if m.interrupted > 0:
-            parts.append(f"{m.interrupted} interrupted")
-        if m.skipped > 0:
-            parts.append(f"{m.skipped} skipped")
-        n_to_run = m.total_experiments - m.completed
-        parts.append(f"{n_to_run} to run")
-        resume_detail = _trunc_detail(", ".join(parts))
-        _expand_console.print(
-            f"   {f'[{_step_n}/{_step_total}]':>7s}  {'Resume':<16s} {resume_detail:<34s}"
-            f"  [bold green]✓[/]  {_fmt_elapsed(0.0)}"
-        )
 
     # Count sweep axes vs groups and explicit experiments from raw YAML for panel display
     raw_sweep = raw.get("sweep", {}) or {}
@@ -665,41 +758,7 @@ def _run_study_impl(
         # Pre-populate completed experiments from manifest on resume.
         # Uses sequential index (1, 2, 3...) for historical rows.
         if is_resume and _resume_manifest is not None:
-            historical: list[
-                tuple[
-                    int,
-                    str,
-                    str,
-                    float,
-                    float | None,
-                    float | None,
-                    float | None,
-                    float | None,
-                    float | None,
-                ]
-            ] = []
-            hist_idx = 0
-            for entry in _resume_manifest.experiments:
-                if entry.status not in ("completed", "failed"):
-                    continue
-                hist_idx += 1
-                elapsed = entry.elapsed_seconds or 0.0
-                if elapsed == 0.0 and entry.started_at and entry.completed_at:
-                    elapsed = (entry.completed_at - entry.started_at).total_seconds()
-                status = "OK" if entry.status == "completed" else "FAIL"
-                historical.append(
-                    (
-                        hist_idx,
-                        status,
-                        entry.config_summary,
-                        elapsed,
-                        entry.inference_seconds,
-                        entry.energy_joules,
-                        entry.adj_energy_joules,
-                        entry.throughput_tok_s,
-                        entry.mj_per_tok,
-                    )
-                )
+            historical = _build_historical_rows(_resume_manifest)
             if historical:
                 study_display.add_historical_rows(historical)
 


### PR DESCRIPTION
Part of a stacked refactor/cleanup series (8/9), based on `refactor/cleanup-7-docker-stream-decomp`.

## Summary
Behaviour-preserving decomposition of the CLI/API orchestrators into phase helpers: `_run_study_impl` (C901=37), `api/_impl._run` dispatcher (C901=23), and `config_command` (C901=25). Guarded by the cli-run, api, and cli-config tests.

## Commits
- refactor(cli): decompose _run_study_impl into phase helpers
- refactor(api): decompose _run dispatcher into phase helpers
- refactor(cli): decompose config_command into per-section helpers

## Test plan
Full suite green (2421 passed); ruff + mypy clean.
