### PR TITLE
fix(cli): revive VRAM dry-run estimate and harden CLI robustness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0",
     "typer>=0.9",
+    "huggingface-hub>=0.20",
     "pyyaml>=6.0",
     "platformdirs>=3.0",
     "nvidia-ml-py>=12.0",

--- a/src/llenergymeasure/api/report_gaps.py
+++ b/src/llenergymeasure/api/report_gaps.py
@@ -231,6 +231,16 @@ def find_runtime_gaps(
             f"Expected one of: {sorted(_ALLOWED_ENGINES)}."
         )
 
+    # Fail loud on a missing / non-directory study dir. A typo'd path would
+    # otherwise yield "No gaps found" with exit 0 - a false all-clear on a
+    # corpus-gating command.
+    for study_dir in study_dirs:
+        path = Path(study_dir)
+        if not path.exists():
+            raise ReportGapsError(f"Study directory does not exist: {path}")
+        if not path.is_dir():
+            raise ReportGapsError(f"Study path is not a directory: {path}")
+
     records: list[_Record] = []
     sidecar_failures = 0
     for study_dir in study_dirs:

--- a/src/llenergymeasure/cli/_display.py
+++ b/src/llenergymeasure/cli/_display.py
@@ -274,12 +274,19 @@ def print_study_dry_run(
         print(f"  {i:>{width}}  {format_experiment_header(exp)}")
     print()
 
-    # VRAM estimate for the peak model (largest weight estimate)
+    # VRAM estimate for the peak model (largest weight estimate).
+    # Memoize on (model, dtype) so a sweep of N experiments over one model does
+    # not make N identical HuggingFace Hub round-trips - only one per unique key.
     gpu_vram_gb = get_gpu_vram_gb()
     peak_vram: dict[str, float] | None = None
     peak_config: ExperimentConfig | None = None
+    vram_cache: dict[tuple[str, str | None], dict[str, float] | None] = {}
     for exp in study_config.experiments:
-        vram = estimate_vram(exp)
+        exp_section = getattr(exp, exp.engine, None)
+        cache_key = (exp.task.model, getattr(exp_section, "dtype", None))
+        if cache_key not in vram_cache:
+            vram_cache[cache_key] = estimate_vram(exp)
+        vram = vram_cache[cache_key]
         if vram is not None and (peak_vram is None or vram["total_gb"] > peak_vram["total_gb"]):
             peak_vram = vram
             peak_config = exp

--- a/src/llenergymeasure/cli/_vram.py
+++ b/src/llenergymeasure/cli/_vram.py
@@ -6,9 +6,8 @@ try/except and return None on any failure. Network errors never block the CLI.
 
 from __future__ import annotations
 
-from typing import Any
-
 from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.domain.model_info import ModelArchInfo, extract_model_arch
 
 # Bytes per parameter for each dtype.
 DTYPE_BYTES: dict[str, float] = {
@@ -18,6 +17,66 @@ DTYPE_BYTES: dict[str, float] = {
     "int8": 1,
     "int4": 0.5,
 }
+
+# Per-engine field that carries the effective inference batch size. transformers
+# uses a fixed batch; vLLM/tensorrt expose their max concurrency knob, which
+# bounds the KV cache the same way for a worst-case estimate.
+_BATCH_FIELDS: dict[str, str] = {
+    "transformers": "batch_size",
+    "vllm": "max_num_seqs",
+    "tensorrt": "max_batch_size",
+}
+
+
+def _effective_batch_size(config: ExperimentConfig) -> int:
+    """Return the configured batch size for the active engine (defaults to 1)."""
+    engine_section = getattr(config, config.engine, None)
+    field = _BATCH_FIELDS.get(str(config.engine))
+    if engine_section is not None and field is not None:
+        value = getattr(engine_section, field, None)
+        if value is not None:
+            return int(value)
+    return 1
+
+
+def _fetch_model_info(model: str) -> tuple[int | None, ModelArchInfo | None]:
+    """Fetch (param_count, arch) from HuggingFace Hub. Non-blocking.
+
+    Returns (None, None) on any failure (network error, model not found, or
+    HuggingFace Hub unavailable). Applies a short socket timeout so the CLI
+    never blocks on a slow network.
+    """
+    import socket
+
+    param_count: int | None = None
+    arch: ModelArchInfo | None = None
+    try:
+        original_timeout = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(5)
+        try:
+            from huggingface_hub import HfApi
+
+            model_info = HfApi().model_info(model)
+
+            # Parameter count from safetensors metadata.
+            safetensors = getattr(model_info, "safetensors", None)
+            total = getattr(safetensors, "total", None) if safetensors is not None else None
+            if total is not None:
+                param_count = int(total)
+
+            # Architecture for KV-cache sizing. HF Hub's ModelInfo.config is the
+            # model's config.json contents (a dict); extract_model_arch handles
+            # both dict and attribute-style configs.
+            cfg = getattr(model_info, "config", None)
+            if cfg is not None:
+                arch = extract_model_arch(cfg)
+        finally:
+            socket.setdefaulttimeout(original_timeout)
+    except Exception:
+        # Non-blocking: network errors, model not found, HF Hub unavailable.
+        return None, None
+
+    return param_count, arch
 
 
 def estimate_vram(config: ExperimentConfig) -> dict[str, float] | None:
@@ -30,62 +89,7 @@ def estimate_vram(config: ExperimentConfig) -> dict[str, float] | None:
     This function is non-blocking: all network operations have a 5-second timeout
     and are wrapped in try/except.
     """
-    import socket
-
-    # Try to fetch model metadata from HuggingFace Hub
-    param_count: int | None = None
-    n_layers: int | None = None
-    n_heads: int | None = None
-    head_dim: int | None = None
-
-    try:
-        # Apply a short connection timeout to avoid blocking the CLI
-        original_timeout = socket.getdefaulttimeout()
-        socket.setdefaulttimeout(5)
-        try:
-            from huggingface_hub import HfApi
-
-            api = HfApi()
-            model_info = api.model_info(config.task.model)
-
-            # Extract parameter count from safetensors metadata
-            if (
-                hasattr(model_info, "safetensors")
-                and model_info.safetensors is not None
-                and hasattr(model_info.safetensors, "total")
-                and model_info.safetensors.total is not None
-            ):
-                param_count = int(model_info.safetensors.total)
-
-            # Try to extract architecture details for KV cache estimation.
-            # HF Hub's ModelInfo.config is a plain dict (the model's config.json
-            # contents) in production, so read via dict access; tolerate an
-            # attribute-style object too at this external-API edge.
-            if hasattr(model_info, "config") and model_info.config is not None:
-                cfg = model_info.config
-
-                def _cfg_get(*names: str) -> Any:
-                    for name in names:
-                        value = cfg.get(name) if isinstance(cfg, dict) else getattr(cfg, name, None)
-                        if value is not None:
-                            return value
-                    return None
-
-                # Common field names across model families
-                _n_layers = _cfg_get("num_hidden_layers", "n_layer", "num_layers")
-                _n_heads = _cfg_get("num_attention_heads", "n_head", "num_heads")
-                _hidden = _cfg_get("hidden_size", "d_model", "n_embd")
-                n_layers = int(_n_layers) if _n_layers is not None else None
-                n_heads = int(_n_heads) if _n_heads is not None else None
-                if n_heads and _hidden is not None:
-                    head_dim = int(_hidden) // n_heads
-        finally:
-            socket.setdefaulttimeout(original_timeout)
-
-    except Exception:
-        # Non-blocking: network errors, model not found, HF Hub unavailable
-        pass
-
+    param_count, arch = _fetch_model_info(config.task.model)
     if param_count is None:
         return None
 
@@ -95,12 +99,21 @@ def estimate_vram(config: ExperimentConfig) -> dict[str, float] | None:
     bytes_per_param = DTYPE_BYTES.get(dtype or "bfloat16", 2)
     weights_gb = (param_count * bytes_per_param) / 1e9
 
-    # KV cache estimation (sequence length 1 = single inference pass)
+    # KV cache: 2 (key + value) * layers * batch * seq_len * kv_heads * head_dim.
+    # GQA/MQA models size K/V by num_key_value_heads (< num_attention_heads).
     kv_gb = 0.0
-    if n_layers is not None and n_heads is not None and head_dim is not None:
-        # 2 = key + value, 1 = batch size 1
+    if arch is not None:
         seq_len = config.task.max_input_tokens or 512  # fallback for VRAM estimate
-        kv_bytes = 2 * int(n_layers) * 1 * seq_len * int(n_heads) * int(head_dim) * bytes_per_param
+        batch_size = _effective_batch_size(config)
+        kv_bytes = (
+            2
+            * arch.num_layers
+            * batch_size
+            * seq_len
+            * arch.num_key_value_heads
+            * arch.head_dim
+            * bytes_per_param
+        )
         kv_gb = kv_bytes / 1e9
 
     # Empirical 15% overhead for activations and framework buffers

--- a/src/llenergymeasure/cli/doctor_cmd.py
+++ b/src/llenergymeasure/cli/doctor_cmd.py
@@ -19,8 +19,9 @@ def doctor_command() -> None:
 
     report = run_doctor_checks()
 
+    # "transformers" is 12 chars; width 13 keeps the column aligned.
     header = (
-        f"{'Engine':<10s}  {'Image':<50s}  "
+        f"{'Engine':<13s}  {'Image':<50s}  "
         f"{'Pkg ver':<10s}  {'Img SHA-256':<14s}  {'Host SHA-256':<14s}  {'Status':<12s}"
     )
     typer.echo(header)
@@ -33,12 +34,12 @@ def doctor_command() -> None:
         img_fp = (row.image_fingerprint or "-")[:12]
         status_text = row.status.value
         line = (
-            f"{row.engine:<10s}  {img:<50s}  "
+            f"{row.engine:<13s}  {img:<50s}  "
             f"{pkg:<10s}  {img_fp:<14s}  {host_fp_short:<14s}  {status_text:<12s}"
         )
         typer.echo(line)
         if row.detail:
-            typer.echo(f"{'':<10s}  └─ {row.detail}")
+            typer.echo(f"{'':<13s}  └─ {row.detail}")
 
     typer.echo("")
     typer.echo(f"Host llenergymeasure version: {report.host_pkg_version}")

--- a/src/llenergymeasure/cli/report_gaps.py
+++ b/src/llenergymeasure/cli/report_gaps.py
@@ -61,8 +61,16 @@ def report_gaps_cmd(
             ),
         ),
     ] = False,
+    verbose: Annotated[
+        int,
+        typer.Option("--verbose", "-v", count=True, help="Increase verbosity (-v=INFO, -vv=DEBUG)"),
+    ] = 0,
 ) -> None:
     """Propose rules corpus entries from captured runtime observations."""
+    from llenergymeasure.cli import _setup_logging
+
+    _setup_logging(verbose)
+
     if source != "runtime-warnings":
         raise typer.BadParameter(
             f"Unsupported source {source!r}. Only 'runtime-warnings' is wired in this release.",

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -272,6 +272,22 @@ def _run_impl(
         )
         return
 
+    # Single-experiment path: warn about any study-only flags the user set.
+    # These are parsed by run() for study mode but silently ignored here, so
+    # --cycles 5 on a single experiment would run once with no feedback.
+    _warn_ignored_study_flags(
+        cycles=cycles,
+        order=order,
+        no_gaps=no_gaps,
+        resume=resume,
+        resume_dir=resume_dir,
+        fail_fast=fail_fast,
+        no_circuit_breaker=no_circuit_breaker,
+        timeout=timeout,
+        no_lock=no_lock,
+        no_dedup=no_dedup,
+    )
+
     # Load/resolve the experiment config
     experiment_config = load_experiment_config(
         path=config,
@@ -338,6 +354,50 @@ def _run_impl(
 
     if output:
         print(f"Saved: {output}", file=sys.stderr)
+
+
+def _warn_ignored_study_flags(
+    *,
+    cycles: int | None,
+    order: str | None,
+    no_gaps: bool,
+    resume: bool,
+    resume_dir: Path | None,
+    fail_fast: bool,
+    no_circuit_breaker: bool,
+    timeout: float | None,
+    no_lock: bool,
+    no_dedup: bool,
+) -> None:
+    """Warn when study-only flags are set on a single-experiment run.
+
+    These flags only take effect in study mode (a YAML with ``sweep:`` or
+    ``experiments:``). On a single experiment they are silently ignored, which
+    hides mistakes like ``--cycles 5`` on a one-off run.
+    """
+    set_flags = [
+        name
+        for name, is_set in (
+            ("--cycles", cycles is not None),
+            ("--order", order is not None),
+            ("--no-gaps", no_gaps),
+            ("--resume", resume),
+            ("--resume-dir", resume_dir is not None),
+            ("--fail-fast", fail_fast),
+            ("--no-circuit-breaker", no_circuit_breaker),
+            ("--timeout", timeout is not None),
+            ("--no-lock", no_lock),
+            ("--no-dedup", no_dedup),
+        )
+        if is_set
+    ]
+    if set_flags:
+        print(
+            f"Warning: study-only flag(s) ignored on a single-experiment run: "
+            f"{', '.join(set_flags)}. These apply only to study configs "
+            f"(YAML with sweep: or experiments:).",
+            file=sys.stderr,
+        )
 
 
 def _resolve_progress_mode(quiet: bool, verbose: bool) -> str:

--- a/tests/unit/api/test_report_gaps.py
+++ b/tests/unit/api/test_report_gaps.py
@@ -365,6 +365,25 @@ def test_empty_study_dir_list_raises() -> None:
         find_runtime_gaps([], engine_invariants={})
 
 
+def test_nonexistent_study_dir_raises(tmp_path: Path) -> None:
+    """A typo'd / missing study dir raises instead of a false 'no gaps' all-clear."""
+    from llenergymeasure.api.report_gaps import ReportGapsError
+
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(ReportGapsError, match="does not exist"):
+        find_runtime_gaps([missing], engine_invariants=_build_empty_invariants())
+
+
+def test_study_path_not_a_directory_raises(tmp_path: Path) -> None:
+    """A --study-dir pointing at a file (not a dir) raises a clear error."""
+    from llenergymeasure.api.report_gaps import ReportGapsError
+
+    not_a_dir = tmp_path / "afile.txt"
+    not_a_dir.write_text("x", encoding="utf-8")
+    with pytest.raises(ReportGapsError, match="not a directory"):
+        find_runtime_gaps([not_a_dir], engine_invariants=_build_empty_invariants())
+
+
 # ---------------------------------------------------------------------------
 # YAML round-trip through loader
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_cli_display.py
+++ b/tests/unit/cli/test_cli_display.py
@@ -500,3 +500,30 @@ def test_print_study_dry_run_vram_peak(capsys, monkeypatch):
     assert "VRAM estimate (peak)" in out
     assert "0.3" in out  # weights of larger config
     assert "OK" in out
+
+
+def test_print_study_dry_run_vram_memoized_per_model(capsys, monkeypatch):
+    """A sweep over one model+dtype fetches VRAM once, not once per experiment."""
+    from llenergymeasure.cli._display import print_study_dry_run
+    from llenergymeasure.config.models import StudyConfig
+    from tests.conftest import make_config
+
+    # Four experiments over the SAME model and dtype: estimate_vram does a HF
+    # Hub round-trip, so it must be called exactly once (memoized), not 4x.
+    configs = [make_config(model="gpt2", dtype="float16") for _ in range(4)]
+    study = StudyConfig(experiments=configs, study_name="memoize-test")
+
+    calls: list[str] = []
+
+    def mock_estimate(config):
+        calls.append(config.task.model)
+        return {"weights_gb": 0.2, "kv_cache_gb": 0.0, "overhead_gb": 0.03, "total_gb": 0.23}
+
+    import llenergymeasure.cli._vram as _vram_mod
+
+    monkeypatch.setattr(_vram_mod, "estimate_vram", mock_estimate)
+    monkeypatch.setattr(_vram_mod, "get_gpu_vram_gb", lambda: None)
+
+    print_study_dry_run(study)
+
+    assert len(calls) == 1, f"expected one memoized fetch, got {len(calls)}"

--- a/tests/unit/cli/test_cli_run.py
+++ b/tests/unit/cli/test_cli_run.py
@@ -291,6 +291,71 @@ def test_run_dry_run_calls_estimate_vram():
 
 
 # ---------------------------------------------------------------------------
+# Study-only flags ignored on single-experiment runs (C4)
+# ---------------------------------------------------------------------------
+
+
+def test_single_run_warns_on_study_only_flag():
+    """--cycles on a single-experiment run warns that the flag is ignored."""
+    mock_config = _make_mock_config()
+
+    with (
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "estimate_vram", return_value=None),
+        patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None),
+        patch.object(cli_run_mod, "print_dry_run"),
+    ):
+        result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run", "--cycles", "5"])
+
+    assert result.exit_code == 0
+    out = _strip_ansi(result.output).lower()
+    assert "study-only" in out
+    assert "--cycles" in out
+
+
+def test_single_run_no_warning_without_study_flags():
+    """A clean single-experiment run emits no study-only-flag warning."""
+    mock_config = _make_mock_config()
+
+    with (
+        patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
+        patch.object(cli_run_mod, "estimate_vram", return_value=None),
+        patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None),
+        patch.object(cli_run_mod, "print_dry_run"),
+    ):
+        result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "study-only" not in _strip_ansi(result.output).lower()
+
+
+def test_study_run_does_not_warn_on_study_flags(tmp_path):
+    """A study run with --cycles does not emit the single-run ignored-flag warning."""
+    from tests.conftest import make_study_result
+
+    study_yaml = tmp_path / "study.yaml"
+    study_yaml.write_text(
+        "name: test\nmodel: test/model\nengine: transformers\nsweep:\n  transformers.dtype: [float32, float16]\n"
+    )
+    mock_study_result = make_study_result()
+
+    with (
+        patch("llenergymeasure.run_study", return_value=mock_study_result),
+        patch("llenergymeasure.api.load_study") as mock_load,
+        patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
+    ):
+        mock_config = MagicMock()
+        mock_config.experiments = [MagicMock(), MagicMock()]
+        mock_config.study_execution.n_cycles = 1
+        mock_config.skipped_configs = []
+        mock_load.return_value = mock_config
+        result = runner.invoke(app, ["run", str(study_yaml), "--cycles", "5"])
+
+    assert result.exit_code == 0, f"Output: {result.output}"
+    assert "study-only" not in _strip_ansi(result.output).lower()
+
+
+# ---------------------------------------------------------------------------
 # Quiet flag test
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/cli/test_doctor_cmd.py
+++ b/tests/unit/cli/test_doctor_cmd.py
@@ -115,6 +115,31 @@ def test_skip_check_warning_rendered() -> None:
     assert "LLEM_SKIP_IMAGE_CHECK" in result.output
 
 
+def test_engine_column_aligns_for_transformers() -> None:
+    """The Engine column is wide enough for 'transformers' (12 chars) - no overflow."""
+    report = _report(
+        [
+            EngineDoctorResult(
+                engine="transformers",
+                image="llenergymeasure:pytorch",
+                pkg_version="0.9.0",
+                image_fingerprint="a" * 64,
+                status=SchemaStatus.OK,
+            )
+        ]
+    )
+    with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
+        result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    lines = result.output.splitlines()
+    header_line = next(line for line in lines if line.startswith("Engine"))
+    data_line = next(line for line in lines if line.startswith("transformers"))
+    # The Image column must start at the same offset in both rows - i.e. the
+    # long engine name did not push its row's columns out of alignment.
+    assert header_line.index("Image") == data_line.index("llenergymeasure:pytorch")
+
+
 def test_host_footer_rendered() -> None:
     report = _report(
         [

--- a/tests/unit/cli/test_report_gaps.py
+++ b/tests/unit/cli/test_report_gaps.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from llenergymeasure.cli import app
@@ -140,6 +141,86 @@ def test_report_gaps_missing_out_errors(tmp_path: Path) -> None:
     assert result.exit_code != 0
     stripped = _strip(result.output).lower()
     assert "--out" in stripped or "out" in stripped
+
+
+def test_report_gaps_nonexistent_study_dir_exits_nonzero(tmp_path: Path) -> None:
+    """A typo'd --study-dir exits nonzero with an error, not a false 'No gaps found'."""
+    out = tmp_path / "proposals.yaml"
+    missing = tmp_path / "typo-study"  # never created
+    result = runner.invoke(
+        app,
+        [
+            "report-gaps",
+            "--source",
+            "runtime-warnings",
+            "--study-dir",
+            str(missing),
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "No gaps found" not in result.output
+    assert "does not exist" in _strip(result.output)
+
+
+def test_report_gaps_verbose_surfaces_skip_message(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """--verbose raises the log level so the 'no observations; skipping' INFO surfaces."""
+    study = tmp_path / "no-obs-study"
+    study.mkdir()  # exists but has no runtime_observations JSONL
+    out = tmp_path / "proposals.yaml"
+
+    with caplog.at_level("INFO", logger="llenergymeasure"):
+        result = runner.invoke(
+            app,
+            [
+                "report-gaps",
+                "--source",
+                "runtime-warnings",
+                "--study-dir",
+                str(study),
+                "--out",
+                str(out),
+                "--verbose",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert any("skipping" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_report_gaps_no_verbose_suppresses_skip_message(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Without --verbose the INFO skip log stays below the default WARNING threshold."""
+    study = tmp_path / "no-obs-study"
+    study.mkdir()
+    out = tmp_path / "proposals.yaml"
+
+    # Reset the llenergymeasure logger to default so a prior --verbose test does
+    # not leak an INFO level into this assertion.
+    import logging
+
+    logging.getLogger("llenergymeasure").setLevel(logging.WARNING)
+
+    with caplog.at_level("WARNING", logger="llenergymeasure"):
+        result = runner.invoke(
+            app,
+            [
+                "report-gaps",
+                "--source",
+                "runtime-warnings",
+                "--study-dir",
+                str(study),
+                "--out",
+                str(out),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert not any("skipping" in r.getMessage().lower() for r in caplog.records)
 
 
 def test_report_gaps_unsupported_source_errors(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_vram.py
+++ b/tests/unit/cli/test_vram.py
@@ -26,8 +26,15 @@ _LLAMA_7B_PARAMS = 6_738_415_616
 _VRAM_DEFAULTS = {"model": "meta-llama/Llama-2-7b-hf"}
 
 
-def _make_model_info(param_count: int | None = _LLAMA_7B_PARAMS, with_config: bool = True):
-    """Build a mock HuggingFace model_info object."""
+def _make_model_info(
+    param_count: int | None = _LLAMA_7B_PARAMS,
+    with_config: bool = True,
+    config: dict | None = None,
+):
+    """Build a mock HuggingFace model_info object.
+
+    Pass ``config`` to override the architecture dict (e.g. to add GQA fields).
+    """
     model_info = MagicMock()
 
     # safetensors metadata
@@ -41,7 +48,7 @@ def _make_model_info(param_count: int | None = _LLAMA_7B_PARAMS, with_config: bo
     # HF Hub's ModelInfo.config is a plain dict in production, so the mock must
     # be a dict too - an attribute-style object would mask the dict-access bug.
     if with_config:
-        model_info.config = {
+        model_info.config = config or {
             "num_hidden_layers": 32,
             "num_attention_heads": 32,
             "hidden_size": 4096,
@@ -217,6 +224,84 @@ def test_estimate_vram_kv_cache_nonzero_with_architecture():
 
     assert result is not None
     assert result["kv_cache_gb"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# estimate_vram - GQA-aware KV cache and batch size (reuses extract_model_arch)
+# ---------------------------------------------------------------------------
+
+# Llama-2-7B style arch but with GQA: 8 kv heads instead of 32 attention heads.
+_GQA_CONFIG = {
+    "num_hidden_layers": 32,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "hidden_size": 4096,
+}
+_MHA_EQUIVALENT_CONFIG = {
+    "num_hidden_layers": 32,
+    "num_attention_heads": 32,
+    "hidden_size": 4096,
+}
+
+
+def test_estimate_vram_kv_cache_is_gqa_aware():
+    """GQA (kv_heads < attention_heads) shrinks the KV term vs the MHA equivalent."""
+    config = make_config(**_VRAM_DEFAULTS, dtype="float16")
+
+    gqa_info = _make_model_info(config=_GQA_CONFIG)
+    ctx_gqa, _ = _patch_hfapi(model_info_return=gqa_info)
+    with ctx_gqa:
+        gqa_result = estimate_vram(config)
+
+    mha_info = _make_model_info(config=_MHA_EQUIVALENT_CONFIG)
+    ctx_mha, _ = _patch_hfapi(model_info_return=mha_info)
+    with ctx_mha:
+        mha_result = estimate_vram(config)
+
+    assert gqa_result is not None and mha_result is not None
+    # 8 kv heads vs 32 attention heads -> KV term is exactly 1/4.
+    assert gqa_result["kv_cache_gb"] < mha_result["kv_cache_gb"]
+    assert gqa_result["kv_cache_gb"] == pytest.approx(mha_result["kv_cache_gb"] / 4, rel=1e-6)
+
+
+def test_estimate_vram_kv_cache_scales_with_batch_size():
+    """KV cache scales linearly with the configured batch size, not a hardcoded 1."""
+    config_b1 = make_config(**_VRAM_DEFAULTS, dtype="float16", transformers={"batch_size": 1})
+    config_b4 = make_config(**_VRAM_DEFAULTS, dtype="float16", transformers={"batch_size": 4})
+
+    ctx1, _ = _patch_hfapi(model_info_return=_make_model_info())
+    with ctx1:
+        result_b1 = estimate_vram(config_b1)
+
+    ctx4, _ = _patch_hfapi(model_info_return=_make_model_info())
+    with ctx4:
+        result_b4 = estimate_vram(config_b4)
+
+    assert result_b1 is not None and result_b4 is not None
+    assert result_b4["kv_cache_gb"] == pytest.approx(result_b1["kv_cache_gb"] * 4, rel=1e-6)
+
+
+def test_estimate_vram_reuses_extract_model_arch():
+    """estimate_vram delegates arch parsing to domain.model_info.extract_model_arch."""
+    config = make_config(**_VRAM_DEFAULTS, dtype="float16")
+    model_info = _make_model_info(config=_GQA_CONFIG)
+
+    ctx, _ = _patch_hfapi(model_info_return=model_info)
+    with (
+        ctx,
+        patch(
+            "llenergymeasure.cli._vram.extract_model_arch",
+            wraps=__import__(
+                "llenergymeasure.domain.model_info", fromlist=["extract_model_arch"]
+            ).extract_model_arch,
+        ) as spy,
+    ):
+        result = estimate_vram(config)
+
+    assert result is not None
+    spy.assert_called_once()
+    # It was handed the raw HF config dict, not a re-parsed shape.
+    assert spy.call_args.args[0] == _GQA_CONFIG
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -256,14 +256,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -518,6 +518,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
 name = "grimp"
 version = "3.14"
 source = { registry = "https://pypi.org/simple" }
@@ -642,6 +651,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +708,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/7e/fad82ad491b226e832d2da90a1a59f36acd4526cda8c726f639834754aa4/huggingface_hub-1.20.1.tar.gz", hash = "sha256:9f6d63bfbeab2d2a8357200a9bc4f18cd2c8bfac9579f792f5922e77bf6471d0", size = 859910, upload-time = "2026-06-18T22:06:53.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/b5/ff8516e74b459da3dce9567540c39f2d305ee7a2655109f6802873ff1588/huggingface_hub-1.20.1-py3-none-any.whl", hash = "sha256:274448a45c1ba6f112fe2fb168ead05574c654faa156904157a84085cfae14bd", size = 719837, upload-time = "2026-06-18T22:06:51.486Z" },
 ]
 
 [[package]]
@@ -803,6 +865,7 @@ version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },
+    { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "nvidia-ml-py" },
     { name = "platformdirs" },
@@ -839,6 +902,7 @@ dev = [
 requires-dist = [
     { name = "codecarbon", marker = "extra == 'codecarbon'", specifier = ">=2.8" },
     { name = "filelock", specifier = ">=3.12" },
+    { name = "huggingface-hub", specifier = ">=0.20" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "nvidia-ml-py", specifier = ">=12.0" },
     { name = "platformdirs", specifier = ">=3.0" },
@@ -2023,6 +2087,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fifth PR of the behavioral-audit cleanup campaign. Revives the dead VRAM dry-run estimate and fixes four CLI robustness gaps.

- **D4 - VRAM dry-run was dead** (`cli/_vram.py`, `pyproject.toml`): `estimate_vram` depended on `huggingface_hub`, which was imported under a blanket `except` but never declared as a dependency, so it always returned None ("unavailable"). Declares `huggingface-hub`; reuses the `domain.model_info.extract_model_arch` helper (from #725) for the architecture fields instead of re-parsing config field variants inline; makes the KV-cache term GQA/MQA-aware (`num_key_value_heads`) and batch-aware (per-engine batch field) instead of hardcoding batch=1 + full MHA; and memoizes the study dry-run loop by `(model, dtype)` so a sweep of N experiments over one model makes one HF Hub round-trip, not N.
- **C2 - report-gaps false all-clear** (`api/report_gaps.py`): a missing / typo'd `--study-dir` silently yielded "No gaps found" with exit 0. Now raises and exits nonzero with a clear message.
- **C3 - report-gaps verbosity** (`cli/report_gaps.py`): adds `--verbose/-v`, making the previously-unreachable dir-skipped log path observable.
- **C4 - silently-ignored study flags** (`cli/run.py`): single-experiment runs now warn when study-only flags (`--cycles`, `--order`, `--resume`, ...) are set.
- **C5 - doctor column overflow** (`cli/doctor_cmd.py`): widen the Engine column so "transformers" no longer breaks alignment.

## Test plan

- New / updated tests across `tests/unit/cli/{test_vram,test_cli_display,test_cli_run,test_doctor_cmd,test_report_gaps}.py` and `tests/unit/api/test_report_gaps.py`: VRAM returns a GQA-aware estimate (not None) with the right KV scaling + batch size; the study loop fetches once per unique model (memoization); report-gaps exits nonzero on a missing dir; `-v` surfaces the skip message; single-exp study-flag warning fires; doctor table aligns.
- Verified at the real surface: `llem report-gaps --study-dir /nonexistent --out ...` exits 2 with "Study directory does not exist"; `estimate_vram` on a mocked Llama-3-8B (GQA) returns weights ~16 GB + a modest GQA KV term.
- `make lint` (import-linter 4 contracts kept) + `make typecheck` (mypy clean) pass.
- Full suite: 2442 passed, 0 failed (skips dropped 52 -> 43 because huggingface_hub now lets optional-dep tests run).

## Doc audit

No doc regeneration needed. `huggingface-hub` added to runtime dependencies in pyproject.toml.