### PR TITLE
feat(config): record rejecting rule id on skipped sweep configs

### DIFF
--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -7,6 +7,7 @@ import itertools
 import json
 import logging
 import random
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -55,6 +56,13 @@ class SkippedConfig:
     raw_config: dict[str, Any]
     reason: str
     errors: list[dict[str, Any]] = field(default_factory=list)
+    rule_id: str | None = None
+    """Engine rule that rejected this config, or None for a non-rule failure.
+
+    Populated from the ValidationError entries via :func:`_extract_rule_id`;
+    None when the config failed on a type error, unknown field, or any other
+    validation that is not an engine-rule rejection.
+    """
 
     @property
     def short_label(self) -> str:
@@ -65,6 +73,11 @@ class SkippedConfig:
         dtype = engine_params.get("dtype", "?") if isinstance(engine_params, dict) else "?"
         return f"{engine}, {dtype}"
 
+    @property
+    def display_reason(self) -> str:
+        """Compact reason for digests: the rejecting rule id, or the raw reason."""
+        return f"rule {self.rule_id}" if self.rule_id is not None else self.reason
+
     def to_dict(self) -> dict[str, Any]:
         """Serialise for StudyConfig.skipped_configs."""
         return {
@@ -72,7 +85,48 @@ class SkippedConfig:
             "reason": self.reason,
             "short_label": self.short_label,
             "errors": self.errors,
+            "rule_id": self.rule_id,
         }
+
+
+_RULE_ID_MARKER = re.compile(r"^\[([a-z0-9_]+)\]")
+
+
+def _raw_rule_message(err: dict[str, Any]) -> str:
+    """Return a value_error entry's message with the ``[rule_id]`` marker leading.
+
+    Prefer the original exception carried in ``ctx`` (its str keeps the marker
+    at position 0); fall back to stripping Pydantic's ``Value error, `` prefix
+    from ``msg`` when no exception object is present.
+    """
+    ctx = err.get("ctx")
+    if isinstance(ctx, dict):
+        original = ctx.get("error")
+        if isinstance(original, BaseException):
+            return str(original)
+    msg = str(err.get("msg", ""))
+    prefix = "Value error, "
+    return msg[len(prefix) :] if msg.startswith(prefix) else msg
+
+
+def _extract_rule_id(errors: list[dict[str, Any]]) -> str | None:
+    """Return the engine-rule id that rejected a config, or None.
+
+    Engine rules raise ``ValueError(f"[{rule.id}] {message}")`` in
+    ``ExperimentConfig._apply_rules``; Pydantic wraps that as a ``value_error``
+    entry whose original exception carries the leading ``[rule_id]`` marker.
+    Rule ids are snake_case, so the anchored regex stays conservative and never
+    matches bracketed prose later in a message. Only one rule fires per config
+    (``_apply_rules`` raises on the first error match), so the first marker
+    found is authoritative.
+    """
+    for err in errors:
+        if err.get("type") != "value_error":
+            continue
+        match = _RULE_ID_MARKER.match(_raw_rule_message(err))
+        if match is not None:
+            return match.group(1)
+    return None
 
 
 # =============================================================================
@@ -142,13 +196,20 @@ def expand_grid(
             errors: list[dict[str, Any]] = []
             if isinstance(exc, ValidationError):
                 errors = [dict(e) for e in exc.errors()]
-            skipped.append(SkippedConfig(raw_config=raw_config, reason=reason, errors=errors))
+            skipped.append(
+                SkippedConfig(
+                    raw_config=raw_config,
+                    reason=reason,
+                    errors=errors,
+                    rule_id=_extract_rule_id(errors),
+                )
+            )
 
     total = len(valid) + len(skipped)
 
     # Guard: all configs invalid
     if len(valid) == 0:
-        first_reasons = "; ".join(s.reason[:120] for s in skipped[:5])
+        first_reasons = "; ".join(s.display_reason[:120] for s in skipped[:5])
         raise ConfigError(
             f"nothing to run - all {total} generated config(s) are invalid. "
             f"First failures: {first_reasons}"
@@ -163,7 +224,7 @@ def expand_grid(
             total,
         )
         for s in skipped:
-            logger.warning("  Skipped (%s): %s", s.short_label, s.reason[:200])
+            logger.warning("  Skipped (%s): %s", s.short_label, s.display_reason[:200])
 
     # Combinatorial explosion warnings (tiered)
     n_valid = len(valid)

--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -405,6 +405,64 @@ class TestExpandGridInvalidHandling:
             expand_grid(raw)
 
 
+class TestSkippedConfigRuleAttribution:
+    """expand_grid records which engine rule rejected which config."""
+
+    def test_rule_rejection_records_rule_id(self):
+        """A sweep point that violates a corpus rule carries the rejecting rule id.
+
+        num_beams=2 with num_return_sequences=4 fires the transformers
+        cross-section rule; the num_return_sequences=1 point stays valid.
+        """
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "transformers": {"engine_params": {"num_beams": 2}},
+            "sweep": {"transformers.sampling_params.num_return_sequences": [1, 4]},
+        }
+        valid, skipped = expand_grid(raw)
+
+        assert len(valid) == 1
+        assert len(skipped) == 1
+        assert (
+            skipped[0].rule_id
+            == "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences"
+        )
+
+    def test_non_rule_failure_has_no_rule_id(self):
+        """A non-rule rejection (wrong engine section) leaves rule_id None."""
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "sweep": {"transformers.engine_params.dtype": ["float16"]},
+            "experiments": [
+                {"task": {"model": "gpt2"}, "engine": "transformers", "vllm": {"max_num_seqs": 64}},
+            ],
+        }
+        valid, skipped = expand_grid(raw)
+
+        assert len(valid) == 1
+        assert len(skipped) == 1
+        assert skipped[0].rule_id is None
+
+    def test_to_dict_includes_rule_id(self):
+        """rule_id round-trips through the serialised form."""
+        sc = SkippedConfig(
+            raw_config={"engine": "transformers", "transformers": {}},
+            reason="[some_rule_id] boom",
+            rule_id="some_rule_id",
+        )
+        assert sc.to_dict()["rule_id"] == "some_rule_id"
+
+    def test_to_dict_rule_id_none_by_default(self):
+        """A skipped config with no rule attribution serialises rule_id as None."""
+        sc = SkippedConfig(
+            raw_config={"engine": "vllm", "vllm": {}},
+            reason="type error",
+        )
+        assert sc.to_dict()["rule_id"] is None
+
+
 class TestMultiBackendSectionStripping:
     """Top-level engine sections are stripped for non-matching engines in multi-engine studies."""
 


### PR DESCRIPTION
## Summary

Sweep-grid skip collection now records which engine rule rejected which config,
so a downstream study-plan preview can show structured attribution (declared ->
invalid-pruned WITH rule ids -> dedup -> runs).

Engine rules raise `ValueError(f"[{rule.id}] {message}")` in
`ExperimentConfig._apply_rules`, which Pydantic wraps into a `value_error`
entry. The rule id was previously buried in the `str(ValidationError)` prose.

## Changes

- `SkippedConfig` gains a `rule_id: str | None` field (None when the failure was
  not an engine-rule rejection, e.g. a type error or unknown-field rejection).
- Extraction (`_extract_rule_id`): scans the ValidationError `value_error`
  entries and anchors a conservative snake_case regex `^\[([a-z0-9_]+)\]` on the
  raw marker. It prefers the original exception carried in the entry `ctx`
  (marker at position 0) and falls back to stripping Pydantic's `Value error, `
  prefix from `msg`. Only one rule fires per config (`_apply_rules` raises on the
  first error match), so a single Optional field is correct; the first marker
  found is returned. In practice a single marker appears per skipped config.
- `SkippedConfig.to_dict()` includes `rule_id` (additive; existing consumers -
  `StudyConfig.skipped_configs`, CLI display, study loading - keep their
  behaviour since they read by key / count).
- The all-invalid `first_reasons` digest and the >50%-skip warning now show the
  rule id for rule-rejected entries via a `display_reason` property, instead of
  the raw reason slice. Minimal legibility improvement, no new flags.

## Tests (firing-level, public path)

- expand_grid on a sweep whose expansion includes a rule-violating point
  (transformers `num_beams=2` with `num_return_sequences=4`) asserts the skipped
  entry's `rule_id` equals the corpus rule id and the valid point still comes
  through.
- A non-rule failure (wrong engine section) -> `rule_id` is None.
- `to_dict()` round-trip includes `rule_id` (set and None-default cases).

## Validation

- `make lint`: ruff check + format clean, import-linter 4/4 contracts kept.
- `make typecheck`: mypy Success, no issues in 284 source files.
- `uv run pytest tests/unit -q`: 2592 passed, 45 skipped, 0 failures.
- `git diff origin/main... -- 'src/llenergymeasure/engines/*/rules.yaml' 'engine_versions/'`: empty (byte-frozen data untouched).

Out of scope (untouched): study-plan preview CLI, `study/library_resolution.py`,
engine_rules loader internals, mined/generated data, CI workflows.