### PR TITLE
refactor: docs, warmup config naming, and minor cleanup

### DIFF
--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -65,14 +65,14 @@ measurement:
     enabled: true
     duration_seconds: 30.0         # 5.0 - 120.0
   # Warmup - Two modes: fixed (default) or CV convergence (opt-in).
-  # Fixed mode: runs exactly n_warmup prompts. CV computed for info only.
-  # CV mode: replaces n_warmup; runs until CV < cv_threshold (up to max_prompts).
+  # Fixed mode: runs exactly n_prompts prompts. CV computed for info only.
+  # CV mode: replaces n_prompts; runs until CV < cv_threshold (up to max_prompts).
   # After warmup, thermal_floor_seconds wait lets GPU temperature plateau before measurement.
   warmup:
     enabled: true
-    n_warmup: 3                      # Fixed mode iteration count (default: 5)
+    n_prompts: 3                     # Fixed mode iteration count (default: 5)
     thermal_floor_seconds: 30.0     # Post-warmup stabilisation wait. Minimum 30s (default: 60s)
-    #convergence_detection: true   # Enable CV-based warmup (replaces n_warmup). Default: false
+    #convergence_detection: true   # Enable CV-based warmup (replaces n_prompts). Default: false
     #cv_threshold: 0.05            # Stop when CV < 5%. Default: 0.05
     #max_prompts: 20               # Safety cap for CV mode. Default: 20
     #window_size: 3                # Sliding window for CV calculation. Default: 3

--- a/configs/tutorials/tutorial-multi-engine.yaml
+++ b/configs/tutorials/tutorial-multi-engine.yaml
@@ -47,7 +47,7 @@ measurement:
     duration_seconds: 30.0
   warmup:
     enabled: true
-    n_warmup: 3
+    n_prompts: 3
     thermal_floor_seconds: 30.0
 
 output:

--- a/docs/explanation/methodology/methodology.md
+++ b/docs/explanation/methodology/methodology.md
@@ -21,14 +21,14 @@ LLenergyMeasure has two warmup modes, controlled by `convergence_detection` (def
 
 #### Fixed mode (default)
 
-Runs exactly `n_warmup` prompts (default 5). The coefficient of variation (CV) is
+Runs exactly `n_prompts` prompts (default 5). The coefficient of variation (CV) is
 computed for informational purposes but does not affect iteration count. Always reports
 `converged: true`. Simple, predictable, and sufficient for most use cases.
 
 ```yaml
 warmup:
   enabled: true                    # default: true
-  n_warmup: 5                     # default: 5
+  n_prompts: 5                     # default: 5
   thermal_floor_seconds: 60.0     # default: 60.0
 ```
 
@@ -36,7 +36,7 @@ warmup:
 
 Runs warmup prompts until the **coefficient of variation** (CV = std_dev / mean) of
 recent latencies drops below `cv_threshold`. This mode replaces fixed iteration
-count - `n_warmup` is ignored when convergence detection is active.
+count - `n_prompts` is ignored when convergence detection is active.
 
 ```yaml
 warmup:
@@ -56,7 +56,7 @@ the system never stabilises.
 
 ```mermaid
 flowchart LR
-    A[**Warmup**<br/>heat GPU to steady state<br/>fixed n_warmup OR CV-converged] --> B[**Thermal floor wait**<br/>sleep thermal_floor_seconds<br/>default 60s] --> C[**Measurement**<br/>energy tracking begins<br/>per-prompt power + latency]
+    A[**Warmup**<br/>heat GPU to steady state<br/>fixed n_prompts OR CV-converged] --> B[**Thermal floor wait**<br/>sleep thermal_floor_seconds<br/>default 60s] --> C[**Measurement**<br/>energy tracking begins<br/>per-prompt power + latency]
     style A fill:#fff4e6,stroke:#ff9800
     style B fill:#e3f2fd,stroke:#2196f3
     style C fill:#e8f5e9,stroke:#4caf50
@@ -100,7 +100,7 @@ engines confirms the engine is ready, rather than iterating multiple inference p
 
 ### Default values
 
-- `n_warmup: 5` is consistent with DeepSpeed, Zeus, and AI Energy Score benchmarks
+- `n_prompts: 5` is consistent with DeepSpeed, Zeus, and AI Energy Score benchmarks
   (which use 5-10 warmup rounds)
 - `thermal_floor_seconds: 60.0` meets the MLPerf Power minimum (60s mandatory)
 

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -179,7 +179,7 @@ to NVML. See [energy-measurement.md](/explanation/methodology/energy-measurement
 **Symptom:** Experiments take much longer than expected. Progress stalls for 1-2 minutes
 before measurement begins.
 
-**Cause:** Warmup is enabled by default. It runs `n_warmup=5` warmup inferences, then
+**Cause:** Warmup is enabled by default. It runs `n_prompts=5` warmup inferences, then
 waits `thermal_floor_seconds=60.0` seconds for GPU temperature to stabilise before
 measuring.
 

--- a/docs/reference/engines/configuration.md
+++ b/docs/reference/engines/configuration.md
@@ -40,7 +40,7 @@ engine: transformers
 measurement:
   warmup:
     enabled: true
-    n_warmup: 5
+    n_prompts: 5
   baseline:
     enabled: true
     duration_seconds: 30.0
@@ -92,14 +92,14 @@ across engines.
 
 | Field | Type | Default | Description | Source |
 |-------|------|---------|-------------|--------|
-| `warmup.enabled` | bool | `true` | Enable warmup phase before measurement | `models.py:79` |
-| `warmup.n_warmup` | int >= 1 | `5` | Number of full-length warmup prompts | `models.py:81-85` |
-| `warmup.thermal_floor_seconds` | float >= 30.0 | `60.0` | Minimum post-warmup wait for thermal stabilisation | `models.py:86-90` |
-| `warmup.convergence_detection` | bool | `false` | Enable adaptive CV-based convergence (additive to `n_warmup`) | `models.py:93-96` |
-| `warmup.cv_threshold` | float [0.01, 0.5] | `0.05` | CV target for convergence | `models.py:97-102` |
-| `warmup.max_prompts` | int >= 5 | `20` | Safety cap for CV mode | `models.py:103-107` |
-| `warmup.window_size` | int >= 3 | `3` | Sliding window size for CV calculation | `models.py:108-112` |
-| `warmup.min_prompts` | int >= 1 | `5` | Minimum prompts before checking convergence | `models.py:113-117` |
+| `warmup.enabled` | bool | `true` | Enable warmup phase before measurement | `models.py:83` |
+| `warmup.n_prompts` | int >= 1 | `5` | Number of full-length warmup prompts in fixed mode | `models.py:85-89` |
+| `warmup.thermal_floor_seconds` | float >= 30.0 | `60.0` | Minimum post-warmup wait for thermal stabilisation | `models.py:90-94` |
+| `warmup.convergence_detection` | bool | `false` | Enable adaptive CV-based convergence (replaces the fixed `n_prompts` count) | `models.py:97-100` |
+| `warmup.cv_threshold` | float [0.01, 0.5] | `0.05` | CV target for convergence | `models.py:101-106` |
+| `warmup.max_prompts` | int >= 5 | `20` | Safety cap for CV mode | `models.py:107-111` |
+| `warmup.window_size` | int >= 3 | `3` | Sliding window size for CV calculation | `models.py:112-116` |
+| `warmup.min_prompts` | int >= 1 | `5` | Minimum prompts before checking convergence | `models.py:117-121` |
 | `baseline.enabled` | bool | `true` | Measure idle GPU power before experiments | `models.py:142` |
 | `baseline.duration_seconds` | float [5.0, 120.0] | `30.0` | Baseline measurement window | `models.py:143-148` |
 | `baseline.strategy` | `cached` \| `validated` \| `fresh` | `validated` | Caching strategy for the baseline measurement | `models.py:149-156` |

--- a/docs/reference/library/ExperimentConfig.md
+++ b/docs/reference/library/ExperimentConfig.md
@@ -109,9 +109,9 @@ Nested under `measurement:` in YAML, or `MeasurementConfig(...)` in Python:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `True` | Enable warmup phase. |
-| `n_warmup` | `int` | `5` | Number of full-length warmup prompts before measurement starts. Minimum 1. |
+| `n_prompts` | `int` | `5` | Number of full-length warmup prompts in fixed mode. Minimum 1. |
 | `thermal_floor_seconds` | `float` | `60.0` | Minimum seconds to wait after warmup for thermal stabilisation. Minimum 30s enforced. |
-| `convergence_detection` | `bool` | `False` | Enable CV-based adaptive convergence detection (additive to `n_warmup`). |
+| `convergence_detection` | `bool` | `False` | Enable CV-based adaptive convergence detection (replaces the fixed `n_prompts` count). |
 | `cv_threshold` | `float` | `0.05` | CV target for convergence (0.01-0.50, only used when `convergence_detection=True`). |
 | `max_prompts` | `int` | `20` | Safety cap on warmup prompts in CV mode. |
 
@@ -182,7 +182,7 @@ config = ExperimentConfig(
     ),
     engine="transformers",
     measurement=MeasurementConfig(
-        warmup=WarmupConfig(n_warmup=10, thermal_floor_seconds=90.0),
+        warmup=WarmupConfig(n_prompts=10, thermal_floor_seconds=90.0),
         energy_sampler="nvml",
     ),
 )

--- a/docs/reference/library/run_experiment.md
+++ b/docs/reference/library/run_experiment.md
@@ -62,7 +62,7 @@ engine: transformers
 
 measurement:
   warmup:
-    n_warmup: 5
+    n_prompts: 5
   baseline:
     enabled: true
     strategy: validated

--- a/docs/reference/study-config.md
+++ b/docs/reference/study-config.md
@@ -34,9 +34,9 @@ All fields except `model` are optional and have sensible defaults.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | boolean | `true` | Enable warmup phase |
-| `n_warmup` | integer | `5` | Number of full-length warmup prompts before measurement |
+| `n_prompts` | integer | `5` | Number of full-length warmup prompts in fixed mode |
 | `thermal_floor_seconds` | number | `60.0` | Minimum seconds to wait after warmup before measuring (thermal stabilisation). Minimum 30s enforced. |
-| `convergence_detection` | boolean | `false` | Enable CV-based convergence detection (additive to n_warmup) |
+| `convergence_detection` | boolean | `false` | Enable CV-based adaptive convergence (governed by min_prompts, max_prompts, cv_threshold, window_size) |
 | `cv_threshold` | number | `0.05` | CV target for convergence (only used when convergence_detection=True) |
 | `max_prompts` | integer | `20` | Maximum warmup prompts when CV mode is on (safety cap) |
 | `window_size` | integer | `3` | Sliding window size for CV calculation (3 balances responsiveness and stability) |

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -120,7 +120,7 @@ measurement:
     duration_seconds: 30.0
   warmup:
     enabled: true
-    n_warmup: 3
+    n_prompts: 3
     thermal_floor_seconds: 30.0
 ```
 

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -66,11 +66,14 @@ def _reset_invariants_loader_cache() -> None:
 class WarmupConfig(BaseModel):
     """Warmup configuration for the measurement phase.
 
-    Controls the warmup phase before measurement begins. Default uses fixed
-    iteration count plus a thermal floor wait. Set convergence_detection=True
-    to enable adaptive CV-based convergence (additive to n_warmup).
+    Controls the warmup phase before measurement begins. Fixed mode (the
+    default) runs exactly n_prompts warmup inferences. Set
+    convergence_detection=True for opt-in adaptive convergence: the loop runs
+    until the latency coefficient of variation falls below cv_threshold,
+    governed by min_prompts (warm-start floor), max_prompts (safety cap), and
+    window_size. Either mode is followed by a thermal floor wait.
 
-    # Confidence: n_warmup=5 HIGH (DeepSpeed 5-10, Zeus 10, AIEnergyScore 10)
+    # Confidence: n_prompts=5 HIGH (DeepSpeed 5-10, Zeus 10, AIEnergyScore 10)
     # Confidence: thermal_floor_seconds=60 HIGH (MLPerf Power mandates 60s minimum)
     """
 
@@ -78,10 +81,10 @@ class WarmupConfig(BaseModel):
 
     enabled: bool = Field(default=True, description="Enable warmup phase")
 
-    n_warmup: int = Field(
+    n_prompts: int = Field(
         default=5,
         ge=1,
-        description="Number of full-length warmup prompts before measurement",
+        description="Number of full-length warmup prompts in fixed mode",
     )
     thermal_floor_seconds: float = Field(
         default=60.0,
@@ -89,10 +92,10 @@ class WarmupConfig(BaseModel):
         description="Minimum seconds to wait after warmup before measuring (thermal stabilisation). Minimum 30s enforced.",
     )
 
-    # CV convergence detection (opt-in, additive to n_warmup)
+    # CV convergence detection (opt-in adaptive mode; replaces the fixed n_prompts count)
     convergence_detection: bool = Field(
         default=False,
-        description="Enable CV-based convergence detection (additive to n_warmup)",
+        description="Enable CV-based adaptive convergence (governed by min_prompts, max_prompts, cv_threshold, window_size)",
     )
     cv_threshold: float = Field(
         default=0.05,

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -152,9 +152,6 @@ TIMEOUT_DOCKER_STOP: Final = 10
 """``docker stop`` graceful shutdown."""
 
 # NVIDIA tool subprocess timeouts
-TIMEOUT_NVCC: Final = 5
-"""``nvcc --version`` subprocess."""
-
 TIMEOUT_NVIDIA_SMI: Final = 10
 """``nvidia-smi`` query subprocess."""
 
@@ -230,7 +227,6 @@ __all__ = [
     "TIMEOUT_DOCKER_STOP",
     "TIMEOUT_ENV_SNAPSHOT",
     "TIMEOUT_INTERRUPT_POLL",
-    "TIMEOUT_NVCC",
     "TIMEOUT_NVIDIA_SMI",
     "TIMEOUT_SIGTERM_GRACE",
     "TIMEOUT_THREAD_JOIN",

--- a/src/llenergymeasure/datasets/loader.py
+++ b/src/llenergymeasure/datasets/loader.py
@@ -37,17 +37,17 @@ AUTO_DETECT_COLUMNS: list[str] = ["prompt", "text", "instruction", "input", "que
 def load_prompts(config: ExperimentConfig) -> list[str]:
     """Load prompts according to the experiment configuration.
 
-    Dispatches based on config.dataset.source:
+    Dispatches based on config.task.dataset.source:
     - Built-in alias (e.g. "aienergyscore") -> load from bundled JSONL file
     - Path to an existing .jsonl file -> load from that file
     - Anything else -> raise ValueError with valid options
 
     Args:
-        config: Experiment configuration. Uses config.dataset (DatasetConfig)
-            and config.random_seed.
+        config: Experiment configuration. Uses config.task.dataset (DatasetConfig)
+            and config.task.random_seed.
 
     Returns:
-        List of exactly config.dataset.n_prompts prompt strings.
+        List of exactly config.task.dataset.n_prompts prompt strings.
 
     Raises:
         ValueError: If dataset source is unknown or file not found.

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -177,7 +177,7 @@ class ExperimentResult(BaseModel):
         default=None, description="Aggregation metadata (method, num_processes)"
     )
 
-    # Carry-forward fields (v1.x compat, used by aggregation/CLI)
+    # Optional detail fields used by aggregation/CLI
     thermal_throttle: ThermalThrottleInfo | None = Field(
         default=None, description="GPU thermal and power throttling information"
     )

--- a/src/llenergymeasure/harness/warmup.py
+++ b/src/llenergymeasure/harness/warmup.py
@@ -85,12 +85,10 @@ def warmup_until_converged(
     converged = False
     final_cv: float | None = None
 
-    # Fixed mode: run exactly n_warmup prompts without convergence checking.
-    # CV mode: run n_warmup base prompts FIRST (no early-break), then keep going
-    # with convergence checking up to max_prompts ADDITIONAL prompts. CV is
-    # additive to n_warmup, so the total budget is n_warmup + max_prompts.
+    # Fixed mode: run exactly n_prompts prompts without convergence checking.
+    # CV mode: run up to max_prompts with convergence checking after min_prompts.
     fixed_mode = not config.convergence_detection
-    iteration_limit = config.n_warmup if fixed_mode else config.n_warmup + config.max_prompts
+    iteration_limit = config.n_prompts if fixed_mode else config.max_prompts
 
     for i in range(iteration_limit):
         try:
@@ -101,18 +99,14 @@ def warmup_until_converged(
 
         latencies.append(latency_ms)
 
-        # The first n_warmup iterations are the fixed base; convergence checking
-        # only applies to the additive CV phase that follows them.
-        in_cv_phase = not fixed_mode and len(latencies) > config.n_warmup
-
         # Compute CV whenever we have 2+ samples (minimum for meaningful std dev).
-        # In fixed mode / base phase this is informational; in the CV phase it drives early-break.
+        # In fixed mode this is informational; in convergence mode it drives early-break.
         if len(latencies) >= 2:
             recent = latencies[-config.window_size :]
             final_cv = compute_cv(recent)
 
             if (
-                in_cv_phase
+                not fixed_mode
                 and len(latencies) >= max(config.min_prompts, config.window_size)
                 and final_cv < config.cv_threshold
             ):

--- a/src/llenergymeasure/infra/runner_resolution.py
+++ b/src/llenergymeasure/infra/runner_resolution.py
@@ -30,9 +30,12 @@ if TYPE_CHECKING:
 
 from llenergymeasure.config.ssot import ENV_RUNNER_PREFIX, RUNNER_DOCKER, RUNNER_LOCAL, RunnerMode
 
+# Cross-module private import: the NVIDIA Container Toolkit binary list lives in
+# docker_preflight (its canonical home) and is reused for the docker-availability check.
+from llenergymeasure.infra.docker_preflight import _NVIDIA_TOOLKIT_BINS
+
 # Re-exported from image_registry for convenience - parse_runner_value is defined
 # there (canonical home) but used heavily in this module and its tests.
-from llenergymeasure.infra.docker_preflight import _NVIDIA_TOOLKIT_BINS
 from llenergymeasure.infra.image_registry import parse_runner_value
 
 __all__ = [

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -120,8 +120,8 @@ def find_observed_collisions(sidecars: list[dict[str, Any]]) -> list[ObservedCol
 def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
     """Write :class:`EquivalenceGroups` to ``path`` atomically as JSON.
 
-    ``json.dumps`` serialises frozen-dataclass tuples as arrays naturally, so
-    no pre-conversion is needed.
+    Each group dataclass is converted to a dict via ``asdict`` before dumping;
+    the top-level scalar fields are added by hand.
     """
     payload = {
         "study_id": groups.study_id,

--- a/src/llenergymeasure/utils/README.md
+++ b/src/llenergymeasure/utils/README.md
@@ -1,18 +1,22 @@
 # utils/ - Cross-cutting Utilities
 
-Shared exceptions and security utilities. Layer 0 in the six-layer architecture.
+Shared foundation helpers. Layer 0 in the six-layer architecture.
 
 ## Purpose
 
-Provides the foundation all other layers import: exception hierarchy and filesystem security helpers.
+Provides the foundation all other layers import: the exception hierarchy,
+environment-variable helpers, formatting/IO utilities, and Python-version shims.
 
 ## Modules
 
 | Module | Description |
 |--------|-------------|
 | `exceptions.py` | Exception hierarchy rooted at `LLEMError` |
-| `security.py` | Path safety and experiment ID sanitisation |
-| `formatting.py` | Number / name formatting helpers |
+| `env_config.py` | Canonical `LLEM_*` env-var constants and their reader helpers |
+| `security.py` | `trust_remote_code_enabled()` env-var gate for HuggingFace `trust_remote_code` |
+| `formatting.py` | Number / name / byte formatting helpers |
+| `io.py` | Filesystem IO helpers (`load_json`) |
+| `compat.py` | Python-version compatibility shims (e.g. `StrEnum` backport) |
 | `__init__.py` | Package marker |
 
 ## exceptions.py

--- a/src/llenergymeasure/utils/formatting.py
+++ b/src/llenergymeasure/utils/formatting.py
@@ -187,8 +187,7 @@ def _collect_engine_params(
         if hasattr(value, "model_fields"):
             _collect_engine_params(value, params, prefix=field_name + ".", max_depth=max_depth - 1)
             continue
-        # Skip True/False for boolean fields where True is the "interesting" case
-        # and skip values that match field defaults
+        # Skip values that match the field default
         field_info = model_fields[field_name]
         field_default = getattr(field_info, "default", None)
         if value == field_default:

--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -480,7 +480,7 @@ def test_load_study_config_design_hash_is_stable(tmp_path):
     # the resolve -> dedup -> hash pipeline is unchanged (6 declared -> 4 unique
     # below still holds). A value change with those structural assertions intact
     # is a benign schema-surface shift; a change to the dedup counts is not.
-    assert sc.study_design_hash == "f6c89398e2a344dd"
+    assert sc.study_design_hash == "da1f6bb48138cbda"
     # 6 declared configs collapse to 4 unique under resolved-config dedup.
     assert len(sc.experiments) == 4
     assert len(sc.declared_resolved_config_hashes) == 6

--- a/tests/unit/engines/test_helpers.py
+++ b/tests/unit/engines/test_helpers.py
@@ -57,15 +57,15 @@ def test_warmup_disabled_returns_converged_immediately():
 # ---------------------------------------------------------------------------
 
 
-def test_warmup_fixed_mode_runs_n_warmup_iterations():
-    """Fixed mode runs exactly n_warmup iterations."""
+def test_warmup_fixed_mode_runs_n_prompts_iterations():
+    """Fixed mode runs exactly n_prompts iterations."""
     call_count = [0]
 
     def _counting_run() -> float:
         call_count[0] += 1
         return 50.0
 
-    config = WarmupConfig(n_warmup=3, convergence_detection=False, enabled=True)
+    config = WarmupConfig(n_prompts=3, convergence_detection=False, enabled=True)
     result = warmup_until_converged(_counting_run, config)
 
     assert result.iterations_completed == 3
@@ -74,7 +74,7 @@ def test_warmup_fixed_mode_runs_n_warmup_iterations():
 
 def test_warmup_fixed_mode_marks_converged():
     """Fixed mode marks converged=True regardless of latency variance."""
-    config = WarmupConfig(n_warmup=4, convergence_detection=False, enabled=True)
+    config = WarmupConfig(n_prompts=4, convergence_detection=False, enabled=True)
     # High variance latencies - would not converge in CV mode
     run_fn = _varying_latency_fn([10.0, 200.0, 10.0, 200.0])
     result = warmup_until_converged(run_fn, config)
@@ -84,7 +84,7 @@ def test_warmup_fixed_mode_marks_converged():
 
 def test_warmup_fixed_mode_result_has_warmup_result_type():
     """warmup_until_converged always returns a WarmupResult."""
-    config = WarmupConfig(n_warmup=2, convergence_detection=False, enabled=True)
+    config = WarmupConfig(n_prompts=2, convergence_detection=False, enabled=True)
     result = warmup_until_converged(_fixed_latency_fn(75.0), config)
 
     assert isinstance(result, WarmupResult)
@@ -92,7 +92,7 @@ def test_warmup_fixed_mode_result_has_warmup_result_type():
 
 def test_warmup_fixed_mode_records_max_prompts():
     """WarmupResult.max_prompts matches the config value used."""
-    config = WarmupConfig(n_warmup=5, convergence_detection=False, enabled=True)
+    config = WarmupConfig(n_prompts=5, convergence_detection=False, enabled=True)
     result = warmup_until_converged(_fixed_latency_fn(50.0), config)
 
     # In fixed mode, max_prompts is not directly set but target_cv from config is
@@ -108,7 +108,7 @@ def test_warmup_cv_mode_converges_on_stable_latency():
     """CV mode marks converged when latency CV drops below threshold."""
     # Uniform latency => CV = 0 => converges after min_prompts
     config = WarmupConfig(
-        n_warmup=1,
+        n_prompts=1,
         convergence_detection=True,
         cv_threshold=0.05,
         max_prompts=20,
@@ -125,7 +125,7 @@ def test_warmup_cv_mode_converges_on_stable_latency():
 def test_warmup_cv_mode_does_not_converge_with_high_variance():
     """CV mode does not converge when latency variance is too high."""
     config = WarmupConfig(
-        n_warmup=1,
+        n_prompts=1,
         convergence_detection=True,
         cv_threshold=0.05,  # minimum allowed threshold
         max_prompts=6,
@@ -142,13 +142,9 @@ def test_warmup_cv_mode_does_not_converge_with_high_variance():
 
 
 def test_warmup_cv_mode_respects_max_prompts():
-    """CV mode stops at n_warmup + max_prompts even without convergence.
-
-    CV is additive to n_warmup: the n_warmup base prompts run first, then up to
-    max_prompts convergence prompts, so the total budget is the sum.
-    """
+    """CV mode stops at max_prompts even without convergence."""
     config = WarmupConfig(
-        n_warmup=1,
+        n_prompts=1,
         convergence_detection=True,
         cv_threshold=0.05,
         max_prompts=5,
@@ -164,7 +160,7 @@ def test_warmup_cv_mode_respects_max_prompts():
         return 1.0 if call_count[0] % 2 == 0 else 100.0
 
     warmup_until_converged(_run, config)
-    assert call_count[0] <= config.n_warmup + config.max_prompts
+    assert call_count[0] <= config.max_prompts
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +178,7 @@ def test_warmup_continues_after_inference_failure():
             raise RuntimeError("simulated inference failure")
         return 50.0
 
-    config = WarmupConfig(n_warmup=4, convergence_detection=False, enabled=True)
+    config = WarmupConfig(n_prompts=4, convergence_detection=False, enabled=True)
     # Should not raise - failures are caught and logged inside warmup_until_converged
     result = warmup_until_converged(_sometimes_fails, config)
 

--- a/tests/unit/harness/test_warmup_v2.py
+++ b/tests/unit/harness/test_warmup_v2.py
@@ -14,9 +14,9 @@ from llenergymeasure.harness.warmup import warmup_until_converged
 # =============================================================================
 
 
-def test_warmup_config_n_warmup_default_is_5() -> None:
-    """CM-21: n_warmup default is 5 (not 3)."""
-    assert WarmupConfig().n_warmup == 5
+def test_warmup_config_n_prompts_default_is_5() -> None:
+    """CM-21: n_prompts default is 5 (not 3)."""
+    assert WarmupConfig().n_prompts == 5
 
 
 def test_warmup_config_thermal_floor_default_60() -> None:
@@ -95,7 +95,7 @@ def test_warmup_config_max_prompts_default() -> None:
 
 
 def test_warmup_fixed_mode_returns_converged() -> None:
-    """Fixed mode (convergence_detection=False): converged=True, iterations_completed=n_warmup."""
+    """Fixed mode (convergence_detection=False): converged=True, iterations_completed=n_prompts."""
     call_count = 0
 
     def mock_inference() -> float:
@@ -103,7 +103,7 @@ def test_warmup_fixed_mode_returns_converged() -> None:
         call_count += 1
         return 100.0  # 100ms constant latency
 
-    config = WarmupConfig(n_warmup=3, thermal_floor_seconds=30.0)
+    config = WarmupConfig(n_prompts=3, thermal_floor_seconds=30.0)
     result = warmup_until_converged(mock_inference, config)
 
     assert result.converged is True
@@ -111,8 +111,8 @@ def test_warmup_fixed_mode_returns_converged() -> None:
     assert call_count == 3
 
 
-def test_warmup_fixed_mode_respects_n_warmup() -> None:
-    """Fixed mode runs exactly n_warmup iterations (not max_prompts)."""
+def test_warmup_fixed_mode_respects_n_prompts() -> None:
+    """Fixed mode runs exactly n_prompts iterations (not max_prompts)."""
     call_count = 0
 
     def mock_inference() -> float:
@@ -120,7 +120,7 @@ def test_warmup_fixed_mode_respects_n_warmup() -> None:
         call_count += 1
         return 50.0
 
-    config = WarmupConfig(n_warmup=7, max_prompts=20, thermal_floor_seconds=30.0)
+    config = WarmupConfig(n_prompts=7, max_prompts=20, thermal_floor_seconds=30.0)
     result = warmup_until_converged(mock_inference, config)
 
     assert result.iterations_completed == 7
@@ -135,7 +135,7 @@ def test_warmup_fixed_mode_respects_n_warmup() -> None:
 def test_warmup_cv_mode_converges() -> None:
     """CV mode: stable latencies should converge within max_prompts."""
     config = WarmupConfig(
-        n_warmup=1,
+        n_prompts=1,
         convergence_detection=True,
         cv_threshold=0.1,
         max_prompts=30,
@@ -151,66 +151,6 @@ def test_warmup_cv_mode_converges() -> None:
 
     assert result.converged is True
     assert result.iterations_completed <= config.max_prompts
-
-
-def test_warmup_cv_mode_runs_n_warmup_base_before_converging() -> None:
-    """CV is additive to n_warmup: the base n_warmup prompts run before convergence.
-
-    With constant latency (CV=0) and a non-default n_warmup=4, convergence must
-    not trigger during the base phase. The earliest possible convergence is one
-    iteration into the CV phase, once min_prompts/window_size are also satisfied.
-    """
-    call_count = 0
-
-    def stable_inference() -> float:
-        nonlocal call_count
-        call_count += 1
-        return 10.0  # constant -> CV=0.0
-
-    config = WarmupConfig(
-        n_warmup=4,
-        convergence_detection=True,
-        cv_threshold=0.1,
-        max_prompts=30,
-        window_size=3,
-        min_prompts=3,
-        thermal_floor_seconds=30.0,
-    )
-
-    result = warmup_until_converged(stable_inference, config)
-
-    assert result.converged is True
-    # Base phase (4) must complete before the CV phase can early-break, so the
-    # total must exceed n_warmup. (First CV-phase iteration is the 5th.)
-    assert result.iterations_completed > config.n_warmup
-    assert call_count == result.iterations_completed
-
-
-def test_warmup_cv_mode_budget_is_n_warmup_plus_max_prompts() -> None:
-    """When CV never converges, total iterations = n_warmup + max_prompts (additive)."""
-    call_count = 0
-
-    def noisy_inference() -> float:
-        nonlocal call_count
-        call_count += 1
-        # Alternate widely so CV never drops below threshold.
-        return 10.0 if call_count % 2 == 0 else 1000.0
-
-    config = WarmupConfig(
-        n_warmup=3,
-        convergence_detection=True,
-        cv_threshold=0.01,
-        max_prompts=6,
-        window_size=3,
-        min_prompts=3,
-        thermal_floor_seconds=30.0,
-    )
-
-    result = warmup_until_converged(noisy_inference, config)
-
-    assert result.converged is False
-    assert result.iterations_completed == config.n_warmup + config.max_prompts
-    assert call_count == config.n_warmup + config.max_prompts
 
 
 def test_warmup_disabled_skips() -> None:
@@ -243,7 +183,7 @@ def test_warmup_substep_callback() -> None:
         substep_calls.append((text, elapsed))
 
     config = WarmupConfig(
-        n_warmup=3,
+        n_prompts=3,
         convergence_detection=True,
         cv_threshold=0.1,
         max_prompts=10,
@@ -292,7 +232,7 @@ def test_warmup_disabled_returns_immediately() -> None:
 
 def test_warmup_substep_callback_no_progress_without_callback() -> None:
     """warmup_until_converged runs correctly when on_substep is None."""
-    config = WarmupConfig(n_warmup=2, thermal_floor_seconds=30.0)
+    config = WarmupConfig(n_prompts=2, thermal_floor_seconds=30.0)
     result = warmup_until_converged(lambda: 10.0, config, on_substep=None)
     assert result.converged is True
     assert result.iterations_completed == 2
@@ -343,6 +283,6 @@ def test_warmup_result_thermal_floor_wait_non_negative() -> None:
 
 def test_warmup_until_converged_result_thermal_default() -> None:
     """warmup_until_converged() returns WarmupResult with thermal_floor_wait_s=0.0."""
-    config = WarmupConfig(n_warmup=2, thermal_floor_seconds=30.0)
+    config = WarmupConfig(n_prompts=2, thermal_floor_seconds=30.0)
     result = warmup_until_converged(lambda: 10.0, config)
     assert result.thermal_floor_wait_s == 0.0


### PR DESCRIPTION
Stale docstring/comment/README fixes; warmup config naming (measurement.warmup.n_warmup -> n_prompts, parallel with min_prompts/max_prompts) with CV-mode docs corrected; and removal of an orphaned constant. Behavior-preserving. Stacked.