### PR TITLE
refactor(config): remove dead introspection surface and fix capability-matrix ordering

### DIFF
--- a/docs/reference/engines/invalid-combos.md
+++ b/docs/reference/engines/invalid-combos.md
@@ -1,7 +1,7 @@
 # Invalid Parameter Combinations
 
 > Auto-generated from config validators and test results.
-> Last updated: 2026-06-10 16:34 UTC
+> Last updated: 2026-06-19 12:24 UTC
 
 This document lists parameter combinations that will fail validation or runtime.
 The tool validates these at config load time and provides clear error messages.
@@ -64,19 +64,19 @@ due to hardware, model, or package requirements.
 
 | Feature | Transformers | vLLM | TensorRT |
 |---------|---------|------|----------|
-| Tensor Parallel | Yes | No | Yes |
+| Tensor Parallel | No | Yes | Yes |
 | Data Parallel | No | No | No |
-| BitsAndBytes (4-bit) | No | Yes | No |
-| BitsAndBytes (8-bit) | No | Yes | No |
-| Native Quantization | INT8/W4A16_AWQ/W4A16_GPTQ/FP8 | No | AWQ/GPTQ/FP8 |
-| float32 precision | No | Yes | Yes |
+| BitsAndBytes (4-bit) | Yes | No | No |
+| BitsAndBytes (8-bit) | Yes | No | No |
+| Native Quantization | No | AWQ/GPTQ/FP8 | INT8/W4A16_AWQ/W4A16_GPTQ/FP8 |
+| float32 precision | Yes | Yes | No |
 | float16 precision | Yes | Yes | Yes |
 | bfloat16 precision | Yes | Yes | Yes |
-| Prefix Caching | No | No | Yes |
-| torch.compile | No | Yes | No |
-| Beam Search | No | Yes | Yes |
-| Speculative Decoding | No | Yes | No |
-| Static KV Cache | No | Yes | No |
+| Prefix Caching | No | Yes | No |
+| torch.compile | Yes | No | No |
+| Beam Search | Yes | Yes | No |
+| Speculative Decoding | Yes | No | No |
+| Static KV Cache | Yes | No | No |
 
 **Notes:**
 - vLLM supports 4-bit via AWQ/GPTQ quantized models, not bitsandbytes

--- a/src/llenergymeasure/cli/_step_display.py
+++ b/src/llenergymeasure/cli/_step_display.py
@@ -748,41 +748,19 @@ class StudyStepDisplay:
             )
             self._live.start()
 
-    def add_historical_rows(
-        self,
-        rows: list[
-            tuple[
-                int,
-                str,
-                str,
-                float,
-                float | None,
-                float | None,
-                float | None,
-                float | None,
-                float | None,
-            ]
-        ],
-    ) -> None:
+    def add_historical_rows(self, rows: list[_CompletedRow]) -> None:
         """Pre-populate the completed table with rows from a previous run.
 
         Used by --resume to show previously completed experiments in the same
         table format as live results. Must be called before start().
 
-        Historical rows use status "PREV_OK" / "PREV_FAIL" to render dimmed
-        with a distinct marker, visually separating them from live results.
-
-        Args:
-            rows: List of (index, status, config_summary, elapsed_seconds,
-                  inference_sec, energy_j, adj_energy_j, throughput, mj_tok).
-                  status is "OK" or "FAIL".
+        Each row's status ("OK" / "FAIL") is prefixed to "PREV_OK" / "PREV_FAIL"
+        so historical rows render dimmed with a distinct marker, visually
+        separating them from live results.
         """
         with self._lock:
-            for idx, status, config, elapsed, infer, energy, adj_e, tput, mj in rows:
-                hist_status = f"PREV_{status}"
-                self._completed_rows.append(
-                    _CompletedRow(idx, hist_status, config, elapsed, infer, energy, adj_e, tput, mj)
-                )
+            for row in rows:
+                self._completed_rows.append(row._replace(status=f"PREV_{row.status}"))
 
     def stop(self) -> None:
         """Stop Rich Live."""

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -6,7 +6,7 @@ import signal
 import sys
 import time
 from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 from pydantic import ValidationError
@@ -32,6 +32,9 @@ from llenergymeasure.utils.exceptions import (
     PreFlightError,
     StudyError,
 )
+
+if TYPE_CHECKING:
+    from llenergymeasure.cli._step_display import _CompletedRow
 
 # ---------------------------------------------------------------------------
 # Command
@@ -396,11 +399,6 @@ def _build_header(config: Any, runner_tag: str = RUNNER_LOCAL) -> str:
 # ---------------------------------------------------------------------------
 
 
-_HistoricalRow = tuple[
-    int, str, str, float, float | None, float | None, float | None, float | None, float | None
-]
-
-
 def _resolve_resume_target(
     resume: bool, resume_dir: Path | None, output: str | None
 ) -> tuple[Path | None, Any, bool]:
@@ -548,13 +546,15 @@ def _print_config_summary(
         )
 
 
-def _build_historical_rows(resume_manifest: Any) -> list[_HistoricalRow]:
+def _build_historical_rows(resume_manifest: Any) -> list[_CompletedRow]:
     """Build completed/failed experiment rows from a resume manifest for pre-population.
 
     Uses a sequential display index (1, 2, 3...) for historical rows and derives
     elapsed from started/completed timestamps when the stored value is missing.
     """
-    historical: list[_HistoricalRow] = []
+    from llenergymeasure.cli._step_display import _CompletedRow
+
+    historical: list[_CompletedRow] = []
     hist_idx = 0
     for entry in resume_manifest.experiments:
         if entry.status not in ("completed", "failed"):
@@ -563,18 +563,17 @@ def _build_historical_rows(resume_manifest: Any) -> list[_HistoricalRow]:
         elapsed = entry.elapsed_seconds or 0.0
         if elapsed == 0.0 and entry.started_at and entry.completed_at:
             elapsed = (entry.completed_at - entry.started_at).total_seconds()
-        status = "OK" if entry.status == "completed" else "FAIL"
         historical.append(
-            (
-                hist_idx,
-                status,
-                entry.config_summary,
-                elapsed,
-                entry.inference_seconds,
-                entry.energy_joules,
-                entry.adj_energy_joules,
-                entry.throughput_tok_s,
-                entry.mj_per_tok,
+            _CompletedRow(
+                idx=hist_idx,
+                status="OK" if entry.status == "completed" else "FAIL",
+                config=entry.config_summary,
+                elapsed=elapsed,
+                inference_sec=entry.inference_seconds,
+                energy_j=entry.energy_joules,
+                adj_energy_j=entry.adj_energy_joules,
+                throughput=entry.throughput_tok_s,
+                mj_per_tok=entry.mj_per_tok,
             )
         )
     return historical

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -8,17 +8,11 @@ maintaining separate parameter lists.
 Usage:
     from llenergymeasure.config.introspection import (
         get_engine_params,
-        get_shared_params,
-        get_all_params,
-        get_param_test_values,
         get_experiment_config_schema,
     )
 
     # Get all params for an engine
     transformers_params = get_engine_params("transformers")
-
-    # Get test values for a param
-    values = get_param_test_values("transformers.batch_size")
 
     # Get full JSON schema
     schema = get_experiment_config_schema()
@@ -32,9 +26,7 @@ from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
-from llenergymeasure.config.ssot import ALL_ENGINES, Engine
-
-_ALL_ENGINES_LIST: list[Engine] = list(ALL_ENGINES)
+from llenergymeasure.config.ssot import ALL_ENGINES
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
@@ -331,89 +323,6 @@ def get_engine_params(engine: str) -> dict[str, dict[str, Any]]:
     return params
 
 
-def get_shared_params() -> dict[str, dict[str, Any]]:
-    """Get shared/universal parameters from ExperimentConfig sub-models.
-
-    Returns params that are universal across all engines:
-    - Top-level: n, max_input_tokens, max_output_tokens, random_seed
-    - Dataset: source, n_prompts, order
-
-    Note: dtype and sampling params (temperature, top_k, top_p, etc.) are not
-    shared - they live per-engine on each engine's config section and are
-    discovered via :func:`get_engine_params`.
-    """
-    shared: dict[str, dict[str, Any]] = {}
-
-    shared["dataset.source"] = {
-        "path": "dataset.source",
-        "name": "source",
-        "type_str": "str",
-        "default": "aienergyscore",
-        "description": "Dataset source: built-in alias or .jsonl file path",
-        "options": None,
-        "test_values": ["aienergyscore"],
-        "constraints": {"min_length": 1},
-        "optional": False,
-        "engine_support": _ALL_ENGINES_LIST,
-    }
-    shared["dataset.n_prompts"] = {
-        "path": "dataset.n_prompts",
-        "name": "n_prompts",
-        "type_str": "int",
-        "default": 100,
-        "description": "Number of prompts to load",
-        "options": None,
-        "test_values": [10, 100, 500],
-        "constraints": {"ge": 1},
-        "optional": False,
-        "engine_support": _ALL_ENGINES_LIST,
-    }
-    shared["dataset.order"] = {
-        "path": "dataset.order",
-        "name": "order",
-        "type_str": "str",
-        "default": "interleaved",
-        "description": "Prompt ordering: interleaved, grouped, or shuffled",
-        "options": ["interleaved", "grouped", "shuffled"],
-        "test_values": ["interleaved", "grouped", "shuffled"],
-        "constraints": {},
-        "optional": False,
-        "engine_support": _ALL_ENGINES_LIST,
-    }
-    shared["max_input_tokens"] = {
-        "path": "max_input_tokens",
-        "name": "max_input_tokens",
-        "type_str": "int | None",
-        "default": 256,
-        "description": (
-            "Max input token length for truncation. Keeps computation workload "
-            "constant across experiments for fair comparison. None = no truncation."
-        ),
-        "options": None,
-        "test_values": [64, 128, 256, None],
-        "constraints": {"ge": 1},
-        "optional": True,
-        "engine_support": _ALL_ENGINES_LIST,
-    }
-    shared["max_output_tokens"] = {
-        "path": "max_output_tokens",
-        "name": "max_output_tokens",
-        "type_str": "int | None",
-        "default": 256,
-        "description": (
-            "Max output tokens (max_new_tokens for generation). "
-            "None = generate until EOS or model context limit."
-        ),
-        "options": None,
-        "test_values": [32, 128, 256, None],
-        "constraints": {"ge": 1},
-        "optional": True,
-        "engine_support": _ALL_ENGINES_LIST,
-    }
-
-    return shared
-
-
 def get_experiment_config_schema() -> dict[str, Any]:
     """Return the full ExperimentConfig JSON schema (Pydantic v2 schema).
 
@@ -426,178 +335,6 @@ def get_experiment_config_schema() -> dict[str, Any]:
     from llenergymeasure.config.models import ExperimentConfig
 
     return ExperimentConfig.model_json_schema()
-
-
-def get_all_params() -> dict[str, dict[str, dict[str, Any]]]:
-    """Get all parameters organised by engine + shared.
-
-    Returns:
-        {
-            "shared": {...},
-            "transformers": {...},
-            "vllm": {...},
-            "tensorrt": {...},
-        }
-    """
-    return {"shared": get_shared_params(), **{e: get_engine_params(e) for e in ALL_ENGINES}}
-
-
-def get_param_test_values(param_path: str) -> list[Any]:
-    """Get test values for a specific parameter.
-
-    Args:
-        param_path: Full param path, e.g., "transformers.batch_size" or "transformers.sampling.temperature".
-
-    Returns:
-        List of test values.
-    """
-    all_params = get_all_params()
-
-    for section in all_params.values():
-        if param_path in section:
-            test_values: list[Any] = section[param_path].get("test_values", [])
-            return test_values
-
-    return []
-
-
-def get_param_options(param_path: str) -> list[Any] | None:
-    """Get valid options for a Literal-typed parameter.
-
-    Args:
-        param_path: Full param path.
-
-    Returns:
-        List of options for Literal types, None otherwise.
-    """
-    all_params = get_all_params()
-
-    for section in all_params.values():
-        if param_path in section:
-            return section[param_path].get("options")
-
-    return None
-
-
-def list_all_param_paths(engine: str | None = None) -> list[str]:
-    """List all parameter paths, optionally filtered by engine.
-
-    Args:
-        engine: Optional engine filter ("transformers", "vllm", "tensorrt", "shared").
-
-    Returns:
-        Sorted list of param paths.
-    """
-    all_params = get_all_params()
-
-    if engine:
-        if engine not in all_params:
-            raise ValueError(f"Unknown engine: {engine}")
-        return sorted(all_params[engine].keys())
-
-    paths: list[str] = []
-    for section in all_params.values():
-        paths.extend(section.keys())
-    return sorted(set(paths))
-
-
-def get_engine_specific_params() -> dict[str, list[str]]:
-    """Get params that are only valid for specific engines.
-
-    Derived from the Pydantic engine models via ``get_engine_params`` - never
-    hand-maintained. Adding or removing a typed field in
-    ``engine_configs.py`` is automatically reflected here.
-
-    Fields reachable only through ``extra="allow"`` passthrough (e.g. dropped
-    typed fields still settable in YAML) are not included, since they are not
-    part of the typed contract this function describes.
-
-    Returns:
-        Dict mapping engine name to list of dotted param paths exclusive to
-        that engine.
-    """
-    return {engine: sorted(get_engine_params(engine).keys()) for engine in _ALL_ENGINES_LIST}
-
-
-def get_special_test_models() -> dict[str, str]:
-    """Get parameters that require special pre-quantized test models.
-
-    Some parameters (like AWQ/GPTQ quantization) require models that have
-    been pre-quantized with that method. Using a non-quantized model will fail.
-
-    Returns:
-        Dict mapping param value patterns to appropriate test model names.
-    """
-    return {
-        # vLLM quantization methods requiring pre-quantized models
-        "vllm.engine.quantization=awq": "Qwen/Qwen2.5-0.5B-Instruct-AWQ",
-        "vllm.engine.quantization=gptq": "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int4",
-        # TensorRT quantisation methods requiring pre-quantized models
-        "tensorrt.quant_config.quant_algo=W4A16_AWQ": "Qwen/Qwen2.5-0.5B-Instruct-AWQ",
-        "tensorrt.quant_config.quant_algo=W4A16_GPTQ": "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int4",
-    }
-
-
-def get_params_requiring_gpu_capability(min_compute_capability: float = 8.0) -> list[str]:
-    """Get params that require specific GPU compute capabilities.
-
-    Args:
-        min_compute_capability: Minimum compute capability (default 8.0 = Ampere).
-
-    Returns:
-        List of param paths that require the specified compute capability.
-    """
-    # These features require Ampere (8.0) or newer GPUs
-    ampere_required = [
-        "vllm.engine.quantization=fp8",
-        "tensorrt.quant_config.quant_algo=FP8",
-        "transformers.attn_implementation=flash_attention_2",
-        "transformers.attn_implementation=flash_attention_3",
-    ]
-
-    # These features require Hopper (9.0) or newer GPUs
-    hopper_required: list[str] = []
-
-    if min_compute_capability >= 9.0:
-        return ampere_required + hopper_required
-    return ampere_required
-
-
-def get_param_skip_conditions() -> dict[str, str]:
-    """Get conditions under which params should be skipped during testing.
-
-    Returns:
-        Dict mapping param paths to skip reasons for documentation/logging.
-    """
-    return {
-        # Multi-GPU params - skip if single GPU
-        "vllm.engine.tensor_parallel_size>1": "Requires 2+ GPUs",
-        "tensorrt.tensor_parallel_size>1": "Requires 2+ GPUs",
-        # Flash Attention 2 - requires flash-attn package
-        "transformers.attn_implementation=flash_attention_2": "Requires flash-attn package",
-        # Flash Attention 3 - requires flash_attn_3 package (built from flash-attn hopper/)
-        "transformers.attn_implementation=flash_attention_3": "Requires flash_attn_3 package (Ampere+ GPU, compute capability 8.0+)",
-        # torch.compile - may not work on all model architectures
-        "transformers.torch_compile=True": "May fail on some model architectures (non-fatal fallback)",
-        # FP8 - Ampere or newer
-        "vllm.engine.quantization=fp8": "Requires Ampere+ GPU",
-        "tensorrt.quant_config.quant_algo=FP8": "Requires Ada Lovelace+ GPU (SM >= 8.9)",
-        # TensorRT quantisation - requires pre-quantized models
-        "tensorrt.quant_config.quant_algo=W4A16_AWQ": "Requires AWQ-quantized model",
-        "tensorrt.quant_config.quant_algo=W4A16_GPTQ": "Requires GPTQ-quantized model",
-        # Quantization - requires pre-quantized models (see get_special_test_models)
-        "vllm.engine.quantization=awq": "Requires AWQ-quantized model",
-        "vllm.engine.quantization=gptq": "Requires GPTQ-quantized model",
-        # Transformers optional dependencies
-        "transformers.load_in_4bit": "Requires compatible bitsandbytes version",
-        "transformers.load_in_8bit": "Requires compatible bitsandbytes version",
-        # BitsAndBytes 4-bit sub-options
-        "transformers.bnb_4bit_compute_dtype": "Requires load_in_4bit=True and bitsandbytes package",
-        "transformers.bnb_4bit_quant_type": "Requires load_in_4bit=True and bitsandbytes package",
-        "transformers.bnb_4bit_use_double_quant": "Requires load_in_4bit=True and bitsandbytes package",
-        # Prompt lookup speculative decoding
-        "transformers.prompt_lookup_num_tokens": "Requires compatible model and sufficient prompt overlap",
-    }
 
 
 # =============================================================================

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
-from llenergymeasure.config.ssot import ALL_ENGINES
+from llenergymeasure.config.ssot import Engine
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
@@ -499,7 +499,9 @@ def get_capability_matrix_markdown() -> str:
         display_name = display_names.get(cap_key, cap_key)
         cells = []
 
-        for engine in ALL_ENGINES:
+        # Engine definition order matches the header above; ALL_ENGINES (a frozenset)
+        # has no stable order, which reordered/mislabelled the columns.
+        for engine in Engine:
             value = cap_values.get(engine, False)
             if value is True:
                 cells.append("Yes")

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -10,16 +10,12 @@ from __future__ import annotations
 import pytest
 
 from llenergymeasure.config.introspection import (
-    get_all_params,
     get_display_label,
     get_engine_params,
     get_experiment_config_schema,
     get_field_role,
-    get_param_test_values,
-    get_shared_params,
     get_swept_field_paths,
     get_validation_rules,
-    list_all_param_paths,
 )
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.config.ssot import DTYPE_SUPPORT
@@ -77,50 +73,6 @@ def test_get_engine_params_unknown_engine_raises():
 
 
 # ---------------------------------------------------------------------------
-# get_shared_params
-# ---------------------------------------------------------------------------
-
-
-def test_get_shared_params_returns_model_field():
-    """get_shared_params() returns dataset and decoder params.
-
-    dtype lives per-engine, not in the shared bucket. Shared now means
-    decoder.* params and dataset.* params.
-    """
-    params = get_shared_params()
-    assert isinstance(params, dict)
-    # Dataset params are shared
-    assert "dataset.n_prompts" in params
-
-
-def test_get_shared_params_does_not_contain_dtype():
-    """get_shared_params() does not expose 'dtype' - it's per-engine."""
-    params = get_shared_params()
-    assert "dtype" not in params
-
-
-def test_get_shared_params_contains_n():
-    """get_shared_params() contains 'dataset.n_prompts' (prompt count)."""
-    params = get_shared_params()
-    assert "dataset.n_prompts" in params
-
-
-def test_get_shared_params_no_longer_contains_decoder():
-    """Sampling params live per-engine - they're not in get_shared_params()."""
-    params = get_shared_params()
-    assert "decoder.temperature" not in params
-    assert "decoder.top_k" not in params
-
-
-def test_get_shared_params_all_have_engine_support():
-    """Every shared param has engine_support list."""
-    params = get_shared_params()
-    for param_path, meta in params.items():
-        assert "engine_support" in meta, f"Missing engine_support on {param_path}"
-        assert isinstance(meta["engine_support"], list)
-
-
-# ---------------------------------------------------------------------------
 # get_experiment_config_schema
 # ---------------------------------------------------------------------------
 
@@ -148,101 +100,6 @@ def test_get_experiment_config_schema_contains_engine_field():
 
 
 # ---------------------------------------------------------------------------
-# get_param_test_values (INF-11: SSOT-driven test value generation)
-# ---------------------------------------------------------------------------
-
-
-def test_get_param_test_values_pytorch_batch_size_returns_list():
-    """get_param_test_values('transformers.batch_size') returns a list containing 1."""
-    values = get_param_test_values("transformers.batch_size")
-    assert isinstance(values, list)
-    assert 1 in values
-
-
-def test_get_param_test_values_dtype_returns_all_options():
-    """get_param_test_values('transformers.dtype') returns all 3 dtype options."""
-    values = get_param_test_values("transformers.dtype")
-    assert set(values) == {"float32", "float16", "bfloat16"}
-
-
-def test_get_param_test_values_decoder_temperature_returns_floats():
-    """get_param_test_values('decoder.temperature') returns a list of floats."""
-    values = get_param_test_values("decoder.temperature")
-    assert isinstance(values, list)
-    assert all(isinstance(v, int | float) for v in values)
-
-
-def test_get_param_test_values_unknown_param_returns_empty():
-    """get_param_test_values for unknown param path returns empty list."""
-    values = get_param_test_values("nonexistent.param.path")
-    assert values == []
-
-
-# ---------------------------------------------------------------------------
-# get_all_params
-# ---------------------------------------------------------------------------
-
-
-def test_get_all_params_covers_all_engines():
-    """get_all_params() returns dict with 'transformers', 'vllm', 'tensorrt' keys."""
-    all_params = get_all_params()
-    assert "transformers" in all_params
-    assert "vllm" in all_params
-    assert "tensorrt" in all_params
-
-
-def test_get_all_params_has_shared_key():
-    """get_all_params() includes a 'shared' section."""
-    all_params = get_all_params()
-    assert "shared" in all_params
-
-
-def test_get_all_params_pytorch_section_contains_batch_size():
-    """get_all_params()['transformers'] contains the batch_size param."""
-    all_params = get_all_params()
-    assert "transformers.batch_size" in all_params["transformers"]
-
-
-# ---------------------------------------------------------------------------
-# list_all_param_paths
-# ---------------------------------------------------------------------------
-
-
-def test_list_all_param_paths_contains_expected_paths():
-    """list_all_param_paths() returns a sorted list containing known param paths."""
-    paths = list_all_param_paths()
-    assert isinstance(paths, list)
-    assert "transformers.batch_size" in paths
-    assert "transformers.dtype" in paths
-
-
-def test_list_all_param_paths_contains_known_paths():
-    """list_all_param_paths() contains expected well-known param paths."""
-    paths = list_all_param_paths()
-    assert "transformers.batch_size" in paths
-    # Sampling params live per-engine, not on a universal decoder
-    assert "transformers.sampling.temperature" in paths
-    assert "vllm.sampling.temperature" in paths
-    assert "tensorrt.sampling.temperature" in paths
-    # dtype also lives per-engine
-    assert "transformers.dtype" in paths
-    assert "vllm.dtype" in paths
-    assert "tensorrt.dtype" in paths
-
-
-def test_list_all_param_paths_filtered_by_engine():
-    """list_all_param_paths(engine='transformers') returns only pytorch paths."""
-    paths = list_all_param_paths(engine="transformers")
-    assert all(p.startswith("transformers.") for p in paths)
-
-
-def test_list_all_param_paths_unknown_engine_raises():
-    """list_all_param_paths with unknown engine raises ValueError."""
-    with pytest.raises(ValueError, match="Unknown engine"):
-        list_all_param_paths(engine="nonexistent")
-
-
-# ---------------------------------------------------------------------------
 # SSOT schema-driven test generation (INF-11)
 # ---------------------------------------------------------------------------
 
@@ -252,14 +109,6 @@ def test_all_pytorch_dtype_values_produce_valid_config(dt):
     """Schema-driven: each SSOT DTYPE_SUPPORT['transformers'] value creates a valid config."""
     config = make_config(dtype=dt)
     assert config.transformers.dtype == dt
-
-
-def test_ssot_dtype_values_match_param_test_values():
-    """DTYPE_SUPPORT['transformers'] values match get_param_test_values('transformers.dtype')."""
-    from_ssot = set(DTYPE_SUPPORT["transformers"])  # type: ignore[index]  # Engine is str-enum
-    from_introspection = set(get_param_test_values("transformers.dtype"))
-    # The test values from introspection should cover all SSOT dtype values
-    assert from_ssot == from_introspection
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of a stacked refactor/cleanup series (9/9), based on `refactor/cleanup-8-cli-api-decomp`.

## Summary
Config introspection cleanup + a real bug fix:
- Removes 9 dead `config/introspection.py` functions (5 zero-reference + 4 reachable only from their own tests) and a redundant ordered copy of the SSOT `ALL_ENGINES`. Verified doc-output-neutral (`make docs-all` byte-identical for deterministic docs).
- Fixes the capability-matrix column ordering: it iterated the unordered `ALL_ENGINES` frozenset against a hardcoded header, so columns were reordered/mislabelled and `invalid-combos.md` was non-deterministic. Now iterates the `Engine` enum (header order); the regenerated doc is included.
- Carries historical resume rows as the `_CompletedRow` NamedTuple (completes the 631694c7 migration at the producer->consumer seam).

## Commits
- refactor(config): drop dead introspection helpers and redundant engine list
- fix(config): order capability-matrix columns to match the header
- docs: regenerate invalid-combos after capability-matrix ordering fix
- refactor(cli): carry historical resume rows as _CompletedRow

## Test plan
Full suite green (2421 passed); ruff + mypy clean; make docs-check passes.
