### PR TITLE
feat(results): record runner provenance and load environment.json sidecar

### DIFF
--- a/src/llenergymeasure/config/README.md
+++ b/src/llenergymeasure/config/README.md
@@ -76,16 +76,17 @@ These CLI flags **still work** but emit deprecation warnings:
 
 ### Override Tracking
 
-All CLI overrides are recorded in result metadata for traceability:
+All CLI overrides are recorded in the per-experiment `_resolution.json` sidecar for
+traceability (which fields were overridden and why):
 
 ```json
 {
-  "effective_config": { "batch_size": 8, ... },
-  "cli_overrides": {
-    "batching.batch_size": { "original": 1, "new": 8 }
-  }
+  "batching.batch_size": { "original": 1, "new": 8, "source": "cli" }
 }
 ```
+
+The fully resolved configuration (all defaults filled in) is written to the
+`effective_config.json` sidecar next to `result.json`.
 
 ### Workflow Examples
 
@@ -696,18 +697,18 @@ lem config new -o my-config.yaml  # Specify output path
 
 ## Reproducibility
 
-Results include `effective_config` and `cli_overrides` fields for full reproducibility:
+Each experiment directory ships sidecars for full reproducibility next to `result.json`:
+
+- `effective_config.json` - the fully resolved configuration (every parameter value used,
+  including engine defaults that were not explicitly specified).
+- `_resolution.json` - which fields were overridden and why (CLI flag, sweep, YAML).
 
 ```json
+// effective_config.json
 {
-  "effective_config": {
-    "model_name": "meta-llama/Llama-2-7b-hf",
-    "batch_size": 8,
-    "dtype": "float16"
-  },
-  "cli_overrides": {
-    "batching.batch_size": {"new": 8, "original": 1}
-  }
+  "model_name": "meta-llama/Llama-2-7b-hf",
+  "batch_size": 8,
+  "dtype": "float16"
 }
 ```
 

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
+from llenergymeasure.domain.environment import EnvironmentSnapshot
 from llenergymeasure.domain.metrics import (
     EnergyBreakdown,
     ExtendedEfficiencyMetrics,
@@ -182,6 +183,15 @@ class ExperimentResult(BaseModel):
     timeseries: str | None = Field(
         default=None,
         description="Relative filename of timeseries sidecar (e.g. 'timeseries.parquet')",
+    )
+
+    # Environment sidecar (loaded from environment.json by load_result; excluded
+    # from result.json serialisation - the sidecar is the on-disk home).
+    environment: EnvironmentSnapshot | None = Field(
+        default=None,
+        exclude=True,
+        description="Hardware/runtime environment loaded from the environment.json sidecar. "
+        "None when no sidecar is present. Not serialised back into result.json.",
     )
 
     # Timestamps

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -50,6 +50,28 @@ def mj_per_token(energy_j: float, total_tokens: float) -> float | None:
     return (energy_j / total_tokens * 1000.0) if total_tokens > 0 else None
 
 
+class RunnerProvenance(BaseModel):
+    """How an experiment was executed - local process or Docker container.
+
+    Persisted reproducibility metadata mirroring the fields of the infra-layer
+    ``RunnerSpec``. Kept in the domain layer (no infra import) so it can live on
+    ``ExperimentResult`` and serialise into result.json.
+    """
+
+    mode: str = Field(..., description='Execution mode - "local" or "docker"')
+    image: str | None = Field(default=None, description="Docker image used (None for local mode)")
+    source: str | None = Field(
+        default=None,
+        description='Precedence layer that produced the runner ("env", "yaml", '
+        '"user_config", "auto_detected", "default", "local")',
+    )
+    image_source: str | None = Field(
+        default=None, description="Where the Docker image was resolved from (None for local mode)"
+    )
+
+    model_config = {"frozen": True, "extra": "forbid"}
+
+
 class AggregationMetadata(BaseModel):
     """Metadata about the aggregation process."""
 
@@ -183,6 +205,14 @@ class ExperimentResult(BaseModel):
     timeseries: str | None = Field(
         default=None,
         description="Relative filename of timeseries sidecar (e.g. 'timeseries.parquet')",
+    )
+
+    # Runner provenance - how this experiment was executed (local vs docker).
+    # Persisted into result.json (unlike environment) as reproducibility metadata.
+    runner_provenance: RunnerProvenance | None = Field(
+        default=None,
+        description="How the experiment was executed (local process or Docker container). "
+        "None when no runner spec was available.",
     )
 
     # Environment sidecar (loaded from environment.json by load_result; excluded

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -306,7 +306,7 @@ class DockerRunner:
                  >= ``timeout`` are accepted but redundant with the
                  wall-clock - the watchdog raises whichever fires first.
         source:  Runner resolution source string (e.g. ``"yaml"``, ``"auto_detected"``).
-                 Recorded in result effective_config for traceability.
+                 Recorded in the result's runner_provenance for traceability.
     """
 
     def __init__(
@@ -1101,11 +1101,3 @@ class DockerRunner:
             shutil.rmtree(exchange_dir)
         except Exception as exc:
             logger.warning("Could not remove exchange dir %s: %s", exchange_dir, exc)
-
-    def get_runner_metadata(self) -> dict[str, str]:
-        """Return runner metadata dict for inclusion in effective_config sidecar."""
-        return {
-            "runner_type": "docker",
-            "runner_image": self.image,
-            "runner_source": self.source,
-        }

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -250,11 +250,16 @@ def load_result(path: Path) -> ExperimentResult:
     but the file is missing, loads successfully and emits a UserWarning
     (graceful degradation).
 
+    When an environment.json sidecar is present, it is parsed and attached
+    to ``result.environment``. This is best-effort: a missing or corrupt
+    sidecar leaves ``result.environment`` as None and never raises.
+
     Args:
         path: Path to result.json (as returned by save_result()).
 
     Returns:
-        ExperimentResult loaded from disk.
+        ExperimentResult loaded from disk, with ``environment`` populated
+        from the environment.json sidecar when one is present.
     """
     from llenergymeasure.domain.experiment import ExperimentResult
 
@@ -271,4 +276,28 @@ def load_result(path: Path) -> ExperimentResult:
             stacklevel=2,
         )
 
+    environment = _load_environment_sidecar(path.parent / "environment.json")
+    if environment is not None:
+        result = result.model_copy(update={"environment": environment})
+
     return result
+
+
+def _load_environment_sidecar(path: Path) -> EnvironmentSnapshot | None:
+    """Load an environment.json sidecar into an EnvironmentSnapshot.
+
+    Best-effort: returns None when the sidecar is absent or cannot be parsed,
+    so a missing or corrupt sidecar never breaks load_result. The sidecar's
+    extra ``experiment_id`` / ``measurement_config_hash`` keys are ignored by
+    EnvironmentSnapshot validation.
+    """
+    if not path.exists():
+        return None
+
+    from llenergymeasure.domain.environment import EnvironmentSnapshot
+
+    try:
+        return EnvironmentSnapshot.model_validate_json(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("Could not load environment sidecar %s: %s", path, exc)
+        return None

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -71,6 +71,7 @@ from llenergymeasure.utils.io import load_json
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig, StudyConfig
     from llenergymeasure.domain.environment import EnvironmentSnapshot
+    from llenergymeasure.domain.experiment import RunnerProvenance
     from llenergymeasure.domain.progress import StudyProgressCallback
     from llenergymeasure.infra.runner_resolution import RunnerSpec
     from llenergymeasure.study.manifest import ManifestWriter
@@ -90,6 +91,26 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
+def _provenance_from_spec(spec: RunnerSpec | None) -> RunnerProvenance:
+    """Build a RunnerProvenance from a resolved RunnerSpec.
+
+    The infra-layer ``RunnerSpec`` cannot live on the domain result (layer
+    violation), so its execution-mode fields are mirrored onto the domain-layer
+    ``RunnerProvenance``. When no spec is available (pure in-process local run),
+    records ``mode="local"`` with ``source="local"`` and no image.
+    """
+    from llenergymeasure.domain.experiment import RunnerProvenance
+
+    if spec is None:
+        return RunnerProvenance(mode="local", image=None, source="local", image_source=None)
+    return RunnerProvenance(
+        mode=spec.mode,
+        image=spec.image,
+        source=spec.source,
+        image_source=spec.image_source,
+    )
+
+
 def _save_and_record(
     result: Any,
     study_dir: Path,
@@ -102,6 +123,7 @@ def _save_and_record(
     environment_snapshot: Any | None = None,
     resolution_log: dict[str, Any] | None = None,
     resolved_config_hash: str | None = None,
+    runner_provenance: RunnerProvenance | None = None,
 ) -> None:
     """Save result to disk and update manifest. Appends result path to result_files.
 
@@ -113,11 +135,18 @@ def _save_and_record(
         ts_source_dir: Directory where the harness wrote timeseries.parquet.
         environment_snapshot: EnvironmentSnapshot for per-experiment environment.json sidecar.
         resolution_log: Pre-built resolution log for this experiment (written as _resolution.json).
+        runner_provenance: How the experiment was executed (local vs docker). Attached to the
+            frozen result via model_copy before saving so it persists into result.json.
 
     On save failure, marks the experiment as completed with empty path.
     """
     try:
         from llenergymeasure.results.persistence import save_environment, save_result
+
+        # Attach runner provenance to the frozen result before saving (it
+        # serialises into result.json, unlike the environment sidecar).
+        if runner_provenance is not None and hasattr(result, "model_copy"):
+            result = result.model_copy(update={"runner_provenance": runner_provenance})
 
         # Resolve timeseries sidecar from result fields.
         # MeasurementHarness writes timeseries.parquet to the output_dir and
@@ -811,6 +840,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
             )
 
         exp_elapsed = time.monotonic() - exp_start
+        local_spec = self._runner_specs.get(config.engine) if self._runner_specs else None
         self._handle_result(
             result,
             config_hash,
@@ -819,6 +849,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
             exp_elapsed,
             ts_source_dir=ts_tmpdir,
             environment_snapshot=self._get_env_snapshot() if not isinstance(result, dict) else None,
+            runner_provenance=_provenance_from_spec(local_spec),
         )
 
         # Clean up the temp dir created for timeseries parquet output.
@@ -837,6 +868,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         elapsed: float,
         ts_source_dir: Path | None = None,
         environment_snapshot: Any | None = None,
+        runner_provenance: RunnerProvenance | None = None,
     ) -> None:
         """Update manifest and signal study display based on experiment outcome."""
         if isinstance(result, dict) and "type" in result:
@@ -861,6 +893,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
                 environment_snapshot=environment_snapshot,
                 resolution_log=self._resolution_logs.get(config_hash),
                 resolved_config_hash=self._resolved_hashes.get(config_hash),
+                runner_provenance=runner_provenance,
             )
             if self._progress:
                 host_path = self.result_files[-1] if self.result_files else None
@@ -1026,6 +1059,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
             exp_elapsed,
             ts_source_dir=docker_ts_dir,
             environment_snapshot=self._get_env_snapshot() if not isinstance(result, dict) else None,
+            runner_provenance=_provenance_from_spec(spec),
         )
 
         # Clean up the temp dir after _save_and_record has copied the parquet.

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -48,7 +48,7 @@ def run_single_experiment(
     discard a completed measurement.
     """
     from llenergymeasure.domain.experiment import compute_declared_config_hash
-    from llenergymeasure.study.runner import _save_and_record
+    from llenergymeasure.study.runner import _provenance_from_spec, _save_and_record
 
     config = study.experiments[0]
     config_hash = compute_declared_config_hash(config)
@@ -187,6 +187,7 @@ def run_single_experiment(
         environment_snapshot=snapshot,
         resolution_log=(resolution_logs or {}).get(config_hash),
         resolved_config_hash=resolved_config_hash,
+        runner_provenance=_provenance_from_spec(spec),
     )
 
     # Clean up temp dirs

--- a/tests/integration/test_docker_runner.py
+++ b/tests/integration/test_docker_runner.py
@@ -112,18 +112,19 @@ class TestDockerRunnerIntegration:
         assert result.avg_tokens_per_second > 0
         assert result.total_tokens > 0
 
-    def test_runner_metadata_injected(self, tmp_path):
-        """Result effective_config contains Docker runner metadata."""
-        from llenergymeasure.infra.docker_runner import DockerRunner
+    def test_runner_provenance_recorded(self, tmp_path):
+        """Docker runner provenance is recorded on the saved result."""
+        from llenergymeasure.domain.experiment import RunnerProvenance
+        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.study.runner import _provenance_from_spec
 
-        config = self._make_config(tmp_path)
-        runner = DockerRunner(image=IMAGE, timeout=300, source="test")
-        result = runner.run(config)
-
-        ec = result.effective_config or {}
-        assert ec.get("runner_mode") == "docker"
-        assert ec.get("runner_image") == IMAGE
-        assert ec.get("runner_source") == "test"
+        provenance = _provenance_from_spec(
+            RunnerSpec(mode="docker", image=IMAGE, source="test", image_source="registry")
+        )
+        assert isinstance(provenance, RunnerProvenance)
+        assert provenance.mode == "docker"
+        assert provenance.image == IMAGE
+        assert provenance.source == "test"
 
     def test_exchange_dir_cleaned_on_success(self, tmp_path):
         """Exchange dir is removed after successful run (no temp dir leak)."""

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -140,37 +140,6 @@ class TestSuccessPath:
 
         assert returned.experiment_id == result.experiment_id
 
-    def test_runner_metadata_injected_into_effective_config(self, tmp_path):
-        """Runner metadata is injected into the result's effective_config."""
-        config = make_config()
-        result = make_result()
-
-        exchange_dir = tmp_path / "llem-meta"
-        exchange_dir.mkdir()
-
-        with (
-            patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
-                return_value=str(exchange_dir),
-            ),
-            patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
-                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
-            ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
-        ):
-            config_hash = _docker_config_hash(config)
-            result_path = exchange_dir / f"{config_hash}_result.json"
-            result_path.write_text(result.model_dump_json(), encoding="utf-8")
-
-            runner = DockerRunner(image=IMAGE, source="yaml")
-            _returned, _ts_dir = runner.run(config)
-
-        metadata = runner.get_runner_metadata()
-        assert metadata["runner_type"] == "docker"
-        assert metadata["runner_image"] == IMAGE
-        assert metadata["runner_source"] == "yaml"
-
 
 # ---------------------------------------------------------------------------
 # Test 2: Container failure - image not found
@@ -535,19 +504,11 @@ class TestHFTokenPropagation:
 
 
 # ---------------------------------------------------------------------------
-# Test 10: Runner metadata in effective_config (explicit verification)
+# Test 10: DockerRunner.run() return shape
 # ---------------------------------------------------------------------------
 
 
 class TestRunnerMetadata:
-    def test_get_runner_metadata_returns_correct_keys(self):
-        """get_runner_metadata() returns runner_type, runner_image, runner_source."""
-        runner = DockerRunner(image=IMAGE, source="auto_detected")
-        metadata = runner.get_runner_metadata()
-        assert metadata["runner_type"] == "docker"
-        assert metadata["runner_image"] == IMAGE
-        assert metadata["runner_source"] == "auto_detected"
-
     def test_run_returns_tuple(self, tmp_path):
         """DockerRunner.run() returns (result, ts_tmpdir) tuple."""
         config = make_config()

--- a/tests/unit/harness/test_measurement_integration.py
+++ b/tests/unit/harness/test_measurement_integration.py
@@ -681,8 +681,8 @@ def test_harness_build_result_populates_timeseries_field() -> None:
     )
 
 
-def test_harness_build_result_populates_effective_config() -> None:
-    """_build_result() populates result.effective_config with the model name (RES-16)."""
+def test_harness_build_result_populates_model_name() -> None:
+    """_build_result() populates result.model_name from the config (RES-16)."""
     from llenergymeasure.harness import MeasurementHarness
 
     harness = MeasurementHarness()

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -13,8 +13,9 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from llenergymeasure.domain.experiment import ExperimentResult
-from llenergymeasure.study.runner import _save_and_record
+from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
+from llenergymeasure.infra.runner_resolution import RunnerSpec
+from llenergymeasure.study.runner import _provenance_from_spec, _save_and_record
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -216,6 +217,52 @@ def test_save_and_record_writes_resolved_config_hash(tmp_path: Path) -> None:
     )
     # Source sidecar must be cleaned up
     assert not config_sidecar_src.exists()
+
+
+def test_provenance_from_spec_docker() -> None:
+    """A docker RunnerSpec maps onto a docker RunnerProvenance."""
+    spec = RunnerSpec(mode="docker", image="img:1.0", source="yaml", image_source="registry")
+    provenance = _provenance_from_spec(spec)
+    assert provenance == RunnerProvenance(
+        mode="docker", image="img:1.0", source="yaml", image_source="registry"
+    )
+
+
+def test_provenance_from_spec_none_defaults_to_local() -> None:
+    """No spec (pure in-process local) records mode=local, source=local, no image."""
+    provenance = _provenance_from_spec(None)
+    assert provenance.mode == "local"
+    assert provenance.image is None
+    assert provenance.source == "local"
+    assert provenance.image_source is None
+
+
+def test_save_and_record_attaches_runner_provenance(tmp_path: Path) -> None:
+    """runner_provenance passed to _save_and_record is written into result.json."""
+    import json
+
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+
+    result = _make_result(with_timeseries=False)
+    manifest = MagicMock()
+    result_files: list[str] = []
+
+    _save_and_record(
+        result,
+        study_dir,
+        manifest,
+        "aabb1122",
+        1,
+        result_files,
+        runner_provenance=RunnerProvenance(mode="docker", image="img:2.0", source="env"),
+    )
+
+    assert len(result_files) == 1
+    payload = json.loads(Path(result_files[0]).read_text())
+    assert payload["runner_provenance"]["mode"] == "docker"
+    assert payload["runner_provenance"]["image"] == "img:2.0"
+    assert payload["runner_provenance"]["source"] == "env"
 
 
 def test_save_and_record_calls_mark_failed_on_exception(tmp_path: Path) -> None:

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -239,6 +239,63 @@ def test_steady_state_window_round_trips(tmp_path: Path, hf_model_result: Experi
 
 
 # ---------------------------------------------------------------------------
+# Runner provenance
+# ---------------------------------------------------------------------------
+
+
+def test_runner_provenance_docker_round_trips(
+    tmp_path: Path, minimal_result: ExperimentResult
+) -> None:
+    """A docker runner_provenance survives save/load and serialises into result.json."""
+    import json
+
+    from llenergymeasure.domain.experiment import RunnerProvenance
+
+    result = minimal_result.model_copy(
+        update={
+            "runner_provenance": RunnerProvenance(
+                mode="docker",
+                image="ghcr.io/example/transformers:1.0.0",
+                source="yaml",
+                image_source="registry",
+            )
+        }
+    )
+    result_path = save_result(result, tmp_path)
+
+    # Persisted into result.json (NOT excluded, unlike environment).
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["runner_provenance"]["mode"] == "docker"
+    assert payload["runner_provenance"]["image"] == "ghcr.io/example/transformers:1.0.0"
+    assert payload["runner_provenance"]["source"] == "yaml"
+
+    loaded = load_result(result_path)
+    assert loaded.runner_provenance is not None
+    assert loaded.runner_provenance.mode == "docker"
+    assert loaded.runner_provenance.image == "ghcr.io/example/transformers:1.0.0"
+    assert loaded.runner_provenance.source == "yaml"
+    assert loaded.runner_provenance.image_source == "registry"
+
+
+def test_runner_provenance_local_round_trips(
+    tmp_path: Path, minimal_result: ExperimentResult
+) -> None:
+    """A local runner_provenance survives save/load with no image."""
+    from llenergymeasure.domain.experiment import RunnerProvenance
+
+    result = minimal_result.model_copy(
+        update={"runner_provenance": RunnerProvenance(mode="local", image=None, source="local")}
+    )
+    result_path = save_result(result, tmp_path)
+    loaded = load_result(result_path)
+
+    assert loaded.runner_provenance is not None
+    assert loaded.runner_provenance.mode == "local"
+    assert loaded.runner_provenance.image is None
+    assert loaded.runner_provenance.source == "local"
+
+
+# ---------------------------------------------------------------------------
 # Timeseries sidecar
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -19,8 +19,15 @@ from pathlib import Path
 
 import pytest
 
+from llenergymeasure.domain.environment import (
+    CPUEnvironment,
+    CUDAEnvironment,
+    EnvironmentMetadata,
+    EnvironmentSnapshot,
+    GPUEnvironment,
+)
 from llenergymeasure.domain.experiment import ExperimentResult
-from llenergymeasure.results.persistence import load_result, save_result
+from llenergymeasure.results.persistence import load_result, save_environment, save_result
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -302,3 +309,92 @@ def test_save_experiment_index_in_directory_name(
     result_path = save_result(minimal_result, tmp_path, experiment_index=5, cycle=3)
     dir_name = result_path.parent.name
     assert dir_name.startswith("005_c3_"), f"Expected '005_c3_' prefix in '{dir_name}'"
+
+
+# ---------------------------------------------------------------------------
+# Environment sidecar
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def env_snapshot() -> EnvironmentSnapshot:
+    """Minimal EnvironmentSnapshot for sidecar round-trip tests."""
+    hardware = EnvironmentMetadata(
+        gpu=GPUEnvironment(name="NVIDIA A100-SXM4-80GB", vram_total_mb=81920),
+        cuda=CUDAEnvironment(version="12.4", driver_version="535.104"),
+        cpu=CPUEnvironment(platform="Linux"),
+        collected_at=datetime(2026, 1, 1, 12, 0, 0),
+    )
+    return EnvironmentSnapshot(
+        hardware=hardware,
+        python_version="3.11.5",
+        tool_version="0.9.0",
+        cuda_version="12.4",
+        cuda_version_source="torch",
+    )
+
+
+def test_load_result_attaches_environment_sidecar(
+    tmp_path: Path,
+    minimal_result: ExperimentResult,
+    env_snapshot: EnvironmentSnapshot,
+) -> None:
+    """load_result() reads back the environment.json sidecar onto result.environment."""
+    result_path = save_result(minimal_result, tmp_path)
+    save_environment(
+        env_snapshot,
+        minimal_result.experiment_id,
+        minimal_result.measurement_config_hash,
+        result_path.parent,
+    )
+
+    loaded = load_result(result_path)
+
+    assert loaded.environment is not None
+    assert loaded.environment.python_version == "3.11.5"
+    assert loaded.environment.cuda_version == "12.4"
+    assert loaded.environment.cuda_version_source == "torch"
+    assert loaded.environment.hardware.gpu.name == "NVIDIA A100-SXM4-80GB"
+
+
+def test_load_result_without_environment_sidecar(
+    tmp_path: Path, minimal_result: ExperimentResult
+) -> None:
+    """load_result() leaves environment as None when no sidecar is present (best-effort)."""
+    result_path = save_result(minimal_result, tmp_path)
+    loaded = load_result(result_path)
+    assert loaded.environment is None
+
+
+def test_load_result_corrupt_environment_sidecar(
+    tmp_path: Path, minimal_result: ExperimentResult
+) -> None:
+    """A corrupt environment.json must not break load_result (best-effort)."""
+    result_path = save_result(minimal_result, tmp_path)
+    (result_path.parent / "environment.json").write_text("{ not valid json", encoding="utf-8")
+
+    loaded = load_result(result_path)
+
+    assert loaded.environment is None
+    assert loaded.experiment_id == minimal_result.experiment_id
+
+
+def test_environment_field_excluded_from_result_json(
+    tmp_path: Path,
+    minimal_result: ExperimentResult,
+    env_snapshot: EnvironmentSnapshot,
+) -> None:
+    """environment is loader-only - it never serialises back into result.json."""
+    result_path = save_result(minimal_result, tmp_path)
+    save_environment(
+        env_snapshot,
+        minimal_result.experiment_id,
+        minimal_result.measurement_config_hash,
+        result_path.parent,
+    )
+
+    loaded = load_result(result_path)
+    assert loaded.environment is not None
+    # model_dump_json drops the excluded field, so the re-serialised result
+    # matches the on-disk result.json (no environment leakage).
+    assert "environment" not in loaded.model_dump_json()


### PR DESCRIPTION
## Summary

Records reproducibility metadata on each experiment result. Two related pieces (issue #718, items D8a / D8b / RE3 / RE4):

### D8a - runner provenance (`runner_provenance` on `ExperimentResult`)
How an experiment was executed (local process vs Docker container) is now persisted on the result.

- New domain-layer model `RunnerProvenance` (frozen, `extra=forbid`) mirrors the infra-layer `RunnerSpec` fields: `mode` ("local" | "docker"), `image`, `source`, `image_source`. It lives in the domain layer (no infra import) so it can sit on `ExperimentResult` without a layer violation - import-linter stays green.
- New `ExperimentResult.runner_provenance: RunnerProvenance | None` field. Unlike `environment` (which is `exclude=True`), this **does** serialise into `result.json` as persisted reproducibility metadata. Additive change to the stable schema; no `schema_version` bump.
- Wired at the save seam: `_save_and_record` takes a `runner_provenance` kwarg and attaches it to the frozen result via `model_copy` before saving. All four call sites build it from the in-scope `RunnerSpec` via a small `_provenance_from_spec` helper: single-local + single-docker (`study/single.py`), multi-local (`_run_one`) + multi-docker (`_run_one_docker`) (`study/runner.py`). With no spec (pure in-process local run) it records `mode="local"`, `image=None`, `source="local"`.
- Removed the dead `DockerRunner.get_runner_metadata()` (never called in `src/`, divergent `runner_type/runner_image/runner_source` shape) and its unit tests. Fixed `config/README.md` and a `docker_runner` docstring that referenced a non-existent `effective_config` field on the result (it is an on-disk sidecar, not a result field).

### D8b / RE4 - environment.json sidecar loading
Wires the per-experiment `environment.json` sidecar back into `load_result`.

- `environment.json` was a write-only sidecar: `save_environment` wrote it but nothing read it back. `load_result` now auto-discovers and parses the sidecar (mirroring how it already auto-discovers `timeseries.parquet`) onto the `ExperimentResult.environment` field. The field is `EnvironmentSnapshot | None` with `exclude=True`, so it is populated on load but never serialises back into `result.json` (the sidecar stays the on-disk home). Best-effort: a missing or corrupt sidecar leaves `environment` as `None` and never raises.
- **RE3** - `load_result`'s docstring already claimed it auto-discovers `environment.json`; that claim is now true and the docstring describes the attach-to-`result.environment` behaviour and best-effort semantics.

## Test plan
Added to `tests/unit/test_persistence_v2.py`:
- docker `runner_provenance` round-trips (save -> load) and serialises into `result.json`
- local `runner_provenance` round-trips with `mode="local"` and no image
- env sidecar round-trips onto `result.environment`; `None` when absent; corrupt sidecar tolerated; `environment` stays out of `result.json`

Added to `tests/unit/study/test_save_and_record.py`:
- `_provenance_from_spec` maps a docker spec correctly and defaults `None` -> `mode="local"`, `source="local"`
- `_save_and_record` writes the passed `runner_provenance` into `result.json`

Removed the orphaned `get_runner_metadata` unit tests.

- `make lint` - green (ruff + format + import-linter, domain does not import infra)
- `make typecheck` - green (mypy, 270 files)
- `uv run pytest` - 2471 passed / 43 skipped / 0 failed
- Behavioural round-trip verified manually in temp dirs: a docker-spec result and a local result both round-trip; `runner_provenance` appears in `result.json` while `environment` is excluded.

## Doc audit
- `config/README.md` - corrected the override-tracking / reproducibility sections that described non-existent `effective_config` / `cli_overrides` result fields; now point to the real `_resolution.json` and `effective_config.json` sidecars.
- `docker_runner` `source` docstring updated to reference `runner_provenance` instead of the removed metadata path.
- `load_result` docstring updated to match the now-implemented `environment.json` loading (RE3).

## Stacking
This PR is **stacked on `feat/steady-state-measurement`** (base is that branch, not `main`). Merge after the steady-state PR lands.
