### PR TITLE
fix(harness): correct FLOPs counts, per-token energy, and provenance

### DIFF
--- a/src/llenergymeasure/domain/metrics.py
+++ b/src/llenergymeasure/domain/metrics.py
@@ -47,14 +47,15 @@ class EnergyMetrics(BaseModel):
     ram_energy_j: float = Field(0.0, description="RAM energy in Joules")
     gpu_power_w: float = Field(0.0, description="Average GPU power in Watts")
     cpu_power_w: float = Field(0.0, description="Average CPU power in Watts")
+    ram_power_w: float = Field(0.0, description="Average RAM power in Watts")
     duration_sec: float = Field(..., description="Measurement duration in seconds")
     emissions_kg_co2: float = Field(0.0, description="Carbon emissions in kg CO2")
     energy_per_token_j: float = Field(0.0, description="Energy per token in Joules")
 
     @property
     def total_power_w(self) -> float:
-        """Total average power consumption."""
-        return self.gpu_power_w + self.cpu_power_w
+        """Total average power consumption (GPU + CPU + RAM)."""
+        return self.gpu_power_w + self.cpu_power_w + (self.ram_power_w or 0.0)
 
 
 # =============================================================================

--- a/src/llenergymeasure/domain/model_info.py
+++ b/src/llenergymeasure/domain/model_info.py
@@ -1,0 +1,109 @@
+"""Model architecture introspection - normalise HuggingFace config field variants.
+
+Transformer configs use inconsistent field names across model families
+(``num_hidden_layers`` vs ``n_layer``, ``hidden_size`` vs ``d_model`` vs
+``n_embd``, etc.). This module pulls the architecture dimensions needed for
+parameter counting into a single normalised shape, handling the common
+field-name variants and GQA/MQA grouped-query attention.
+
+Low-layer (domain) so both the harness FLOPs estimator and later VRAM
+KV-cache sizing can reuse it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+def _first_attr(config: Any, names: tuple[str, ...]) -> Any:
+    """Return the first present (non-None) value among *names* on *config*.
+
+    Accepts either a mapping (dict-like) or an attribute-bearing object
+    (e.g. a HuggingFace ``PretrainedConfig``). Returns None when none match.
+    """
+    for name in names:
+        value = config.get(name) if isinstance(config, dict) else getattr(config, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+@dataclass(frozen=True)
+class ModelArchInfo:
+    """Normalised transformer architecture dimensions for parameter counting.
+
+    GQA/MQA aware: ``num_key_value_heads`` may be smaller than
+    ``num_attention_heads`` (grouped-query / multi-query attention), which
+    shrinks the K and V projection matrices.
+    """
+
+    num_layers: int
+    hidden_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    intermediate_size: int
+    vocab_size: int | None
+    tie_word_embeddings: bool
+
+
+def extract_model_arch(config: Any) -> ModelArchInfo | None:
+    """Extract normalised architecture dimensions from a model config.
+
+    Handles the common field-name variants across model families and falls
+    back to multi-head attention (kv heads = attention heads) when
+    ``num_key_value_heads`` is absent.
+
+    Args:
+        config: A HuggingFace config object or a plain dict of config values.
+
+    Returns:
+        ModelArchInfo, or None when the mandatory dimensions
+        (layers, hidden size, attention heads) cannot be resolved.
+    """
+    num_layers = _first_attr(config, ("num_hidden_layers", "n_layer", "num_layers"))
+    hidden_size = _first_attr(config, ("hidden_size", "d_model", "n_embd"))
+    num_attention_heads = _first_attr(config, ("num_attention_heads", "n_head", "num_heads"))
+
+    if num_layers is None or hidden_size is None or num_attention_heads is None:
+        return None
+
+    num_layers = int(num_layers)
+    hidden_size = int(hidden_size)
+    num_attention_heads = int(num_attention_heads)
+
+    # GQA/MQA: kv heads < attention heads. Fall back to MHA when absent.
+    kv_heads = _first_attr(config, ("num_key_value_heads", "num_kv_heads"))
+    num_key_value_heads = int(kv_heads) if kv_heads is not None else num_attention_heads
+
+    # head_dim is usually hidden_size // num_attention_heads but some configs
+    # set it explicitly (and it need not equal that ratio).
+    explicit_head_dim = _first_attr(config, ("head_dim",))
+    head_dim = (
+        int(explicit_head_dim)
+        if explicit_head_dim is not None
+        else hidden_size // num_attention_heads
+    )
+
+    intermediate = _first_attr(config, ("intermediate_size", "ffn_dim", "n_inner"))
+    intermediate_size = int(intermediate) if intermediate is not None else hidden_size * 4
+
+    vocab = _first_attr(config, ("vocab_size",))
+    vocab_size = int(vocab) if vocab is not None else None
+
+    tie_word_embeddings = bool(_first_attr(config, ("tie_word_embeddings",)) or False)
+
+    return ModelArchInfo(
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        head_dim=head_dim,
+        intermediate_size=intermediate_size,
+        vocab_size=vocab_size,
+        tie_word_embeddings=tie_word_embeddings,
+    )
+
+
+__all__ = ["ModelArchInfo", "extract_model_arch"]

--- a/src/llenergymeasure/harness/flops.py
+++ b/src/llenergymeasure/harness/flops.py
@@ -14,6 +14,7 @@ import logging
 from typing import Any
 
 from llenergymeasure.domain.metrics import FlopsResult
+from llenergymeasure.domain.model_info import ModelArchInfo, extract_model_arch
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,25 @@ def estimate_flops_palm(
     )
 
 
+def _count_params_from_arch(arch: ModelArchInfo) -> int:
+    """Non-embedding parameter count from normalised architecture dimensions.
+
+    GQA/MQA aware: Q and O projections scale with the full attention-head
+    width, but K and V projections scale with the (possibly smaller) number
+    of key/value heads. Embeddings are excluded (PaLM formula counts
+    non-embedding params only; they are memory-bound lookups, not MAC ops),
+    so tied vs untied embeddings do not affect this count.
+    """
+    h = arch.hidden_size
+    q_dim = arch.num_attention_heads * arch.head_dim
+    kv_dim = arch.num_key_value_heads * arch.head_dim
+    # Attention per layer: Q (h x q_dim) + K,V (h x kv_dim each) + O (q_dim x h)
+    attn = (2 * h * q_dim + 2 * h * kv_dim) * arch.num_layers
+    # FFN per layer: up (h x intermediate) + down (intermediate x h)
+    ffn = 2 * h * arch.intermediate_size * arch.num_layers
+    return int(attn + ffn)
+
+
 def _count_params_from_config(model_name: str) -> int | None:
     """Extract non-embedding parameter count from HuggingFace model config.
 
@@ -80,13 +100,10 @@ def _count_params_from_config(model_name: str) -> int | None:
         from llenergymeasure.utils.security import trust_remote_code_enabled
 
         cfg = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code_enabled())
-        h = cfg.hidden_size
-        layers = cfg.num_hidden_layers
-        intermediate = getattr(cfg, "intermediate_size", h * 4)
-        # Non-embedding params: attention (Q,K,V,O) + FFN (up,down) per layer
-        attn = 4 * h * h * layers
-        ffn = 2 * h * intermediate * layers
-        return int(attn + ffn)
+        arch = extract_model_arch(cfg)
+        if arch is None:
+            return None
+        return _count_params_from_arch(arch)
     except Exception:
         return None
 
@@ -136,6 +153,7 @@ def estimate_flops_palm_from_config(
 
 __all__ = [
     "_count_non_embedding_params",
+    "_count_params_from_arch",
     "_count_params_from_config",
     "estimate_flops_palm",
     "estimate_flops_palm_from_config",

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -489,6 +489,10 @@ class MeasurementHarness:
                 config.measurement.warmup,
                 on_substep=warmup_substep,
             )
+            # The probe at line above ran one extra discarded inference that
+            # warmup_until_converged() does not count; fold it into the warmup
+            # total so warmup_excluded_samples reflects every discarded inference.
+            warmup_result.iterations_completed += 1
         else:
             from llenergymeasure.domain.metrics import WarmupResult
 
@@ -811,26 +815,14 @@ class MeasurementHarness:
     ) -> Any:
         """Estimate FLOPs from model and token counts.
 
-        Fallback chain:
-        1. AutoConfig path - uses estimate_flops_palm_from_config(config.task.model).
-           Works for all engines (no model weights needed).
-        2. hf_model path - uses estimate_flops_palm(hf_model) when extras['hf_model'] is set.
-           Higher-confidence since it counts actual loaded parameters.
+        Fallback chain (highest confidence first):
+        1. hf_model path - uses estimate_flops_palm(hf_model) when extras['hf_model']
+           is set. Higher confidence: counts the actual loaded parameters.
+        2. AutoConfig path - uses estimate_flops_palm_from_config(config.task.model).
+           Works for engines that do not expose a model object (vLLM, TensorRT-LLM).
         3. None - FLOPs unavailable.
         """
-        # Step 1: AutoConfig path (works without loaded model weights)
-        try:
-            result = estimate_flops_palm_from_config(
-                model_name=config.task.model,
-                n_input_tokens=output.input_tokens,
-                n_output_tokens=output.output_tokens,
-            )
-            if result is not None:
-                return result
-        except Exception as e:
-            logger.debug("AutoConfig FLOPs estimation failed: %s", e)
-
-        # Step 2: hf_model path (higher confidence - uses actual loaded parameters)
+        # Step 1: hf_model path (higher confidence - uses actual loaded parameters)
         model_obj = output.extras.get("hf_model")
         if model_obj is not None:
             try:
@@ -841,6 +833,18 @@ class MeasurementHarness:
                 )
             except Exception as e:
                 logger.debug("hf_model FLOPs estimation failed: %s", e)
+
+        # Step 2: AutoConfig path (works without a loaded model object)
+        try:
+            result = estimate_flops_palm_from_config(
+                model_name=config.task.model,
+                n_input_tokens=output.input_tokens,
+                n_output_tokens=output.output_tokens,
+            )
+            if result is not None:
+                return result
+        except Exception as e:
+            logger.debug("AutoConfig FLOPs estimation failed: %s", e)
 
         # Step 3: FLOPs unavailable
         return None
@@ -897,9 +901,10 @@ class MeasurementHarness:
         """Map an engine-declared latency mode string to LatencyMeasurementMode.
 
         The engine sets ``output.latency_measurement_mode`` explicitly whenever it
-        emits TTFT. If it is missing while TTFT is present, that is an engine bug:
-        log a warning and fall back to the field's default (TRUE_STREAMING),
-        noting it in measurement_warnings.
+        emits TTFT. If it is missing - or an unrecognised string - that is an engine
+        bug: log a warning and fall back to the field's default (TRUE_STREAMING),
+        noting it in measurement_warnings. A bad engine string must never crash
+        result assembly.
         """
         from llenergymeasure.domain.metrics import LatencyMeasurementMode
 
@@ -913,7 +918,19 @@ class MeasurementHarness:
                 "provenance defaulted to true_streaming (engine should set it explicitly)."
             )
             return LatencyMeasurementMode.TRUE_STREAMING
-        return LatencyMeasurementMode(declared_mode)
+        try:
+            return LatencyMeasurementMode(declared_mode)
+        except ValueError:
+            logger.warning(
+                "Engine emitted unrecognised latency_measurement_mode %r; "
+                "defaulting provenance to TRUE_STREAMING.",
+                declared_mode,
+            )
+            measurement_warnings.append(
+                f"latency_measurement_mode {declared_mode!r} unrecognised; "
+                "provenance defaulted to true_streaming."
+            )
+            return LatencyMeasurementMode.TRUE_STREAMING
 
     @staticmethod
     def _append_latency_profiling_warnings(
@@ -1045,11 +1062,12 @@ class MeasurementHarness:
                     ),
                 )
 
-        # mJ/tok derived fields (energy in millijoules per token)
-        _mj_total = mj_per_token(total_energy_j, output.total_tokens)
+        # mJ/tok derived fields (energy in millijoules per OUTPUT token, matching
+        # avg_energy_per_token_j; input tokens are prefilled, not "generated").
+        _mj_total = mj_per_token(total_energy_j, output_tokens)
         energy_adjusted_j = energy_breakdown.adjusted_j if energy_breakdown else None
         _mj_adjusted = (
-            mj_per_token(energy_adjusted_j, output.total_tokens)
+            mj_per_token(energy_adjusted_j, output_tokens)
             if energy_adjusted_j is not None
             else None
         )

--- a/tests/unit/domain/test_metrics.py
+++ b/tests/unit/domain/test_metrics.py
@@ -42,8 +42,15 @@ class TestFlopsResult:
 class TestEnergyMetrics:
     """total_power_w property."""
 
-    def test_total_power_w(self):
+    def test_total_power_w_sums_gpu_cpu_ram(self):
+        """E5: total_power_w folds in ram_power_w alongside GPU and CPU."""
+        em = make_energy_metrics(gpu_power_w=100.0, cpu_power_w=25.0, ram_power_w=10.0)
+        assert em.total_power_w == pytest.approx(135.0)
+
+    def test_total_power_w_default_ram_zero(self):
+        """ram_power_w defaults to 0.0, so the total reduces to GPU + CPU."""
         em = make_energy_metrics(gpu_power_w=100.0, cpu_power_w=25.0)
+        assert em.ram_power_w == 0.0
         assert em.total_power_w == pytest.approx(125.0)
 
 

--- a/tests/unit/domain/test_model_info.py
+++ b/tests/unit/domain/test_model_info.py
@@ -1,0 +1,118 @@
+"""Unit tests for domain/model_info.py - architecture field normalisation."""
+
+from __future__ import annotations
+
+from llenergymeasure.domain.model_info import ModelArchInfo, extract_model_arch
+
+
+def test_extract_standard_fields() -> None:
+    """Canonical HuggingFace field names are read directly."""
+    cfg = {
+        "num_hidden_layers": 32,
+        "hidden_size": 4096,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "intermediate_size": 11008,
+        "vocab_size": 32000,
+        "tie_word_embeddings": False,
+    }
+    arch = extract_model_arch(cfg)
+    assert arch == ModelArchInfo(
+        num_layers=32,
+        hidden_size=4096,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=128,  # 4096 // 32
+        intermediate_size=11008,
+        vocab_size=32000,
+        tie_word_embeddings=False,
+    )
+
+
+def test_extract_gpt2_field_variants() -> None:
+    """GPT-2-style aliases (n_layer/n_embd/n_head/n_inner) are resolved."""
+    cfg = {
+        "n_layer": 12,
+        "n_embd": 768,
+        "n_head": 12,
+        "n_inner": 3072,
+        "vocab_size": 50257,
+    }
+    arch = extract_model_arch(cfg)
+    assert arch is not None
+    assert arch.num_layers == 12
+    assert arch.hidden_size == 768
+    assert arch.num_attention_heads == 12
+    assert arch.intermediate_size == 3072
+    assert arch.head_dim == 64  # 768 // 12
+
+
+def test_mha_fallback_when_kv_heads_absent() -> None:
+    """num_key_value_heads defaults to num_attention_heads (MHA)."""
+    arch = extract_model_arch(
+        {"num_hidden_layers": 4, "hidden_size": 512, "num_attention_heads": 8}
+    )
+    assert arch is not None
+    assert arch.num_key_value_heads == arch.num_attention_heads == 8
+
+
+def test_explicit_head_dim_overrides_ratio() -> None:
+    """An explicit head_dim is honoured even when it != hidden // heads."""
+    arch = extract_model_arch(
+        {
+            "num_hidden_layers": 4,
+            "hidden_size": 512,
+            "num_attention_heads": 8,
+            "head_dim": 128,
+        }
+    )
+    assert arch is not None
+    assert arch.head_dim == 128  # not 512 // 8 == 64
+
+
+def test_intermediate_size_default() -> None:
+    """Missing intermediate_size defaults to 4 * hidden_size."""
+    arch = extract_model_arch(
+        {"num_hidden_layers": 4, "hidden_size": 512, "num_attention_heads": 8}
+    )
+    assert arch is not None
+    assert arch.intermediate_size == 2048
+
+
+def test_tie_word_embeddings_truthy() -> None:
+    """tie_word_embeddings is normalised to a bool."""
+    tied = extract_model_arch(
+        {
+            "num_hidden_layers": 2,
+            "hidden_size": 128,
+            "num_attention_heads": 4,
+            "tie_word_embeddings": True,
+        }
+    )
+    untied = extract_model_arch(
+        {"num_hidden_layers": 2, "hidden_size": 128, "num_attention_heads": 4}
+    )
+    assert tied is not None and tied.tie_word_embeddings is True
+    assert untied is not None and untied.tie_word_embeddings is False
+
+
+def test_missing_mandatory_returns_none() -> None:
+    """None when any of layers / hidden / heads cannot be resolved."""
+    assert extract_model_arch({"hidden_size": 512}) is None
+    assert extract_model_arch({"num_hidden_layers": 4, "hidden_size": 512}) is None
+    assert extract_model_arch({}) is None
+
+
+def test_accepts_attribute_object() -> None:
+    """Works with attribute-bearing config objects (e.g. PretrainedConfig)."""
+
+    class Cfg:
+        num_hidden_layers = 4
+        hidden_size = 512
+        num_attention_heads = 8
+        num_key_value_heads = 2
+
+    arch = extract_model_arch(Cfg())
+    assert arch is not None
+    assert arch.num_key_value_heads == 2
+    assert arch.num_attention_heads == 8

--- a/tests/unit/harness/test_flops_v2.py
+++ b/tests/unit/harness/test_flops_v2.py
@@ -299,43 +299,34 @@ def test_flops_derived_fields_none_when_zero() -> None:
 # =============================================================================
 
 
-def _make_autoconfig_mock(
-    hidden_size: int = 4096,
-    num_hidden_layers: int = 32,
-    intermediate_size: int | None = None,
-) -> MagicMock:
-    """Build a mock AutoConfig object with standard architecture fields."""
-    cfg = MagicMock()
-    cfg.hidden_size = hidden_size
-    cfg.num_hidden_layers = num_hidden_layers
-    if intermediate_size is not None:
-        cfg.intermediate_size = intermediate_size
-    else:
-        # getattr fallback: MagicMock will return a MagicMock for missing attrs,
-        # so we set it explicitly to simulate the fallback default
-        del cfg.intermediate_size  # Remove auto-attribute so getattr uses default
-    return cfg
+def _patch_autoconfig(cfg: object):
+    """Patch transformers.AutoConfig.from_pretrained to return *cfg*."""
+    mock_autoconfig_cls = MagicMock()
+    mock_autoconfig_cls.from_pretrained.return_value = cfg
+    return patch.dict(sys.modules, {"transformers": MagicMock(AutoConfig=mock_autoconfig_cls)})
 
 
 def test_count_params_from_config_success() -> None:
-    """_count_params_from_config returns correct count with known config values.
+    """_count_params_from_config returns correct count for an MHA config.
 
-    Formula: attn = 4 * h * h * layers; ffn = 2 * h * intermediate * layers
-    Total = attn + ffn
+    GQA-aware formula reduces to the MHA formula when kv heads == attn heads:
+    attn = (2*h*q_dim + 2*h*kv_dim) * layers == 4 * h * h * layers (MHA),
+    ffn = 2 * h * intermediate * layers.
     """
     hidden = 64
     layers = 4
+    heads = 8
     intermediate = 256  # = hidden * 4
 
-    mock_cfg = MagicMock()
-    mock_cfg.hidden_size = hidden
-    mock_cfg.num_hidden_layers = layers
-    mock_cfg.intermediate_size = intermediate
+    cfg = {
+        "hidden_size": hidden,
+        "num_hidden_layers": layers,
+        "num_attention_heads": heads,
+        "num_key_value_heads": heads,  # MHA: kv heads == attn heads
+        "intermediate_size": intermediate,
+    }
 
-    mock_autoconfig_cls = MagicMock()
-    mock_autoconfig_cls.from_pretrained.return_value = mock_cfg
-
-    with patch.dict(sys.modules, {"transformers": MagicMock(AutoConfig=mock_autoconfig_cls)}):
+    with _patch_autoconfig(cfg):
         result = _count_params_from_config("test/model")
 
     expected_attn = 4 * hidden * hidden * layers  # 4 * 64 * 64 * 4 = 65_536
@@ -349,20 +340,76 @@ def test_count_params_from_config_intermediate_size_default() -> None:
     """_count_params_from_config uses hidden * 4 as default for intermediate_size."""
     hidden = 128
     layers = 2
+    heads = 8
 
-    mock_cfg = MagicMock(spec=["hidden_size", "num_hidden_layers"])
-    mock_cfg.hidden_size = hidden
-    mock_cfg.num_hidden_layers = layers
+    cfg = {
+        "hidden_size": hidden,
+        "num_hidden_layers": layers,
+        "num_attention_heads": heads,
+    }
 
-    mock_autoconfig_cls = MagicMock()
-    mock_autoconfig_cls.from_pretrained.return_value = mock_cfg
-
-    with patch.dict(sys.modules, {"transformers": MagicMock(AutoConfig=mock_autoconfig_cls)}):
+    with _patch_autoconfig(cfg):
         result = _count_params_from_config("test/model")
 
     intermediate = hidden * 4  # default
+    # No kv heads -> MHA fallback -> 4 * h * h * layers attention.
     expected = 4 * hidden * hidden * layers + 2 * hidden * intermediate * layers
     assert result == expected
+
+
+def test_count_params_from_config_gqa_below_mha() -> None:
+    """GQA config (kv heads < attn heads) yields fewer params than MHA."""
+    hidden = 512
+    layers = 4
+    heads = 8
+    intermediate = 2048
+
+    mha = {
+        "hidden_size": hidden,
+        "num_hidden_layers": layers,
+        "num_attention_heads": heads,
+        "num_key_value_heads": heads,
+        "intermediate_size": intermediate,
+    }
+    gqa = {**mha, "num_key_value_heads": 2}
+
+    with _patch_autoconfig(mha):
+        mha_params = _count_params_from_config("m/mha")
+    with _patch_autoconfig(gqa):
+        gqa_params = _count_params_from_config("m/gqa")
+
+    assert gqa_params is not None and mha_params is not None
+    assert gqa_params < mha_params
+
+    # GQA shrinks only K and V projections (2 of the 4 attention matrices).
+    q_dim = heads * (hidden // heads)
+    kv_dim = 2 * (hidden // heads)
+    expected_attn = (2 * hidden * q_dim + 2 * hidden * kv_dim) * layers
+    expected = expected_attn + 2 * hidden * intermediate * layers
+    assert gqa_params == expected
+
+
+def test_count_params_from_config_mha_fallback_when_kv_absent() -> None:
+    """Absent num_key_value_heads falls back to MHA (kv heads == attn heads)."""
+    hidden = 512
+    layers = 4
+    heads = 8
+    intermediate = 2048
+
+    no_kv = {
+        "hidden_size": hidden,
+        "num_hidden_layers": layers,
+        "num_attention_heads": heads,
+        "intermediate_size": intermediate,
+    }
+    explicit_mha = {**no_kv, "num_key_value_heads": heads}
+
+    with _patch_autoconfig(no_kv):
+        fallback_params = _count_params_from_config("m/nokv")
+    with _patch_autoconfig(explicit_mha):
+        mha_params = _count_params_from_config("m/mha")
+
+    assert fallback_params == mha_params
 
 
 def test_count_params_from_config_failure() -> None:
@@ -388,18 +435,19 @@ def test_estimate_flops_palm_from_config_success() -> None:
     """estimate_flops_palm_from_config returns FlopsResult with confidence='medium'."""
     hidden = 64
     layers = 4
+    heads = 8
     intermediate = 256
     n_input, n_output = 100, 50
 
-    mock_cfg = MagicMock()
-    mock_cfg.hidden_size = hidden
-    mock_cfg.num_hidden_layers = layers
-    mock_cfg.intermediate_size = intermediate
+    cfg = {
+        "hidden_size": hidden,
+        "num_hidden_layers": layers,
+        "num_attention_heads": heads,
+        "num_key_value_heads": heads,
+        "intermediate_size": intermediate,
+    }
 
-    mock_autoconfig_cls = MagicMock()
-    mock_autoconfig_cls.from_pretrained.return_value = mock_cfg
-
-    with patch.dict(sys.modules, {"transformers": MagicMock(AutoConfig=mock_autoconfig_cls)}):
+    with _patch_autoconfig(cfg):
         result = estimate_flops_palm_from_config("test/model", n_input, n_output)
 
     assert result is not None
@@ -407,7 +455,7 @@ def test_estimate_flops_palm_from_config_success() -> None:
     assert result.method == "palm_formula"
     assert result.value > 0
 
-    # Verify formula: 2 * n_params * total_tokens
+    # Verify formula: 2 * n_params * total_tokens (MHA -> 4 * h * h * layers attn)
     n_params = 4 * hidden * hidden * layers + 2 * hidden * intermediate * layers
     expected = 2 * n_params * (n_input + n_output)
     assert result.value == float(expected)

--- a/tests/unit/harness/test_measurement_integration.py
+++ b/tests/unit/harness/test_measurement_integration.py
@@ -578,3 +578,175 @@ def test_harness_build_result_propagates_baseline_fields() -> None:
     assert result.energy_adjusted_j is not None, (
         "energy_adjusted_j should be populated when baseline is provided"
     )
+
+
+# =============================================================================
+# D1: per-token energy headline divides by OUTPUT tokens only
+# =============================================================================
+
+
+def test_mj_per_tok_uses_output_tokens_only() -> None:
+    """mj_per_tok_total divides energy by OUTPUT tokens, not input+output (D1)."""
+    from llenergymeasure.engines.protocol import InferenceOutput
+    from llenergymeasure.harness import MeasurementHarness
+
+    harness = MeasurementHarness()
+    kwargs = _make_build_result_args()
+    # Asymmetric: 900 input, 100 output. total=1000. energy=100 J.
+    kwargs["output"] = InferenceOutput(
+        elapsed_time_sec=10.0,
+        input_tokens=900,
+        output_tokens=100,
+        peak_memory_mb=0.0,
+        model_memory_mb=0.0,
+    )
+
+    result = harness._build_result(**kwargs)
+
+    # 100 J / 100 output tokens * 1000 = 1000.0 mJ/output-token.
+    # Old (buggy) denominator total_tokens=1000 would give 100.0.
+    assert result.mj_per_tok_total == pytest.approx(1000.0)
+    # Consistent with the existing output-token-only headline.
+    assert result.avg_energy_per_token_j == pytest.approx(100.0 / 100)
+
+
+# =============================================================================
+# H1: FLOPs estimator tries the hf_model (actual params) path FIRST
+# =============================================================================
+
+
+def test_estimate_flops_prefers_hf_model_over_autoconfig() -> None:
+    """_estimate_flops uses the actual-param hf_model path before AutoConfig (H1)."""
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.protocol import InferenceOutput
+    from llenergymeasure.harness import MeasurementHarness
+
+    class _StubParam:
+        def __init__(self, n: int) -> None:
+            self._n = n
+
+        def numel(self) -> int:
+            return self._n
+
+    class _StubModel:
+        def named_parameters(self):
+            # Non-embedding param count that is distinctive and would never
+            # coincide with the AutoConfig estimate for the same model.
+            return iter([("decoder.layer.weight", _StubParam(777))])
+
+    harness = MeasurementHarness()
+    config = ExperimentConfig(task={"model": "gpt2"})
+    output = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=5,
+        peak_memory_mb=0.0,
+        model_memory_mb=0.0,
+        extras={"hf_model": _StubModel()},
+    )
+
+    result = harness._estimate_flops(harness_engine := MagicMock(), config, output)
+    del harness_engine
+
+    # PaLM: 2 * 777 * (10 + 5) = 23310. High confidence proves the hf_model
+    # path ran (AutoConfig would be 'medium' and a different value).
+    assert result is not None
+    assert result.confidence == "high"
+    assert result.value == float(2 * 777 * (10 + 5))
+
+
+def test_estimate_flops_falls_back_to_autoconfig_without_model() -> None:
+    """_estimate_flops falls back to AutoConfig when no hf_model is present (H1)."""
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.protocol import InferenceOutput
+    from llenergymeasure.harness import MeasurementHarness
+
+    harness = MeasurementHarness()
+    config = ExperimentConfig(task={"model": "gpt2"})
+    output = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=5,
+        peak_memory_mb=0.0,
+        model_memory_mb=0.0,
+    )
+
+    fake = MagicMock(value=5e11, confidence="medium")
+    with patch(
+        "llenergymeasure.harness.measurement.estimate_flops_palm_from_config",
+        return_value=fake,
+    ) as mock_cfg:
+        result = harness._estimate_flops(MagicMock(), config, output)
+
+    mock_cfg.assert_called_once()
+    assert result is fake
+
+
+# =============================================================================
+# H6: a bad latency-measurement-mode string must not crash result assembly
+# =============================================================================
+
+
+def test_resolve_measurement_mode_guards_bad_string() -> None:
+    """An unrecognised mode string falls back to TRUE_STREAMING with a warning (H6)."""
+    from llenergymeasure.domain.metrics import LatencyMeasurementMode
+    from llenergymeasure.harness import MeasurementHarness
+
+    warnings: list[str] = []
+    mode = MeasurementHarness._resolve_measurement_mode("not_a_real_mode", warnings)
+
+    assert mode is LatencyMeasurementMode.TRUE_STREAMING
+    assert any("not_a_real_mode" in w for w in warnings)
+
+
+def test_resolve_measurement_mode_accepts_valid_string() -> None:
+    """A valid mode string maps to its enum member (H6 regression guard)."""
+    from llenergymeasure.domain.metrics import LatencyMeasurementMode
+    from llenergymeasure.harness import MeasurementHarness
+
+    warnings: list[str] = []
+    mode = MeasurementHarness._resolve_measurement_mode("proportional", warnings)
+
+    assert mode is LatencyMeasurementMode.PROPORTIONAL_ESTIMATE
+    assert warnings == []
+
+
+# =============================================================================
+# H5: warmup_excluded_samples counts the discarded probe inference
+# =============================================================================
+
+
+def test_warmup_excluded_samples_includes_probe() -> None:
+    """_run_warmup counts the discarded strategy-probe inference (H5).
+
+    Fixed mode runs n_prompts loop inferences; the harness also runs one probe
+    inference up front to pick the warmup strategy. That probe is discarded but
+    must still be counted, so iterations_completed == n_prompts + 1.
+    """
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.harness import MeasurementHarness
+
+    n_prompts = 3
+    config = ExperimentConfig(
+        task={"model": "gpt2"},
+        measurement={
+            "warmup": {
+                "enabled": True,
+                "convergence_detection": False,
+                "n_prompts": n_prompts,
+                "thermal_floor_seconds": 30.0,
+            }
+        },
+    )
+
+    engine = MagicMock()
+    # Positive latency -> CV/fixed branch (the one with the extra probe).
+    engine.run_warmup_prompt.return_value = 12.5
+
+    harness = MeasurementHarness()
+    with patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0):
+        warmup_result = harness._run_warmup(engine, config, MagicMock(), ["p"], None)
+
+    # 1 probe + n_prompts loop inferences all ran and were discarded.
+    assert engine.run_warmup_prompt.call_count == n_prompts + 1
+    assert warmup_result.iterations_completed == n_prompts + 1


### PR DESCRIPTION
## Summary

Six measurement-correctness fixes in the FLOPs estimator, the per-token energy headline, warmup accounting, and power totals. The energy integration math (trapezoidal, baseline subtraction, kWh->J, multi-GPU summation) is untouched.

- **H1 - FLOPs fallback order inverted.** `_estimate_flops` (harness/measurement.py) tried the approximate `AutoConfig` path first, so every transformers run reported the weaker estimate even when the loaded model object was available. It now tries the high-confidence `hf_model` path (counts actual loaded params) FIRST, falling back to `AutoConfig` only for engines with no model object (vLLM, TensorRT-LLM).
- **D1 - per-token energy uses output tokens only.** `mj_per_tok_total` / `mj_per_tok_adjusted` divided energy by input+output tokens; they now divide by OUTPUT tokens only, consistent with `avg_energy_per_token_j`.
- **D7 - GQA/MQA-aware param count + tied embeddings.** The config-path param count assumed full multi-head attention, over-counting K/V projections for grouped-query models (about 14% high for Llama-3-8B). K and V projections now scale with `num_key_value_heads` (MHA fallback when absent). A new low-layer `domain/model_info.py` extracts and normalises the architecture config (field-name variants, explicit `head_dim`, `vocab_size`, `tie_word_embeddings`) so a later VRAM KV-cache PR can reuse it. (Embeddings are excluded from the PaLM non-embedding count, so tied-embedding handling is exposed via the helper for the future VRAM consumer rather than affecting the FLOPs count.)
- **H5 - warmup_excluded_samples off-by-one.** The warmup strategy probe runs one extra discarded inference that `warmup_until_converged()` does not count. It is now folded into `iterations_completed`, so `warmup_excluded_samples` no longer undercounts by one.
- **H6 - guard LatencyMeasurementMode.** An unrecognised engine-provided mode string raised `ValueError` and crashed result assembly. It now falls back to `TRUE_STREAMING` with a warning.
- **E5 - total_power_w omits ram_power_w.** `EnergyMetrics.total_power_w` summed GPU + CPU only. Added a `ram_power_w` field (default 0.0) and folded it into the total.

## Test plan

- `make lint` (ruff + ruff format + import-linter): clean. New `domain/model_info.py` sits in the domain layer; all 4 import-linter contracts KEPT.
- `make typecheck` (mypy src + tests): `Success: no issues found in 268 source files`.
- `uv run pytest` (full suite): `2420 passed, 52 skipped, 10 deselected, 0 failed`.
- New / updated regression tests:
  - H1: `_estimate_flops` prefers the actual-param `hf_model` path (confidence `high`, distinctive value) and falls back to `AutoConfig` only without a model object.
  - D1: asymmetric tokens (900 in / 100 out) -> `mj_per_tok_total` divides by 100 output tokens.
  - D7: GQA config yields fewer params than MHA; MHA fallback when kv heads absent; MHA formula unchanged; plus a dedicated `test_model_info.py` covering field-name variants, explicit `head_dim`, tied-embeddings, and missing-mandatory -> None.
  - H5: `_run_warmup` counts the discarded probe (`iterations_completed == n_prompts + 1`).
  - H6: a bad mode string returns the guarded default with a warning; a valid string still maps cleanly.
  - E5: `total_power_w` includes `ram_power_w`.
  - Existing config-path FLOPs tests were rewritten (not duplicated) to supply attention-head config; they assert the GQA-aware formula (which reduces to the old MHA formula for MHA models).
- Behavioural spot-checks (no GPU): Llama-3-8B-style GQA config -> corrected non-embedding params are 13.6% lower than the naive MHA count; `mj_per_token` with asymmetric tokens divides by output only.

## Doc audit

- `_estimate_flops` docstring updated to describe the new highest-confidence-first fallback order.
- `mj_per_tok` denominator comment updated to state output-tokens-only.
- `_resolve_measurement_mode` docstring updated to cover the unrecognised-string guard.
- `EnergyMetrics.total_power_w` docstring updated to "(GPU + CPU + RAM)".
- No product-facing docs reference the changed internals; `domain/README.md` example for `EnergyMetrics` is illustrative (already omits several fields) and was left unchanged.