### PR TITLE
fix(engines): align transformers measurements with vllm/tensorrt

### DIFF
--- a/src/llenergymeasure/cli/config_cmd.py
+++ b/src/llenergymeasure/cli/config_cmd.py
@@ -51,9 +51,9 @@ def _probe_engine_version(engine: str) -> str | None:
     """Try to retrieve version string for an installed inference engine."""
     try:
         if engine == Engine.TRANSFORMERS:
-            import torch
+            import transformers
 
-            return str(torch.__version__)
+            return str(transformers.__version__)
         elif engine == Engine.VLLM:
             import vllm
 

--- a/src/llenergymeasure/engines/_observed.py
+++ b/src/llenergymeasure/engines/_observed.py
@@ -207,14 +207,22 @@ def extract_decode_itl(outputs: Any) -> list[float]:
     The engine does not expose a true per-token timestamp stream, so this derives
     one average ITL per request from the decode phase: the wall time between the
     first generated token and request completion, divided by the number of decode
-    intervals (``n_out - 1``). This is a PROPORTIONAL_ESTIMATE, not a true
-    per-token measurement - it assumes uniform spacing across decode steps.
+    intervals. This is a PROPORTIONAL_ESTIMATE, not a true per-token measurement -
+    it assumes uniform spacing across decode steps.
+
+    When a request has N>1 parallel outputs (n>1 sampling), the completions stream
+    CONCURRENTLY and finish around the same wall-clock time, so the single
+    ``(finished - first_token)`` interval spans one sequence's worth of decode
+    steps, not the sum across sequences. The number of decode intervals is
+    therefore the LONGEST single output's token count (``max``), not the summed
+    token count - summing would N-fold understate the ITL. For n=1 this is
+    identical to the single output's length, so the n=1 result is unchanged.
 
     Best-effort: a request is skipped (no sample produced) unless
-    ``first_token_time`` and ``finished_time`` are both present and the request
-    produced more than one output token (``n_out > 1``). The ``SimpleNamespace``
-    shape of ``o.metrics`` / ``o.outputs[*].token_ids`` makes this testable
-    without a live engine.
+    ``first_token_time`` and ``finished_time`` are both present and the longest
+    output produced more than one token (``decode_len > 1``). The
+    ``SimpleNamespace`` shape of ``o.metrics`` / ``o.outputs[*].token_ids`` makes
+    this testable without a live engine.
 
     Args:
         outputs: Iterable of ``RequestOutput`` objects.
@@ -234,8 +242,10 @@ def extract_decode_itl(outputs: Any) -> list[float]:
         request_outputs = getattr(o, "outputs", None)
         if not request_outputs:
             continue
-        n_out = sum(len(getattr(out, "token_ids", ()) or ()) for out in request_outputs)
-        if n_out <= 1:
+        # Per-sequence decode length = longest single output (n parallel streams
+        # share one wall-time interval), not the summed token count.
+        decode_len = max(len(getattr(out, "token_ids", ()) or ()) for out in request_outputs)
+        if decode_len <= 1:
             continue
-        itl_ms.append((finished - first_token) * 1000.0 / (n_out - 1))
+        itl_ms.append((finished - first_token) * 1000.0 / (decode_len - 1))
     return itl_ms

--- a/src/llenergymeasure/engines/transformers/plugin.py
+++ b/src/llenergymeasure/engines/transformers/plugin.py
@@ -67,9 +67,9 @@ class TransformersEngine:
     def version(self) -> str:
         """Transformers library version string."""
         try:
-            import torch
+            import transformers
 
-            return torch.__version__  # type: ignore[no-any-return]
+            return str(transformers.__version__)
         except Exception:
             return "unknown"
 
@@ -382,14 +382,39 @@ class TransformersEngine:
 
         gen_cfg = None
         try:
-            from transformers import GenerationConfig
+            import copy
 
-            gen_cfg = GenerationConfig(**generate_kwargs)
+            # Capture the EFFECTIVE merged generation config the model used, not a
+            # rebuild from the requested kwargs alone. generate() internally starts
+            # from a deepcopy of the model's own generation_config (the live merged
+            # defaults) and overlays the explicit kwargs; replicate that so the
+            # observed config reflects model-defaults + overrides.
+            base_cfg = getattr(hf_model, "generation_config", None)
+            if base_cfg is not None:
+                gen_cfg = copy.deepcopy(base_cfg)
+                gen_cfg.update(**generate_kwargs)
+            else:
+                # No live model config (e.g. mock without one); fall back to a
+                # config built from the requested kwargs only.
+                from transformers import GenerationConfig
+
+                gen_cfg = GenerationConfig(**generate_kwargs)
         except Exception as exc:  # pragma: no cover - best-effort capture
-            logger.debug("transformers GenerationConfig construction failed: %s", exc)
+            logger.debug("transformers GenerationConfig capture failed: %s", exc)
 
         engine_params: dict[str, Any] = {}
         pt = config.transformers
+
+        # Record the RESOLVED dtype the model actually ran in (D2). With dtype unset
+        # we pass torch_dtype="auto" so transformers infers from the checkpoint; the
+        # only authoritative source for what it settled on is the loaded model.
+        try:
+            resolved_dtype = getattr(hf_model, "dtype", None)
+            if resolved_dtype is not None:
+                engine_params["dtype"] = str(resolved_dtype)
+        except Exception as exc:  # pragma: no cover - best-effort capture
+            logger.debug("transformers resolved dtype capture failed: %s", exc)
+
         if pt is not None and (pt.load_in_4bit or pt.load_in_8bit):
             try:
                 bnb = getattr(hf_model, "quantization_config", None)
@@ -464,8 +489,11 @@ class TransformersEngine:
         """
         pt = config.transformers
         dtype = pt.dtype if pt is not None else None
+        # When dtype is unset, do NOT force a default - pass "auto" so transformers
+        # infers from the checkpoint, matching vllm/tensorrt which forward nothing
+        # and let each engine use its own default (comparability fix D2).
         kwargs: dict[str, Any] = {
-            "torch_dtype": self._resolve_torch_dtype(dtype or "bfloat16"),
+            "torch_dtype": self._resolve_torch_dtype(dtype or "auto"),
         }
 
         from llenergymeasure.utils.env_config import default_device_map
@@ -593,9 +621,16 @@ class TransformersEngine:
 
     @staticmethod
     def _resolve_torch_dtype(dtype: str) -> Any:
-        """Map dtype string to torch dtype object."""
+        """Map dtype string to torch dtype object, passing "auto" through unchanged.
+
+        from_pretrained() accepts the string "auto" to infer the checkpoint's own
+        dtype, so it is forwarded verbatim. Explicit float dtypes map to the torch
+        dtype object.
+        """
         import torch
 
+        if dtype == "auto":
+            return "auto"
         return {
             "float32": torch.float32,
             "float16": torch.float16,
@@ -662,10 +697,31 @@ class TransformersEngine:
             outputs = model.generate(**inputs, **gen_kwargs)
         elapsed = time.perf_counter() - t0
 
-        # Count only the newly generated tokens per sequence (handles padding correctly)
-        input_lengths = inputs["attention_mask"].sum(dim=1)  # shape: (batch,)
+        # Count newly generated tokens across EVERY output row. With
+        # num_return_sequences=N (incl. beam search) HF returns N rows per input
+        # prompt, so outputs.shape[0] == len(batch) * N; output row j maps to its
+        # source input via j // N. Counting only the batch rows would N-fold
+        # undercount generated tokens (EN4).
+        input_lengths = [int(x) for x in inputs["attention_mask"].sum(dim=1).tolist()]
+        n_inputs = len(batch)
+        n_rows = int(outputs.shape[0])
+        if n_inputs > 0 and n_rows % n_inputs == 0:
+            n_return = n_rows // n_inputs
+        else:
+            # Row count is not an exact multiple of the input count: fall back to
+            # mapping each row to inputs in order (clamped), and log the anomaly.
+            n_return = 1
+            logger.warning(
+                "transformers output rows (%d) not an exact multiple of input "
+                "prompts (%d); falling back to per-row input mapping for token count.",
+                n_rows,
+                n_inputs,
+            )
         output_token_count = int(
-            sum(max(0, outputs.shape[1] - int(inp_len.item())) for inp_len in input_lengths)
+            sum(
+                max(0, int(outputs.shape[1]) - input_lengths[min(j // n_return, n_inputs - 1)])
+                for j in range(n_rows)
+            )
         )
         return input_token_count, output_token_count, elapsed, padding_tokens
 

--- a/src/llenergymeasure/engines/transformers/plugin.py
+++ b/src/llenergymeasure/engines/transformers/plugin.py
@@ -385,10 +385,12 @@ class TransformersEngine:
             import copy
 
             # Capture the EFFECTIVE merged generation config the model used, not a
-            # rebuild from the requested kwargs alone. generate() internally starts
-            # from a deepcopy of the model's own generation_config (the live merged
-            # defaults) and overlays the explicit kwargs; replicate that so the
-            # observed config reflects model-defaults + overrides.
+            # rebuild from the requested kwargs alone. generate() starts from a
+            # deepcopy of the model's own generation_config (the live merged
+            # defaults) and overlays the explicit kwargs; we approximate that so the
+            # observed sampling shape reflects model-defaults + overrides. (We do
+            # not reproduce generate()'s further use_model_defaults backfill /
+            # max-length resolution, which do not affect the observed sampling hash.)
             base_cfg = getattr(hf_model, "generation_config", None)
             if base_cfg is not None:
                 gen_cfg = copy.deepcopy(base_cfg)

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -296,16 +296,16 @@ def test_probe_gpu_returns_none_on_error() -> None:
 
 
 def test_probe_engine_version_transformers() -> None:
-    """_probe_engine_version returns torch.__version__ for transformers engine."""
+    """_probe_engine_version returns transformers.__version__ for transformers engine."""
     from llenergymeasure.cli.config_cmd import _probe_engine_version
 
-    mock_torch = MagicMock()
-    mock_torch.__version__ = "2.2.0"
+    mock_transformers = MagicMock()
+    mock_transformers.__version__ = "4.46.0"
 
-    with patch.dict("sys.modules", {"torch": mock_torch}):
+    with patch.dict("sys.modules", {"transformers": mock_transformers}):
         result = _probe_engine_version("transformers")
 
-    assert result == "2.2.0"
+    assert result == "4.46.0"
 
 
 def test_probe_engine_version_returns_none_on_import_error() -> None:

--- a/tests/unit/engines/test_engine_protocol.py
+++ b/tests/unit/engines/test_engine_protocol.py
@@ -160,6 +160,9 @@ def test_model_load_kwargs_contains_base_keys(monkeypatch):
     kwargs = engine._model_load_kwargs(config)
 
     assert "torch_dtype" in kwargs
+    # dtype unset -> "auto" (do not force bfloat16), so transformers infers from
+    # the checkpoint, matching vllm/tensorrt comparability (D2).
+    assert kwargs["torch_dtype"] == "auto"
     assert kwargs["device_map"] == "auto"
     # HF default - env var LLEM_TRUST_REMOTE_CODE not set, no typed override
     assert kwargs["trust_remote_code"] is False
@@ -514,6 +517,14 @@ def test_resolve_torch_dtype_bf16():
     assert TransformersEngine._resolve_torch_dtype("bfloat16") == torch.bfloat16
 
 
+def test_resolve_torch_dtype_auto_passthrough():
+    """'auto' is forwarded verbatim (from_pretrained reads the checkpoint dtype)."""
+    pytest.importorskip("torch")
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    assert TransformersEngine._resolve_torch_dtype("auto") == "auto"
+
+
 def test_resolve_torch_dtype_unknown_raises():
     """Unknown dtype string raises KeyError."""
     pytest.importorskip("torch")
@@ -521,6 +532,37 @@ def test_resolve_torch_dtype_unknown_raises():
 
     with pytest.raises(KeyError):
         TransformersEngine._resolve_torch_dtype("int8")
+
+
+def test_model_load_kwargs_explicit_dtype_maps_to_torch(monkeypatch):
+    """An explicit dtype is unchanged: float16 -> torch.float16, not 'auto'."""
+    torch = pytest.importorskip("torch")
+    from llenergymeasure.config.engine_configs import TransformersConfig
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    engine = TransformersEngine()
+    config = ExperimentConfig(
+        task={"model": "gpt2"},
+        transformers=TransformersConfig(dtype="float16"),
+    )
+    kwargs = engine._model_load_kwargs(config)
+
+    assert kwargs["torch_dtype"] == torch.float16
+
+
+def test_model_load_kwargs_dtype_unset_is_auto():
+    """dtype unset -> torch_dtype='auto', NOT a forced bfloat16 default (D2)."""
+    torch = pytest.importorskip("torch")
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    engine = TransformersEngine()
+    config = ExperimentConfig(task={"model": "gpt2"})
+    kwargs = engine._model_load_kwargs(config)
+
+    assert kwargs["torch_dtype"] == "auto"
+    assert kwargs["torch_dtype"] != torch.bfloat16
 
 
 # =============================================================================
@@ -732,12 +774,36 @@ def test_model_load_kwargs_device_map_still_works():
 # =============================================================================
 
 
-def test_pytorch_version_returns_torch_version():
-    """TransformersEngine.version returns torch.__version__."""
-    torch = pytest.importorskip("torch")
+def test_transformers_version_returns_transformers_version():
+    """TransformersEngine.version returns transformers.__version__, not torch's."""
+    import sys
+    import types
+    from unittest.mock import patch
+
     from llenergymeasure.engines.transformers import TransformersEngine
 
-    assert TransformersEngine().version == torch.__version__
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers.__version__ = "4.99.0"  # type: ignore[attr-defined]
+    with patch.dict(sys.modules, {"transformers": fake_transformers}):
+        assert TransformersEngine().version == "4.99.0"
+
+
+def test_transformers_version_unknown_when_import_fails():
+    """version falls back to 'unknown' when transformers cannot be imported."""
+    import builtins
+    from unittest.mock import patch
+
+    from llenergymeasure.engines.transformers import TransformersEngine
+
+    real_import = builtins.__import__
+
+    def _fail_transformers(name, *args, **kwargs):
+        if name == "transformers":
+            raise ImportError("no transformers")
+        return real_import(name, *args, **kwargs)
+
+    with patch.object(builtins, "__import__", _fail_transformers):
+        assert TransformersEngine().version == "unknown"
 
 
 def test_vllm_version_returns_string():

--- a/tests/unit/engines/test_extended_capture.py
+++ b/tests/unit/engines/test_extended_capture.py
@@ -120,6 +120,50 @@ class TestExtractDecodeItl:
         assert extract_decode_itl([]) == []
 
 
+def _req_decode_multi(first_token, finished, out_lens):
+    """RequestOutput with N parallel CompletionOutputs (n>1 sampling).
+
+    ``out_lens`` is a list of per-output token counts. The N completions stream
+    concurrently and share the single ``(finished - first_token)`` wall-time.
+    """
+    metrics = SimpleNamespace(first_token_time=first_token, finished_time=finished)
+    outputs = [SimpleNamespace(token_ids=list(range(n))) for n in out_lens]
+    return SimpleNamespace(metrics=metrics, outputs=outputs)
+
+
+class TestExtractDecodeItlParallelOutputs:
+    """EN5: n>1 parallel outputs use per-sequence (max) decode length, not sum."""
+
+    def test_n2_uses_max_not_sum(self):
+        # Two parallel outputs of 10 tokens each over a 0.9s decode window.
+        # Correct: max=10 -> 9 intervals -> 100 ms.
+        # Buggy (sum): 20 tokens -> 19 intervals -> ~47.4 ms (understated ~1/N).
+        outputs = [_req_decode_multi(first_token=1.0, finished=1.9, out_lens=[10, 10])]
+        itl = extract_decode_itl(outputs)
+        assert itl == pytest.approx([100.0])
+        # Prove it is NOT the summed-denominator value.
+        summed = 0.9 * 1000.0 / (20 - 1)
+        assert itl[0] != pytest.approx(summed)
+
+    def test_uneven_parallel_outputs_use_longest(self):
+        # Outputs of length 8 and 5: decode length is the longest (8) -> 7 intervals.
+        # 0.7s / 7 = 100 ms.
+        outputs = [_req_decode_multi(first_token=0.0, finished=0.7, out_lens=[8, 5])]
+        itl = extract_decode_itl(outputs)
+        assert itl == pytest.approx([100.0])
+
+    def test_n1_via_multi_helper_matches_single(self):
+        # A single parallel output behaves exactly as the n=1 path: max == its len.
+        outputs = [_req_decode_multi(first_token=1.0, finished=1.9, out_lens=[10])]
+        itl = extract_decode_itl(outputs)
+        assert itl == pytest.approx([100.0])
+
+    def test_all_parallel_outputs_single_token_skipped(self):
+        # Longest output has 1 token -> decode_len <= 1 -> skipped (no intervals).
+        outputs = [_req_decode_multi(first_token=1.0, finished=2.0, out_lens=[1, 1])]
+        assert extract_decode_itl(outputs) == []
+
+
 # ---------------------------------------------------------------------------
 # _capture_kv_cache_stats
 # ---------------------------------------------------------------------------

--- a/tests/unit/engines/test_transformers_observed_capture.py
+++ b/tests/unit/engines/test_transformers_observed_capture.py
@@ -1,0 +1,106 @@
+"""Tests for TransformersEngine._capture_observed_params (EN2 + D2 resolved dtype).
+
+Host-safe: no GPU, no torch, no transformers import. The model's
+``generation_config`` and resolved ``dtype`` are modelled with a fake object
+that mirrors the HuggingFace ``GenerationConfig`` merge semantics
+(``copy.deepcopy`` of the model's live config, then ``update(**kwargs)`` overlay)
+and is dumpable via ``__dict__``, which is what the observed-params extractor
+falls back to.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llenergymeasure.config.models import ExperimentConfig
+from llenergymeasure.engines.transformers.plugin import TransformersEngine
+
+
+class _FakeGenerationConfig:
+    """Minimal stand-in for transformers.GenerationConfig.
+
+    ``update(**kwargs)`` sets recognised attributes in place (mirroring HF, which
+    overlays explicit kwargs on top of the model's merged defaults). Dumped via
+    ``__dict__`` by :func:`extract_observed_params`.
+    """
+
+    def __init__(self, **fields: Any) -> None:
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+    def update(self, **kwargs: Any) -> dict[str, Any]:
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        return {}
+
+
+class _FakeHFModel:
+    def __init__(self, generation_config: Any = None, dtype: Any = None) -> None:
+        if generation_config is not None:
+            self.generation_config = generation_config
+        if dtype is not None:
+            self.dtype = dtype
+
+
+def _config() -> ExperimentConfig:
+    return ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+
+
+class TestEN2MergedGenerationConfig:
+    """EN2: capture the EFFECTIVE merged config (model defaults + overrides)."""
+
+    def test_model_default_survives_when_not_in_kwargs(self) -> None:
+        # Model default repetition_penalty=1.3 is NOT in generate_kwargs.
+        model = _FakeHFModel(
+            generation_config=_FakeGenerationConfig(
+                repetition_penalty=1.3, temperature=1.0, do_sample=False
+            )
+        )
+        generate_kwargs = {"temperature": 0.7, "do_sample": True}
+
+        observed = TransformersEngine._capture_observed_params(_config(), model, generate_kwargs)
+        sampling = observed["sampling"]
+
+        # Merged: model default preserved, requested override applied.
+        assert sampling["repetition_penalty"] == 1.3, "model default must survive the merge"
+        assert sampling["temperature"] == 0.7, "requested override must be applied"
+        assert sampling["do_sample"] is True
+
+    def test_override_does_not_get_dropped(self) -> None:
+        # Even when the model already has the field, the override wins.
+        model = _FakeHFModel(generation_config=_FakeGenerationConfig(temperature=1.0, top_p=0.9))
+        generate_kwargs = {"temperature": 0.2}
+
+        observed = TransformersEngine._capture_observed_params(_config(), model, generate_kwargs)
+        sampling = observed["sampling"]
+
+        assert sampling["temperature"] == 0.2
+        assert sampling["top_p"] == 0.9  # untouched model default kept
+
+    def test_falls_back_to_kwargs_when_no_model_config(self) -> None:
+        # No live generation_config (e.g. a mock model without one) and no real
+        # transformers installed: the GenerationConfig(**kwargs) fallback raises
+        # on import, so sampling capture is empty but the call still succeeds.
+        model = _FakeHFModel()  # no generation_config attribute
+        observed = TransformersEngine._capture_observed_params(
+            _config(), model, {"temperature": 0.5}
+        )
+        assert observed["sampling"] == {}
+        assert observed["engine"] == {}
+
+
+class TestD2ResolvedDtypeCapture:
+    """D2: record the resolved dtype the model actually ran in."""
+
+    def test_resolved_dtype_recorded(self) -> None:
+        model = _FakeHFModel(
+            generation_config=_FakeGenerationConfig(temperature=1.0),
+            dtype="torch.bfloat16",
+        )
+        observed = TransformersEngine._capture_observed_params(_config(), model, {})
+        assert observed["engine"]["dtype"] == "torch.bfloat16"
+
+    def test_dtype_absent_when_model_has_none(self) -> None:
+        model = _FakeHFModel(generation_config=_FakeGenerationConfig(temperature=1.0))
+        observed = TransformersEngine._capture_observed_params(_config(), model, {})
+        assert "dtype" not in observed["engine"]

--- a/tests/unit/engines/test_transformers_token_counting.py
+++ b/tests/unit/engines/test_transformers_token_counting.py
@@ -5,12 +5,28 @@ import pytest
 torch = pytest.importorskip("torch")
 
 
-def _count_tokens(inputs: dict, outputs: "torch.Tensor") -> tuple[int, int]:  # type: ignore[name-defined]  # torch via importorskip
-    """Replicate the token counting logic from TransformersEngine._run_batch()."""
+def _count_tokens(
+    inputs: dict,
+    outputs: "torch.Tensor",  # type: ignore[name-defined]  # torch via importorskip
+    n_inputs: int | None = None,
+) -> tuple[int, int]:
+    """Replicate the token counting logic from TransformersEngine._run_batch().
+
+    ``n_inputs`` is the number of input prompts (the batch list length); it
+    defaults to the attention_mask row count for the n=1 case but must be passed
+    explicitly when ``outputs`` has ``n_inputs * num_return_sequences`` rows.
+    """
     input_token_count = int(inputs["attention_mask"].sum().item())
-    input_lengths = inputs["attention_mask"].sum(dim=1)  # shape: (batch,)
+    input_lengths = [int(x) for x in inputs["attention_mask"].sum(dim=1).tolist()]
+    if n_inputs is None:
+        n_inputs = len(input_lengths)
+    n_rows = int(outputs.shape[0])
+    n_return = n_rows // n_inputs if n_inputs > 0 and n_rows % n_inputs == 0 else 1
     output_token_count = int(
-        sum(max(0, outputs.shape[1] - int(inp_len.item())) for inp_len in input_lengths)
+        sum(
+            max(0, int(outputs.shape[1]) - input_lengths[min(j // n_return, n_inputs - 1)])
+            for j in range(n_rows)
+        )
     )
     return input_token_count, output_token_count
 
@@ -103,6 +119,66 @@ class TestPaddedBatch:
         _, new_out = _count_tokens(inputs, outputs)
 
         assert new_out == 0, f"Expected 0 output tokens when no generation, got {new_out}"
+
+
+class TestNumReturnSequences:
+    """EN4: outputs.shape[0] == batch * num_return_sequences; count ALL rows.
+
+    HF returns N rows per input prompt when num_return_sequences=N (incl. beam
+    search). The old loop counted only ``batch`` rows -> N-fold undercount.
+    """
+
+    def test_n1_unchanged_baseline(self) -> None:
+        # n=1: 2 prompts, input length 4, output length 6 -> 2 new tokens each = 4.
+        input_ids = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        attention_mask = torch.ones_like(input_ids)
+        inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+        outputs = torch.zeros((2, 6), dtype=torch.long)  # 2 rows (n=1)
+
+        _, out_n1 = _count_tokens(inputs, outputs, n_inputs=2)
+        assert out_n1 == 4
+
+    def test_n3_counts_all_rows(self) -> None:
+        # 2 prompts, num_return_sequences=3 -> outputs has 6 rows. Each output row
+        # is length 6, every input length 4 -> 2 new tokens per row * 6 rows = 12.
+        # The n=1 count for the same inputs/output width would be 4, so n=3 == 3x.
+        input_ids = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        attention_mask = torch.ones_like(input_ids)
+        inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+        outputs = torch.zeros((6, 6), dtype=torch.long)  # 2 inputs * 3 returns
+
+        _, out_n3 = _count_tokens(inputs, outputs, n_inputs=2)
+        assert out_n3 == 12, f"Expected 12 (all 6 rows), got {out_n3}"
+
+        # Equivalence to n=1 * N.
+        outputs_n1 = torch.zeros((2, 6), dtype=torch.long)
+        _, out_n1 = _count_tokens(inputs, outputs_n1, n_inputs=2)
+        assert out_n3 == 3 * out_n1
+
+    def test_n2_padded_maps_rows_to_source_input(self) -> None:
+        # Padded inputs: seq1 real length 3, seq2 real length 5. n=2 -> 4 rows.
+        # Output width 7. Rows map j//2: rows 0,1 -> input0 (len 3 -> 4 new),
+        # rows 2,3 -> input1 (len 5 -> 2 new). Total = 4+4+2+2 = 12.
+        input_ids = torch.tensor([[1, 2, 3, 0, 0], [4, 5, 6, 7, 8]])
+        attention_mask = torch.tensor([[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]])
+        inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+        outputs = torch.zeros((4, 7), dtype=torch.long)
+
+        _, out = _count_tokens(inputs, outputs, n_inputs=2)
+        assert out == 12, f"Expected 12 with per-source-input mapping, got {out}"
+
+    def test_non_multiple_row_count_falls_back(self) -> None:
+        # Defensive guard: 5 output rows for 2 inputs is not an exact multiple, so
+        # n_return falls back to 1 and rows map j//1 clamped to last input.
+        # Rows 0,1 -> input0 (len 4 -> 2 new), rows 2,3,4 -> input1 (clamped).
+        # input1 len 4 -> 2 new. Total = 5 rows * 2 = 10.
+        input_ids = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+        attention_mask = torch.ones_like(input_ids)
+        inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+        outputs = torch.zeros((5, 6), dtype=torch.long)
+
+        _, out = _count_tokens(inputs, outputs, n_inputs=2)
+        assert out == 10
 
 
 def _count_padding(inputs: dict) -> int:


### PR DESCRIPTION
## Summary

Five cross-engine **comparability** fixes so the transformers engine measures the same logical config the same way as vllm/tensorrt. These are correctness bugs that make transformers diverge from vllm/tensorrt for the SAME logical config.

- **EN2** - capture the EFFECTIVE merged generation config. `_capture_observed_params` rebuilt a `GenerationConfig` from the requested kwargs only, missing the model's own merged defaults, so `observed_config_hash` did not reflect what the model actually generated with. Now it deepcopies `hf_model.generation_config` (the live merged defaults) and overlays `generate_kwargs`, mirroring HF `generate()`'s `copy.deepcopy(self.generation_config); gc.update(**kwargs)`. Falls back to `GenerationConfig(**kwargs)` only when no live config is present. (`src/.../transformers/plugin.py`)
- **EN4** - output-token undercount when `num_return_sequences > 1`. HF returns N rows per input prompt (incl. beam search), so `outputs.shape[0] == len(batch) * N`. The old loop counted only `batch` rows, an N-fold undercount that corrupts throughput and per-token energy. Now counts every output row, mapping row `j` to its source input via `j // n_return`, with a defensive fallback (and warning) when the row count is not an exact multiple of the input count. (`src/.../transformers/plugin.py`, `_run_batch`)
- **EN5** - decode ITL understated ~1/N for n>1 parallel outputs. `extract_decode_itl` divided the single decode wall-time by `sum(token counts) - 1`, treating N concurrent streams as one serial stream. Now uses the per-sequence (longest) output length: `max(len(out.token_ids)) - 1`. (`src/.../engines/_observed.py`)
- **D2** - stop forcing bfloat16; record the resolved dtype. `_model_load_kwargs` forced `bfloat16` when dtype was unset, so the same config measured a different dtype on transformers vs vllm/tensorrt. Now passes `torch_dtype="auto"` when unset (transformers infers from the checkpoint); `_resolve_torch_dtype` passes `"auto"` through unchanged and still maps explicit float dtypes. The model's actual resolved dtype is recorded best-effort in the observed-params capture under `engine.dtype`. (`src/.../transformers/plugin.py`)
- **D3** - `version` returned `torch.__version__` despite the docstring saying "Transformers library version string". Now returns `transformers.__version__`, matching how vllm/tensorrt report their real lib version. (`src/.../transformers/plugin.py`)

## COMPARABILITY IMPACT

D2 changes measured numbers BY DESIGN: a config with dtype unset previously ran transformers in bfloat16; it now runs in the checkpoint's own dtype ("auto"), which can change energy/throughput/memory. EN4 increases reported output-token counts (and therefore throughput / per-token-energy denominators) whenever `num_return_sequences > 1`. EN5 increases reported decode ITL for n>1 sampling. EN2/D3 change recorded provenance (observed_config_hash inputs and engine_version), not the inference itself. n=1 / single-output / explicitly-set-dtype paths are unchanged.

## Test plan

Gates (run from repo root):
- `make lint` - ruff + import-linter: all checks pass, 4 contracts kept.
- `make typecheck` - mypy: Success, no issues in 272 source files.
- `uv run pytest` full suite: **2492 passed, 45 skipped, 0 failed** (baseline was 2481/43; +11 runnable new tests, +2 torch-gated skips).

New / changed coverage (the previously-untested n>1 paths):
- EN2: `test_transformers_observed_capture.py` - model default (`repetition_penalty=1.3`) absent from kwargs survives the merge; requested override applied; fallback when no model config.
- EN4: `test_transformers_token_counting.py::TestNumReturnSequences` - n=3 counts all `batch*N` rows (== N * the n=1 count); padded n=2 row->source mapping; non-multiple fallback; n=1 baseline unchanged.
- EN5: `test_extended_capture.py::TestExtractDecodeItlParallelOutputs` - n>1 uses max (not sum) decode length; uneven parallel outputs use longest; n=1-via-multi matches single; all-single-token skipped.
- D2: `test_engine_protocol.py` - `torch_dtype=="auto"` when unset (not bfloat16); explicit `float16` still maps to `torch.float16`; `_resolve_torch_dtype("auto")` passthrough; resolved dtype recorded in observed capture.
- D3: `test_engine_protocol.py` - `version` returns `transformers.__version__` (replaces the old assertion of torch's version); "unknown" fallback on import failure.

Note: torch and transformers are NOT installed on this host, so the torch-gated tests (`importorskip`) and the real-tensor `_run_batch` path run only in CI. The EN4 math is additionally verified host-safe via a plain-Python replica in the token-counting test, and the production loop matches it line-for-line.

---

**STACKED** on `fix/capability-matrix-docs`. Do not merge standalone.