### PR TITLE
feat(producers): schema surface diff tool

### DIFF
--- a/scripts/diff_schema_surface.py
+++ b/scripts/diff_schema_surface.py
@@ -170,6 +170,10 @@ def _diff_field_map(old_map: dict[str, Any], new_map: dict[str, Any]) -> dict[st
     return {"added": added, "removed": removed, "changed": changed}
 
 
+def _map_has_changes(diff: dict[str, Any]) -> bool:
+    return bool(diff["added"] or diff["removed"] or diff["changed"])
+
+
 def _diff_defs(old_defs: dict[str, Any], new_defs: dict[str, Any]) -> dict[str, Any]:
     """Diff the ``$defs`` class inventory: added / removed / changed classes.
 
@@ -195,16 +199,12 @@ def _diff_defs(old_defs: dict[str, Any], new_defs: dict[str, Any]) -> dict[str, 
                 old_props if isinstance(old_props, dict) else {},
                 new_props if isinstance(new_props, dict) else {},
             )
-            if props_delta["added"] or props_delta["removed"] or props_delta["changed"]:
+            if _map_has_changes(props_delta):
                 entry["properties"] = props_delta
 
         if entry:
             changed[name] = entry
     return {"added": added, "removed": removed, "changed": changed}
-
-
-def _map_has_changes(diff: dict[str, Any]) -> bool:
-    return bool(diff["added"] or diff["removed"] or diff["changed"])
 
 
 def build_report(old_schema: dict[str, Any], new_schema: dict[str, Any]) -> dict[str, Any]:
@@ -232,6 +232,16 @@ def build_report(old_schema: dict[str, Any], new_schema: dict[str, Any]) -> dict
 # ---------------------------------------------------------------------------
 
 
+def _render_enum_delta(enum: dict[str, list[Any]]) -> str:
+    """Render an enum-membership delta as ``+[added] -[removed]``."""
+    parts = []
+    if enum["added"]:
+        parts.append(f"+{enum['added']}")
+    if enum["removed"]:
+        parts.append(f"-{enum['removed']}")
+    return " ".join(parts)
+
+
 def _render_field_changes(name: str, changes: dict[str, Any], indent: str) -> list[str]:
     lines = [f"{indent}~ {name}"]
     if "type" in changes:
@@ -245,13 +255,7 @@ def _render_field_changes(name: str, changes: dict[str, Any], indent: str) -> li
             f"{indent}    bounds:  {changes['bounds']['old']} -> {changes['bounds']['new']}"
         )
     if "enum" in changes:
-        enum = changes["enum"]
-        parts = []
-        if enum["added"]:
-            parts.append(f"+{enum['added']}")
-        if enum["removed"]:
-            parts.append(f"-{enum['removed']}")
-        lines.append(f"{indent}    enum:    {' '.join(parts)}")
+        lines.append(f"{indent}    enum:    {_render_enum_delta(changes['enum'])}")
     return lines
 
 
@@ -297,13 +301,7 @@ def render_text(report: dict[str, Any]) -> str:
     for name, entry in changed.items():
         lines.append(f"  ~ {name}")
         if "enum" in entry:
-            enum = entry["enum"]
-            parts = []
-            if enum["added"]:
-                parts.append(f"+{enum['added']}")
-            if enum["removed"]:
-                parts.append(f"-{enum['removed']}")
-            lines.append(f"      enum: {' '.join(parts)}")
+            lines.append(f"      enum: {_render_enum_delta(entry['enum'])}")
         if "properties" in entry:
             lines.append(f"      properties: {_counts(entry['properties'])}")
             lines.extend(_render_field_map(entry["properties"], "        "))

--- a/scripts/diff_schema_surface.py
+++ b/scripts/diff_schema_surface.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Report what changed in an engine's config surface between two versions.
+
+This is the bump-review aid the absorb workflow reaches for after a schema
+re-mine: given two version snapshots of one engine, it names every field-level
+change in the discovered configuration surface so a human can read the delta
+instead of eyeballing two large JSON files.
+
+It reads only ``schema.discovered.json`` (resolved through
+``engine_versions/_outputs``); it imports no engine libraries and runs
+anywhere. Per section (``engine_params``, ``sampling_params``) and per ``$defs``
+class it reports:
+
+- fields added / removed,
+- type changes,
+- bound changes (minimum / maximum / exclusiveMinimum / exclusiveMaximum),
+- enum-membership changes (members added / removed),
+- default changes.
+
+Output is deterministic: every listing is sorted by name, and enum-membership
+deltas preserve the source declaration order.
+
+Usage::
+
+    python scripts/diff_schema_surface.py --engine vllm --old 0.7.3 --new 0.19.1
+    python scripts/diff_schema_surface.py --engine vllm --old 0.7.3 --new 0.19.1 --format json
+
+Exit codes:
+    0 - the two surfaces are identical
+    1 - surface changes were found (the expected outcome of a real bump)
+    2 - error (an unknown engine/version, or an unreadable/malformed snapshot)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from engine_versions import _outputs  # noqa: E402
+
+#: Config-surface sections diffed field-by-field.
+_SECTIONS = ("engine_params", "sampling_params")
+
+#: Numeric-bound keys compared per field (JSON-Schema spelling, as discovered).
+_BOUND_KEYS = ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum")
+
+#: Rendered stand-in for a field that declares no default at all (distinct from
+#: a field whose default is ``None``).
+_ABSENT = "<absent>"
+
+
+class SurfaceDiffError(Exception):
+    """A snapshot could not be resolved, read, or parsed."""
+
+
+# ---------------------------------------------------------------------------
+# Field normalisation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FieldShape:
+    """The comparable shape of one field, distilled from its raw schema entry."""
+
+    type: str | None
+    has_default: bool
+    default: Any
+    bounds: tuple[tuple[str, Any], ...]
+    enum: tuple[Any, ...] | None
+
+
+def _type_token(schema: dict[str, Any]) -> str | None:
+    """A single comparable type string for a field or nested member.
+
+    Prefers the explicit ``type`` (the top-level sections carry Python-style
+    type strings); falls back to a ``$ref`` target or a rendered ``anyOf``
+    union (the shapes ``$defs`` object properties use).
+    """
+    if "type" in schema:
+        return str(schema["type"])
+    if "$ref" in schema:
+        return str(schema["$ref"])
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        members = [_type_token(m) or "?" for m in any_of if isinstance(m, dict)]
+        if members:
+            return " | ".join(members)
+    return None
+
+
+def _enum_members(schema: dict[str, Any]) -> tuple[Any, ...] | None:
+    """The declared enum members of a field or class, or ``None`` if not an enum."""
+    members = schema.get("enum")
+    return tuple(members) if isinstance(members, list) else None
+
+
+def _normalise(schema: dict[str, Any]) -> FieldShape:
+    return FieldShape(
+        type=_type_token(schema),
+        has_default="default" in schema,
+        default=schema.get("default"),
+        bounds=tuple((key, schema[key]) for key in _BOUND_KEYS if key in schema),
+        enum=_enum_members(schema),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+def _enum_delta(old: tuple[Any, ...] | None, new: tuple[Any, ...] | None) -> dict[str, list[Any]]:
+    """Members added and removed between two enum member tuples.
+
+    Uses value containment (not sets): enum members can be unhashable, e.g.
+    vLLM's ``CUDAGraphMode`` carries list-valued members.
+    """
+    old_members = list(old or ())
+    new_members = list(new or ())
+    added = [member for member in new_members if member not in old_members]
+    removed = [member for member in old_members if member not in new_members]
+    return {"added": added, "removed": removed}
+
+
+def _default_repr(shape: FieldShape) -> Any:
+    return shape.default if shape.has_default else _ABSENT
+
+
+def _diff_shapes(old: FieldShape, new: FieldShape) -> dict[str, Any]:
+    """The set of dimensions in which one field changed (empty if unchanged)."""
+    changes: dict[str, Any] = {}
+    if old.type != new.type:
+        changes["type"] = {"old": old.type, "new": new.type}
+    if (old.has_default, old.default) != (new.has_default, new.default):
+        changes["default"] = {"old": _default_repr(old), "new": _default_repr(new)}
+    if old.bounds != new.bounds:
+        changes["bounds"] = {"old": dict(old.bounds), "new": dict(new.bounds)}
+    enum_delta = _enum_delta(old.enum, new.enum)
+    if enum_delta["added"] or enum_delta["removed"]:
+        changes["enum"] = enum_delta
+    return changes
+
+
+def _diff_field_map(old_map: dict[str, Any], new_map: dict[str, Any]) -> dict[str, Any]:
+    """Diff a name -> field-schema map into added / removed / changed."""
+    old_fields = {name: fs for name, fs in old_map.items() if isinstance(fs, dict)}
+    new_fields = {name: fs for name, fs in new_map.items() if isinstance(fs, dict)}
+
+    added = {
+        name: _type_token(new_fields[name])
+        for name in sorted(new_fields.keys() - old_fields.keys())
+    }
+    removed = {
+        name: _type_token(old_fields[name])
+        for name in sorted(old_fields.keys() - new_fields.keys())
+    }
+    changed: dict[str, Any] = {}
+    for name in sorted(old_fields.keys() & new_fields.keys()):
+        delta = _diff_shapes(_normalise(old_fields[name]), _normalise(new_fields[name]))
+        if delta:
+            changed[name] = delta
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+def _diff_defs(old_defs: dict[str, Any], new_defs: dict[str, Any]) -> dict[str, Any]:
+    """Diff the ``$defs`` class inventory: added / removed / changed classes.
+
+    A common class is reported when its enum membership shifts (enum classes)
+    or its ``properties`` map changes (object classes).
+    """
+    added = sorted(new_defs.keys() - old_defs.keys())
+    removed = sorted(old_defs.keys() - new_defs.keys())
+    changed: dict[str, Any] = {}
+    for name in sorted(old_defs.keys() & new_defs.keys()):
+        old_class = old_defs[name] if isinstance(old_defs[name], dict) else {}
+        new_class = new_defs[name] if isinstance(new_defs[name], dict) else {}
+        entry: dict[str, Any] = {}
+
+        enum_delta = _enum_delta(_enum_members(old_class), _enum_members(new_class))
+        if enum_delta["added"] or enum_delta["removed"]:
+            entry["enum"] = enum_delta
+
+        old_props = old_class.get("properties")
+        new_props = new_class.get("properties")
+        if isinstance(old_props, dict) or isinstance(new_props, dict):
+            props_delta = _diff_field_map(
+                old_props if isinstance(old_props, dict) else {},
+                new_props if isinstance(new_props, dict) else {},
+            )
+            if props_delta["added"] or props_delta["removed"] or props_delta["changed"]:
+                entry["properties"] = props_delta
+
+        if entry:
+            changed[name] = entry
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+def _map_has_changes(diff: dict[str, Any]) -> bool:
+    return bool(diff["added"] or diff["removed"] or diff["changed"])
+
+
+def build_report(old_schema: dict[str, Any], new_schema: dict[str, Any]) -> dict[str, Any]:
+    """Build the structured surface diff of two discovered-schema dicts."""
+    sections = {
+        section: _diff_field_map(
+            old_schema.get(section, {}) or {}, new_schema.get(section, {}) or {}
+        )
+        for section in _SECTIONS
+    }
+    defs = _diff_defs(old_schema.get("$defs", {}) or {}, new_schema.get("$defs", {}) or {})
+    changed = any(_map_has_changes(diff) for diff in sections.values()) or _map_has_changes(defs)
+    return {
+        "engine": new_schema.get("engine") or old_schema.get("engine"),
+        "old_version": old_schema.get("engine_version"),
+        "new_version": new_schema.get("engine_version"),
+        "changed": changed,
+        "sections": sections,
+        "defs": defs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Text rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_field_changes(name: str, changes: dict[str, Any], indent: str) -> list[str]:
+    lines = [f"{indent}~ {name}"]
+    if "type" in changes:
+        lines.append(f"{indent}    type:    {changes['type']['old']} -> {changes['type']['new']}")
+    if "default" in changes:
+        lines.append(
+            f"{indent}    default: {changes['default']['old']!r} -> {changes['default']['new']!r}"
+        )
+    if "bounds" in changes:
+        lines.append(
+            f"{indent}    bounds:  {changes['bounds']['old']} -> {changes['bounds']['new']}"
+        )
+    if "enum" in changes:
+        enum = changes["enum"]
+        parts = []
+        if enum["added"]:
+            parts.append(f"+{enum['added']}")
+        if enum["removed"]:
+            parts.append(f"-{enum['removed']}")
+        lines.append(f"{indent}    enum:    {' '.join(parts)}")
+    return lines
+
+
+def _render_field_map(diff: dict[str, Any], indent: str) -> list[str]:
+    lines: list[str] = []
+    for name, type_str in diff["added"].items():
+        lines.append(f"{indent}+ {name}: {type_str}")
+    for name in diff["removed"]:
+        lines.append(f"{indent}- {name}")
+    for name, changes in diff["changed"].items():
+        lines.extend(_render_field_changes(name, changes, indent))
+    return lines
+
+
+def _counts(diff: dict[str, Any]) -> str:
+    return f"+{len(diff['added'])} -{len(diff['removed'])} ~{len(diff['changed'])}"
+
+
+def render_text(report: dict[str, Any]) -> str:
+    engine = report["engine"] or "<unknown>"
+    lines = [
+        f"Schema surface diff [{engine}]: {report['old_version']} -> {report['new_version']}",
+    ]
+    if not report["changed"]:
+        lines.append("")
+        lines.append("No surface changes.")
+        return "\n".join(lines)
+
+    for section in _SECTIONS:
+        diff = report["sections"][section]
+        lines.append("")
+        lines.append(f"{section}: {_counts(diff)}")
+        lines.extend(_render_field_map(diff, "  "))
+
+    defs = report["defs"]
+    added, removed, changed = defs["added"], defs["removed"], defs["changed"]
+    lines.append("")
+    lines.append(f"$defs classes: +{len(added)} -{len(removed)} ~{len(changed)}")
+    for name in added:
+        lines.append(f"  + {name}")
+    for name in removed:
+        lines.append(f"  - {name}")
+    for name, entry in changed.items():
+        lines.append(f"  ~ {name}")
+        if "enum" in entry:
+            enum = entry["enum"]
+            parts = []
+            if enum["added"]:
+                parts.append(f"+{enum['added']}")
+            if enum["removed"]:
+                parts.append(f"-{enum['removed']}")
+            lines.append(f"      enum: {' '.join(parts)}")
+        if "properties" in entry:
+            lines.append(f"      properties: {_counts(entry['properties'])}")
+            lines.extend(_render_field_map(entry["properties"], "        "))
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Loading + CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_schema(engine: str, version: str) -> dict[str, Any]:
+    path = _outputs.schema_path(engine, version)
+    if not path.is_file():
+        available = _outputs.workspace_versions(engine)
+        raise SurfaceDiffError(
+            f"no discovered schema for {engine} {version} at {path}; "
+            f"workspace has: {', '.join(available) or '(none)'}"
+        )
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SurfaceDiffError(f"could not read {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SurfaceDiffError(f"{path}: expected a JSON object, got {type(data).__name__}")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", required=True, choices=_outputs.ENGINES)
+    parser.add_argument("--old", required=True, metavar="VERSION", help="Baseline version.")
+    parser.add_argument(
+        "--new", required=True, metavar="VERSION", help="Version compared against it."
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    try:
+        old_schema = _load_schema(args.engine, args.old)
+        new_schema = _load_schema(args.engine, args.new)
+    except SurfaceDiffError as exc:
+        print(f"schema-surface-diff error: {exc}", file=sys.stderr)
+        return 2
+
+    report = build_report(old_schema, new_schema)
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_text(report))
+
+    return 1 if report["changed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_diff_schema_surface.py
+++ b/tests/unit/scripts/test_diff_schema_surface.py
@@ -1,0 +1,294 @@
+"""Tests for scripts/diff_schema_surface.py.
+
+Unit tests exercise the pure diff functions on small synthetic schemas; the
+real-data tests assert known deltas across the committed vLLM and TensorRT
+version-pair snapshots.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from engine_versions import _outputs  # noqa: E402
+from scripts import diff_schema_surface as dss  # noqa: E402
+
+
+def _schema(
+    *,
+    engine: str = "vllm",
+    engine_version: str = "0.0.0",
+    engine_params: dict[str, Any] | None = None,
+    sampling_params: dict[str, Any] | None = None,
+    defs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "engine": engine,
+        "engine_version": engine_version,
+        "engine_params": engine_params or {},
+        "sampling_params": sampling_params or {},
+    }
+    if defs is not None:
+        schema["$defs"] = defs
+    return schema
+
+
+# ---------------------------------------------------------------------------
+# Normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestTypeToken:
+    def test_explicit_type(self) -> None:
+        assert dss._type_token({"type": "int | None"}) == "int | None"
+
+    def test_ref(self) -> None:
+        assert dss._type_token({"$ref": "#/$defs/Foo"}) == "#/$defs/Foo"
+
+    def test_any_of_union(self) -> None:
+        token = dss._type_token({"anyOf": [{"type": "string"}, {"type": "null"}]})
+        assert token == "string | null"
+
+    def test_no_type(self) -> None:
+        assert dss._type_token({"default": 1}) is None
+
+
+class TestEnumMembers:
+    def test_present(self) -> None:
+        assert dss._enum_members({"enum": ["a", "b"]}) == ("a", "b")
+
+    def test_absent(self) -> None:
+        assert dss._enum_members({"type": "str"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Field-shape diff
+# ---------------------------------------------------------------------------
+
+
+def _diff(old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+    return dss._diff_shapes(dss._normalise(old), dss._normalise(new))
+
+
+class TestDiffShapes:
+    def test_identical(self) -> None:
+        assert _diff({"type": "int", "default": 0}, {"type": "int", "default": 0}) == {}
+
+    def test_type_change(self) -> None:
+        delta = _diff({"type": "int | None"}, {"type": "int"})
+        assert delta["type"] == {"old": "int | None", "new": "int"}
+
+    def test_default_change(self) -> None:
+        delta = _diff({"type": "float", "default": 0.9}, {"type": "float", "default": 0.95})
+        assert delta["default"] == {"old": 0.9, "new": 0.95}
+
+    def test_default_absent_vs_none(self) -> None:
+        # A field gaining an explicit ``default: null`` is a change distinct
+        # from having had no default at all.
+        delta = _diff({"type": "int"}, {"type": "int", "default": None})
+        assert delta["default"] == {"old": dss._ABSENT, "new": None}
+
+    def test_bounds_added(self) -> None:
+        delta = _diff({"type": "int"}, {"type": "int", "minimum": 0})
+        assert delta["bounds"] == {"old": {}, "new": {"minimum": 0}}
+
+    def test_enum_members_added(self) -> None:
+        delta = _diff({"enum": ["a"]}, {"enum": ["a", "b"]})
+        assert delta["enum"] == {"added": ["b"], "removed": []}
+
+    def test_enum_introduced(self) -> None:
+        delta = _diff({"type": "str"}, {"type": "str", "enum": ["a", "b"]})
+        assert delta["enum"] == {"added": ["a", "b"], "removed": []}
+
+    def test_enum_reorder_is_not_a_change(self) -> None:
+        # Membership, not order: a reordered enum with the same members is inert.
+        assert "enum" not in _diff({"enum": ["a", "b"]}, {"enum": ["b", "a"]})
+
+    def test_unhashable_enum_members(self) -> None:
+        # vLLM CUDAGraphMode carries list-valued members; containment, not sets.
+        delta = _diff({"enum": [0, 1]}, {"enum": [0, 1, [2, 0]]})
+        assert delta["enum"] == {"added": [[2, 0]], "removed": []}
+
+
+# ---------------------------------------------------------------------------
+# Field-map and $defs diff
+# ---------------------------------------------------------------------------
+
+
+class TestFieldMap:
+    def test_added_removed_changed_sorted(self) -> None:
+        diff = dss._diff_field_map(
+            {"keep": {"type": "int"}, "gone": {"type": "str"}, "morph": {"type": "int"}},
+            {"keep": {"type": "int"}, "morph": {"type": "int | None"}, "fresh": {"type": "bool"}},
+        )
+        assert diff["added"] == {"fresh": "bool"}
+        assert diff["removed"] == {"gone": "str"}
+        assert list(diff["changed"]) == ["morph"]
+
+    def test_non_dict_entries_ignored(self) -> None:
+        # Malformed (non-dict) entries are skipped, never crash the diff.
+        diff = dss._diff_field_map({"x": "not-a-dict"}, {"x": "still-not"})
+        assert diff["added"] == {} and diff["removed"] == {} and diff["changed"] == {}
+
+
+class TestDefs:
+    def test_class_added_and_removed(self) -> None:
+        diff = dss._diff_defs({"Old": {"enum": [1]}}, {"New": {"enum": [1]}})
+        assert diff["added"] == ["New"]
+        assert diff["removed"] == ["Old"]
+
+    def test_enum_class_membership(self) -> None:
+        diff = dss._diff_defs({"Mode": {"enum": [0, 1]}}, {"Mode": {"enum": [0, 1, 2]}})
+        assert diff["changed"]["Mode"]["enum"] == {"added": [2], "removed": []}
+
+    def test_object_class_property_diff(self) -> None:
+        diff = dss._diff_defs(
+            {"Cfg": {"type": "object", "properties": {"a": {"type": "int"}}}},
+            {"Cfg": {"type": "object", "properties": {"a": {"type": "int"}, "b": {"type": "str"}}}},
+        )
+        assert diff["changed"]["Cfg"]["properties"]["added"] == {"b": "str"}
+
+
+# ---------------------------------------------------------------------------
+# Report + rendering
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport:
+    def test_no_changes(self) -> None:
+        schema = _schema(engine_params={"model": {"type": "str"}})
+        report = dss.build_report(schema, schema)
+        assert report["changed"] is False
+        assert report["engine"] == "vllm"
+
+    def test_change_flag_set(self) -> None:
+        report = dss.build_report(
+            _schema(engine_params={"model": {"type": "str"}}),
+            _schema(engine_params={"model": {"type": "str"}, "extra": {"type": "int"}}),
+        )
+        assert report["changed"] is True
+        assert "extra" in report["sections"]["engine_params"]["added"]
+
+    def test_version_metadata(self) -> None:
+        report = dss.build_report(_schema(engine_version="0.7.3"), _schema(engine_version="0.19.1"))
+        assert report["old_version"] == "0.7.3"
+        assert report["new_version"] == "0.19.1"
+
+
+class TestRenderText:
+    def test_no_change_message(self) -> None:
+        schema = _schema(engine_params={"model": {"type": "str"}})
+        assert "No surface changes." in dss.render_text(dss.build_report(schema, schema))
+
+    def test_change_markers(self) -> None:
+        report = dss.build_report(
+            _schema(engine_params={"gone": {"type": "str"}, "morph": {"type": "int"}}),
+            _schema(engine_params={"fresh": {"type": "bool"}, "morph": {"type": "int | None"}}),
+        )
+        text = dss.render_text(report)
+        assert "+ fresh: bool" in text
+        assert "- gone" in text
+        assert "~ morph" in text
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_no_change_exit_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        code = dss.main(["--engine", "vllm", "--old", "0.7.3", "--new", "0.7.3"])
+        assert code == 0
+        assert "No surface changes." in capsys.readouterr().out
+
+    def test_changes_exit_one(self, capsys: pytest.CaptureFixture[str]) -> None:
+        code = dss.main(["--engine", "vllm", "--old", "0.7.3", "--new", "0.19.1"])
+        assert code == 1
+
+    def test_json_format_parseable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        code = dss.main(
+            ["--engine", "vllm", "--old", "0.7.3", "--new", "0.19.1", "--format", "json"]
+        )
+        assert code == 1
+        report = json.loads(capsys.readouterr().out)
+        assert report["engine"] == "vllm"
+        assert report["changed"] is True
+
+    def test_unknown_version_exit_two(self, capsys: pytest.CaptureFixture[str]) -> None:
+        code = dss.main(["--engine", "vllm", "--old", "9.9.9", "--new", "0.7.3"])
+        assert code == 2
+        assert "no discovered schema" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Real-data deltas (committed workspace snapshots)
+# ---------------------------------------------------------------------------
+
+
+def _load_real(engine: str, version: str) -> dict[str, Any]:
+    path = _outputs.schema_path(engine, version)
+    if not path.is_file():
+        pytest.skip(f"snapshot missing: {path}")
+    return json.loads(path.read_text())
+
+
+class TestRealDataVllm:
+    @pytest.fixture(scope="class")
+    def report(self) -> dict[str, Any]:
+        return dss.build_report(_load_real("vllm", "0.7.3"), _load_real("vllm", "0.19.1"))
+
+    def test_engine_params_added(self, report: dict[str, Any]) -> None:
+        added = report["sections"]["engine_params"]["added"]
+        assert "async_scheduling" in added
+        assert "attention_backend" in added
+
+    def test_engine_params_removed(self, report: dict[str, Any]) -> None:
+        removed = report["sections"]["engine_params"]["removed"]
+        assert "device" in removed
+        assert "guided_decoding_backend" in removed
+
+    def test_dtype_gained_enum(self, report: dict[str, Any]) -> None:
+        dtype = report["sections"]["engine_params"]["changed"]["dtype"]
+        assert "float16" in dtype["enum"]["added"]
+        assert dtype["enum"]["removed"] == []
+
+    def test_cpu_offload_gb_gained_bound(self, report: dict[str, Any]) -> None:
+        bounds = report["sections"]["engine_params"]["changed"]["cpu_offload_gb"]["bounds"]
+        assert bounds["new"] == {"minimum": 0}
+
+    def test_sampling_params_delta(self, report: dict[str, Any]) -> None:
+        sampling = report["sections"]["sampling_params"]
+        assert "structured_outputs" in sampling["added"]
+        assert "best_of" in sampling["removed"]
+
+    def test_defs_delta(self, report: dict[str, Any]) -> None:
+        assert "AttentionConfig" in report["defs"]["added"]
+        assert "GuidedDecodingParams" in report["defs"]["removed"]
+
+    def test_changed_flag(self, report: dict[str, Any]) -> None:
+        assert report["changed"] is True
+
+
+class TestRealDataTensorrt:
+    @pytest.fixture(scope="class")
+    def report(self) -> dict[str, Any]:
+        return dss.build_report(_load_real("tensorrt", "0.21.0"), _load_real("tensorrt", "1.0.0"))
+
+    def test_engine_params_delta(self, report: dict[str, Any]) -> None:
+        engine_params = report["sections"]["engine_params"]
+        assert "fail_fast_on_attention_window_too_large" in engine_params["added"]
+        assert "max_loras" in engine_params["removed"]
+
+    def test_sampling_params_stable(self, report: dict[str, Any]) -> None:
+        sampling = report["sections"]["sampling_params"]
+        assert sampling["added"] == {}
+        assert sampling["removed"] == {}


### PR DESCRIPTION
## Summary

Adds `scripts/diff_schema_surface.py`: the bump-review aid that reports what
changed in an engine's discovered config surface between two workspace
version snapshots. This is the mechanical-diff step the absorb workflow runs
after a schema re-mine.

- Reads `schema.discovered.json` for two versions of one engine, resolved
  through `engine_versions/_outputs` (no reimplemented path logic).
- Reports, per section (`engine_params`, `sampling_params`) and per `$defs`
  class: fields added / removed, type changes, bound changes
  (minimum / maximum / exclusiveMinimum / exclusiveMaximum), enum-membership
  changes (members added / removed, order-insensitive), and default changes
  (a field with no default is distinct from `default: null`).
- Deterministic output: all listings sorted by name; byte-identical across
  runs. Human-readable text by default, `--format json` for structure.
- Exit codes: 0 = no surface change, 1 = changes found (the expected outcome
  of a real bump), 2 = error (unknown version, unreadable snapshot). Unknown
  versions list what the workspace actually has.

Design notes:

- Re-architected rather than ported: the reference implementation was a
  coarse count census (how many fields carry an enum, per-provenance rule
  tallies) over multiple mined artifacts. This tool answers the bump-review
  question instead - WHICH fields changed and HOW - and reads only the
  discovered schema.
- `main` already has `scripts/diff_discovered_schemas.py` (safe/breaking
  classifier used by the engine-pipeline schemas cell). This tool is a
  different consumer at a different grain (field-level review delta including
  bounds, enum membership, and `$defs` classes; version-addressed via the
  workspace resolver rather than file paths). Consolidation, if wanted, can
  follow when the schemas cell is reworked.

Authored size: 364 lines tool + 294 lines tests = 658 physical lines total.

## Test plan

- 38 unit tests in `tests/unit/scripts/test_diff_schema_surface.py`:
  normalisation (type tokens from `type` / `$ref` / `anyOf`), field-shape
  diffing (type / default / bounds / enum membership, absent-vs-null default,
  unhashable enum members, enum reorder inertness), field-map and `$defs`
  diffing, report assembly, text rendering, CLI exit codes.
- Real-data tests against the committed workspace snapshots:
  - vllm 0.7.3 -> 0.19.1: asserts known added fields (`async_scheduling`,
    `attention_backend`), removed fields (`device`,
    `guided_decoding_backend`), `dtype` gaining its enum, `cpu_offload_gb`
    gaining `minimum: 0`, sampling `best_of` removal, `$defs`
    `AttentionConfig` added / `GuidedDecodingParams` removed.
  - tensorrt 0.21.0 -> 1.0.0: asserts
    `fail_fast_on_attention_window_too_large` added, `max_loras` removed,
    sampling section stable.
- `make lint`, `make typecheck`, full `pytest` green.
- Manual: both real pairs render correctly; same-version diff exits 0 with
  "No surface changes."; JSON output byte-identical across runs.

## Doc audit

No doc update needed: new standalone review tool, purely additive; no existing docs, CLI flags, or user-visible strings touched.
