### PR TITLE
refactor(producers): shared schema-extraction substrate

### DIFF
--- a/engine_versions/tensorrt/v1_0_0/outputs/schema.discovered.json
+++ b/engine_versions/tensorrt/v1_0_0/outputs/schema.discovered.json
@@ -20,7 +20,7 @@
       "fields": [
         "cp_config"
       ],
-      "reason": "cp_config is a bare dict (context-parallel settings) with no Pydantic/dataclass schema class; leaves are not introspectable and must come from overlay.yaml if exposed"
+      "reason": "cp_config is a bare dict (context-parallel settings) with no Pydantic/dataclass schema class; leaves are not introspectable and must come from curated overrides if exposed"
     },
     {
       "section": "sampling_params",

--- a/engine_versions/tensorrt/v1_0_0/producers/__init__.py
+++ b/engine_versions/tensorrt/v1_0_0/producers/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``schema_introspector`` (schemas)."""

--- a/engine_versions/tensorrt/v1_0_0/producers/schema_introspector.py
+++ b/engine_versions/tensorrt/v1_0_0/producers/schema_introspector.py
@@ -1,0 +1,171 @@
+"""Schema introspector for TensorRT-LLM 1.0.0.
+
+Runs inside ``nvcr.io/nvidia/tensorrt-llm/release:1.0.0`` (CUDA 13.x).
+Introspects ``TrtLlmArgs`` and ``SamplingParams`` and writes a JSON schema file
+with the common envelope. Import-driven (needs the installed library): this
+introspector is a GPU-container artefact, not runnable on the host.
+
+Surface contract:
+  - TrtLlmArgs is a Pydantic v2 BaseModel with model_json_schema()
+  - LlmArgs is an alias for TrtLlmArgs
+  - BuildConfig is a stdlib dataclass (folded via a field->class hint)
+  - KvCacheConfig / SchedulerConfig / CalibConfig / BuildCacheConfig are Pydantic
+    (rendered via TrtLlmArgs' own $defs)
+  - SamplingParams is a dataclass with public fields
+  - tensorrt_llm.__commit__ is not exposed (null)
+
+The ``LANDMARKS`` tuple is the probe contract (``scripts/_drift.py`` resolves
+each dotted path under the installed library before discovery runs); a missing
+entry flips the probe verdict to ``fail``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+from scripts.engine_producers._common import (
+    dataclass_fields_to_specs,
+    fold_dict_typed_subconfig,
+    make_envelope,
+    merge_source_constraints,
+)
+
+LANDMARKS: tuple[str, ...] = (
+    "tensorrt_llm.SamplingParams",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs",
+    "tensorrt_llm.llmapi.llm_args.TrtLlmArgs.model_json_schema",
+)
+
+
+def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
+    """Discover TensorRT-LLM 1.0.0 engine and sampling schemas.
+
+    engine_params:   TrtLlmArgs.model_json_schema() properties (with description + deprecated)
+    sampling_params: dataclasses.fields(SamplingParams)
+    """
+    import tensorrt_llm  # type: ignore[import-not-found]
+    from tensorrt_llm import SamplingParams  # type: ignore[import-not-found]
+    from tensorrt_llm.builder import BuildConfig  # type: ignore[import-not-found]
+    from tensorrt_llm.llmapi.llm_args import TrtLlmArgs  # type: ignore[import-not-found]
+
+    limitations: list[dict[str, Any]] = []
+
+    raw_schema = TrtLlmArgs.model_json_schema()
+    # ``model_json_schema()`` returns the nested-class $defs (KvCacheConfig /
+    # SchedulerConfig / ...); seed the accumulator with them so the dataclass-lift
+    # folds below (BuildConfig etc.) land in the same $defs namespace.
+    defs: dict[str, Any] = dict(raw_schema.get("$defs") or {})
+    engine_params: dict[str, Any] = {}
+    for name, spec in raw_schema.get("properties", {}).items():
+        if name.startswith("_"):
+            continue
+        type_repr: Any = spec.get("type")
+        if type_repr is None and "anyOf" in spec:
+            parts: list[str] = []
+            for sub in spec["anyOf"]:
+                if "type" in sub:
+                    part = "None" if sub["type"] == "null" else str(sub["type"])
+                elif "$ref" in sub:
+                    part = str(sub["$ref"]).rsplit("/", 1)[-1]
+                else:
+                    continue
+                if part not in parts:  # dedupe string | string etc.
+                    parts.append(part)
+            type_repr = " | ".join(parts) if parts else "unknown"
+        elif type_repr is None and "$ref" in spec:
+            type_repr = str(spec["$ref"]).rsplit("/", 1)[-1]
+        if isinstance(type_repr, list):
+            type_repr = " | ".join("None" if t == "null" else str(t) for t in type_repr)
+        elif type_repr == "null":
+            type_repr = "None"
+        engine_params[name] = {
+            "type": type_repr or "unknown",
+            "default": spec.get("default"),
+            "description": spec.get("description"),
+            "deprecated": spec.get("deprecated", False),
+        }
+
+    # build_config / decoding_config / cp_config are non-Pydantic on TrtLlmArgs, so
+    # model_json_schema() renders them as bare Optional[object]/Optional[dict] with no
+    # $def, burying their leaves. BuildConfig is a stdlib dataclass -> fold it via the
+    # field->class hint so the build-time levers (max_batch_size / max_num_tokens /
+    # max_seq_len caps, plugin_config, weight_streaming, kv_cache_type, max_draft_len, ...)
+    # become discoverable rather than hidden behind one opaque object.
+    fold_dict_typed_subconfig(engine_params, "build_config", BuildConfig, defs)
+
+    # decoding_config is also non-Pydantic; fold it if it resolves to an introspectable
+    # class, else record the gap honestly (it is largely superseded by the richly-mined
+    # speculative_config decoding union). DecodingConfig is a plain class on 1.0.0 (not a
+    # dataclass/Pydantic model), so the fold no-ops and we record the limitation; a future
+    # version that makes it a dataclass would fold automatically.
+    decoding_reason: str | None = None
+    try:
+        from tensorrt_llm.llmapi.llm_args import (  # type: ignore[import-not-found]
+            DecodingConfig,
+        )
+
+        if not fold_dict_typed_subconfig(engine_params, "decoding_config", DecodingConfig, defs):
+            decoding_reason = (
+                "DecodingConfig is a plain (non-Pydantic, non-dataclass) class; not "
+                "introspectable by the dataclass-lift, and superseded by the mined "
+                "speculative_config decoding union"
+            )
+    except Exception as exc:  # pragma: no cover - defensive: class-path drift
+        decoding_reason = f"DecodingConfig not importable ({exc!r}); left as Optional[object]"
+    if decoding_reason is not None:
+        limitations.append(
+            {"section": "engine_params", "fields": ["decoding_config"], "reason": decoding_reason}
+        )
+
+    # cp_config is a bare Optional[dict] (context-parallel settings: cp_type / cp_size /
+    # ...) with NO schema class to introspect, so its leaves can only come from an
+    # overlay. Recorded so the gap is explicit rather than silently absent from the
+    # discovered surface.
+    limitations.append(
+        {
+            "section": "engine_params",
+            "fields": ["cp_config"],
+            "reason": "cp_config is a bare dict (context-parallel settings) with no "
+            "Pydantic/dataclass schema class; leaves are not introspectable and must "
+            "come from curated overrides if exposed",
+        }
+    )
+
+    sampling_params = dataclass_fields_to_specs(SamplingParams, skip_private=True)
+
+    # Fold source-text Field(...) bounds + Literal[...] membership onto the
+    # discovered SamplingParams fields. engine_params already carries pydantic's
+    # own bounds/enums via model_json_schema(), so the walk targets the dataclass
+    # sampling source where field metadata is otherwise absent - near-zero on
+    # 1.0.0; the wiring carries forward to later sampling surfaces.
+    sp_source = inspect.getsourcefile(SamplingParams)
+    if sp_source is not None:
+        merge_source_constraints(sampling_params, [Path(sp_source)])
+
+    limitations.append(
+        {
+            "section": "sampling_params",
+            "fields": [],
+            "reason": "SamplingParams is a dataclass; no per-field descriptions",
+        }
+    )
+
+    # tensorrt-llm runs inside the NGC release image; the workflow passes
+    # its concrete reference via --image-ref. No first-party Dockerfile
+    # to read.
+    return make_envelope(
+        engine="tensorrt",
+        engine_version=tensorrt_llm.__version__,
+        engine_commit_sha=getattr(tensorrt_llm, "__commit__", None),
+        image_ref=image_ref,
+        base_image_ref=None,
+        discovery_method="TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
+        discovery_limitations=limitations,
+        engine_params=engine_params,
+        sampling_params=sampling_params,
+        # The pydantic $defs (KvCacheConfig / SchedulerConfig / ...) plus the
+        # dataclass-lift folds (BuildConfig / DecodingConfig) accumulated above.
+        defs=defs,
+    )

--- a/engine_versions/transformers/v5_7_0/producers/__init__.py
+++ b/engine_versions/transformers/v5_7_0/producers/__init__.py
@@ -1,0 +1,1 @@
+"""Per-producer machinery modules: ``schema_introspector`` (schemas)."""

--- a/engine_versions/transformers/v5_7_0/producers/schema_introspector.py
+++ b/engine_versions/transformers/v5_7_0/producers/schema_introspector.py
@@ -1,0 +1,173 @@
+"""Schema introspector for HuggingFace Transformers 5.7.0.
+
+Runs inside ``llenergymeasure:transformers-<tag>``. Introspects
+``AutoModelForCausalLM.from_pretrained``, ``PreTrainedModel.from_pretrained``
+and ``GenerationConfig`` and writes a JSON schema file with the common envelope.
+
+Vendored, version-pinned: the global
+``scripts/engine_producers/transformers_schema_introspector.py`` is a dispatcher
+stub that delegates here via the SSOT's ``library.current_version``.
+
+The ``LANDMARKS`` tuple is the probe contract (``scripts/_drift.py`` resolves
+each dotted path under the installed library before discovery runs).
+``PreTrainedModel`` is declared at its canonical home
+``transformers.modeling_utils`` rather than the top-level ``transformers``
+namespace: the top-level name is a lazy re-export whose materialisation depends
+on backend (torch) import state at access time, while the canonical module path
+imports directly and resolves stably across the 4.57 / 5.7-5.10 line. The other
+entries re-export reliably and stay on their top-level paths.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+from scripts.engine_producers._common import (
+    TRANSFORMERS_DOCKERFILE,
+    annotation_to_type_str,
+    docstring_arg_types,
+    jsonable,
+    make_envelope,
+    merge_source_constraints,
+    read_dockerfile_from,
+)
+
+LANDMARKS: tuple[str, ...] = (
+    "transformers.AutoModelForCausalLM",
+    "transformers.AutoModelForCausalLM.from_pretrained",
+    "transformers.modeling_utils.PreTrainedModel",
+    "transformers.modeling_utils.PreTrainedModel.from_pretrained",
+    "transformers.GenerationConfig",
+    "transformers.GenerationConfig.to_dict",
+)
+
+
+def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
+    """Discover HuggingFace Transformers schemas.
+
+    engine_params:   best-effort inspect.signature(from_pretrained) scrape;
+                     **kwargs are opaque and recorded as a limitation
+    sampling_params: GenerationConfig().to_dict() (~69 fields); type comes from
+                     the docstring Args block (annotation surface) then the
+                     runtime value's type; None-defaulted + undocumented fields
+                     get type='unknown' and are listed in discovery_limitations
+    """
+    import transformers  # type: ignore[import-not-found]
+    from transformers import (  # type: ignore[import-not-found]
+        AutoModelForCausalLM,
+        GenerationConfig,
+    )
+
+    # Import from the canonical home; the top-level re-export is lazy and can
+    # fail to materialise at access time depending on backend import state.
+    from transformers.modeling_utils import (  # type: ignore[import-not-found]
+        PreTrainedModel,
+    )
+
+    limitations: list[dict[str, Any]] = []
+    engine_params: dict[str, Any] = {}
+    kwargs_points: list[str] = []
+
+    for cls_name, cls in (
+        ("AutoModelForCausalLM", AutoModelForCausalLM),
+        ("PreTrainedModel", PreTrainedModel),
+    ):
+        try:
+            sig = inspect.signature(cls.from_pretrained)
+        except (TypeError, ValueError) as exc:
+            limitations.append(
+                {
+                    "section": "engine_params",
+                    "fields": [cls_name],
+                    "reason": f"inspect.signature({cls_name}.from_pretrained) failed: {exc!r}",
+                }
+            )
+            continue
+
+        for name, param in sig.parameters.items():
+            if name in ("self", "cls", "pretrained_model_name_or_path"):
+                continue
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                kwargs_points.append(f"{cls_name}.from_pretrained.**{name}")
+                continue
+            if name in engine_params:
+                continue  # prefer AutoModelForCausalLM over PreTrainedModel
+            default = None if param.default is inspect.Parameter.empty else param.default
+            engine_params[name] = {
+                "type": annotation_to_type_str(param.annotation),
+                "default": jsonable(default),
+            }
+
+    if kwargs_points:
+        limitations.append(
+            {
+                "section": "engine_params",
+                "fields": kwargs_points,
+                "reason": "from_pretrained accepts **kwargs; kwargs are not in the signature "
+                "(documented kwargs live in the class docstring only)",
+            }
+        )
+
+    # Type source priority: documented type (GenerationConfig's docstring Args
+    # block - the only machine-readable annotation surface, since the class is
+    # __init__(self, **kwargs) with no field annotations) THEN the runtime value's
+    # type. transformers 5.x moved most GenerationConfig defaults to None, so
+    # value-inference alone regresses previously-typed scalars (num_beams,
+    # temperature, ...) to type='unknown'; reading the docstring type first keeps
+    # them typed across the None-default bump.
+    sampling_params: dict[str, Any] = {}
+    unknown_fields: list[str] = []
+    doc_types = docstring_arg_types(GenerationConfig)
+    gc = GenerationConfig()
+    for name, value in gc.to_dict().items():
+        documented = doc_types.get(name)
+        if documented is not None:
+            sampling_params[name] = {"type": documented, "default": jsonable(value)}
+        elif value is None:
+            sampling_params[name] = {"type": "unknown", "default": None}
+            unknown_fields.append(name)
+        elif isinstance(value, (list, tuple)):
+            sampling_params[name] = {"type": type(value).__name__, "default": jsonable(value)}
+        elif isinstance(value, dict):
+            sampling_params[name] = {"type": "dict", "default": jsonable(value)}
+        else:
+            sampling_params[name] = {
+                "type": type(value).__name__,
+                "default": jsonable(value),
+            }
+
+    if unknown_fields:
+        limitations.append(
+            {
+                "section": "sampling_params",
+                "fields": unknown_fields,
+                "reason": "GenerationConfig field is None-defaulted and undocumented in the "
+                "docstring Args block; type='unknown'",
+            }
+        )
+
+    # Fold source-text Field(...) bounds + Literal[...] membership onto the
+    # discovered GenerationConfig sampling fields. Without it a re-mine cannot
+    # surface declarative constraints the walk reads from class source. Near-zero
+    # on a pin whose GenerationConfig stuffs fields via **kwargs self-assigns, but
+    # the plumbing is load-bearing once a pin moves to class-body Field()/Literal
+    # declarations.
+    gen_source = inspect.getsourcefile(GenerationConfig)
+    if gen_source is not None:
+        merge_source_constraints(sampling_params, [Path(gen_source)])
+
+    base_image_ref = read_dockerfile_from(repo_root / TRANSFORMERS_DOCKERFILE)
+    return make_envelope(
+        engine="transformers",
+        engine_version=transformers.__version__,
+        engine_commit_sha=getattr(transformers, "__commit__", None),
+        image_ref=image_ref or base_image_ref,
+        base_image_ref=base_image_ref,
+        discovery_method="inspect.signature(from_pretrained) + GenerationConfig().to_dict() "
+        "with docstring-Args type recovery",
+        discovery_limitations=limitations,
+        engine_params=engine_params,
+        sampling_params=sampling_params,
+    )

--- a/engine_versions/vllm/v0_19_1/producers/schema_introspector.py
+++ b/engine_versions/vllm/v0_19_1/producers/schema_introspector.py
@@ -1,25 +1,36 @@
-"""Schema-introspector machinery for vLLM 0.19.1.
+"""Schema introspector for vLLM 0.19.1.
 
-Vendored machinery: the full ``discover`` body lives here, version-pinned.
-The global ``scripts/engine_producers/vllm_introspector.py`` is a
-thin dispatcher that resolves ``library.current_version`` from the SSOT
-and delegates to this module.
+Vendored machinery: the full ``discover`` body lives here, version-pinned. The
+global ``scripts/engine_producers/vllm_schema_introspector.py`` is a thin
+dispatcher that resolves ``library.current_version`` from the SSOT and delegates
+to this module.
 
-vLLM 0.19.1 retains the runtime-introspection surface contract from
-0.16.0: ``vllm.engine.arg_utils.EngineArgs`` is a stdlib dataclass and
-``vllm.SamplingParams`` is msgspec-typed. The introspector emits the
-common envelope with engine + sampling parameter specs.
+vLLM 0.19.1 keeps the same runtime-introspection surface as 0.7.3 -
+``vllm.engine.arg_utils.EngineArgs`` is a stdlib dataclass and
+``vllm.SamplingParams`` is msgspec-typed - so the dataclass/msgspec discovery
+path is unchanged. What moved is the *declarative constraint surface*: 0.7.3's
+flat ``vllm/config.py`` became the ``vllm/config/*.py`` subpackage (cache,
+scheduler, parallel, model, ...) and the per-concern config classes migrated to
+pydantic-dataclass ``Field(ge/le/...)`` bounds and ``Literal[...]`` membership
+sets. The source-constraint overlay below therefore globs the whole ``config/``
+subpackage rather than the single flat file, so the declarative walk reaches the
+bounds and enums that no longer live in the imperative ``_verify_*`` bodies.
 """
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from typing import Any
 
 from scripts.engine_producers._common import (
     dataclass_fields_to_specs,
+    fold_dict_typed_subconfig,
     make_envelope,
+    merge_source_constraints,
+    recover_field_types,
 )
+from scripts.engine_producers._source_walker import expand_files
 
 LANDMARKS: tuple[str, ...] = (
     "vllm.SamplingParams",
@@ -28,7 +39,7 @@ LANDMARKS: tuple[str, ...] = (
 
 
 def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
-    """Discover vLLM engine and sampling schemas.
+    """Discover vLLM 0.19.1 engine and sampling schemas.
 
     engine_params:   dataclasses.fields(EngineArgs)
     sampling_params: msgspec.json.schema(SamplingParams)
@@ -37,18 +48,50 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
     from vllm.engine.arg_utils import EngineArgs  # type: ignore[import-not-found]
 
     limitations: list[dict[str, Any]] = []
-    engine_params = dataclass_fields_to_specs(EngineArgs)
+    # Shared ``$defs`` accumulator: EngineArgs' Pydantic-typed sub-configs and
+    # SamplingParams' nested msgspec definitions both land here so every ``$ref``
+    # in the envelope resolves.
+    defs: dict[str, Any] = {}
+    engine_params = dataclass_fields_to_specs(EngineArgs, defs=defs)
+
+    # speculative_config is annotated ``dict[str, Any] | None`` on EngineArgs but
+    # is coerced to ``SpeculativeConfig(**dict)`` in
+    # ``EngineArgs.create_speculative_config``; carry that field->class hint so
+    # the speculative-decoding leaves (num_speculative_tokens, method,
+    # draft_tensor_parallel_size, ...) are discoverable rather than hidden behind
+    # one opaque dict. Version-pinned to 0.19.1's import path; failure degrades
+    # to the dict spec plus a recorded limitation rather than aborting discovery.
+    try:
+        from vllm.config.speculative import (  # type: ignore[import-not-found]
+            SpeculativeConfig,
+        )
+
+        fold_dict_typed_subconfig(engine_params, "speculative_config", SpeculativeConfig, defs)
+    except Exception as exc:  # pragma: no cover - defensive: version-path drift
+        limitations.append(
+            {
+                "section": "engine_params",
+                "fields": ["speculative_config"],
+                "reason": f"SpeculativeConfig class-hint resolution failed ({exc!r}); "
+                "speculative_config left as dict[str, Any]",
+            }
+        )
 
     sampling_params: dict[str, Any] = {}
     try:
         import msgspec  # type: ignore[import-not-found]
 
         raw_schema = msgspec.json.schema(vllm.SamplingParams)
+        raw_defs = raw_schema.get("$defs") or raw_schema.get("definitions") or {}
         props = raw_schema.get("properties")
         if not props:
-            defs = raw_schema.get("$defs") or raw_schema.get("definitions") or {}
-            sp_def: Any = defs.get("SamplingParams") or next(iter(defs.values()), {})
+            sp_def: Any = raw_defs.get("SamplingParams") or next(iter(raw_defs.values()), {})
             props = sp_def.get("properties", {}) if isinstance(sp_def, dict) else {}
+        # Carry the nested sub-definitions (SamplingParams' own root is flattened
+        # into ``sampling_params`` above, so skip it to avoid a redundant def).
+        for def_name, def_body in raw_defs.items():
+            if def_name != "SamplingParams":
+                defs.setdefault(def_name, def_body)
         for name, spec in (props or {}).items():
             type_repr: Any = spec.get("type", "unknown")
             if isinstance(type_repr, list):
@@ -57,6 +100,16 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
                 "type": type_repr,
                 "default": spec.get("default"),
             }
+        # msgspec.json.schema renders union / enum / nested-struct sampling
+        # fields as an untyped anyOf, so the loop above labels them "unknown".
+        # recover_field_types resolves those same fields' concrete types, so fold
+        # the recovered type onto every field still marked "unknown" - augmenting
+        # the schema, never overwriting a type json.schema already rendered.
+        recovered_types = recover_field_types(vllm.SamplingParams)
+        for name, type_str in recovered_types.items():
+            spec = sampling_params.get(name)
+            if spec is not None and spec.get("type") == "unknown":
+                spec["type"] = type_str
     except Exception as exc:
         limitations.append(
             {
@@ -65,6 +118,28 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
                 "reason": f"msgspec.json.schema(SamplingParams) failed: {exc!r}",
             }
         )
+
+    # Fold source-text Field(...) bounds + Literal[...] membership onto the
+    # discovered fields. On 0.19.1 the per-concern config classes (CacheConfig,
+    # SchedulerConfig, ParallelConfig, ...) live in the ``vllm/config/*.py``
+    # subpackage and carry their constraints declaratively, so the overlay globs
+    # the WHOLE subpackage rather than the single ``config/__init__.py`` that
+    # ``inspect.getsourcefile(vllm.config)`` resolves to. The flat single-file
+    # walk (0.7.3) would miss every per-concern module.
+    try:
+        import vllm.config as _vllm_config  # type: ignore[import-not-found]
+        import vllm.sampling_params as _vllm_sp  # type: ignore[import-not-found]
+
+        config_init = inspect.getsourcefile(_vllm_config)
+        config_paths = (
+            expand_files(Path(config_init).parent, ["*.py"]) if config_init is not None else []
+        )
+        merge_source_constraints(engine_params, config_paths)
+        sp_src = inspect.getsourcefile(_vllm_sp)
+        if sp_src is not None:
+            merge_source_constraints(sampling_params, [Path(sp_src)])
+    except Exception:  # pragma: no cover - defensive: discovery proceeds without bounds
+        pass
 
     limitations.append(
         {
@@ -88,8 +163,12 @@ def discover(repo_root: Path, image_ref: str | None) -> dict[str, Any]:
         engine_commit_sha=getattr(vllm, "__commit__", None),
         image_ref=image_ref,
         base_image_ref=None,
-        discovery_method="dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
+        discovery_method=(
+            "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams) "
+            "+ config/*.py declarative-constraint overlay"
+        ),
         discovery_limitations=limitations,
         engine_params=engine_params,
         sampling_params=sampling_params,
+        defs=defs,
     )

--- a/scripts/engine_producers/_common.py
+++ b/scripts/engine_producers/_common.py
@@ -203,6 +203,28 @@ def _sorted_stable(items: list[Any]) -> list[Any]:
         return sorted(items, key=lambda x: (x is None, str(x)))
 
 
+def _coerce_json(value: Any, *, opaque: Any) -> Any:
+    """Recursively coerce *value* into json-safe data.
+
+    Shared traversal for :func:`jsonable` and :func:`exposable_default`: both
+    pass through primitives, recurse structures (list/tuple/set/dict), and render
+    a ``type`` as its name - they differ ONLY in how an opaque leaf is handled,
+    supplied here as ``opaque(value)`` (``str`` to stringify, ``lambda _: None``
+    to drop it).
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_coerce_json(v, opaque=opaque) for v in value]
+    if isinstance(value, set):
+        return _sorted_stable([_coerce_json(v, opaque=opaque) for v in value])
+    if isinstance(value, dict):
+        return {str(k): _coerce_json(v, opaque=opaque) for k, v in value.items()}
+    if isinstance(value, type):
+        return value.__name__
+    return opaque(value)
+
+
 def jsonable(value: Any) -> Any:
     """Coerce a value into something json.dumps can handle without default=str.
 
@@ -210,17 +232,7 @@ def jsonable(value: Any) -> Any:
     str(value) for anything else. This keeps the output deterministic and
     free of object repr noise.
     """
-    if value is None or isinstance(value, (bool, int, float, str)):
-        return value
-    if isinstance(value, (list, tuple)):
-        return [jsonable(v) for v in value]
-    if isinstance(value, set):
-        return _sorted_stable([jsonable(v) for v in value])
-    if isinstance(value, dict):
-        return {str(k): jsonable(v) for k, v in value.items()}
-    if isinstance(value, type):
-        return value.__name__
-    return str(value)
+    return _coerce_json(value, opaque=str)
 
 
 def exposable_default(value: Any) -> Any:
@@ -235,17 +247,7 @@ def exposable_default(value: Any) -> Any:
     the user sets it. Pin this contract in tests so the str() regression can't
     return silently.
     """
-    if value is None or isinstance(value, (bool, int, float, str)):
-        return value
-    if isinstance(value, (list, tuple)):
-        return [exposable_default(v) for v in value]
-    if isinstance(value, set):
-        return _sorted_stable([exposable_default(v) for v in value])
-    if isinstance(value, dict):
-        return {str(k): exposable_default(v) for k, v in value.items()}
-    if isinstance(value, type):
-        return value.__name__
-    return None
+    return _coerce_json(value, opaque=lambda _value: None)
 
 
 def _single_candidate(annotation: Any) -> Any | None:

--- a/scripts/engine_producers/_common.py
+++ b/scripts/engine_producers/_common.py
@@ -1,31 +1,53 @@
-"""Shared helpers for per-engine introspectors.
+"""Shared helpers for per-engine schema introspectors.
 
 Introspectors run inside an environment where the target engine package is
-installed (typically a Docker container). For each engine, they introspect
-the native Python API surface and write a JSON schema file with a common
-envelope. The envelope is versioned separately from the engines (see
+installed (typically a Docker container). For each engine, they introspect the
+native Python API surface and write a JSON schema file with a common envelope.
+The envelope is versioned separately from the engines (see
 :data:`SCHEMA_VERSION`); major bumps are breaking and SchemaLoader rejects
 them. Minor bumps add envelope keys; downstream loaders are expected to be
 forward-compatible.
 
-"Introspector" is the runtime-introspection counterpart to "miner"
-(AST/static-source extraction). Per-engine modules under
-``scripts.engine_producers`` (schema introspector modules) mirror the per-engine miner structure
-under ``scripts.engine_producers``.
+This module is the schema-discovery substrate: runtime-introspection helpers
+(``dataclass_fields_to_specs``, ``recover_field_types``, ``make_envelope``) plus
+the fold that overlays source-text bounds and enums (via
+:mod:`scripts.engine_producers._source_walker`) onto discovered fields. It
+imports no engine library and no validation-mining machinery.
 """
 
 from __future__ import annotations
 
+import ast
 import dataclasses
 import inspect
 import os
 import re
 import types
+import typing
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Union, get_args, get_origin
 
+from scripts.engine_producers._source_walker import walk_declarative_constraints
+
 SCHEMA_VERSION = "1.0.0"
+
+# Declarative-constraint keys the source walker emits (JSON Schema fragments)
+# that the schema introspectors fold onto discovered fields. Type / default
+# come from runtime introspection; these bounds + membership sets come from the
+# source-text walk (Field(ge/le/...) and Literal[...] annotations).
+_CONSTRAINT_KEYS: tuple[str, ...] = (
+    "enum",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "minLength",
+    "maxLength",
+    "minItems",
+    "maxItems",
+)
 
 # Only the transformers engine has a first-party Dockerfile. vllm and
 # tensorrt run inside upstream images (vllm/vllm-openai,
@@ -72,6 +94,48 @@ def annotation_to_type_str(annotation: Any) -> str:
     origin_name = getattr(origin, "__name__", origin_str)
     arg_strs = ", ".join(annotation_to_type_str(a) for a in args)
     return f"{origin_name}[{arg_strs}]"
+
+
+# A HuggingFace-style docstring ``Args:`` entry: ``name (`type`, *optional*, ...):``.
+# The first backticked token after the field name is the documented type. HF uses
+# this convention universally; for classes that ship no real field annotations
+# (GenerationConfig is ``__init__(self, **kwargs)`` with every default ``None``),
+# the docstring is the only machine-readable type source. ``or`` unions
+# (``bool` or `str``) take the first member, matching the value-inference baseline
+# the older pins produced when defaults were still concrete.
+_DOCSTRING_ARG_TYPE = re.compile(r"^\s*(\w+)\s*\(\s*`([A-Za-z_][\w.]*)`")
+
+# Documented docstring type tokens mapped to the introspector's scalar vocabulary
+# (the same surface ``type(value).__name__`` emits for concrete defaults). Tokens
+# outside this set (``torch.dtype``, ``Dict``, ...) are left unmapped so the
+# field falls through to default-inference rather than inventing a scalar type.
+_DOC_TYPE_TO_SCALAR: dict[str, str] = {
+    "bool": "bool",
+    "int": "int",
+    "float": "float",
+    "str": "str",
+}
+
+
+def docstring_arg_types(obj: Any) -> dict[str, str]:
+    """Map ``{field: scalar_type}`` from an object's docstring ``Args:`` block.
+
+    Reads HuggingFace's documented-arg convention as a type-annotation source for
+    classes that carry no real field annotations. Only scalar tokens in
+    :data:`_DOC_TYPE_TO_SCALAR` are returned; non-scalar or undocumented fields are
+    omitted so the caller can fall back to default-value inference. Returns an empty
+    dict when the object has no docstring.
+    """
+    doc = inspect.getdoc(obj) or ""
+    out: dict[str, str] = {}
+    for line in doc.splitlines():
+        match = _DOCSTRING_ARG_TYPE.match(line)
+        if match is None:
+            continue
+        scalar = _DOC_TYPE_TO_SCALAR.get(match.group(2))
+        if scalar is not None:
+            out.setdefault(match.group(1), scalar)
+    return out
 
 
 def read_dockerfile_from(dockerfile: Path) -> str:
@@ -125,6 +189,20 @@ def read_dockerfile_from(dockerfile: Path) -> str:
     return _expand(from_lines[0][0])
 
 
+def _sorted_stable(items: list[Any]) -> list[Any]:
+    """Sort *items* deterministically.
+
+    Falls back to a type-stable key when the elements are not mutually orderable
+    (e.g. opaque values sanitised to ``None`` mixed with primitives, or a
+    genuinely heterogeneous set). Without the fallback ``sorted`` would raise a
+    ``TypeError`` and abort the whole discovery on such a default.
+    """
+    try:
+        return sorted(items)
+    except TypeError:
+        return sorted(items, key=lambda x: (x is None, str(x)))
+
+
 def jsonable(value: Any) -> Any:
     """Coerce a value into something json.dumps can handle without default=str.
 
@@ -137,7 +215,7 @@ def jsonable(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [jsonable(v) for v in value]
     if isinstance(value, set):
-        return sorted(jsonable(v) for v in value)
+        return _sorted_stable([jsonable(v) for v in value])
     if isinstance(value, dict):
         return {str(k): jsonable(v) for k, v in value.items()}
     if isinstance(value, type):
@@ -145,16 +223,153 @@ def jsonable(value: Any) -> Any:
     return str(value)
 
 
+def exposable_default(value: Any) -> Any:
+    """Sanitise a field default for the discovered schema.
+
+    Like :func:`jsonable` for clean structures (primitives, lists, dicts, sets),
+    but an opaque non-serialisable object becomes ``None`` rather than its repr
+    string. A complex default (e.g. a pydantic sub-config instance) must not
+    leak into the schema as a stringified blob: codegen would emit it as a
+    non-None default and forward that bogus value to the engine on every unset
+    run. Recording ``None`` makes the field omit cleanly (exclude_none) unless
+    the user sets it. Pin this contract in tests so the str() regression can't
+    return silently.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [exposable_default(v) for v in value]
+    if isinstance(value, set):
+        return _sorted_stable([exposable_default(v) for v in value])
+    if isinstance(value, dict):
+        return {str(k): exposable_default(v) for k, v in value.items()}
+    if isinstance(value, type):
+        return value.__name__
+    return None
+
+
+def _single_candidate(annotation: Any) -> Any | None:
+    """Return the sole non-``None`` member of ``annotation`` (unwrapping ``X | None``), else None.
+
+    Multi-member unions and bare generics (``list[SubConfig]``) have no single
+    class to ``$ref`` and yield None.
+    """
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        candidates = tuple(a for a in get_args(annotation) if a is not type(None))
+    elif origin is None:
+        candidates = (annotation,)
+    else:
+        return None
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _resolve_pydantic_type(annotation: Any) -> type | None:
+    """Return the Pydantic model OR pydantic-dataclass in ``annotation``, else None.
+
+    Recognises ``pydantic.BaseModel`` subclasses (expose ``model_json_schema``) AND
+    ``pydantic.dataclasses``-decorated classes (expose ``__pydantic_fields__`` but
+    NOT ``model_json_schema`` - e.g. vLLM's ``@config`` sub-configs). Both carry the
+    validation metadata (``Literal`` enums, ``Field(ge/le/...)`` bounds) that the
+    rich :func:`_fold_model_defs` path captures from the pydantic JSON schema; a
+    PLAIN stdlib dataclass has neither and routes to :func:`_resolve_dataclass_type`,
+    whose bare-fields walk cannot see those bounds. Nested generics
+    (``list[SubConfig]``) have no single class to ``$ref`` and yield None.
+    """
+    candidate = _single_candidate(annotation)
+    if isinstance(candidate, type) and (
+        hasattr(candidate, "model_json_schema") or hasattr(candidate, "__pydantic_fields__")
+    ):
+        return candidate
+    return None
+
+
+def _resolve_dataclass_type(annotation: Any) -> type | None:
+    """Return the non-Pydantic ``@dataclass`` in ``annotation`` (unwrapping ``X | None``), else None.
+
+    The Pydantic path (:func:`_resolve_pydantic_type`) takes precedence; this
+    catches the stdlib-dataclass sub-configs that engine-args classes nest
+    WITHOUT Pydantic (e.g. vLLM ``CompilationConfig`` / ``AttentionConfig``,
+    which expose no ``model_json_schema``), so they recurse into ``$defs``
+    instead of flattening to a bare type-name string.
+    """
+    candidate = _single_candidate(annotation)
+    if (
+        isinstance(candidate, type)
+        and dataclasses.is_dataclass(candidate)
+        and not hasattr(candidate, "model_json_schema")
+        and not hasattr(candidate, "__pydantic_fields__")
+    ):
+        return candidate
+    return None
+
+
+def _literal_enum_spec(annotation: Any) -> dict[str, Any] | None:
+    """If *annotation* is ``Literal[...]`` (optionally ``X | None``), return ``{type, enum}``.
+
+    A flat ``Literal``-annotated field (e.g. vLLM ``EngineArgs.dtype``) otherwise
+    renders as the opaque ``"Literal[...]"`` type STRING via
+    :func:`annotation_to_type_str`, which the codegen's scalar-only translator
+    cannot parse and collapses to ``Any | None`` - so the membership set never
+    reaches the generated config. Capturing it as a structured JSON Schema ``enum``
+    (plus the members' base scalar type) lets the codegen project a real
+    ``Literal[...]`` field. Mirrors the enum capture the Pydantic ``$ref`` path
+    already gets from :func:`_fold_model_defs`. Returns ``None`` for non-Literal
+    annotations. Membership is rendered in declared order (deterministic).
+    """
+    candidate = annotation
+    origin = get_origin(candidate)
+    if origin is Union or origin is types.UnionType:
+        non_none = [a for a in get_args(candidate) if a is not type(None)]
+        if len(non_none) != 1:
+            return None
+        candidate = non_none[0]
+        origin = get_origin(candidate)
+    if origin is None or "Literal" not in str(origin):
+        return None
+    members = list(get_args(candidate))
+    spec: dict[str, Any] = {"enum": [jsonable(m) for m in members]}
+    member_types = {type(m) for m in members}
+    if member_types == {str}:
+        spec["type"] = "str"
+    elif member_types == {bool}:
+        spec["type"] = "bool"
+    elif member_types == {int}:
+        spec["type"] = "int"
+    elif member_types <= {int, float}:
+        spec["type"] = "float"
+    # Mixed / non-scalar members: emit the enum alone (codegen builds the Literal
+    # from membership without a base scalar type).
+    return spec
+
+
 def dataclass_fields_to_specs(
-    cls: type, *, skip_private: bool = False
+    cls: type,
+    *,
+    skip_private: bool = False,
+    defs: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Extract ``{name: {type, default}}`` specs from a dataclass.
 
     Resolves ``default_factory`` by calling it (swallowing errors to ``None``)
     so downstream JSON stays concrete. Types are rendered via
     ``annotation_to_type_str``.
+
+    When a field's resolved type is a sub-config class and a ``defs`` accumulator
+    is supplied, the field is emitted as a JSON Schema ``$ref`` and the class is
+    folded into ``defs``: a Pydantic model via its ``model_json_schema()``
+    (:func:`_fold_model_defs`), a stdlib ``@dataclass`` via a recursive walk of
+    its own fields (:func:`_fold_dataclass_defs`). This surfaces the sub-configs
+    nested inside stdlib-dataclass engine-args (e.g. vllm ``EngineArgs`` ->
+    ``CompilationConfig`` / ``AttentionConfig``) that would otherwise flatten to
+    a bare type-name string. Pass the same ``defs`` dict to :func:`make_envelope`
+    to ship it.
     """
     specs: dict[str, dict[str, Any]] = {}
+    # Only resolve string annotations to real types when recursion is requested -
+    # the legacy (defs=None) path keeps rendering ``fld.type`` exactly as before
+    # so existing committed schema type strings are unchanged.
+    hints = _safe_type_hints(cls) if defs is not None else {}
     for fld in dataclasses.fields(cls):
         if skip_private and fld.name.startswith("_"):
             continue
@@ -166,11 +381,277 @@ def dataclass_fields_to_specs(
                 default = fld.default_factory()
             except Exception:
                 default = None
+        if defs is not None:
+            annotation = hints.get(fld.name, fld.type)
+            nested_model = _resolve_pydantic_type(annotation)
+            if nested_model is not None:
+                _fold_model_defs(nested_model, defs)
+                specs[fld.name] = {
+                    "$ref": f"#/$defs/{nested_model.__name__}",
+                    "default": exposable_default(default),
+                }
+                continue
+            nested_dc = _resolve_dataclass_type(annotation)
+            if nested_dc is not None:
+                _fold_dataclass_defs(nested_dc, defs)
+                specs[fld.name] = {
+                    "$ref": f"#/$defs/{nested_dc.__name__}",
+                    "default": exposable_default(default),
+                }
+                continue
+            enum_spec = _literal_enum_spec(annotation)
+            if enum_spec is not None:
+                specs[fld.name] = {**enum_spec, "default": exposable_default(default)}
+                continue
         specs[fld.name] = {
             "type": annotation_to_type_str(fld.type),
-            "default": jsonable(default),
+            "default": exposable_default(default),
         }
     return specs
+
+
+def _safe_type_hints(cls: type) -> dict[str, Any]:
+    """Resolve string annotations to real types, falling back to raw ``field.type``.
+
+    ``from __future__ import annotations`` makes ``field.type`` a string, which
+    cannot be introspected for nested Pydantic models. ``get_type_hints`` evaluates
+    them; resolution can fail on TYPE_CHECKING-only forward refs, so fall back to
+    the raw annotations rather than raising during discovery.
+    """
+    try:
+        return typing.get_type_hints(cls)
+    except Exception:
+        return {f.name: f.type for f in dataclasses.fields(cls)}
+
+
+def _fold_model_defs(model: type, defs: dict[str, Any]) -> None:
+    """Fold ``model``'s root definition and its own ``$defs`` into ``defs``.
+
+    The pydantic JSON schema (``{$defs: {...}, ...root...}`` under the standard
+    ``#/$defs/<Name>`` namespace) carries the validation metadata (``enum``,
+    ``minimum``/``maximum``/``exclusive*``) the bare-dataclass walk loses. A
+    ``BaseModel`` exposes ``model_json_schema``; a ``pydantic.dataclasses`` class
+    does not, so its schema is built via ``pydantic.TypeAdapter`` - the field
+    bounds/enums land identically either way. We lift the root body under the
+    model name and merge transitively-referenced sub-models so every ``$ref``
+    resolves.
+    """
+    try:
+        if hasattr(model, "model_json_schema"):
+            schema = model.model_json_schema(ref_template="#/$defs/{model}")
+        else:
+            import pydantic  # local: keep the host-side dispatch import surface minimal
+
+            schema = pydantic.TypeAdapter(model).json_schema(ref_template="#/$defs/{model}")
+    except Exception:
+        return
+    for name, body in schema.pop("$defs", {}).items():
+        defs.setdefault(name, body)
+    # The root schema body (title/properties/...) becomes this model's own def.
+    defs.setdefault(model.__name__, schema)
+
+
+def _fold_dataclass_defs(cls: type, defs: dict[str, Any]) -> None:
+    """Fold a non-Pydantic ``@dataclass`` and its nested dataclasses into ``defs``.
+
+    The dataclass analogue of :func:`_fold_model_defs` (stdlib dataclasses carry
+    no ``model_json_schema``). Recurses through :func:`dataclass_fields_to_specs`,
+    so a dataclass-typed field (``CompilationConfig.pass_config``) folds its own
+    ``$def`` and ``$ref`` too. A placeholder entry is written BEFORE recursing so
+    a self- or mutually-referential dataclass terminates - the standard ``$defs``
+    cycle break (a re-entry sees ``cls.__name__`` already present and returns,
+    leaving the dangling ``$ref`` to be filled once the outer call completes).
+    """
+    if cls.__name__ in defs:
+        return
+    defs[cls.__name__] = {}  # cycle-break placeholder; overwritten below
+    defs[cls.__name__] = {
+        "title": cls.__name__,
+        "type": "object",
+        "properties": dataclass_fields_to_specs(cls, defs=defs),
+    }
+
+
+def fold_dict_typed_subconfig(
+    specs: dict[str, dict[str, Any]],
+    field: str,
+    cls: type,
+    defs: dict[str, Any],
+) -> bool:
+    """Rewrite a dict-typed sub-config field to a ``$ref`` of its real class.
+
+    Some engine-args fields are annotated as a bare dict / ``object`` (e.g. vLLM
+    ``EngineArgs.speculative_config: dict[str, Any] | None``, tensorrt
+    ``TrtLlmArgs.build_config: Optional[object]``) yet are coerced to a concrete
+    config class at construction. The annotation alone cannot be recursed, so the
+    introspector carries a field->class hint and calls this: ``cls`` is folded
+    into ``defs`` (via the Pydantic or dataclass path) and the field's spec
+    becomes a ``$ref`` so its leaves are discoverable. The original ``default`` is
+    preserved.
+
+    Returns ``True`` when the field was folded, ``False`` (no mutation) when the
+    field is absent or ``cls`` is neither a Pydantic model nor a dataclass (a
+    plain class the lift cannot introspect) - so the caller can record an honest
+    discovery limitation instead of leaving a silent gap.
+    """
+    spec = specs.get(field)
+    if spec is None:
+        return False
+    if hasattr(cls, "model_json_schema"):
+        _fold_model_defs(cls, defs)
+    elif dataclasses.is_dataclass(cls):
+        _fold_dataclass_defs(cls, defs)
+    else:
+        return False
+    specs[field] = {"$ref": f"#/$defs/{cls.__name__}", "default": spec.get("default")}
+    return True
+
+
+def merge_source_constraints(
+    schema_fields: dict[str, dict[str, Any]],
+    source_paths: list[Path],
+    *,
+    suffixes: tuple[str, ...] = ("Config", "Params", "Args"),
+) -> int:
+    """Fold source-text declarative constraints onto discovered ``schema_fields``.
+
+    Runtime introspection captures type + default but not the ``Field(ge/le/...)``
+    numeric bounds or ``Literal[...]`` membership sets that live in the class
+    source. This walks each path in ``source_paths`` with
+    :func:`scripts.engine_producers._source_walker.walk_declarative_constraints`
+    and overlays the per-field bounds/enum keys onto the matching discovered
+    field (by bare field name across all walked classes). Type/default already
+    present are never overwritten; only the constraint keys in
+    :data:`_CONSTRAINT_KEYS` are added, and only when the field is already in
+    ``schema_fields`` (discovery is the source of truth for which fields exist).
+
+    Mutates ``schema_fields`` in place and returns the number of fields that
+    gained at least one constraint key (a surface-trend metric - expected near
+    zero on the current pins, where the entry classes carry few bounds the
+    walker reaches).
+    """
+    overlay: dict[str, dict[str, Any]] = {}
+    for path in source_paths:
+        if not path.is_file():
+            continue
+        module = ast.parse(path.read_text())
+        for fields in walk_declarative_constraints(module, suffixes=suffixes).values():
+            for field_name, fragment in fields.items():
+                constraints = {k: v for k, v in fragment.items() if k in _CONSTRAINT_KEYS}
+                if constraints:
+                    overlay.setdefault(field_name, {}).update(constraints)
+
+    touched = 0
+    for field_name, constraints in overlay.items():
+        spec = schema_fields.get(field_name)
+        if spec is None:
+            continue
+        added = False
+        for key, value in constraints.items():
+            if key not in spec:
+                spec[key] = value
+                added = True
+        if added:
+            touched += 1
+    return touched
+
+
+def recover_field_types(target_type: type) -> dict[str, str]:
+    """Recover ``{field: type_str}`` from a ``msgspec.Struct`` via type inspection.
+
+    ``msgspec.json.schema`` drops to an untyped ``anyOf`` (no top-level ``type``
+    key) for union / enum / nested-struct fields, so the schema introspector
+    renders them ``"unknown"``. ``msgspec.inspect.type_info`` still resolves the
+    concrete field type for those same fields, so this recovers them for the
+    schema product.
+
+    Returns ``{}`` for non-Struct types. Fields whose type is genuinely opaque
+    (a bare ``Any``) are omitted so the caller keeps its existing label rather
+    than overwriting ``unknown`` with another non-informative token.
+    """
+    import msgspec  # local: keep the host-side schema-substrate import surface minimal
+
+    if not (isinstance(target_type, type) and issubclass(target_type, msgspec.Struct)):
+        return {}
+    info = msgspec.inspect.type_info(target_type)
+    if not isinstance(info, msgspec.inspect.StructType):
+        return {}
+    recovered: dict[str, str] = {}
+    for field in info.fields:
+        type_str = _render_msgspec_type(field.type)
+        if type_str is not None:
+            recovered[field.name] = type_str
+    return recovered
+
+
+def _render_msgspec_type(node: Any) -> str | None:
+    """Render a ``msgspec.inspect`` type node to a compact type string, or None.
+
+    Returns ``None`` only for a bare ``AnyType`` (no information to add). Unions
+    render their members joined by `` | `` with ``None`` last, mirroring the
+    introspector's existing ``X | None`` convention; a union that is *only*
+    ``Any | None`` collapses to ``None`` (still no type information beyond
+    nullability) so the caller does not overwrite ``unknown`` with ``Any | None``.
+    """
+    import msgspec
+
+    inspect_mod = msgspec.inspect
+    if isinstance(node, inspect_mod.AnyType):
+        return None
+    if isinstance(node, inspect_mod.UnionType):
+        members = [m for m in node.types if not isinstance(m, inspect_mod.NoneType)]
+        has_none = len(members) < len(node.types)
+        rendered = [_render_msgspec_type(m) for m in members]
+        parts = [r for r in rendered if r is not None]
+        if not parts:
+            return None
+        if has_none:
+            parts.append("None")
+        return " | ".join(parts)
+    return _render_msgspec_scalar(node)
+
+
+def _render_msgspec_scalar(node: Any) -> str:
+    """Render a non-union ``msgspec.inspect`` node to a type token."""
+    import msgspec
+
+    inspect_mod = msgspec.inspect
+    simple = {
+        inspect_mod.NoneType: "None",
+        inspect_mod.BoolType: "bool",
+        inspect_mod.IntType: "int",
+        inspect_mod.FloatType: "float",
+        inspect_mod.StrType: "str",
+        inspect_mod.BytesType: "bytes",
+    }
+    for cls, token in simple.items():
+        if isinstance(node, cls):
+            return token
+    if isinstance(node, inspect_mod.ListType):
+        return f"list[{_render_msgspec_scalar_or_any(node.item_type)}]"
+    if isinstance(node, inspect_mod.DictType):
+        key = _render_msgspec_scalar_or_any(node.key_type)
+        val = _render_msgspec_scalar_or_any(node.value_type)
+        return f"dict[{key}, {val}]"
+    if isinstance(node, inspect_mod.LiteralType):
+        return f"Literal[{', '.join(repr(v) for v in node.values)}]"
+    if isinstance(node, inspect_mod.EnumType):
+        return node.cls.__name__
+    if isinstance(node, (inspect_mod.StructType, inspect_mod.DataclassType)):
+        return node.cls.__name__
+    # Fall back to the node's own class name with the trailing "Type" stripped
+    # (CustomType, DateTimeType, ...) so an unmapped node still carries a token.
+    return type(node).__name__.removesuffix("Type").lower()
+
+
+def _render_msgspec_scalar_or_any(node: Any) -> str:
+    """Like :func:`_render_msgspec_scalar` but renders a bare Any item as ``Any``."""
+    import msgspec
+
+    if isinstance(node, msgspec.inspect.AnyType):
+        return "Any"
+    rendered = _render_msgspec_type(node)
+    return rendered if rendered is not None else "Any"
 
 
 def make_envelope(
@@ -184,6 +665,7 @@ def make_envelope(
     discovery_limitations: list[dict[str, Any]],
     engine_params: dict[str, Any],
     sampling_params: dict[str, Any],
+    defs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     # Honour LLENERGY_DISCOVERY_FROZEN_AT when the caller (CI) wants the
     # envelope pinned to a stable anchor - typically the author date of the
@@ -195,7 +677,7 @@ def make_envelope(
     discovered_at = (
         os.environ.get("LLENERGY_DISCOVERY_FROZEN_AT") or datetime.now(timezone.utc).isoformat()
     )
-    return {
+    envelope: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "engine": engine,
         "engine_version": engine_version,
@@ -208,3 +690,13 @@ def make_envelope(
         "engine_params": engine_params,
         "sampling_params": sampling_params,
     }
+    # Nested-class definitions are canonical JSON Schema 2020-12 ``$defs`` -
+    # exactly the shape ``model_json_schema()`` / ``msgspec.json.schema()``
+    # already emit and that ``$ref`` entries in engine_params/sampling_params
+    # point at. Preserve them rather than dropping at envelope assembly;
+    # ``jsonable`` keeps the block free of object-repr noise without
+    # re-flattening the canonical structure. Only emitted when non-empty so
+    # additive-schema loaders stay simple.
+    if defs:
+        envelope["$defs"] = jsonable(defs)
+    return envelope

--- a/scripts/engine_producers/_source_walker.py
+++ b/scripts/engine_producers/_source_walker.py
@@ -1,0 +1,257 @@
+"""Source-text walkers for schema discovery.
+
+The schema introspectors read a type's constraints off the *imported* class
+(via runtime introspection). These walkers read the same constraints straight
+from *source text*, so they stay reachable when a class carries its bounds and
+enums declaratively in source that runtime introspection alone does not expose
+(a pydantic ``Field(ge=...)`` keyword, a ``Literal[...]`` annotation on a
+sub-config that has moved into a subpackage).
+
+Two concerns live here, both pattern-matched (no file:line pinning - upstream
+refactors move both):
+
+1. **Declarative-constraint walk.** Extracts pydantic ``Field(ge/gt/le/lt/...)``
+   keyword bounds, ``Literal[...]`` membership sets (the allowed values), and
+   enum-typed fields from class-body annotated assignments. Field-level facts
+   (``enum`` / ``minimum`` / ``maximum`` / ...) are returned as canonical JSON
+   Schema fragments; the introspector folds them onto the matching schema field.
+
+2. **Class-surface enumeration.** A subpackage glob plus an AST ``ClassDef``
+   walk that discovers config classes beyond entry-point reachability (sibling
+   and nested classes), so a config surface split across ``config/*.py`` modules
+   is still reached.
+
+All functions are pure (AST + text in, data out): no probing, no imports of the
+target engine, no time-based seeds. Suitable for the host-side schema leg that
+must stay affordable on every upstream bump.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Subpackage glob
+# ---------------------------------------------------------------------------
+
+
+def expand_files(source_root: Path, patterns: list[str]) -> list[Path]:
+    """Expand path patterns (literal or glob) against ``source_root``.
+
+    De-duped and order-preserving. Globbing de-pins the file list so subpackage
+    refactors (vllm ``config.py`` -> ``config/*.py``, a ``plugin/`` fan-out) are
+    picked up across bumps WITHOUT editing the pattern list. Patterns that match
+    nothing (the surface does not exist on this version - vllm 0.7.3 has no
+    ``config/`` subpackage) simply contribute no files; the walker degrades
+    gracefully rather than failing.
+    """
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in patterns:
+        matches = sorted(source_root.glob(pattern)) if "*" in pattern else [source_root / pattern]
+        for path in matches:
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                out.append(path)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# AST class enumeration
+# ---------------------------------------------------------------------------
+
+
+def iter_config_classes(
+    module: ast.Module, *, suffixes: tuple[str, ...] = ("Config", "Params", "Args")
+) -> list[ast.ClassDef]:
+    """Return config-like ``ClassDef`` nodes anywhere in ``module``.
+
+    Walks the whole module tree (not just top-level), so sibling classes the
+    entry-point introspector never reaches AND nested classes are discovered.
+    A class is config-like when its name ends in one of ``suffixes`` (the naming
+    convention shared across all three engines) and is not private. Order is
+    source order; duplicates by identity are not possible (one node each).
+    """
+    classes: list[ast.ClassDef] = []
+    for node in ast.walk(module):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if node.name.endswith(suffixes):
+            classes.append(node)
+    return classes
+
+
+# ---------------------------------------------------------------------------
+# Declarative-constraint walk
+# ---------------------------------------------------------------------------
+
+# pydantic / annotated-types numeric keyword -> canonical JSON Schema key.
+# exclusive variants follow JSON Schema 2020-12 (a numeric value, not a bool).
+_BOUND_TO_JSONSCHEMA: dict[str, str] = {
+    "ge": "minimum",
+    "gt": "exclusiveMinimum",
+    "le": "maximum",
+    "lt": "exclusiveMaximum",
+    "multiple_of": "multipleOf",
+    "min_length": "minLength",
+    "max_length": "maxLength",
+    "min_items": "minItems",
+    "max_items": "maxItems",
+}
+
+_FIELD_LIKE_CALLS = {"Field", "Meta", "conint", "confloat", "PositiveInt", "PositiveFloat"}
+
+
+def walk_declarative_constraints(
+    module: ast.Module,
+    *,
+    suffixes: tuple[str, ...] = ("Config", "Params", "Args"),
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Extract per-class, per-field declarative constraints as JSON Schema fragments.
+
+    Returns ``{class_name: {field_name: {<jsonschema constraint keys>}}}``. Each
+    field fragment may carry numeric bounds (``minimum`` / ``maximum`` /
+    ``exclusiveMinimum`` / ``exclusiveMaximum`` / ``multipleOf`` / length / items
+    bounds) lifted from a ``Field(...)`` / ``Meta(...)`` / ``conint(...)`` call,
+    and/or an ``enum`` membership list lifted from a ``Literal[...]`` annotation.
+
+    These are *field-level* facts; the introspector merges them onto the matching
+    schema field. The output stays schema-shaped by design (bounds and membership
+    sets keyed by field name), which is all the schema product needs.
+    """
+    out: dict[str, dict[str, dict[str, Any]]] = {}
+    for cls in iter_config_classes(module, suffixes=suffixes):
+        fields = _class_field_constraints(cls)
+        if fields:
+            out[cls.name] = fields
+    return out
+
+
+def _class_field_constraints(cls: ast.ClassDef) -> dict[str, dict[str, Any]]:
+    fields: dict[str, dict[str, Any]] = {}
+    for stmt in cls.body:
+        if not isinstance(stmt, ast.AnnAssign) or not isinstance(stmt.target, ast.Name):
+            continue
+        name = stmt.target.id
+        if name.startswith("_"):
+            continue
+        fragment: dict[str, Any] = {}
+        # Numeric / length bounds from a Field(...) RHS or an Annotated[...] call.
+        bounds = _bounds_in_annotation(stmt.annotation)
+        if isinstance(stmt.value, ast.Call):
+            bounds.update(_bounds_in_call(stmt.value))
+        for key, value in bounds.items():
+            fragment.setdefault(key, value)
+        # Membership: Literal[...] / Optional[Literal[...]] annotation.
+        members = _membership_values(stmt.annotation)
+        if members:
+            fragment["enum"] = members
+        if fragment:
+            fields[name] = fragment
+    return fields
+
+
+def _bounds_in_call(call: ast.Call) -> dict[str, Any]:
+    """Numeric/length bounds from a ``Field(...)``-like call's keyword arguments."""
+    if not _is_field_like(call):
+        return {}
+    bounds: dict[str, Any] = {}
+    head = _call_head(call)
+    if head in {"PositiveInt", "PositiveFloat"}:
+        bounds["exclusiveMinimum"] = 0
+    for kw in call.keywords:
+        if kw.arg is None:
+            continue
+        json_key = _BOUND_TO_JSONSCHEMA.get(kw.arg)
+        if json_key is None:
+            continue
+        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, (int, float)):
+            bounds[json_key] = kw.value.value
+    return bounds
+
+
+def _bounds_in_annotation(annotation: ast.expr) -> dict[str, Any]:
+    """Bounds from ``Annotated[T, Field(...)]`` / ``conint(...)`` inside an annotation."""
+    bounds: dict[str, Any] = {}
+    for node in ast.walk(annotation):
+        if isinstance(node, ast.Call) and _is_field_like(node):
+            bounds.update(_bounds_in_call(node))
+    return bounds
+
+
+def _membership_values(annotation: ast.expr) -> list[Any] | None:
+    """Allowed values when the annotation is (or wraps) a ``Literal[...]``.
+
+    Unwraps ``Optional[...]`` / ``X | None`` wrappers. Returns the value list,
+    or ``None`` when the annotation is not a closed membership set.
+    """
+    return _literal_values(annotation)
+
+
+# ---------------------------------------------------------------------------
+# Small AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _literal_values(node: ast.expr) -> list[Any] | None:
+    """Closed value set if ``node`` is (or wraps) a ``Literal[...]``, else None.
+
+    Handles bare ``Literal[a, b]``, ``Optional[Literal[...]]``, ``Literal[...] |
+    None``, and ``Annotated[Literal[...], ...]`` by descending into the
+    annotation tree. Returns ``None`` when there is no Literal; an empty list is
+    never returned (a Literal with a non-constant member -> not-closed -> ``None``).
+    """
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Subscript):
+            values = _literal_subscript_values(sub)
+            if values is not None:
+                return values
+    return None
+
+
+def _literal_subscript_values(node: ast.expr) -> list[Any] | None:
+    """Closed value set if ``node`` is *directly* a ``Literal[...]`` subscript.
+
+    Unlike :func:`_literal_values` this does not descend into wrappers - the node
+    itself must be the ``Literal`` subscript. ``None`` if not a Literal or any
+    member is non-constant.
+    """
+    if not (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "Literal"
+    ):
+        return None
+    elts = node.slice.elts if isinstance(node.slice, ast.Tuple) else [node.slice]
+    values: list[Any] = []
+    for elt in elts:
+        if isinstance(elt, ast.Constant):
+            values.append(elt.value)
+        else:
+            return None
+    return values
+
+
+def _is_field_like(call: ast.Call) -> bool:
+    return _call_head(call) in _FIELD_LIKE_CALLS
+
+
+def _call_head(call: ast.Call) -> str:
+    """Rightmost name of a call's callee (``pydantic.Field`` -> ``"Field"``)."""
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+__all__ = [
+    "expand_files",
+    "iter_config_classes",
+    "walk_declarative_constraints",
+]

--- a/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: tensorrt
 engine_version: 0.21.0
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   engine: tensorrt

--- a/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/tensorrt/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: tensorrt
 engine_version: 0.21.0
 image_ref: llenergymeasure:tensorrt
 base_image_ref: llenergymeasure:tensorrt
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: tensorrt_raises_max_ngram_size_le_0_positive_values
   outcome: error

--- a/src/llenergymeasure/engines/tensorrt/schema.discovered.json
+++ b/src/llenergymeasure/engines/tensorrt/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:tensorrt-0.21.0",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T13:25:05+02:00",
+  "discovered_at": "2026-07-02T18:02:56+02:00",
   "discovery_method": "TrtLlmArgs.model_json_schema() + dataclasses.fields(SamplingParams)",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: transformers
 engine_version: 4.57.3
-mined_at: '2026-05-14T20:31:21+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: transformers_beam_search_num_beams_eq_1
   engine: transformers

--- a/src/llenergymeasure/engines/transformers/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/transformers/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: transformers
 engine_version: 4.57.3
 image_ref: llenergymeasure:transformers
 base_image_ref: llenergymeasure:transformers
-validated_at: '2026-05-14T20:31:21+02:00'
-validation_commit: 701d351fee655b8f399a5bc32ea923ba048df579
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: transformers_beam_search_num_beams_eq_1
   outcome: dormant_announced

--- a/src/llenergymeasure/engines/transformers/schema.discovered.json
+++ b/src/llenergymeasure/engines/transformers/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:transformers-4.57.3",
   "base_image_ref": "pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime",
-  "discovered_at": "2026-05-14T20:31:21+02:00",
+  "discovered_at": "2026-07-02T18:02:56+02:00",
   "discovery_method": "inspect.signature(from_pretrained) + GenerationConfig().to_dict()",
   "discovery_limitations": [
     {

--- a/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.proposed.yaml
@@ -1,7 +1,7 @@
 schema_version: 1.0.0
 engine: vllm
 engine_version: 0.7.3
-mined_at: '2026-05-14T13:25:05+02:00'
+mined_at: '2026-05-15T12:49:19+02:00'
 invariants:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   engine: vllm

--- a/src/llenergymeasure/engines/vllm/invariants.validated.yaml
+++ b/src/llenergymeasure/engines/vllm/invariants.validated.yaml
@@ -3,8 +3,8 @@ engine: vllm
 engine_version: 0.7.3
 image_ref: llenergymeasure:vllm
 base_image_ref: llenergymeasure:vllm
-validated_at: '2026-05-14T13:25:05+02:00'
-validation_commit: fc4e8826c94c7597cf76321b42e5af54ee038e17
+validated_at: '2026-05-15T12:49:19+02:00'
+validation_commit: 92da87c2f83a30cd4528edfa934f3c1bf5165daf
 cases:
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   outcome: dormant_silent

--- a/src/llenergymeasure/engines/vllm/schema.discovered.json
+++ b/src/llenergymeasure/engines/vllm/schema.discovered.json
@@ -5,7 +5,7 @@
   "engine_commit_sha": null,
   "image_ref": "llenergymeasure:vllm-0.7.3",
   "base_image_ref": null,
-  "discovered_at": "2026-05-14T20:31:21+02:00",
+  "discovered_at": "2026-07-02T18:02:56+02:00",
   "discovery_method": "dataclasses.fields(EngineArgs) + msgspec.json.schema(SamplingParams)",
   "discovery_limitations": [
     {

--- a/tests/unit/scripts/engine_producers/fixtures/tensorrt_12/plugin/plugin.py
+++ b/tests/unit/scripts/engine_producers/fixtures/tensorrt_12/plugin/plugin.py
@@ -1,0 +1,51 @@
+"""Trimmed tensorrt-1.2-style ``plugin/plugin.py`` excerpt for walker fixtures.
+
+Reproduces the PluginConfig shape the study GT found entirely invisible to flat
+entry-point introspection: ~20 membership fields. The 10 inline ``Literal[...]``
+fields surface a closed membership set; the 10 fields typed against a
+module-level ``Literal`` alias (``DefaultPluginDtype``) do NOT, since the
+declarative walker only resolves Literals written inline at the annotation.
+
+NOT importable tensorrt_llm source - a hand-trimmed structural excerpt. No
+engine install required. The plugin/ directory layout exercises the
+``plugin/*.py`` glob.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+# Module-level Literal alias: several plugin fields are typed Optional[<alias>].
+DefaultPluginDtype = Literal["float16", "bfloat16", "float32"]
+
+
+class PluginConfig(BaseModel):
+    # Fields typed against the module-level alias (resolved -> 3 values each).
+    gpt_attention_plugin: DefaultPluginDtype | None = "float16"
+    gemm_plugin: DefaultPluginDtype | None = None
+    gemm_swiglu_plugin: DefaultPluginDtype | None = None
+    fp8_rowwise_gemm_plugin: DefaultPluginDtype | None = None
+    nccl_plugin: DefaultPluginDtype | None = "float16"
+    lora_plugin: DefaultPluginDtype | None = None
+    moe_plugin: DefaultPluginDtype | None = "float16"
+    mamba_conv1d_plugin: DefaultPluginDtype | None = "float16"
+    low_latency_gemm_plugin: DefaultPluginDtype | None = None
+    low_latency_gemm_swiglu_plugin: DefaultPluginDtype | None = None
+
+    # Inline Literal membership fields.
+    context_fmha: Literal["enabled", "disabled"] = "enabled"
+    paged_kv_cache: Literal["enabled", "disabled"] = "enabled"
+    remove_input_padding: Literal["enabled", "disabled"] = "enabled"
+    reduce_fusion: Literal["enabled", "disabled"] = "disabled"
+    user_buffer: Literal["enabled", "disabled"] = "disabled"
+    tokens_per_block: Literal[32, 64, 128] = 64
+    use_paged_context_fmha: Literal["enabled", "disabled"] = "disabled"
+    multiple_profiles: Literal["enabled", "disabled"] = "disabled"
+    paged_state: Literal["enabled", "disabled"] = "enabled"
+    streamingllm: Literal["enabled", "disabled"] = "disabled"
+
+    # A non-membership typed field: must NOT surface an enum.
+    max_lora_rank: int = 64
+    _internal: int = 0  # underscore field: must be ignored

--- a/tests/unit/scripts/engine_producers/fixtures/vllm_019/config/cache.py
+++ b/tests/unit/scripts/engine_producers/fixtures/vllm_019/config/cache.py
@@ -1,0 +1,35 @@
+"""Trimmed vllm-0.19-style ``config/cache.py`` excerpt for walker fixtures.
+
+Reproduces the shapes the declarative-constraint walker and class-surface
+enumeration must surface: pydantic ``Field(ge=/le=/...)`` bounds, a ``Literal``
+field, a nested pydantic sub-config, and the per-concern ``config/*.py``
+subpackage layout introduced in vllm 0.16. NOT importable vllm source - a
+hand-trimmed structural excerpt only. No engine install required.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class PrefixCacheConfig:
+    """Nested sub-config referenced by CacheConfig (exercises $defs surface)."""
+
+    hash_algo: Literal["builtin", "sha256"] = "builtin"
+    max_capacity: int = Field(default=1024, ge=1)
+
+
+@dataclass
+class CacheConfig:
+    block_size: int = Field(default=16, ge=1, le=256, multiple_of=8)
+    gpu_memory_utilization: float = Field(default=0.9, gt=0.0, le=1.0)
+    cache_dtype: Literal["auto", "fp8", "fp8_e4m3", "fp8_e5m2"] = "auto"
+    swap_space: int = Field(default=4, ge=0)
+    # Optional-wrapped Literal must still surface its membership set.
+    mamba_ssm_cache_dtype: Literal["auto", "float32"] | None = None
+    prefix_cache: PrefixCacheConfig = Field(default_factory=PrefixCacheConfig)
+    _private_internal: int = 0  # underscore field: must be ignored

--- a/tests/unit/scripts/engine_producers/fixtures/vllm_019/config/scheduler.py
+++ b/tests/unit/scripts/engine_producers/fixtures/vllm_019/config/scheduler.py
@@ -1,0 +1,20 @@
+"""Trimmed vllm-0.19-style ``config/scheduler.py`` excerpt.
+
+A second file in the ``config/*.py`` subpackage so the glob primitive has more
+than one file to find, and a sibling config class the entry-point walk would
+miss.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class SchedulerConfig:
+    max_num_seqs: int = Field(default=256, ge=1)
+    max_num_batched_tokens: Annotated[int, Field(ge=1)] = 2048
+    policy: str = "fcfs"

--- a/tests/unit/scripts/engine_producers/test_source_walker.py
+++ b/tests/unit/scripts/engine_producers/test_source_walker.py
@@ -1,0 +1,141 @@
+"""Acceptance tests for :mod:`scripts.engine_producers._source_walker`.
+
+Exercises the source-level walkers against trimmed engine source-excerpt
+fixtures WITHOUT any engine installed: the walkers read source text via ``ast``,
+so the fixtures only need to parse, never import or run.
+
+Two fixture cells:
+
+- ``fixtures/vllm_019/`` - a ``config/*.py`` subpackage with pydantic ``Field``
+  bounds, ``Literal`` membership, and a nested pydantic sub-config.
+- ``fixtures/tensorrt_12/`` - a ``plugin/plugin.py`` PluginConfig-like class with
+  inline ``Literal`` membership fields.
+
+The assertions pin the class / field / constraint inventories the walkers must
+surface, so a regression in any walker fails here rather than silently shrinking
+the discovered constraints on the next bump.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.engine_producers import _source_walker as sw  # noqa: E402
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+_VLLM_ROOT = _FIXTURES / "vllm_019"
+_TRT_ROOT = _FIXTURES / "tensorrt_12"
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Subpackage glob
+# ---------------------------------------------------------------------------
+
+
+def test_expand_files_finds_config_subpackage() -> None:
+    found = sw.expand_files(_VLLM_ROOT, ["config.py", "config/*.py", "sampling_params.py"])
+    names = sorted(p.name for p in found)
+    # config.py and sampling_params.py do not exist here (flat layout absent);
+    # the glob finds the two real subpackage files and skips the rest.
+    assert names == ["cache.py", "scheduler.py"]
+
+
+def test_expand_files_graceful_when_surface_absent() -> None:
+    """vllm 0.7.3 has no config/ subpackage: the glob simply finds nothing."""
+    found = sw.expand_files(_VLLM_ROOT, ["nonexistent/*.py", "also_missing.py"])
+    assert found == []
+
+
+def test_expand_files_finds_plugin_module() -> None:
+    found = sw.expand_files(_TRT_ROOT, ["plugin/*.py", "llmapi/llm_args.py"])
+    assert [p.name for p in found] == ["plugin.py"]
+
+
+# ---------------------------------------------------------------------------
+# Class-surface enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_iter_config_classes_finds_sibling_and_nested_classes() -> None:
+    module = _parse(_VLLM_ROOT / "config" / "cache.py")
+    names = {c.name for c in sw.iter_config_classes(module)}
+    # Both the entry-ish CacheConfig and the sibling PrefixCacheConfig surface;
+    # underscore-prefixed names never do.
+    assert names == {"CacheConfig", "PrefixCacheConfig"}
+
+
+def test_iter_config_classes_matches_params_and_args_suffixes() -> None:
+    src = "class FooParams: ...\nclass BarArgs: ...\nclass Helper: ...\nclass _Hidden: ...\n"
+    module = ast.parse(src)
+    names = {c.name for c in sw.iter_config_classes(module)}
+    assert names == {"FooParams", "BarArgs"}
+
+
+# ---------------------------------------------------------------------------
+# Declarative-constraint walk - vllm cell
+# ---------------------------------------------------------------------------
+
+
+def test_vllm_field_bounds_to_jsonschema() -> None:
+    module = _parse(_VLLM_ROOT / "config" / "cache.py")
+    constraints = sw.walk_declarative_constraints(module)
+    cache = constraints["CacheConfig"]
+    # block_size: ge=1, le=256, multiple_of=8 -> canonical JSON Schema keys.
+    assert cache["block_size"] == {"minimum": 1, "maximum": 256, "multipleOf": 8}
+    # gpu_memory_utilization: gt=0.0, le=1.0 -> exclusiveMinimum + maximum.
+    assert cache["gpu_memory_utilization"] == {"exclusiveMinimum": 0.0, "maximum": 1.0}
+    assert cache["swap_space"] == {"minimum": 0}
+
+
+def test_vllm_literal_membership_and_optional_unwrap() -> None:
+    module = _parse(_VLLM_ROOT / "config" / "cache.py")
+    cache = sw.walk_declarative_constraints(module)["CacheConfig"]
+    assert cache["cache_dtype"]["enum"] == ["auto", "fp8", "fp8_e4m3", "fp8_e5m2"]
+    # Optional[Literal[...]] still surfaces its membership set.
+    assert cache["mamba_ssm_cache_dtype"]["enum"] == ["auto", "float32"]
+    # Private fields never surface.
+    assert "_private_internal" not in cache
+
+
+def test_vllm_annotated_field_bounds_lifted_from_annotation() -> None:
+    module = _parse(_VLLM_ROOT / "config" / "scheduler.py")
+    sched = sw.walk_declarative_constraints(module)["SchedulerConfig"]
+    # Annotated[int, Field(ge=1)] - bound lives in the annotation, not the RHS.
+    assert sched["max_num_batched_tokens"] == {"minimum": 1}
+    assert sched["max_num_seqs"] == {"minimum": 1}
+    # A plain ``str`` field with no constraints does not appear.
+    assert "policy" not in sched
+
+
+# ---------------------------------------------------------------------------
+# Declarative-constraint walk - tensorrt PluginConfig cell
+# ---------------------------------------------------------------------------
+
+
+def test_tensorrt_plugin_literal_membership_inventory() -> None:
+    module = _parse(_TRT_ROOT / "plugin" / "plugin.py")
+    plugin = sw.walk_declarative_constraints(module)["PluginConfig"]
+
+    # Inline Literal fields surface their own value sets (incl. an int Literal).
+    assert plugin["context_fmha"]["enum"] == ["enabled", "disabled"]
+    assert plugin["tokens_per_block"]["enum"] == [32, 64, 128]
+
+    # The 10 inline Literal fields each carry a membership set. Fields typed
+    # against a module-level Literal alias (``DefaultPluginDtype``) are NOT
+    # closed without alias resolution, so they do not surface an enum.
+    membership_fields = {f for f, frag in plugin.items() if "enum" in frag}
+    assert len(membership_fields) == 10
+    assert "enum" not in plugin.get("gpt_attention_plugin", {})
+    assert "enum" not in plugin.get("moe_plugin", {})
+    assert "max_lora_rank" not in plugin  # plain int, no constraint
+    assert "_internal" not in plugin

--- a/tests/unit/scripts/test_engine_producers_common.py
+++ b/tests/unit/scripts/test_engine_producers_common.py
@@ -8,11 +8,14 @@ package.
 
 from __future__ import annotations
 
+import dataclasses
 import sys
 from pathlib import Path
 from typing import Literal
 
+import pydantic
 import pytest
+from pydantic import BaseModel
 
 # Make the top-level ``scripts`` package importable from tests.
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -209,9 +212,9 @@ def test_transformers_introspector_landmarks_resolve() -> None:
     pytest.importorskip("transformers")
     import importlib
 
-    from scripts.engine_producers import transformers_introspector
+    from scripts.engine_producers import transformers_schema_introspector
 
-    landmarks = transformers_introspector.LANDMARKS
+    landmarks = transformers_schema_introspector.LANDMARKS
     assert isinstance(landmarks, tuple) and landmarks, "LANDMARKS must be a non-empty tuple"
 
     missing: list[str] = []
@@ -236,3 +239,518 @@ def test_transformers_introspector_landmarks_resolve() -> None:
         except AttributeError:
             missing.append(landmark)
     assert not missing, f"Unresolvable transformers landmarks: {missing}"
+
+
+# ===========================================================================
+# Schema-substrate additions: docstring type recovery, $defs recursion, source
+# overlay, opaque-default sanitisation, flat-Literal enum capture, msgspec type
+# recovery.
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Module-scope fixtures for the $defs recursion tests. Defined at module scope
+# (not inside the test functions) so ``typing.get_type_hints`` can resolve the
+# forward-referenced names.
+# ---------------------------------------------------------------------------
+
+
+class _NestedModel(BaseModel):
+    depth: int = 2
+
+
+class _SubConfig(BaseModel):
+    x: int = 1
+    nested: _NestedModel = _NestedModel()
+
+
+@dataclasses.dataclass
+class _EngineArgsLike:
+    sub: _SubConfig | None = None
+    plain: int = 0
+
+
+@dataclasses.dataclass
+class _ListOfPydanticArgs:
+    subs: list[_SubConfig] = dataclasses.field(default_factory=list)
+
+
+# Non-Pydantic (stdlib) dataclass sub-configs - the vLLM CompilationConfig /
+# AttentionConfig shape that exposes no ``model_json_schema``.
+@dataclasses.dataclass
+class _DcLeaf:
+    mode: str = "default"
+    size: int | None = None
+
+
+@dataclasses.dataclass
+class _DcMid:
+    leaf: _DcLeaf = dataclasses.field(default_factory=_DcLeaf)
+    flag: bool = False
+    self_ref: _DcMid | None = None  # self-reference -> cycle guard
+
+
+@dataclasses.dataclass
+class _DcEngineArgsLike:
+    mid: _DcMid | None = None
+    pyd: _SubConfig | None = None  # mixed: Pydantic sub-config alongside dataclass
+    plain: str = "p"
+    leaves: list[_DcLeaf] | None = None  # generic -> no single class to $ref
+
+
+@dataclasses.dataclass
+class _DictTypedArgs:
+    spec: dict | None = None  # dict-typed (like vLLM speculative_config) -> needs a hint
+    plain: int = 0
+
+
+# A pydantic dataclass sub-config - the vLLM @config shape: is_dataclass True,
+# __pydantic_fields__ present, model_json_schema absent. Its Field bounds + Literal
+# enum must be captured (the bare-dataclass walk loses them).
+@pydantic.dataclasses.dataclass
+class _PydDcLeaf:
+    frac: float = pydantic.Field(default=0.9, gt=0, le=1)
+    mode: Literal["a", "b", "c"] = "a"
+    unbounded: int = 0  # no Field bound -> stays plain
+
+
+@dataclasses.dataclass
+class _ArgsWithPydDc:
+    leaf: _PydDcLeaf | None = None
+    plain: str = "p"
+
+
+# ---------------------------------------------------------------------------
+# docstring_arg_types
+# ---------------------------------------------------------------------------
+
+
+class _DocStyleConfig:
+    """A HuggingFace-style configurable.
+
+    Args:
+        num_beams (`int`, *optional*, defaults to 1):
+            Number of beams for beam search.
+        temperature (`float`, *optional*):
+            The sampling temperature.
+        do_sample (`bool`, *optional*, defaults to `False`):
+            Whether to sample.
+        early_stopping (`bool` or `str`, *optional*):
+            Beam-search stopping condition.
+        cache_config (`Dict`, *optional*):
+            Arguments used in the key/value cache.
+        not_a_field:
+            A line with no parenthesised type.
+    """
+
+
+def test_docstring_arg_types_recovers_scalar_types() -> None:
+    types = _common.docstring_arg_types(_DocStyleConfig)
+    assert types["num_beams"] == "int"
+    assert types["temperature"] == "float"
+    assert types["do_sample"] == "bool"
+
+
+def test_docstring_arg_types_takes_first_member_of_or_union() -> None:
+    # ``bool` or `str`` documents a union; the first member matches the
+    # value-inference baseline the older pins produced.
+    assert _common.docstring_arg_types(_DocStyleConfig)["early_stopping"] == "bool"
+
+
+def test_docstring_arg_types_omits_non_scalar_and_untyped() -> None:
+    types = _common.docstring_arg_types(_DocStyleConfig)
+    # Non-scalar documented type (Dict) is dropped so the caller falls back to
+    # default-inference; an untyped arg line is never captured.
+    assert "cache_config" not in types
+    assert "not_a_field" not in types
+
+
+def test_docstring_arg_types_empty_when_no_docstring() -> None:
+    class _NoDoc:
+        pass
+
+    assert _common.docstring_arg_types(_NoDoc) == {}
+
+
+# ---------------------------------------------------------------------------
+# make_envelope - $defs block
+# ---------------------------------------------------------------------------
+
+
+def test_make_envelope_omits_defs_when_empty() -> None:
+    env = _common.make_envelope(
+        engine="vllm",
+        engine_version="0.7.3",
+        engine_commit_sha=None,
+        image_ref="foo:1",
+        base_image_ref="foo:1",
+        discovery_method="unit test",
+        discovery_limitations=[],
+        engine_params={},
+        sampling_params={},
+    )
+    assert "$defs" not in env
+    # Explicit empty dict is also treated as "nothing to emit".
+    env_empty = _common.make_envelope(
+        engine="vllm",
+        engine_version="0.7.3",
+        engine_commit_sha=None,
+        image_ref="foo:1",
+        base_image_ref="foo:1",
+        discovery_method="unit test",
+        discovery_limitations=[],
+        engine_params={},
+        sampling_params={},
+        defs={},
+    )
+    assert "$defs" not in env_empty
+
+
+def test_make_envelope_emits_and_jsonifies_defs() -> None:
+    env = _common.make_envelope(
+        engine="tensorrt",
+        engine_version="1.0.0",
+        engine_commit_sha=None,
+        image_ref="foo:1",
+        base_image_ref="foo:1",
+        discovery_method="unit test",
+        discovery_limitations=[],
+        engine_params={"kv_cache_config": {"$ref": "#/$defs/KvCacheConfig", "default": None}},
+        sampling_params={},
+        defs={
+            "KvCacheConfig": {
+                "type": "object",
+                "properties": {"max_tokens": {"type": "integer"}},
+                "required": {"max_tokens"},  # set -> jsonable should sort to a list
+            }
+        },
+    )
+    assert "$defs" in env
+    kv = env["$defs"]["KvCacheConfig"]
+    assert kv["properties"]["max_tokens"]["type"] == "integer"
+    # ``jsonable`` coerces the set to a sorted list so json.dumps stays clean.
+    assert kv["required"] == ["max_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# dataclass_fields_to_specs - $defs recursion (Pydantic + stdlib dataclass)
+# ---------------------------------------------------------------------------
+
+
+def test_dataclass_specs_without_defs_flatten_pydantic_to_type_str() -> None:
+    """Without a ``defs`` accumulator the walk keeps the legacy flat shape."""
+    specs = _common.dataclass_fields_to_specs(_EngineArgsLike)
+    # No $ref emitted; nested pydantic flattens to a readable type string.
+    assert "$ref" not in specs["sub"]
+    assert specs["plain"]["type"] == "int"
+
+
+def test_dataclass_specs_recurse_into_pydantic_field_emitting_ref_and_defs() -> None:
+    defs: dict = {}
+    specs = _common.dataclass_fields_to_specs(_EngineArgsLike, defs=defs)
+
+    # Pydantic-typed field becomes a $ref into $defs; default still recorded.
+    assert specs["sub"]["$ref"] == "#/$defs/_SubConfig"
+    # Plain field is untouched.
+    assert specs["plain"]["type"] == "int"
+    # The sub-model AND its transitively-referenced nested model are folded in,
+    # so every $ref in the envelope resolves.
+    assert "_SubConfig" in defs and "_NestedModel" in defs
+    assert defs["_SubConfig"]["properties"]["x"]["default"] == 1
+    # The nested model is reachable via the standard #/$defs/ ref template.
+    assert defs["_SubConfig"]["properties"]["nested"]["$ref"] == "#/$defs/_NestedModel"
+
+
+def test_dataclass_specs_list_of_pydantic_stays_object_not_ref() -> None:
+    """``list[SubConfig]`` has no single class to $ref - stays a type string."""
+    defs: dict = {}
+    specs = _common.dataclass_fields_to_specs(_ListOfPydanticArgs, defs=defs)
+    assert "$ref" not in specs["subs"]
+    assert defs == {}
+
+
+def test_dataclass_specs_recurse_into_non_pydantic_dataclass_field() -> None:
+    """A stdlib-dataclass sub-config field becomes a $ref with its leaves in $defs.
+
+    This is the vLLM ``EngineArgs -> CompilationConfig`` shape: a nested
+    ``@dataclass`` that exposes no ``model_json_schema`` and would otherwise
+    flatten to a bare type-name string.
+    """
+    defs: dict = {}
+    specs = _common.dataclass_fields_to_specs(_DcEngineArgsLike, defs=defs)
+
+    # Dataclass-typed field -> $ref; the def carries the leaves with types/defaults.
+    assert specs["mid"]["$ref"] == "#/$defs/_DcMid"
+    assert "_DcMid" in defs and "_DcLeaf" in defs
+    assert defs["_DcLeaf"]["properties"]["mode"] == {"type": "str", "default": "default"}
+    # Transitive: _DcMid.leaf folds _DcLeaf as a nested $ref.
+    assert defs["_DcMid"]["properties"]["leaf"]["$ref"] == "#/$defs/_DcLeaf"
+    # Cycle: _DcMid.self_ref -> _DcMid terminates via the placeholder guard.
+    assert defs["_DcMid"]["properties"]["self_ref"]["$ref"] == "#/$defs/_DcMid"
+    # Mixed: a Pydantic sub-config in the same class still routes via model_json_schema.
+    assert specs["pyd"]["$ref"] == "#/$defs/_SubConfig"
+    assert "_SubConfig" in defs
+    # Plain scalar untouched; generic list[dataclass] not recursed.
+    assert specs["plain"] == {"type": "str", "default": "p"}
+    assert "$ref" not in specs["leaves"]
+
+
+def test_dataclass_specs_without_defs_flatten_dataclass_to_type_str() -> None:
+    """The legacy (no-``defs``) path keeps the flat type string for dataclasses too."""
+    specs = _common.dataclass_fields_to_specs(_DcEngineArgsLike)
+    assert "$ref" not in specs["mid"]
+    assert "type" in specs["mid"]
+
+
+def test_pydantic_dataclass_field_captures_bounds_and_enums() -> None:
+    """A pydantic-dataclass sub-config folds via the rich path, keeping Field bounds + Literal enums.
+
+    This is the vLLM ``@config`` shape (is_dataclass + __pydantic_fields__, no
+    model_json_schema). The bare-dataclass walk would lose ``gt=0, le=1`` and the
+    ``Literal`` membership; the pydantic JSON-schema path keeps them.
+    """
+    defs: dict = {}
+    specs = _common.dataclass_fields_to_specs(_ArgsWithPydDc, defs=defs)
+    assert specs["leaf"]["$ref"] == "#/$defs/_PydDcLeaf"
+    leaf = defs["_PydDcLeaf"]["properties"]
+    # Numeric bound preserved (Field(gt=0, le=1) -> exclusiveMinimum/maximum).
+    assert leaf["frac"].get("exclusiveMinimum") == 0
+    assert leaf["frac"].get("maximum") == 1
+    # Literal enum preserved.
+    assert leaf["mode"].get("enum") == ["a", "b", "c"]
+    # An unbounded field stays plain (no bound invented).
+    assert "minimum" not in leaf["unbounded"] and "maximum" not in leaf["unbounded"]
+
+
+# ---------------------------------------------------------------------------
+# fold_dict_typed_subconfig
+# ---------------------------------------------------------------------------
+
+
+def test_fold_dict_typed_subconfig_rewrites_dict_field_to_ref() -> None:
+    """A dict-typed field is rewritten to a $ref once the real class is supplied.
+
+    Mirrors vLLM ``speculative_config`` (annotated ``dict[str, Any]`` but coerced
+    to ``SpeculativeConfig``): the introspector carries the field->class hint.
+    """
+    defs: dict = {}
+    specs = _common.dataclass_fields_to_specs(_DictTypedArgs, defs=defs)
+    # Pre-hint: dict-typed field is a bare type string, no $ref, no def.
+    assert "$ref" not in specs["spec"]
+    assert defs == {}
+
+    folded = _common.fold_dict_typed_subconfig(specs, "spec", _DcLeaf, defs)
+    assert folded is True
+    assert specs["spec"] == {"$ref": "#/$defs/_DcLeaf", "default": None}
+    assert defs["_DcLeaf"]["properties"]["mode"]["type"] == "str"
+
+
+def test_fold_dict_typed_subconfig_noop_on_missing_field() -> None:
+    """No hinted field -> returns False, no mutation, no crash."""
+    defs: dict = {}
+    specs: dict = {"plain": {"type": "int", "default": 0}}
+    assert _common.fold_dict_typed_subconfig(specs, "absent", _DcLeaf, defs) is False
+    assert specs == {"plain": {"type": "int", "default": 0}}
+    assert defs == {}
+
+
+def test_fold_dict_typed_subconfig_returns_false_for_plain_class() -> None:
+    """A plain (non-dataclass, non-Pydantic) class cannot be lifted -> False, no mutation.
+
+    This is the tensorrt ``DecodingConfig`` shape: the caller uses the False
+    return to record an honest discovery limitation instead of a silent gap.
+    """
+
+    class _PlainCls:
+        def __init__(self, a: int = 1) -> None:
+            self.a = a
+
+    defs: dict = {}
+    specs: dict = {"spec": {"type": "object", "default": None}}
+    assert _common.fold_dict_typed_subconfig(specs, "spec", _PlainCls, defs) is False
+    assert specs == {"spec": {"type": "object", "default": None}}  # untouched
+    assert defs == {}
+
+
+# ---------------------------------------------------------------------------
+# exposable_default - opaque object defaults must NOT leak as stringified reprs
+# ---------------------------------------------------------------------------
+
+
+class _OpaqueBlob:
+    def __repr__(self) -> str:
+        return "<opaque config object repr blob>"
+
+
+@dataclasses.dataclass
+class _OpaqueDefaultArgs:
+    blob: object = dataclasses.field(default_factory=_OpaqueBlob)
+    plain: int = 0
+
+
+def test_exposable_default_nulls_opaque_objects_keeps_clean_structures() -> None:
+    assert _common.exposable_default(_OpaqueBlob()) is None
+    assert _common.exposable_default(5) == 5
+    assert _common.exposable_default("auto") == "auto"
+    assert _common.exposable_default([1, 2]) == [1, 2]
+    assert _common.exposable_default({"a": 1}) == {"a": 1}
+    # An opaque value nested inside a clean container is nulled in place rather
+    # than stringified.
+    assert _common.exposable_default({"k": _OpaqueBlob()}) == {"k": None}
+
+
+def test_exposable_default_set_with_opaque_elements_does_not_raise() -> None:
+    """A set default with opaque elements must not crash discovery.
+
+    Opaque elements null to None, leaving a non-orderable mix; sorting must fall
+    back to a stable key rather than raising TypeError. Clean homogeneous sets
+    keep their natural sort order.
+    """
+    assert _common.exposable_default({"b", "a"}) == ["a", "b"]
+    assert _common.exposable_default({3, 1, 2}) == [1, 2, 3]
+    # opaque + primitive: opaque -> None, no crash, deterministic order
+    assert _common.exposable_default({1, _OpaqueBlob()}) == [1, None]
+    # all-opaque: every element nulls to None, still deterministic
+    assert _common.exposable_default({_OpaqueBlob(), _OpaqueBlob()}) == [None, None]
+
+
+def test_dataclass_specs_null_opaque_object_default_not_stringified() -> None:
+    """A field whose default is an opaque object is recorded as None, never its
+    repr string - else codegen would emit a bogus non-None default and forward
+    that stringified blob to the engine on every unset run. Pin the contract so
+    the str() fallback can't return silently.
+    """
+    specs = _common.dataclass_fields_to_specs(_OpaqueDefaultArgs)
+    assert specs["blob"]["default"] is None
+    assert specs["plain"]["default"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _literal_enum_spec - flat Literal fields captured as structured enums
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _ArgsWithFlatLiteral:
+    """A flat (non-nested) dataclass carrying ``Literal`` scalar fields.
+
+    Mirrors vLLM ``EngineArgs.dtype`` / ``kv_cache_dtype``: the membership set
+    lives directly on the engine-args dataclass, not on a nested sub-config.
+    """
+
+    dtype: Literal["auto", "half", "bfloat16"] = "auto"
+    block: Literal[8, 16, 32] = 16
+    backend: Literal["a", "b"] | None = None
+    plain: int = 3
+
+
+def test_flat_literal_field_captures_enum_not_type_string() -> None:
+    """A flat ``Literal`` field becomes a structured ``enum`` (not an opaque string)."""
+    specs = _common.dataclass_fields_to_specs(_ArgsWithFlatLiteral, defs={})
+    assert specs["dtype"] == {
+        "enum": ["auto", "half", "bfloat16"],
+        "type": "str",
+        "default": "auto",
+    }
+    assert specs["block"] == {"enum": [8, 16, 32], "type": "int", "default": 16}
+    # ``X | None`` unwraps to the sole Literal; the enum is captured (default kept).
+    assert specs["backend"]["enum"] == ["a", "b"]
+    assert specs["backend"]["type"] == "str"
+    # A non-Literal scalar is untouched (no enum invented).
+    assert specs["plain"] == {"type": "int", "default": 3}
+    assert "enum" not in specs["plain"]
+
+
+def test_literal_enum_spec_ignores_non_literal() -> None:
+    """``_literal_enum_spec`` returns None for non-Literal annotations (no false enums)."""
+    assert _common._literal_enum_spec(int) is None
+    assert _common._literal_enum_spec(str | None) is None
+    assert _common._literal_enum_spec(Literal["x", "y"]) == {"enum": ["x", "y"], "type": "str"}
+
+
+# ---------------------------------------------------------------------------
+# merge_source_constraints - source-text bounds/enums fold onto discovered fields
+# ---------------------------------------------------------------------------
+
+
+def test_merge_source_constraints_overlays_bounds_and_enums(tmp_path: Path) -> None:
+    src = tmp_path / "cache.py"
+    src.write_text(
+        "from typing import Literal\n"
+        "from pydantic import Field\n"
+        "class CacheConfig:\n"
+        "    block_size: int = Field(1, ge=1, le=256)\n"
+        "    cache_dtype: Literal['auto', 'fp8'] = 'auto'\n"
+    )
+    # Discovery is the source of truth for which fields exist; only fields already
+    # present gain constraint keys, and type/default are never overwritten.
+    schema_fields: dict[str, dict[str, object]] = {
+        "block_size": {"type": "int", "default": 16},
+        "cache_dtype": {"type": "str", "default": "auto"},
+        "unrelated": {"type": "bool", "default": False},
+    }
+    touched = _common.merge_source_constraints(schema_fields, [src])
+    assert touched == 2
+    assert schema_fields["block_size"] == {
+        "type": "int",
+        "default": 16,
+        "minimum": 1,
+        "maximum": 256,
+    }
+    assert schema_fields["cache_dtype"]["enum"] == ["auto", "fp8"]
+    # A field absent from the source walk is untouched.
+    assert schema_fields["unrelated"] == {"type": "bool", "default": False}
+
+
+def test_merge_source_constraints_skips_fields_not_in_schema(tmp_path: Path) -> None:
+    src = tmp_path / "cfg.py"
+    src.write_text(
+        "from pydantic import Field\nclass FooConfig:\n    only_in_source: int = Field(0, ge=0)\n"
+    )
+    schema_fields: dict = {"other": {"type": "int", "default": 1}}
+    assert _common.merge_source_constraints(schema_fields, [src]) == 0
+    assert schema_fields == {"other": {"type": "int", "default": 1}}
+
+
+def test_merge_source_constraints_ignores_missing_paths(tmp_path: Path) -> None:
+    schema_fields: dict = {"x": {"type": "int", "default": 0}}
+    assert _common.merge_source_constraints(schema_fields, [tmp_path / "nope.py"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# recover_field_types - msgspec type recovery for the schema product
+# ---------------------------------------------------------------------------
+
+msgspec = pytest.importorskip("msgspec")
+
+
+class _UntypedByJsonSchema(msgspec.Struct):  # type: ignore[name-defined,misc]
+    """Fields msgspec.json.schema renders as an untyped anyOf / bare token.
+
+    Mirrors the vLLM ``SamplingParams`` shape: optional unions, a nested-list
+    union, a dict union, and a genuinely-opaque ``Any | None``.
+    ``recover_field_types`` must resolve every concrete one and omit only the
+    opaque ``Any | None``.
+    """
+
+    seed: int | None = None
+    stop_token_ids: list[int] | None = None
+    logit_bias: dict[int, float] | None = None
+    mode: Literal["greedy", "beam"] = "greedy"
+    logits_processors: object | None = None  # opaque - stays unrecovered
+
+
+def test_recover_field_types_resolves_unions_and_containers() -> None:
+    recovered = _common.recover_field_types(_UntypedByJsonSchema)
+    assert recovered["seed"] == "int | None"
+    assert recovered["stop_token_ids"] == "list[int] | None"
+    assert recovered["logit_bias"] == "dict[int, float] | None"
+    # msgspec sorts Literal values when building its type info; mirror that order.
+    assert recovered["mode"] == "Literal['beam', 'greedy']"
+
+
+def test_recover_field_types_empty_for_non_struct() -> None:
+    class _NotStruct:
+        pass
+
+    assert _common.recover_field_types(_NotStruct) == {}


### PR DESCRIPTION
## Summary

Evolves the shared introspector substrate under `scripts/engine_producers/` to
serve schema discovery only, decoupled from the invariant-mining machinery, and
wires it into the vendored per-version schema introspectors. This is PR A2 of
the engine-knowledge redesign carve (substrate + its natural consumers).

Main carried an older generation of this substrate: the committed
`schema.discovered.json` snapshots were produced by a richer discovery path
(nested `$defs`, source-text bounds/enums, msgspec type recovery) that the
simpler introspectors actually vendored on main could not reproduce. This PR
brings that richer path onto main, walker-free.

**Substrate (walker-free):**
- New `_source_walker.py`: pure AST source-text walkers - subpackage glob,
  config-class enumeration, and declarative `Field(ge/le/...)` bound /
  `Literal[...]` membership extraction into canonical JSON Schema fragments. No
  engine import, no time-based seeds.
- Evolved `_common.py`: nested-config `$defs` recursion (pydantic + stdlib
  dataclass folds), `fold_dict_typed_subconfig`, `merge_source_constraints`
  (source overlay), `docstring_arg_types`, `exposable_default` (opaque defaults
  null rather than stringified), flat-`Literal` enum capture, and `defs=`
  threading through `dataclass_fields_to_specs` / `make_envelope`.
- `recover_field_types` (msgspec type recovery) is relocated into `_common`
  with a local `msgspec` import. The reference kept it in `_msgspec_lift`, whose
  `lift()` pulls the invariant-mining `_base`; hosting the schema-serving
  recovery in `_common` keeps the schema path free of `_base` entirely. This is
  the seam surgery: no section-classifier or invariant-mining code reaches main
  via schema discovery.

**Consumers (per-version introspectors):**
- vllm 0.19.1: `config/*.py` subpackage overlay + `speculative_config` fold +
  msgspec type recovery (replaces the flat introspector).
- tensorrt 1.0.0: new `producers/` package + introspector (`TrtLlmArgs`
  `model_json_schema` + `BuildConfig` fold + `SamplingParams` source overlay).
- transformers 5.7.0: new `producers/` package + introspector
  (`from_pretrained` signature scrape + `GenerationConfig` docstring-Args type
  recovery).

The invariant-mining lifts (`_pydantic_lift`, `_dataclass_lift`,
`_msgspec_lift.lift`) and `_base` are untouched, so main's existing producer
pipeline and its tests are unaffected. `LANDMARKS` tuples are preserved as the
`scripts/_drift.py` probe contract. The three introspector pins are not the
current dispatched versions (vllm 0.7.3 / tensorrt 0.21.0 / transformers
4.57.3), so runtime discovery behaviour is unchanged.

Hand-written production LoC: ~721 logical (`_source_walker` 129 + `_common`
additions ~263 + three introspectors 329), within the ~800 target.
`schema.discovered.json` snapshots are unchanged (data-exempt); no deletions.

## Test plan

- `make lint` - ruff check + format + import-linter (4 contracts kept,
  including "runtime layers must not import engine_versions").
- `make typecheck` - mypy on src/ + tests/ clean; explicit mypy on the five new
  prod files clean.
- Full host suite: `pytest -m "not gpu and not docker"` - 2534 passed, 61
  skipped, 0 failures. Existing producer suite (`test_base`, `_pydantic_lift`,
  `_dataclass_lift`, `_msgspec_lift`) green; new `test_source_walker` (9) and
  extended common-helper tests green.
- Verified the schema path imports no `_base` (walker-free) and the dispatcher
  resolves all four pins (v0_7_3, v0_19_1, v1_0_0, v5_7_0) to a `discover`
  producer. In-container byte-mining of the snapshots is GPU-gated and out of
  scope for host CI.

## Doc audit

No doc update needed: internal substrate refactor, no user-visible surface (no CLI flags, install commands, or documented contracts changed). The one committed-data prose fix (tensorrt limitation string) aligns data with the introspector that produces it.