### PR TITLE
fix(study): repair four study/result data-integrity bugs

### DIFF
--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -433,9 +433,13 @@ def _run(
 
     wall_time = time.monotonic() - wall_start
 
-    # Mark manifest as completed - only reached on success (SIGINT path calls
-    # manifest.mark_interrupted() then sys.exit(130) before returning here).
-    manifest.mark_study_completed()
+    # Mark the study completed - but never overwrite a terminal abort status the
+    # runner already set (wall-clock timeout or circuit-breaker). Doing so would make
+    # an aborted study look completed and therefore non-resumable, leaving its skipped
+    # experiments to never re-run. The SIGINT path calls mark_interrupted() then
+    # sys.exit(130) before returning here, so 'interrupted' is not normally seen.
+    if manifest.status not in ("timed_out", "circuit_breaker", "interrupted"):
+        manifest.mark_study_completed()
 
     completed = sum(1 for r in experiment_results if r is not None)
     failed = len(experiment_results) - completed

--- a/src/llenergymeasure/study/loading.py
+++ b/src/llenergymeasure/study/loading.py
@@ -78,14 +78,22 @@ def finalise_study(raw: LoadedStudyRaw) -> StudyConfig:
         shuffle_seed=execution.shuffle_seed,
     )
 
-    # Serialise pre-run equivalence groups for the sidecar writer.
+    # Serialise pre-run equivalence groups for the sidecar writer. The runner's deserialiser
+    # (StudyRunner._write_equivalence_groups_sidecar) reads member_experiment_ids /
+    # representative_experiment_id, so map the dedup group's member indices back to their
+    # declared-config-hash experiment ids and emit those keys. (This previously hand-rolled
+    # member_indices / representative_index - the wrong keys and raw ints - so every loaded
+    # group came back with empty members.)
+    from llenergymeasure.domain.experiment import compute_declared_config_hash
+
+    experiment_ids = [compute_declared_config_hash(exp) for exp in raw.valid_experiments]
     pre_run_groups: list[dict[str, Any]] = [
         {
             "resolved_config_hash": g.resolved_config_hash,
             "canonical_config_excerpt": g.canonical_excerpt,
-            "member_indices": list(g.member_indices),
+            "member_experiment_ids": [experiment_ids[i] for i in g.member_indices],
             "member_count": g.member_count,
-            "representative_index": g.representative_index,
+            "representative_experiment_id": experiment_ids[g.representative_index],
             "would_dedup": g.member_count > 1,
             "deduplicated": dedup.deduplicated and g.member_count > 1,
         }

--- a/src/llenergymeasure/study/manifest.py
+++ b/src/llenergymeasure/study/manifest.py
@@ -168,6 +168,11 @@ class ManifestWriter:
     # Public interface
     # ------------------------------------------------------------------
 
+    @property
+    def status(self) -> str:
+        """Current study-level status (e.g. 'running', 'completed', 'timed_out')."""
+        return self.manifest.status
+
     def mark_running(self, config_hash: str, cycle: int) -> None:
         """Mark a pending experiment as running."""
         entry = self._find(config_hash, cycle)

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -109,34 +109,48 @@ def run_single_experiment(
     else:
         # Local in-process path - errors propagate naturally (PreFlightError, EngineError)
         import tempfile
+        import uuid
 
         from llenergymeasure.engines import get_engine
         from llenergymeasure.harness import MeasurementHarness
         from llenergymeasure.harness.preflight import run_preflight
-
-        if progress:
-            progress.on_step_start("container_preflight", "Checking", "CUDA, model access")
-        t0 = time.perf_counter()
-        run_preflight(config)
-        if progress:
-            progress.on_step_done("container_preflight", time.perf_counter() - t0)
+        from llenergymeasure.study.runtime_observations import capture_runtime_observations
 
         # Create temp dir for timeseries parquet (if enabled)
         ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES)) if save_ts else None
 
+        # Wrap the in-process body (preflight -> engine import -> harness.run) in
+        # capture_runtime_observations so single-experiment studies emit
+        # runtime_observations.jsonl like the multi-experiment worker path
+        # (study/worker.py). Without it, report-gaps finds nothing for single-exp studies.
+        obs_ctx = capture_runtime_observations(
+            config,
+            study_dir=study_dir,
+            study_run_id=str(uuid.uuid4()),
+            cycle=cycle,
+            config_hash=config_hash,
+        )
         try:
-            engine = get_engine(config.engine)
-            harness = MeasurementHarness()
-            gpu_indices = _resolve_gpu_indices(config)
-            result = harness.run(
-                engine,
-                config,
-                snapshot=snapshot,
-                gpu_indices=gpu_indices,
-                progress=progress,
-                output_dir=str(ts_tmpdir) if ts_tmpdir else None,
-                save_timeseries=save_ts,
-            )
+            with obs_ctx:
+                if progress:
+                    progress.on_step_start("container_preflight", "Checking", "CUDA, model access")
+                t0 = time.perf_counter()
+                run_preflight(config)
+                if progress:
+                    progress.on_step_done("container_preflight", time.perf_counter() - t0)
+
+                engine = get_engine(config.engine)
+                harness = MeasurementHarness()
+                gpu_indices = _resolve_gpu_indices(config)
+                result = harness.run(
+                    engine,
+                    config,
+                    snapshot=snapshot,
+                    gpu_indices=gpu_indices,
+                    progress=progress,
+                    output_dir=str(ts_tmpdir) if ts_tmpdir else None,
+                    save_timeseries=save_ts,
+                )
         except Exception:
             if ts_tmpdir is not None:
                 shutil.rmtree(ts_tmpdir, ignore_errors=True)
@@ -148,6 +162,17 @@ def run_single_experiment(
         error_message = result.get("message", "")
         manifest.mark_failed(config_hash, cycle, error_type, error_message)
         return [], [None], [error_message]
+
+    # Resolved-config hash for the config.json sidecar - mirrors the multi-experiment
+    # runner path (StudyRunner._build_resolved_hashes) so single- and multi-experiment
+    # studies write identical sidecar fields. Best-effort: None on failure.
+    resolved_config_hash: str | None = None
+    try:
+        from llenergymeasure.study.hashing import build_resolved_view, hash_config
+
+        resolved_config_hash = hash_config(build_resolved_view(config))
+    except Exception:  # pragma: no cover - best-effort, mirrors the runner
+        resolved_config_hash = None
 
     result_files: list[str] = []
     warnings: list[str] = []
@@ -161,6 +186,7 @@ def run_single_experiment(
         ts_source_dir=ts_tmpdir,
         environment_snapshot=snapshot,
         resolution_log=(resolution_logs or {}).get(config_hash),
+        resolved_config_hash=resolved_config_hash,
     )
 
     # Clean up temp dirs

--- a/tests/integration/test_sweep_dedup_end_to_end.py
+++ b/tests/integration/test_sweep_dedup_end_to_end.py
@@ -56,6 +56,16 @@ def test_greedy_temperature_sweep_collapses(tmp_path: Path) -> None:
     assert max(group_sizes) >= 2
     assert sum(group_sizes) == 6
 
+    # ST2 regression: pre-run groups must carry real member ids. The producer previously
+    # hand-rolled member_indices / representative_index (the wrong keys + raw ints), so the
+    # runner's deserialiser - which reads member_experiment_ids / representative_experiment_id -
+    # loaded every group with empty members.
+    for g in study_config.pre_run_equivalence_groups:
+        assert "member_indices" not in g and "representative_index" not in g
+        assert len(g["member_experiment_ids"]) == g["member_count"]
+        assert g["representative_experiment_id"]
+        assert g["representative_experiment_id"] in g["member_experiment_ids"]
+
 
 def test_no_dedup_preserves_all_configs(tmp_path: Path) -> None:
     """With ``deduplicate_equivalent: false`` every declared config runs."""

--- a/tests/unit/study/test_single.py
+++ b/tests/unit/study/test_single.py
@@ -105,3 +105,88 @@ def test_run_single_experiment_calls_gpu_memory_check(monkeypatch, tmp_path):
     assert len(gpu_check_calls) == 1, (
         f"Expected check_gpu_memory_residual to be called once, got {len(gpu_check_calls)}"
     )
+
+
+def test_single_experiment_passes_resolved_config_hash(monkeypatch, tmp_path):
+    """ST3: the single-experiment path passes resolved_config_hash to _save_and_record.
+
+    The multi-experiment runner path includes it; the single path previously omitted it,
+    so single-experiment config.json sidecars lacked resolved_config_hash.
+    """
+    import llenergymeasure.engines as engines_module
+    import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.runner as runner_module
+    from llenergymeasure.study.hashing import build_resolved_view, hash_config
+
+    mock_result = make_result(experiment_id="resolved-hash-test")
+    mock_engine = _MockBackend(mock_result)
+
+    captured: dict = {}
+
+    def fake_save_and_record(result, study_dir, manifest, config_hash, cycle, result_files, **kw):
+        captured.update(kw)
+
+    monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
+    monkeypatch.setattr(engines_module, "get_engine", lambda name: mock_engine)
+    _patch_harness(monkeypatch, mock_result)
+    monkeypatch.setattr(
+        "llenergymeasure.study.gpu_memory.check_gpu_memory_residual", lambda *a, **k: None
+    )
+    monkeypatch.setattr(runner_module, "_save_and_record", fake_save_and_record)
+
+    from unittest.mock import MagicMock
+
+    from llenergymeasure.study.manifest import ManifestWriter
+
+    mock_manifest = MagicMock(spec=ManifestWriter)
+    config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    study = StudyConfig(experiments=[config])
+
+    run_single_experiment(study, mock_manifest, tmp_path, runner_specs=None)
+
+    assert captured.get("resolved_config_hash") == hash_config(build_resolved_view(config))
+    assert captured["resolved_config_hash"]
+
+
+def test_single_experiment_writes_runtime_observations(monkeypatch, tmp_path):
+    """ST4: the single-experiment local path emits runtime_observations.jsonl.
+
+    The multi-experiment worker wraps execution in capture_runtime_observations; the
+    single path previously did not, so report-gaps found nothing for single-exp studies.
+    """
+    import json
+
+    import llenergymeasure.engines as engines_module
+    import llenergymeasure.harness.preflight as pf_module
+
+    mock_result = make_result(experiment_id="runtime-obs-test")
+    mock_engine = _MockBackend(mock_result)
+
+    monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
+    monkeypatch.setattr(engines_module, "get_engine", lambda name: mock_engine)
+    _patch_harness(monkeypatch, mock_result)
+    monkeypatch.setattr(
+        "llenergymeasure.study.gpu_memory.check_gpu_memory_residual", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "llenergymeasure.results.persistence.save_result",
+        lambda result, output_dir, **kw: tmp_path / "result.json",
+    )
+
+    from unittest.mock import MagicMock
+
+    from llenergymeasure.study.manifest import ManifestWriter
+
+    mock_manifest = MagicMock(spec=ManifestWriter)
+    config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    study = StudyConfig(experiments=[config])
+
+    run_single_experiment(study, mock_manifest, tmp_path, runner_specs=None)
+
+    obs_file = tmp_path / "runtime_observations.jsonl"
+    assert obs_file.exists(), "runtime_observations.jsonl was not written"
+    lines = [ln for ln in obs_file.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["config_hash"]
+    assert record["outcome"] == "success"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -357,6 +357,50 @@ def test_run_calls_preflight_once_per_config(monkeypatch, tmp_path):
     assert preflight_calls[0].task.model == "gpt2"
 
 
+@pytest.mark.parametrize("abort_status", ["timed_out", "circuit_breaker"])
+def test_run_preserves_runner_abort_status(monkeypatch, tmp_path, abort_status):
+    """ST1: _run() must not overwrite a terminal abort status the runner set.
+
+    On wall-clock timeout / circuit-breaker abort the StudyRunner marks the study
+    'timed_out'/'circuit_breaker' and returns; _run() previously called
+    mark_study_completed() unconditionally, clobbering that status and leaving the
+    aborted study looking completed (and therefore non-resumable).
+    """
+    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.preflight as study_pf_module
+
+    captured: dict = {}
+
+    def fake_run_via_runner(study, manifest, study_dir, **kw):
+        if abort_status == "timed_out":
+            manifest.mark_study_timed_out()
+        else:
+            manifest.mark_study_circuit_breaker()
+        captured["manifest"] = manifest
+        return [], [None, None], []
+
+    monkeypatch.setattr(api_module, "_run_via_runner", fake_run_via_runner)
+    monkeypatch.setattr(study_pf_module, "run_study_preflight", _mock_preflight_return)
+    monkeypatch.setattr(
+        "llenergymeasure.infra.runner_resolution.is_docker_available", lambda: False
+    )
+    monkeypatch.setattr(
+        "llenergymeasure.study.manifest.create_study_dir",
+        lambda name, output_dir: tmp_path,
+    )
+
+    # Two experiments -> multi-experiment path -> dispatches via _run_via_runner.
+    study = StudyConfig(
+        experiments=[
+            ExperimentConfig(task={"model": "gpt2"}),
+            ExperimentConfig(task={"model": "distilgpt2"}),
+        ]
+    )
+    api_module._run(study)
+
+    assert captured["manifest"].status == abort_status
+
+
 def test_run_skips_preflight_when_preresolved_supplied(monkeypatch, tmp_path):
     """_run() does NOT re-run study preflight when preresolved is provided."""
     import llenergymeasure.api._impl as api_module


### PR DESCRIPTION
## Summary

First PR of the behavioral-audit cleanup campaign. Fixes four confirmed study/result data-integrity bugs found by the 8-agent audit against `origin/main` (`9bd60d6e`). Each is repro-confirmed and carries a regression test.

- **ST1 - abort-status clobber** (`api/_impl.py`): on wall-clock timeout or circuit-breaker abort the `StudyRunner` correctly marks the study `timed_out`/`circuit_breaker` and returns, but `_run()` then called `mark_study_completed()` unconditionally - overwriting that status, so the aborted study looked complete and became non-resumable (skipped experiments never re-ran). Now gated on the status not already being terminal-aborted. Adds a small `ManifestWriter.status` accessor.
- **ST2 - equivalence-group key/type mismatch** (`study/loading.py`): the producer hand-rolled `member_indices`/`representative_index` (raw ints), but the runner's deserialiser reads `member_experiment_ids`/`representative_experiment_id` (id strings), so every loaded pre-run group came back with empty members. Now maps the dedup group's member indices to their declared-config-hash experiment ids and emits the keys the consumer reads.
- **ST3 - single-exp missing `resolved_config_hash`** (`study/single.py`): the single-experiment path omitted `resolved_config_hash` from the `config.json` sidecar that the multi-experiment path includes. Now computed and passed (mirrors `StudyRunner._build_resolved_hashes`).
- **ST4 - single-exp no runtime observations** (`study/single.py`): the single-experiment local path never wrapped execution in `capture_runtime_observations`, so single-experiment studies produced no `runtime_observations.jsonl` and `report-gaps` found nothing for them. Now wrapped like the multi-experiment worker path.

## Test plan

- New regression tests: `test_run_preserves_runner_abort_status` (ST1, parametrised timeout + circuit-breaker), strengthened `test_greedy_temperature_sweep_collapses` (ST2 member ids), `test_single_experiment_passes_resolved_config_hash` (ST3), `test_single_experiment_writes_runtime_observations` (ST4).
- ST2 additionally verified end-to-end through the real `load_study` API + round-trip through the runner's deserialiser.
- `make lint` (ruff + import-linter: 4 contracts kept) and `make typecheck` (mypy: clean) pass.
- Full suite: 2399 passed, 52 skipped, 0 failed.

## Doc audit

No doc changes needed - these are internal correctness fixes; no public schema or CLI surface changed.