### PR TITLE
refactor(engines): establish engine-knowledge SSOT workspace layout

### DIFF
--- a/engine_versions/README.md
+++ b/engine_versions/README.md
@@ -1,0 +1,70 @@
+# engine_versions workspace
+
+This directory is the single source of truth for what llem knows about each
+supported inference engine at each version it supports. It is a workspace: the
+files here are the inputs that later steps read to generate the typed
+configuration models and validation rules that ship inside the package. The
+directory lives at the repository root, outside `src/`, so it is never bundled
+into the built wheel.
+
+## Layout
+
+```
+engine_versions/
+  <engine>/
+    current.yaml                     which version is deployed right now
+    v<safe_version>/
+      outputs/
+        schema.discovered.json       full config surface for this version
+        curated.yaml                 which of those fields llem exposes
+```
+
+`<engine>` is one of `vllm`, `tensorrt`, `transformers`. `<safe_version>` is
+the version number with dots turned into underscores and a leading `v`, so
+`0.7.3` becomes `v0_7_3`. A version directory is a snapshot: several can exist
+side by side, one per version the project keeps knowledge for.
+
+### The two mined files
+
+- `schema.discovered.json` is the complete configuration surface for one
+  engine version: every field the engine accepts, with its type, bounds, and
+  allowed values. It is produced by inspecting the engine and is treated as
+  data, not hand-edited.
+- `curated.yaml` is the maintainer's allowlist. Of all the fields the schema
+  discovered, it names the subset llem promotes to first-class typed fields.
+  Curation is an exposure decision made here; discovery never narrows.
+
+Both files carry the engine version they describe in an `engine_version`
+field, so a snapshot is self-identifying.
+
+### current.yaml
+
+`current.yaml` records the single version of each engine that is deployed
+today, under `library.current_version`. It is the pointer; the version
+directories are the snapshots it can point at. Renovate updates this pointer
+when a new engine release lands.
+
+## Active snapshots
+
+| engine       | versions in the workspace |
+| ------------ | ------------------------- |
+| vllm         | 0.7.3, 0.19.1             |
+| tensorrt     | 0.21.0, 1.0.0             |
+| transformers | 5.7.0                     |
+
+## Resolving paths in code
+
+`_outputs.py` is the one module that knows this layout. It is a plain path
+resolver with no engine imports and no dynamic loading:
+
+```python
+from engine_versions import _outputs
+
+_outputs.schema_path("vllm", "0.7.3")     # .../vllm/v0_7_3/outputs/schema.discovered.json
+_outputs.curated_path("vllm", "0.7.3")    # .../vllm/v0_7_3/outputs/curated.yaml
+_outputs.workspace_versions("vllm")       # ["0.7.3", "0.19.1"]
+```
+
+`workspace_versions` reports which versions are present by scanning for
+snapshots that carry both mined files, so the directory tree is the source of
+truth and there is no list to keep in sync by hand.

--- a/engine_versions/README.md
+++ b/engine_versions/README.md
@@ -44,14 +44,6 @@ today, under `library.current_version`. It is the pointer; the version
 directories are the snapshots it can point at. Renovate updates this pointer
 when a new engine release lands.
 
-## Active snapshots
-
-| engine       | versions in the workspace |
-| ------------ | ------------------------- |
-| vllm         | 0.7.3, 0.19.1             |
-| tensorrt     | 0.21.0, 1.0.0             |
-| transformers | 5.7.0                     |
-
 ## Resolving paths in code
 
 `_outputs.py` is the one module that knows this layout. It is a plain path

--- a/engine_versions/_outputs.py
+++ b/engine_versions/_outputs.py
@@ -1,0 +1,95 @@
+"""Locate the mined-schema outputs for each engine version snapshot.
+
+The SSOT workspace stores one snapshot per engine version under
+``engine_versions/<engine>/v<safe_version>/outputs/``. Each snapshot holds
+two files:
+
+- ``schema.discovered.json``: the full configuration surface discovered for
+  that engine version (typed models, bounds, enums).
+- ``curated.yaml``: the maintainer allowlist naming which discovered fields
+  llem exposes as first-class typed fields.
+
+This module is the one place that knows how those paths are laid out. It is a
+plain path resolver: no imports of engine libraries, no dynamic module
+loading, no magic attribute delegation. Callers pass an engine name and a
+dotted version string and get back a path.
+
+Version strings are dotted PEP 440 (``"0.7.3"``); directory names are the
+identifier-safe form (``"v0_7_3"``) produced by :func:`safe_version`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packaging.version import Version
+
+#: Engines that ship a mined-schema workspace.
+ENGINES: tuple[str, ...] = ("vllm", "tensorrt", "transformers")
+
+SCHEMA_FILENAME = "schema.discovered.json"
+CURATED_FILENAME = "curated.yaml"
+
+_WORKSPACE_ROOT = Path(__file__).resolve().parent
+
+
+def safe_version(version: str) -> str:
+    """Map a dotted PEP 440 version to its identifier-safe directory name.
+
+    ``"0.7.3"`` -> ``"v0_7_3"``. Raises :class:`ValueError` when the result
+    would not be a legal Python identifier fragment (any character other than
+    a digit, letter, dot, or dash in the input).
+    """
+    safe = "v" + version.replace(".", "_").replace("-", "_")
+    if not safe.replace("_", "").isalnum():
+        raise ValueError(
+            f"Cannot derive a directory name from version {version!r}: "
+            f"candidate {safe!r} contains non-alphanumeric characters."
+        )
+    return safe
+
+
+def outputs_dir(engine: str, version: str) -> Path:
+    """Return the ``outputs/`` directory for one engine version snapshot."""
+    return _WORKSPACE_ROOT / engine / safe_version(version) / "outputs"
+
+
+def schema_path(engine: str, version: str) -> Path:
+    """Return the discovered-schema JSON path for one engine version."""
+    return outputs_dir(engine, version) / SCHEMA_FILENAME
+
+
+def curated_path(engine: str, version: str) -> Path:
+    """Return the curated-allowlist YAML path for one engine version."""
+    return outputs_dir(engine, version) / CURATED_FILENAME
+
+
+def workspace_versions(engine: str) -> list[str]:
+    """Return the dotted versions of *engine* present in the workspace.
+
+    A version counts as present when its ``outputs/`` directory holds both a
+    ``schema.discovered.json`` and a ``curated.yaml`` (an incomplete snapshot
+    is ignored). The result is sorted low-to-high by version number.
+    """
+    engine_root = _WORKSPACE_ROOT / engine
+    if not engine_root.is_dir():
+        return []
+
+    found: list[tuple[Version, str]] = []
+    for child in sorted(engine_root.iterdir()):
+        if not child.is_dir() or not child.name.startswith("v"):
+            continue
+        outputs = child / "outputs"
+        if not (outputs / SCHEMA_FILENAME).is_file():
+            continue
+        if not (outputs / CURATED_FILENAME).is_file():
+            continue
+        dotted = child.name[1:].replace("_", ".")
+        try:
+            parsed = Version(dotted)
+        except ValueError:
+            continue
+        found.append((parsed, dotted))
+
+    found.sort(key=lambda pair: pair[0])
+    return [dotted for _, dotted in found]

--- a/engine_versions/tensorrt/v0_21_0/outputs/curated.yaml
+++ b/engine_versions/tensorrt/v0_21_0/outputs/curated.yaml
@@ -1,0 +1,42 @@
+# Exposure allowlist for tensorrt-llm 0.21.0 (Move 2: curation as data).
+#
+# Field names llem exposes as first-class typed fields on the generated
+# Config class. Non-curated engine fields stay reachable through the
+# extra="allow" passthrough with soft validation against the full
+# discovered schema. Curation is an exposure-time decision; mining never
+# narrows.
+#
+# Originally bootstrapped from the TensorRTConfig / TensorRTSamplingConfig
+# field sets in the deleted hand-written engine config classes (pre-v0.10).
+# TensorRT-LLM has
+# no llem-orchestration residual (HarnessConfig is empty for tensorrt).
+#
+# Each entry is cross-checked against schema.discovered.json for this pin.
+# Every curated field is present in the discovered schema; this pin carries
+# no discovery debt.
+schema_version: 1.0.0
+engine: tensorrt
+engine_version: 0.21.0
+exposed_fields:
+  engine_params:
+    - max_batch_size
+    - tensor_parallel_size
+    - pipeline_parallel_size
+    - max_input_len
+    - max_seq_len
+    - max_num_tokens
+    - dtype
+    - fast_build
+    - backend
+    - quant_config
+    - kv_cache_config
+    - scheduler_config
+  sampling_params:
+    - temperature
+    - top_k
+    - top_p
+    - repetition_penalty
+    - min_p
+    - min_tokens
+    - n
+    - ignore_eos

--- a/engine_versions/tensorrt/v1_0_0/__init__.py
+++ b/engine_versions/tensorrt/v1_0_0/__init__.py
@@ -1,0 +1,1 @@
+"""Mined engine-knowledge snapshot for tensorrt-llm 1.0.0."""

--- a/engine_versions/tensorrt/v1_0_0/outputs/curated.yaml
+++ b/engine_versions/tensorrt/v1_0_0/outputs/curated.yaml
@@ -1,0 +1,42 @@
+# Exposure allowlist for tensorrt-llm 0.21.0 (Move 2: curation as data).
+#
+# Field names llem exposes as first-class typed fields on the generated
+# Config class. Non-curated engine fields stay reachable through the
+# extra="allow" passthrough with soft validation against the full
+# discovered schema. Curation is an exposure-time decision; mining never
+# narrows.
+#
+# Originally bootstrapped from the TensorRTConfig / TensorRTSamplingConfig
+# field sets in the deleted hand-written engine config classes (pre-v0.10).
+# TensorRT-LLM has
+# no llem-orchestration residual (HarnessConfig is empty for tensorrt).
+#
+# Each entry is cross-checked against schema.discovered.json for this pin.
+# Every curated field is present in the discovered schema; this pin carries
+# no discovery debt.
+schema_version: 1.0.0
+engine: tensorrt
+engine_version: 1.0.0
+exposed_fields:
+  engine_params:
+    - max_batch_size
+    - tensor_parallel_size
+    - pipeline_parallel_size
+    - max_input_len
+    - max_seq_len
+    - max_num_tokens
+    - dtype
+    - fast_build
+    - backend
+    - quant_config
+    - kv_cache_config
+    - scheduler_config
+  sampling_params:
+    - temperature
+    - top_k
+    - top_p
+    - repetition_penalty
+    - min_p
+    - min_tokens
+    - n
+    - ignore_eos

--- a/engine_versions/tensorrt/v1_0_0/outputs/schema.discovered.json
+++ b/engine_versions/tensorrt/v1_0_0/outputs/schema.discovered.json
@@ -1,19 +1,26 @@
 {
   "schema_version": "1.0.0",
   "engine": "tensorrt",
-  "engine_version": "0.21.0",
+  "engine_version": "1.0.0",
   "engine_commit_sha": null,
-  "image_ref": "llenergymeasure:tensorrt-0.21.0",
+  "image_ref": "nvcr.io/nvidia/tensorrt-llm/release:1.0.0",
   "base_image_ref": null,
-  "discovered_at": "2026-06-12T01:49:06+02:00",
+  "discovered_at": "2026-06-22T20:11:44.265856+00:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {
       "section": "engine_params",
       "fields": [
-        "build_config"
+        "decoding_config"
       ],
-      "reason": "BuildConfig is not a Pydantic model; appears as Optional[object] in the schema"
+      "reason": "DecodingConfig is a plain (non-Pydantic, non-dataclass) class; not introspectable by the dataclass-lift, and superseded by the mined speculative_config decoding union"
+    },
+    {
+      "section": "engine_params",
+      "fields": [
+        "cp_config"
+      ],
+      "reason": "cp_config is a bare dict (context-parallel settings) with no Pydantic/dataclass schema class; leaves are not introspectable and must come from overlay.yaml if exposed"
     },
     {
       "section": "sampling_params",
@@ -130,52 +137,22 @@
       "description": "The format to load the model.",
       "deprecated": false
     },
+    "fail_fast_on_attention_window_too_large": {
+      "type": "boolean",
+      "default": false,
+      "description": "Fail fast when attention window is too large to fit even a single sequence in the KV cache.",
+      "deprecated": false
+    },
     "enable_lora": {
       "type": "boolean",
       "default": false,
       "description": "Enable LoRA.",
       "deprecated": false
     },
-    "max_lora_rank": {
-      "type": "integer | None",
-      "default": null,
-      "description": "The maximum LoRA rank.",
-      "deprecated": true
-    },
-    "max_loras": {
-      "type": "integer",
-      "default": 4,
-      "description": "The maximum number of LoRA.",
-      "deprecated": true
-    },
-    "max_cpu_loras": {
-      "type": "integer",
-      "default": 4,
-      "description": "The maximum number of LoRA on CPU.",
-      "deprecated": true
-    },
     "lora_config": {
       "type": "LoraConfig | None",
       "default": null,
       "description": "LoRA configuration for the model.",
-      "deprecated": false
-    },
-    "enable_prompt_adapter": {
-      "type": "boolean",
-      "default": false,
-      "description": "Enable prompt adapter.",
-      "deprecated": false
-    },
-    "max_prompt_adapter_token": {
-      "type": "integer",
-      "default": 0,
-      "description": "The maximum number of prompt adapter tokens.",
-      "deprecated": false
-    },
-    "quant_config": {
-      "type": "QuantConfig | None",
-      "default": null,
-      "description": "Quantization config.",
       "deprecated": false
     },
     "kv_cache_config": {
@@ -193,7 +170,7 @@
     "guided_decoding_backend": {
       "type": "string | None",
       "default": null,
-      "description": "Guided decoding backend.",
+      "description": "Guided decoding backend. llguidance is supported in PyTorch backend only.",
       "deprecated": false
     },
     "batched_logits_processor": {
@@ -233,21 +210,9 @@
       "deprecated": false
     },
     "speculative_config": {
-      "type": "LookaheadDecodingConfig | MedusaDecodingConfig | EagleDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | DraftTargetDecodingConfig | None",
+      "type": "DraftTargetDecodingConfig | EagleDecodingConfig | LookaheadDecodingConfig | MedusaDecodingConfig | MTPDecodingConfig | NGramDecodingConfig | UserProvidedDecodingConfig | AutoDecodingConfig | None",
       "default": null,
       "description": "Speculative decoding config.",
-      "deprecated": false
-    },
-    "batching_type": {
-      "type": "BatchingType | None",
-      "default": null,
-      "description": "Batching type.",
-      "deprecated": false
-    },
-    "normalize_log_probs": {
-      "type": "boolean",
-      "default": false,
-      "description": "Normalize log probabilities.",
       "deprecated": false
     },
     "max_batch_size": {
@@ -304,14 +269,8 @@
       "description": "The parser to separate reasoning content from output.",
       "deprecated": false
     },
-    "garbage_collection_gen0_threshold": {
-      "type": "integer",
-      "default": 20000,
-      "description": "Threshold for Python garbage collection of generation 0 objects.Lower values trigger more frequent garbage collection.",
-      "deprecated": false
-    },
     "decoding_config": {
-      "type": "Optional[DecodingConfig]",
+      "type": "Optional[tensorrt_llm.llmapi.llm_args.DecodingConfig]",
       "default": null,
       "description": "The decoding config.",
       "deprecated": true
@@ -364,6 +323,12 @@
       "description": "Calibration config.",
       "deprecated": false
     },
+    "quant_config": {
+      "type": "QuantConfig | None",
+      "default": null,
+      "description": "Quantization config.",
+      "deprecated": false
+    },
     "embedding_parallel_mode": {
       "type": "string",
       "default": "SHARDING_ALONG_VOCAB",
@@ -377,9 +342,31 @@
       "deprecated": false
     },
     "build_config": {
-      "type": "Optional[tensorrt_llm.builder.BuildConfig]",
+      "$ref": "#/$defs/BuildConfig",
+      "default": null
+    },
+    "enable_prompt_adapter": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable prompt adapter.",
+      "deprecated": false
+    },
+    "max_prompt_adapter_token": {
+      "type": "integer",
+      "default": 0,
+      "description": "The maximum number of prompt adapter tokens.",
+      "deprecated": false
+    },
+    "batching_type": {
+      "type": "BatchingType | None",
       "default": null,
-      "description": "Build config.",
+      "description": "Batching type.",
+      "deprecated": false
+    },
+    "normalize_log_probs": {
+      "type": "boolean",
+      "default": false,
+      "description": "Normalize log probabilities.",
       "deprecated": false
     }
   },
@@ -574,6 +561,42 @@
     }
   },
   "$defs": {
+    "AutoDecodingConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for auto speculative decoding.\n\nThis config is used to automatically select the best speculative decoding algorithm.\n\nAccording to benchmark results, the best algorithm in general is NGRAM with low concurrency <= 32.\nDefault heuristic:\n    With concurrency <= 4, max_draft_len = 5, max_matching_ngram_size = 3\n    With concurrency <= 32, max_draft_len = 3, max_matching_ngram_size = 5\n    With concurrency > 32, speculative decoding is disabled.",
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model Dir"
+        }
+      },
+      "title": "AutoDecodingConfig",
+      "type": "object"
+    },
     "BatchingType": {
       "enum": [
         "STATIC",
@@ -583,9 +606,29 @@
       "type": "string"
     },
     "CacheTransceiverConfig": {
+      "additionalProperties": false,
       "description": "Configuration for the cache transceiver.",
       "properties": {
-        "max_num_tokens": {
+        "backend": {
+          "anyOf": [
+            {
+              "enum": [
+                "DEFAULT",
+                "UCX",
+                "NIXL",
+                "MPI"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The communication backend type to use for the cache transceiver.",
+          "title": "Backend"
+        },
+        "max_tokens_in_buffer": {
           "anyOf": [
             {
               "type": "integer"
@@ -596,13 +639,14 @@
           ],
           "default": null,
           "description": "The max number of tokens the transfer buffer can fit.",
-          "title": "Max Num Tokens"
+          "title": "Max Tokens In Buffer"
         }
       },
       "title": "CacheTransceiverConfig",
       "type": "object"
     },
     "CalibConfig": {
+      "additionalProperties": false,
       "description": "Calibration configuration.",
       "properties": {
         "device": {
@@ -674,6 +718,7 @@
       "type": "string"
     },
     "DraftTargetDecodingConfig": {
+      "additionalProperties": false,
       "properties": {
         "max_draft_len": {
           "anyOf": [
@@ -687,7 +732,7 @@
           "default": null,
           "title": "Max Draft Len"
         },
-        "speculative_model": {
+        "speculative_model_dir": {
           "anyOf": [
             {
               "type": "string"
@@ -701,25 +746,14 @@
             }
           ],
           "default": null,
-          "title": "Speculative Model"
-        },
-        "pytorch_weights_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Pytorch Weights Path"
+          "title": "Speculative Model Dir"
         }
       },
       "title": "DraftTargetDecodingConfig",
       "type": "object"
     },
     "DynamicBatchConfig": {
+      "additionalProperties": false,
       "description": "Dynamic batch configuration.\n\nControls how batch size and token limits are dynamically adjusted at runtime.",
       "properties": {
         "enable_batch_size_tuning": {
@@ -747,6 +781,7 @@
       "type": "object"
     },
     "EagleDecodingConfig": {
+      "additionalProperties": false,
       "properties": {
         "max_draft_len": {
           "anyOf": [
@@ -760,7 +795,7 @@
           "default": null,
           "title": "Max Draft Len"
         },
-        "speculative_model": {
+        "speculative_model_dir": {
           "anyOf": [
             {
               "type": "string"
@@ -774,7 +809,7 @@
             }
           ],
           "default": null,
-          "title": "Speculative Model"
+          "title": "Speculative Model Dir"
         },
         "eagle_choices": {
           "anyOf": [
@@ -866,18 +901,6 @@
           "default": null,
           "title": "Max Non Leaves Per Layer"
         },
-        "pytorch_weights_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Pytorch Weights Path"
-        },
         "eagle3_one_model": {
           "anyOf": [
             {
@@ -895,6 +918,7 @@
       "type": "object"
     },
     "ExtendedRuntimePerfKnobConfig": {
+      "additionalProperties": false,
       "description": "Configuration for extended runtime performance knobs.",
       "properties": {
         "multi_block_mode": {
@@ -926,6 +950,7 @@
       "type": "object"
     },
     "KvCacheConfig": {
+      "additionalProperties": false,
       "description": "Configuration for the KV cache.",
       "properties": {
         "enable_block_reuse": {
@@ -1051,12 +1076,25 @@
           "description": "Whether partially matched blocks that are in use can be reused after copying them.",
           "title": "Copy On Partial Reuse",
           "type": "boolean"
+        },
+        "use_uvm": {
+          "default": false,
+          "description": "Whether to use UVM for the KV cache.",
+          "title": "Use Uvm",
+          "type": "boolean"
+        },
+        "dtype": {
+          "default": "auto",
+          "description": "The data type to use for the KV cache.",
+          "title": "Dtype",
+          "type": "string"
         }
       },
       "title": "KvCacheConfig",
       "type": "object"
     },
     "LookaheadDecodingConfig": {
+      "additionalProperties": false,
       "description": "Configuration for lookahead speculative decoding.",
       "properties": {
         "max_draft_len": {
@@ -1071,7 +1109,7 @@
           "default": null,
           "title": "Max Draft Len"
         },
-        "speculative_model": {
+        "speculative_model_dir": {
           "anyOf": [
             {
               "type": "string"
@@ -1085,7 +1123,7 @@
             }
           ],
           "default": null,
-          "title": "Speculative Model"
+          "title": "Speculative Model Dir"
         },
         "max_window_size": {
           "default": 4,
@@ -1143,20 +1181,40 @@
           "type": "object"
         },
         "max_loras": {
-          "default": 4,
-          "title": "Max Loras",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Loras"
         },
         "max_cpu_loras": {
-          "default": 4,
-          "title": "Max Cpu Loras",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Cpu Loras"
+        },
+        "swap_gate_up_proj_lora_b_weight": {
+          "default": true,
+          "title": "Swap Gate Up Proj Lora B Weight",
+          "type": "boolean"
         }
       },
       "title": "LoraConfig",
       "type": "object"
     },
     "MTPDecodingConfig": {
+      "additionalProperties": false,
       "properties": {
         "max_draft_len": {
           "anyOf": [
@@ -1170,7 +1228,7 @@
           "default": null,
           "title": "Max Draft Len"
         },
-        "speculative_model": {
+        "speculative_model_dir": {
           "anyOf": [
             {
               "type": "string"
@@ -1184,61 +1242,54 @@
             }
           ],
           "default": null,
-          "title": "Speculative Model"
+          "title": "Speculative Model Dir"
         },
         "num_nextn_predict_layers": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": 1,
-          "title": "Num Nextn Predict Layers"
+          "title": "Num Nextn Predict Layers",
+          "type": "integer"
         },
         "use_relaxed_acceptance_for_thinking": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": false,
-          "title": "Use Relaxed Acceptance For Thinking"
+          "title": "Use Relaxed Acceptance For Thinking",
+          "type": "boolean"
         },
         "relaxed_topk": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": 1,
-          "title": "Relaxed Topk"
+          "title": "Relaxed Topk",
+          "type": "integer"
         },
         "relaxed_delta": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": 0.0,
-          "title": "Relaxed Delta"
+          "title": "Relaxed Delta",
+          "type": "number"
+        },
+        "use_mtp_vanilla": {
+          "default": false,
+          "title": "Use Mtp Vanilla",
+          "type": "boolean"
+        },
+        "num_nextn_predict_layers_from_model_config": {
+          "default": 1,
+          "title": "Num Nextn Predict Layers From Model Config",
+          "type": "integer"
+        },
+        "BEGIN_THINKING_PHASE_TOKEN": {
+          "default": 128798,
+          "title": "Begin Thinking Phase Token",
+          "type": "integer"
+        },
+        "END_THINKING_PHASE_TOKEN": {
+          "default": 128799,
+          "title": "End Thinking Phase Token",
+          "type": "integer"
         }
       },
       "title": "MTPDecodingConfig",
       "type": "object"
     },
     "MedusaDecodingConfig": {
+      "additionalProperties": false,
       "properties": {
         "max_draft_len": {
           "anyOf": [
@@ -1252,7 +1303,7 @@
           "default": null,
           "title": "Max Draft Len"
         },
-        "speculative_model": {
+        "speculative_model_dir": {
           "anyOf": [
             {
               "type": "string"
@@ -1266,7 +1317,7 @@
             }
           ],
           "default": null,
-          "title": "Speculative Model"
+          "title": "Speculative Model Dir"
         },
         "medusa_choices": {
           "anyOf": [
@@ -1303,7 +1354,8 @@
       "type": "object"
     },
     "NGramDecodingConfig": {
-      "description": "Configuration for NGram drafter speculative decoding.\n\nArguments:\n    prompt_lookup_num_tokens: int\n            The length maximum of draft tokens (can be understood as length maximum of output draft tokens).\n\n    max_matching_ngram_size: int\n        The length maximum of searching tokens (can be understood as length maximum of input tokens to search).\n\n    is_keep_all: bool = True\n        Whether to keep all candidate pattern-matches pairs, only one match is kept for each pattern if False.\n\n    is_use_oldest: bool = True\n        Whether to provide the oldest match when pattern is hit, the newest one is provided if False.\n\n    is_public_pool: bool = True\n        Whether to use a common pool for all requests, or the pool is private for each request if False.",
+      "additionalProperties": false,
+      "description": "Configuration for NGram drafter speculative decoding.\n\nArguments:\n    max_draft_len: int\n            The length maximum of draft tokens (can be understood as length maximum of output draft tokens).\n\n    max_matching_ngram_size: int\n        The length maximum of searching tokens (can be understood as length maximum of input tokens to search).\n\n    is_keep_all: bool = True\n        Whether to keep all candidate pattern-matches pairs, only one match is kept for each pattern if False.\n\n    is_use_oldest: bool = True\n        Whether to provide the oldest match when pattern is hit, the newest one is provided if False.\n\n    is_public_pool: bool = True\n        Whether to use a common pool for all requests, or the pool is private for each request if False.",
       "properties": {
         "max_draft_len": {
           "anyOf": [
@@ -1317,7 +1369,7 @@
           "default": null,
           "title": "Max Draft Len"
         },
-        "speculative_model": {
+        "speculative_model_dir": {
           "anyOf": [
             {
               "type": "string"
@@ -1331,15 +1383,10 @@
             }
           ],
           "default": null,
-          "title": "Speculative Model"
-        },
-        "prompt_lookup_num_tokens": {
-          "default": 2,
-          "title": "Prompt Lookup Num Tokens",
-          "type": "integer"
+          "title": "Speculative Model Dir"
         },
         "max_matching_ngram_size": {
-          "default": 4,
+          "default": 0,
           "title": "Max Matching Ngram Size",
           "type": "integer"
         },
@@ -1357,23 +1404,29 @@
           "default": true,
           "title": "Is Public Pool",
           "type": "boolean"
+        },
+        "is_auto_heuristic": {
+          "default": false,
+          "title": "Is Auto Heuristic",
+          "type": "boolean"
         }
       },
       "title": "NGramDecodingConfig",
       "type": "object"
     },
     "PeftCacheConfig": {
+      "additionalProperties": false,
       "description": "Configuration for the PEFT cache.",
       "properties": {
         "num_host_module_layer": {
           "default": 0,
-          "description": "number of max sized 1-layer 1-module adapterSize=1 sets of weights that can be stored in host cache",
+          "description": "number of max sized 1-layer 1-module adapterSize=1 sets of weights that can be stored in host cache, affects host cache size and overrides value of host_cache_size",
           "title": "Num Host Module Layer",
           "type": "integer"
         },
         "num_device_module_layer": {
           "default": 0,
-          "description": "number of max sized 1-layer 1-module sets of weights that can be stored in host cache",
+          "description": "number of max sized 1-layer 1-module sets of weights that can be stored in device cache, affects device cache size and overrides value of device_cache_percent",
           "title": "Num Device Module Layer",
           "type": "integer"
         },
@@ -1420,30 +1473,16 @@
           "type": "integer"
         },
         "device_cache_percent": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "percent of memory after engine load to use for cache",
-          "title": "Device Cache Percent"
+          "default": 0.02,
+          "description": "Proportion of free device memory after engine load to use for cache, as a fraction from 0 to 1",
+          "title": "Device Cache Percent",
+          "type": "number"
         },
         "host_cache_size": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
+          "default": 1073741824,
           "description": "size in bytes to use for host cache",
-          "title": "Host Cache Size"
+          "title": "Host Cache Size",
+          "type": "integer"
         },
         "lora_prefetch_dir": {
           "anyOf": [
@@ -1455,7 +1494,7 @@
             }
           ],
           "default": null,
-          "description": "folder to store the LoRA weights we hope to load during engine initialization",
+          "description": "folder to store the LoRA weights we hope to load during engine initialization, currently not supported",
           "title": "Lora Prefetch Dir"
         }
       },
@@ -1573,6 +1612,7 @@
       "type": "object"
     },
     "SchedulerConfig": {
+      "additionalProperties": false,
       "properties": {
         "capacity_scheduler_policy": {
           "$ref": "#/$defs/CapacitySchedulerPolicy",
@@ -1606,6 +1646,533 @@
       },
       "title": "SchedulerConfig",
       "type": "object"
+    },
+    "UserProvidedDecodingConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "max_draft_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Draft Len"
+        },
+        "speculative_model_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speculative Model Dir"
+        },
+        "drafter": {
+          "title": "Drafter"
+        },
+        "resource_manager": {
+          "default": null,
+          "title": "Resource Manager"
+        }
+      },
+      "required": [
+        "drafter"
+      ],
+      "title": "UserProvidedDecodingConfig",
+      "type": "object"
+    },
+    "BuildConfig": {
+      "title": "BuildConfig",
+      "type": "object",
+      "properties": {
+        "max_input_len": {
+          "type": "int",
+          "default": 1024
+        },
+        "max_seq_len": {
+          "type": "int",
+          "default": null
+        },
+        "opt_batch_size": {
+          "type": "int",
+          "default": 8
+        },
+        "max_batch_size": {
+          "type": "int",
+          "default": 2048
+        },
+        "max_beam_width": {
+          "type": "int",
+          "default": 1
+        },
+        "max_num_tokens": {
+          "type": "int",
+          "default": 8192
+        },
+        "opt_num_tokens": {
+          "type": "int | None",
+          "default": null
+        },
+        "max_prompt_embedding_table_size": {
+          "type": "int",
+          "default": 0
+        },
+        "kv_cache_type": {
+          "type": "KVCacheType",
+          "default": null
+        },
+        "gather_context_logits": {
+          "type": "int",
+          "default": false
+        },
+        "gather_generation_logits": {
+          "type": "int",
+          "default": false
+        },
+        "strongly_typed": {
+          "type": "bool",
+          "default": true
+        },
+        "force_num_profiles": {
+          "type": "int | None",
+          "default": null
+        },
+        "profiling_verbosity": {
+          "type": "str",
+          "default": "layer_names_only"
+        },
+        "enable_debug_output": {
+          "type": "bool",
+          "default": false
+        },
+        "max_draft_len": {
+          "type": "int",
+          "default": 0
+        },
+        "speculative_decoding_mode": {
+          "type": "SpeculativeDecodingMode",
+          "default": 1
+        },
+        "use_refit": {
+          "type": "bool",
+          "default": false
+        },
+        "input_timing_cache": {
+          "type": "str",
+          "default": null
+        },
+        "output_timing_cache": {
+          "type": "str",
+          "default": "model.cache"
+        },
+        "lora_config": {
+          "$ref": "#/$defs/LoraConfig",
+          "default": null
+        },
+        "auto_parallel_config": {
+          "$ref": "#/$defs/AutoParallelConfig",
+          "default": null
+        },
+        "weight_sparsity": {
+          "type": "bool",
+          "default": false
+        },
+        "weight_streaming": {
+          "type": "bool",
+          "default": false
+        },
+        "plugin_config": {
+          "$ref": "#/$defs/PluginConfig",
+          "default": null
+        },
+        "use_strip_plan": {
+          "type": "bool",
+          "default": false
+        },
+        "max_encoder_input_len": {
+          "type": "int",
+          "default": 1024
+        },
+        "dry_run": {
+          "type": "bool",
+          "default": false
+        },
+        "visualize_network": {
+          "type": "str",
+          "default": null
+        },
+        "monitor_memory": {
+          "type": "bool",
+          "default": false
+        },
+        "use_mrope": {
+          "type": "bool",
+          "default": false
+        }
+      }
+    },
+    "AutoParallelConfig": {
+      "title": "AutoParallelConfig",
+      "type": "object",
+      "properties": {
+        "world_size": {
+          "type": "int",
+          "default": 1
+        },
+        "gpus_per_node": {
+          "type": "int",
+          "default": 8
+        },
+        "cluster_key": {
+          "type": "str",
+          "default": null
+        },
+        "cluster_info": {
+          "$ref": "#/$defs/ClusterInfo",
+          "default": null
+        },
+        "sharding_cost_model": {
+          "type": "str",
+          "default": "alpha_beta"
+        },
+        "comm_cost_model": {
+          "type": "str",
+          "default": "alpha_beta"
+        },
+        "enable_pipeline_parallelism": {
+          "type": "bool",
+          "default": false
+        },
+        "enable_shard_unbalanced_shape": {
+          "type": "bool",
+          "default": false
+        },
+        "enable_shard_dynamic_shape": {
+          "type": "bool",
+          "default": false
+        },
+        "enable_reduce_scatter": {
+          "type": "bool",
+          "default": true
+        },
+        "builder_flags": {
+          "type": "int | None",
+          "default": null
+        },
+        "debug_mode": {
+          "type": "bool",
+          "default": false
+        },
+        "infer_shape": {
+          "type": "bool",
+          "default": true
+        },
+        "validation_mode": {
+          "type": "bool",
+          "default": false
+        },
+        "same_buffer_io": {
+          "type": "dict[str, str]",
+          "default": {}
+        },
+        "same_spec_io": {
+          "type": "dict[str, str]",
+          "default": {}
+        },
+        "sharded_io_allowlist": {
+          "type": "list[str]",
+          "default": []
+        },
+        "fill_weights": {
+          "type": "bool",
+          "default": false
+        },
+        "parallel_config_cache": {
+          "type": "str | None",
+          "default": null
+        },
+        "profile_cache": {
+          "type": "str | None",
+          "default": null
+        },
+        "dump_path": {
+          "type": "str | None",
+          "default": null
+        },
+        "debug_outputs": {
+          "type": "list[str] | str",
+          "default": []
+        }
+      }
+    },
+    "ClusterInfo": {
+      "title": "ClusterInfo",
+      "type": "object",
+      "properties": {
+        "inter_node_bw_per_device": {
+          "type": "int",
+          "default": 25
+        },
+        "intra_node_bw_per_device": {
+          "type": "int",
+          "default": 0
+        },
+        "inter_node_latency": {
+          "type": "int",
+          "default": 10
+        },
+        "intra_node_latency": {
+          "type": "int",
+          "default": 10
+        },
+        "intra_node_sharp": {
+          "type": "bool",
+          "default": false
+        },
+        "inter_node_sharp": {
+          "type": "bool",
+          "default": true
+        },
+        "memory_bw": {
+          "type": "int",
+          "default": 0
+        },
+        "memory_budget_per_device": {
+          "type": "int",
+          "default": 0
+        },
+        "math_throughput": {
+          "$ref": "#/$defs/MathThroughput",
+          "default": null
+        },
+        "memory_efficiency": {
+          "type": "float",
+          "default": 1.0
+        },
+        "math_efficiency": {
+          "type": "float",
+          "default": 1.0
+        },
+        "communication_efficiency": {
+          "type": "float",
+          "default": 1.0
+        }
+      }
+    },
+    "MathThroughput": {
+      "title": "MathThroughput",
+      "type": "object",
+      "properties": {
+        "int4": {
+          "type": "int",
+          "default": 0
+        },
+        "int8": {
+          "type": "int",
+          "default": 0
+        },
+        "fp8": {
+          "type": "int",
+          "default": 0
+        },
+        "float16": {
+          "type": "int",
+          "default": 0
+        },
+        "bfloat16": {
+          "type": "int",
+          "default": 0
+        },
+        "float32": {
+          "type": "int",
+          "default": 0
+        }
+      }
+    },
+    "PluginConfig": {
+      "title": "PluginConfig",
+      "type": "object",
+      "properties": {
+        "_dtype": {
+          "type": "str",
+          "default": "float16"
+        },
+        "_bert_attention_plugin": {
+          "type": "str | None",
+          "default": "auto"
+        },
+        "_gpt_attention_plugin": {
+          "type": "str | None",
+          "default": "auto"
+        },
+        "_gemm_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_explicitly_disable_gemm_plugin": {
+          "type": "bool",
+          "default": false
+        },
+        "_gemm_swiglu_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_fp8_rowwise_gemm_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_qserve_gemm_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_identity_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_nccl_plugin": {
+          "type": "str | None",
+          "default": "auto"
+        },
+        "_lora_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_dora_plugin": {
+          "type": "bool",
+          "default": false
+        },
+        "_weight_only_groupwise_quant_matmul_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_weight_only_quant_matmul_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_smooth_quant_plugins": {
+          "type": "bool",
+          "default": true
+        },
+        "_smooth_quant_gemm_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_layernorm_quantization_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_rmsnorm_quantization_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_quantize_per_token_plugin": {
+          "type": "bool",
+          "default": false
+        },
+        "_quantize_tensor_plugin": {
+          "type": "bool",
+          "default": false
+        },
+        "_moe_plugin": {
+          "type": "str | None",
+          "default": "auto"
+        },
+        "_mamba_conv1d_plugin": {
+          "type": "str | None",
+          "default": "auto"
+        },
+        "_low_latency_gemm_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_low_latency_gemm_swiglu_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_gemm_allreduce_plugin": {
+          "type": "str | None",
+          "default": null
+        },
+        "_context_fmha": {
+          "type": "bool",
+          "default": true
+        },
+        "_bert_context_fmha_fp32_acc": {
+          "type": "bool",
+          "default": false
+        },
+        "_paged_kv_cache": {
+          "type": "bool | None",
+          "default": null
+        },
+        "_remove_input_padding": {
+          "type": "bool",
+          "default": true
+        },
+        "_norm_quant_fusion": {
+          "type": "bool",
+          "default": false
+        },
+        "_reduce_fusion": {
+          "type": "bool",
+          "default": false
+        },
+        "_user_buffer": {
+          "type": "bool",
+          "default": false
+        },
+        "_tokens_per_block": {
+          "type": "int",
+          "default": 32
+        },
+        "_use_paged_context_fmha": {
+          "type": "bool",
+          "default": true
+        },
+        "_use_fp8_context_fmha": {
+          "type": "bool",
+          "default": true
+        },
+        "_fuse_fp4_quant": {
+          "type": "bool",
+          "default": false
+        },
+        "_multiple_profiles": {
+          "type": "bool",
+          "default": false
+        },
+        "_paged_state": {
+          "type": "bool",
+          "default": true
+        },
+        "_streamingllm": {
+          "type": "bool",
+          "default": false
+        },
+        "_manage_weights": {
+          "type": "bool",
+          "default": false
+        },
+        "_use_fused_mlp": {
+          "type": "bool",
+          "default": true
+        },
+        "_pp_reduce_scatter": {
+          "type": "bool",
+          "default": false
+        }
+      }
     }
   }
 }

--- a/engine_versions/transformers/v5_7_0/__init__.py
+++ b/engine_versions/transformers/v5_7_0/__init__.py
@@ -1,0 +1,1 @@
+"""Mined engine-knowledge snapshot for transformers 5.7.0."""

--- a/engine_versions/transformers/v5_7_0/outputs/curated.yaml
+++ b/engine_versions/transformers/v5_7_0/outputs/curated.yaml
@@ -1,0 +1,54 @@
+# Exposure allowlist for transformers 5.7.0 (Move 2: curation as data).
+# Curation carried forward unchanged from the 4.57.3 pin; curation is a
+# human exposure-time decision and survives version bumps until revised.
+#
+# Field names llem exposes as first-class typed fields on the generated
+# Config class. Non-curated engine fields stay reachable through the
+# extra="allow" passthrough with soft validation against the full
+# discovered schema. Curation is an exposure-time decision; mining never
+# narrows.
+#
+# Originally bootstrapped from the TransformersConfig / TransformersSamplingConfig
+# field sets in the deleted hand-written engine config classes (pre-v0.10).
+# The 7 genuine
+# llem-orchestration knobs (batch_size, torch_compile, torch_compile_mode,
+# torch_compile_backend, allow_tf32, autocast_enabled, autocast_dtype) are
+# deliberately excluded: they belong to a future HarnessConfig, not engine
+# curation.
+#
+# Each entry is cross-checked against schema.discovered.json for this pin.
+# Fields tagged "discovery debt" are accepted by the engine (via **kwargs,
+# sibling param classes, or nested config classes) but missed by signature-
+# based discovery; they remain exposed and are tracked for miner deepening.
+schema_version: 1.0.0
+engine: transformers
+engine_version: 5.7.0
+exposed_fields:
+  engine_params:
+    - dtype                        # discovery debt: HF-native, passed via from_pretrained **kwargs
+    - attn_implementation          # discovery debt: runtime kwarg, not in from_pretrained signature
+    - load_in_4bit                 # discovery debt: BitsAndBytesConfig via **kwargs
+    - load_in_8bit                 # discovery debt: BitsAndBytesConfig via **kwargs
+    - bnb_4bit_compute_dtype       # discovery debt: BitsAndBytesConfig via **kwargs
+    - bnb_4bit_quant_type          # discovery debt: BitsAndBytesConfig via **kwargs
+    - bnb_4bit_use_double_quant    # discovery debt: BitsAndBytesConfig via **kwargs
+    - use_cache
+    - cache_implementation
+    - num_beams
+    - early_stopping
+    - length_penalty
+    - no_repeat_ngram_size
+    - prompt_lookup_num_tokens
+    - device_map                   # discovery debt: from_pretrained **kwargs
+    - max_memory                   # discovery debt: from_pretrained **kwargs
+    - low_cpu_mem_usage            # discovery debt: documented in from_pretrained docstring only
+    - tp_plan                      # discovery debt: accelerate/from_pretrained **kwargs
+    - tp_size                      # discovery debt: accelerate/from_pretrained **kwargs
+  sampling_params:
+    - temperature
+    - do_sample
+    - top_k
+    - top_p
+    - repetition_penalty
+    - min_p
+    - min_new_tokens

--- a/engine_versions/transformers/v5_7_0/outputs/schema.discovered.json
+++ b/engine_versions/transformers/v5_7_0/outputs/schema.discovered.json
@@ -1,0 +1,372 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "transformers",
+  "engine_version": "5.7.0",
+  "engine_commit_sha": null,
+  "image_ref": "llenergymeasure:transformers-5.7.0",
+  "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
+  "discovered_at": "2026-06-12T10:04:46+02:00",
+  "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict() with docstring-Args type recovery",
+  "discovery_limitations": [
+    {
+      "section": "engine_params",
+      "fields": [
+        "AutoModelForCausalLM.from_pretrained.**model_args",
+        "AutoModelForCausalLM.from_pretrained.**kwargs",
+        "PreTrainedModel.from_pretrained.**model_args",
+        "PreTrainedModel.from_pretrained.**kwargs"
+      ],
+      "reason": "from_pretrained accepts **kwargs; kwargs are not in the signature (documented kwargs live in the class docstring only)"
+    },
+    {
+      "section": "sampling_params",
+      "fields": [
+        "stop_strings",
+        "cache_config",
+        "bad_words_ids",
+        "exponential_decay_length_penalty",
+        "suppress_tokens",
+        "begin_suppress_tokens",
+        "sequence_bias",
+        "watermarking_config",
+        "eos_token_id",
+        "compile_config",
+        "continuous_batching_config",
+        "low_memory",
+        "penalty_alpha",
+        "dola_layers",
+        "diversity_penalty",
+        "num_beam_groups",
+        "constraints",
+        "force_words_ids",
+        "prefill_chunk_size",
+        "_from_model_config"
+      ],
+      "reason": "GenerationConfig field is None-defaulted and undocumented in the docstring Args block; type='unknown'"
+    }
+  ],
+  "engine_params": {
+    "config": {
+      "type": "PreTrainedConfig | str | PathLike | None",
+      "default": null
+    },
+    "cache_dir": {
+      "type": "str | PathLike | None",
+      "default": null
+    },
+    "ignore_mismatched_sizes": {
+      "type": "bool",
+      "default": false
+    },
+    "force_download": {
+      "type": "bool",
+      "default": false
+    },
+    "local_files_only": {
+      "type": "bool",
+      "default": false
+    },
+    "token": {
+      "type": "str | bool | None",
+      "default": null
+    },
+    "revision": {
+      "type": "str",
+      "default": "main"
+    },
+    "use_safetensors": {
+      "type": "bool | None",
+      "default": null
+    },
+    "weights_only": {
+      "type": "bool",
+      "default": true
+    },
+    "fusion_config": {
+      "type": "dict[str, bool | dict[str, Any]] | None",
+      "default": null
+    },
+    "disable_mmap": {
+      "type": "bool | None",
+      "default": null
+    }
+  },
+  "sampling_params": {
+    "max_length": {
+      "type": "int",
+      "default": null
+    },
+    "max_new_tokens": {
+      "type": "int",
+      "default": null
+    },
+    "min_length": {
+      "type": "int",
+      "default": null
+    },
+    "min_new_tokens": {
+      "type": "int",
+      "default": null
+    },
+    "early_stopping": {
+      "type": "bool",
+      "default": null
+    },
+    "max_time": {
+      "type": "float",
+      "default": null
+    },
+    "stop_strings": {
+      "type": "unknown",
+      "default": null
+    },
+    "do_sample": {
+      "type": "bool",
+      "default": null
+    },
+    "num_beams": {
+      "type": "int",
+      "default": null
+    },
+    "use_cache": {
+      "type": "bool",
+      "default": null
+    },
+    "cache_implementation": {
+      "type": "str",
+      "default": null
+    },
+    "cache_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "temperature": {
+      "type": "float",
+      "default": null
+    },
+    "top_k": {
+      "type": "int",
+      "default": null
+    },
+    "top_p": {
+      "type": "float",
+      "default": null
+    },
+    "min_p": {
+      "type": "float",
+      "default": null
+    },
+    "top_h": {
+      "type": "float",
+      "default": null
+    },
+    "typical_p": {
+      "type": "float",
+      "default": null
+    },
+    "epsilon_cutoff": {
+      "type": "float",
+      "default": null
+    },
+    "eta_cutoff": {
+      "type": "float",
+      "default": null
+    },
+    "repetition_penalty": {
+      "type": "float",
+      "default": null
+    },
+    "encoder_repetition_penalty": {
+      "type": "float",
+      "default": null
+    },
+    "length_penalty": {
+      "type": "float",
+      "default": null
+    },
+    "no_repeat_ngram_size": {
+      "type": "int",
+      "default": null
+    },
+    "bad_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "renormalize_logits": {
+      "type": "bool",
+      "default": null
+    },
+    "forced_bos_token_id": {
+      "type": "int",
+      "default": null
+    },
+    "forced_eos_token_id": {
+      "type": "int",
+      "default": null
+    },
+    "remove_invalid_values": {
+      "type": "bool",
+      "default": null
+    },
+    "exponential_decay_length_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "begin_suppress_tokens": {
+      "type": "unknown",
+      "default": null
+    },
+    "sequence_bias": {
+      "type": "unknown",
+      "default": null
+    },
+    "token_healing": {
+      "type": "bool",
+      "default": null
+    },
+    "guidance_scale": {
+      "type": "float",
+      "default": null
+    },
+    "watermarking_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_return_sequences": {
+      "type": "int",
+      "default": null
+    },
+    "output_attentions": {
+      "type": "bool",
+      "default": null
+    },
+    "output_hidden_states": {
+      "type": "bool",
+      "default": null
+    },
+    "output_scores": {
+      "type": "bool",
+      "default": null
+    },
+    "output_logits": {
+      "type": "bool",
+      "default": null
+    },
+    "return_dict_in_generate": {
+      "type": "bool",
+      "default": null
+    },
+    "pad_token_id": {
+      "type": "int",
+      "default": null
+    },
+    "bos_token_id": {
+      "type": "int",
+      "default": null
+    },
+    "eos_token_id": {
+      "type": "unknown",
+      "default": null
+    },
+    "encoder_no_repeat_ngram_size": {
+      "type": "int",
+      "default": null
+    },
+    "decoder_start_token_id": {
+      "type": "int",
+      "default": null
+    },
+    "is_assistant": {
+      "type": "bool",
+      "default": null
+    },
+    "num_assistant_tokens": {
+      "type": "int",
+      "default": null
+    },
+    "num_assistant_tokens_schedule": {
+      "type": "str",
+      "default": null
+    },
+    "assistant_confidence_threshold": {
+      "type": "float",
+      "default": null
+    },
+    "prompt_lookup_num_tokens": {
+      "type": "int",
+      "default": null
+    },
+    "max_matching_ngram_size": {
+      "type": "int",
+      "default": null
+    },
+    "assistant_early_exit": {
+      "type": "int",
+      "default": null
+    },
+    "assistant_lookbehind": {
+      "type": "int",
+      "default": null
+    },
+    "target_lookbehind": {
+      "type": "int",
+      "default": null
+    },
+    "compile_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "disable_compile": {
+      "type": "bool",
+      "default": null
+    },
+    "continuous_batching_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "low_memory": {
+      "type": "unknown",
+      "default": null
+    },
+    "penalty_alpha": {
+      "type": "unknown",
+      "default": null
+    },
+    "dola_layers": {
+      "type": "unknown",
+      "default": null
+    },
+    "diversity_penalty": {
+      "type": "unknown",
+      "default": null
+    },
+    "num_beam_groups": {
+      "type": "unknown",
+      "default": null
+    },
+    "constraints": {
+      "type": "unknown",
+      "default": null
+    },
+    "force_words_ids": {
+      "type": "unknown",
+      "default": null
+    },
+    "prefill_chunk_size": {
+      "type": "unknown",
+      "default": null
+    },
+    "_from_model_config": {
+      "type": "unknown",
+      "default": null
+    },
+    "transformers_version": {
+      "type": "str",
+      "default": "5.7.0"
+    }
+  }
+}

--- a/engine_versions/vllm/v0_19_1/outputs/curated.yaml
+++ b/engine_versions/vllm/v0_19_1/outputs/curated.yaml
@@ -1,0 +1,59 @@
+# Exposure allowlist for vllm 0.7.3 (Move 2: curation as data).
+#
+# Field names llem exposes as first-class typed fields on the generated
+# Config class. Non-curated engine fields stay reachable through the
+# extra="allow" passthrough with soft validation against the full
+# discovered schema. Curation is an exposure-time decision; mining never
+# narrows.
+#
+# Originally bootstrapped from the VLLMConfig / VLLMEngineConfig /
+# VLLMSamplingConfig field sets in the deleted hand-written engine config
+# classes (pre-v0.10).
+# vLLM has no llem-orchestration residual (HarnessConfig is empty for vllm).
+#
+# Each entry is cross-checked against schema.discovered.json for this pin.
+# Fields tagged "discovery debt" are accepted by the engine but missed by
+# signature-based discovery (nested sub-config container names whose leaf
+# fields are individually discovered, or kwargs the walker has not reached);
+# they remain exposed and are tracked for miner deepening.
+schema_version: 1.0.0
+engine: vllm
+engine_version: 0.19.1
+exposed_fields:
+  engine_params:
+    - dtype
+    - gpu_memory_utilization
+    - cpu_offload_gb
+    - block_size
+    - kv_cache_dtype
+    - enforce_eager
+    - enable_chunked_prefill
+    - max_num_seqs
+    - max_num_batched_tokens
+    - max_model_len
+    - tensor_parallel_size
+    - pipeline_parallel_size
+    - distributed_executor_backend
+    - enable_prefix_caching
+    - quantization
+    - speculative_config
+    - offload_group_size
+    - offload_num_in_group
+    - offload_prefetch_step
+    - offload_params
+    - disable_custom_all_reduce
+    - kv_cache_memory_bytes
+    - compilation_config
+    - attention                     # discovery debt: nested AttentionConfig container not surfaced as a $defs entry
+    - beam_search                   # discovery debt: nested BeamSearchParams container not surfaced as a $defs entry
+  sampling_params:
+    - temperature
+    - top_k
+    - top_p
+    - repetition_penalty
+    - min_p
+    - min_tokens
+    - presence_penalty
+    - frequency_penalty
+    - ignore_eos
+    - n

--- a/engine_versions/vllm/v0_19_1/outputs/schema.discovered.json
+++ b/engine_versions/vllm/v0_19_1/outputs/schema.discovered.json
@@ -1,0 +1,3769 @@
+{
+  "schema_version": "1.0.0",
+  "engine": "vllm",
+  "engine_version": "0.19.1",
+  "engine_commit_sha": null,
+  "image_ref": "vllm/vllm-openai:v0.19.1",
+  "base_image_ref": null,
+  "discovered_at": "2026-06-22T16:20:19.046420+00:00",
+  "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams) + config/*.py declarative-constraint overlay",
+  "discovery_limitations": [
+    {
+      "section": "sampling_params",
+      "fields": [],
+      "reason": "constraints (e.g. temperature>=0, top_p in (0,1]) live in imperative _verify_args() and are not introspectable from field metadata"
+    },
+    {
+      "section": "engine_params",
+      "fields": [],
+      "reason": "per-field descriptions unavailable (vLLM EngineArgs has only a class docstring)"
+    }
+  ],
+  "engine_params": {
+    "model": {
+      "type": "str",
+      "default": "Qwen/Qwen3-0.6B"
+    },
+    "enable_return_routed_experts": {
+      "type": "bool",
+      "default": false
+    },
+    "model_weights": {
+      "type": "str",
+      "default": ""
+    },
+    "served_model_name": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "tokenizer": {
+      "type": "str | None",
+      "default": null
+    },
+    "hf_config_path": {
+      "type": "str | None",
+      "default": null
+    },
+    "runner": {
+      "enum": [
+        "auto",
+        "generate",
+        "pooling",
+        "draft"
+      ],
+      "type": "str",
+      "default": "auto"
+    },
+    "convert": {
+      "enum": [
+        "auto",
+        "none",
+        "embed",
+        "classify"
+      ],
+      "type": "str",
+      "default": "auto"
+    },
+    "skip_tokenizer_init": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_prompt_embeds": {
+      "type": "bool",
+      "default": false
+    },
+    "tokenizer_mode": {
+      "type": "Literal['auto', 'hf', 'slow', 'mistral', 'deepseek_v32'] | str",
+      "default": "auto"
+    },
+    "trust_remote_code": {
+      "type": "bool",
+      "default": false
+    },
+    "allowed_local_media_path": {
+      "type": "str",
+      "default": ""
+    },
+    "allowed_media_domains": {
+      "type": "list[str] | None",
+      "default": null
+    },
+    "download_dir": {
+      "type": "str | None",
+      "default": null
+    },
+    "safetensors_load_strategy": {
+      "type": "str | None",
+      "default": null
+    },
+    "load_format": {
+      "type": "str | Any",
+      "default": "auto"
+    },
+    "config_format": {
+      "type": "str",
+      "default": "auto"
+    },
+    "dtype": {
+      "enum": [
+        "auto",
+        "half",
+        "float16",
+        "bfloat16",
+        "float",
+        "float32"
+      ],
+      "type": "str",
+      "default": "auto"
+    },
+    "kv_cache_dtype": {
+      "enum": [
+        "auto",
+        "float16",
+        "bfloat16",
+        "fp8",
+        "fp8_e4m3",
+        "fp8_e5m2",
+        "fp8_inc",
+        "fp8_ds_mla"
+      ],
+      "type": "str",
+      "default": "auto"
+    },
+    "seed": {
+      "type": "int",
+      "default": 0
+    },
+    "max_model_len": {
+      "type": "int",
+      "default": null,
+      "minimum": 1
+    },
+    "cudagraph_capture_sizes": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "max_cudagraph_capture_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "distributed_executor_backend": {
+      "type": "str | Literal['ray', 'mp', 'uni', 'external_launcher'] | type[Any] | None",
+      "default": null
+    },
+    "pipeline_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "master_addr": {
+      "type": "str",
+      "default": "127.0.0.1"
+    },
+    "master_port": {
+      "type": "int",
+      "default": 29501
+    },
+    "nnodes": {
+      "type": "int",
+      "default": 1
+    },
+    "node_rank": {
+      "type": "int",
+      "default": 0
+    },
+    "distributed_timeout_seconds": {
+      "type": "int | None",
+      "default": null
+    },
+    "tensor_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "prefill_context_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "decode_context_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "dcp_comm_backend": {
+      "enum": [
+        "ag_rs",
+        "a2a"
+      ],
+      "type": "str",
+      "default": "ag_rs"
+    },
+    "dcp_kv_cache_interleave_size": {
+      "type": "int",
+      "default": 1
+    },
+    "cp_kv_cache_interleave_size": {
+      "type": "int",
+      "default": 1
+    },
+    "data_parallel_size": {
+      "type": "int",
+      "default": 1
+    },
+    "data_parallel_rank": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_start_rank": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_size_local": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_address": {
+      "type": "str | None",
+      "default": null
+    },
+    "data_parallel_rpc_port": {
+      "type": "int | None",
+      "default": null
+    },
+    "data_parallel_hybrid_lb": {
+      "type": "bool",
+      "default": false
+    },
+    "data_parallel_external_lb": {
+      "type": "bool",
+      "default": false
+    },
+    "data_parallel_backend": {
+      "enum": [
+        "ray",
+        "mp"
+      ],
+      "type": "str",
+      "default": "mp"
+    },
+    "enable_expert_parallel": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_ep_weight_filter": {
+      "type": "bool",
+      "default": false
+    },
+    "moe_backend": {
+      "enum": [
+        "auto",
+        "triton",
+        "deep_gemm",
+        "cutlass",
+        "flashinfer_trtllm",
+        "flashinfer_cutlass",
+        "flashinfer_cutedsl",
+        "marlin",
+        "aiter"
+      ],
+      "type": "str",
+      "default": "auto"
+    },
+    "all2all_backend": {
+      "enum": [
+        "naive",
+        "pplx",
+        "deepep_high_throughput",
+        "deepep_low_latency",
+        "mori",
+        "nixl_ep",
+        "allgather_reducescatter",
+        "flashinfer_all2allv",
+        "flashinfer_nvlink_two_sided",
+        "flashinfer_nvlink_one_sided"
+      ],
+      "type": "str",
+      "default": "allgather_reducescatter"
+    },
+    "enable_elastic_ep": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_dbo": {
+      "type": "bool",
+      "default": false
+    },
+    "ubatch_size": {
+      "type": "int",
+      "default": 0
+    },
+    "dbo_decode_token_threshold": {
+      "type": "int",
+      "default": 32
+    },
+    "dbo_prefill_token_threshold": {
+      "type": "int",
+      "default": 512
+    },
+    "disable_nccl_for_dp_synchronization": {
+      "type": "bool | None",
+      "default": null
+    },
+    "eplb_config": {
+      "$ref": "#/$defs/EPLBConfig",
+      "default": null
+    },
+    "enable_eplb": {
+      "type": "bool",
+      "default": false
+    },
+    "expert_placement_strategy": {
+      "enum": [
+        "linear",
+        "round_robin"
+      ],
+      "type": "str",
+      "default": "linear"
+    },
+    "_api_process_count": {
+      "type": "int",
+      "default": 1
+    },
+    "_api_process_rank": {
+      "type": "int",
+      "default": 0
+    },
+    "max_parallel_loading_workers": {
+      "type": "int | None",
+      "default": null
+    },
+    "block_size": {
+      "type": "int | None",
+      "default": null
+    },
+    "enable_prefix_caching": {
+      "type": "bool | None",
+      "default": null
+    },
+    "prefix_caching_hash_algo": {
+      "enum": [
+        "sha256",
+        "sha256_cbor",
+        "xxhash",
+        "xxhash_cbor"
+      ],
+      "type": "str",
+      "default": "sha256"
+    },
+    "disable_sliding_window": {
+      "type": "bool",
+      "default": false
+    },
+    "disable_cascade_attn": {
+      "type": "bool",
+      "default": true
+    },
+    "offload_backend": {
+      "type": "str",
+      "default": "auto"
+    },
+    "cpu_offload_gb": {
+      "type": "float",
+      "default": 0,
+      "minimum": 0
+    },
+    "cpu_offload_params": {
+      "type": "set[str]",
+      "default": []
+    },
+    "offload_group_size": {
+      "type": "int",
+      "default": 0,
+      "minimum": 0
+    },
+    "offload_num_in_group": {
+      "type": "int",
+      "default": 1,
+      "minimum": 1
+    },
+    "offload_prefetch_step": {
+      "type": "int",
+      "default": 1,
+      "minimum": 0
+    },
+    "offload_params": {
+      "type": "set[str]",
+      "default": []
+    },
+    "gpu_memory_utilization": {
+      "type": "float",
+      "default": 0.9,
+      "exclusiveMinimum": 0,
+      "maximum": 1
+    },
+    "kv_cache_memory_bytes": {
+      "type": "int | None",
+      "default": null
+    },
+    "max_num_batched_tokens": {
+      "type": "int | None",
+      "default": null,
+      "minimum": 1
+    },
+    "max_num_partial_prefills": {
+      "type": "int",
+      "default": 1,
+      "minimum": 1
+    },
+    "max_long_partial_prefills": {
+      "type": "int",
+      "default": 1,
+      "minimum": 1
+    },
+    "long_prefill_token_threshold": {
+      "type": "int",
+      "default": 0
+    },
+    "max_num_seqs": {
+      "type": "int | None",
+      "default": null,
+      "minimum": 1
+    },
+    "max_logprobs": {
+      "type": "int",
+      "default": 20
+    },
+    "logprobs_mode": {
+      "enum": [
+        "raw_logits",
+        "raw_logprobs",
+        "processed_logits",
+        "processed_logprobs"
+      ],
+      "type": "str",
+      "default": "raw_logprobs"
+    },
+    "disable_log_stats": {
+      "type": "bool",
+      "default": false
+    },
+    "aggregate_engine_logging": {
+      "type": "bool",
+      "default": false
+    },
+    "revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "code_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "hf_token": {
+      "type": "bool | str | None",
+      "default": null
+    },
+    "hf_overrides": {
+      "type": "dict[str, Any] | Callable[[typing.Any], Any]",
+      "default": {}
+    },
+    "tokenizer_revision": {
+      "type": "str | None",
+      "default": null
+    },
+    "quantization": {
+      "type": "Any | str | None",
+      "default": null
+    },
+    "allow_deprecated_quantization": {
+      "type": "bool",
+      "default": false
+    },
+    "enforce_eager": {
+      "type": "bool",
+      "default": false
+    },
+    "disable_custom_all_reduce": {
+      "type": "bool",
+      "default": false
+    },
+    "language_model_only": {
+      "type": "bool",
+      "default": false
+    },
+    "limit_mm_per_prompt": {
+      "type": "dict[str, int | dict[str, int]]",
+      "default": {}
+    },
+    "enable_mm_embeds": {
+      "type": "bool",
+      "default": false
+    },
+    "interleave_mm_strings": {
+      "type": "bool",
+      "default": false
+    },
+    "media_io_kwargs": {
+      "type": "dict[str, dict[str, Any]]",
+      "default": {}
+    },
+    "mm_processor_kwargs": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "mm_processor_cache_gb": {
+      "type": "float",
+      "default": 4,
+      "minimum": 0
+    },
+    "mm_processor_cache_type": {
+      "enum": [
+        "shm",
+        "lru"
+      ],
+      "type": "str",
+      "default": "lru"
+    },
+    "mm_shm_cache_max_object_size_mb": {
+      "type": "int",
+      "default": 128,
+      "minimum": 0
+    },
+    "mm_encoder_only": {
+      "type": "bool",
+      "default": false
+    },
+    "mm_encoder_tp_mode": {
+      "enum": [
+        "weights",
+        "data"
+      ],
+      "type": "str",
+      "default": "weights"
+    },
+    "mm_encoder_attn_backend": {
+      "type": "AttentionBackendEnum | str | None",
+      "default": null
+    },
+    "io_processor_plugin": {
+      "type": "str | None",
+      "default": null
+    },
+    "renderer_num_workers": {
+      "type": "int",
+      "default": 1
+    },
+    "skip_mm_profiling": {
+      "type": "bool",
+      "default": false
+    },
+    "video_pruning_rate": {
+      "type": "float | None",
+      "default": null,
+      "minimum": 0.0,
+      "exclusiveMaximum": 1.0
+    },
+    "mm_tensor_ipc": {
+      "enum": [
+        "direct_rpc",
+        "torch_shm"
+      ],
+      "type": "str",
+      "default": "direct_rpc"
+    },
+    "enable_lora": {
+      "type": "bool",
+      "default": false
+    },
+    "max_loras": {
+      "type": "int",
+      "default": 1,
+      "minimum": 1
+    },
+    "max_lora_rank": {
+      "enum": [
+        1,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        320,
+        512
+      ],
+      "type": "int",
+      "default": 16
+    },
+    "default_mm_loras": {
+      "type": "dict[str, str] | None",
+      "default": null
+    },
+    "fully_sharded_loras": {
+      "type": "bool",
+      "default": false
+    },
+    "max_cpu_loras": {
+      "type": "int | None",
+      "default": null
+    },
+    "lora_dtype": {
+      "type": "str | dtype | None",
+      "default": "auto"
+    },
+    "lora_target_modules": {
+      "type": "list[str] | None",
+      "default": null
+    },
+    "enable_tower_connector_lora": {
+      "type": "bool",
+      "default": false
+    },
+    "specialize_active_lora": {
+      "type": "bool",
+      "default": false
+    },
+    "ray_workers_use_nsight": {
+      "type": "bool",
+      "default": false
+    },
+    "num_gpu_blocks_override": {
+      "type": "int | None",
+      "default": null
+    },
+    "model_loader_extra_config": {
+      "type": "dict",
+      "default": {}
+    },
+    "ignore_patterns": {
+      "type": "str | list[str]",
+      "default": [
+        "original/**/*"
+      ]
+    },
+    "enable_chunked_prefill": {
+      "type": "bool | None",
+      "default": null
+    },
+    "disable_chunked_mm_input": {
+      "type": "bool",
+      "default": false
+    },
+    "scheduler_reserve_full_isl": {
+      "type": "bool",
+      "default": true
+    },
+    "disable_hybrid_kv_cache_manager": {
+      "type": "bool | None",
+      "default": null
+    },
+    "structured_outputs_config": {
+      "$ref": "#/$defs/StructuredOutputsConfig",
+      "default": null
+    },
+    "reasoning_parser": {
+      "type": "str",
+      "default": ""
+    },
+    "reasoning_parser_plugin": {
+      "type": "str | None",
+      "default": null
+    },
+    "speculative_config": {
+      "$ref": "#/$defs/SpeculativeConfig",
+      "default": null
+    },
+    "show_hidden_metrics_for_version": {
+      "type": "str | None",
+      "default": null
+    },
+    "otlp_traces_endpoint": {
+      "type": "str | None",
+      "default": null
+    },
+    "collect_detailed_traces": {
+      "type": "list[Literal['model', 'worker', 'all']] | None",
+      "default": null
+    },
+    "kv_cache_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "kv_cache_metrics_sample": {
+      "type": "float",
+      "default": 0.01,
+      "exclusiveMinimum": 0,
+      "maximum": 1
+    },
+    "cudagraph_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_layerwise_nvtx_tracing": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_mfu_metrics": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_logging_iteration_details": {
+      "type": "bool",
+      "default": false
+    },
+    "enable_mm_processor_stats": {
+      "type": "bool",
+      "default": false
+    },
+    "scheduling_policy": {
+      "enum": [
+        "fcfs",
+        "priority"
+      ],
+      "type": "str",
+      "default": "fcfs"
+    },
+    "scheduler_cls": {
+      "type": "str | type[object] | None",
+      "default": null
+    },
+    "pooler_config": {
+      "$ref": "#/$defs/PoolerConfig",
+      "default": null
+    },
+    "compilation_config": {
+      "$ref": "#/$defs/CompilationConfig",
+      "default": null
+    },
+    "attention_config": {
+      "$ref": "#/$defs/AttentionConfig",
+      "default": null
+    },
+    "kernel_config": {
+      "$ref": "#/$defs/KernelConfig",
+      "default": null
+    },
+    "enable_flashinfer_autotune": {
+      "type": "bool",
+      "default": null
+    },
+    "worker_cls": {
+      "type": "str",
+      "default": "auto"
+    },
+    "worker_extension_cls": {
+      "type": "str",
+      "default": ""
+    },
+    "profiler_config": {
+      "$ref": "#/$defs/ProfilerConfig",
+      "default": null
+    },
+    "kv_transfer_config": {
+      "$ref": "#/$defs/KVTransferConfig",
+      "default": null
+    },
+    "kv_events_config": {
+      "$ref": "#/$defs/KVEventsConfig",
+      "default": null
+    },
+    "ec_transfer_config": {
+      "$ref": "#/$defs/ECTransferConfig",
+      "default": null
+    },
+    "reasoning_config": {
+      "$ref": "#/$defs/ReasoningConfig",
+      "default": null
+    },
+    "generation_config": {
+      "type": "str",
+      "default": "auto"
+    },
+    "enable_sleep_mode": {
+      "type": "bool",
+      "default": false
+    },
+    "override_generation_config": {
+      "type": "dict[str, Any]",
+      "default": {}
+    },
+    "model_impl": {
+      "type": "str",
+      "default": "auto"
+    },
+    "override_attention_dtype": {
+      "type": "str | None",
+      "default": null
+    },
+    "attention_backend": {
+      "type": "AttentionBackendEnum | None",
+      "default": null
+    },
+    "calculate_kv_scales": {
+      "type": "bool",
+      "default": false
+    },
+    "kv_cache_dtype_skip_layers": {
+      "type": "list[str]",
+      "default": []
+    },
+    "mamba_cache_dtype": {
+      "enum": [
+        "auto",
+        "float32",
+        "float16"
+      ],
+      "type": "str",
+      "default": "auto"
+    },
+    "mamba_ssm_cache_dtype": {
+      "enum": [
+        "auto",
+        "float32",
+        "float16"
+      ],
+      "type": "str",
+      "default": "auto"
+    },
+    "mamba_block_size": {
+      "type": "int | None",
+      "default": null,
+      "exclusiveMinimum": 0
+    },
+    "mamba_cache_mode": {
+      "enum": [
+        "all",
+        "align",
+        "none"
+      ],
+      "type": "str",
+      "default": "none"
+    },
+    "additional_config": {
+      "type": "dict[str, Any]",
+      "default": {}
+    },
+    "use_tqdm_on_load": {
+      "type": "bool",
+      "default": true
+    },
+    "pt_load_map_location": {
+      "type": "str | dict[str, str]",
+      "default": "cpu"
+    },
+    "logits_processors": {
+      "type": "list[str | type[LogitsProcessor]] | None",
+      "default": null
+    },
+    "async_scheduling": {
+      "type": "bool | None",
+      "default": null
+    },
+    "stream_interval": {
+      "type": "int",
+      "default": 1,
+      "minimum": 1
+    },
+    "kv_sharing_fast_prefill": {
+      "type": "bool",
+      "default": false
+    },
+    "optimization_level": {
+      "type": "OptimizationLevel",
+      "default": 2
+    },
+    "performance_mode": {
+      "enum": [
+        "balanced",
+        "interactivity",
+        "throughput"
+      ],
+      "type": "str",
+      "default": "balanced"
+    },
+    "kv_offloading_size": {
+      "type": "float | None",
+      "default": null
+    },
+    "kv_offloading_backend": {
+      "enum": [
+        "native",
+        "lmcache"
+      ],
+      "type": "str",
+      "default": "native"
+    },
+    "tokens_only": {
+      "type": "bool",
+      "default": false
+    },
+    "shutdown_timeout": {
+      "type": "int",
+      "default": 0,
+      "minimum": 0
+    },
+    "weight_transfer_config": {
+      "$ref": "#/$defs/WeightTransferConfig",
+      "default": null
+    },
+    "fail_on_environ_validation": {
+      "type": "bool",
+      "default": false
+    },
+    "gdn_prefill_backend": {
+      "enum": [
+        "flashinfer",
+        "triton"
+      ],
+      "type": "str",
+      "default": null
+    }
+  },
+  "sampling_params": {
+    "n": {
+      "type": "integer",
+      "default": 1
+    },
+    "presence_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "frequency_penalty": {
+      "type": "number",
+      "default": 0.0
+    },
+    "repetition_penalty": {
+      "type": "number",
+      "default": 1.0
+    },
+    "temperature": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_p": {
+      "type": "number",
+      "default": 1.0
+    },
+    "top_k": {
+      "type": "integer",
+      "default": 0
+    },
+    "min_p": {
+      "type": "number",
+      "default": 0.0
+    },
+    "seed": {
+      "type": "int | None",
+      "default": null
+    },
+    "stop": {
+      "type": "str | list[str] | None",
+      "default": null
+    },
+    "stop_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "ignore_eos": {
+      "type": "boolean",
+      "default": false
+    },
+    "max_tokens": {
+      "type": "int | None",
+      "default": 16
+    },
+    "min_tokens": {
+      "type": "integer",
+      "default": 0
+    },
+    "logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "prompt_logprobs": {
+      "type": "int | None",
+      "default": null
+    },
+    "flat_logprobs": {
+      "type": "boolean",
+      "default": false
+    },
+    "detokenize": {
+      "type": "boolean",
+      "default": true
+    },
+    "skip_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "spaces_between_special_tokens": {
+      "type": "boolean",
+      "default": true
+    },
+    "include_stop_str_in_output": {
+      "type": "boolean",
+      "default": false
+    },
+    "output_kind": {
+      "type": "RequestOutputKind",
+      "default": 0
+    },
+    "skip_clone": {
+      "type": "boolean",
+      "default": false
+    },
+    "output_text_buffer_length": {
+      "type": "integer",
+      "default": 0
+    },
+    "_eos_token_id": {
+      "type": "int | None",
+      "default": null
+    },
+    "_all_stop_token_ids": {
+      "type": "array",
+      "default": []
+    },
+    "structured_outputs": {
+      "type": "StructuredOutputsParams | None",
+      "default": null
+    },
+    "logit_bias": {
+      "type": "dict[int, float] | None",
+      "default": null
+    },
+    "allowed_token_ids": {
+      "type": "list[int] | None",
+      "default": null
+    },
+    "extra_args": {
+      "type": "dict[str, Any] | None",
+      "default": null
+    },
+    "bad_words": {
+      "type": "list[str] | None",
+      "default": null
+    },
+    "_bad_words_token_ids": {
+      "type": "list[list[int]] | None",
+      "default": null
+    },
+    "skip_reading_prefix_cache": {
+      "type": "bool | None",
+      "default": null
+    },
+    "thinking_token_budget": {
+      "type": "int | None",
+      "default": null
+    },
+    "repetition_detection": {
+      "type": "RepetitionDetectionParams | None",
+      "default": null
+    }
+  },
+  "$defs": {
+    "EPLBConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for Expert Parallel Load Balancing (EP).",
+      "properties": {
+        "window_size": {
+          "default": 1000,
+          "title": "Window Size",
+          "type": "integer"
+        },
+        "step_interval": {
+          "default": 3000,
+          "title": "Step Interval",
+          "type": "integer"
+        },
+        "num_redundant_experts": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Num Redundant Experts",
+          "type": "integer"
+        },
+        "log_balancedness": {
+          "default": false,
+          "title": "Log Balancedness",
+          "type": "boolean"
+        },
+        "log_balancedness_interval": {
+          "default": 1,
+          "title": "Log Balancedness Interval",
+          "type": "integer"
+        },
+        "use_async": {
+          "default": false,
+          "title": "Use Async",
+          "type": "boolean"
+        },
+        "policy": {
+          "const": "default",
+          "default": "default",
+          "title": "Policy",
+          "type": "string"
+        }
+      },
+      "title": "EPLBConfig",
+      "type": "object"
+    },
+    "StructuredOutputsConfig": {
+      "additionalProperties": false,
+      "description": "Dataclass which contains structured outputs config for the engine.",
+      "properties": {
+        "backend": {
+          "default": "auto",
+          "enum": [
+            "auto",
+            "xgrammar",
+            "guidance",
+            "outlines",
+            "lm-format-enforcer"
+          ],
+          "title": "Backend",
+          "type": "string"
+        },
+        "disable_any_whitespace": {
+          "default": false,
+          "title": "Disable Any Whitespace",
+          "type": "boolean"
+        },
+        "disable_additional_properties": {
+          "default": false,
+          "title": "Disable Additional Properties",
+          "type": "boolean"
+        },
+        "reasoning_parser": {
+          "default": "",
+          "title": "Reasoning Parser",
+          "type": "string"
+        },
+        "reasoning_parser_plugin": {
+          "default": "",
+          "title": "Reasoning Parser Plugin",
+          "type": "string"
+        },
+        "enable_in_reasoning": {
+          "default": false,
+          "title": "Enable In Reasoning",
+          "type": "boolean"
+        }
+      },
+      "title": "StructuredOutputsConfig",
+      "type": "object"
+    },
+    "PoolerConfig": {
+      "additionalProperties": false,
+      "description": "Controls the behavior of output pooling in pooling models.",
+      "properties": {
+        "task": {
+          "anyOf": [
+            {
+              "enum": [
+                "embed",
+                "classify",
+                "token_embed",
+                "token_classify",
+                "plugin",
+                "embed&token_classify"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Task"
+        },
+        "pooling_type": {
+          "anyOf": [
+            {
+              "enum": [
+                "CLS",
+                "LAST",
+                "MEAN"
+              ],
+              "type": "string"
+            },
+            {
+              "enum": [
+                "ALL",
+                "STEP"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pooling Type"
+        },
+        "seq_pooling_type": {
+          "anyOf": [
+            {
+              "enum": [
+                "CLS",
+                "LAST",
+                "MEAN"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seq Pooling Type"
+        },
+        "tok_pooling_type": {
+          "anyOf": [
+            {
+              "enum": [
+                "ALL",
+                "STEP"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tok Pooling Type"
+        },
+        "use_activation": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Use Activation"
+        },
+        "dimensions": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dimensions"
+        },
+        "enable_chunked_processing": {
+          "default": false,
+          "title": "Enable Chunked Processing",
+          "type": "boolean"
+        },
+        "max_embed_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Embed Len"
+        },
+        "logit_bias": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logit Bias"
+        },
+        "step_tag_id": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Step Tag Id"
+        },
+        "returned_token_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Returned Token Ids"
+        }
+      },
+      "title": "PoolerConfig",
+      "type": "object"
+    },
+    "CUDAGraphMode": {
+      "description": "Constants for the cudagraph mode in CompilationConfig.\nMeanwhile, the subset enum `NONE`, `PIECEWISE` and `FULL` are also\ntreated as concrete runtime mode for cudagraph runtime dispatching.",
+      "enum": [
+        0,
+        1,
+        2,
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "title": "CUDAGraphMode"
+    },
+    "CompilationMode": {
+      "description": "The compilation approach used for torch.compile-based compilation of the\nmodel.",
+      "enum": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "title": "CompilationMode",
+      "type": "integer"
+    },
+    "DynamicShapesConfig": {
+      "additionalProperties": false,
+      "description": "Configuration to control/debug torch compile dynamic shapes.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/DynamicShapesType",
+          "default": "backed"
+        },
+        "evaluate_guards": {
+          "default": false,
+          "title": "Evaluate Guards",
+          "type": "boolean"
+        },
+        "assume_32_bit_indexing": {
+          "default": false,
+          "title": "Assume 32 Bit Indexing",
+          "type": "boolean"
+        }
+      },
+      "title": "DynamicShapesConfig",
+      "type": "object"
+    },
+    "DynamicShapesType": {
+      "description": "Types of dynamic shapes handling in torch.compile().\nsee  Dynamic shapes and vllm guard dropping in torch_compile.md\nfor more details.",
+      "enum": [
+        "backed",
+        "unbacked",
+        "backed_size_oblivious"
+      ],
+      "title": "DynamicShapesType",
+      "type": "string"
+    },
+    "PassConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for custom Inductor passes.\n\nThis is separate from general `CompilationConfig` so that inductor passes\ndon't all have access to full configuration - that would create a cycle as\nthe `PassManager` is set as a property of config.\n\nYou must pass PassConfig to VLLMConfig constructor via the CompilationConfig\nconstructor. VLLMConfig's post_init does further initialization.\nIf used outside of the VLLMConfig, some fields may be left in an\nimproper state.",
+      "properties": {
+        "fuse_norm_quant": {
+          "default": null,
+          "title": "Fuse Norm Quant",
+          "type": "boolean"
+        },
+        "fuse_act_quant": {
+          "default": null,
+          "title": "Fuse Act Quant",
+          "type": "boolean"
+        },
+        "fuse_attn_quant": {
+          "default": null,
+          "title": "Fuse Attn Quant",
+          "type": "boolean"
+        },
+        "eliminate_noops": {
+          "default": true,
+          "title": "Eliminate Noops",
+          "type": "boolean"
+        },
+        "enable_sp": {
+          "default": null,
+          "title": "Enable Sp",
+          "type": "boolean"
+        },
+        "fuse_gemm_comms": {
+          "default": null,
+          "title": "Fuse Gemm Comms",
+          "type": "boolean"
+        },
+        "fuse_allreduce_rms": {
+          "default": null,
+          "title": "Fuse Allreduce Rms",
+          "type": "boolean"
+        },
+        "fuse_minimax_qk_norm": {
+          "default": null,
+          "title": "Fuse Minimax Qk Norm",
+          "type": "boolean"
+        },
+        "enable_qk_norm_rope_fusion": {
+          "default": false,
+          "title": "Enable Qk Norm Rope Fusion",
+          "type": "boolean"
+        },
+        "fuse_act_padding": {
+          "default": null,
+          "title": "Fuse Act Padding",
+          "type": "boolean"
+        },
+        "fuse_rope_kvcache": {
+          "default": null,
+          "title": "Fuse Rope Kvcache",
+          "type": "boolean"
+        },
+        "rope_kvcache_fusion_max_token_num": {
+          "default": 256,
+          "title": "Rope Kvcache Fusion Max Token Num",
+          "type": "integer"
+        },
+        "fi_allreduce_fusion_max_size_mb": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fi Allreduce Fusion Max Size Mb"
+        },
+        "sp_min_token_num": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sp Min Token Num"
+        }
+      },
+      "title": "PassConfig",
+      "type": "object"
+    },
+    "CompilationConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for compilation.\n\nYou must pass CompilationConfig to VLLMConfig constructor.\nVLLMConfig's post_init does further initialization. If used outside of the\nVLLMConfig, some fields will be left in an improper state.\n\nIt contains PassConfig, which controls the custom fusion/transformation passes.\nThe rest has three parts:\n\n- Top-level Compilation control:\n    - [`mode`][vllm.config.CompilationConfig.mode]\n    - [`debug_dump_path`][vllm.config.CompilationConfig.debug_dump_path]\n    - [`cache_dir`][vllm.config.CompilationConfig.cache_dir]\n    - [`backend`][vllm.config.CompilationConfig.backend]\n    - [`custom_ops`][vllm.config.CompilationConfig.custom_ops]\n    - [`splitting_ops`][vllm.config.CompilationConfig.splitting_ops]\n    - [`compile_mm_encoder`][vllm.config.CompilationConfig.compile_mm_encoder]\n- CudaGraph capture:\n    - [`cudagraph_mode`][vllm.config.CompilationConfig.cudagraph_mode]\n    - [`cudagraph_capture_sizes`]\n    [vllm.config.CompilationConfig.cudagraph_capture_sizes]\n    - [`max_cudagraph_capture_size`]\n    [vllm.config.CompilationConfig.max_cudagraph_capture_size]\n    - [`cudagraph_num_of_warmups`]\n    [vllm.config.CompilationConfig.cudagraph_num_of_warmups]\n    - [`cudagraph_copy_inputs`]\n    [vllm.config.CompilationConfig.cudagraph_copy_inputs]\n- Inductor compilation:\n    - [`compile_sizes`][vllm.config.CompilationConfig.compile_sizes]\n    - [`compile_ranges_endpoints`]\n        [vllm.config.CompilationConfig.compile_ranges_endpoints]\n    - [`inductor_compile_config`]\n    [vllm.config.CompilationConfig.inductor_compile_config]\n    - [`inductor_passes`][vllm.config.CompilationConfig.inductor_passes]\n    - custom inductor passes\n\nWhy we have different sizes for cudagraph and inductor:\n- cudagraph: a cudagraph captured for a specific size can only be used\n    for the same size. We need to capture all the sizes we want to use.\n- inductor: a graph compiled by inductor for a general shape can be used\n    for different sizes. Inductor can also compile for specific sizes,\n    where it can have more information to optimize the graph with fully\n    static shapes. However, we find the general shape compilation is\n    sufficient for most cases. It might be beneficial to compile for\n    certain small batchsizes, where inductor is good at optimizing.",
+      "properties": {
+        "mode": {
+          "$ref": "#/$defs/CompilationMode",
+          "default": null
+        },
+        "debug_dump_path": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Debug Dump Path"
+        },
+        "cache_dir": {
+          "default": "",
+          "title": "Cache Dir",
+          "type": "string"
+        },
+        "compile_cache_save_format": {
+          "enum": [
+            "binary",
+            "unpacked"
+          ],
+          "title": "Compile Cache Save Format",
+          "type": "string"
+        },
+        "backend": {
+          "default": "",
+          "title": "Backend",
+          "type": "string"
+        },
+        "custom_ops": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Custom Ops",
+          "type": "array"
+        },
+        "splitting_ops": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Splitting Ops"
+        },
+        "compile_mm_encoder": {
+          "default": false,
+          "title": "Compile Mm Encoder",
+          "type": "boolean"
+        },
+        "cudagraph_mm_encoder": {
+          "default": false,
+          "title": "Cudagraph Mm Encoder",
+          "type": "boolean"
+        },
+        "encoder_cudagraph_token_budgets": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Encoder Cudagraph Token Budgets",
+          "type": "array"
+        },
+        "encoder_cudagraph_max_images_per_batch": {
+          "default": 0,
+          "title": "Encoder Cudagraph Max Images Per Batch",
+          "type": "integer"
+        },
+        "compile_sizes": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Compile Sizes"
+        },
+        "compile_ranges_endpoints": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Compile Ranges Endpoints"
+        },
+        "inductor_compile_config": {
+          "additionalProperties": true,
+          "title": "Inductor Compile Config",
+          "type": "object"
+        },
+        "inductor_passes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Inductor Passes",
+          "type": "object"
+        },
+        "cudagraph_mode": {
+          "$ref": "#/$defs/CUDAGraphMode",
+          "default": null
+        },
+        "cudagraph_num_of_warmups": {
+          "default": 0,
+          "title": "Cudagraph Num Of Warmups",
+          "type": "integer"
+        },
+        "cudagraph_capture_sizes": {
+          "default": null,
+          "items": {
+            "type": "integer"
+          },
+          "title": "Cudagraph Capture Sizes",
+          "type": "array"
+        },
+        "cudagraph_copy_inputs": {
+          "default": false,
+          "title": "Cudagraph Copy Inputs",
+          "type": "boolean"
+        },
+        "cudagraph_specialize_lora": {
+          "default": true,
+          "title": "Cudagraph Specialize Lora",
+          "type": "boolean"
+        },
+        "use_inductor_graph_partition": {
+          "default": null,
+          "title": "Use Inductor Graph Partition",
+          "type": "boolean"
+        },
+        "pass_config": {
+          "$ref": "#/$defs/PassConfig"
+        },
+        "max_cudagraph_capture_size": {
+          "default": null,
+          "title": "Max Cudagraph Capture Size",
+          "type": "integer"
+        },
+        "dynamic_shapes_config": {
+          "$ref": "#/$defs/DynamicShapesConfig"
+        },
+        "local_cache_dir": {
+          "default": null,
+          "title": "Local Cache Dir",
+          "type": "string"
+        },
+        "fast_moe_cold_start": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fast Moe Cold Start"
+        },
+        "enabled_custom_ops": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Enabled Custom Ops",
+          "type": "object"
+        },
+        "disabled_custom_ops": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Disabled Custom Ops",
+          "type": "object"
+        },
+        "traced_files": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Traced Files",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "compilation_time": {
+          "default": 0.0,
+          "title": "Compilation Time",
+          "type": "number"
+        },
+        "static_forward_context": {
+          "additionalProperties": true,
+          "title": "Static Forward Context",
+          "type": "object"
+        },
+        "static_all_moe_layers": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Static All Moe Layers",
+          "type": "array"
+        }
+      },
+      "title": "CompilationConfig",
+      "type": "object"
+    },
+    "AttentionBackendEnum": {
+      "description": "Enumeration of all supported attention backends.\n\nThe enum value is the default class path, but this can be overridden\nat runtime using register_backend().\n\nTo get the actual backend class (respecting overrides), use:\n    backend.get_class()",
+      "enum": [
+        "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend",
+        "vllm.v1.attention.backends.flash_attn_diffkv.FlashAttentionDiffKVBackend",
+        "vllm.v1.attention.backends.triton_attn.TritonAttentionBackend",
+        "vllm.v1.attention.backends.rocm_attn.RocmAttentionBackend",
+        "vllm.v1.attention.backends.mla.rocm_aiter_mla.AiterMLABackend",
+        "vllm.v1.attention.backends.mla.aiter_triton_mla.AiterTritonMLABackend",
+        "vllm.v1.attention.backends.rocm_aiter_fa.AiterFlashAttentionBackend",
+        "vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse.ROCMAiterMLASparseBackend",
+        "vllm.v1.attention.backends.mla.xpu_mla_sparse.XPUMLASparseBackend",
+        "",
+        "vllm.v1.attention.backends.flashinfer.FlashInferBackend",
+        "vllm.v1.attention.backends.mla.flashinfer_mla.FlashInferMLABackend",
+        "vllm.v1.attention.backends.mla.flashinfer_mla_sparse.FlashInferMLASparseBackend",
+        "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend",
+        "vllm.v1.attention.backends.mla.cutlass_mla.CutlassMLABackend",
+        "vllm.v1.attention.backends.mla.flashmla.FlashMLABackend",
+        "vllm.v1.attention.backends.mla.flashmla_sparse.FlashMLASparseBackend",
+        "vllm.v1.attention.backends.mla.flashattn_mla.FlashAttnMLABackend",
+        "vllm.v1.attention.backends.no_attention.NoAttentionBackend",
+        "vllm.v1.attention.backends.flex_attention.FlexAttentionBackend",
+        "vllm.v1.attention.backends.tree_attn.TreeAttentionBackend",
+        "vllm.v1.attention.backends.rocm_aiter_unified_attn.RocmAiterUnifiedAttentionBackend",
+        "vllm.v1.attention.backends.cpu_attn.CPUAttentionBackend",
+        null
+      ],
+      "title": "AttentionBackendEnum"
+    },
+    "AttentionConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for attention mechanisms in vLLM.",
+      "properties": {
+        "backend": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AttentionBackendEnum"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "flash_attn_version": {
+          "anyOf": [
+            {
+              "enum": [
+                2,
+                3,
+                4
+              ],
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Flash Attn Version"
+        },
+        "use_prefill_decode_attention": {
+          "default": false,
+          "title": "Use Prefill Decode Attention",
+          "type": "boolean"
+        },
+        "flash_attn_max_num_splits_for_cuda_graph": {
+          "default": 32,
+          "title": "Flash Attn Max Num Splits For Cuda Graph",
+          "type": "integer"
+        },
+        "use_cudnn_prefill": {
+          "default": false,
+          "title": "Use Cudnn Prefill",
+          "type": "boolean"
+        },
+        "use_trtllm_ragged_deepseek_prefill": {
+          "default": false,
+          "title": "Use Trtllm Ragged Deepseek Prefill",
+          "type": "boolean"
+        },
+        "use_trtllm_attention": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Use Trtllm Attention"
+        },
+        "disable_flashinfer_prefill": {
+          "default": true,
+          "title": "Disable Flashinfer Prefill",
+          "type": "boolean"
+        },
+        "disable_flashinfer_q_quantization": {
+          "default": false,
+          "title": "Disable Flashinfer Q Quantization",
+          "type": "boolean"
+        },
+        "use_prefill_query_quantization": {
+          "default": false,
+          "title": "Use Prefill Query Quantization",
+          "type": "boolean"
+        }
+      },
+      "title": "AttentionConfig",
+      "type": "object"
+    },
+    "KernelConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for kernel selection and warmup behavior.",
+      "properties": {
+        "enable_flashinfer_autotune": {
+          "default": null,
+          "title": "Enable Flashinfer Autotune",
+          "type": "boolean"
+        },
+        "moe_backend": {
+          "default": "auto",
+          "enum": [
+            "auto",
+            "triton",
+            "deep_gemm",
+            "cutlass",
+            "flashinfer_trtllm",
+            "flashinfer_cutlass",
+            "flashinfer_cutedsl",
+            "marlin",
+            "aiter"
+          ],
+          "title": "Moe Backend",
+          "type": "string"
+        }
+      },
+      "title": "KernelConfig",
+      "type": "object"
+    },
+    "ProfilerConfig": {
+      "additionalProperties": false,
+      "description": "Dataclass which contains profiler config for the engine.",
+      "properties": {
+        "profiler": {
+          "anyOf": [
+            {
+              "enum": [
+                "torch",
+                "cuda"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Profiler"
+        },
+        "torch_profiler_dir": {
+          "default": "",
+          "title": "Torch Profiler Dir",
+          "type": "string"
+        },
+        "torch_profiler_with_stack": {
+          "default": true,
+          "title": "Torch Profiler With Stack",
+          "type": "boolean"
+        },
+        "torch_profiler_with_flops": {
+          "default": false,
+          "title": "Torch Profiler With Flops",
+          "type": "boolean"
+        },
+        "torch_profiler_use_gzip": {
+          "default": true,
+          "title": "Torch Profiler Use Gzip",
+          "type": "boolean"
+        },
+        "torch_profiler_dump_cuda_time_total": {
+          "default": true,
+          "title": "Torch Profiler Dump Cuda Time Total",
+          "type": "boolean"
+        },
+        "torch_profiler_record_shapes": {
+          "default": false,
+          "title": "Torch Profiler Record Shapes",
+          "type": "boolean"
+        },
+        "torch_profiler_with_memory": {
+          "default": false,
+          "title": "Torch Profiler With Memory",
+          "type": "boolean"
+        },
+        "ignore_frontend": {
+          "default": false,
+          "title": "Ignore Frontend",
+          "type": "boolean"
+        },
+        "delay_iterations": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Delay Iterations",
+          "type": "integer"
+        },
+        "max_iterations": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Max Iterations",
+          "type": "integer"
+        },
+        "warmup_iterations": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Warmup Iterations",
+          "type": "integer"
+        },
+        "active_iterations": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Active Iterations",
+          "type": "integer"
+        },
+        "wait_iterations": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Wait Iterations",
+          "type": "integer"
+        }
+      },
+      "title": "ProfilerConfig",
+      "type": "object"
+    },
+    "KVTransferConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for distributed KV cache transfer.",
+      "properties": {
+        "kv_connector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Kv Connector"
+        },
+        "engine_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Engine Id"
+        },
+        "kv_buffer_device": {
+          "title": "Kv Buffer Device",
+          "type": "string"
+        },
+        "kv_buffer_size": {
+          "default": 1000000000.0,
+          "title": "Kv Buffer Size",
+          "type": "number"
+        },
+        "kv_role": {
+          "anyOf": [
+            {
+              "enum": [
+                "kv_producer",
+                "kv_both",
+                "kv_consumer"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Kv Role"
+        },
+        "kv_rank": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Kv Rank"
+        },
+        "kv_parallel_size": {
+          "default": 1,
+          "title": "Kv Parallel Size",
+          "type": "integer"
+        },
+        "kv_ip": {
+          "default": "127.0.0.1",
+          "title": "Kv Ip",
+          "type": "string"
+        },
+        "kv_port": {
+          "default": 14579,
+          "title": "Kv Port",
+          "type": "integer"
+        },
+        "kv_connector_extra_config": {
+          "additionalProperties": true,
+          "title": "Kv Connector Extra Config",
+          "type": "object"
+        },
+        "kv_connector_module_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Kv Connector Module Path"
+        },
+        "enable_permute_local_kv": {
+          "default": false,
+          "title": "Enable Permute Local Kv",
+          "type": "boolean"
+        },
+        "kv_load_failure_policy": {
+          "default": "fail",
+          "enum": [
+            "recompute",
+            "fail"
+          ],
+          "title": "Kv Load Failure Policy",
+          "type": "string"
+        }
+      },
+      "title": "KVTransferConfig",
+      "type": "object"
+    },
+    "KVEventsConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for KV event publishing.",
+      "properties": {
+        "enable_kv_cache_events": {
+          "default": false,
+          "title": "Enable Kv Cache Events",
+          "type": "boolean"
+        },
+        "publisher": {
+          "default": null,
+          "enum": [
+            "null",
+            "zmq"
+          ],
+          "title": "Publisher",
+          "type": "string"
+        },
+        "endpoint": {
+          "default": "tcp://*:5557",
+          "title": "Endpoint",
+          "type": "string"
+        },
+        "replay_endpoint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Replay Endpoint"
+        },
+        "buffer_steps": {
+          "default": 10000,
+          "title": "Buffer Steps",
+          "type": "integer"
+        },
+        "hwm": {
+          "default": 100000,
+          "title": "Hwm",
+          "type": "integer"
+        },
+        "max_queue_size": {
+          "default": 100000,
+          "title": "Max Queue Size",
+          "type": "integer"
+        },
+        "topic": {
+          "default": "",
+          "title": "Topic",
+          "type": "string"
+        }
+      },
+      "title": "KVEventsConfig",
+      "type": "object"
+    },
+    "ECTransferConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for distributed EC cache transfer.",
+      "properties": {
+        "ec_connector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ec Connector"
+        },
+        "engine_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Engine Id"
+        },
+        "ec_buffer_device": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "cuda",
+          "title": "Ec Buffer Device"
+        },
+        "ec_buffer_size": {
+          "default": 1000000000.0,
+          "title": "Ec Buffer Size",
+          "type": "number"
+        },
+        "ec_role": {
+          "anyOf": [
+            {
+              "enum": [
+                "ec_producer",
+                "ec_both",
+                "ec_consumer"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ec Role"
+        },
+        "ec_rank": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ec Rank"
+        },
+        "ec_parallel_size": {
+          "default": 1,
+          "title": "Ec Parallel Size",
+          "type": "integer"
+        },
+        "ec_ip": {
+          "default": "127.0.0.1",
+          "title": "Ec Ip",
+          "type": "string"
+        },
+        "ec_port": {
+          "default": 14579,
+          "title": "Ec Port",
+          "type": "integer"
+        },
+        "ec_connector_extra_config": {
+          "additionalProperties": true,
+          "title": "Ec Connector Extra Config",
+          "type": "object"
+        },
+        "ec_connector_module_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ec Connector Module Path"
+        }
+      },
+      "title": "ECTransferConfig",
+      "type": "object"
+    },
+    "ReasoningConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for reasoning models.\n\nSet `reasoning_start_str` and `reasoning_end_str` to the strings that delimit\nthe reasoning block (e.g. `\"<think>\"` and `\"</think>\"`).  The\ncorresponding token IDs are derived automatically via\n`initialize_token_ids` and are not intended to be set directly.",
+      "properties": {
+        "reasoning_start_str": {
+          "default": "<think>",
+          "title": "Reasoning Start Str",
+          "type": "string"
+        },
+        "reasoning_end_str": {
+          "default": "</think>",
+          "title": "Reasoning End Str",
+          "type": "string"
+        },
+        "_reasoning_start_token_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reasoning Start Token Ids"
+        },
+        "_reasoning_end_token_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reasoning End Token Ids"
+        }
+      },
+      "title": "ReasoningConfig",
+      "type": "object"
+    },
+    "WeightTransferConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for weight transfer during RL training.",
+      "properties": {
+        "backend": {
+          "default": "nccl",
+          "enum": [
+            "nccl",
+            "ipc"
+          ],
+          "title": "Backend",
+          "type": "string"
+        }
+      },
+      "title": "WeightTransferConfig",
+      "type": "object"
+    },
+    "SpeculativeConfig": {
+      "title": "SpeculativeConfig",
+      "type": "object",
+      "properties": {
+        "enforce_eager": {
+          "type": "bool | None",
+          "default": null
+        },
+        "num_speculative_tokens": {
+          "type": "int",
+          "default": null
+        },
+        "model": {
+          "type": "str | None",
+          "default": null
+        },
+        "method": {
+          "enum": [
+            "ngram",
+            "medusa",
+            "mlp_speculator",
+            "draft_model",
+            "suffix",
+            "eagle",
+            "eagle3",
+            "extract_hidden_states",
+            "deepseek_mtp",
+            "mimo_mtp",
+            "glm4_moe_mtp",
+            "glm4_moe_lite_mtp",
+            "glm_ocr_mtp",
+            "ernie_mtp",
+            "nemotron_h_mtp",
+            "exaone_moe_mtp",
+            "qwen3_next_mtp",
+            "qwen3_5_mtp",
+            "longcat_flash_mtp",
+            "mtp",
+            "pangu_ultra_moe_mtp",
+            "step3p5_mtp",
+            "ngram_gpu"
+          ],
+          "type": "str",
+          "default": null
+        },
+        "draft_tensor_parallel_size": {
+          "type": "int | None",
+          "default": null
+        },
+        "tensor_parallel_size": {
+          "type": "int | None",
+          "default": null
+        },
+        "quantization": {
+          "type": "Literal['awq', 'fp8', 'fbgemm_fp8', 'fp_quant', 'modelopt', 'modelopt_fp4', 'modelopt_mxfp8', 'modelopt_mixed', 'gguf', 'gptq_marlin', 'awq_marlin', 'gptq', 'compressed-tensors', 'bitsandbytes', 'experts_int8', 'quark', 'moe_wna16', 'torchao', 'inc', 'mxfp4', 'mxfp8', 'petit_nvfp4', 'cpu_awq'] | str | None",
+          "default": null
+        },
+        "moe_backend": {
+          "enum": [
+            "auto",
+            "triton",
+            "deep_gemm",
+            "cutlass",
+            "flashinfer_trtllm",
+            "flashinfer_cutlass",
+            "flashinfer_cutedsl",
+            "marlin",
+            "aiter"
+          ],
+          "type": "str",
+          "default": null
+        },
+        "max_model_len": {
+          "type": "int | None",
+          "default": null
+        },
+        "revision": {
+          "type": "str | None",
+          "default": null
+        },
+        "code_revision": {
+          "type": "str | None",
+          "default": null
+        },
+        "disable_padded_drafter_batch": {
+          "type": "bool",
+          "default": false
+        },
+        "use_local_argmax_reduction": {
+          "type": "bool",
+          "default": false
+        },
+        "prompt_lookup_max": {
+          "type": "int | None",
+          "default": null
+        },
+        "prompt_lookup_min": {
+          "type": "int | None",
+          "default": null
+        },
+        "speculative_token_tree": {
+          "type": "str | None",
+          "default": null
+        },
+        "parallel_drafting": {
+          "type": "bool",
+          "default": false
+        },
+        "target_model_config": {
+          "$ref": "#/$defs/ModelConfig",
+          "default": null
+        },
+        "target_parallel_config": {
+          "$ref": "#/$defs/ParallelConfig",
+          "default": null
+        },
+        "draft_model_config": {
+          "$ref": "#/$defs/ModelConfig",
+          "default": null
+        },
+        "draft_parallel_config": {
+          "$ref": "#/$defs/ParallelConfig",
+          "default": null
+        },
+        "suffix_decoding_max_tree_depth": {
+          "type": "int",
+          "default": 24
+        },
+        "suffix_decoding_max_cached_requests": {
+          "type": "int",
+          "default": 10000
+        },
+        "suffix_decoding_max_spec_factor": {
+          "type": "float",
+          "default": 1.0
+        },
+        "suffix_decoding_min_token_prob": {
+          "type": "float",
+          "default": 0.1
+        },
+        "draft_load_config": {
+          "$ref": "#/$defs/LoadConfig",
+          "default": null
+        },
+        "rejection_sample_method": {
+          "enum": [
+            "strict",
+            "probabilistic",
+            "synthetic"
+          ],
+          "type": "str",
+          "default": "strict"
+        },
+        "synthetic_acceptance_rate": {
+          "type": "float | None",
+          "default": null
+        }
+      }
+    },
+    "BaseDummyOptions": {
+      "description": "Base options for generating dummy data during profiling.",
+      "properties": {
+        "count": {
+          "default": 999,
+          "minimum": 0,
+          "title": "Count",
+          "type": "integer"
+        }
+      },
+      "title": "BaseDummyOptions",
+      "type": "object"
+    },
+    "MultiModalConfig": {
+      "additionalProperties": false,
+      "description": "Controls the behavior of multimodal models.",
+      "properties": {
+        "language_model_only": {
+          "default": false,
+          "title": "Language Model Only",
+          "type": "boolean"
+        },
+        "limit_per_prompt": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BaseDummyOptions"
+          },
+          "title": "Limit Per Prompt",
+          "type": "object"
+        },
+        "enable_mm_embeds": {
+          "default": false,
+          "title": "Enable Mm Embeds",
+          "type": "boolean"
+        },
+        "media_io_kwargs": {
+          "additionalProperties": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Media Io Kwargs",
+          "type": "object"
+        },
+        "mm_processor_kwargs": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Processor Kwargs"
+        },
+        "mm_processor_cache_gb": {
+          "default": 4,
+          "minimum": 0,
+          "title": "Mm Processor Cache Gb",
+          "type": "number"
+        },
+        "mm_processor_cache_type": {
+          "default": "lru",
+          "enum": [
+            "shm",
+            "lru"
+          ],
+          "title": "Mm Processor Cache Type",
+          "type": "string"
+        },
+        "mm_shm_cache_max_object_size_mb": {
+          "default": 128,
+          "minimum": 0,
+          "title": "Mm Shm Cache Max Object Size Mb",
+          "type": "integer"
+        },
+        "mm_encoder_only": {
+          "default": false,
+          "title": "Mm Encoder Only",
+          "type": "boolean"
+        },
+        "mm_encoder_tp_mode": {
+          "default": "weights",
+          "enum": [
+            "weights",
+            "data"
+          ],
+          "title": "Mm Encoder Tp Mode",
+          "type": "string"
+        },
+        "mm_encoder_attn_backend": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AttentionBackendEnum"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "interleave_mm_strings": {
+          "default": false,
+          "title": "Interleave Mm Strings",
+          "type": "boolean"
+        },
+        "skip_mm_profiling": {
+          "default": false,
+          "title": "Skip Mm Profiling",
+          "type": "boolean"
+        },
+        "video_pruning_rate": {
+          "anyOf": [
+            {
+              "exclusiveMaximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Video Pruning Rate"
+        },
+        "mm_tensor_ipc": {
+          "default": "direct_rpc",
+          "enum": [
+            "direct_rpc",
+            "torch_shm"
+          ],
+          "title": "Mm Tensor Ipc",
+          "type": "string"
+        }
+      },
+      "title": "MultiModalConfig",
+      "type": "object"
+    },
+    "ModelConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for the model.",
+      "properties": {
+        "model": {
+          "default": "Qwen/Qwen3-0.6B",
+          "title": "Model",
+          "type": "string"
+        },
+        "model_weights": {
+          "default": "",
+          "title": "Model Weights",
+          "type": "string"
+        },
+        "runner": {
+          "default": "auto",
+          "enum": [
+            "auto",
+            "generate",
+            "pooling",
+            "draft"
+          ],
+          "title": "Runner",
+          "type": "string"
+        },
+        "convert": {
+          "default": "auto",
+          "enum": [
+            "auto",
+            "none",
+            "embed",
+            "classify"
+          ],
+          "title": "Convert",
+          "type": "string"
+        },
+        "tokenizer": {
+          "default": null,
+          "title": "Tokenizer",
+          "type": "string"
+        },
+        "tokenizer_mode": {
+          "anyOf": [
+            {
+              "enum": [
+                "auto",
+                "hf",
+                "slow",
+                "mistral",
+                "deepseek_v32"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "auto",
+          "title": "Tokenizer Mode"
+        },
+        "trust_remote_code": {
+          "default": false,
+          "title": "Trust Remote Code",
+          "type": "boolean"
+        },
+        "dtype": {
+          "default": "auto",
+          "enum": [
+            "auto",
+            "half",
+            "float16",
+            "bfloat16",
+            "float",
+            "float32"
+          ],
+          "title": "Dtype",
+          "type": "string"
+        },
+        "seed": {
+          "default": 0,
+          "title": "Seed",
+          "type": "integer"
+        },
+        "hf_config_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hf Config Path"
+        },
+        "allowed_local_media_path": {
+          "default": "",
+          "title": "Allowed Local Media Path",
+          "type": "string"
+        },
+        "allowed_media_domains": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Allowed Media Domains"
+        },
+        "revision": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Revision"
+        },
+        "code_revision": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Code Revision"
+        },
+        "tokenizer_revision": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tokenizer Revision"
+        },
+        "max_model_len": {
+          "default": null,
+          "minimum": -1,
+          "title": "Max Model Len",
+          "type": "integer"
+        },
+        "spec_target_max_model_len": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec Target Max Model Len"
+        },
+        "quantization": {
+          "anyOf": [
+            {},
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Quantization"
+        },
+        "allow_deprecated_quantization": {
+          "default": false,
+          "title": "Allow Deprecated Quantization",
+          "type": "boolean"
+        },
+        "enforce_eager": {
+          "default": false,
+          "title": "Enforce Eager",
+          "type": "boolean"
+        },
+        "enable_return_routed_experts": {
+          "default": false,
+          "title": "Enable Return Routed Experts",
+          "type": "boolean"
+        },
+        "max_logprobs": {
+          "default": 20,
+          "title": "Max Logprobs",
+          "type": "integer"
+        },
+        "logprobs_mode": {
+          "default": "raw_logprobs",
+          "enum": [
+            "raw_logits",
+            "raw_logprobs",
+            "processed_logits",
+            "processed_logprobs"
+          ],
+          "title": "Logprobs Mode",
+          "type": "string"
+        },
+        "disable_sliding_window": {
+          "default": false,
+          "title": "Disable Sliding Window",
+          "type": "boolean"
+        },
+        "disable_cascade_attn": {
+          "default": true,
+          "title": "Disable Cascade Attn",
+          "type": "boolean"
+        },
+        "skip_tokenizer_init": {
+          "default": false,
+          "title": "Skip Tokenizer Init",
+          "type": "boolean"
+        },
+        "enable_prompt_embeds": {
+          "default": false,
+          "title": "Enable Prompt Embeds",
+          "type": "boolean"
+        },
+        "served_model_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Served Model Name"
+        },
+        "config_format": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                "auto",
+                "hf",
+                "mistral"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": "auto",
+          "title": "Config Format"
+        },
+        "hf_token": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hf Token"
+        },
+        "hf_overrides": {
+          "additionalProperties": true,
+          "title": "Hf Overrides",
+          "type": "object"
+        },
+        "generation_config": {
+          "default": "auto",
+          "title": "Generation Config",
+          "type": "string"
+        },
+        "override_generation_config": {
+          "additionalProperties": true,
+          "title": "Override Generation Config",
+          "type": "object"
+        },
+        "enable_sleep_mode": {
+          "default": false,
+          "title": "Enable Sleep Mode",
+          "type": "boolean"
+        },
+        "model_impl": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                "auto",
+                "vllm",
+                "transformers",
+                "terratorch"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": "auto",
+          "title": "Model Impl"
+        },
+        "override_attention_dtype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Override Attention Dtype"
+        },
+        "logits_processors": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logits Processors"
+        },
+        "io_processor_plugin": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Io Processor Plugin"
+        },
+        "renderer_num_workers": {
+          "default": 1,
+          "title": "Renderer Num Workers",
+          "type": "integer"
+        },
+        "pooler_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PoolerConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "multimodal_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultiModalConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "language_model_only": {
+          "default": false,
+          "title": "Language Model Only",
+          "type": "boolean"
+        },
+        "limit_mm_per_prompt": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "additionalProperties": {
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit Mm Per Prompt"
+        },
+        "enable_mm_embeds": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Enable Mm Embeds"
+        },
+        "media_io_kwargs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Media Io Kwargs"
+        },
+        "mm_processor_kwargs": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Processor Kwargs"
+        },
+        "mm_processor_cache_gb": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Processor Cache Gb"
+        },
+        "mm_processor_cache_type": {
+          "anyOf": [
+            {
+              "enum": [
+                "shm",
+                "lru"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Processor Cache Type"
+        },
+        "mm_shm_cache_max_object_size_mb": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Shm Cache Max Object Size Mb"
+        },
+        "mm_encoder_only": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Encoder Only"
+        },
+        "mm_encoder_tp_mode": {
+          "anyOf": [
+            {
+              "enum": [
+                "weights",
+                "data"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Encoder Tp Mode"
+        },
+        "mm_encoder_attn_backend": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AttentionBackendEnum"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mm Encoder Attn Backend"
+        },
+        "interleave_mm_strings": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Interleave Mm Strings"
+        },
+        "skip_mm_profiling": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Skip Mm Profiling"
+        },
+        "video_pruning_rate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Video Pruning Rate"
+        },
+        "mm_tensor_ipc": {
+          "default": null,
+          "enum": [
+            "direct_rpc",
+            "torch_shm"
+          ],
+          "title": "Mm Tensor Ipc",
+          "type": "string"
+        }
+      },
+      "title": "ModelConfig",
+      "type": "object"
+    },
+    "ParallelConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for the distributed execution.",
+      "properties": {
+        "pipeline_parallel_size": {
+          "default": 1,
+          "title": "Pipeline Parallel Size",
+          "type": "integer"
+        },
+        "tensor_parallel_size": {
+          "default": 1,
+          "title": "Tensor Parallel Size",
+          "type": "integer"
+        },
+        "prefill_context_parallel_size": {
+          "default": 1,
+          "title": "Prefill Context Parallel Size",
+          "type": "integer"
+        },
+        "data_parallel_size": {
+          "default": 1,
+          "title": "Data Parallel Size",
+          "type": "integer"
+        },
+        "data_parallel_size_local": {
+          "default": 1,
+          "title": "Data Parallel Size Local",
+          "type": "integer"
+        },
+        "data_parallel_rank": {
+          "default": 0,
+          "title": "Data Parallel Rank",
+          "type": "integer"
+        },
+        "data_parallel_rank_local": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Data Parallel Rank Local"
+        },
+        "data_parallel_master_ip": {
+          "default": "127.0.0.1",
+          "title": "Data Parallel Master Ip",
+          "type": "string"
+        },
+        "data_parallel_rpc_port": {
+          "default": 29550,
+          "title": "Data Parallel Rpc Port",
+          "type": "integer"
+        },
+        "data_parallel_master_port": {
+          "default": 29500,
+          "title": "Data Parallel Master Port",
+          "type": "integer"
+        },
+        "data_parallel_backend": {
+          "default": "mp",
+          "enum": [
+            "ray",
+            "mp"
+          ],
+          "title": "Data Parallel Backend",
+          "type": "string"
+        },
+        "data_parallel_external_lb": {
+          "default": false,
+          "title": "Data Parallel External Lb",
+          "type": "boolean"
+        },
+        "data_parallel_hybrid_lb": {
+          "default": false,
+          "title": "Data Parallel Hybrid Lb",
+          "type": "boolean"
+        },
+        "is_moe_model": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Is Moe Model"
+        },
+        "enable_expert_parallel": {
+          "default": false,
+          "title": "Enable Expert Parallel",
+          "type": "boolean"
+        },
+        "enable_ep_weight_filter": {
+          "default": false,
+          "title": "Enable Ep Weight Filter",
+          "type": "boolean"
+        },
+        "enable_eplb": {
+          "default": false,
+          "title": "Enable Eplb",
+          "type": "boolean"
+        },
+        "eplb_config": {
+          "$ref": "#/$defs/EPLBConfig"
+        },
+        "expert_placement_strategy": {
+          "default": "linear",
+          "enum": [
+            "linear",
+            "round_robin"
+          ],
+          "title": "Expert Placement Strategy",
+          "type": "string"
+        },
+        "all2all_backend": {
+          "default": "allgather_reducescatter",
+          "enum": [
+            "naive",
+            "pplx",
+            "deepep_high_throughput",
+            "deepep_low_latency",
+            "mori",
+            "nixl_ep",
+            "allgather_reducescatter",
+            "flashinfer_all2allv",
+            "flashinfer_nvlink_two_sided",
+            "flashinfer_nvlink_one_sided"
+          ],
+          "title": "All2All Backend",
+          "type": "string"
+        },
+        "max_parallel_loading_workers": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Parallel Loading Workers"
+        },
+        "disable_custom_all_reduce": {
+          "default": false,
+          "title": "Disable Custom All Reduce",
+          "type": "boolean"
+        },
+        "enable_elastic_ep": {
+          "default": false,
+          "title": "Enable Elastic Ep",
+          "type": "boolean"
+        },
+        "enable_dbo": {
+          "default": false,
+          "title": "Enable Dbo",
+          "type": "boolean"
+        },
+        "ubatch_size": {
+          "default": 0,
+          "title": "Ubatch Size",
+          "type": "integer"
+        },
+        "dbo_decode_token_threshold": {
+          "default": 32,
+          "title": "Dbo Decode Token Threshold",
+          "type": "integer"
+        },
+        "dbo_prefill_token_threshold": {
+          "default": 512,
+          "title": "Dbo Prefill Token Threshold",
+          "type": "integer"
+        },
+        "disable_nccl_for_dp_synchronization": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Disable Nccl For Dp Synchronization"
+        },
+        "ray_workers_use_nsight": {
+          "default": false,
+          "title": "Ray Workers Use Nsight",
+          "type": "boolean"
+        },
+        "ray_runtime_env": {
+          "anyOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ray Runtime Env"
+        },
+        "placement_group": {
+          "anyOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Placement Group"
+        },
+        "distributed_executor_backend": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                "ray",
+                "mp",
+                "uni",
+                "external_launcher"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Distributed Executor Backend"
+        },
+        "worker_cls": {
+          "default": "auto",
+          "title": "Worker Cls",
+          "type": "string"
+        },
+        "sd_worker_cls": {
+          "default": "auto",
+          "title": "Sd Worker Cls",
+          "type": "string"
+        },
+        "worker_extension_cls": {
+          "default": "",
+          "title": "Worker Extension Cls",
+          "type": "string"
+        },
+        "master_addr": {
+          "default": "127.0.0.1",
+          "title": "Master Addr",
+          "type": "string"
+        },
+        "master_port": {
+          "default": 29501,
+          "title": "Master Port",
+          "type": "integer"
+        },
+        "node_rank": {
+          "default": 0,
+          "title": "Node Rank",
+          "type": "integer"
+        },
+        "nnodes": {
+          "default": 1,
+          "title": "Nnodes",
+          "type": "integer"
+        },
+        "distributed_timeout_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Distributed Timeout Seconds"
+        },
+        "world_size": {
+          "title": "World Size",
+          "type": "integer"
+        },
+        "rank": {
+          "default": 0,
+          "title": "Rank",
+          "type": "integer"
+        },
+        "_data_parallel_master_port_list": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Data Parallel Master Port List",
+          "type": "array"
+        },
+        "_coord_store_port": {
+          "default": 0,
+          "title": "Coord Store Port",
+          "type": "integer"
+        },
+        "decode_context_parallel_size": {
+          "default": 1,
+          "title": "Decode Context Parallel Size",
+          "type": "integer"
+        },
+        "dcp_kv_cache_interleave_size": {
+          "default": 1,
+          "title": "Dcp Kv Cache Interleave Size",
+          "type": "integer"
+        },
+        "dcp_comm_backend": {
+          "default": "ag_rs",
+          "enum": [
+            "ag_rs",
+            "a2a"
+          ],
+          "title": "Dcp Comm Backend",
+          "type": "string"
+        },
+        "cp_kv_cache_interleave_size": {
+          "default": 1,
+          "title": "Cp Kv Cache Interleave Size",
+          "type": "integer"
+        },
+        "data_parallel_index": {
+          "title": "Data Parallel Index",
+          "type": "integer"
+        },
+        "_api_process_count": {
+          "default": 1,
+          "exclusiveMinimum": 0,
+          "title": "Api Process Count",
+          "type": "integer"
+        },
+        "_api_process_rank": {
+          "default": 0,
+          "minimum": -1,
+          "title": "Api Process Rank",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "world_size",
+        "data_parallel_index"
+      ],
+      "title": "ParallelConfig",
+      "type": "object"
+    },
+    "LoadConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for loading the model weights.",
+      "properties": {
+        "load_format": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {}
+          ],
+          "default": "auto",
+          "title": "Load Format"
+        },
+        "download_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Download Dir"
+        },
+        "safetensors_load_strategy": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Safetensors Load Strategy"
+        },
+        "model_loader_extra_config": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {}
+          ],
+          "title": "Model Loader Extra Config"
+        },
+        "device": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Device"
+        },
+        "ignore_patterns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "title": "Ignore Patterns"
+        },
+        "use_tqdm_on_load": {
+          "default": true,
+          "title": "Use Tqdm On Load",
+          "type": "boolean"
+        },
+        "pt_load_map_location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "default": "cpu",
+          "title": "Pt Load Map Location"
+        }
+      },
+      "title": "LoadConfig",
+      "type": "object"
+    },
+    "RequestOutputKind": {
+      "title": "RequestOutputKind",
+      "enum": [
+        0,
+        1,
+        2
+      ]
+    },
+    "StructuredOutputsParams": {
+      "title": "StructuredOutputsParams",
+      "type": "object",
+      "properties": {
+        "json": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "regex": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "choice": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grammar": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "json_object": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "disable_any_whitespace": {
+          "type": "boolean",
+          "default": false
+        },
+        "disable_additional_properties": {
+          "type": "boolean",
+          "default": false
+        },
+        "whitespace_pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "structural_tag": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "_backend": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "_backend_was_auto": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": []
+    },
+    "RepetitionDetectionParams": {
+      "title": "RepetitionDetectionParams",
+      "description": "Parameters for detecting repetitive N-gram patterns in output tokens.",
+      "type": "object",
+      "properties": {
+        "max_pattern_size": {
+          "type": "integer",
+          "default": 0
+        },
+        "min_pattern_size": {
+          "type": "integer",
+          "default": 0
+        },
+        "min_count": {
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "required": []
+    }
+  }
+}

--- a/engine_versions/vllm/v0_7_3/outputs/curated.yaml
+++ b/engine_versions/vllm/v0_7_3/outputs/curated.yaml
@@ -1,0 +1,62 @@
+# Exposure allowlist for vllm 0.7.3 (Move 2: curation as data).
+#
+# Field names llem exposes as first-class typed fields on the generated
+# Config class. Non-curated engine fields stay reachable through the
+# extra="allow" passthrough with soft validation against the full
+# discovered schema. Curation is an exposure-time decision; mining never
+# narrows.
+#
+# Originally bootstrapped from the VLLMConfig / VLLMEngineConfig /
+# VLLMSamplingConfig field sets in the deleted hand-written engine config
+# classes (pre-v0.10).
+# vLLM has no llem-orchestration residual (HarnessConfig is empty for vllm).
+#
+# Each entry is cross-checked against schema.discovered.json for this pin.
+# Fields tagged "discovery debt" are accepted by the engine but missed by
+# signature-based discovery (nested sub-config container names whose leaf
+# fields are individually discovered, or kwargs the walker has not reached);
+# they remain exposed and are tracked for miner deepening.
+schema_version: 1.0.0
+engine: vllm
+engine_version: 0.7.3
+exposed_fields:
+  engine_params:
+    - dtype
+    - gpu_memory_utilization
+    - swap_space
+    - cpu_offload_gb
+    - block_size
+    - kv_cache_dtype
+    - enforce_eager
+    - enable_chunked_prefill
+    - max_num_seqs
+    - max_num_batched_tokens
+    - max_model_len
+    - num_scheduler_steps
+    - tensor_parallel_size
+    - pipeline_parallel_size
+    - distributed_executor_backend
+    - enable_prefix_caching
+    - quantization
+    - max_seq_len_to_capture
+    - speculative_config            # discovery debt: nested sub-config container not surfaced as a $defs entry
+    - offload_group_size            # discovery debt: CPU-offload kwargs not in EngineArgs signature
+    - offload_num_in_group          # discovery debt: CPU-offload kwargs not in EngineArgs signature
+    - offload_prefetch_step         # discovery debt: CPU-offload kwargs not in EngineArgs signature
+    - offload_params                # discovery debt: CPU-offload kwargs not in EngineArgs signature
+    - disable_custom_all_reduce
+    - kv_cache_memory_bytes         # discovery debt: absolute KV-cache knob not in discovered schema
+    - compilation_config
+    - attention                     # discovery debt: nested AttentionConfig container not surfaced as a $defs entry
+    - beam_search                   # discovery debt: nested BeamSearchParams container not surfaced as a $defs entry
+  sampling_params:
+    - temperature
+    - top_k
+    - top_p
+    - repetition_penalty
+    - min_p
+    - min_tokens
+    - presence_penalty
+    - frequency_penalty
+    - ignore_eos
+    - n

--- a/engine_versions/vllm/v0_7_3/outputs/schema.discovered.json
+++ b/engine_versions/vllm/v0_7_3/outputs/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-06T22:57:22+02:00",
+  "discovered_at": "2026-06-12T01:49:06+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {
@@ -401,7 +401,7 @@
       "default": null
     },
     "compilation_config": {
-      "type": "CompilationConfig | None",
+      "$ref": "#/$defs/CompilationConfig",
       "default": null
     },
     "worker_cls": {
@@ -409,7 +409,7 @@
       "default": "auto"
     },
     "kv_transfer_config": {
-      "type": "KVTransferConfig | None",
+      "$ref": "#/$defs/KVTransferConfig",
       "default": null
     },
     "generation_config": {
@@ -536,7 +536,8 @@
     },
     "truncate_prompt_tokens": {
       "type": "unknown",
-      "default": null
+      "default": null,
+      "minimum": 1
     },
     "output_kind": {
       "type": "unknown",
@@ -561,6 +562,370 @@
     "allowed_token_ids": {
       "type": "unknown",
       "default": null
+    }
+  },
+  "$defs": {
+    "PassConfig": {
+      "description": "Configuration for custom Inductor passes.\nThis is separate from general CompilationConfig so that inductor passes\ndon't all have access to full configuration - that would create a cycle\nas the PassManager is set as a property of config.\n- dump_graph_stages: list of stages for which we want to dump the graph.\n    Each pass defines its own stages (before, after, maybe in-between).\n- dump_graph_dir: directory to dump the graphs. Default is .\n- enable_fusion: whether to enable the custom fusion pass.\n- enable_reshape: whether to enable the custom reshape elimination pass.\n    TODO better pass enabling system.",
+      "properties": {
+        "dump_graph_stages": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Dump Graph Stages",
+          "type": "array"
+        },
+        "dump_graph_dir": {
+          "default": ".",
+          "format": "path",
+          "title": "Dump Graph Dir",
+          "type": "string"
+        },
+        "enable_fusion": {
+          "default": true,
+          "title": "Enable Fusion",
+          "type": "boolean"
+        },
+        "enable_reshape": {
+          "default": true,
+          "title": "Enable Reshape",
+          "type": "boolean"
+        }
+      },
+      "title": "PassConfig",
+      "type": "object"
+    },
+    "CompilationConfig": {
+      "description": "Configuration for compilation.\nIt has three parts:\n- Top-level Compilation control:\n    - level: the level of compilation.\n        - 0: no compilation.\n        - 1: dynamo as is.\n        - 2: dynamo once.\n        - 3: piecewise compilation.\n    - debug_dump_path: the path to dump the debug information.\n    - cache_dir: the directory to store the compiled graph, to\n        accelerate Inductor compilation. By default, it will use\n        model-related information to generate a cache directory.\n    - backend: the backend for compilation. It needs to be a string.\n        - \"\" (empty string): use the default backend.\n        - \"eager\"/\"openxla\"/...: use the specified backend registered in PyTorch.\n        - \"full.module.name\": a qualified name which can be used to import the backend function.\n        We use string to avoid serialization issues when using compilation in a distributed setting.\n        When the compilation level is 1 or 2, the backend is used for the compilation directly (it sees the whole graph).\n        When the compilation level is 3, the backend is used for the piecewise compilation (it sees a part of the graph).\n    - custom_ops: fine-grained control over which custom ops to enable/disable.\n        Use 'all' to enable all, 'none' to disable all.\n        Also specify a list of custom op names to enable (prefixed with a '+'),\n        or disable (prefixed with a '-').\n        Examples:\n            - 'all,-op1' to enable all except op1\n            - 'none,+op1,+op2' to enable only op1 and op2\n        By default, all custom ops are enabled when running without Inductor\n            and disabled when running with Inductor (compile_level >= Inductor).\n    - splitting_ops: a list of ops to split the full graph into subgraphs, used in piecewise compilation.\n- CudaGraph capture:\n    - use_cudagraph: whether to use cudagraph inside compilation.\n        - False: cudagraph inside compilation is not used.\n        - True: cudagraph inside compilation is used. It requires\n            that all input buffers have fixed addresses, and all\n            splitting ops write their outputs to input buffers.\n        Note that this is orthogonal to the cudagraph capture logic\n        outside of compilation.\n        TODO: move outside cudagraph logic into compilation.\n        torch.compile will handle cudagraph capture logic in the future.\n    - cudagraph_capture_sizes: sizes to capture cudagraph.\n        - None (default): capture sizes are inferred from vllm config.\n        - List[int]: capture sizes are specified as given.\n    - cudagraph_num_of_warmups: number of warmup runs for cudagraph.\n        It means the first several runs will be treated as warmup runs.\n        Only after that, the execution will be recorded, and the recorded\n        cudagraph will be used for subsequent runs.\n    - cudagraph_copy_inputs: whether to copy input tensors for\n        cudagraph. If the caller can guarantee that the same input buffers\n        are always used, it can set this to False. Otherwise, it should\n        set this to True, and the compiler will copy the input to an\n        internally managed buffer. Default is False.\n- Inductor compilation:\n    - use_inductor: whether to use inductor compilation.\n        - False: inductor compilation is not used. graph runs in eager.\n        - True: inductor compilation is used. one graph for symbolic shape\n            is compiled. In addition, compile for compile_sizes,\n            using configurations in inductor_compile_config.\n    - compile_sizes: sizes to compile for inductor. In addition\n        to integers, it also supports \"cudagraph_capture_sizes\" to\n        specify the sizes for cudagraph capture.\n    - inductor_compile_config: additional configurations for inductor.\n        - None: use default configurations.\n    - inductor_passes: additional passes for inductor. It is a dictionary\n        from pass name to pass function qualified name. We use function\n        name because the config uses json format. If we pass the config\n        from Python, functions can also be passed directly via Python object\n        constructor, e.g. `CompilationConfig(inductor_passes={\"a\": func})`\n    - custom inductor passes: see PassConfig for more details\n\nWhy we have different sizes for cudagraph and inductor:\n- cudagraph: a cudagraph captured for a specific size can only be used\n    for the same size. We need to capture all the sizes we want to use.\n- inductor: a graph compiled by inductor for a general shape can be used\n    for different sizes. Inductor can also compile for specific sizes,\n    where it can have more information to optimize the graph with fully\n    static shapes. However, we find the general shape compilation is\n    sufficient for most cases. It might be beneficial to compile for\n    certain small batchsizes, where inductor is good at optimizing.",
+      "properties": {
+        "level": {
+          "default": 0,
+          "title": "Level",
+          "type": "integer"
+        },
+        "debug_dump_path": {
+          "default": "",
+          "title": "Debug Dump Path",
+          "type": "string"
+        },
+        "cache_dir": {
+          "default": "",
+          "title": "Cache Dir",
+          "type": "string"
+        },
+        "backend": {
+          "default": "",
+          "title": "Backend",
+          "type": "string"
+        },
+        "custom_ops": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Custom Ops",
+          "type": "array"
+        },
+        "splitting_ops": {
+          "default": null,
+          "items": {
+            "type": "string"
+          },
+          "title": "Splitting Ops",
+          "type": "array"
+        },
+        "use_inductor": {
+          "default": true,
+          "title": "Use Inductor",
+          "type": "boolean"
+        },
+        "compile_sizes": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Compile Sizes"
+        },
+        "inductor_compile_config": {
+          "title": "Inductor Compile Config",
+          "type": "object"
+        },
+        "inductor_passes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Inductor Passes",
+          "type": "object"
+        },
+        "use_cudagraph": {
+          "default": false,
+          "title": "Use Cudagraph",
+          "type": "boolean"
+        },
+        "cudagraph_num_of_warmups": {
+          "default": 0,
+          "title": "Cudagraph Num Of Warmups",
+          "type": "integer"
+        },
+        "cudagraph_capture_sizes": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cudagraph Capture Sizes"
+        },
+        "cudagraph_copy_inputs": {
+          "default": false,
+          "title": "Cudagraph Copy Inputs",
+          "type": "boolean"
+        },
+        "pass_config": {
+          "$ref": "#/$defs/PassConfig"
+        },
+        "max_capture_size": {
+          "title": "Max Capture Size",
+          "type": "integer"
+        },
+        "local_cache_dir": {
+          "title": "Local Cache Dir",
+          "type": "string"
+        },
+        "bs_to_padded_graph_size": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Bs To Padded Graph Size",
+          "type": "array"
+        },
+        "enabled_custom_ops": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Enabled Custom Ops",
+          "type": "object"
+        },
+        "disabled_custom_ops": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Disabled Custom Ops",
+          "type": "object"
+        },
+        "traced_files": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Traced Files",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "compilation_time": {
+          "title": "Compilation Time",
+          "type": "number"
+        },
+        "static_forward_context": {
+          "title": "Static Forward Context",
+          "type": "object"
+        }
+      },
+      "title": "CompilationConfig",
+      "type": "object"
+    },
+    "KVTransferConfig": {
+      "description": "Configuration for distributed KV cache transfer.",
+      "properties": {
+        "kv_connector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Kv Connector"
+        },
+        "kv_buffer_device": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "cuda",
+          "title": "Kv Buffer Device"
+        },
+        "kv_buffer_size": {
+          "default": 1000000000.0,
+          "title": "Kv Buffer Size",
+          "type": "number"
+        },
+        "kv_role": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Kv Role"
+        },
+        "kv_rank": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Kv Rank"
+        },
+        "kv_parallel_size": {
+          "default": 1,
+          "title": "Kv Parallel Size",
+          "type": "integer"
+        },
+        "kv_ip": {
+          "default": "127.0.0.1",
+          "title": "Kv Ip",
+          "type": "string"
+        },
+        "kv_port": {
+          "default": 14579,
+          "title": "Kv Port",
+          "type": "integer"
+        }
+      },
+      "title": "KVTransferConfig",
+      "type": "object"
+    },
+    "RequestOutputKind": {
+      "title": "RequestOutputKind",
+      "enum": [
+        0,
+        1,
+        2
+      ]
+    },
+    "GuidedDecodingParams": {
+      "title": "GuidedDecodingParams",
+      "description": "One of these fields will be used to build a logit processor.",
+      "type": "object",
+      "properties": {
+        "json": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "regex": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "choice": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grammar": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "json_object": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "backend": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "whitespace_pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": []
     }
   }
 }

--- a/tests/_engine_archive/test_ssot_layout.py
+++ b/tests/_engine_archive/test_ssot_layout.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from packaging.version import Version
 
 from engine_versions import _outputs
 
@@ -70,14 +71,10 @@ def test_curated_parses_and_self_identifies(engine: str, version: str) -> None:
 
 @pytest.mark.parametrize(("engine", "versions"), ACTIVE_PINS.items())
 def test_workspace_versions_matches_active_pins(engine: str, versions: tuple[str, ...]) -> None:
-    assert _outputs.workspace_versions(engine) == sorted(versions, key=_version_key)
+    assert _outputs.workspace_versions(engine) == sorted(versions, key=Version)
 
 
 def test_outputs_dir_is_under_the_workspace() -> None:
     resolved = _outputs.outputs_dir("vllm", "0.7.3").resolve()
     workspace = (Path(_outputs.__file__).resolve().parent).resolve()
     assert workspace in resolved.parents
-
-
-def _version_key(version: str) -> tuple[int, ...]:
-    return tuple(int(part) for part in version.split("."))

--- a/tests/_engine_archive/test_ssot_layout.py
+++ b/tests/_engine_archive/test_ssot_layout.py
@@ -1,0 +1,83 @@
+"""Integrity tests for the engine_versions SSOT workspace and its path resolver.
+
+Covers two things this layer ships:
+
+- Every active version snapshot holds both mined files
+  (``schema.discovered.json`` + ``curated.yaml``), each parses, and the
+  schema's ``engine_version`` matches the directory it lives in.
+- ``engine_versions._outputs`` resolves those files by (engine, version) and
+  reports the present versions by scanning the tree.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from engine_versions import _outputs
+
+# The version snapshots this layer establishes, per engine. Kept explicit here
+# (rather than derived) so the test pins the expected workspace shape; the
+# resolver derives the same set from the directory tree at runtime.
+ACTIVE_PINS: dict[str, tuple[str, ...]] = {
+    "vllm": ("0.7.3", "0.19.1"),
+    "tensorrt": ("0.21.0", "1.0.0"),
+    "transformers": ("5.7.0",),
+}
+
+_PINS = [(engine, version) for engine, versions in ACTIVE_PINS.items() for version in versions]
+
+
+def test_engines_match_resolver() -> None:
+    assert set(ACTIVE_PINS) == set(_outputs.ENGINES)
+
+
+@pytest.mark.parametrize("version", ["0.7.3", "5.11.0", "1.0.0"])
+def test_safe_version_maps_dots_to_underscores(version: str) -> None:
+    assert _outputs.safe_version(version) == "v" + version.replace(".", "_")
+
+
+def test_safe_version_rejects_illegal_input() -> None:
+    with pytest.raises(ValueError):
+        _outputs.safe_version("0.7.3/../etc")
+
+
+@pytest.mark.parametrize(("engine", "version"), _PINS)
+def test_snapshot_has_both_mined_files(engine: str, version: str) -> None:
+    schema = _outputs.schema_path(engine, version)
+    curated = _outputs.curated_path(engine, version)
+    assert schema.is_file(), f"missing schema for {engine} {version}: {schema}"
+    assert curated.is_file(), f"missing curated for {engine} {version}: {curated}"
+
+
+@pytest.mark.parametrize(("engine", "version"), _PINS)
+def test_schema_parses_and_self_identifies(engine: str, version: str) -> None:
+    data = json.loads(_outputs.schema_path(engine, version).read_text())
+    assert data.get("engine") == engine
+    assert data.get("engine_version") == version
+
+
+@pytest.mark.parametrize(("engine", "version"), _PINS)
+def test_curated_parses_and_self_identifies(engine: str, version: str) -> None:
+    data = yaml.safe_load(_outputs.curated_path(engine, version).read_text())
+    assert isinstance(data, dict)
+    assert data.get("engine") == engine
+    assert data.get("engine_version") == version
+
+
+@pytest.mark.parametrize(("engine", "versions"), ACTIVE_PINS.items())
+def test_workspace_versions_matches_active_pins(engine: str, versions: tuple[str, ...]) -> None:
+    assert _outputs.workspace_versions(engine) == sorted(versions, key=_version_key)
+
+
+def test_outputs_dir_is_under_the_workspace() -> None:
+    resolved = _outputs.outputs_dir("vllm", "0.7.3").resolve()
+    workspace = (Path(_outputs.__file__).resolve().parent).resolve()
+    assert workspace in resolved.parents
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))


### PR DESCRIPTION
## Summary

Establishes the engine-knowledge SSOT workspace layout on top of current main.
The workspace stores one mined snapshot per active engine version under
`engine_versions/<engine>/v<safe_version>/outputs/`, each holding:

- `schema.discovered.json` - the full configuration surface discovered for that
  engine version.
- `curated.yaml` - the maintainer allowlist naming which discovered fields llem
  exposes as first-class typed fields.

Active snapshots landed (schema + curated, byte-copied in as mined data):

| engine       | versions          |
| ------------ | ----------------- |
| vllm         | 0.7.3, 0.19.1     |
| tensorrt     | 0.21.0, 1.0.0     |
| transformers | 5.7.0             |

Hand-written additions:

- `engine_versions/_outputs.py` - a plain path resolver mapping
  `(engine, version)` to the two mined files, plus `workspace_versions()` which
  reports present versions by scanning the tree (directory is the source of
  truth; no hand-maintained list). No engine imports, no dynamic module
  loading, no magic attribute delegation.
- `engine_versions/README.md` - plain-language description of the layout.
- Minimal `__init__.py` for the two new version directories.

Scope boundaries (deferred to later steps):

- `current.yaml` is left at its existing version pins, and `src/` schema
  shadows are untouched. Those two move together with schema regeneration; the
  CI schema-version check couples `current.yaml::library.current_version` to
  `src/.../schema.discovered.json::engine_version`, so advancing the pointer
  here (without regenerating `src/`) would break that check. The pointer
  advance belongs with the codegen step.
- No rules-corpus files, no producer modules, no overlay files are introduced
  or ported.

Data files (`schema.discovered.json`, `curated.yaml`) are mined artifacts and
exempt from the LoC budget; hand-written production code is ~167 lines.

## Test plan

- `make lint` (ruff check, ruff format --check, import-linter): pass. The
  `engine_versions is CI-time tooling; runtime layers must not import it`
  contract stays kept.
- `make typecheck` (mypy strict on `src/` + `tests/`): pass; the new module is
  type-checked via the test import.
- New `tests/_engine_archive/test_ssot_layout.py` (24 cases): every active
  snapshot has both mined files, each parses and self-identifies its engine +
  version, and the resolver's scan matches the expected active pins.
- Full engine-knowledge blast-radius subset (265 cases: dispatcher, smoke,
  lazy, renovate, schema-version check, drift, diff, version-handshake,
  schema-loader, all miner tests): 242 passed, 25 skipped.
