### PR TITLE
fix(infra): repair Docker baseline import, env clobber, doc nit

### DIFF
--- a/scripts/container_entrypoint.sh
+++ b/scripts/container_entrypoint.sh
@@ -118,11 +118,16 @@ else
     LAUNCH=(python3)
 fi
 
+# Framework module to exec. Defaults to the experiment container entrypoint;
+# the baseline dispatch overrides it with LLEM_ENTRY_MODULE so it reuses this
+# same package-mount + dep-prime bootstrap instead of duplicating it.
+ENTRY_MODULE="${LLEM_ENTRY_MODULE:-llenergymeasure.entrypoints.container}"
+
 # Engine-conditional final exec. TensorRT-LLM upstream image needs
 # nvidia_entrypoint.sh to set up LD_LIBRARY_PATH for libnvinfer.so
 # (closes #608); other engines exec python3 directly.
 if [ "${LLEM_ENGINE:-}" = "tensorrt" ]; then
-    exec /opt/nvidia/nvidia_entrypoint.sh "${LAUNCH[@]}" -m llenergymeasure.entrypoints.container "$@"
+    exec /opt/nvidia/nvidia_entrypoint.sh "${LAUNCH[@]}" -m "${ENTRY_MODULE}" "$@"
 else
-    exec "${LAUNCH[@]}" -m llenergymeasure.entrypoints.container "$@"
+    exec "${LAUNCH[@]}" -m "${ENTRY_MODULE}" "$@"
 fi

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -119,6 +119,11 @@ wrap the final exec in mpirun -n N --allow-run-as-root."""
 ENV_DEPS_CACHE_DIR: Final = "LLEM_DEPS_CACHE_DIR"
 """Override for the host-side runtime-deps cache directory. Defaults to
 ``platformdirs.user_cache_dir('llem')/deps`` when unset."""
+ENV_ENTRY_MODULE: Final = "LLEM_ENTRY_MODULE"
+"""Framework module the container entrypoint script exec's with ``python3 -m``.
+Defaults to ``llenergymeasure.entrypoints.container`` (the experiment path);
+the baseline dispatch sets it to ``llenergymeasure.entrypoints.baseline_measure``
+so both share the same package-mount + dep-prime bootstrap."""
 
 # ---------------------------------------------------------------------------
 # Temp file/directory prefixes

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -40,9 +40,11 @@ from llenergymeasure._version import __version__
 from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
     DOCKER_PULL_TIMEOUT,
+    ENV_BASELINE_SPEC_PATH,
     ENV_CONFIG_PATH,
     ENV_DEPS_CACHE_DIR,
     ENV_ENGINE,
+    ENV_ENTRY_MODULE,
     ENV_HF_TOKEN,
     ENV_HOST_GID,
     ENV_HOST_UID,
@@ -66,9 +68,29 @@ from llenergymeasure.infra.docker_errors import (
 from llenergymeasure.utils.exceptions import DockerError
 from llenergymeasure.utils.io import load_json
 
-__all__ = ["DockerRunner"]
+__all__ = ["DockerRunner", "append_package_dispatch"]
 
 logger = logging.getLogger(__name__)
+
+# Reserved exchange env keys the docker command builders set deliberately
+# (via -e or --env-file). The blanket "forward every host LLEM_* var" loop
+# must skip these: docker applies -e last-wins over --env-file, so a stray
+# host LLEM_CONFIG_PATH / LLEM_OUTPUT_DIR / ... would silently clobber the
+# intended dispatch value. Built from the actual ENV_* constants so it can't
+# drift from what the builders set.
+_RESERVED_EXCHANGE_ENV: frozenset[str] = frozenset(
+    {
+        ENV_CONFIG_PATH,
+        ENV_OUTPUT_DIR,
+        ENV_SAVE_TIMESERIES,
+        ENV_ENGINE,
+        ENV_ENTRY_MODULE,
+        ENV_HOST_UID,
+        ENV_HOST_GID,
+        ENV_MPI_NP,
+        ENV_BASELINE_SPEC_PATH,
+    }
+)
 
 # Watchdog poll cadence: small enough to surface timeouts promptly, large
 # enough to keep idle CPU near zero. 0.5s gives users at most a half-second
@@ -186,6 +208,70 @@ def _ensure_deps_cache_dir() -> Path:
         cache_dir = Path(platformdirs.user_cache_dir("llem")) / "deps"
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir
+
+
+def append_package_dispatch(
+    cmd: list[str],
+    *,
+    engine: str,
+    entry_module: str | None = None,
+    mpi_np: int | None = None,
+) -> None:
+    """Append the bind-mounts + env + entrypoint that make the package importable.
+
+    Upstream engine images (vllm, tensorrt) and even our transformers image do
+    NOT have ``llenergymeasure`` installed; the framework runs from the host
+    source bind-mounted at ``/llem-src``. This appends the four mounts the
+    in-container entrypoint script needs (package source, pyproject.toml, the
+    script itself, and the host deps cache), the env it reads, and points
+    ``--entrypoint`` at the script. The script sets ``PYTHONPATH`` to include
+    ``/llem-src`` and primes any missing runtime deps, then exec's the module
+    named by ``LLEM_ENTRY_MODULE``.
+
+    Shared by the experiment dispatch (``DockerRunner._build_docker_cmd``) and
+    the baseline dispatch (``study.baseline_container.build_baseline_docker_cmd``)
+    so the two package-import setups cannot drift.
+
+    Args:
+        cmd: Docker command list to mutate in place (mounts/env appended before
+            the image name, which the caller adds afterwards).
+        engine: Engine value; sets ``LLEM_ENGINE`` so the script routes tensorrt
+            through ``nvidia_entrypoint.sh`` for the libnvinfer ``LD_LIBRARY_PATH``.
+        entry_module: Override for the module the script exec's. ``None`` leaves
+            the script default (``llenergymeasure.entrypoints.container``).
+        mpi_np: When > 1, sets ``LLEM_MPI_NP`` so the script wraps the exec in
+            ``mpirun -n N`` (TRT-LLM tensor parallelism).
+    """
+    pkg_parent = _resolve_package_parent_dir()
+    repo_root = _resolve_repo_root()
+    entry_script = repo_root / "scripts" / "container_entrypoint.sh"
+    pyproject = repo_root / "pyproject.toml"
+    deps_cache = _ensure_deps_cache_dir()
+    cmd.extend(
+        [
+            "-v",
+            f"{pkg_parent}:/llem-src:ro",
+            "-v",
+            f"{pyproject}:/llem-pyproject.toml:ro",
+            "-v",
+            f"{entry_script}:/llem-entry.sh:ro",
+            "-v",
+            f"{deps_cache}:/llem-runtime-deps",
+            "-e",
+            "PYTHONDONTWRITEBYTECODE=1",
+            "-e",
+            f"{ENV_ENGINE}={engine}",
+            "-e",
+            f"{ENV_HOST_UID}={os.getuid()}",
+            "-e",
+            f"{ENV_HOST_GID}={os.getgid()}",
+        ]
+    )
+    if entry_module is not None:
+        cmd.extend(["-e", f"{ENV_ENTRY_MODULE}={entry_module}"])
+    if mpi_np is not None and mpi_np > 1:
+        cmd.extend(["-e", f"{ENV_MPI_NP}={mpi_np}"])
+    cmd.extend(["--entrypoint", "/llem-entry.sh"])
 
 
 class DockerRunner:
@@ -910,9 +996,13 @@ class DockerRunner:
 
         # Forward LLEM_* env vars into the container so framework defaults set
         # on the host (e.g. LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP) reach the
-        # experiment process, which actually runs inside the container.
+        # experiment process, which actually runs inside the container. Reserved
+        # exchange keys are excluded: we set those deliberately above (or via
+        # the package-dispatch helper), and docker's -e is last-wins over the
+        # --env-file, so a stray host copy would silently clobber the intended
+        # value.
         for env_key, env_val in os.environ.items():
-            if env_key.startswith("LLEM_") and env_val:
+            if env_key.startswith("LLEM_") and env_val and env_key not in _RESERVED_EXCHANGE_ENV:
                 cmd.extend(["-e", f"{env_key}={env_val}"])
 
         # Extra volume mounts (engine cache, model cache, etc.)
@@ -924,57 +1014,15 @@ class DockerRunner:
         if config.engine == Engine.TENSORRT and config.tensorrt is not None:
             tp_size = config.tensorrt.tensor_parallel_size
 
-        # All engines: bind-mount the host package source, pyproject.toml
-        # (consulted by the entrypoint script's runtime-dep diff),
-        # the entrypoint script itself, and the host deps cache. The
-        # entrypoint script primes any missing runtime deps on first
-        # dispatch (and short-circuits subsequent ones via a pyproject-hash
-        # stamp), sets PYTHONPATH to include /llem-src and the deps cache,
-        # then exec's the framework entrypoint module - routing through
-        # /opt/nvidia/nvidia_entrypoint.sh when LLEM_ENGINE=tensorrt so the
-        # NGC LD_LIBRARY_PATH setup runs, and wrapping in mpirun when
-        # LLEM_MPI_NP is set (TP > 1).
-        #
-        # PYTHONDONTWRITEBYTECODE prevents __pycache__ litter on the
-        # bind-mounted source. LLEM_HOST_UID/LLEM_HOST_GID let the
-        # entrypoint script chown the primed deps to the host user, so
-        # the cache can be cleaned without sudo even though the container
-        # itself runs as root (default for upstream engine images).
-        pkg_parent = _resolve_package_parent_dir()
-        repo_root = _resolve_repo_root()
-        entry_script = repo_root / "scripts" / "container_entrypoint.sh"
-        pyproject = repo_root / "pyproject.toml"
-        deps_cache = _ensure_deps_cache_dir()
-        # ``Engine`` is a (str, Enum) so ``f"{config.engine}"`` resolves to
-        # the raw value via its ``__str__`` override.
-        cmd.extend(
-            [
-                "-v",
-                f"{pkg_parent}:/llem-src:ro",
-                "-v",
-                f"{pyproject}:/llem-pyproject.toml:ro",
-                "-v",
-                f"{entry_script}:/llem-entry.sh:ro",
-                "-v",
-                f"{deps_cache}:/llem-runtime-deps",
-                "-e",
-                "PYTHONDONTWRITEBYTECODE=1",
-                "-e",
-                f"{ENV_ENGINE}={config.engine}",
-                "-e",
-                f"{ENV_HOST_UID}={os.getuid()}",
-                "-e",
-                f"{ENV_HOST_GID}={os.getgid()}",
-            ]
-        )
-        if tp_size is not None and tp_size > 1:
-            cmd.extend(["-e", f"{ENV_MPI_NP}={tp_size}"])
-
-        # The entrypoint script handles the engine-conditional final exec
-        # (TRT-LLM routes through nvidia_entrypoint.sh; others exec python3
-        # directly) and the mpirun wrap for TP > 1, so docker_runner only
-        # needs to point --entrypoint at the script.
-        cmd.extend(["--entrypoint", "/llem-entry.sh"])
+        # All engines: bind-mount the host package source + bootstrap (so the
+        # package is importable in images that don't ship it) and point
+        # --entrypoint at the script. Shared with the baseline dispatch via
+        # append_package_dispatch so the two cannot drift. The experiment path
+        # uses the script's default entry module
+        # (``llenergymeasure.entrypoints.container``), so entry_module stays None.
+        # ``Engine`` is a (str, Enum) so ``f"{config.engine}"`` resolves to the
+        # raw value via its ``__str__`` override.
+        append_package_dispatch(cmd, engine=f"{config.engine}", mpi_np=tp_size)
 
         # Container name and labels for lifecycle management (cleanup, reaper).
         # These must appear before the image name in the docker run command.

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -20,7 +20,7 @@ Two-tier handshake:
    the image (e.g. ``vllm.__version__``) matches the version that our
    vendored invariants and discovered schemas in
    ``src/llenergymeasure/engines/{engine}/`` were generated against
-   (recorded in ``engine_versions/{engine}.yaml::library.current_version``).
+   (recorded in ``engine_versions/{engine}/current.yaml::library.current_version``).
    The probe is run only when the label-based check is inconclusive
    (no labels, or a literal ``"unknown"`` fingerprint left by a legacy
    build) so that label-based-OK paths stay cheap.

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -34,6 +34,7 @@ from llenergymeasure.config.ssot import (
     TEMP_PREFIX_EXCHANGE,
 )
 from llenergymeasure.harness.baseline import BaselineCache
+from llenergymeasure.infra.docker_runner import append_package_dispatch
 from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
@@ -58,19 +59,30 @@ _STAGE_LINE_PREFIX = f"{STAGE_LINE_PREFIX} stage="
 BASELINE_SPEC_FILENAME = "baseline_spec.json"
 
 
+_BASELINE_ENTRY_MODULE = "llenergymeasure.entrypoints.baseline_measure"
+
+
 def build_baseline_docker_cmd(
     image: str,
     exchange_dir: str,
     gpu_indices: list[int],
+    engine: str,
 ) -> list[str]:
     """Build the ``docker run`` command list for a baseline-only container.
+
+    Reuses ``infra.docker_runner.append_package_dispatch`` (the same mechanism
+    the experiment path uses) to bind-mount the host package source and route
+    through ``/llem-entry.sh``. Upstream engine images do not ship the
+    ``llenergymeasure`` package, so without this the baseline entry module would
+    fail with ``ModuleNotFoundError``. The script exec's the baseline entry
+    module (set via ``LLEM_ENTRY_MODULE``) instead of the experiment one.
 
     Kept separate from ``run_baseline_container`` so tests can assert on the
     command shape without mocking subprocess internals.
     """
     cuda_visible = ",".join(str(i) for i in gpu_indices) if gpu_indices else ""
     spec_container_path = f"{CONTAINER_EXCHANGE_DIR}/{BASELINE_SPEC_FILENAME}"
-    return [
+    cmd = [
         "docker",
         "run",
         "--rm",
@@ -82,11 +94,12 @@ def build_baseline_docker_cmd(
         f"{ENV_BASELINE_SPEC_PATH}={spec_container_path}",
         "-e",
         f"CUDA_VISIBLE_DEVICES={cuda_visible}",
-        image,
-        "python3",
-        "-m",
-        "llenergymeasure.entrypoints.baseline_measure",
     ]
+    # Mount the package + bootstrap and point --entrypoint at /llem-entry.sh,
+    # which makes the package importable and exec's the baseline entry module.
+    append_package_dispatch(cmd, engine=engine, entry_module=_BASELINE_ENTRY_MODULE)
+    cmd.append(image)
+    return cmd
 
 
 def parse_stage_line(line: str) -> tuple[str, dict[str, str]] | None:
@@ -117,6 +130,7 @@ def run_baseline_container(
     mode: str,
     duration_sec: float,
     gpu_indices: list[int],
+    engine: str,
     timeout_sec: float | None = None,
     on_stage: StageCallback | None = None,
 ) -> BaselineCache | None:
@@ -137,6 +151,9 @@ def run_baseline_container(
         gpu_indices: GPUs to measure. Translated to ``CUDA_VISIBLE_DEVICES`` so
             the baseline container sees exactly the same GPUs the experiment
             container will.
+        engine: Engine value of the image. Passed to the entrypoint script so
+            tensorrt baselines route through ``nvidia_entrypoint.sh`` (matching
+            the experiment container's libnvinfer setup).
         timeout_sec: Subprocess timeout. Defaults to
             ``max(duration_sec * 2 + 60, 120)`` - enough for cold-start,
             sampling, and teardown with headroom.
@@ -170,6 +187,7 @@ def run_baseline_container(
         image=image,
         exchange_dir=str(exchange_dir),
         gpu_indices=list(gpu_indices),
+        engine=engine,
     )
 
     logger.debug(

--- a/src/llenergymeasure/study/baseline_measure.py
+++ b/src/llenergymeasure/study/baseline_measure.py
@@ -388,6 +388,7 @@ class _BaselineMixin:
             mode="measure",
             duration_sec=config.measurement.baseline.duration_seconds,
             gpu_indices=gpu_indices,
+            engine=f"{config.engine}",
             on_stage=on_stage,
         )
 
@@ -418,6 +419,7 @@ class _BaselineMixin:
             mode="spot_check",
             duration_sec=5.0,
             gpu_indices=gpu_indices,
+            engine=f"{config.engine}",
         )
         return result.power_w if result is not None else None
 

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -16,6 +16,8 @@ from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
     ENV_CONFIG_PATH,
     ENV_HF_TOKEN,
+    ENV_OUTPUT_DIR,
+    ENV_SAVE_TIMESERIES,
     Engine,
 )
 from llenergymeasure.infra.docker_errors import (
@@ -1496,3 +1498,62 @@ class TestMountPivot:
         cmd = self._build("transformers", tmp_path)
         expected_mount = f"{_resolve_package_parent_dir()}:/llem-src:ro"
         assert expected_mount in cmd
+
+
+# ---------------------------------------------------------------------------
+# Test: reserved exchange env keys are not clobbered by the LLEM_* forward loop
+# ---------------------------------------------------------------------------
+
+
+class TestReservedEnvForwarding:
+    """A stray host ``LLEM_*`` reserved exchange var must not override the
+    intended dispatch value. Docker applies ``-e`` last-wins over ``--env-file``,
+    so forwarding a host ``LLEM_CONFIG_PATH`` (etc.) would silently clobber the
+    value the builder set deliberately. The forward loop must skip reserved keys.
+    """
+
+    @staticmethod
+    def _forwarded_value(cmd: list[str], key: str) -> str | None:
+        """Last ``-e KEY=VALUE`` value for *key* (last-wins, as docker applies)."""
+        value = None
+        for i, arg in enumerate(cmd):
+            if arg == "-e" and i + 1 < len(cmd):
+                pair = cmd[i + 1]
+                if pair.startswith(f"{key}="):
+                    value = pair.split("=", 1)[1]
+        return value
+
+    def test_stray_reserved_keys_not_forwarded(self, monkeypatch):
+        """Stray host reserved keys are excluded from the blanket forward loop,
+        so the builder's intended exchange values win."""
+        config = make_config()
+        # Stray host values that would clobber the dispatch if forwarded.
+        monkeypatch.setenv(ENV_CONFIG_PATH, "/host/stray/config.json")
+        monkeypatch.setenv(ENV_OUTPUT_DIR, "/host/stray/out")
+        monkeypatch.setenv(ENV_SAVE_TIMESERIES, "0")
+
+        runner = DockerRunner(image=IMAGE)
+        cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
+
+        # CONFIG_PATH is set once, to the intended exchange-dir path - not the stray.
+        config_vals = [
+            cmd[i + 1].split("=", 1)[1]
+            for i, arg in enumerate(cmd)
+            if arg == "-e" and cmd[i + 1].startswith(f"{ENV_CONFIG_PATH}=")
+        ]
+        assert config_vals == [f"{CONTAINER_EXCHANGE_DIR}/abc123_config.json"]
+        assert "/host/stray/config.json" not in config_vals
+        # OUTPUT_DIR / SAVE_TIMESERIES travel via --env-file, never via -e here,
+        # so the stray host values must not appear as -e args.
+        assert self._forwarded_value(cmd, ENV_OUTPUT_DIR) is None
+        assert self._forwarded_value(cmd, ENV_SAVE_TIMESERIES) is None
+
+    def test_non_reserved_llem_var_still_forwarded(self, monkeypatch):
+        """Non-reserved framework-default LLEM_* vars are still forwarded."""
+        config = make_config()
+        monkeypatch.setenv("LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP", "auto")
+
+        runner = DockerRunner(image=IMAGE)
+        cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
+
+        assert self._forwarded_value(cmd, "LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP") == "auto"

--- a/tests/unit/study/test_baseline_container.py
+++ b/tests/unit/study/test_baseline_container.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from llenergymeasure.config.ssot import ENV_BASELINE_SPEC_PATH
+from llenergymeasure.config.ssot import ENV_BASELINE_SPEC_PATH, ENV_ENGINE, ENV_ENTRY_MODULE
 from llenergymeasure.study import baseline_container
 
 _MODULE = "llenergymeasure.study.baseline_container"
@@ -75,6 +75,7 @@ class TestBuildBaselineDockerCmd:
             image="ghcr.io/foo/bar:v1",
             exchange_dir=str(tmp_path),
             gpu_indices=[0, 2],
+            engine="vllm",
         )
         assert cmd[0] == "docker"
         assert "run" in cmd
@@ -83,18 +84,49 @@ class TestBuildBaselineDockerCmd:
         # env vars
         assert any(f"{ENV_BASELINE_SPEC_PATH}=" in part for part in cmd)
         assert any("CUDA_VISIBLE_DEVICES=0,2" in part for part in cmd)
-        # image
-        assert "ghcr.io/foo/bar:v1" in cmd
-        # entrypoint
-        assert "python3" in cmd
-        assert "-m" in cmd
-        assert "llenergymeasure.entrypoints.baseline_measure" in cmd
+        # image is the LAST arg (the entrypoint script invokes the module itself)
+        assert cmd[-1] == "ghcr.io/foo/bar:v1"
+
+    def test_cmd_makes_package_importable(self, tmp_path: Path):
+        """The baseline command must mount the host package + route through the
+        entrypoint script so the upstream engine image can import the package.
+
+        Without this, every Docker baseline run fails with ModuleNotFoundError:
+        upstream engine images do not ship the llenergymeasure package.
+        """
+        cmd = baseline_container.build_baseline_docker_cmd(
+            image="img:latest",
+            exchange_dir=str(tmp_path),
+            gpu_indices=[0],
+            engine="vllm",
+        )
+        # Package source bind-mount (makes the package importable via PYTHONPATH).
+        assert any(arg.endswith(":/llem-src:ro") for arg in cmd)
+        # Dispatch routes through the shared in-container bootstrap script.
+        ep_idx = cmd.index("--entrypoint")
+        assert cmd[ep_idx + 1] == "/llem-entry.sh"
+        # The script exec's the baseline module (not the experiment one).
+        assert f"{ENV_ENTRY_MODULE}=llenergymeasure.entrypoints.baseline_measure" in cmd
+        # Engine is propagated so the script can route tensorrt correctly.
+        assert f"{ENV_ENGINE}=vllm" in cmd
+        # The old, broken trailing "python3 -m ..." form must be gone.
+        assert "python3" not in cmd
+
+    def test_cmd_tensorrt_engine_propagated(self, tmp_path: Path):
+        cmd = baseline_container.build_baseline_docker_cmd(
+            image="img:latest",
+            exchange_dir=str(tmp_path),
+            gpu_indices=[0],
+            engine="tensorrt",
+        )
+        assert f"{ENV_ENGINE}=tensorrt" in cmd
 
     def test_cmd_empty_gpu_indices(self, tmp_path: Path):
         cmd = baseline_container.build_baseline_docker_cmd(
             image="img:latest",
             exchange_dir=str(tmp_path),
             gpu_indices=[],
+            engine="transformers",
         )
         assert any("CUDA_VISIBLE_DEVICES=" in part for part in cmd)
 
@@ -145,6 +177,7 @@ class TestRunBaselineContainerSuccess:
                 mode="measure",
                 duration_sec=30.0,
                 gpu_indices=[0],
+                engine="vllm",
             )
 
         assert result is not None
@@ -168,6 +201,7 @@ class TestRunBaselineContainerSuccess:
                 mode="measure",
                 duration_sec=1.0,
                 gpu_indices=[0],
+                engine="vllm",
             )
 
         assert not exchange_dir.exists()
@@ -206,6 +240,7 @@ class TestRunBaselineContainerSuccess:
                 mode="measure",
                 duration_sec=30.0,
                 gpu_indices=[0],
+                engine="vllm",
                 on_stage=on_stage,
             )
 
@@ -249,6 +284,7 @@ class TestRunBaselineContainerSuccess:
                 mode="measure",
                 duration_sec=30.0,
                 gpu_indices=[0],
+                engine="vllm",
                 on_stage=broken,
             )
 
@@ -288,6 +324,7 @@ class TestRunBaselineContainerFailure:
                 mode="measure",
                 duration_sec=1.0,
                 gpu_indices=[0],
+                engine="vllm",
             )
 
         assert result is None
@@ -308,6 +345,7 @@ class TestRunBaselineContainerFailure:
                 mode="measure",
                 duration_sec=1.0,
                 gpu_indices=[0],
+                engine="vllm",
             )
 
         assert result is None
@@ -349,6 +387,7 @@ class TestRunBaselineContainerFailure:
                 mode="measure",
                 duration_sec=1.0,
                 gpu_indices=[0],
+                engine="vllm",
             )
 
         assert result is None
@@ -376,6 +415,7 @@ class TestRunBaselineContainerFailure:
                 mode="measure",
                 duration_sec=1.0,
                 gpu_indices=[0],
+                engine="vllm",
             )
 
         assert result is None
@@ -391,6 +431,7 @@ class TestRunBaselineContainerFailure:
                 mode="measure",
                 duration_sec=1.0,
                 gpu_indices=[0],
+                engine="vllm",
             )
 
         assert result is None


### PR DESCRIPTION
## Summary

Three Docker / infra correctness fixes from the behavioural audit.

**IN1 (HIGH) - every Docker baseline run was broken.** `study/baseline_container.build_baseline_docker_cmd` ran `python3 -m ...baseline_measure` against the raw engine image, but upstream engine images do not ship the `llenergymeasure` package and the command mounted neither the package source nor a PYTHONPATH, so every Docker baseline measurement (cached / validated strategies) failed with `ModuleNotFoundError: No module named 'llenergymeasure'`. The experiment path (`DockerRunner._build_docker_cmd`) makes the package importable by bind-mounting the host source at `/llem-src` and routing through `/llem-entry.sh` (which sets `PYTHONPATH` and primes runtime deps). 

Fix (reuse, not duplication): extract a shared `append_package_dispatch` helper in the infra layer. It appends the package-source + bootstrap mounts and points `--entrypoint` at the script. Both builders now call it, so the two package-import setups cannot drift. The entrypoint script exec's the module named by `LLEM_ENTRY_MODULE` (default `...entrypoints.container`; the baseline sets it to `...entrypoints.baseline_measure`). `engine` is threaded through the baseline path so tensorrt baselines route via `nvidia_entrypoint.sh`, matching the experiment container.

**IN3 (HIGH) - silent env clobber.** `DockerRunner._build_docker_cmd` forwarded every host `LLEM_*` env var as `-e`. Because docker applies `-e` last-wins over `--env-file`, a stray host `LLEM_CONFIG_PATH` / `LLEM_OUTPUT_DIR` / `LLEM_SAVE_TIMESERIES` (or any reserved exchange key) silently overrode the intended dispatch value. Fix: exclude a shared `frozenset` of reserved keys (built from the `ENV_*` constants, not string literals) from the blanket forward loop. Non-reserved `LLEM_*` framework-default vars are still forwarded.

**IN4 (minor doc nit).** Corrected a stale SSOT path in `version_handshake.py` docstring: `engine_versions/{engine}.yaml` -> `engine_versions/{engine}/current.yaml` (the real layout, confirmed against the repo and `read_ssot_engine_version`).

## Test plan

- New `TestBuildBaselineDockerCmd.test_cmd_makes_package_importable`: asserts the baseline command mounts `/llem-src`, routes through `/llem-entry.sh`, sets `LLEM_ENTRY_MODULE=...baseline_measure`, and no longer contains the broken trailing `python3 -m ...`.
- New `TestReservedEnvForwarding`: sets stray host `LLEM_CONFIG_PATH` / `LLEM_OUTPUT_DIR` / `LLEM_SAVE_TIMESERIES` and asserts they are NOT forwarded (intended value wins), while a non-reserved `LLEM_*` var still is.
- Updated existing baseline-container tests (which asserted the buggy `python3 -m` shape and called the helpers without `engine`) to the new shape.
- Verified at the real surface (no GPU/docker needed): called both builders directly and inspected the emitted command list to confirm the package is importable and reserved keys are excluded.
- `make lint` (ruff + format + import-linter, 4 layer contracts KEPT), `make typecheck` (mypy clean, 266 files), full `uv run pytest`: 2403 passed, 52 skipped, 0 failed.

## Doc audit

- No em-dashes / en-dashes introduced (ASCII hyphen only).
- Updated `scripts/container_entrypoint.sh` and `docker_runner` docstrings to describe the shared dispatch + `LLEM_ENTRY_MODULE` override.
- Out of scope (left untouched): `engines/README.md` still references the old `engine_versions/{engine}.yaml` path; IN4 was scoped to `version_handshake.py`.