### PR TITLE
fix: correctness bugs found in audit

### DIFF
--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -274,8 +274,8 @@ model, or package requirements.
 
 | Feature | Transformers | vLLM | TensorRT |
 |---------|---------|------|----------|
-| Tensor Parallel | Yes (HF native) | Yes | Yes |
-| Data Parallel | Yes | No | No |
+| Tensor Parallel | No | Yes | Yes |
+| Data Parallel | No | No | No |
 | BitsAndBytes (4-bit) | Yes | No | No |
 | BitsAndBytes (8-bit) | Yes | No | No |
 | Native Quantization | No | AWQ / GPTQ / FP8 | INT8 / W4A16 (AWQ/GPTQ) / FP8 |

--- a/docs/reference/engines/invalid-combos.md
+++ b/docs/reference/engines/invalid-combos.md
@@ -1,7 +1,7 @@
 # Invalid Parameter Combinations
 
 > Auto-generated from config validators and test results.
-> Last updated: 2026-06-19 12:24 UTC
+> Last updated: 2026-06-20 08:03 UTC
 
 This document lists parameter combinations that will fail validation or runtime.
 The tool validates these at config load time and provides clear error messages.
@@ -75,7 +75,7 @@ due to hardware, model, or package requirements.
 | Prefix Caching | No | Yes | No |
 | torch.compile | Yes | No | No |
 | Beam Search | Yes | Yes | No |
-| Speculative Decoding | Yes | No | No |
+| Speculative Decoding | Yes | Yes | No |
 | Static KV Cache | Yes | No | No |
 
 **Notes:**

--- a/src/llenergymeasure/cli/_vram.py
+++ b/src/llenergymeasure/cli/_vram.py
@@ -55,27 +55,28 @@ def estimate_vram(config: ExperimentConfig) -> dict[str, float] | None:
             ):
                 param_count = int(model_info.safetensors.total)
 
-            # Try to extract architecture details for KV cache estimation
+            # Try to extract architecture details for KV cache estimation.
+            # HF Hub's ModelInfo.config is a plain dict (the model's config.json
+            # contents) in production, so read via dict access; tolerate an
+            # attribute-style object too at this external-API edge.
             if hasattr(model_info, "config") and model_info.config is not None:
                 cfg = model_info.config
+
+                def _cfg_get(*names: str) -> object | None:
+                    for name in names:
+                        value = cfg.get(name) if isinstance(cfg, dict) else getattr(cfg, name, None)
+                        if value is not None:
+                            return value
+                    return None
+
                 # Common field names across model families
-                n_layers = (
-                    getattr(cfg, "num_hidden_layers", None)
-                    or getattr(cfg, "n_layer", None)
-                    or getattr(cfg, "num_layers", None)
-                )
-                n_heads = (
-                    getattr(cfg, "num_attention_heads", None)
-                    or getattr(cfg, "n_head", None)
-                    or getattr(cfg, "num_heads", None)
-                )
-                hidden_size = (
-                    getattr(cfg, "hidden_size", None)
-                    or getattr(cfg, "d_model", None)
-                    or getattr(cfg, "n_embd", None)
-                )
-                if n_heads and hidden_size:
-                    head_dim = hidden_size // n_heads
+                _n_layers = _cfg_get("num_hidden_layers", "n_layer", "num_layers")
+                _n_heads = _cfg_get("num_attention_heads", "n_head", "num_heads")
+                _hidden = _cfg_get("hidden_size", "d_model", "n_embd")
+                n_layers = int(_n_layers) if _n_layers is not None else None
+                n_heads = int(_n_heads) if _n_heads is not None else None
+                if n_heads and _hidden is not None:
+                    head_dim = int(_hidden) // n_heads
         finally:
             socket.setdefaulttimeout(original_timeout)
 

--- a/src/llenergymeasure/cli/_vram.py
+++ b/src/llenergymeasure/cli/_vram.py
@@ -6,6 +6,8 @@ try/except and return None on any failure. Network errors never block the CLI.
 
 from __future__ import annotations
 
+from typing import Any
+
 from llenergymeasure.config.models import ExperimentConfig
 
 # Bytes per parameter for each dtype.
@@ -62,7 +64,7 @@ def estimate_vram(config: ExperimentConfig) -> dict[str, float] | None:
             if hasattr(model_info, "config") and model_info.config is not None:
                 cfg = model_info.config
 
-                def _cfg_get(*names: str) -> object | None:
+                def _cfg_get(*names: str) -> Any:
                     for name in names:
                         value = cfg.get(name) if isinstance(cfg, dict) else getattr(cfg, name, None)
                         if value is not None:

--- a/src/llenergymeasure/config/engine_detection.py
+++ b/src/llenergymeasure/config/engine_detection.py
@@ -27,8 +27,7 @@ def is_engine_available(engine: str) -> bool:
             # Unknown engine
             return False
         return True
-    except (ImportError, OSError, Exception):
+    except (ImportError, OSError):
         # ImportError: package not installed
         # OSError: library dependency missing (tensorrt_llm on some systems)
-        # Exception: catch-all for any other import-time errors
         return False

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -451,7 +451,7 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
         },
         "speculative_decoding": {
             "transformers": "prompt_lookup_num_tokens" in transformers_fields,
-            "vllm": "speculative_model" in vllm_fields,
+            "vllm": "speculative_config" in vllm_fields,
             "tensorrt": False,
         },
         "static_kv_cache": {

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -127,6 +127,10 @@ TEMP_PREFIX_ENV_FILE: Final = "llem-env"
 TEMP_PREFIX_TIMESERIES: Final = "llem-ts-"
 """Prefix for temp directories holding timeseries parquet files."""
 
+STAGE_LINE_PREFIX: Final = "[llem.baseline]"
+"""Wire-protocol line prefix for baseline stage markers: emitted by
+entrypoints/baseline_measure._emit_stage and parsed by study/baseline_container."""
+
 # ---------------------------------------------------------------------------
 # Subprocess / thread timeout constants (seconds)
 # ---------------------------------------------------------------------------
@@ -211,6 +215,7 @@ __all__ = [
     "RUNNER_LOCAL",
     "SAMPLING_PRESETS",
     "SOURCE_MULTI_ENGINE_ELEVATION",
+    "STAGE_LINE_PREFIX",
     "TEMP_PREFIX_ENV_FILE",
     "TEMP_PREFIX_EXCHANGE",
     "TEMP_PREFIX_TIMESERIES",

--- a/src/llenergymeasure/energy/__init__.py
+++ b/src/llenergymeasure/energy/__init__.py
@@ -27,18 +27,12 @@ Usage::
 from __future__ import annotations
 
 import importlib.util
-from typing import TYPE_CHECKING
 
 from llenergymeasure.energy.base import EnergySampler  # canonical definition
+from llenergymeasure.energy.codecarbon import CodeCarbonSampler
 from llenergymeasure.energy.nvml import EnergyMeasurement, NVMLSampler
 from llenergymeasure.energy.zeus import ZeusSampler
 from llenergymeasure.utils.exceptions import ConfigError
-
-if TYPE_CHECKING:
-    from llenergymeasure.energy.codecarbon import (
-        CodeCarbonSampler as CodeCarbonSampler,
-    )
-
 
 # ---------------------------------------------------------------------------
 # v2.0 auto-selection API
@@ -110,8 +104,6 @@ def _auto_select(gpu_indices: list[int] | None = None) -> EnergySampler | None:
 
     # CodeCarbon - software fallback (no gpu_indices: CodeCarbon handles its own GPU detection)
     if importlib.util.find_spec("codecarbon") is not None:
-        from llenergymeasure.energy.codecarbon import CodeCarbonSampler
-
         cc_sampler = CodeCarbonSampler()
         if cc_sampler.is_available():
             return cc_sampler
@@ -138,8 +130,6 @@ def _instantiate(name: str, gpu_indices: list[int] | None = None) -> EnergySampl
     if name == "zeus":
         return ZeusSampler(gpu_indices=gpu_indices)
     if name == "codecarbon":
-        from llenergymeasure.energy.codecarbon import CodeCarbonSampler
-
         return CodeCarbonSampler()
 
     known = ", ".join(["nvml", "zeus", "codecarbon", "auto"])

--- a/src/llenergymeasure/energy/codecarbon.py
+++ b/src/llenergymeasure/energy/codecarbon.py
@@ -7,7 +7,7 @@ import warnings
 from dataclasses import dataclass
 from typing import Any
 
-from llenergymeasure.domain.metrics import EnergyMetrics
+from llenergymeasure.energy.nvml import EnergyMeasurement
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,7 @@ class CodeCarbonData:
     ram_energy: float | None
     total_energy_kwh: float
     emissions_kg: float | None
+    duration_sec: float
 
 
 class CodeCarbonSampler:
@@ -104,40 +105,34 @@ class CodeCarbonSampler:
             logger.warning("Continuing without energy metrics (common in containers)")
             return None
 
-    def stop_tracking(self, tracker: Any) -> EnergyMetrics:
-        """Stop tracking and return energy metrics.
+    def stop_tracking(self, tracker: Any) -> EnergyMeasurement:
+        """Stop tracking and return energy measurement.
+
+        Mirrors the NVML/Zeus backends: returns an :class:`EnergyMeasurement`
+        with ``total_j`` and ``duration_sec``. CodeCarbon tracks at the process
+        level and does not expose a per-GPU breakdown, so ``per_gpu_j`` is None.
 
         Args:
             tracker: EmissionsTracker from start_tracking.
 
         Returns:
-            EnergyMetrics with collected data.
+            EnergyMeasurement with collected energy data.
         """
         if tracker is None:
-            logger.debug("Energy tracker was unavailable, returning empty metrics")
-            return self._empty_metrics()
+            logger.debug("Energy tracker was unavailable, returning empty measurement")
+            return self._empty_measurement()
 
         try:
             tracker.stop()
             data = self._extract_data(tracker)
-            return self._convert_to_metrics(data)
+            return self._convert_to_measurement(data)
         except Exception as e:
             logger.warning("Failed to stop energy tracking: %s", e)
-            return self._empty_metrics()
+            return self._empty_measurement()
 
-    def _empty_metrics(self) -> EnergyMetrics:
-        """Return empty metrics for error cases."""
-        return EnergyMetrics(
-            total_energy_j=0.0,
-            gpu_energy_j=0.0,
-            cpu_energy_j=0.0,
-            ram_energy_j=0.0,
-            gpu_power_w=0.0,
-            cpu_power_w=0.0,
-            duration_sec=0.0,
-            emissions_kg_co2=0.0,
-            energy_per_token_j=0.0,
-        )
+    def _empty_measurement(self) -> EnergyMeasurement:
+        """Return an empty measurement for error cases."""
+        return EnergyMeasurement(total_j=0.0, duration_sec=0.0, samples=[], per_gpu_j=None)
 
     def _extract_data(self, tracker: Any) -> CodeCarbonData:
         """Extract data from the tracker."""
@@ -154,6 +149,7 @@ class CodeCarbonSampler:
                 ram_energy=None,
                 total_energy_kwh=0.0,
                 emissions_kg=None,
+                duration_sec=0.0,
             )
 
         energy_kwh = getattr(emissions_data, "energy_consumed", 0.0) or 0.0
@@ -167,30 +163,17 @@ class CodeCarbonSampler:
             ram_energy=getattr(emissions_data, "ram_energy", None),
             total_energy_kwh=energy_kwh,
             emissions_kg=getattr(emissions_data, "emissions", None),
+            duration_sec=getattr(emissions_data, "duration", 0.0) or 0.0,
         )
 
-    def _convert_to_metrics(self, data: CodeCarbonData) -> EnergyMetrics:
-        """Convert CodeCarbon data to our EnergyMetrics format."""
+    def _convert_to_measurement(self, data: CodeCarbonData) -> EnergyMeasurement:
+        """Convert CodeCarbon data to the shared EnergyMeasurement shape."""
         # Convert kWh to Joules (1 kWh = 3.6e6 J)
-        total_energy_j = data.total_energy_kwh * 3.6e6
+        total_j = data.total_energy_kwh * 3.6e6
 
-        # Convert individual energy values (if available)
-        gpu_energy_j = (data.gpu_energy or 0.0) * 3.6e6 if data.gpu_energy else 0.0
-        cpu_energy_j = (data.cpu_energy or 0.0) * 3.6e6 if data.cpu_energy else 0.0
-        ram_energy_j = (data.ram_energy or 0.0) * 3.6e6 if data.ram_energy else 0.0
-
-        # Duration is difficult to get from CodeCarbon directly
-        # We'll set it to 0 here - the caller should set it from their timing
-        duration_sec = 0.0
-
-        return EnergyMetrics(
-            total_energy_j=total_energy_j,
-            gpu_energy_j=gpu_energy_j,
-            cpu_energy_j=cpu_energy_j,
-            ram_energy_j=ram_energy_j,
-            gpu_power_w=data.gpu_power or 0.0,
-            cpu_power_w=data.cpu_power or 0.0,
-            duration_sec=duration_sec,
-            emissions_kg_co2=data.emissions_kg or 0.0,
-            energy_per_token_j=0.0,  # Caller should set this
+        return EnergyMeasurement(
+            total_j=total_j,
+            duration_sec=data.duration_sec,
+            samples=[],
+            per_gpu_j=None,
         )

--- a/src/llenergymeasure/entrypoints/baseline_measure.py
+++ b/src/llenergymeasure/entrypoints/baseline_measure.py
@@ -44,18 +44,11 @@ import sys
 import traceback
 from pathlib import Path
 
-from llenergymeasure.config.ssot import ENV_BASELINE_SPEC_PATH
+from llenergymeasure.config.ssot import ENV_BASELINE_SPEC_PATH, STAGE_LINE_PREFIX
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["_emit_stage", "_prime_cuda", "main", "run_baseline_measurement"]
-
-
-# Line prefix for stage markers emitted to stdout. The host dispatcher
-# (``study/baseline_container.py``) matches this prefix when streaming the
-# subprocess output line-by-line, so it can surface live sub-step progress
-# in the CLI instead of the user staring at a single spinner for ~30s.
-STAGE_LINE_PREFIX = "[llem.baseline]"
 
 
 def _emit_stage(name: str, **kv: object) -> None:

--- a/src/llenergymeasure/harness/warmup.py
+++ b/src/llenergymeasure/harness/warmup.py
@@ -86,9 +86,11 @@ def warmup_until_converged(
     final_cv: float | None = None
 
     # Fixed mode: run exactly n_warmup prompts without convergence checking.
-    # CV mode: run up to max_prompts with convergence checking after min_prompts.
+    # CV mode: run n_warmup base prompts FIRST (no early-break), then keep going
+    # with convergence checking up to max_prompts ADDITIONAL prompts. CV is
+    # additive to n_warmup, so the total budget is n_warmup + max_prompts.
     fixed_mode = not config.convergence_detection
-    iteration_limit = config.n_warmup if fixed_mode else config.max_prompts
+    iteration_limit = config.n_warmup if fixed_mode else config.n_warmup + config.max_prompts
 
     for i in range(iteration_limit):
         try:
@@ -99,14 +101,18 @@ def warmup_until_converged(
 
         latencies.append(latency_ms)
 
+        # The first n_warmup iterations are the fixed base; convergence checking
+        # only applies to the additive CV phase that follows them.
+        in_cv_phase = not fixed_mode and len(latencies) > config.n_warmup
+
         # Compute CV whenever we have 2+ samples (minimum for meaningful std dev).
-        # In fixed mode this is informational; in convergence mode it drives early-break.
+        # In fixed mode / base phase this is informational; in the CV phase it drives early-break.
         if len(latencies) >= 2:
             recent = latencies[-config.window_size :]
             final_cv = compute_cv(recent)
 
             if (
-                not fixed_mode
+                in_cv_phase
                 and len(latencies) >= max(config.min_prompts, config.window_size)
                 and final_cv < config.cv_threshold
             ):

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -30,9 +30,9 @@ from pathlib import Path
 from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
     ENV_BASELINE_SPEC_PATH,
+    STAGE_LINE_PREFIX,
     TEMP_PREFIX_EXCHANGE,
 )
-from llenergymeasure.entrypoints.baseline_measure import STAGE_LINE_PREFIX
 from llenergymeasure.harness.baseline import BaselineCache
 
 logger = logging.getLogger(__name__)

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -32,6 +32,7 @@ from llenergymeasure.config.ssot import (
     ENV_BASELINE_SPEC_PATH,
     TEMP_PREFIX_EXCHANGE,
 )
+from llenergymeasure.entrypoints.baseline_measure import STAGE_LINE_PREFIX
 from llenergymeasure.harness.baseline import BaselineCache
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,10 @@ __all__ = [
 # Positional args: (stage_name, elapsed_since_subprocess_start, kv_tags).
 StageCallback = Callable[[str, float, "dict[str, str]"], None]
 
-_STAGE_LINE_PREFIX = "[llem.baseline] stage="
+# Full marker the producer (entrypoints/baseline_measure._emit_stage) prints:
+# "<STAGE_LINE_PREFIX> stage=<name> ...". Derived from the producer's exported
+# prefix so the two sides cannot drift.
+_STAGE_LINE_PREFIX = f"{STAGE_LINE_PREFIX} stage="
 
 
 BASELINE_SPEC_FILENAME = "baseline_spec.json"

--- a/tests/unit/cli/test_vram.py
+++ b/tests/unit/cli/test_vram.py
@@ -37,20 +37,15 @@ def _make_model_info(param_count: int | None = _LLAMA_7B_PARAMS, with_config: bo
     else:
         model_info.safetensors = None
 
-    # architecture config (Llama-2-7B defaults)
+    # architecture config (Llama-2-7B defaults).
+    # HF Hub's ModelInfo.config is a plain dict in production, so the mock must
+    # be a dict too - an attribute-style object would mask the dict-access bug.
     if with_config:
-        cfg = SimpleNamespace(
-            num_hidden_layers=32,
-            num_attention_heads=32,
-            hidden_size=4096,
-            n_layer=None,
-            n_head=None,
-            num_layers=None,
-            num_heads=None,
-            d_model=None,
-            n_embd=None,
-        )
-        model_info.config = cfg
+        model_info.config = {
+            "num_hidden_layers": 32,
+            "num_attention_heads": 32,
+            "hidden_size": 4096,
+        }
     else:
         model_info.config = None
 

--- a/tests/unit/config/test_engine_detection.py
+++ b/tests/unit/config/test_engine_detection.py
@@ -92,8 +92,13 @@ class TestIsEngineAvailable:
 
         assert result is False
 
-    def test_handles_generic_exception_during_import(self):
-        """Unexpected exception during import should be caught and return False."""
+    def test_unexpected_error_during_import_propagates(self):
+        """A non-import error during import propagates (not masked as 'unavailable').
+
+        Only ImportError / OSError mean "engine not installed"; an unexpected
+        error (e.g. a CUDA init failure inside the package) is a real bug and
+        must surface rather than being silently swallowed.
+        """
         import llenergymeasure.config.engine_detection as _bd_mod
 
         real_import = __import__
@@ -107,11 +112,10 @@ class TestIsEngineAvailable:
         with _hide_module("vllm"):
             _bd_mod.__builtins__["__import__"] = _raise_runtime  # type: ignore[index]
             try:
-                result = is_engine_available("vllm")
+                with pytest.raises(RuntimeError, match="CUDA init failed"):
+                    is_engine_available("vllm")
             finally:
                 if original_builtins_import is not None:
                     _bd_mod.__builtins__["__import__"] = original_builtins_import  # type: ignore[index]
                 else:
                     del _bd_mod.__builtins__["__import__"]  # type: ignore[attr-defined]
-
-        assert result is False

--- a/tests/unit/energy/test_energy_backends_v2.py
+++ b/tests/unit/energy/test_energy_backends_v2.py
@@ -435,3 +435,52 @@ def test_nvml_multi_gpu_energy_per_gpu_dict_populated() -> None:
         result.per_gpu_j[0] + result.per_gpu_j[1] + result.per_gpu_j[2],
         abs=1e-9,
     )
+
+
+# ---------------------------------------------------------------------------
+# CodeCarbonSampler - protocol shape (total_j / per_gpu_j)
+# ---------------------------------------------------------------------------
+
+
+def test_codecarbon_backend_name() -> None:
+    """CodeCarbonSampler.name must return 'codecarbon'."""
+    from llenergymeasure.energy.codecarbon import CodeCarbonSampler
+
+    assert CodeCarbonSampler().name == "codecarbon"
+
+
+def test_codecarbon_stop_tracking_returns_energy_measurement() -> None:
+    """stop_tracking() returns an EnergyMeasurement exposing total_j and per_gpu_j.
+
+    The harness reads ``.total_j`` and ``.per_gpu_j``; CodeCarbon must mirror the
+    NVML/Zeus return shape, not the old EnergyMetrics(total_energy_j=...) shape.
+    """
+    from llenergymeasure.energy.codecarbon import CodeCarbonSampler
+
+    # Mock tracker whose _prepare_emissions_data() yields kWh + duration.
+    emissions_data = MagicMock()
+    emissions_data.energy_consumed = 0.003  # kWh -> 10800 J
+    emissions_data.duration = 12.5
+    emissions_data.gpu_power = 200.0
+    emissions_data.cpu_power = 10.0
+    emissions_data.emissions = 0.0001
+    tracker = MagicMock()
+    tracker._prepare_emissions_data.return_value = emissions_data
+
+    result = CodeCarbonSampler().stop_tracking(tracker)
+
+    assert isinstance(result, EnergyMeasurement)
+    # Protocol fields the harness depends on:
+    assert result.total_j == pytest.approx(0.003 * 3.6e6, abs=1e-6)
+    assert result.duration_sec == pytest.approx(12.5)
+    assert result.per_gpu_j is None  # CodeCarbon is process-level, no per-GPU split
+
+
+def test_codecarbon_stop_tracking_none_tracker_is_empty() -> None:
+    """stop_tracking(None) returns a zeroed EnergyMeasurement, not a crash."""
+    from llenergymeasure.energy.codecarbon import CodeCarbonSampler
+
+    result = CodeCarbonSampler().stop_tracking(None)
+    assert isinstance(result, EnergyMeasurement)
+    assert result.total_j == 0.0
+    assert result.per_gpu_j is None

--- a/tests/unit/engines/test_helpers.py
+++ b/tests/unit/engines/test_helpers.py
@@ -142,7 +142,11 @@ def test_warmup_cv_mode_does_not_converge_with_high_variance():
 
 
 def test_warmup_cv_mode_respects_max_prompts():
-    """CV mode stops at max_prompts even without convergence."""
+    """CV mode stops at n_warmup + max_prompts even without convergence.
+
+    CV is additive to n_warmup: the n_warmup base prompts run first, then up to
+    max_prompts convergence prompts, so the total budget is the sum.
+    """
     config = WarmupConfig(
         n_warmup=1,
         convergence_detection=True,
@@ -160,7 +164,7 @@ def test_warmup_cv_mode_respects_max_prompts():
         return 1.0 if call_count[0] % 2 == 0 else 100.0
 
     warmup_until_converged(_run, config)
-    assert call_count[0] <= config.max_prompts
+    assert call_count[0] <= config.n_warmup + config.max_prompts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/harness/test_warmup_v2.py
+++ b/tests/unit/harness/test_warmup_v2.py
@@ -153,6 +153,66 @@ def test_warmup_cv_mode_converges() -> None:
     assert result.iterations_completed <= config.max_prompts
 
 
+def test_warmup_cv_mode_runs_n_warmup_base_before_converging() -> None:
+    """CV is additive to n_warmup: the base n_warmup prompts run before convergence.
+
+    With constant latency (CV=0) and a non-default n_warmup=4, convergence must
+    not trigger during the base phase. The earliest possible convergence is one
+    iteration into the CV phase, once min_prompts/window_size are also satisfied.
+    """
+    call_count = 0
+
+    def stable_inference() -> float:
+        nonlocal call_count
+        call_count += 1
+        return 10.0  # constant -> CV=0.0
+
+    config = WarmupConfig(
+        n_warmup=4,
+        convergence_detection=True,
+        cv_threshold=0.1,
+        max_prompts=30,
+        window_size=3,
+        min_prompts=3,
+        thermal_floor_seconds=30.0,
+    )
+
+    result = warmup_until_converged(stable_inference, config)
+
+    assert result.converged is True
+    # Base phase (4) must complete before the CV phase can early-break, so the
+    # total must exceed n_warmup. (First CV-phase iteration is the 5th.)
+    assert result.iterations_completed > config.n_warmup
+    assert call_count == result.iterations_completed
+
+
+def test_warmup_cv_mode_budget_is_n_warmup_plus_max_prompts() -> None:
+    """When CV never converges, total iterations = n_warmup + max_prompts (additive)."""
+    call_count = 0
+
+    def noisy_inference() -> float:
+        nonlocal call_count
+        call_count += 1
+        # Alternate widely so CV never drops below threshold.
+        return 10.0 if call_count % 2 == 0 else 1000.0
+
+    config = WarmupConfig(
+        n_warmup=3,
+        convergence_detection=True,
+        cv_threshold=0.01,
+        max_prompts=6,
+        window_size=3,
+        min_prompts=3,
+        thermal_floor_seconds=30.0,
+    )
+
+    result = warmup_until_converged(noisy_inference, config)
+
+    assert result.converged is False
+    assert result.iterations_completed == config.n_warmup + config.max_prompts
+    assert call_count == config.n_warmup + config.max_prompts
+
+
 def test_warmup_disabled_skips() -> None:
     """When enabled=False, warmup returns immediately with converged=True."""
     call_count = 0


### PR DESCRIPTION
Correctness bugs from the audit: codecarbon backend returned the wrong shape (crashed when selected) and now returns total_j/per_gpu_j matching NVML/Zeus; the _vram KV-cache estimate was always 0.0 (dict-vs-attr on HF ModelInfo.config); the capability matrix tested a renamed field (speculative_config); a CodeCarbonSampler __all__ NameError on import *; and an over-broad except was narrowed. invalid-combos.md regenerated for the speculative capability change. Stacked on #fix-audit-1.