### PR TITLE
chore(ci): revive Renovate engine-version scanning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "enabledManagers": ["dockerfile", "custom.regex", "pep621", "github-actions"],
+  "gitIgnoredAuthors": ["llem-ci-bot[bot]"],
   "dockerfile": {
     "fileMatch": ["docker/Dockerfile\\..*"]
   },
@@ -67,13 +68,9 @@
       "rangeStrategy": "replace"
     },
     {
-      "description": "Only auto-PR when Mend merge-confidence signal is high or very-high. Filters out releases that other repos have flagged as unstable via CI / revert patterns.",
+      "description": "Only auto-PR when Mend merge-confidence is high or very-high. Applied ONLY to transformers and pytorch, which have dense merge-confidence data. vllm and tensorrt-llm have sparse merge-confidence (releases rarely score high), so this gate silently suppressed every PR for them; they are excluded here and rely on the 14-day minimumReleaseAge for stability instead.",
       "matchPackageNames": [
         "transformers",
-        "vllm",
-        "tensorrt-llm",
-        "vllm/vllm-openai",
-        "nvcr.io/nvidia/tensorrt-llm/release",
         "pytorch/pytorch"
       ],
       "matchConfidence": ["high", "very high"]


### PR DESCRIPTION
## Problem
Renovate has opened no engine-version PRs for 5+ weeks. Two causes:
1. `gitIgnoredAuthors` was missing, so `llem-ci-bot[bot]` writeback commits could make Renovate treat its own branches as modified and close/reopen them.
2. The `matchConfidence: [high, very high]` gate covered vllm and tensorrt-llm, which have sparse Mend merge-confidence data, so every release scored below the bar and was silently suppressed.

## Fix
- Add `gitIgnoredAuthors: ["llem-ci-bot[bot]"]`.
- Narrow the confidence gate to transformers + pytorch (dense data); vllm and tensorrt-llm now rely on the 14-day `minimumReleaseAge`.

## Operational follow-up (after merge; not code)
- Delete the stale `renovate/transformers-5.x` branch so Renovate re-evaluates from a clean slate (it last fired on the pre-migration flat path).
- On the Dependency Dashboard, hit retry/rebase-all and confirm Detected Dependencies lists `engine_versions/*/current.yaml`, not the old flat paths.