### PR TITLE
feat(harness): wire real steady-state and windowed energy measurement

### DIFF
--- a/docs/explanation/methodology/energy-measurement.md
+++ b/docs/explanation/methodology/energy-measurement.md
@@ -196,6 +196,53 @@ Use `n >= 50` prompts to ensure sufficient measurement duration.
 
 ---
 
+## Measurement Window
+
+By default LLenergyMeasure integrates energy over the **whole** inference run
+(`measurement_methodology: total`). Two opt-in modes restrict the measured region so that
+warm-up transients (kernel autotuning, clock ramp, cache fill) do not bias energy-per-token
+and throughput:
+
+```yaml
+measurement:
+  measurement_methodology: total        # total | windowed | steady_state  (default: total)
+
+  # windowed mode: explicit window relative to inference start
+  measurement_window: [2.0, 8.0]        # (start_sec, end_sec)
+
+  # steady_state mode: discard a warm-up prefix, measure the remainder
+  warmup_discard_fraction: 0.1          # discard first 10% (default)
+  warmup_discard_seconds: 1.5           # OR discard a fixed number of seconds
+  steady_state_auto_detect: false       # opt-in sliding-window stability detector
+```
+
+- **`total`** - whole run, unchanged default. No pre-cleaning or windowing is applied.
+- **`windowed`** - integrate energy and attribute tokens over an explicit
+  `[start_sec, end_sec]` window.
+- **`steady_state`** - discard a deterministic warm-up prefix (a fraction by default, or a
+  fixed number of seconds) and measure the remainder. Setting `steady_state_auto_detect`
+  enables a lightweight sliding-window stability test (coefficient-of-variation /
+  variance-ratio) that finds the steady-state onset; on failure it falls back to the fixed
+  discard and sets the `steady_state_not_detected` flag in the result.
+
+For `windowed` and `steady_state`, energy is **re-integrated** by feeding the trapezoidal
+integrator only the power samples inside the window (after dropping zero / impossible
+samples and median-filtering transient NVML dropouts). The realised window, the
+methodology actually used, the discard fraction, and the `steady_state_not_detected` flag
+are recorded in the result for auditability.
+
+Tokens and throughput are attributed to the sub-window **proportionally by time**: the
+harness captures per-request and inter-token durations but not absolute per-token
+timestamps, so a window covering 60% of the cleaned inference span is credited with 60% of
+the output tokens. A measurement warning records this approximation, and a second warning
+fires when the realised window is too short to be meaningful.
+
+The survey behind this design (MLPerf Power, SPECpower, the VM-warmup steady-state study,
+and the Cao-Rhinehart detector choice) is recorded in
+[`.product/research/steady-state-measurement-methodology.md`](../../../.product/research/steady-state-measurement-methodology.md).
+
+---
+
 ## Baseline Power
 
 Before inference, LLenergyMeasure measures idle GPU power draw. This baseline represents

--- a/docs/explanation/methodology/energy-measurement.md
+++ b/docs/explanation/methodology/energy-measurement.md
@@ -238,8 +238,8 @@ the output tokens. A measurement warning records this approximation, and a secon
 fires when the realised window is too short to be meaningful.
 
 The survey behind this design (MLPerf Power, SPECpower, the VM-warmup steady-state study,
-and the Cao-Rhinehart detector choice) is recorded in
-[`.product/research/steady-state-measurement-methodology.md`](../../../.product/research/steady-state-measurement-methodology.md).
+and the Cao-Rhinehart detector choice) is recorded in the repository at
+`.product/research/steady-state-measurement-methodology.md`.
 
 ---
 

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -307,6 +307,73 @@ class MeasurementConfig(BaseModel):
         ),
         json_schema_extra={"display_label": "Latency Profiling"},
     )
+    measurement_methodology: Literal["total", "windowed", "steady_state"] = Field(
+        default="total",
+        description=(
+            "Which part of the run to measure. 'total' (default) integrates the "
+            "whole run unchanged. 'windowed' measures an explicit "
+            "measurement_window. 'steady_state' discards a warm-up prefix and "
+            "measures the remainder (optionally auto-detecting the onset)."
+        ),
+        json_schema_extra={"display_label": "Measurement Window Mode"},
+    )
+    measurement_window: tuple[float, float] | None = Field(
+        default=None,
+        description=(
+            "Explicit (start_sec, end_sec) window relative to inference start, in "
+            "seconds. Required when measurement_methodology='windowed'; ignored "
+            "otherwise."
+        ),
+        json_schema_extra={"display_label": "Measurement Window"},
+    )
+    warmup_discard_fraction: float = Field(
+        default=0.1,
+        ge=0.0,
+        lt=1.0,
+        description=(
+            "Fraction of the run discarded as warm-up before measuring, for "
+            "measurement_methodology='steady_state'. Default 0.1 (first 10%). "
+            "Ignored unless warmup_discard_seconds is None."
+        ),
+        json_schema_extra={"display_label": "Warm-up Discard Fraction"},
+    )
+    warmup_discard_seconds: float | None = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Fixed warm-up duration in seconds to discard before measuring, for "
+            "measurement_methodology='steady_state'. When set, takes precedence "
+            "over warmup_discard_fraction. Ignored otherwise."
+        ),
+        json_schema_extra={"display_label": "Warm-up Discard Seconds"},
+    )
+    steady_state_auto_detect: bool = Field(
+        default=False,
+        description=(
+            "Opt-in sliding-window stability detector for "
+            "measurement_methodology='steady_state'. When enabled, a "
+            "coefficient-of-variation / variance-ratio test over the cleaned power "
+            "series locates the steady-state onset; on failure it falls back to the "
+            "fixed warm-up discard and sets steady_state_not_detected in the result."
+        ),
+        json_schema_extra={"display_label": "Steady-state Auto-detect"},
+    )
+
+    @model_validator(mode="after")
+    def _validate_measurement_window(self) -> MeasurementConfig:
+        """Cross-field checks for the measurement-window modes."""
+        if self.measurement_methodology == "windowed":
+            if self.measurement_window is None:
+                raise ValueError(
+                    "measurement_window (start_sec, end_sec) is required when "
+                    "measurement_methodology='windowed'"
+                )
+            start, end = self.measurement_window
+            if start < 0.0:
+                raise ValueError("measurement_window start_sec must be >= 0")
+            if end <= start:
+                raise ValueError("measurement_window end_sec must be > start_sec")
+        return self
 
 
 # =============================================================================

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -94,6 +94,16 @@ class ExperimentResult(BaseModel):
         default=None,
         description="(start_sec, end_sec) of measurement window relative to experiment start",
     )
+    measurement_window_discard_fraction: float | None = Field(
+        default=None,
+        description="Warm-up fraction discarded for steady_state methodology. None for "
+        "total/windowed.",
+    )
+    steady_state_not_detected: bool = Field(
+        default=False,
+        description="True when steady_state auto-detection was requested but found no "
+        "stable region and fell back to the fixed warm-up discard.",
+    )
 
     # Core metrics
     total_tokens: int = Field(..., description="Total tokens across all processes")

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -39,8 +39,13 @@ def compute_declared_config_hash(config: ExperimentConfig) -> str:
     return _hash_canonical(canonical)
 
 
-def mj_per_token(energy_j: float, total_tokens: int) -> float | None:
-    """Millijoules per token. Returns None when total_tokens is zero."""
+def mj_per_token(energy_j: float, total_tokens: float) -> float | None:
+    """Millijoules per token. Returns None when total_tokens is non-positive.
+
+    ``total_tokens`` is usually an integer count, but the windowed/steady-state
+    measurement modes attribute a fractional token share to a sub-window, so a float
+    is accepted.
+    """
     return (energy_j / total_tokens * 1000.0) if total_tokens > 0 else None
 
 

--- a/src/llenergymeasure/energy/nvml.py
+++ b/src/llenergymeasure/energy/nvml.py
@@ -34,6 +34,49 @@ class EnergyMeasurement:
     per_gpu_j: dict[int, float] | None = None
 
 
+def integrate_power_samples(samples: list[Any]) -> dict[int, float]:
+    """Integrate power samples to joules per GPU via the trapezoidal rule.
+
+    For each consecutive sample pair within a GPU group,
+    ``energy += (p[i] + p[i+1]) / 2 * dt``. Pairs where either ``power_w`` is
+    None are skipped rather than failing. Samples are grouped by ``gpu_index``
+    so multiple GPUs integrate independently.
+
+    This is the single source of truth for the energy integration math; both the
+    NVML sampler and the windowed re-integration path call it. It must not be
+    altered without re-validating energy accuracy.
+
+    Args:
+        samples: Power samples (any object with ``power_w``, ``timestamp``, and
+            optionally ``gpu_index`` attributes), in timestamp order per GPU.
+
+    Returns:
+        Mapping of gpu_index -> joules. Empty when fewer than two samples.
+    """
+    per_gpu_j: dict[int, float] = {}
+    if len(samples) < 2:
+        return per_gpu_j
+
+    by_gpu: dict[int, list[Any]] = {}
+    for s in samples:
+        gpu_idx = getattr(s, "gpu_index", 0)
+        by_gpu.setdefault(gpu_idx, []).append(s)
+
+    for gpu_idx, gpu_samples in by_gpu.items():
+        gpu_j = 0.0
+        for i in range(len(gpu_samples) - 1):
+            s_a = gpu_samples[i]
+            s_b = gpu_samples[i + 1]
+            if s_a.power_w is None or s_b.power_w is None:
+                continue
+            dt = s_b.timestamp - s_a.timestamp
+            avg_power = (s_a.power_w + s_b.power_w) / 2.0
+            gpu_j += avg_power * dt
+        per_gpu_j[gpu_idx] = gpu_j
+
+    return per_gpu_j
+
+
 class NVMLSampler:
     """Energy sampler using NVML via PowerThermalSampler.
 
@@ -129,24 +172,9 @@ class NVMLSampler:
                         max_gap_ms,
                     )
 
-            # Group samples by gpu_index for per-GPU integration
-            by_gpu: dict[int, list[Any]] = {}
-            for s in samples:
-                gpu_idx = getattr(s, "gpu_index", self._gpu_indices[0])
-                by_gpu.setdefault(gpu_idx, []).append(s)
-
-            for gpu_idx, gpu_samples in by_gpu.items():
-                gpu_j = 0.0
-                for i in range(len(gpu_samples) - 1):
-                    s_a = gpu_samples[i]
-                    s_b = gpu_samples[i + 1]
-                    if s_a.power_w is None or s_b.power_w is None:
-                        continue
-                    dt = s_b.timestamp - s_a.timestamp
-                    avg_power = (s_a.power_w + s_b.power_w) / 2.0
-                    gpu_j += avg_power * dt
-                per_gpu_j[gpu_idx] = gpu_j
-                total_j += gpu_j
+            # Trapezoidal integration per GPU (shared with windowed re-integration)
+            per_gpu_j = integrate_power_samples(samples)
+            total_j = sum(per_gpu_j.values())
 
         return EnergyMeasurement(
             total_j=total_j,

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -1093,7 +1093,9 @@ class MeasurementHarness:
         energy_duration = (
             measured_time_sec
             if window_result is not None
-            else (energy_measurement.duration_sec if energy_measurement is not None else duration_sec)
+            else (
+                energy_measurement.duration_sec if energy_measurement is not None else duration_sec
+            )
         )
         energy_breakdown = create_energy_breakdown(total_energy_j, baseline, energy_duration)
 
@@ -1251,10 +1253,7 @@ class MeasurementHarness:
             measurement_warnings.extend(window_result.warnings)
             discard_fraction = (
                 window_result.window[0] / output.inference_time_sec
-                if (
-                    window_result.methodology == "steady_state"
-                    and output.inference_time_sec > 0
-                )
+                if (window_result.methodology == "steady_state" and output.inference_time_sec > 0)
                 else None
             )
         else:

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -963,6 +963,31 @@ class MeasurementHarness:
                 "no per-token timing was captured."
             )
 
+    def _resolve_measurement_window(
+        self,
+        config: ExperimentConfig,
+        output: InferenceOutput,
+        energy_measurement: Any,
+        timeseries_samples: list[PowerThermalSample] | None,
+    ) -> Any:
+        """Apply the configured measurement window, or None for total mode.
+
+        Prefers the energy sampler's own power samples (NVML) for re-integration, and
+        falls back to the harness PowerThermalSampler timeseries (always present even
+        with Zeus/CodeCarbon, which expose no raw samples). Returns a WindowResult, or
+        None when the window cannot be applied (keeping the unchanged total figures).
+        """
+        from llenergymeasure.harness.windowing import apply_measurement_window
+
+        if config.measurement.measurement_methodology == "total":
+            return None
+
+        sampler_samples = getattr(energy_measurement, "samples", None) or []
+        power_samples = sampler_samples if len(sampler_samples) >= 2 else (timeseries_samples or [])
+        return apply_measurement_window(
+            power_samples, config.measurement, output.inference_time_sec
+        )
+
     def _build_result(
         self,
         engine_name: str,
@@ -1022,52 +1047,86 @@ class MeasurementHarness:
 
         experiment_id = f"{config.task.model}_{start_time.strftime('%Y%m%d_%H%M%S')}"
 
-        avg_tokens_per_second = (
-            output.total_tokens / output.inference_time_sec
-            if output.inference_time_sec > 0
-            else 0.0
+        # Resolve the measurement window (None for total mode = unchanged path).
+        window_result = self._resolve_measurement_window(
+            config, output, energy_measurement, timeseries_samples
         )
 
-        # Real energy values from energy sampler
-        total_energy_j = energy_measurement.total_j if energy_measurement is not None else 0.0
+        # Reported inference time: window duration for windowed/steady_state, else full run.
+        measured_time_sec = (
+            window_result.window_duration_sec
+            if window_result is not None
+            else output.inference_time_sec
+        )
+
+        # Real energy values from energy sampler (windowed re-integration overrides
+        # the sampler total when a window is in effect).
+        if window_result is not None:
+            total_energy_j = window_result.energy_j
+        else:
+            total_energy_j = energy_measurement.total_j if energy_measurement is not None else 0.0
         # duration_sec is passed in from run() - computed once, not recalculated here
 
-        # Energy per token: output tokens only (input tokens are not "generated")
+        # Token counts reported describe the full workload; for a sub-window, energy and
+        # throughput are normalised by the window-attributed token share (proportional by
+        # time - the harness has no absolute per-token timestamps).
         output_tokens = output.output_tokens if output.output_tokens > 0 else output.total_tokens
+        token_fraction = window_result.token_fraction if window_result is not None else 1.0
+        windowed_output_tokens = output_tokens * token_fraction
+        windowed_total_tokens = output.total_tokens * token_fraction
+
+        avg_tokens_per_second = (
+            windowed_total_tokens / measured_time_sec if measured_time_sec > 0 else 0.0
+        )
+
+        # Energy per token: output tokens only (input tokens are not "generated")
         avg_energy_per_token_j = (
-            total_energy_j / output_tokens if (total_energy_j > 0 and output_tokens > 0) else 0.0
+            total_energy_j / windowed_output_tokens
+            if (total_energy_j > 0 and windowed_output_tokens > 0)
+            else 0.0
         )
 
         # Energy breakdown with baseline adjustment.
         # Use energy sampler's window duration for baseline adjustment,
-        # not harness datetime duration, to avoid CUDA sync latency skew.
+        # not harness datetime duration, to avoid CUDA sync latency skew. For a
+        # sub-window, the realised window duration is the correct baseline span.
         energy_duration = (
-            energy_measurement.duration_sec if energy_measurement is not None else duration_sec
+            measured_time_sec
+            if window_result is not None
+            else (energy_measurement.duration_sec if energy_measurement is not None else duration_sec)
         )
         energy_breakdown = create_energy_breakdown(total_energy_j, baseline, energy_duration)
 
-        # Per-GPU energy breakdown from EnergyMeasurement.per_gpu_j
+        # Per-GPU energy breakdown. A window re-integrates per-GPU energy; otherwise the
+        # sampler's per-GPU totals are used.
+        per_gpu_source = (
+            window_result.per_gpu_j
+            if window_result is not None
+            else (energy_measurement.per_gpu_j if energy_measurement is not None else None)
+        )
         energy_per_device_j = None
         multi_gpu = None
-        if energy_measurement is not None and energy_measurement.per_gpu_j:
-            sorted_indices = sorted(energy_measurement.per_gpu_j.keys())
-            energy_per_device_j = [energy_measurement.per_gpu_j[i] for i in sorted_indices]
+        if per_gpu_source:
+            sorted_indices = sorted(per_gpu_source.keys())
+            energy_per_device_j = [per_gpu_source[i] for i in sorted_indices]
             if len(sorted_indices) > 1:
                 multi_gpu = MultiGPUMetrics(
                     num_gpus=len(sorted_indices),
                     energy_per_gpu_j=energy_per_device_j,
                     energy_total_j=total_energy_j,
                     energy_per_output_token_j=(
-                        total_energy_j / output_tokens if output_tokens > 0 else 0.0
+                        total_energy_j / windowed_output_tokens
+                        if windowed_output_tokens > 0
+                        else 0.0
                     ),
                 )
 
         # mJ/tok derived fields (energy in millijoules per OUTPUT token, matching
         # avg_energy_per_token_j; input tokens are prefilled, not "generated").
-        _mj_total = mj_per_token(total_energy_j, output_tokens)
+        _mj_total = mj_per_token(total_energy_j, windowed_output_tokens)
         energy_adjusted_j = energy_breakdown.adjusted_j if energy_breakdown else None
         _mj_adjusted = (
-            mj_per_token(energy_adjusted_j, output_tokens)
+            mj_per_token(energy_adjusted_j, windowed_output_tokens)
             if energy_adjusted_j is not None
             else None
         )
@@ -1183,7 +1242,27 @@ class MeasurementHarness:
         # Latency profiling provenance warnings (appended to measurement_warnings).
         self._append_latency_profiling_warnings(config, output, engine_name, measurement_warnings)
 
-        steady_state_window = (0.0, output.inference_time_sec)
+        # Measurement-methodology provenance. For total mode the window spans the whole
+        # run (unchanged); for windowed/steady_state the realised window is recorded.
+        if window_result is not None:
+            measurement_methodology = window_result.methodology
+            steady_state_window = window_result.window
+            steady_state_not_detected = window_result.steady_state_not_detected
+            measurement_warnings.extend(window_result.warnings)
+            discard_fraction = (
+                window_result.window[0] / output.inference_time_sec
+                if (
+                    window_result.methodology == "steady_state"
+                    and output.inference_time_sec > 0
+                )
+                else None
+            )
+        else:
+            measurement_methodology = "total"
+            steady_state_window = (0.0, output.inference_time_sec)
+            steady_state_not_detected = False
+            discard_fraction = None
+
         warmup_excluded_samples = (
             warmup_result.iterations_completed if warmup_result is not None else None
         )
@@ -1192,7 +1271,7 @@ class MeasurementHarness:
             experiment_id=experiment_id,
             measurement_config_hash=compute_declared_config_hash(config),
             llenergymeasure_version=__version__,
-            measurement_methodology="total",
+            measurement_methodology=measurement_methodology,
             engine=engine_name,
             engine_version=engine_version,
             aggregation=AggregationMetadata(
@@ -1201,7 +1280,7 @@ class MeasurementHarness:
             ),
             total_tokens=output.total_tokens,
             total_energy_j=total_energy_j,
-            total_inference_time_sec=output.inference_time_sec,
+            total_inference_time_sec=measured_time_sec,
             avg_tokens_per_second=avg_tokens_per_second,
             avg_energy_per_token_j=avg_energy_per_token_j,
             total_flops=total_flops,
@@ -1225,5 +1304,7 @@ class MeasurementHarness:
             extended_metrics=extended_metrics,
             latency_stats=latency_stats,
             steady_state_window=steady_state_window,
+            measurement_window_discard_fraction=discard_fraction,
+            steady_state_not_detected=steady_state_not_detected,
             warmup_excluded_samples=warmup_excluded_samples,
         )

--- a/src/llenergymeasure/harness/windowing.py
+++ b/src/llenergymeasure/harness/windowing.py
@@ -1,0 +1,373 @@
+"""Steady-state / windowed energy measurement.
+
+Restricts the measured region of a run to a sub-window of the NVML power series so
+that warm-up transients do not bias energy-per-token and throughput. Three modes,
+selected by ``MeasurementConfig.measurement_methodology``:
+
+- ``total`` - the whole run (handled by the caller; this module is not invoked).
+- ``windowed`` - an explicit ``(start_sec, end_sec)`` window.
+- ``steady_state`` - discard a deterministic warm-up prefix, optionally auto-detecting
+  the steady-state onset with a sliding-window stability test.
+
+The energy integration math itself is NOT reimplemented here: the cleaned, windowed
+sample subset is fed to the existing trapezoidal integrator
+(:func:`llenergymeasure.energy.nvml.integrate_power_samples`).
+
+The methodology survey behind this design is recorded in
+``.product/research/steady-state-measurement-methodology.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from llenergymeasure.energy.nvml import integrate_power_samples
+
+if TYPE_CHECKING:
+    from llenergymeasure.config.models import MeasurementConfig
+    from llenergymeasure.device.power_thermal import PowerThermalSample
+
+logger = logging.getLogger(__name__)
+
+#: Median-filter kernel for transient-dropout removal (odd, small per the SOTA).
+_MEDIAN_KERNEL = 3
+
+#: Minimum realised window duration (seconds) below which the measurement is flagged
+#: as too short to be meaningful. Mirrors MLPerf Power's minimum-duration floor,
+#: scaled down because LLenergyMeasure runs are far shorter than datacentre sweeps.
+_MIN_WINDOW_SEC = 1.0
+
+#: Default auto-detector tuning. The sliding window spans this fraction of the cleaned
+#: series, and a window is "stable" when its coefficient of variation is at or below
+#: the threshold. Deliberately lenient: the detector only needs to find a plateau onset,
+#: and it always has the fixed-discard fallback.
+_AUTO_WINDOW_FRACTION = 0.2
+_AUTO_CV_THRESHOLD = 0.05
+_AUTO_MIN_WINDOW_SAMPLES = 4
+
+
+@dataclass
+class WindowResult:
+    """Outcome of applying a measurement window to a power series.
+
+    Attributes:
+        methodology: The methodology actually used ("total", "windowed",
+            "steady_state").
+        energy_j: Re-integrated total energy over the window (sum across GPUs).
+        per_gpu_j: Per-GPU re-integrated energy.
+        window: Realised ``(start_sec, end_sec)`` relative to inference start.
+        window_duration_sec: ``end_sec - start_sec`` of the realised window.
+        token_fraction: Fraction of the cleaned inference span the window covers;
+            tokens/throughput are attributed proportionally by this fraction.
+        steady_state_not_detected: True when auto-detection was requested but failed
+            and the run fell back to the fixed warm-up discard.
+        warnings: Provenance / quality warnings to surface in the result.
+    """
+
+    methodology: str
+    energy_j: float
+    per_gpu_j: dict[int, float]
+    window: tuple[float, float]
+    window_duration_sec: float
+    token_fraction: float
+    steady_state_not_detected: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+
+def _clean_samples(samples: list[PowerThermalSample]) -> list[PowerThermalSample]:
+    """Drop zero / physically-impossible power samples and median-filter dropouts.
+
+    Pre-cleaning is mandatory before windowing or stability detection because NVML
+    under-samples transitions and emits occasional zero / spurious readings. Samples
+    without a power reading or with non-positive power are dropped; the survivors are
+    median-filtered (kernel 3) per GPU to kill single-sample transients.
+
+    Timestamps are preserved (the median filter only smooths ``power_w``), so the
+    trapezoidal integrator still sees the real time base.
+    """
+    by_gpu: dict[int, list[PowerThermalSample]] = {}
+    for s in samples:
+        if s.power_w is None or s.power_w <= 0.0:
+            continue
+        by_gpu.setdefault(s.gpu_index, []).append(s)
+
+    cleaned: list[PowerThermalSample] = []
+    half = _MEDIAN_KERNEL // 2
+    for gpu_samples in by_gpu.values():
+        powers = [s.power_w for s in gpu_samples]
+        for i, s in enumerate(gpu_samples):
+            lo = max(0, i - half)
+            hi = min(len(gpu_samples), i + half + 1)
+            window = sorted(powers[lo:hi])
+            median = window[len(window) // 2]
+            # Replace only the smoothed power; keep timestamp / gpu_index intact.
+            cleaned.append(_with_power(s, median))
+
+    cleaned.sort(key=lambda s: s.timestamp)
+    return cleaned
+
+
+def _with_power(sample: PowerThermalSample, power_w: float) -> PowerThermalSample:
+    """Return a shallow copy of ``sample`` with ``power_w`` replaced."""
+    from dataclasses import replace
+
+    return replace(sample, power_w=power_w)
+
+
+def _filter_to_window(
+    samples: list[PowerThermalSample], origin: float, start_sec: float, end_sec: float
+) -> list[PowerThermalSample]:
+    """Return samples whose timestamp falls in ``[origin+start, origin+end]``.
+
+    Endpoints are added by interpolation when the window cuts between samples so the
+    trapezoid covers exactly ``[start_sec, end_sec]`` rather than snapping to the
+    nearest sample. Interpolation is linear in power, consistent with the trapezoidal
+    rule the integrator already assumes between samples.
+    """
+    by_gpu: dict[int, list[PowerThermalSample]] = {}
+    for s in samples:
+        by_gpu.setdefault(s.gpu_index, []).append(s)
+
+    abs_start = origin + start_sec
+    abs_end = origin + end_sec
+    result: list[PowerThermalSample] = []
+    for gpu_samples in by_gpu.values():
+        gpu_samples = sorted(gpu_samples, key=lambda s: s.timestamp)
+        result.extend(_clip_gpu_window(gpu_samples, abs_start, abs_end))
+    result.sort(key=lambda s: s.timestamp)
+    return result
+
+
+def _clip_gpu_window(
+    gpu_samples: list[PowerThermalSample], abs_start: float, abs_end: float
+) -> list[PowerThermalSample]:
+    """Clip one GPU's ordered samples to ``[abs_start, abs_end]`` with edge interpolation."""
+    inside = [s for s in gpu_samples if abs_start <= s.timestamp <= abs_end]
+    clipped: list[PowerThermalSample] = list(inside)
+
+    # Interpolate a leading edge sample at abs_start if the window starts mid-gap.
+    start_edge = _interp_edge(gpu_samples, abs_start)
+    if start_edge is not None and (not inside or inside[0].timestamp > abs_start):
+        clipped.append(start_edge)
+    # Interpolate a trailing edge sample at abs_end.
+    end_edge = _interp_edge(gpu_samples, abs_end)
+    if end_edge is not None and (not inside or inside[-1].timestamp < abs_end):
+        clipped.append(end_edge)
+
+    clipped.sort(key=lambda s: s.timestamp)
+    return clipped
+
+
+def _interp_edge(
+    gpu_samples: list[PowerThermalSample], at: float
+) -> PowerThermalSample | None:
+    """Linearly interpolate a sample at timestamp ``at`` between bracketing samples.
+
+    Returns None when ``at`` is outside the sample span (nothing to interpolate).
+    """
+    for i in range(len(gpu_samples) - 1):
+        a = gpu_samples[i]
+        b = gpu_samples[i + 1]
+        if a.timestamp <= at <= b.timestamp:
+            if b.timestamp == a.timestamp or a.power_w is None or b.power_w is None:
+                return None
+            frac = (at - a.timestamp) / (b.timestamp - a.timestamp)
+            power = a.power_w + frac * (b.power_w - a.power_w)
+            return _with_power_at(a, power, at)
+    return None
+
+
+def _with_power_at(
+    sample: PowerThermalSample, power_w: float, timestamp: float
+) -> PowerThermalSample:
+    """Return a copy of ``sample`` with ``power_w`` and ``timestamp`` replaced."""
+    from dataclasses import replace
+
+    return replace(sample, power_w=power_w, timestamp=timestamp)
+
+
+def _detect_steady_state(
+    powers: list[float], times: list[float]
+) -> float | None:
+    """Find the steady-state onset (seconds from series start) via sliding-window CV.
+
+    Implements the lightweight windowed-stability test from the SOTA survey (a
+    coefficient-of-variation / variance-ratio test in the Cao-Rhinehart R-statistic
+    family): slide a window of ``_AUTO_WINDOW_FRACTION`` of the series and return the
+    start time of the EARLIEST window whose coefficient of variation (std / mean) is at
+    or below ``_AUTO_CV_THRESHOLD`` and which stays stable through the end of the
+    series. Returns None when no such region exists (the caller then falls back to the
+    fixed discard and flags ``steady_state_not_detected``).
+
+    No heavy change-point library is used: this is a direct ~40-line stability test, as
+    the survey found PELT / ruptures / BOCPD fragile on short noisy autocorrelated series.
+    """
+    n = len(powers)
+    if n < _AUTO_MIN_WINDOW_SAMPLES * 2:
+        return None
+    win = max(_AUTO_MIN_WINDOW_SAMPLES, int(n * _AUTO_WINDOW_FRACTION))
+    if win >= n:
+        return None
+
+    for start in range(n - win + 1):
+        if _is_stable_through_end(powers, start, win):
+            return times[start] - times[0]
+    return None
+
+
+def _is_stable_through_end(powers: list[float], start: int, win: int) -> bool:
+    """True when every window of size ``win`` from ``start`` to the end is stable.
+
+    Stability is "coefficient of variation at or below threshold". Requiring stability
+    through the end (not just at ``start``) rejects a brief flat spot during the warm-up
+    ramp - the plateau must persist, matching how production benchmarks define steady
+    state.
+    """
+    n = len(powers)
+    for s in range(start, n - win + 1):
+        if _coefficient_of_variation(powers[s : s + win]) > _AUTO_CV_THRESHOLD:
+            return False
+    return True
+
+
+def _coefficient_of_variation(values: list[float]) -> float:
+    """Std / mean of ``values``. Returns infinity for a non-positive mean."""
+    n = len(values)
+    mean = sum(values) / n
+    if mean <= 0.0:
+        return float("inf")
+    variance = sum((v - mean) ** 2 for v in values) / n
+    return (variance**0.5) / mean
+
+
+def _resolve_steady_state_window(
+    cleaned: list[PowerThermalSample],
+    span: float,
+    config: MeasurementConfig,
+) -> tuple[float, float, bool, list[str]]:
+    """Resolve the steady-state window: auto-detect if opted in, else fixed discard.
+
+    Returns ``(start_sec, end_sec, not_detected, warnings)`` where the bounds are
+    relative to the cleaned series origin.
+    """
+    warnings: list[str] = []
+
+    # Fixed-discard onset (the default and the fallback).
+    if config.warmup_discard_seconds is not None:
+        fixed_start = min(config.warmup_discard_seconds, span)
+    else:
+        fixed_start = span * config.warmup_discard_fraction
+
+    if not config.steady_state_auto_detect:
+        return fixed_start, span, False, warnings
+
+    # Auto-detect over the per-GPU-pooled cleaned series (single GPU is the common case;
+    # for multi-GPU the pooled CV is a conservative stability proxy).
+    origin = cleaned[0].timestamp
+    times = [s.timestamp for s in cleaned]
+    powers = [s.power_w for s in cleaned if s.power_w is not None]
+    onset = _detect_steady_state(powers, times) if len(powers) == len(times) else None
+
+    if onset is None:
+        warnings.append(
+            "steady_state auto-detection found no stable region; "
+            "fell back to fixed warm-up discard."
+        )
+        return fixed_start, span, True, warnings
+
+    _ = origin  # onset is already relative to series start
+    return onset, span, False, warnings
+
+
+def apply_measurement_window(
+    samples: list[PowerThermalSample],
+    config: MeasurementConfig,
+    inference_time_sec: float,
+) -> WindowResult | None:
+    """Apply the configured measurement window and re-integrate energy over it.
+
+    Pre-cleans the NVML power series, resolves the window for the selected
+    methodology, filters samples to the window, and re-integrates energy with the
+    existing trapezoidal integrator. Token / throughput attribution is proportional
+    by time (the harness has no absolute per-token timestamps); ``token_fraction``
+    carries the multiplier and a provenance warning is attached.
+
+    Args:
+        samples: Raw NVML power samples (``PowerThermalSample``) spanning the run.
+        config: Measurement configuration (methodology + window/discard params).
+        inference_time_sec: Harness-measured inference span (perf_counter delta),
+            used as the window denominator and as the end bound for steady_state.
+
+    Returns:
+        A WindowResult, or None when windowing cannot be applied (too few clean
+        samples) so the caller keeps the unchanged ``total`` figures.
+    """
+    methodology = config.measurement_methodology
+    if methodology == "total":
+        return None
+
+    cleaned = _clean_samples(samples)
+    if len(cleaned) < 2:
+        logger.warning(
+            "measurement_methodology=%s requested but only %d usable power "
+            "samples after cleaning; keeping total-run figures.",
+            methodology,
+            len(cleaned),
+        )
+        return None
+
+    origin = cleaned[0].timestamp
+    span = cleaned[-1].timestamp - origin
+    warnings: list[str] = []
+    not_detected = False
+
+    if methodology == "windowed":
+        assert config.measurement_window is not None  # enforced by config validation
+        start_sec, end_sec = config.measurement_window
+        end_sec = min(end_sec, span)
+        start_sec = min(start_sec, end_sec)
+    else:  # steady_state
+        start_sec, end_sec, not_detected, ss_warnings = _resolve_steady_state_window(
+            cleaned, span, config
+        )
+        warnings.extend(ss_warnings)
+
+    windowed = _filter_to_window(cleaned, origin, start_sec, end_sec)
+    per_gpu_j = integrate_power_samples(windowed)
+    energy_j = sum(per_gpu_j.values())
+
+    window_duration = end_sec - start_sec
+    if window_duration < _MIN_WINDOW_SEC:
+        warnings.append(
+            f"measurement window is {window_duration:.2f}s, below the "
+            f"{_MIN_WINDOW_SEC:.1f}s minimum-duration floor; energy/throughput over "
+            "this window have high relative uncertainty."
+        )
+
+    # Proportional-by-time token attribution. The harness captures per-request and
+    # inter-token durations but no absolute per-token timestamps, so tokens are
+    # credited by the window's share of the cleaned inference span. Documented as an
+    # approximation in the result provenance.
+    denom = span if span > 0.0 else inference_time_sec
+    token_fraction = (window_duration / denom) if denom > 0.0 else 0.0
+    token_fraction = max(0.0, min(1.0, token_fraction))
+    if methodology in ("windowed", "steady_state"):
+        warnings.append(
+            "tokens and throughput attributed to the measurement window "
+            f"proportionally by time (window covers {token_fraction:.0%} of the "
+            "cleaned inference span); the harness captures no absolute per-token "
+            "timestamps for exact attribution."
+        )
+
+    return WindowResult(
+        methodology=methodology,
+        energy_j=energy_j,
+        per_gpu_j=per_gpu_j,
+        window=(start_sec, end_sec),
+        window_duration_sec=window_duration,
+        token_fraction=token_fraction,
+        steady_state_not_detected=not_detected,
+        warnings=warnings,
+    )

--- a/src/llenergymeasure/harness/windowing.py
+++ b/src/llenergymeasure/harness/windowing.py
@@ -244,17 +244,19 @@ def _coefficient_of_variation(values: list[float]) -> float:
 
 def _resolve_steady_state_window(
     cleaned: list[PowerThermalSample],
+    origin: float,
     span: float,
     config: MeasurementConfig,
 ) -> tuple[float, float, bool, list[str]]:
     """Resolve the steady-state window: auto-detect if opted in, else fixed discard.
 
     Returns ``(start_sec, end_sec, not_detected, warnings)`` where the bounds are
-    relative to the cleaned series origin.
+    relative to ``origin`` (the raw inference-start anchor). ``span`` is the realised
+    end bound; the onset is the resolved discard.
     """
     warnings: list[str] = []
 
-    # Fixed-discard onset (the default and the fallback).
+    # Fixed-discard onset (the default and the fallback), relative to the anchor.
     if config.warmup_discard_seconds is not None:
         fixed_start = min(config.warmup_discard_seconds, span)
     else:
@@ -264,8 +266,8 @@ def _resolve_steady_state_window(
         return fixed_start, span, False, warnings
 
     # Auto-detect over the per-GPU-pooled cleaned series (single GPU is the common case;
-    # for multi-GPU the pooled CV is a conservative stability proxy).
-    origin = cleaned[0].timestamp
+    # for multi-GPU the pooled CV is a conservative stability proxy). Onset is returned
+    # relative to the cleaned series start, then re-anchored to ``origin``.
     times = [s.timestamp for s in cleaned]
     powers = [s.power_w for s in cleaned if s.power_w is not None]
     onset = _detect_steady_state(powers, times) if len(powers) == len(times) else None
@@ -277,7 +279,8 @@ def _resolve_steady_state_window(
         )
         return fixed_start, span, True, warnings
 
-    _ = origin  # onset is already relative to series start
+    # _detect_steady_state returns onset relative to cleaned start; re-anchor to origin.
+    onset += cleaned[0].timestamp - origin
     return onset, span, False, warnings
 
 
@@ -308,6 +311,16 @@ def apply_measurement_window(
     if methodology == "total":
         return None
 
+    if len(samples) < 2:
+        return None
+
+    # Anchor the window to the RAW series origin (the sampler starts at inference
+    # start), so a window relative to inference start is not shifted when cleaning
+    # drops leading samples.
+    origin = min(s.timestamp for s in samples)
+    end_ts = max(s.timestamp for s in samples)
+    span = end_ts - origin
+
     cleaned = _clean_samples(samples)
     if len(cleaned) < 2:
         logger.warning(
@@ -318,8 +331,6 @@ def apply_measurement_window(
         )
         return None
 
-    origin = cleaned[0].timestamp
-    span = cleaned[-1].timestamp - origin
     warnings: list[str] = []
     not_detected = False
 
@@ -330,7 +341,7 @@ def apply_measurement_window(
         start_sec = min(start_sec, end_sec)
     else:  # steady_state
         start_sec, end_sec, not_detected, ss_warnings = _resolve_steady_state_window(
-            cleaned, span, config
+            cleaned, origin, span, config
         )
         warnings.extend(ss_warnings)
 

--- a/src/llenergymeasure/harness/windowing.py
+++ b/src/llenergymeasure/harness/windowing.py
@@ -20,7 +20,8 @@ The methodology survey behind this design is recorded in
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+import math
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 from llenergymeasure.energy.nvml import integrate_power_samples
@@ -96,7 +97,8 @@ def _clean_samples(samples: list[PowerThermalSample]) -> list[PowerThermalSample
     cleaned: list[PowerThermalSample] = []
     half = _MEDIAN_KERNEL // 2
     for gpu_samples in by_gpu.values():
-        powers = [s.power_w for s in gpu_samples]
+        # power_w is guaranteed non-None here (None / non-positive dropped above).
+        powers = [s.power_w for s in gpu_samples if s.power_w is not None]
         for i, s in enumerate(gpu_samples):
             lo = max(0, i - half)
             hi = min(len(gpu_samples), i + half + 1)
@@ -111,8 +113,6 @@ def _clean_samples(samples: list[PowerThermalSample]) -> list[PowerThermalSample
 
 def _with_power(sample: PowerThermalSample, power_w: float) -> PowerThermalSample:
     """Return a shallow copy of ``sample`` with ``power_w`` replaced."""
-    from dataclasses import replace
-
     return replace(sample, power_w=power_w)
 
 
@@ -160,9 +160,7 @@ def _clip_gpu_window(
     return clipped
 
 
-def _interp_edge(
-    gpu_samples: list[PowerThermalSample], at: float
-) -> PowerThermalSample | None:
+def _interp_edge(gpu_samples: list[PowerThermalSample], at: float) -> PowerThermalSample | None:
     """Linearly interpolate a sample at timestamp ``at`` between bracketing samples.
 
     Returns None when ``at`` is outside the sample span (nothing to interpolate).
@@ -183,14 +181,10 @@ def _with_power_at(
     sample: PowerThermalSample, power_w: float, timestamp: float
 ) -> PowerThermalSample:
     """Return a copy of ``sample`` with ``power_w`` and ``timestamp`` replaced."""
-    from dataclasses import replace
-
     return replace(sample, power_w=power_w, timestamp=timestamp)
 
 
-def _detect_steady_state(
-    powers: list[float], times: list[float]
-) -> float | None:
+def _detect_steady_state(powers: list[float], times: list[float]) -> float | None:
     """Find the steady-state onset (seconds from series start) via sliding-window CV.
 
     Implements the lightweight windowed-stability test from the SOTA survey (a
@@ -239,7 +233,7 @@ def _coefficient_of_variation(values: list[float]) -> float:
     if mean <= 0.0:
         return float("inf")
     variance = sum((v - mean) ** 2 for v in values) / n
-    return (variance**0.5) / mean
+    return math.sqrt(variance) / mean
 
 
 def _resolve_steady_state_window(

--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -475,12 +475,13 @@ def test_load_study_config_design_hash_is_stable(tmp_path):
     )
     sc = _load_study(study_yaml)
     # Pinned over the full resolved-config surface (config.model_dump). Re-pinned
-    # when MeasurementConfig gained the opt-in latency_profiling field: a new
-    # defaulted field shifts the canonical JSON, so the fingerprint moves while
-    # the resolve -> dedup -> hash pipeline is unchanged (6 declared -> 4 unique
-    # below still holds). A value change with those structural assertions intact
-    # is a benign schema-surface shift; a change to the dedup counts is not.
-    assert sc.study_design_hash == "da1f6bb48138cbda"
+    # when MeasurementConfig gained the measurement-window fields (methodology,
+    # window, warmup-discard, auto-detect): new defaulted fields shift the
+    # canonical JSON, so the fingerprint moves while the resolve -> dedup -> hash
+    # pipeline is unchanged (6 declared -> 4 unique below still holds). A value
+    # change with those structural assertions intact is a benign schema-surface
+    # shift; a change to the dedup counts is not.
+    assert sc.study_design_hash == "3bff73061a555b8d"
     # 6 declared configs collapse to 4 unique under resolved-config dedup.
     assert len(sc.experiments) == 4
     assert len(sc.declared_resolved_config_hashes) == 6

--- a/tests/unit/harness/test_measurement_integration.py
+++ b/tests/unit/harness/test_measurement_integration.py
@@ -519,9 +519,7 @@ def _flat_samples():
     """11 samples 0..1.0s at constant 100 W (full-run energy = 100 J)."""
     from llenergymeasure.device.power_thermal import PowerThermalSample
 
-    return [
-        PowerThermalSample(timestamp=i * 0.1, power_w=100.0, gpu_index=0) for i in range(11)
-    ]
+    return [PowerThermalSample(timestamp=i * 0.1, power_w=100.0, gpu_index=0) for i in range(11)]
 
 
 def test_methodology_total_is_unchanged_default() -> None:

--- a/tests/unit/harness/test_measurement_integration.py
+++ b/tests/unit/harness/test_measurement_integration.py
@@ -466,6 +466,146 @@ def test_harness_build_result_zero_energy_when_no_engine() -> None:
     assert len(result.measurement_warnings) == 1
 
 
+# =============================================================================
+# Measurement-methodology wiring (total / windowed / steady_state)
+# =============================================================================
+
+
+def _methodology_build_result(measurement: dict, *, samples, output_tokens=100):
+    """Run _build_result with a flat-100W timeseries and return the result."""
+    from datetime import datetime
+
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.domain.metrics import ThermalThrottleInfo
+    from llenergymeasure.energy.nvml import EnergyMeasurement
+    from llenergymeasure.engines.protocol import InferenceOutput
+    from llenergymeasure.harness import MeasurementHarness
+
+    harness = MeasurementHarness()
+    config = ExperimentConfig(task={"model": "test/model"}, measurement=measurement)
+    output = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=0,
+        output_tokens=output_tokens,
+        peak_memory_mb=0.0,
+        model_memory_mb=0.0,
+    )
+    output.inference_time_sec = 1.0
+    # Sampler total (100 J over the full run) - the windowed path re-integrates from
+    # the timeseries and overrides this; total mode keeps it.
+    energy_measurement = EnergyMeasurement(total_j=100.0, duration_sec=1.0)
+    now = datetime.now()
+    return harness._build_result(
+        engine_name="transformers",
+        engine_version=None,
+        config=config,
+        output=output,
+        model_memory_mb=0.0,
+        snapshot=None,
+        start_time=now,
+        end_time=now,
+        duration_sec=1.0,
+        thermal_info=ThermalThrottleInfo(),
+        energy_measurement=energy_measurement,
+        baseline=None,
+        flops_result=None,
+        timeseries_path=None,
+        measurement_warnings=[],
+        timeseries_samples=samples,
+    )
+
+
+def _flat_samples():
+    """11 samples 0..1.0s at constant 100 W (full-run energy = 100 J)."""
+    from llenergymeasure.device.power_thermal import PowerThermalSample
+
+    return [
+        PowerThermalSample(timestamp=i * 0.1, power_w=100.0, gpu_index=0) for i in range(11)
+    ]
+
+
+def test_methodology_total_is_unchanged_default() -> None:
+    """Default total mode keeps the sampler total and spans the whole run."""
+    result = _methodology_build_result({}, samples=_flat_samples())
+    assert result.measurement_methodology == "total"
+    assert result.total_energy_j == pytest.approx(100.0)
+    assert result.total_inference_time_sec == pytest.approx(1.0)
+    assert result.steady_state_window == (0.0, 1.0)
+    assert result.steady_state_not_detected is False
+    assert result.measurement_window_discard_fraction is None
+    # output_tokens=100 over 100 J -> 1.0 J/token, mj 1000.
+    assert result.avg_energy_per_token_j == pytest.approx(1.0)
+
+
+def test_methodology_windowed_reintegrates_and_attributes_tokens() -> None:
+    """windowed [0.2,0.7] re-integrates 50 J and attributes 50% of tokens."""
+    result = _methodology_build_result(
+        {"measurement_methodology": "windowed", "measurement_window": (0.2, 0.7)},
+        samples=_flat_samples(),
+    )
+    assert result.measurement_methodology == "windowed"
+    assert result.total_energy_j == pytest.approx(50.0)
+    assert result.steady_state_window == (0.2, 0.7)
+    assert result.total_inference_time_sec == pytest.approx(0.5)
+    # 50 J over 50% of 100 output tokens = 50 J / 50 tokens = 1.0 J/token.
+    assert result.avg_energy_per_token_j == pytest.approx(1.0)
+    # throughput: 50% of 100 total tokens over 0.5s window = 100 tok/s.
+    assert result.avg_tokens_per_second == pytest.approx(100.0)
+    assert any("proportionally by time" in w for w in result.measurement_warnings)
+
+
+def test_methodology_steady_state_fixed_discard() -> None:
+    """steady_state fixed fraction 0.3 -> window [0.3,1.0], 70 J, discard fraction recorded."""
+    result = _methodology_build_result(
+        {"measurement_methodology": "steady_state", "warmup_discard_fraction": 0.3},
+        samples=_flat_samples(),
+    )
+    assert result.measurement_methodology == "steady_state"
+    assert result.total_energy_j == pytest.approx(70.0)
+    assert result.steady_state_window[0] == pytest.approx(0.3)
+    assert result.steady_state_window[1] == pytest.approx(1.0)
+    assert result.measurement_window_discard_fraction == pytest.approx(0.3)
+    assert result.steady_state_not_detected is False
+
+
+def test_methodology_steady_state_auto_not_detected_flag() -> None:
+    """auto-detect on a never-stable series sets the not-detected flag in the result."""
+    import math
+
+    from llenergymeasure.device.power_thermal import PowerThermalSample
+
+    noisy = [
+        PowerThermalSample(
+            timestamp=t / 10,
+            power_w=50.0 + 40.0 * math.sin(t) * (1 + t / 10) + (t * 3),
+            gpu_index=0,
+        )
+        for t in range(60)
+    ]
+    result = _methodology_build_result(
+        {
+            "measurement_methodology": "steady_state",
+            "steady_state_auto_detect": True,
+            "warmup_discard_fraction": 0.1,
+        },
+        samples=noisy,
+    )
+    assert result.measurement_methodology == "steady_state"
+    assert result.steady_state_not_detected is True
+    assert any("auto-detection found no stable region" in w for w in result.measurement_warnings)
+
+
+def test_methodology_falls_back_to_total_without_samples() -> None:
+    """No timeseries samples -> windowing cannot apply, total figures retained."""
+    result = _methodology_build_result(
+        {"measurement_methodology": "windowed", "measurement_window": (0.2, 0.7)},
+        samples=[],
+    )
+    # Keeps the sampler total and reports total methodology (window not applied).
+    assert result.measurement_methodology == "total"
+    assert result.total_energy_j == pytest.approx(100.0)
+
+
 def test_inference_output_tracks_input_output_tokens() -> None:
     """InferenceOutput separates input_tokens and output_tokens."""
     from llenergymeasure.engines.protocol import InferenceOutput

--- a/tests/unit/harness/test_windowing.py
+++ b/tests/unit/harness/test_windowing.py
@@ -1,0 +1,299 @@
+"""Tests for steady-state / windowed energy measurement.
+
+The energy assertions are hand-computed trapezoids over a known synthetic power
+series, so a regression in the windowing or re-integration math fails here loudly.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from llenergymeasure.config.models import MeasurementConfig
+from llenergymeasure.device.power_thermal import PowerThermalSample
+from llenergymeasure.harness.windowing import (
+    _clean_samples,
+    _coefficient_of_variation,
+    _detect_steady_state,
+    apply_measurement_window,
+)
+
+
+def _flat_series(
+    n: int = 11, dt: float = 0.1, power: float = 100.0, gpu_index: int = 0
+) -> list[PowerThermalSample]:
+    """Constant-power series: ``n`` samples ``dt`` apart at ``power`` watts."""
+    return [
+        PowerThermalSample(timestamp=i * dt, power_w=power, gpu_index=gpu_index)
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# total mode: not invoked (caller short-circuits)
+# ---------------------------------------------------------------------------
+
+
+def test_total_mode_returns_none():
+    """total methodology must not produce a window (caller keeps full-run figures)."""
+    cfg = MeasurementConfig(measurement_methodology="total")
+    assert apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0) is None
+
+
+# ---------------------------------------------------------------------------
+# windowed mode: energy equals the hand-computed trapezoid over the window
+# ---------------------------------------------------------------------------
+
+
+def test_windowed_energy_matches_hand_trapezoid():
+    """[0.2, 0.7] over a flat 100W series = 0.5s * 100W = 50 J exactly."""
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.2, 0.7)
+    )
+    r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
+    assert r is not None
+    assert r.methodology == "windowed"
+    assert r.energy_j == pytest.approx(50.0)
+    assert r.window == (0.2, 0.7)
+    assert r.window_duration_sec == pytest.approx(0.5)
+
+
+def test_windowed_edge_interpolation_between_samples():
+    """A window cutting between samples integrates exactly via edge interpolation.
+
+    Linear ramp 50W..150W over 0..1.0s (slope 100 W/s, non-zero floor so no sample is
+    dropped by pre-clean). Window [0.25, 0.75]: power(0.25)=75W, power(0.75)=125W,
+    trapezoid = (75+125)/2 * 0.5 = 50 J.
+    """
+    samples = [
+        PowerThermalSample(timestamp=i * 0.1, power_w=50.0 + 100.0 * (i * 0.1), gpu_index=0)
+        for i in range(11)
+    ]
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.25, 0.75)
+    )
+    r = apply_measurement_window(samples, cfg, inference_time_sec=1.0)
+    assert r is not None
+    assert r.energy_j == pytest.approx(50.0)
+
+
+def test_windowed_token_fraction_is_window_share():
+    """token_fraction is the window's share of the cleaned inference span."""
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.0, 0.6)
+    )
+    r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
+    assert r is not None
+    # cleaned span is 1.0s (0..1.0); window 0.6s -> 0.6 fraction.
+    assert r.token_fraction == pytest.approx(0.6)
+    assert any("proportionally by time" in w for w in r.warnings)
+
+
+def test_windowed_clamps_end_to_span():
+    """An end beyond the sample span clamps to the realised span, not past it."""
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.0, 5.0)
+    )
+    r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
+    assert r is not None
+    assert r.window[1] == pytest.approx(1.0)
+    assert r.energy_j == pytest.approx(100.0)
+
+
+# ---------------------------------------------------------------------------
+# steady_state fixed-discard: discards the right prefix
+# ---------------------------------------------------------------------------
+
+
+def test_steady_state_fixed_fraction_discards_prefix():
+    """Fraction 0.3 over a flat 100W 1.0s run -> window [0.3, 1.0] = 70 J."""
+    cfg = MeasurementConfig(
+        measurement_methodology="steady_state", warmup_discard_fraction=0.3
+    )
+    r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
+    assert r is not None
+    assert r.methodology == "steady_state"
+    assert r.window[0] == pytest.approx(0.3)
+    assert r.window[1] == pytest.approx(1.0)
+    assert r.energy_j == pytest.approx(70.0)
+    assert r.steady_state_not_detected is False
+
+
+def test_steady_state_fixed_seconds_takes_precedence():
+    """warmup_discard_seconds overrides the fraction: discard 0.4s -> [0.4,1.0]=60 J."""
+    cfg = MeasurementConfig(
+        measurement_methodology="steady_state",
+        warmup_discard_fraction=0.9,  # would discard almost everything if used
+        warmup_discard_seconds=0.4,
+    )
+    r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
+    assert r is not None
+    assert r.window[0] == pytest.approx(0.4)
+    assert r.energy_j == pytest.approx(60.0)
+
+
+# ---------------------------------------------------------------------------
+# auto-detector: finds plateau onset / falls back and flags on failure
+# ---------------------------------------------------------------------------
+
+
+def test_auto_detector_finds_plateau_onset():
+    """A warm-up ramp then a flat plateau: the onset lands in the plateau region."""
+    ramp = [
+        PowerThermalSample(timestamp=t / 10, power_w=20.0 + (180.0) * (t / 20), gpu_index=0)
+        for t in range(20)
+    ]
+    plateau = [
+        PowerThermalSample(timestamp=2.0 + t / 10, power_w=200.0, gpu_index=0)
+        for t in range(41)
+    ]
+    cfg = MeasurementConfig(
+        measurement_methodology="steady_state",
+        steady_state_auto_detect=True,
+        warmup_discard_fraction=0.1,
+    )
+    r = apply_measurement_window(ramp + plateau, cfg, inference_time_sec=6.0)
+    assert r is not None
+    assert r.steady_state_not_detected is False
+    # Onset must land at or after the start of the ramp-to-plateau transition and
+    # before the plateau ends, i.e. inside roughly [1.5, 2.5]s.
+    assert 1.5 <= r.window[0] <= 2.5
+    # Energy over the plateau-dominated window is close to 200W * duration.
+    expected = 200.0 * (r.window[1] - r.window[0])
+    assert r.energy_j == pytest.approx(expected, rel=0.05)
+
+
+def test_auto_detector_falls_back_when_never_stable():
+    """A series that never stabilises sets the flag and falls back to fixed discard."""
+    noisy = [
+        PowerThermalSample(
+            timestamp=t / 10,
+            power_w=50.0 + 40.0 * math.sin(t) * (1 + t / 10) + (t * 3),
+            gpu_index=0,
+        )
+        for t in range(60)
+    ]
+    cfg = MeasurementConfig(
+        measurement_methodology="steady_state",
+        steady_state_auto_detect=True,
+        warmup_discard_fraction=0.1,
+    )
+    r = apply_measurement_window(noisy, cfg, inference_time_sec=6.0)
+    assert r is not None
+    assert r.steady_state_not_detected is True
+    assert any("auto-detection found no stable region" in w for w in r.warnings)
+    # Fell back to fixed discard: start ~ 10% of the cleaned span.
+    span = noisy[-1].timestamp - noisy[0].timestamp
+    assert r.window[0] == pytest.approx(0.1 * span, rel=0.05)
+
+
+def test_detect_steady_state_directly():
+    """The detector returns an onset for ramp->plateau and None for a pure ramp."""
+    times = [t / 10 for t in range(60)]
+    plateau_powers = [20.0 + 9.0 * t if t < 20 else 200.0 for t in range(60)]
+    onset = _detect_steady_state(plateau_powers, times)
+    assert onset is not None
+    assert onset >= 1.5
+
+    ramp_powers = [float(t) for t in range(60)]  # strictly increasing, never flat
+    assert _detect_steady_state(ramp_powers, times) is None
+
+
+def test_coefficient_of_variation():
+    """CV is std/mean; a constant series has CV 0, a non-positive mean is infinite."""
+    assert _coefficient_of_variation([100.0, 100.0, 100.0]) == pytest.approx(0.0)
+    assert _coefficient_of_variation([0.0, 0.0]) == float("inf")
+    assert _coefficient_of_variation([90.0, 110.0]) == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# pre-clean: zero / None dropouts do not corrupt the window
+# ---------------------------------------------------------------------------
+
+
+def test_preclean_zero_and_none_dropouts():
+    """A zero sample and a None sample do not corrupt a flat 100W integral."""
+    samples = _flat_series()
+    samples[5].power_w = 0.0  # physically-impossible dropout
+    samples[7].power_w = None  # missing reading
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.0, 1.0)
+    )
+    r = apply_measurement_window(samples, cfg, inference_time_sec=1.0)
+    assert r is not None
+    # Median filter repairs the zero; the None is dropped. Energy stays ~100 J.
+    assert r.energy_j == pytest.approx(100.0, rel=0.02)
+
+
+def test_clean_drops_nonpositive_and_smooths():
+    """_clean_samples drops None / non-positive power and median-smooths transients."""
+    samples = [
+        PowerThermalSample(timestamp=0.0, power_w=100.0, gpu_index=0),
+        PowerThermalSample(timestamp=0.1, power_w=0.0, gpu_index=0),  # dropout
+        PowerThermalSample(timestamp=0.2, power_w=100.0, gpu_index=0),
+        PowerThermalSample(timestamp=0.3, power_w=None, gpu_index=0),  # missing
+        PowerThermalSample(timestamp=0.4, power_w=100.0, gpu_index=0),
+    ]
+    cleaned = _clean_samples(samples)
+    # None / zero dropped before filtering -> 3 survivors, all ~100W after smoothing.
+    assert len(cleaned) == 3
+    assert all(s.power_w == pytest.approx(100.0) for s in cleaned)
+    # Timestamps preserved.
+    assert [s.timestamp for s in cleaned] == [0.0, 0.2, 0.4]
+
+
+# ---------------------------------------------------------------------------
+# min-duration guard
+# ---------------------------------------------------------------------------
+
+
+def test_min_duration_guard_fires_on_short_window():
+    """A sub-second window trips the minimum-duration warning."""
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.0, 0.3)
+    )
+    r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
+    assert r is not None
+    assert any("minimum-duration floor" in w for w in r.warnings)
+
+
+def test_min_duration_guard_silent_on_long_window():
+    """A window over the floor does not emit the minimum-duration warning."""
+    samples = _flat_series(n=31, dt=0.1)  # 3.0s span
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.0, 2.0)
+    )
+    r = apply_measurement_window(samples, cfg, inference_time_sec=3.0)
+    assert r is not None
+    assert not any("minimum-duration floor" in w for w in r.warnings)
+
+
+# ---------------------------------------------------------------------------
+# degenerate: too few clean samples -> None (caller keeps total figures)
+# ---------------------------------------------------------------------------
+
+
+def test_too_few_samples_returns_none():
+    """Fewer than two usable samples after cleaning falls back to total figures."""
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.0, 1.0)
+    )
+    one = [PowerThermalSample(timestamp=0.0, power_w=100.0, gpu_index=0)]
+    assert apply_measurement_window(one, cfg, inference_time_sec=1.0) is None
+
+
+def test_multi_gpu_window_integrates_per_gpu():
+    """Two GPUs each integrate independently over the window."""
+    samples = []
+    for i in range(11):
+        samples.append(PowerThermalSample(timestamp=i * 0.1, power_w=100.0, gpu_index=0))
+        samples.append(PowerThermalSample(timestamp=i * 0.1, power_w=50.0, gpu_index=1))
+    cfg = MeasurementConfig(
+        measurement_methodology="windowed", measurement_window=(0.0, 1.0)
+    )
+    r = apply_measurement_window(samples, cfg, inference_time_sec=1.0)
+    assert r is not None
+    assert r.per_gpu_j[0] == pytest.approx(100.0)
+    assert r.per_gpu_j[1] == pytest.approx(50.0)
+    assert r.energy_j == pytest.approx(150.0)

--- a/tests/unit/harness/test_windowing.py
+++ b/tests/unit/harness/test_windowing.py
@@ -25,8 +25,7 @@ def _flat_series(
 ) -> list[PowerThermalSample]:
     """Constant-power series: ``n`` samples ``dt`` apart at ``power`` watts."""
     return [
-        PowerThermalSample(timestamp=i * dt, power_w=power, gpu_index=gpu_index)
-        for i in range(n)
+        PowerThermalSample(timestamp=i * dt, power_w=power, gpu_index=gpu_index) for i in range(n)
     ]
 
 
@@ -48,9 +47,7 @@ def test_total_mode_returns_none():
 
 def test_windowed_energy_matches_hand_trapezoid():
     """[0.2, 0.7] over a flat 100W series = 0.5s * 100W = 50 J exactly."""
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.2, 0.7)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.2, 0.7))
     r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
     assert r is not None
     assert r.methodology == "windowed"
@@ -70,9 +67,7 @@ def test_windowed_edge_interpolation_between_samples():
         PowerThermalSample(timestamp=i * 0.1, power_w=50.0 + 100.0 * (i * 0.1), gpu_index=0)
         for i in range(11)
     ]
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.25, 0.75)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.25, 0.75))
     r = apply_measurement_window(samples, cfg, inference_time_sec=1.0)
     assert r is not None
     assert r.energy_j == pytest.approx(50.0)
@@ -80,9 +75,7 @@ def test_windowed_edge_interpolation_between_samples():
 
 def test_windowed_token_fraction_is_window_share():
     """token_fraction is the window's share of the cleaned inference span."""
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.0, 0.6)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.0, 0.6))
     r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
     assert r is not None
     # cleaned span is 1.0s (0..1.0); window 0.6s -> 0.6 fraction.
@@ -92,9 +85,7 @@ def test_windowed_token_fraction_is_window_share():
 
 def test_windowed_clamps_end_to_span():
     """An end beyond the sample span clamps to the realised span, not past it."""
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.0, 5.0)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.0, 5.0))
     r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
     assert r is not None
     assert r.window[1] == pytest.approx(1.0)
@@ -108,9 +99,7 @@ def test_windowed_clamps_end_to_span():
 
 def test_steady_state_fixed_fraction_discards_prefix():
     """Fraction 0.3 over a flat 100W 1.0s run -> window [0.3, 1.0] = 70 J."""
-    cfg = MeasurementConfig(
-        measurement_methodology="steady_state", warmup_discard_fraction=0.3
-    )
+    cfg = MeasurementConfig(measurement_methodology="steady_state", warmup_discard_fraction=0.3)
     r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
     assert r is not None
     assert r.methodology == "steady_state"
@@ -145,8 +134,7 @@ def test_auto_detector_finds_plateau_onset():
         for t in range(20)
     ]
     plateau = [
-        PowerThermalSample(timestamp=2.0 + t / 10, power_w=200.0, gpu_index=0)
-        for t in range(41)
+        PowerThermalSample(timestamp=2.0 + t / 10, power_w=200.0, gpu_index=0) for t in range(41)
     ]
     cfg = MeasurementConfig(
         measurement_methodology="steady_state",
@@ -217,9 +205,7 @@ def test_preclean_zero_and_none_dropouts():
     samples = _flat_series()
     samples[5].power_w = 0.0  # physically-impossible dropout
     samples[7].power_w = None  # missing reading
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.0, 1.0)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.0, 1.0))
     r = apply_measurement_window(samples, cfg, inference_time_sec=1.0)
     assert r is not None
     # Median filter repairs the zero; the None is dropped. Energy stays ~100 J.
@@ -250,9 +236,7 @@ def test_clean_drops_nonpositive_and_smooths():
 
 def test_min_duration_guard_fires_on_short_window():
     """A sub-second window trips the minimum-duration warning."""
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.0, 0.3)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.0, 0.3))
     r = apply_measurement_window(_flat_series(), cfg, inference_time_sec=1.0)
     assert r is not None
     assert any("minimum-duration floor" in w for w in r.warnings)
@@ -261,9 +245,7 @@ def test_min_duration_guard_fires_on_short_window():
 def test_min_duration_guard_silent_on_long_window():
     """A window over the floor does not emit the minimum-duration warning."""
     samples = _flat_series(n=31, dt=0.1)  # 3.0s span
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.0, 2.0)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.0, 2.0))
     r = apply_measurement_window(samples, cfg, inference_time_sec=3.0)
     assert r is not None
     assert not any("minimum-duration floor" in w for w in r.warnings)
@@ -276,9 +258,7 @@ def test_min_duration_guard_silent_on_long_window():
 
 def test_too_few_samples_returns_none():
     """Fewer than two usable samples after cleaning falls back to total figures."""
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.0, 1.0)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.0, 1.0))
     one = [PowerThermalSample(timestamp=0.0, power_w=100.0, gpu_index=0)]
     assert apply_measurement_window(one, cfg, inference_time_sec=1.0) is None
 
@@ -289,9 +269,7 @@ def test_multi_gpu_window_integrates_per_gpu():
     for i in range(11):
         samples.append(PowerThermalSample(timestamp=i * 0.1, power_w=100.0, gpu_index=0))
         samples.append(PowerThermalSample(timestamp=i * 0.1, power_w=50.0, gpu_index=1))
-    cfg = MeasurementConfig(
-        measurement_methodology="windowed", measurement_window=(0.0, 1.0)
-    )
+    cfg = MeasurementConfig(measurement_methodology="windowed", measurement_window=(0.0, 1.0))
     r = apply_measurement_window(samples, cfg, inference_time_sec=1.0)
     assert r is not None
     assert r.per_gpu_j[0] == pytest.approx(100.0)


### PR DESCRIPTION
## Summary

Wires the three measurement-window modes that the result schema already declared but
left unwired (`measurement_methodology` was hardcoded `"total"` and `steady_state_window`
was always the whole run). Selected by a new `MeasurementConfig.measurement_methodology`
input:

- **`total`** (default, unchanged): integrate the whole run. The default path is
  byte-for-byte identical to prior behaviour - when the mode is not opted into,
  `apply_measurement_window` returns `None` and the harness keeps the sampler totals,
  full inference time, and `token_fraction = 1.0`.
- **`windowed`**: user supplies an explicit `measurement_window: (start_sec, end_sec)`
  relative to inference start. Energy is re-integrated over the window and tokens /
  throughput are attributed to it.
- **`steady_state`**: discard a deterministic warm-up prefix (`warmup_discard_fraction`,
  default 0.1; or `warmup_discard_seconds`, which takes precedence) and measure the
  remainder. Opt-in `steady_state_auto_detect` runs a lightweight sliding-window
  coefficient-of-variation stability test (Cao-Rhinehart R-statistic family) to find the
  steady-state onset; on failure it falls back to the fixed discard and sets
  `steady_state_not_detected`.

New module `harness/windowing.py` owns pre-clean + windowing + re-integration + the
detector. The verified-correct trapezoidal integrator is **not** reimplemented: it is
extracted verbatim from `NVMLSampler` into a shared `integrate_power_samples` and the
windowed path feeds it the cleaned, windowed sample subset. Pre-clean drops zero /
impossible samples and median-filters (kernel 3) transient NVML dropouts before windowing
or detection. A minimum-duration guard (1.0s floor) warns on too-short windows.

New config inputs on `MeasurementConfig`: `measurement_methodology`, `measurement_window`,
`warmup_discard_fraction`, `warmup_discard_seconds`, `steady_state_auto_detect`, with a
cross-field validator (window required + ordered for `windowed`). New result fields:
`measurement_window_discard_fraction`, `steady_state_not_detected`. The previously
hardcoded `measurement_methodology` and `steady_state_window` are now populated with the
realised values.

## Token-attribution approach (and its approximation)

The hard part. The harness captures per-request and inter-token *durations* (TTFT, ITL,
per-request latency) only when latency profiling is opted in, but **no absolute per-token
timestamps anchored to the inference clock**. Exact per-token attribution would require a
large cross-engine capture change. Tokens and throughput are therefore attributed to the
sub-window **proportionally by time** (the window's share of the cleaned inference span),
and the approximation is recorded in a `measurement_warnings` provenance entry on every
windowed/steady_state run. This is the same proportional approximation the engines already
use for derived ITL. The approximation is documented in the research doc (Token attribution
section), the user-facing methodology doc, and the `apply_measurement_window` docstring.
Energy re-integration is exact (real windowed trapezoid, not proportional).

## Test plan

`tests/unit/harness/test_windowing.py` (17) + new cases in
`test_measurement_integration.py` cover:
- total mode returns None / `_build_result` keeps unchanged figures
- windowed energy equals the hand-computed trapezoid over a known synthetic series
  (50 J over `[0.2,0.7]` of flat 100W); edge interpolation between samples; token fraction
- steady_state fixed-fraction discards the right prefix (70 J over `[0.3,1.0]`);
  `warmup_discard_seconds` precedence
- auto-detector finds the plateau onset on a ramp-then-flat series; falls back and sets
  `steady_state_not_detected` on a never-stable series
- pre-clean: a zero / None dropout does not corrupt the integral
- min-duration guard fires on a short window, silent on a long one
- multi-GPU per-GPU integration; too-few-samples falls back to None

Gate: `make lint` (ruff + 4 import-linter contracts kept), `make typecheck`
(mypy clean, 270 files), full `uv run pytest` = **2464 passed, 43 skipped, 0 failed**
(baseline 2442 passed; +22 new tests, no regressions). Behaviourally verified the detector
+ windowed integration against hand calculations on synthetic series.

## Doc audit

- New research doc `.product/research/steady-state-measurement-methodology.md` records the
  SOTA survey driving the design (MLPerf Power, MLPerf Inference, SPECpower/SERT, trtexec,
  ML.ENERGY, TokenPowerBench; the VM-warmup steady-state study for the opt-in-detector
  decision; Cao-Rhinehart R-statistic vs PELT/ruptures/BOCPD; NVML under-sampling ->
  pre-clean). Reference list with arXiv ids.
- `docs/explanation/methodology/energy-measurement.md` gains a "Measurement Window" section
  with config examples; bidirectional cross-link with the research doc ("See also").
- No em/en-dashes; no tooling-pointer references in shipped text.