### PR TITLE
refactor: concision and de-duplication cleanup

### DIFF
--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -6,6 +6,7 @@ This module is internal (underscore prefix). Import via llenergymeasure.__init__
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any, overload
@@ -24,6 +25,8 @@ from llenergymeasure.domain.progress import ProgressCallback
 from llenergymeasure.infra.runner_resolution import RunnerSpec
 from llenergymeasure.study.single import run_single_experiment
 from llenergymeasure.utils.exceptions import ConfigError
+
+logger = logging.getLogger(__name__)
 
 # Single source of truth for n_prompts default - derived from DatasetConfig field default
 # so run_experiment() kwargs and DatasetConfig always agree.
@@ -485,11 +488,7 @@ def _resolve_runner_specs(
     multi-engine studies without Docker, or auto-elevating when available), emits
     preflight progress, and warns when the study mixes local and Docker runners.
     """
-    import logging
-
     from llenergymeasure.study.preflight import run_study_preflight
-
-    _api_logger = logging.getLogger(__name__)
 
     if preresolved is not None:
         runner_specs, system_overrides = preresolved
@@ -516,7 +515,7 @@ def _resolve_runner_specs(
     # Warn on mixed runners (some local, some docker)
     modes = {spec.mode for spec in runner_specs.values()}
     if len(modes) > 1:
-        _api_logger.warning(
+        logger.warning(
             "Mixed runners detected. For consistent measurements, "
             "consider running all engines in Docker."
         )
@@ -535,9 +534,6 @@ def _write_study_artefacts(
     the system-overrides record, and the software environment snapshot. Each write is
     best-effort and logs on failure rather than aborting the run.
     """
-    import logging
-
-    _api_logger = logging.getLogger(__name__)
 
     # Identity fields for all study-level artefacts
     _study_hash = study.study_design_hash or ""
@@ -550,9 +546,9 @@ def _write_study_artefacts(
             original = Path(config_path).read_text(encoding="utf-8")
             header = f"# study_design_hash: {_study_hash} | study_name: {_study_name}\n"
             dest.write_text(header + original, encoding="utf-8")
-            _api_logger.info("Config YAML copied to %s", dest)
+            logger.info("Config YAML copied to %s", dest)
         except FileNotFoundError:
-            _api_logger.warning("Config YAML %s not found, skipping copy", config_path)
+            logger.warning("Config YAML %s not found, skipping copy", config_path)
 
     # Persist skipped config details to _study-artefacts/.
     if study.skipped_configs:
@@ -570,9 +566,9 @@ def _write_study_artefacts(
             overrides_path.write_text(
                 json.dumps(overrides_with_identity, indent=2), encoding="utf-8"
             )
-            _api_logger.info("System overrides written to %s", overrides_path)
+            logger.info("System overrides written to %s", overrides_path)
         except OSError as exc:
-            _api_logger.warning("Failed to write system_overrides.json: %s", exc)
+            logger.warning("Failed to write system_overrides.json: %s", exc)
 
     # Write study-level environment.json (installed_packages + software constants).
     try:
@@ -586,9 +582,9 @@ def _write_study_artefacts(
         }
         env_path = artefacts_dir / "environment.json"
         env_path.write_text(json.dumps(study_env, indent=2), encoding="utf-8")
-        _api_logger.info("Study-level environment written to %s", env_path)
+        logger.info("Study-level environment written to %s", env_path)
     except Exception as exc:
-        _api_logger.warning("Failed to write study-level environment.json: %s", exc)
+        logger.warning("Failed to write study-level environment.json: %s", exc)
 
 
 def _build_resolution_logs(
@@ -599,10 +595,6 @@ def _build_resolution_logs(
     Computed once here so runners don't need to know about resolution logic.
     Best-effort: returns whatever was built before any failure.
     """
-    import logging
-
-    _api_logger = logging.getLogger(__name__)
-
     resolution_logs: dict[str, dict[str, Any]] = {}
     try:
         from llenergymeasure.config.introspection import get_swept_field_paths
@@ -622,7 +614,7 @@ def _build_resolution_logs(
                 swept_fields=swept_fields,
             )
     except Exception as exc:
-        _api_logger.debug("Failed to build resolution logs: %s", exc)
+        logger.debug("Failed to build resolution logs: %s", exc)
     return resolution_logs
 
 

--- a/src/llenergymeasure/api/report_gaps.py
+++ b/src/llenergymeasure/api/report_gaps.py
@@ -49,6 +49,7 @@ from llenergymeasure.config.engine_invariants import (
 from llenergymeasure.config.ssot import Engine
 from llenergymeasure.study.message_normalise import build_template_regex, normalise
 from llenergymeasure.study.runtime_observations import RUNTIME_OBSERVATIONS_FILENAME
+from llenergymeasure.utils.io import load_json
 
 __all__ = [
     "GapProposal",
@@ -465,7 +466,7 @@ def _load_kwargs_via_manifest(
     study_dir: Path, manifest_path: Path
 ) -> tuple[dict[str, dict[str, Any]], int]:
     try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = load_json(manifest_path)
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Failed to read manifest.json at %s: %s", manifest_path, exc)
         return {}, 0
@@ -528,7 +529,7 @@ def _read_resolution_sidecar(
 ) -> tuple[dict[str, Any] | None, bool]:
     """Parse ``_resolution.json`` at ``path``; return (flat_dict or None, failed)."""
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = load_json(path)
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Failed to parse _resolution.json at %s: %s", path, exc)
         return None, True

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -142,6 +142,7 @@ def run(
     from llenergymeasure.cli import _setup_logging
 
     _setup_logging(verbose)
+    verbose_on = verbose > 0
 
     # Install SIGINT handler so Ctrl-C exits with code 130
     def _handle_sigint(signum: int, frame: Any) -> None:
@@ -160,7 +161,7 @@ def run(
             output=output,
             dry_run=dry_run,
             quiet=quiet,
-            verbose=verbose > 0,
+            verbose=verbose_on,
             cycles=cycles,
             order=order,
             no_gaps=no_gaps,
@@ -174,10 +175,10 @@ def run(
             no_dedup=no_dedup,
         )
     except ConfigError as e:
-        print(format_error(e, verbose=verbose > 0), file=sys.stderr)
+        print(format_error(e, verbose=verbose_on), file=sys.stderr)
         raise typer.Exit(code=2) from None
     except (PreFlightError, ExperimentError, EngineError, StudyError) as e:
-        print(format_error(e, verbose=verbose > 0), file=sys.stderr)
+        print(format_error(e, verbose=verbose_on), file=sys.stderr)
         raise typer.Exit(code=1) from None
     except ValidationError as e:
         print(format_validation_error(e), file=sys.stderr)
@@ -765,9 +766,7 @@ def _run_study_impl(
         study_display.start(print_header=False)
 
     # Track elapsed time around the study run
-    import time as _time
-
-    _study_start = _time.monotonic()
+    _study_start = time.monotonic()
 
     # Run the study with live progress display.
     # skip_preflight=True because we already ran preflight above.
@@ -791,7 +790,7 @@ def _run_study_impl(
         if study_display is not None:
             study_display.stop()
 
-    _study_elapsed = _time.monotonic() - _study_start
+    _study_elapsed = time.monotonic() - _study_start
 
     # Study completion footer
     if study_display is not None:

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -31,6 +31,24 @@ from llenergymeasure.config.ssot import Engine
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
+
+def _literal_options(field_info: FieldInfo | None) -> list[str]:
+    """Extract the string options from an ``Optional[Literal[...]]`` field.
+
+    Returns an empty list when the field is missing, unannotated, or not a
+    Literal union.
+    """
+    if not field_info or not field_info.annotation:
+        return []
+    for arg in get_args(field_info.annotation):
+        if arg is type(None):
+            continue
+        inner_args = get_args(arg)
+        if inner_args:
+            return [a for a in inner_args if a is not None]
+    return []
+
+
 # =============================================================================
 # Field Metadata Helpers (SSOT display labels and roles)
 # =============================================================================
@@ -367,27 +385,8 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
     tensorrt_fields = set(TensorRTConfig.model_fields.keys())
 
     # Get quantization Literal values for vLLM and TensorRT
-    vllm_quant_field = VLLMEngineConfig.model_fields.get("quantization")
-    vllm_quant_options: list[str] = []
-    if vllm_quant_field and vllm_quant_field.annotation:
-        args = get_args(vllm_quant_field.annotation)
-        # Filter out None from Optional[Literal[...]]
-        for arg in args:
-            if arg is not type(None):
-                inner_args = get_args(arg)
-                if inner_args:
-                    vllm_quant_options = [a for a in inner_args if a is not None]
-
-    trt_quant_field = TensorRTQuantConfig.model_fields.get("quant_algo")
-    trt_quant_options: list[str] = []
-    if trt_quant_field and trt_quant_field.annotation:
-        args = get_args(trt_quant_field.annotation)
-        # Filter out None from Optional[Literal[...]]
-        for arg in args:
-            if arg is not type(None):
-                inner_args = get_args(arg)
-                if inner_args:
-                    trt_quant_options = [a for a in inner_args if a is not None]
+    vllm_quant_options = _literal_options(VLLMEngineConfig.model_fields.get("quantization"))
+    trt_quant_options = _literal_options(TensorRTQuantConfig.model_fields.get("quant_algo"))
 
     return {
         "tensor_parallel": {

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from llenergymeasure.config.ssot import SAMPLING_PRESETS, Engine
 from llenergymeasure.config.warnings import ConfigValidationWarning
+from llenergymeasure.domain.experiment import engine_str
 
 logger = logging.getLogger(__name__)
 
@@ -393,7 +394,7 @@ class ExperimentConfig(BaseModel):
         if not preset_name or preset_name not in SAMPLING_PRESETS:
             return data
         engine = data.get("engine", Engine.TRANSFORMERS)
-        engine_key = engine.value if hasattr(engine, "value") else str(engine)
+        engine_key = engine_str(engine)
         # Ensure the engine section and its sampling sub-dict exist as dicts
         # (an explicit ``engine: null`` in YAML would otherwise leave None here).
         engine_section = data.get(engine_key)

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -24,9 +24,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from llenergymeasure.config.ssot import SAMPLING_PRESETS, Engine
+from llenergymeasure.config.ssot import SAMPLING_PRESETS, Engine, engine_str
 from llenergymeasure.config.warnings import ConfigValidationWarning
-from llenergymeasure.domain.experiment import engine_str
 
 logger = logging.getLogger(__name__)
 

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -58,6 +58,12 @@ class Engine(str, Enum):
 ALL_ENGINES: Final[frozenset[Engine]] = frozenset(Engine)
 """Unordered engine set - use for O(1) membership checks (``engine in ALL_ENGINES``)."""
 
+
+def engine_str(engine: Any) -> str:
+    """Coerce an Engine enum (or plain string) to its string value."""
+    return engine.value if hasattr(engine, "value") else str(engine)
+
+
 # ---------------------------------------------------------------------------
 # Runner mode constants
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/config/user_config.py
+++ b/src/llenergymeasure/config/user_config.py
@@ -66,12 +66,7 @@ class UserRunnersConfig(BaseModel):
                     f"Singularity runner not yet supported (runners.{field_name}='{value}'). "
                     "Use 'auto', 'local', 'docker', or 'docker:<image>'."
                 )
-            if (
-                value != "auto"
-                and value != "local"
-                and value != "docker"
-                and not value.startswith("docker:")
-            ):
+            if value not in {"auto", "local", "docker"} and not value.startswith("docker:"):
                 raise ValueError(
                     f"runners.{field_name}: expected 'auto', 'local', 'docker', or 'docker:<image>', "
                     f"got '{value}'"

--- a/src/llenergymeasure/device/environment.py
+++ b/src/llenergymeasure/device/environment.py
@@ -7,8 +7,8 @@ with reasonable defaults instead of crashing.
 
 import importlib.util
 import logging
-import os
 import platform
+import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -23,6 +23,7 @@ from llenergymeasure.domain.environment import (
     GPUEnvironment,
     ThermalEnvironment,
 )
+from llenergymeasure.utils.formatting import bytes_to_mb
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ def _collect_gpu(pynvml: Any, handle: Any) -> GPUEnvironment:
 
     try:
         mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-        vram_total_mb = mem_info.total / (1024 * 1024)
+        vram_total_mb = bytes_to_mb(mem_info.total)
         logger.debug("Environment: VRAM = %.0f MB", vram_total_mb)
     except pynvml.NVMLError as e:
         logger.debug("Environment: failed to get memory info: %s", e)
@@ -199,7 +200,7 @@ def _collect_cpu() -> CPUEnvironment:
 
 def _collect_container() -> ContainerEnvironment:
     """Detect container runtime."""
-    detected = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+    detected = Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
     runtime: str | None = None
 
     if detected:
@@ -227,9 +228,9 @@ def _collect_container() -> ContainerEnvironment:
 
 def _detect_container_runtime() -> str | None:
     """Detect which container runtime is in use."""
-    if os.path.exists("/.dockerenv"):
+    if Path("/.dockerenv").exists():
         return "docker"
-    if os.path.exists("/run/.containerenv"):
+    if Path("/run/.containerenv").exists():
         return "podman"
     return None
 
@@ -270,8 +271,6 @@ def detect_cuda_version_with_source() -> tuple[str | None, str | None]:
             logger.debug("CUDA version: torch source failed", exc_info=True)
 
     # Source 2: /usr/local/cuda/version.txt or version.json
-    import re
-
     for version_file in (
         "/usr/local/cuda/version.txt",
         "/usr/local/cuda/version.json",

--- a/src/llenergymeasure/device/power_thermal.py
+++ b/src/llenergymeasure/device/power_thermal.py
@@ -17,8 +17,17 @@ from dataclasses import dataclass
 
 from llenergymeasure.device.gpu_info import nvml_context
 from llenergymeasure.domain.metrics import ThermalThrottleInfo
+from llenergymeasure.utils.formatting import bytes_to_mb
 
 logger = logging.getLogger(__name__)
+
+
+def _throttle_bit(pynvml: object, new_name: str, old_name: str) -> int:
+    """Resolve an NVML clocks-reason bit by its new (NVML 12+) or legacy name.
+
+    Returns 0 when neither constant is present, so the bit is simply never set.
+    """
+    return getattr(pynvml, new_name, getattr(pynvml, old_name, 0))
 
 
 @dataclass
@@ -147,7 +156,7 @@ class PowerThermalSampler:
                     "nvmlClocksThrottleReasonHwThermalSlowdown",
                 ),
             ]:
-                thermal_bits |= getattr(pynvml, attr_new, getattr(pynvml, attr_old, 0))
+                thermal_bits |= _throttle_bit(pynvml, attr_new, attr_old)
 
             # Prefer non-deprecated clock reasons query (NVML 12+)
             _get_clocks_reasons = getattr(
@@ -175,8 +184,8 @@ class PowerThermalSampler:
                             # Memory
                             try:
                                 mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-                                sample.memory_used_mb = mem_info.used / (1024 * 1024)
-                                sample.memory_total_mb = mem_info.total / (1024 * 1024)
+                                sample.memory_used_mb = bytes_to_mb(mem_info.used)
+                                sample.memory_total_mb = bytes_to_mb(mem_info.total)
                             except pynvml.NVMLError:
                                 pass
 
@@ -244,25 +253,25 @@ class PowerThermalSampler:
             for s in self._samples:
                 combined_reasons |= s.throttle_reasons
 
-            hw_thermal_bit = getattr(
+            hw_thermal_bit = _throttle_bit(
                 pynvml,
                 "nvmlClocksEventReasonHwThermalSlowdown",
-                getattr(pynvml, "nvmlClocksThrottleReasonHwThermalSlowdown", 0),
+                "nvmlClocksThrottleReasonHwThermalSlowdown",
             )
-            sw_thermal_bit = getattr(
+            sw_thermal_bit = _throttle_bit(
                 pynvml,
                 "nvmlClocksEventReasonSwThermalSlowdown",
-                getattr(pynvml, "nvmlClocksThrottleReasonSwThermalSlowdown", 0),
+                "nvmlClocksThrottleReasonSwThermalSlowdown",
             )
-            power_bit = getattr(
+            power_bit = _throttle_bit(
                 pynvml,
                 "nvmlClocksEventReasonSwPowerCap",
-                getattr(pynvml, "nvmlClocksThrottleReasonSwPowerCap", 0),
+                "nvmlClocksThrottleReasonSwPowerCap",
             )
-            hw_power_bit = getattr(
+            hw_power_bit = _throttle_bit(
                 pynvml,
                 "nvmlClocksEventReasonHwPowerBrakeSlowdown",
-                getattr(pynvml, "nvmlClocksThrottleReasonHwPowerBrakeSlowdown", 0),
+                "nvmlClocksThrottleReasonHwPowerBrakeSlowdown",
             )
             # Combined "any thermal" bit: True if either hw or sw thermal throttling occurred
             thermal_bit = hw_thermal_bit | sw_thermal_bit

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
 
+def engine_str(engine: Any) -> str:
+    """Coerce an Engine enum (or plain string) to its string value."""
+    return engine.value if hasattr(engine, "value") else str(engine)
+
+
 @functools.lru_cache(maxsize=128)
 def _hash_canonical(canonical: str) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()[:16]

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -23,11 +23,6 @@ if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
 
-def engine_str(engine: Any) -> str:
-    """Coerce an Engine enum (or plain string) to its string value."""
-    return engine.value if hasattr(engine, "value") else str(engine)
-
-
 @functools.lru_cache(maxsize=128)
 def _hash_canonical(canonical: str) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()[:16]

--- a/src/llenergymeasure/engines/_cuda.py
+++ b/src/llenergymeasure/engines/_cuda.py
@@ -10,6 +10,8 @@ import gc
 import logging
 from typing import Any
 
+from llenergymeasure.utils.formatting import bytes_to_mb
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +38,7 @@ def get_cuda_peak_memory_mb() -> float:
         import torch
 
         if torch.cuda.is_available():
-            return torch.cuda.max_memory_allocated() / (1024 * 1024)  # type: ignore[no-any-return]
+            return bytes_to_mb(torch.cuda.max_memory_allocated())
     except Exception:
         pass
     return 0.0

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -178,13 +178,7 @@ class TensorRTEngine:
 
         gpu_arch = get_gpu_architecture()
 
-        trt_version = "unknown"
-        try:
-            import tensorrt_llm as _trt
-
-            trt_version = getattr(_trt, "__version__", "unknown")
-        except Exception:
-            pass
+        trt_version = getattr(_trt_mod, "__version__", "unknown")
 
         build_start = time.perf_counter()
 
@@ -256,8 +250,6 @@ class TensorRTEngine:
         Raises:
             EngineError: On OOM or other inference failures.
         """
-        import time
-
         llm, sampling_params = model
 
         # Reset peak stats before the measurement loop

--- a/src/llenergymeasure/engines/transformers/plugin.py
+++ b/src/llenergymeasure/engines/transformers/plugin.py
@@ -11,6 +11,7 @@ warmup_until_converged(), model.generate() inference loop, and cleanup.
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -36,8 +37,6 @@ class _TimingStreamer:
         self._prompt_seen = False
 
     def put(self, value: Any) -> None:
-        import time
-
         # The first put() carries the prompt input_ids (a 2-D tensor); drop it so
         # only generated-token arrivals are timed.
         if not self._prompt_seen:
@@ -92,27 +91,25 @@ class TransformersEngine:
         Returns:
             Tuple of (model, tokenizer).
         """
-        import time as _time
-
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         kwargs = self._model_load_kwargs(config)
         logger.info("Loading model %r with kwargs: %s", config.task.model, list(kwargs.keys()))
 
-        t0 = _time.perf_counter()
+        t0 = time.perf_counter()
         tokenizer = AutoTokenizer.from_pretrained(
             config.task.model, trust_remote_code=kwargs.get("trust_remote_code", False)
         )
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
         if on_substep is not None:
-            on_substep("tokenizer loaded", _time.perf_counter() - t0)
+            on_substep("tokenizer loaded", time.perf_counter() - t0)
 
-        t0 = _time.perf_counter()
+        t0 = time.perf_counter()
         model = AutoModelForCausalLM.from_pretrained(config.task.model, **kwargs)
         model.eval()
         if on_substep is not None:
-            on_substep("model weights loaded", _time.perf_counter() - t0)
+            on_substep("model weights loaded", time.perf_counter() - t0)
 
         # Apply allow_tf32 (Ampere+ TF32 toggle)
         if config.transformers is not None and config.transformers.allow_tf32 is not None:
@@ -127,11 +124,11 @@ class TransformersEngine:
             mode = config.transformers.torch_compile_mode or "default"
             backend = config.transformers.torch_compile_backend or "inductor"
             try:
-                t0 = _time.perf_counter()
+                t0 = time.perf_counter()
                 model = _torch.compile(model, mode=mode, backend=backend)  # type: ignore[assignment]
                 logger.debug("torch.compile applied (mode=%s, backend=%s)", mode, backend)
                 if on_substep is not None:
-                    on_substep(f"torch.compile ({mode})", _time.perf_counter() - t0)
+                    on_substep(f"torch.compile ({mode})", time.perf_counter() - t0)
             except Exception as e:
                 logger.warning("torch.compile failed (non-fatal, continuing without): %s", e)
 
@@ -153,8 +150,6 @@ class TransformersEngine:
         Returns:
             Latency in milliseconds.
         """
-        import time
-
         import torch
 
         hf_model, tokenizer = model
@@ -264,10 +259,8 @@ class TransformersEngine:
             batch = prompts[batch_start : batch_start + batch_size]
             try:
                 if profiling:
-                    import time as _time
-
                     streamer = _TimingStreamer()
-                    t0_ms = _time.perf_counter() * 1000.0
+                    t0_ms = time.perf_counter() * 1000.0
                     batch_input, batch_output, batch_time, batch_padding = self._run_batch(
                         hf_model, tokenizer, config, batch, generate_kwargs, streamer=streamer
                     )
@@ -631,8 +624,6 @@ class TransformersEngine:
         When ``streamer`` is provided (latency profiling), it is forwarded to
         ``generate(streamer=...)`` so per-token arrival times are recorded.
         """
-        import time
-
         import torch
 
         tokenizer_kwargs: dict[str, Any] = {

--- a/src/llenergymeasure/engines/vllm/plugin.py
+++ b/src/llenergymeasure/engines/vllm/plugin.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import time as _time
+import time
 from collections.abc import Callable
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.engines.protocol import InferenceOutput
 from llenergymeasure.utils.exceptions import EngineError
+from llenergymeasure.utils.formatting import bytes_to_mb
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ def _capture_kv_cache_stats(llm: Any) -> dict[str, Any] | None:
             block_bytes = getattr(cache_config, "block_size_bytes", None)
             if isinstance(block_bytes, int) and block_bytes > 0:
                 kv_bytes = usage * num_gpu_blocks * block_bytes
-                stats["kv_cache_mb"] = kv_bytes / (1024 * 1024)
+                stats["kv_cache_mb"] = bytes_to_mb(kv_bytes)
 
     return stats or None
 
@@ -150,10 +151,10 @@ class VLLMEngine:
         )
 
         try:
-            t0 = _time.perf_counter()
+            t0 = time.perf_counter()
             llm = LLM(**kwargs)
             if on_substep is not None:
-                on_substep("vLLM engine loaded", _time.perf_counter() - t0)
+                on_substep("vLLM engine loaded", time.perf_counter() - t0)
         except Exception as e:
             raise EngineError(f"vLLM model loading failed: {e}") from e
 
@@ -217,8 +218,6 @@ class VLLMEngine:
         Raises:
             EngineError: On OOM or other inference failures.
         """
-        import time
-
         from llenergymeasure.engines._cuda import reset_cuda_peak_memory
 
         llm, sampling_params = model
@@ -269,9 +268,9 @@ class VLLMEngine:
             try:
                 import torch
 
-                total_vram = torch.cuda.get_device_properties(
-                    torch.cuda.current_device()
-                ).total_memory / (1024 * 1024)
+                total_vram = bytes_to_mb(
+                    torch.cuda.get_device_properties(torch.cuda.current_device()).total_memory
+                )
                 vllm_cfg = config.vllm
                 gpu_util = 0.9  # vLLM default
                 if (
@@ -581,7 +580,7 @@ class VLLMEngine:
             with nvml_context():
                 handle = pynvml.nvmlDeviceGetHandleByIndex(0)
                 info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-                mem_mb = float(info.used) / (1024 * 1024)
+                mem_mb = bytes_to_mb(float(info.used))
             return mem_mb
         except Exception:
             return None

--- a/src/llenergymeasure/entrypoints/baseline_measure.py
+++ b/src/llenergymeasure/entrypoints/baseline_measure.py
@@ -45,6 +45,7 @@ import traceback
 from pathlib import Path
 
 from llenergymeasure.config.ssot import ENV_BASELINE_SPEC_PATH, STAGE_LINE_PREFIX
+from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ def run_baseline_measurement(spec_path: Path) -> Path:
         measure_spot_check,
     )
 
-    raw = json.loads(spec_path.read_text(encoding="utf-8"))
+    raw = load_json(spec_path)
     mode = raw.get("mode")
     gpu_indices = list(raw.get("gpu_indices") or [])
     duration_sec = float(raw.get("duration_sec", 30.0))

--- a/src/llenergymeasure/entrypoints/container.py
+++ b/src/llenergymeasure/entrypoints/container.py
@@ -39,6 +39,7 @@ from llenergymeasure.config.ssot import (
     ENV_OUTPUT_DIR,
     ENV_SAVE_TIMESERIES,
 )
+from llenergymeasure.utils.io import load_json
 
 __all__ = ["StreamProgressCallback", "main", "run_container_experiment"]
 
@@ -167,7 +168,7 @@ def run_container_experiment(config_path: Path, result_dir: Path) -> Path:
     from llenergymeasure.infra.version_handshake import compute_expconf_fingerprint
 
     # --- Deserialise config ---
-    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    raw = load_json(config_path)
     config = ExperimentConfig.model_validate(raw)
 
     # Diagnostic: log container-side fingerprint so post-mortem analysis can

--- a/src/llenergymeasure/harness/baseline.py
+++ b/src/llenergymeasure/harness/baseline.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from llenergymeasure.device.gpu_info import nvml_context
 from llenergymeasure.domain.metrics import EnergyBreakdown
+from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
 
@@ -312,7 +313,7 @@ def load_baseline_cache(path: Path, ttl: float = 1800.0) -> BaselineCache | None
         return None
 
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw = load_json(path)
     except (json.JSONDecodeError, OSError) as exc:
         logger.warning("Failed to read baseline cache %s: %s", path, exc)
         return None

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -32,6 +32,7 @@ from llenergymeasure.domain.progress import STEP_BASELINE
 from llenergymeasure.energy import select_energy_sampler
 from llenergymeasure.engines.protocol import EnginePlugin, InferenceOutput
 from llenergymeasure.harness.warmup import thermal_floor_wait, warmup_until_converged
+from llenergymeasure.utils.formatting import bytes_to_mb
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
@@ -351,9 +352,6 @@ class MeasurementHarness:
         """
         _p = progress
 
-        def _substep(step: str, text: str, elapsed: float = 0.0) -> None:
-            _emit_substep(_p, step, text, elapsed)
-
         if baseline is not None and config.measurement.baseline.enabled:
             # For cached/validated strategies, progress events are emitted by
             # study/runner.py::_get_baseline. Here we only mark from_cache for
@@ -375,7 +373,8 @@ class MeasurementHarness:
             baseline = measure_baseline_power(dur, gpu_indices=gpu_indices)
             if baseline is not None:
                 cache_label = " (cached)" if baseline.from_cache else ""
-                _substep(
+                _emit_substep(
+                    _p,
                     STEP_BASELINE,
                     f"baseline: {baseline.power_w:.1f}W"
                     f" ({baseline.sample_count} samples{cache_label})",
@@ -405,9 +404,6 @@ class MeasurementHarness:
         """
         _p = progress
 
-        def _substep(step: str, text: str, elapsed: float = 0.0) -> None:
-            _emit_substep(_p, step, text, elapsed)
-
         # 3. Load model via engine plugin
         if _p:
             _p.on_step_start("model", "Loading", f"model {config.task.model}")
@@ -415,7 +411,7 @@ class MeasurementHarness:
 
         # Build model substep callback
         def _on_model_substep(text: str, elapsed: float) -> None:
-            _substep("model", text, elapsed)
+            _emit_substep(_p, "model", text, elapsed)
 
         model = engine.load_model(config, on_substep=_on_model_substep)
 
@@ -430,7 +426,7 @@ class MeasurementHarness:
         # Must happen BEFORE warmup, which allocates KV cache.
         model_memory_mb = self._capture_model_memory_mb(gpu_indices=gpu_indices)
         if model_memory_mb > 0:
-            _substep("model", f"model memory: {model_memory_mb:.0f}MB")
+            _emit_substep(_p, "model", f"model memory: {model_memory_mb:.0f}MB")
 
         return model, snapshot, model_memory_mb
 
@@ -442,9 +438,6 @@ class MeasurementHarness:
         """Load and tokenise prompts before the measurement window (methodology fix)."""
         _p = progress
 
-        def _substep(step: str, text: str, elapsed: float = 0.0) -> None:
-            _emit_substep(_p, step, text, elapsed)
-
         if _p:
             _p.on_step_start(
                 "prompts",
@@ -454,7 +447,7 @@ class MeasurementHarness:
             t0_prompts = time.perf_counter()
         prompts = load_prompts(config)
         logger.debug("Loaded %d prompts via dataset loader", len(prompts))
-        _substep("prompts", f"tokenised {len(prompts)} prompts")
+        _emit_substep(_p, "prompts", f"tokenised {len(prompts)} prompts")
         if _p:
             _p.on_step_done("prompts", time.perf_counter() - t0_prompts)
         return prompts
@@ -472,9 +465,6 @@ class MeasurementHarness:
         Returns the WarmupResult with thermal_floor_wait_s populated.
         """
         _p = progress
-
-        def _substep(step: str, text: str, elapsed: float = 0.0) -> None:
-            _emit_substep(_p, step, text, elapsed)
 
         # 5. Warmup
         if _p:
@@ -522,7 +512,8 @@ class MeasurementHarness:
                 _p.on_step_update("warmup", f"{iters_label} ({converged}{cv_info})")
             _p.on_step_done("warmup", time.perf_counter() - t0_warmup)
         iters = warmup_result.iterations_completed
-        _substep(
+        _emit_substep(
+            _p,
             "warmup",
             f"{iters} iteration{'s' if iters != 1 else ''}"
             + (f"  CV={warmup_result.final_cv:.1%}" if warmup_result.final_cv > 0 else ""),
@@ -565,9 +556,6 @@ class MeasurementHarness:
         """
         _p = progress
 
-        def _substep(step: str, text: str, elapsed: float = 0.0) -> None:
-            _emit_substep(_p, step, text, elapsed)
-
         # 7. Select energy sampler
         if _p:
             _p.on_step_start("energy_select", "Selecting", "energy sampler")
@@ -576,7 +564,7 @@ class MeasurementHarness:
             config.measurement.energy_sampler, gpu_indices=gpu_indices
         )
         sampler_name = type(energy_sampler).__name__ if energy_sampler else "none"
-        _substep("energy_select", f"selected: {sampler_name}")
+        _emit_substep(_p, "energy_select", f"selected: {sampler_name}")
         if _p:
             _p.on_step_update("energy_select", f"energy sampler ({sampler_name})")
             _p.on_step_done("energy_select", time.perf_counter() - t0_energy)
@@ -588,13 +576,13 @@ class MeasurementHarness:
 
         # 9. CUDA sync before inference (Zeus best practice)
         _cuda_sync()
-        _substep("measure", "CUDA sync (pre)")
+        _emit_substep(_p, "measure", "CUDA sync (pre)")
 
         if _p:
             _p.on_step_start(
                 "measure", "Measuring", f"inference ({config.task.dataset.n_prompts} prompts)"
             )
-        _substep("measure", "energy tracker started")
+        _emit_substep(_p, "measure", "energy tracker started")
 
         t_inference_start = time.perf_counter()
         start_time = datetime.now()
@@ -607,7 +595,7 @@ class MeasurementHarness:
 
         # 11. CUDA sync after inference, before stopping energy
         _cuda_sync()
-        _substep("measure", "CUDA sync (post)")
+        _emit_substep(_p, "measure", "CUDA sync (post)")
 
         # 11a. Capture observed params post-window (outside NVML sampling).
         # Must run here - model is still alive; capture overhead (~5-50 ms pure
@@ -628,7 +616,7 @@ class MeasurementHarness:
         if energy_sampler is not None and energy_tracker is not None:
             energy_measurement = energy_sampler.stop_tracking(energy_tracker)
             tracker_duration = energy_measurement.duration_sec if energy_measurement else 0.0
-            _substep("measure", f"energy tracker stopped  {tracker_duration:.1f}s")
+            _emit_substep(_p, "measure", f"energy tracker stopped  {tracker_duration:.1f}s")
         end_time = datetime.now()
 
         # 13. FLOPs estimation (warmup tokens excluded)
@@ -641,7 +629,7 @@ class MeasurementHarness:
                 _p.on_step_update("flops", f"FLOPs: {flops_result.value:.2e}")
             _p.on_step_done("flops", time.perf_counter() - t0_flops)
         if flops_result is not None:
-            _substep("flops", f"FLOPs: {flops_result.value:.2e}")
+            _emit_substep(_p, "flops", f"FLOPs: {flops_result.value:.2e}")
 
         return _MeasuredWindow(
             output=output,
@@ -672,9 +660,6 @@ class MeasurementHarness:
         """Write the timeseries + config sidecars and assemble the ExperimentResult."""
         _p = progress
 
-        def _substep(step: str, text: str, elapsed: float = 0.0) -> None:
-            _emit_substep(_p, step, text, elapsed)
-
         # 14. Write timeseries Parquet sidecar (if output_dir set and save_timeseries enabled)
         resolved_output_dir = Path(output_dir) if output_dir is not None else None
         if _p:
@@ -692,7 +677,7 @@ class MeasurementHarness:
                 resolved_output_dir / "timeseries.parquet",
             )
             timeseries_path = ts_file.name  # relative name in result JSON
-            _substep("save", "timeseries parquet written")
+            _emit_substep(_p, "save", "timeseries parquet written")
 
         # 15. Collect measurement quality warnings
         duration_sec = (window.end_time - window.start_time).total_seconds()
@@ -722,7 +707,7 @@ class MeasurementHarness:
             warmup_result=warmup_result,
             prompt_count=prompt_count,
         )
-        _substep("save", "result assembled")
+        _emit_substep(_p, "save", "result assembled")
 
         # 17. Write config.json sidecar (observed-params + observed_config_hash)
         # Written to output_dir (temp dir, same as timeseries.parquet) so the
@@ -734,7 +719,7 @@ class MeasurementHarness:
                 result=result,
                 output_dir=resolved_output_dir,
             )
-            _substep("save", "config sidecar written")
+            _emit_substep(_p, "save", "config sidecar written")
 
         if _p:
             _p.on_step_done("save", time.perf_counter() - t0_save)
@@ -813,7 +798,7 @@ class MeasurementHarness:
                     if not indices:
                         return 0.0
                     peak = max(torch.cuda.max_memory_allocated(device=idx) for idx in indices)
-                    return float(peak / (1024 * 1024))
+                    return bytes_to_mb(peak)
             except Exception:
                 pass
         return 0.0

--- a/src/llenergymeasure/harness/preflight.py
+++ b/src/llenergymeasure/harness/preflight.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.config.ssot import ENGINE_PACKAGES, Engine
 from llenergymeasure.utils.exceptions import PreFlightError
+from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ def _check_model_accessible(model_id: str) -> str | None:
     (including when we cannot determine reachability).
     """
     # Local path - starts with /, ./, or ~
-    if model_id.startswith("/") or model_id.startswith("./") or model_id.startswith("~"):
+    if model_id.startswith(("/", "./", "~")):
         path = Path(model_id).expanduser()
         if not path.exists():
             return f"{model_id} not found - path does not exist"
@@ -108,10 +109,10 @@ def _read_model_quant_method(model_id: str) -> str | None:
 
     config_data: dict[str, object] | None = None
 
-    if model_id.startswith("/") or model_id.startswith("./") or model_id.startswith("~"):
+    if model_id.startswith(("/", "./", "~")):
         config_path = Path(model_id).expanduser() / "config.json"
         try:
-            config_data = json.loads(config_path.read_text())
+            config_data = load_json(config_path)
         except (OSError, json.JSONDecodeError) as exc:
             logger.debug("Could not read local config.json for %s: %s", model_id, exc)
             return None
@@ -122,7 +123,7 @@ def _read_model_quant_method(model_id: str) -> str | None:
             from huggingface_hub import hf_hub_download
 
             local = hf_hub_download(repo_id=model_id, filename="config.json")
-            config_data = json.loads(Path(local).read_text())
+            config_data = load_json(local)
         except Exception as exc:
             logger.debug("Could not fetch HF config.json for %s: %s", model_id, exc)
             return None

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -64,6 +64,7 @@ from llenergymeasure.infra.docker_errors import (
     translate_docker_error,
 )
 from llenergymeasure.utils.exceptions import DockerError
+from llenergymeasure.utils.io import load_json
 
 __all__ = ["DockerRunner"]
 
@@ -392,7 +393,7 @@ class DockerRunner:
                 error_json_path = exchange_dir / f"{config_hash}_error.json"
                 error: DockerError
                 if error_json_path.exists():
-                    payload = json.loads(error_json_path.read_text(encoding="utf-8"))
+                    payload = load_json(error_json_path)
                     error = DockerContainerError(
                         message=f"{payload.get('type', 'UnknownError')}: {payload.get('message', '')}",
                         fix_suggestion="Check the error traceback in the error JSON for details.",
@@ -810,6 +811,19 @@ class DockerRunner:
             except Exception as exc:
                 logger.debug("Watchdog cleanup %s failed: %s", stage, exc)
 
+    def _mount_if_absent(
+        self, cmd: list[str], host: str | Path, container: str, *, extra_env: str | None = None
+    ) -> None:
+        """Append ``-v host:container`` unless the user already mounts ``container``.
+
+        Optionally appends ``-e <extra_env>`` after the mount (e.g. HF_HOME).
+        """
+        if any(cp == container for _, cp in self.extra_mounts):
+            return
+        cmd.extend(["-v", f"{host}:{container}"])
+        if extra_env is not None:
+            cmd.extend(["-e", extra_env])
+
     def _build_docker_cmd(
         self,
         config: Any,
@@ -873,27 +887,26 @@ class DockerRunner:
 
         # TRT-LLM engine cache: persist compiled engines across ephemeral containers
         if config.engine == Engine.TENSORRT:
-            cache_host = str(Path.home() / ".cache" / "trt-llm")
-            cache_container = "/root/.cache/trt-llm"
-            # Only add if not already in extra_mounts (user may override path)
-            if not any(cp == cache_container for _, cp in self.extra_mounts):
-                cmd.extend(["-v", f"{cache_host}:{cache_container}"])
+            self._mount_if_absent(
+                cmd, str(Path.home() / ".cache" / "trt-llm"), "/root/.cache/trt-llm"
+            )
 
         # Auto-mount the host HuggingFace cache so model weights persist across
         # ephemeral containers; otherwise each run re-downloads the full model.
-        hf_cache_host = Path.home() / ".cache" / "huggingface"
         hf_cache_container = "/root/.cache/huggingface"
-        if not any(cp == hf_cache_container for _, cp in self.extra_mounts):
-            cmd.extend(["-v", f"{hf_cache_host}:{hf_cache_container}"])
-            cmd.extend(["-e", f"HF_HOME={hf_cache_container}"])
+        self._mount_if_absent(
+            cmd,
+            Path.home() / ".cache" / "huggingface",
+            hf_cache_container,
+            extra_env=f"HF_HOME={hf_cache_container}",
+        )
 
         # Auto-mount the host flashinfer JIT cache so TRT-LLM warm runs reuse
         # already-compiled per-arch attention kernels (cold compile is minutes).
         if config.engine == Engine.TENSORRT:
-            fi_cache_host = Path.home() / ".cache" / "flashinfer"
-            fi_cache_container = "/root/.cache/flashinfer"
-            if not any(cp == fi_cache_container for _, cp in self.extra_mounts):
-                cmd.extend(["-v", f"{fi_cache_host}:{fi_cache_container}"])
+            self._mount_if_absent(
+                cmd, Path.home() / ".cache" / "flashinfer", "/root/.cache/flashinfer"
+            )
 
         # Forward LLEM_* env vars into the container so framework defaults set
         # on the host (e.g. LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP) reach the
@@ -999,7 +1012,7 @@ class DockerRunner:
                 fix_suggestion="Check container logs for errors during experiment execution.",
             )
 
-        raw = json.loads(result_path.read_text(encoding="utf-8"))
+        raw = load_json(result_path)
 
         # Container may write an error payload even on exit 0 (defensive check).
         # Error payloads have "type" and "traceback" keys (mirror StudyRunner worker format).

--- a/src/llenergymeasure/infra/image_registry.py
+++ b/src/llenergymeasure/infra/image_registry.py
@@ -106,18 +106,29 @@ def get_default_image(engine: str) -> str:
     return ghcr_image
 
 
+def inspect_image(image: str, *, timeout: float) -> subprocess.CompletedProcess[bytes] | None:
+    """Run ``docker image inspect <image>``; return the result or None on failure.
+
+    Returns None when docker is missing, the call times out, or the OS rejects
+    it (``FileNotFoundError`` / ``TimeoutExpired`` / ``OSError``). A non-zero
+    return code is NOT a failure here - the ``CompletedProcess`` is returned and
+    the caller inspects ``returncode`` / ``stdout``.
+    """
+    try:
+        return subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
 @lru_cache(maxsize=8)
 def _image_exists_locally(image: str) -> bool:
     """Check whether a Docker image tag exists in the local cache."""
-    try:
-        result = subprocess.run(
-            ["docker", "image", "inspect", image],
-            capture_output=True,
-            timeout=TIMEOUT_DOCKER_CLI,
-        )
-        return result.returncode == 0
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return False
+    result = inspect_image(image, timeout=TIMEOUT_DOCKER_CLI)
+    return result is not None and result.returncode == 0
 
 
 def resolve_image(

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from functools import cache, lru_cache
 
 from llenergymeasure.config.ssot import ENGINE_PACKAGES, TIMEOUT_DOCKER_INSPECT, Engine
+from llenergymeasure.infra.image_registry import inspect_image
 from llenergymeasure.utils.compat import StrEnum
 
 __all__ = [
@@ -340,14 +341,9 @@ def inspect_image_stamp(image: str, *, timeout: float = TIMEOUT_DOCKER_INSPECT) 
     timeout, JSON parse error, missing labels). The caller decides whether the
     absence of labels is a warning or an error.
     """
-    try:
-        result = subprocess.run(
-            ["docker", "image", "inspect", image],
-            capture_output=True,
-            timeout=timeout,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        logger.debug("docker image inspect failed for %s: %s", image, exc)
+    result = inspect_image(image, timeout=timeout)
+    if result is None:
+        logger.debug("docker image inspect failed for %s", image)
         return _EMPTY_STAMP
 
     if result.returncode != 0:

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -34,6 +34,7 @@ from llenergymeasure.config.ssot import (
     TEMP_PREFIX_EXCHANGE,
 )
 from llenergymeasure.harness.baseline import BaselineCache
+from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +261,7 @@ def run_baseline_container(
         )
         if error_path.exists():
             try:
-                err = json.loads(error_path.read_text(encoding="utf-8"))
+                err = load_json(error_path)
                 logger.warning(
                     "Baseline container error payload: type=%s message=%s",
                     err.get("type"),
@@ -279,7 +280,7 @@ def run_baseline_container(
         return None
 
     try:
-        raw = json.loads(result_path.read_text(encoding="utf-8"))
+        raw = load_json(result_path)
     except (json.JSONDecodeError, OSError) as exc:
         logger.warning(
             "Baseline container wrote a malformed result: %s. Exchange dir preserved at %s.",

--- a/src/llenergymeasure/study/gpu_memory.py
+++ b/src/llenergymeasure/study/gpu_memory.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 
 from llenergymeasure.device.gpu_info import nvml_context
+from llenergymeasure.utils.formatting import bytes_to_mb
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ def check_gpu_memory_residual(
         try:
             handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
             mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            used_mb = mem_info.used / (1024 * 1024)
+            used_mb = bytes_to_mb(mem_info.used)
         except Exception as e:
             logger.debug("GPU memory check failed: %s", e)
             return

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.domain.experiment import engine_str
 from llenergymeasure.domain.hashing import ConfigHashView, hash_config
 
 __all__ = [
@@ -38,7 +39,7 @@ def build_resolved_view(config: ExperimentConfig) -> ConfigHashView:
     into its own dict so the resolved-config / observed-config ordering separates
     "how the engine constructs" from "what it generates with".
     """
-    engine_name = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    engine_name = engine_str(config.engine)
     section: Any = getattr(config, engine_name, None)
     dump: dict[str, Any] = section.model_dump(mode="python") if section is not None else {}
     sampling = dump.pop("sampling", None) or {}

--- a/src/llenergymeasure/study/hashing.py
+++ b/src/llenergymeasure/study/hashing.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.domain.experiment import engine_str
+from llenergymeasure.config.ssot import engine_str
 from llenergymeasure.domain.hashing import ConfigHashView, hash_config
 
 __all__ = [

--- a/src/llenergymeasure/study/image_prep.py
+++ b/src/llenergymeasure/study/image_prep.py
@@ -26,6 +26,7 @@ from llenergymeasure.config.ssot import (
     RUNNER_DOCKER,
     TIMEOUT_DOCKER_INSPECT,
 )
+from llenergymeasure.infra.image_registry import inspect_image
 from llenergymeasure.infra.version_handshake import (
     ENV_SKIP_IMAGE_CHECK,
     LABEL_SCHEMA_FINGERPRINT,
@@ -156,14 +157,7 @@ class _ImageMixin:
             t0 = time.monotonic()
 
             # Check if image exists locally
-            try:
-                check = subprocess.run(
-                    ["docker", "image", "inspect", image],
-                    capture_output=True,
-                    timeout=TIMEOUT_DOCKER_INSPECT,
-                )
-            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-                check = None
+            check = inspect_image(image, timeout=TIMEOUT_DOCKER_INSPECT)
 
             if check is not None and check.returncode == 0:
                 elapsed = time.monotonic() - t0

--- a/src/llenergymeasure/study/library_resolution.py
+++ b/src/llenergymeasure/study/library_resolution.py
@@ -30,6 +30,7 @@ from llenergymeasure.config.engine_invariants.loader import (
     resolve_field_path,
 )
 from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.domain.experiment import engine_str
 from llenergymeasure.study.hashing import build_resolved_view, hash_config
 
 logger = logging.getLogger(__name__)
@@ -256,7 +257,7 @@ def resolve_library_effective(
     def _invariants_for(cfg: ExperimentConfig) -> tuple[Invariant, ...]:
         if explicit_rules is not None:
             return explicit_rules
-        engine = cfg.engine.value if hasattr(cfg.engine, "value") else str(cfg.engine)
+        engine = engine_str(cfg.engine)
         try:
             return resolved_loader.load_invariants(engine).invariants
         except FileNotFoundError:
@@ -305,7 +306,7 @@ def resolve_library_effective(
 
 def _canonical_excerpt(config: ExperimentConfig) -> dict[str, Any]:
     """Small human-readable excerpt of the canonical form for display/logs."""
-    engine = config.engine.value if hasattr(config.engine, "value") else str(config.engine)
+    engine = engine_str(config.engine)
     excerpt: dict[str, Any] = {
         "engine": engine,
         "task.model": config.task.model,

--- a/src/llenergymeasure/study/library_resolution.py
+++ b/src/llenergymeasure/study/library_resolution.py
@@ -30,7 +30,7 @@ from llenergymeasure.config.engine_invariants.loader import (
     resolve_field_path,
 )
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.domain.experiment import engine_str
+from llenergymeasure.config.ssot import engine_str
 from llenergymeasure.study.hashing import build_resolved_view, hash_config
 
 logger = logging.getLogger(__name__)

--- a/src/llenergymeasure/study/resume.py
+++ b/src/llenergymeasure/study/resume.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from llenergymeasure.utils.exceptions import StudyError
+from llenergymeasure.utils.io import load_json
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import StudyConfig
@@ -44,7 +44,7 @@ def find_resumable_study(output_dir: Path) -> Path | None:
         if not manifest_path.exists():
             continue
         try:
-            data = json.loads(manifest_path.read_text())
+            data = load_json(manifest_path)
             status = data.get("status", "")
             if status not in _RESUMABLE_STATUSES:
                 continue
@@ -91,7 +91,7 @@ def load_resume_state(
         )
 
     try:
-        data = json.loads(manifest_path.read_text())
+        data = load_json(manifest_path)
         manifest = StudyManifest.model_validate(data)
     except Exception as exc:
         raise StudyError(

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -23,6 +23,7 @@ without data corruption.
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import multiprocessing
 import os  # noqa: F401 - patch target: tests patch study.runner.os.{killpg,setpgrp}
@@ -65,6 +66,7 @@ from llenergymeasure.study.worker import (
     _kill_process_group,
     _run_experiment_worker,
 )
+from llenergymeasure.utils.io import load_json
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig, StudyConfig
@@ -152,22 +154,18 @@ def _save_and_record(
         if ts_source_dir is not None:
             config_sidecar_src = ts_source_dir / "config.json"
             if config_sidecar_src.exists():
-                import json as _json
-
                 try:
-                    _payload = _json.loads(config_sidecar_src.read_text())
+                    _payload = load_json(config_sidecar_src)
                     if resolved_config_hash is not None:
                         _payload["resolved_config_hash"] = resolved_config_hash
                     from llenergymeasure.results.persistence import _atomic_write
 
                     _atomic_write(
-                        _json.dumps(_payload, indent=2, default=str),
+                        json.dumps(_payload, indent=2, default=str),
                         result_path.parent / "config.json",
                     )
                 except Exception as exc:  # pragma: no cover - best-effort
-                    import logging as _logging
-
-                    _logging.getLogger(__name__).debug("config.json sidecar move failed: %s", exc)
+                    logger.debug("config.json sidecar move failed: %s", exc)
                 finally:
                     config_sidecar_src.unlink(missing_ok=True)
 
@@ -541,8 +539,6 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         Best-effort - failures are logged at DEBUG to avoid masking study results.
         """
         try:
-            import json as _json
-
             from llenergymeasure.study.equivalence_groups import (
                 EquivalenceGroups,
                 ObservedCollisionGroup,
@@ -578,7 +574,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
             sidecars: list[dict[str, Any]] = []
             for config_json in self.study_dir.rglob("config.json"):
                 with contextlib.suppress(Exception):
-                    sidecars.append(_json.loads(config_json.read_text()))
+                    sidecars.append(load_json(config_json))
             post_run_groups: list[ObservedCollisionGroup] = find_observed_collisions(sidecars)
 
             groups = EquivalenceGroups(
@@ -686,9 +682,8 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
 
         config_hash = compute_declared_config_hash(config)
         # Increment per-config_hash counter: 1st run → cycle=1, 2nd → cycle=2, etc.
-        current = self._cycle_counters.get(config_hash, 0) + 1
-        self._cycle_counters[config_hash] = current
-        cycle = current
+        cycle = self._cycle_counters.get(config_hash, 0) + 1
+        self._cycle_counters[config_hash] = cycle
 
         # Docker dispatch path - check runner spec for this engine
         spec = self._runner_specs.get(config.engine) if self._runner_specs else None
@@ -868,10 +863,10 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
                 resolved_config_hash=self._resolved_hashes.get(config_hash),
             )
             if self._progress:
+                host_path = self.result_files[-1] if self.result_files else None
                 # Emit save paths as substeps BEFORE end_experiment_ok (which clears
                 # inner step display). This makes paths visible inline in TTY mode.
-                if self.result_files:
-                    host_path = self.result_files[-1]
+                if host_path is not None:
                     # Docker experiments: show container path first, then host path.
                     # The original container path is /run/llem; by this point output_dir
                     # has been rewritten to the host temp dir, so use the known constant.
@@ -902,8 +897,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
                     mj_per_tok_total=mj_per_tok_total,
                 )
                 # Also store for finish() footer
-                if self.result_files:
-                    host_path = self.result_files[-1]
+                if host_path is not None:
                     self._progress.on_experiment_saved(index, host_path)
 
     def _run_one_docker(

--- a/src/llenergymeasure/study/runtime_observations.py
+++ b/src/llenergymeasure/study/runtime_observations.py
@@ -40,8 +40,7 @@ from pathlib import Path
 from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.config.ssot import ENGINE_PACKAGES, Engine
-from llenergymeasure.domain.experiment import engine_str
+from llenergymeasure.config.ssot import ENGINE_PACKAGES, Engine, engine_str
 from llenergymeasure.study.message_normalise import normalise
 
 __all__ = [

--- a/src/llenergymeasure/study/runtime_observations.py
+++ b/src/llenergymeasure/study/runtime_observations.py
@@ -41,6 +41,7 @@ from typing import Any
 
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.config.ssot import ENGINE_PACKAGES, Engine
+from llenergymeasure.domain.experiment import engine_str
 from llenergymeasure.study.message_normalise import normalise
 
 __all__ = [
@@ -221,7 +222,7 @@ def _build_record(
     exit_reason: str | None,
     exit_code: int | None,
 ) -> dict[str, Any]:
-    engine_value = _engine_value(config.engine)
+    engine_value = engine_str(config.engine)
     return {
         "schema_version": SCHEMA_VERSION,
         "observed_at": datetime.now(timezone.utc)
@@ -285,10 +286,6 @@ def _serialise_exception(exc: BaseException) -> dict[str, Any]:
 
 def _normalise_message(message: str) -> str:
     return normalise(message).template
-
-
-def _engine_value(engine: Any) -> str:
-    return engine.value if hasattr(engine, "value") else str(engine)
 
 
 @lru_cache(maxsize=8)

--- a/src/llenergymeasure/study/worker.py
+++ b/src/llenergymeasure/study/worker.py
@@ -178,6 +178,18 @@ def _run_experiment_worker(
         conn.close()
 
 
+def _as_failure_payload(payload: Any, config_hash: str) -> dict[str, Any] | None:
+    """Stamp and return ``payload`` if it is a worker error dict, else None.
+
+    A worker error dict carries both ``type`` and ``message`` keys; the
+    ``config_hash`` is added so the parent can attribute the failure.
+    """
+    if isinstance(payload, dict) and "type" in payload and "message" in payload:
+        payload["config_hash"] = config_hash
+        return payload
+    return None
+
+
 def _collect_result(
     p: Any,  # multiprocessing.Process
     parent_conn: Any,  # multiprocessing.Connection (parent end)
@@ -220,16 +232,14 @@ def _collect_result(
         # Non-zero exit - try to read error payload from pipe
         # Use pre-drained payload if available; otherwise poll/recv
         if pipe_payload is not _UNSET:
-            payload = pipe_payload
-            if isinstance(payload, dict) and "type" in payload and "message" in payload:
-                payload["config_hash"] = config_hash
-                return payload
+            failure = _as_failure_payload(pipe_payload, config_hash)
+            if failure is not None:
+                return failure
         elif parent_conn.poll():
             try:
-                payload = parent_conn.recv()
-                if isinstance(payload, dict) and "type" in payload and "message" in payload:
-                    payload["config_hash"] = config_hash
-                    return payload
+                failure = _as_failure_payload(parent_conn.recv(), config_hash)
+                if failure is not None:
+                    return failure
             except Exception:
                 pass
 
@@ -241,22 +251,15 @@ def _collect_result(
 
     # Success path - use pre-drained payload if available
     if pipe_payload is not _UNSET:
-        payload = pipe_payload
         # If payload is an error dict (exception in worker), treat as failure
-        if isinstance(payload, dict) and "type" in payload and "message" in payload:
-            payload["config_hash"] = config_hash
-            return payload
-        return payload
+        return _as_failure_payload(pipe_payload, config_hash) or pipe_payload
 
     # Fallback: read from pipe directly (no pre-drained payload)
     if parent_conn.poll():
         try:
             payload = parent_conn.recv()
             # If payload is an error dict (exception in worker), treat as failure
-            if isinstance(payload, dict) and "type" in payload and "message" in payload:
-                payload["config_hash"] = config_hash
-                return payload
-            return payload
+            return _as_failure_payload(payload, config_hash) or payload
         except Exception as exc:
             return {
                 "type": "PipeError",

--- a/src/llenergymeasure/utils/formatting.py
+++ b/src/llenergymeasure/utils/formatting.py
@@ -9,6 +9,11 @@ if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
 
+def bytes_to_mb(n: float) -> float:
+    """Convert a byte count to mebibytes (MiB)."""
+    return n / (1024 * 1024)
+
+
 def format_elapsed(seconds: float) -> str:
     """Format seconds as human-readable elapsed time.
 

--- a/src/llenergymeasure/utils/io.py
+++ b/src/llenergymeasure/utils/io.py
@@ -1,0 +1,17 @@
+"""Shared filesystem IO helpers (Layer 0 - importable from any layer)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path | str) -> Any:
+    """Read and parse a UTF-8 JSON file.
+
+    Lets ``OSError`` (missing/unreadable file) and ``json.JSONDecodeError``
+    (malformed content) propagate to the caller; callers that tolerate either
+    keep their own try/except.
+    """
+    return json.loads(Path(path).read_text(encoding="utf-8"))


### PR DESCRIPTION
Concision and de-duplication from the audit. Inlines redundant locals, collapses repeated idioms, and consolidates genuinely-repeated logic (3+ sites) into small plain helpers: bytes_to_mb, load_json, engine_str, _mount_if_absent, _as_failure_payload, _throttle_bit, _literal_options. Behavior-preserving, verified at each call site. Stacked.