### PR TITLE
feat(producers): workspace-driven codegen tooling for engine config models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
     "types-pyyaml>=6.0.12",
     "import-linter>=2.9",
     "msgspec",
+    # Backs scripts/engine_producers/regen_engine_configs.py. Pinned exactly:
+    # the generated config.py is byte-compared in CI, and the generator's
+    # output formatting is version-sensitive.
+    "datamodel-code-generator==0.62.0",
 ]
 
 [project.scripts]

--- a/scripts/engine_producers/regen_engine_configs.py
+++ b/scripts/engine_producers/regen_engine_configs.py
@@ -279,7 +279,9 @@ def _load_curated(outputs: Path) -> dict[str, list[str]]:
     curated.yaml is part of the synced SSOT (always present in a complete
     snapshot); a missing section just exposes nothing.
     """
-    raw: dict[str, Any] = yaml.safe_load((outputs / "curated.yaml").read_text("utf-8")) or {}
+    raw: dict[str, Any] = (
+        yaml.safe_load((outputs / _outputs.CURATED_FILENAME).read_text("utf-8")) or {}
+    )
     exposed = raw.get("exposed_fields", {})
     return {section: list(exposed.get(section) or []) for section in SECTIONS}
 
@@ -369,7 +371,7 @@ def _ruff_normalise(path: Path) -> None:
 
 def generate_config(engine: str, version: str, outputs: Path) -> bytes:
     """Generate one engine snapshot's config.py bytes (ruff-normalised)."""
-    discovered = json.loads((outputs / "schema.discovered.json").read_text(encoding="utf-8"))
+    discovered = json.loads((outputs / _outputs.SCHEMA_FILENAME).read_text(encoding="utf-8"))
     curated = _load_curated(outputs)
     synthetic = compose_schema(engine, discovered, curated)
     safe_version = _outputs.safe_version(str(discovered.get("engine_version", version)))

--- a/scripts/engine_producers/regen_engine_configs.py
+++ b/scripts/engine_producers/regen_engine_configs.py
@@ -1,0 +1,493 @@
+"""Generate a per-engine typed Pydantic config.py from mined schema data.
+
+Projects one engine-version snapshot from the workspace SSOT
+(``engine_versions/<engine>/v<safe>/outputs/``) into a vendored, committed,
+typed ``src/llenergymeasure/engines/<engine>/config.py``:
+
+- ``schema.discovered.json`` - the mined configuration surface (types,
+  defaults, enums, bounds);
+- ``curated.yaml`` - the exposure allowlist (only ``exposed_fields`` entries
+  become first-class typed fields).
+
+Generation is delegated to ``datamodel-code-generator`` (a dev-only tool); this
+wrapper owns the llem-specific parts: reshaping the mined envelope into a JSON
+Schema 2020-12 document, filtering it through the curated allowlist, and
+ruff-normalising the output so byte-comparison is stable. The emitted
+``Config`` / ``EngineParams`` / ``SamplingParams`` classes mirror the schema's
+native section split and carry ``extra="allow"`` (the live engine config
+policy).
+
+The snapshot is selected explicitly by ``--engine`` and ``--version``, so the
+tool works against any vendored pin - the active one, or a higher pin being
+prepared for a bump - and never assumes the active pin. ``--output`` picks the
+target file (default: the ``src/`` shadow for that engine).
+
+Two modes: ``--check`` (default) regenerates in memory and byte-compares
+against the target file (exit 1 with a diff on drift); ``--write`` regenerates
+and writes it.
+
+The mined schema carries structured ``enum`` / ``minimum`` / ``maximum`` /
+``exclusiveMinimum`` / ``exclusiveMaximum`` keys, which this wrapper projects
+into real ``Literal`` / bounded fields. Both the mined Python type spelling and
+the JSON-native spelling a model-schema lift emits are mapped, so a bounded
+native-typed field is never silently widened to ``Any | None``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from engine_versions import _outputs  # noqa: E402
+
+# Native schema sections, projected into same-named sub-models.
+SECTIONS: tuple[str, ...] = ("engine_params", "sampling_params")
+
+# Verified datamodel-code-generator flag combo, pinned against the generator
+# version in the dev dependency group. ``--disable-timestamp`` is mandatory for
+# ``--check`` (the banner timestamp would otherwise change every run).
+_DMCG_FLAGS: tuple[str, ...] = (
+    "--input-file-type",
+    "jsonschema",
+    "--output-model-type",
+    "pydantic_v2.BaseModel",
+    "--target-python-version",
+    "3.10",
+    "--use-annotated",
+    "--enum-field-as-literal",
+    "all",
+    "--use-union-operator",
+    "--use-attribute-docstrings",
+    "--use-field-description",
+    # Preserve x-source / x-source-ref provenance as json_schema_extra on
+    # Field(). The bare --field-extra-keys form (literal key names including the
+    # "x-" prefix) is the spelling that works empirically.
+    "--field-extra-keys",
+    "x-source",
+    "x-source-ref",
+    "--disable-timestamp",
+)
+
+
+def _shadow_config_path(engine: str) -> Path:
+    """Return ``src/llenergymeasure/engines/<engine>/config.py``."""
+    return _PROJECT_ROOT / "src" / "llenergymeasure" / "engines" / engine / "config.py"
+
+
+# ---------------------------------------------------------------------------
+# Envelope -> JSON Schema 2020-12 pre-step
+# ---------------------------------------------------------------------------
+
+# Legacy Python-string types in the envelope mapped to a JSON Schema scalar.
+_SCALAR_TYPES: dict[str, str] = {
+    "str": "string",
+    "bool": "boolean",
+    "int": "integer",
+    "float": "number",
+}
+
+# The same scalars in JSON-Schema-native spelling. Sections lifted via a
+# pydantic/msgspec ``model_json_schema`` record types already JSON-native
+# (``"number"`` / ``"integer"`` / ...), unlike the dataclass-introspected
+# sections that record Python strings. Both vocabularies must map, or a bounded
+# native-typed field (``temperature`` -> ``number`` with ``ge`` / ``le``)
+# silently collapses to ``Any | None``.
+_JSON_SCALAR_TYPES: frozenset[str] = frozenset(_SCALAR_TYPES.values())
+
+
+def _scalar_for(member: str) -> str | None:
+    """JSON Schema scalar for one union member, or ``None`` if it is not scalar.
+
+    Accepts both vocabularies: the legacy Python spelling (``int`` ->
+    ``integer``) and a JSON-native scalar already emitted by a model-schema lift
+    (``integer`` -> ``integer``).
+    """
+    if member in _SCALAR_TYPES:
+        return _SCALAR_TYPES[member]
+    if member in _JSON_SCALAR_TYPES:
+        return member
+    return None
+
+
+def _python_type_to_json_schema(type_str: str | None) -> dict[str, Any]:
+    """Translate one envelope ``type`` string into JSON Schema keys.
+
+    - scalars in either Python (``"str"``) or JSON-native (``"string"``)
+      spelling -> ``{"type": ...}``;
+    - the ``"unknown"`` / ``None`` sentinel (fields with no annotation) -> ``{}``
+      (datamodel-codegen renders ``Any | None``);
+    - union strings (``"str | bool | None"``): scalar members map to a JSON
+      Schema ``anyOf``; any non-scalar member (engine class, PathLike, JSON
+      container like ``array`` / ``object``) collapses the whole field to
+      permissive ``Any | None`` (``{}``), since the generated class validates
+      SHAPE only and the engine owns the rest.
+    """
+    if not type_str or type_str == "unknown":
+        return {}
+
+    members = [m.strip() for m in type_str.split("|")]
+    scalars = [s for m in members if (s := _scalar_for(m)) is not None]
+    has_unmappable = any(_scalar_for(m) is None and m != "None" for m in members)
+
+    if has_unmappable or not scalars:
+        return {}
+    if len(scalars) == 1:
+        return {"type": scalars[0]}
+    return {"anyOf": [{"type": s} for s in scalars]}
+
+
+# JSON-Schema-native keys passed through from a mined field shape unchanged.
+_PASSTHROUGH_KEYS: tuple[str, ...] = (
+    "default",
+    "description",
+    "enum",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "x-source",
+    "x-source-ref",
+)
+
+
+def _field_shape_to_property(shape: dict[str, Any]) -> dict[str, Any]:
+    """Translate one ``schema.discovered.json`` field shape to a JSON Schema property."""
+    prop = _python_type_to_json_schema(shape.get("type"))
+    for key in _PASSTHROUGH_KEYS:
+        if key in shape:
+            prop[key] = shape[key]
+    return prop
+
+
+# ---------------------------------------------------------------------------
+# Per-engine wholesale-forwarded nested blob projection
+# ---------------------------------------------------------------------------
+
+# Per-engine set of nested config blobs the engine forwards WHOLESALE and that
+# should be projected into a typed submodel rather than collapsed to
+# ``Any | None``. Each listed blob is projected ONE LEVEL: scalar/enum/bounded
+# interior leaves are typed; any interior leaf that is itself a nested-config
+# ``$ref`` stays permissive ``Any | None`` (no deeper recursion - that would
+# balloon the transitive closure). Engines absent from this map project
+# nothing, so their blobs stay ``Any | None``.
+#
+# vLLM forwards compilation_config / speculative_config WHOLESALE through
+# ``engine_params.model_dump(exclude_none=True)``, so it lists exactly those
+# two; tensorrt / transformers list nothing today.
+_PROJECTED_NESTED_BLOBS: dict[str, frozenset[str]] = {
+    "vllm": frozenset({"compilation_config", "speculative_config"}),
+}
+
+
+def _ref_target(shape: dict[str, Any]) -> str | None:
+    """Return the bare ``$defs`` class name a field shape ``$ref``s, else None."""
+    ref = shape.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/$defs/"):
+        return ref.rsplit("/", 1)[-1]
+    return None
+
+
+def _is_scalar_enum_member(value: Any) -> bool:
+    """True if an enum member is a hashable scalar a Literal can carry.
+
+    Guards against non-scalar enum members (e.g. vLLM ``CUDAGraphMode`` carries
+    nested-list members like ``[2, 0]``) which cannot be spelled as a Literal;
+    such an enum collapses the whole leaf to permissive ``Any | None``.
+    """
+    return isinstance(value, (str, int, float, bool)) and not isinstance(value, list)
+
+
+def _project_nested_leaf(shape: dict[str, Any], discovered_defs: dict[str, Any]) -> dict[str, Any]:
+    """Project one interior leaf of a wholesale blob to a NULLABLE JSON property.
+
+    One-level projection. Returns a property carrying ``enum`` and numeric
+    bounds where the leaf is a clean scalar / enum / bounded value, and a bare
+    ``{}`` (-> ``Any | None``) for anything that is not: a ``$ref`` to a nested
+    config, an enum with non-scalar members, an array / object / path shape.
+
+    The mined ``default`` is deliberately STRIPPED: every projected leaf is
+    nullable with default ``None`` so ``model_dump(exclude_none=True)`` forwards
+    only user-set keys (no injected defaults that would change runtime
+    behavior), while a set value is still validated against the typed leaf.
+    """
+    target_name = _ref_target(shape)
+    if target_name is not None:
+        target = discovered_defs.get(target_name) or {}
+        # $ref to a nested config (has properties) -> no deeper projection.
+        if "properties" in target or "enum" not in target:
+            return {}
+        members = target["enum"]
+        # An enum with a non-scalar member cannot be spelled as a Literal.
+        if not all(_is_scalar_enum_member(m) for m in members):
+            return {}
+        prop: dict[str, Any] = {"enum": list(members)}
+        if "type" in target:
+            prop["type"] = target["type"]
+        return prop
+
+    prop = _python_type_to_json_schema(shape.get("type"))
+    for key in _PASSTHROUGH_KEYS:
+        if key == "default":
+            continue  # strip mined default -> nullable leaf
+        if key in shape:
+            prop[key] = shape[key]
+    return prop
+
+
+def _project_nested_blob(class_name: str, discovered_defs: dict[str, Any]) -> dict[str, Any]:
+    """Build a typed ``$defs`` entry for one wholesale-forwarded blob class.
+
+    ``additionalProperties: true`` forces ``extra="allow"`` (the upstream
+    ``$def`` carries ``additionalProperties: false``, which would reject
+    engine-accepted extras). Interior leaves are projected one level via
+    ``_project_nested_leaf``; properties are emitted in SORTED key order so the
+    codegen output is a deterministic byte-stable fixpoint.
+    """
+    source = discovered_defs.get(class_name) or {}
+    source_props: dict[str, Any] = source.get("properties", {}) or {}
+    projected: dict[str, Any] = {
+        name: _project_nested_leaf(source_props[name], discovered_defs)
+        for name in sorted(source_props)
+    }
+    return {
+        "type": "object",
+        "additionalProperties": True,
+        "properties": projected,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Curation + schema composition
+# ---------------------------------------------------------------------------
+
+
+def _load_curated(outputs: Path) -> dict[str, list[str]]:
+    """Read curated.yaml; return per-section exposure allowlists.
+
+    curated.yaml is part of the synced SSOT (always present in a complete
+    snapshot); a missing section just exposes nothing.
+    """
+    raw: dict[str, Any] = yaml.safe_load((outputs / "curated.yaml").read_text("utf-8")) or {}
+    exposed = raw.get("exposed_fields", {})
+    return {section: list(exposed.get(section) or []) for section in SECTIONS}
+
+
+def compose_schema(
+    engine: str,
+    discovered: dict[str, Any],
+    curated: dict[str, list[str]],
+) -> dict[str, Any]:
+    """Compose a JSON Schema 2020-12 doc from the mined envelope + curation.
+
+    Per section: filter the discovered schema through the curated allowlist. A
+    curated field is resolved against the UNION of discovered sections (the
+    curated split does not line up with the discovered split - e.g. ``use_cache``
+    is curated under engine_params but discovered under sampling_params), then
+    placed in the curated section. A field absent from discovery entirely is a
+    discovery-debt stub: a permissive ``Any | None`` field. A curated field
+    naming a wholesale-forwarded nested blob is projected one level into a typed
+    submodel.
+
+    Each section becomes a named ``$defs`` entry with ``additionalProperties:
+    true`` (the ``extra="allow"`` policy) so datamodel-codegen emits a named
+    sub-class. The root ``Config`` references them by ``$ref``.
+    """
+    discovered_defs: dict[str, Any] = discovered.get("$defs", {}) or {}
+    blob_fields = _PROJECTED_NESTED_BLOBS.get(engine, frozenset())
+    # Resolve curated fields against the union of discovered sections.
+    discovered_fields: dict[str, Any] = {}
+    for section in SECTIONS:
+        discovered_fields.update(discovered.get(section, {}) or {})
+
+    defs: dict[str, Any] = {}
+    properties: dict[str, Any] = {}
+    for section in SECTIONS:
+        section_props: dict[str, Any] = {}
+        for name in curated.get(section, []):
+            mined_shape = discovered_fields.get(name)
+            blob_class = _ref_target(mined_shape) if mined_shape is not None else None
+            if name in blob_fields and blob_class is not None and blob_class in discovered_defs:
+                # Wholesale-forwarded nested blob: project ONE LEVEL into a typed
+                # submodel instead of collapsing to Any | None.
+                defs[blob_class] = _project_nested_blob(blob_class, discovered_defs)
+                section_props[name] = {"$ref": f"#/$defs/{blob_class}"}
+                continue
+            # Absent from discovery -> permissive debt stub ({} -> Any | None).
+            section_props[name] = (
+                _field_shape_to_property(mined_shape) if mined_shape is not None else {}
+            )
+
+        title = "".join(part.capitalize() for part in section.split("_"))
+        defs[title] = {
+            "type": "object",
+            "additionalProperties": True,
+            "properties": section_props,
+        }
+        properties[section] = {"$ref": f"#/$defs/{title}"}
+
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Config",
+        "type": "object",
+        "additionalProperties": True,
+        "properties": properties,
+        # Sorted for a deterministic byte-stable codegen fixpoint.
+        "$defs": {name: defs[name] for name in sorted(defs)},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def _ruff_normalise(path: Path) -> None:
+    """Apply repo ruff style to a generated file in place.
+
+    Load-bearing: datamodel-codegen emits single-quoted strings and its own
+    import order, both of which differ from repo ruff style. Without this the
+    ``--check`` byte-compare goes forever-red on cosmetic quote/import drift.
+    """
+    for cmd in (
+        ["ruff", "check", "--fix", "--quiet", str(path)],
+        ["ruff", "format", "--quiet", str(path)],
+    ):
+        subprocess.run(["uv", "run", *cmd], check=True, cwd=_PROJECT_ROOT, capture_output=True)
+
+
+def generate_config(engine: str, version: str, outputs: Path) -> bytes:
+    """Generate one engine snapshot's config.py bytes (ruff-normalised)."""
+    discovered = json.loads((outputs / "schema.discovered.json").read_text(encoding="utf-8"))
+    curated = _load_curated(outputs)
+    synthetic = compose_schema(engine, discovered, curated)
+    safe_version = _outputs.safe_version(str(discovered.get("engine_version", version)))
+    header = (
+        f"# DO NOT EDIT - regenerated from engine_versions/{engine}/{safe_version}/outputs/"
+        "{curated.yaml,schema.discovered.json}\n"
+        "# Edit those upstream and run `uv run python "
+        f"scripts/engine_producers/regen_engine_configs.py --engine {engine} "
+        f"--version {version} --write`."
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        in_path = Path(tmpdir) / "schema.json"
+        out_path = Path(tmpdir) / "config.py"
+        in_path.write_text(json.dumps(synthetic, indent=2), encoding="utf-8")
+        cmd = [
+            "uv",
+            "run",
+            "datamodel-codegen",
+            "--input",
+            str(in_path),
+            "--output",
+            str(out_path),
+            "--custom-file-header",
+            header,
+            *_DMCG_FLAGS,
+        ]
+        proc = subprocess.run(cmd, check=False, capture_output=True, text=True, cwd=_PROJECT_ROOT)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"datamodel-codegen failed for {engine} {version}:\n{proc.stdout}\n{proc.stderr}"
+            )
+        _ruff_normalise(out_path)
+        return out_path.read_bytes()
+
+
+def _file_diff(generated: bytes, on_disk: Path) -> str:
+    """Unified diff (target vs generated); empty when byte-identical."""
+    old = on_disk.read_text(encoding="utf-8").splitlines(keepends=True) if on_disk.exists() else []
+    new = generated.decode("utf-8").splitlines(keepends=True)
+    return "".join(
+        difflib.unified_diff(old, new, fromfile=str(on_disk), tofile=f"{on_disk} (regenerated)")
+    )
+
+
+def sync(engine: str, version: str, output: Path, *, write: bool) -> str | None:
+    """Generate (or check) one engine snapshot's config.py.
+
+    Returns a drift report string under ``--check`` when the target does not
+    match the freshly generated bytes, else ``None``. Under ``--write`` writes
+    the target and always returns ``None``.
+    """
+    outputs = _outputs.outputs_dir(engine, version)
+    if not outputs.is_dir():
+        raise FileNotFoundError(
+            f"{engine} {version}: snapshot outputs dir not found ({outputs}). "
+            f"Expected a mined {_outputs.SCHEMA_FILENAME} + {_outputs.CURATED_FILENAME} there."
+        )
+
+    generated = generate_config(engine, version, outputs)
+    if write:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(generated)
+        return None
+    if generated == (output.read_bytes() if output.exists() else b""):
+        return None
+    return f"{output} drift:\n{_file_diff(generated, output)}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--engine",
+        required=True,
+        choices=_outputs.ENGINES,
+        help="Engine whose snapshot to generate from.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Dotted engine version (e.g. 0.19.1) - selects the workspace snapshot.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Target config.py (default: the src/ shadow for the engine).",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the target matches regeneration; exit 1 with a diff on drift. Default mode.",
+    )
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help="Regenerate and write the target (mutates the working tree).",
+    )
+    args = parser.parse_args(argv)
+
+    output = args.output if args.output is not None else _shadow_config_path(args.engine)
+    drift = sync(args.engine, args.version, output, write=args.write)
+
+    if args.write:
+        print(f"[regen-configs] wrote: {output}")
+        return 0
+    if drift is not None:
+        print(drift, file=sys.stderr)
+        print(
+            "\nDrift between the generated config.py and the target.\nRegenerate:\n"
+            f"  uv run python scripts/engine_producers/regen_engine_configs.py "
+            f"--engine {args.engine} --version {args.version} --write",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/engine_producers/test_regen_engine_configs.py
+++ b/tests/unit/scripts/engine_producers/test_regen_engine_configs.py
@@ -1,0 +1,374 @@
+"""Tests for scripts/engine_producers/regen_engine_configs.py.
+
+Concerns:
+
+1. Pre-step (mined envelope -> JSON Schema): Python type-string mapping,
+   enum/bounds passthrough.
+2. Curated filter: only exposed fields reach the synthetic schema; a debt
+   field becomes a permissive stub; a curated field discovered in the other
+   section is union-resolved.
+3. Nested-blob projection: a wholesale-forwarded vLLM blob becomes a typed
+   one-level submodel.
+4. End-to-end --write then --check (determinism, including the ruff post-step)
+   against a synthetic snapshot in a tmp dir, plus the CLI exit codes.
+5. Generated-file shape assertions: Literal for an enum, a MINED bound, the
+   extra="allow" policy, and the DO NOT EDIT header.
+6. Real workspace snapshots: byte-stable regeneration, generation off a
+   non-active pin, and the vLLM nested-blob classes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.engine_producers import regen_engine_configs as rec  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Pre-step: Python type-string -> JSON Schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("type_str", "expected"),
+    [
+        ("str", {"type": "string"}),
+        ("bool", {"type": "boolean"}),
+        ("int", {"type": "integer"}),
+        ("float", {"type": "number"}),
+        ("unknown", {}),
+        (None, {}),
+        # Trailing None drops out; a single scalar survives.
+        ("bool | None", {"type": "boolean"}),
+        # Multi-scalar union -> anyOf.
+        ("str | bool | None", {"anyOf": [{"type": "string"}, {"type": "boolean"}]}),
+        # Non-scalar member (engine class / PathLike) -> permissive.
+        ("PretrainedConfig | str | PathLike | None", {}),
+        # JSON-native spelling maps identically to the Python spelling - a
+        # bounded native-typed field must not silently widen to Any | None.
+        ("number", {"type": "number"}),
+        ("integer", {"type": "integer"}),
+        ("boolean", {"type": "boolean"}),
+        ("string", {"type": "string"}),
+        ("integer | None", {"type": "integer"}),
+        ("string | number", {"anyOf": [{"type": "string"}, {"type": "number"}]}),
+        # A JSON container is not a scalar -> stays permissive.
+        ("array", {}),
+        ("object | None", {}),
+    ],
+)
+def test_python_type_to_json_schema(type_str: str | None, expected: dict) -> None:
+    assert rec._python_type_to_json_schema(type_str) == expected
+
+
+def test_field_shape_passes_through_enum_and_bounds() -> None:
+    """JSON-Schema-native keys (enum, bounds, default, x-source) survive."""
+    shape = {
+        "type": "str",
+        "default": "auto",
+        "enum": ["half", "bfloat16", "auto"],
+        "x-source": "module_validation_collection",
+    }
+    prop = rec._field_shape_to_property(shape)
+    assert prop["type"] == "string"
+    assert prop["enum"] == ["half", "bfloat16", "auto"]
+    assert prop["default"] == "auto"
+    assert prop["x-source"] == "module_validation_collection"
+
+
+# ---------------------------------------------------------------------------
+# compose_schema: curation, $defs, union-resolution
+# ---------------------------------------------------------------------------
+
+_DISCOVERED = {
+    "engine_version": "9.9.9",
+    "engine_params": {
+        "dtype": {"type": "str", "default": "auto", "enum": ["half", "bf16", "auto"]},
+        "secret_internal": {"type": "str", "default": "x"},
+    },
+    "sampling_params": {
+        # Curated under engine_params below; discovered here. Tests union-resolution.
+        "use_cache": {"type": "bool", "default": True},
+        "temperature": {"type": "float", "default": 1.0},
+        "uncurated": {"type": "int", "default": 0},
+    },
+}
+
+
+def test_compose_filters_to_curated_only() -> None:
+    curated = {"engine_params": ["dtype", "use_cache"], "sampling_params": ["temperature"]}
+    schema = rec.compose_schema("transformers", _DISCOVERED, curated)
+
+    ep = schema["$defs"]["EngineParams"]["properties"]
+    sp = schema["$defs"]["SamplingParams"]["properties"]
+    # Curated fields present; non-curated absent.
+    assert set(ep) == {"dtype", "use_cache"}
+    assert set(sp) == {"temperature"}
+    assert "secret_internal" not in ep
+    assert "uncurated" not in sp
+    # enum survived to the curated property.
+    assert ep["dtype"]["enum"] == ["half", "bf16", "auto"]
+    # Union-resolution: use_cache (discovered under sampling) typed in engine section.
+    assert ep["use_cache"] == {"type": "boolean", "default": True}
+
+
+def test_compose_marks_sections_extra_allow() -> None:
+    curated = {"engine_params": ["dtype"], "sampling_params": []}
+    schema = rec.compose_schema("transformers", _DISCOVERED, curated)
+    assert schema["$defs"]["EngineParams"]["additionalProperties"] is True
+    assert schema["properties"]["engine_params"] == {"$ref": "#/$defs/EngineParams"}
+
+
+def test_compose_debt_field_becomes_permissive_stub() -> None:
+    """A curated field absent from discovery is a permissive Any | None stub."""
+    curated = {"engine_params": ["device_map"], "sampling_params": []}
+    schema = rec.compose_schema("transformers", _DISCOVERED, curated)
+    assert schema["$defs"]["EngineParams"]["properties"]["device_map"] == {}
+
+
+def test_compose_defs_are_sorted() -> None:
+    """$defs are emitted in sorted key order (byte-stable codegen fixpoint)."""
+    curated = {"engine_params": ["dtype"], "sampling_params": ["temperature"]}
+    schema = rec.compose_schema("transformers", _DISCOVERED, curated)
+    assert list(schema["$defs"]) == sorted(schema["$defs"])
+
+
+# ---------------------------------------------------------------------------
+# Nested-blob projection (wholesale-forwarded vLLM blobs)
+# ---------------------------------------------------------------------------
+
+_BLOB_DISCOVERED = {
+    "engine_version": "0.19.1",
+    "engine_params": {
+        "compilation_config": {"$ref": "#/$defs/CompilationConfig"},
+    },
+    "sampling_params": {},
+    "$defs": {
+        "CompilationConfig": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "level": {"type": "integer", "default": 0, "minimum": 0, "maximum": 3},
+                "backend": {"type": "string", "default": "inductor"},
+                # A $ref leaf stays permissive - no deeper recursion.
+                "pass_config": {"$ref": "#/$defs/PassConfig"},
+            },
+        },
+        "PassConfig": {"type": "object", "properties": {"x": {"type": "integer"}}},
+    },
+}
+
+
+def test_nested_blob_projected_one_level() -> None:
+    curated = {"engine_params": ["compilation_config"], "sampling_params": []}
+    schema = rec.compose_schema("vllm", _BLOB_DISCOVERED, curated)
+    # The blob field references a typed submodel, not Any | None.
+    assert schema["$defs"]["EngineParams"]["properties"]["compilation_config"] == {
+        "$ref": "#/$defs/CompilationConfig"
+    }
+    blob = schema["$defs"]["CompilationConfig"]
+    assert blob["additionalProperties"] is True  # extra="allow" on the submodel
+    props = blob["properties"]
+    # Scalar/bounded leaf typed; its mined default is STRIPPED (nullable leaf).
+    assert props["level"] == {"type": "integer", "minimum": 0, "maximum": 3}
+    assert props["backend"] == {"type": "string"}
+    # A $ref leaf stays permissive (no deeper projection).
+    assert props["pass_config"] == {}
+    # Properties emitted in sorted order for byte-stability.
+    assert list(props) == sorted(props)
+
+
+def test_nested_blob_not_projected_for_engine_without_blobs() -> None:
+    """transformers lists no wholesale blobs: a $ref field collapses to Any | None."""
+    curated = {"engine_params": ["compilation_config"], "sampling_params": []}
+    schema = rec.compose_schema("transformers", _BLOB_DISCOVERED, curated)
+    ep = schema["$defs"]["EngineParams"]["properties"]
+    assert ep["compilation_config"] == {}
+    assert "CompilationConfig" not in schema["$defs"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end --write / --check against a synthetic snapshot in a tmp dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Build a one-engine snapshot under tmp_path wired into the module.
+
+    The discovered schema carries an enum (-> Literal) and a numeric field with
+    MINED bounds (``minimum`` / ``maximum`` -> Field(ge= / le=), now the sole
+    bound path). Returns ``(outputs_dir, output_config_path)``.
+    """
+    outputs = tmp_path / "engine_versions" / "transformers" / "v9_9_9" / "outputs"
+    outputs.mkdir(parents=True)
+    output = tmp_path / "config.py"
+
+    (outputs / "schema.discovered.json").write_text(
+        json.dumps(
+            {
+                "engine_version": "9.9.9",
+                "engine_params": {
+                    "dtype": {"type": "str", "default": "auto", "enum": ["half", "bf16", "auto"]},
+                    "device_map": {"type": "unknown", "default": None},
+                },
+                "sampling_params": {
+                    "temperature": {"type": "float", "default": 1.0},
+                    # Mined bounds straight off the schema: proves the
+                    # minimum/maximum -> Field(ge= / le=) projection.
+                    "top_k": {"type": "int", "default": 50, "minimum": 0, "maximum": 100},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (outputs / "curated.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "engine": "transformers",
+                "exposed_fields": {
+                    "engine_params": ["dtype", "device_map"],
+                    "sampling_params": ["temperature", "top_k"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(rec._outputs, "outputs_dir", lambda engine, version: outputs)
+    return outputs, output
+
+
+def test_write_then_check_is_green(fake_snapshot: tuple[Path, Path]) -> None:
+    """--write materialises config.py; an immediate --check is clean (determinism)."""
+    _outputs, output = fake_snapshot
+    assert (
+        rec.main(
+            ["--engine", "transformers", "--version", "9.9.9", "--write", "--output", str(output)]
+        )
+        == 0
+    )
+    assert output.exists()
+    assert (
+        rec.main(
+            ["--engine", "transformers", "--version", "9.9.9", "--check", "--output", str(output)]
+        )
+        == 0
+    )
+
+
+def test_check_fails_on_drift(fake_snapshot: tuple[Path, Path]) -> None:
+    _outputs, output = fake_snapshot
+    rec.main(["--engine", "transformers", "--version", "9.9.9", "--write", "--output", str(output)])
+    output.write_text(output.read_text(encoding="utf-8") + "# tampered\n", encoding="utf-8")
+    assert (
+        rec.main(
+            ["--engine", "transformers", "--version", "9.9.9", "--check", "--output", str(output)]
+        )
+        == 1
+    )
+
+
+def test_check_defaults_to_check_mode(fake_snapshot: tuple[Path, Path]) -> None:
+    """No mode flag defaults to --check; against an absent target it reports drift."""
+    _outputs, output = fake_snapshot
+    assert (
+        rec.main(["--engine", "transformers", "--version", "9.9.9", "--output", str(output)]) == 1
+    )
+
+
+def test_generated_shape(fake_snapshot: tuple[Path, Path]) -> None:
+    """Literal for the enum, a MINED bound, extra=allow, header.
+
+    Asserts the EXACT generated annotations so the enum -> Literal and
+    minimum/maximum -> Field(ge= / le=) projections are pinned through the full
+    pre-step + datamodel-codegen + ruff path.
+    """
+    _outputs, output = fake_snapshot
+    rec.main(["--engine", "transformers", "--version", "9.9.9", "--write", "--output", str(output)])
+    text = output.read_text(encoding="utf-8")
+
+    assert text.startswith("# DO NOT EDIT")
+    assert "--engine transformers --version 9.9.9 --write" in text
+    # ruff post-step ran: double-quoted strings, not the generator's single quotes.
+    assert 'extra="allow"' in text
+    assert "extra='allow'" not in text
+    # enum -> Literal, exact field annotation.
+    assert 'dtype: Literal["half", "bf16", "auto"] | None = "auto"' in text
+    # MINED minimum/maximum -> Field(ge= / le=), now the sole bound path.
+    assert "ge=0" in text
+    assert "le=100" in text
+    # the three classes are present.
+    for cls in ("class EngineParams", "class SamplingParams", "class Config"):
+        assert cls in text
+
+
+def test_missing_snapshot_dir_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rec._outputs, "outputs_dir", lambda engine, version: tmp_path / "absent")
+    with pytest.raises(FileNotFoundError, match="snapshot outputs dir not found"):
+        rec.main(
+            [
+                "--engine",
+                "vllm",
+                "--version",
+                "9.9.9",
+                "--check",
+                "--output",
+                str(tmp_path / "c.py"),
+            ]
+        )
+
+
+def test_default_output_is_the_src_shadow() -> None:
+    assert rec._shadow_config_path("vllm") == (
+        REPO_ROOT / "src" / "llenergymeasure" / "engines" / "vllm" / "config.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Real workspace snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_real_snapshot_generation_is_byte_stable() -> None:
+    """Two generations off the same real snapshot are byte-identical.
+
+    This is the invariant the CI byte-gate rests on: the tool is a
+    deterministic fixpoint over the committed workspace data.
+    """
+    outputs = rec._outputs.outputs_dir("transformers", "5.7.0")
+    first = rec.generate_config("transformers", "5.7.0", outputs)
+    second = rec.generate_config("transformers", "5.7.0", outputs)
+    assert first == second
+    assert first.startswith(b"# DO NOT EDIT")
+
+
+def test_generates_for_non_active_pin(tmp_path: Path) -> None:
+    """A prior (non-active) pin snapshot generates - the tool is version-scoped."""
+    out = tmp_path / "vllm_073.py"
+    assert (
+        rec.main(["--engine", "vllm", "--version", "0.7.3", "--write", "--output", str(out)]) == 0
+    )
+    text = out.read_text(encoding="utf-8")
+    assert "v0_7_3" in text  # header stamps the snapshot version, not the active pin
+    for cls in ("class EngineParams", "class SamplingParams", "class Config"):
+        assert cls in text
+
+
+def test_vllm_nested_blobs_generate_typed_submodels(tmp_path: Path) -> None:
+    """vLLM wholesale-forwarded blobs become typed submodels against real data."""
+    out = tmp_path / "vllm.py"
+    rec.main(["--engine", "vllm", "--version", "0.19.1", "--write", "--output", str(out)])
+    text = out.read_text(encoding="utf-8")
+    assert "class CompilationConfig" in text
+    assert "class SpeculativeConfig" in text
+    assert "compilation_config: CompilationConfig | None" in text
+    assert "speculative_config: SpeculativeConfig | None" in text

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/c0/c8e94135e66fabf89a120d9b4b123fe6993506beca6c1938a74c24cfa5fd/argcomplete-3.7.0.tar.gz", hash = "sha256:afde224f753f874807b1dc1414e883ab8fe0cda9c04807b6047dcb8e1ac23913", size = 73284, upload-time = "2026-06-30T22:28:22.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/f6/5b8ec087cd9cfa9449491ec83f76fb6b7006b4dff57d2ba8aaab330fe8e4/argcomplete-3.7.0-py3-none-any.whl", hash = "sha256:d8f0f22d2a8a7caa383be1e22b6caf1ecaf0ebd10d8f83cc125e36540c95830c", size = 42575, upload-time = "2026-06-30T22:28:20.547Z" },
+]
+
+[[package]]
 name = "arrow"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -72,6 +81,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/84/b3f55026206a9e8820a91503308075ca48eadc515e436731ca01dbe043b3/black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893", size = 1987719, upload-time = "2026-05-18T17:05:02.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/34/7db312c5e5783d6e76cffd9d5ac8972a32badae4c6e3288dac0eed8d3bed/black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90", size = 1810083, upload-time = "2026-05-18T17:05:04.302Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e2/e0101e73c2c8727634e2efcb35e2b34bd23ad70dfa673789f5773a591b21/black-26.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4", size = 1860633, upload-time = "2026-05-18T17:05:06.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4c/e15c0c5b23cf3651035fe5addcce90e283af3548a3f91bb03d81b83106ab/black-26.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef", size = 1477886, upload-time = "2026-05-18T17:05:07.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3f/59d43ade98d2ce5c8dc34a4e46cbecd177e6d55d7d4092969c6003ccc655/black-26.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22", size = 1277111, upload-time = "2026-05-18T17:05:09.473Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -479,6 +532,26 @@ wheels = [
 ]
 
 [[package]]
+name = "datamodel-code-generator"
+version = "0.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "black", marker = "sys_platform != 'emscripten'" },
+    { name = "genson" },
+    { name = "inflect" },
+    { name = "isort", marker = "sys_platform != 'emscripten'" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/8e/b8f0f8ca0ce41e0065c315eee72ebf1cb82edac8a2c53e005cd3452f2c0e/datamodel_code_generator-0.62.0.tar.gz", hash = "sha256:d467d33dbfc8b1410e199f6526b93bd790697879d094cf7098844a3152e7c17b", size = 1165589, upload-time = "2026-06-10T18:12:26.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/96/16b648ee915ab6682d3141b8017451c5eec494cce673399590a9d836a9ed/datamodel_code_generator-0.62.0-py3-none-any.whl", hash = "sha256:5b66b11e4b150adc2c6fb4b6fd6220479e633f1aa6002d07959a582dfe765720", size = 346648, upload-time = "2026-06-10T18:12:25.002Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -524,6 +597,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
 ]
 
 [[package]]
@@ -757,12 +839,46 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -887,6 +1003,7 @@ zeus = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "datamodel-code-generator" },
     { name = "import-linter" },
     { name = "msgspec" },
     { name = "mypy" },
@@ -918,6 +1035,7 @@ provides-extras = ["zeus", "codecarbon"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "datamodel-code-generator", specifier = "==0.62.0" },
     { name = "import-linter", specifier = ">=2.9" },
     { name = "msgspec" },
     { name = "mypy", specifier = ">=1.0" },
@@ -942,12 +1060,106 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1541,6 +1753,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the codegen tooling that turns workspace schema data into generated typed
pydantic config models. Tooling only: this PR does not commit any generated
`config.py` into `src/`, does not bump engine version pins, and does not touch
`engine_configs.py` (all A4 scope).

`scripts/engine_producers/regen_engine_configs.py`:
- Reads one engine-version snapshot from the SSOT workspace layout
  (`engine_versions/<engine>/v<safe>/outputs/{schema.discovered.json,
  curated.yaml}`) via the `engine_versions._outputs` plain path resolver.
- Emits deterministic typed pydantic model code (`# DO NOT EDIT` header) by
  wrapping `datamodel-code-generator`, then ruff-normalises for byte stability.
- `--check` (default) byte-compares a target file against a fresh
  regeneration (the CI byte-gate primitive); `--write` regenerates it.
- The snapshot is chosen explicitly by `--engine` and `--version`, so the tool
  works against any vendored pin - the active one or a higher pin being
  prepared - and never assumes the active pin. `--output` defaults to the
  `src/` shadow for the engine.

Re-architecture judgments (bound by neither the reference branch nor main):
- Overlay plumbing removed entirely. There is no `overlay.yaml` read path, no
  narrowing/completion machinery, and no `x-narrowing`/`x-completion` codegen
  keys. Semantic value-range bounds belong in the rules corpus, not baked into
  the type surface.
- The shared write-or-check harness was inlined. It existed to be shared with a
  second (corpus) regen script that is not part of this PR; a shared scaffold
  for a single consumer is indirection this PR does not carry.
- No dependency on the legacy current-pin loader: path resolution goes through
  the plain `(engine, version)` resolver. `enumerate_config_classes` is not
  needed by codegen and was not added.
- `datamodel-code-generator==0.62.0` added as a pinned dev tool (its output
  formatting is version-sensitive and byte-compared in CI).

Hand-written production LoC: ~415 (well under budget). `uv.lock` and the dev
dependency are generated/build-tool changes.

## Test plan

- `tests/unit/scripts/engine_producers/test_regen_engine_configs.py` (33
  tests): type-string mapping, enum/bounds passthrough, curated filter and
  union-resolution, debt-stub fields, sorted `$defs` fixpoint, nested-blob
  one-level projection, end-to-end `--write`/`--check` determinism and exit
  codes, exact generated-shape assertions (Literal, mined bound, `extra=allow`,
  header), byte-stable real-snapshot regeneration, generation off a
  non-active pin, and the real vLLM nested-blob submodels.
- Semantic-equivalence validation against the reference branch's committed
  generated models, for the three new-pin snapshots (vllm 0.19.1, tensorrt
  1.0.0, transformers 5.7.0): field sets and defaults are identical; every
  divergence is exactly an entry the killed overlay used to inject (added
  bounds/enums, plus two cases where the overlay narrowed the true mined
  surface - kv_cache_dtype and gpu_memory_utilization). No unexplained field
  loss or type change.
- `make lint` (import-linter contracts kept), `make typecheck` (mypy clean incl.
  the new script), full host `pytest` green (2583 passed, 45 skipped).