### PR TITLE
fix(rules): resolve bare normalised_fields against match scope

### DIFF
--- a/src/llenergymeasure/study/library_resolution.py
+++ b/src/llenergymeasure/study/library_resolution.py
@@ -42,6 +42,17 @@ PoC-F (sweep-dedup.md §10) converged every seeded-corpus case within 2
 passes; 10 is generous headroom that still surfaces a rule cycle quickly.
 """
 
+_STRIP = object()
+"""Marker: drive a dormant field back to *absent* (its library default).
+
+Distinct from ``None``. The resolved-config hash deliberately keeps ``None``
+and missing keys distinguishable (see :mod:`llenergymeasure.domain.hashing`),
+so a field the engine silently ignores (e.g. vLLM ``seed=-1``) must be driven
+to absent - not ``None`` - for it to collapse with a config that never set it.
+The vLLM dormant fields are all pydantic extras, so "absent" means removing the
+extra key.
+"""
+
 
 class LibraryResolutionCycleError(RuntimeError):
     """The library-resolution mechanism did not reach a fixpoint within :data:`_MAX_ITER` passes.
@@ -99,7 +110,13 @@ def _apply_rules_fixpoint(
             if not updates:
                 continue
             for field_path, target_value in updates.items():
-                if resolve_field_path(current, field_path) != target_value:
+                current_value = resolve_field_path(current, field_path)
+                if target_value is _STRIP:
+                    # Canonical form is *absent*; only fire while a value lingers.
+                    already_canonical = current_value is None
+                else:
+                    already_canonical = current_value == target_value
+                if not already_canonical:
                     _assign_field_path(current, field_path, target_value)
                     fired = True
         if not fired:
@@ -107,13 +124,38 @@ def _apply_rules_fixpoint(
     raise LibraryResolutionCycleError(current, _MAX_ITER)
 
 
+def _resolve_normalised_field(name: str, match_fields: dict[str, Any]) -> str:
+    """Resolve a ``normalised_fields`` entry to a dotted config path.
+
+    A dotted entry passes through unchanged. A bare leaf name (the vLLM corpus
+    convention - it stores ``seed``, ``all2all_backend``, ... not the fully
+    dotted paths) is anchored as a *sibling* of the rule's subject match field.
+    Corpus convention orders ``match_fields`` preconditions-first, subject-last,
+    so the anchor is the parent path of the LAST match-field key. This mirrors
+    the bare-``@field_ref`` sibling semantics in the loader's ``_resolve_one_ref``.
+
+    A bare name with no match fields to anchor against passes through unchanged
+    rather than guessing - assignment against config root then no-ops silently,
+    preserving today's behaviour for that (corpus-absent) shape.
+    """
+    if "." in name or not match_fields:
+        return name
+    subject_path = next(reversed(match_fields))
+    parent_parts = subject_path.split(".")[:-1]
+    if not parent_parts:
+        return name
+    return ".".join([*parent_parts, name])
+
+
 def _rule_normalisations(rule: Rule) -> dict[str, Any]:
     """Return ``{field_path: canonical_value}`` the rule normalises to.
 
     Strategy (per sweep-dedup.md §2.1 and the fixpoint test's projection):
 
-    1. If ``normalised_fields`` lists explicit paths, they collapse to ``None``
-       (the universal "strip this field" sentinel).
+    1. If ``normalised_fields`` lists explicit paths, each resolves to a dotted
+       config path (see :func:`_resolve_normalised_field`) and collapses to
+       :data:`_STRIP` - the field is driven back to *absent* (its library
+       default), so a config that set it equals one that never did.
     2. Otherwise, fall back to the rule's *match* predicate: any field
        matched with a ``not_equal`` / ``present`` operator is normalised by
        stripping (setting to ``None`` or the ``not_equal`` sentinel if
@@ -127,9 +169,9 @@ def _rule_normalisations(rule: Rule) -> dict[str, Any]:
     out: dict[str, Any] = {}
 
     explicit = rule.normalised_fields or ()
-    for raw_path in explicit:
-        path = str(raw_path)
-        out[path] = None
+    for raw_name in explicit:
+        path = _resolve_normalised_field(str(raw_name), rule.match_fields)
+        out[path] = _STRIP
 
     if out:
         return out
@@ -165,6 +207,21 @@ def _assign_field_path(config: ExperimentConfig, path: str, value: Any) -> None:
     if parent is None:
         return
     leaf = parts[-1]
+    if value is _STRIP:
+        # Drive the field back to *absent* so it collapses with a config that
+        # never set it. vLLM's dormant fields are pydantic extras; removing the
+        # extra makes the resolved-config view identical to the unset case.
+        if isinstance(parent, dict):
+            parent.pop(leaf, None)
+            return
+        extra = getattr(parent, "__pydantic_extra__", None)
+        if isinstance(extra, dict) and leaf in extra:
+            del extra[leaf]
+            return
+        # Declared field: it cannot be removed, so reset to None as a
+        # best-effort strip - enough to reach a fixpoint (it will not collapse
+        # with a truly-absent field, but no shipped rule hits this branch).
+        value = None
     try:
         if isinstance(parent, dict):
             parent[leaf] = value

--- a/tests/unit/study/test_library_resolution.py
+++ b/tests/unit/study/test_library_resolution.py
@@ -18,6 +18,7 @@ from llenergymeasure.study.hashing import build_resolved_view, hash_config
 from llenergymeasure.study.library_resolution import (
     LibraryResolutionCycleError,
     _apply_rules_fixpoint,
+    _resolve_normalised_field,
     resolve_library_effective,
 )
 
@@ -298,6 +299,79 @@ class TestDedupSweep:
 # ---------------------------------------------------------------------------
 # resolved_config_hashing symmetry
 # ---------------------------------------------------------------------------
+
+
+class TestResolveNormalisedField:
+    """Unit coverage for bare-vs-dotted ``normalised_fields`` path resolution."""
+
+    def test_bare_name_anchors_to_last_match_field_parent(self):
+        # Subject field is last per corpus convention; a bare leaf resolves as
+        # its sibling (parent path of the last match key + the bare name).
+        match = {
+            "vllm.engine_params.distributed_executor_backend": "external_launcher",
+            "vllm.engine_params.data_parallel_rank": {"present": True},
+        }
+        assert (
+            _resolve_normalised_field("data_parallel_rank", match)
+            == "vllm.engine_params.data_parallel_rank"
+        )
+
+    def test_dotted_name_passes_through_untouched(self):
+        match = {"transformers.sampling_params.temperature": {"not_equal": 1.0}}
+        assert (
+            _resolve_normalised_field("transformers.sampling_params.top_p", match)
+            == "transformers.sampling_params.top_p"
+        )
+
+    def test_bare_name_without_match_fields_passes_through(self):
+        assert _resolve_normalised_field("seed", {}) == "seed"
+
+
+class TestVllmDormantDedup:
+    """Real-corpus regressions: bare ``normalised_fields`` now canonicalise.
+
+    On main the corpus's bare leaf names (``seed``, ``all2all_backend``) were
+    handed straight to root-level assignment, no-oped silently, and the dormant
+    vLLM fields never collapsed. These drive the public dedup path end to end.
+    """
+
+    def _vllm(self, sampling=None, engine=None):
+        payload: dict = {}
+        if sampling is not None:
+            payload["sampling_params"] = sampling
+        if engine is not None:
+            payload["engine_params"] = engine
+        return ExperimentConfig(task={"model": "gpt2"}, engine="vllm", vllm=payload)
+
+    def test_seed_neg1_and_unset_collapse(self):
+        # seed=-1 is dormant (vLLM treats it as "no seed"); it must collapse
+        # with a config that never set seed.
+        cfg_seeded = self._vllm(sampling={"seed": -1})
+        cfg_unset = self._vllm(sampling={})
+
+        deduped = resolve_library_effective([cfg_seeded, cfg_unset], deduplicate=True)
+        assert len(deduped.canonical_configs) == 1
+        assert deduped.would_dedup is True
+        assert deduped.deduplicated is True
+
+        kept = resolve_library_effective([cfg_seeded, cfg_unset], deduplicate=False)
+        assert len(kept.canonical_configs) == 2
+        assert kept.would_dedup is True
+
+    def test_all2all_backend_set_and_unset_collapse(self):
+        # engine_params-scoped dormant field: all2all_backend in {pplx, naive}
+        # is ignored, so it must collapse with the unset config.
+        cfg_set = self._vllm(engine={"all2all_backend": "pplx"})
+        cfg_unset = self._vllm(engine={})
+
+        deduped = resolve_library_effective([cfg_set, cfg_unset], deduplicate=True)
+        assert len(deduped.canonical_configs) == 1
+        assert deduped.would_dedup is True
+        assert deduped.deduplicated is True
+
+        kept = resolve_library_effective([cfg_set, cfg_unset], deduplicate=False)
+        assert len(kept.canonical_configs) == 2
+        assert kept.would_dedup is True
 
 
 class TestH1HashSymmetry:


### PR DESCRIPTION
## Bug (pre-existing)

`_rule_normalisations` in `study/library_resolution.py` handed a rule's
explicit `normalised_fields` entries straight to field-path assignment. The
vLLM corpus stores those entries as BARE LEAF NAMES (`seed`,
`all2all_backend`, `data_parallel_rank`, `bad_words`,
`skip_reading_prefix_cache`, `stop_token_ids`) while match fields are fully
dotted. A bare name resolves at config ROOT, so assignment no-oped silently:
the dormant vLLM fields never canonicalised, and `seed=-1` vs `seed`-unset
did not dedup to a single run.

`transformers` and `tensorrt` carry zero `normalised_fields` (they use the
`not_equal` / `present` fallback), so vLLM was the only affected consumer.

## Fix (code-side only, corpora frozen)

1. Resolve a bare `normalised_fields` entry as a SIBLING of the rule's
   subject match field - the parent path of the LAST `match_fields` key
   (corpus convention: preconditions first, subject last). Mirrors the
   bare-`@field_ref` sibling semantics in the loader. Dotted entries and
   bare entries with empty `match_fields` pass through unchanged.
2. vLLM's dormant fields are pydantic extras, and the resolved-config hash
   deliberately keeps `None` distinct from missing. Path resolution alone
   would set `seed=None`, which still differs from unset. So an explicit
   `normalised_fields` entry now strips the extra to ABSENT (via a `_STRIP`
   marker) rather than setting `None`. The `not_equal` / `present` fallback
   is untouched, so transformers / tensorrt behaviour is byte-identical.

## Resolution table (all 6 vLLM rules with normalised_fields)

Each bare name resolves to its dotted path, and each resolves against a
constructed vLLM `ExperimentConfig`:

| rule_id | bare name | resolved path |
| --- | --- | --- |
| vllm_parallelconfig_dormant_all2all_backend_in | all2all_backend | vllm.engine_params.all2all_backend |
| vllm_parallelconfig_dormant_data_parallel_rank_set_true | data_parallel_rank | vllm.engine_params.data_parallel_rank |
| vllm_samplingparams_dormant_bad_words_unset_true | bad_words | vllm.sampling_params.bad_words |
| vllm_samplingparams_dormant_seed_eq_neg1 | seed | vllm.sampling_params.seed |
| vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true | skip_reading_prefix_cache | vllm.sampling_params.skip_reading_prefix_cache |
| vllm_samplingparams_dormant_stop_token_ids_unset_true | stop_token_ids | vllm.sampling_params.stop_token_ids |

## Seed-dedup regression (before / after)

Two vLLM configs differing only in `vllm.sampling_params.seed` (-1 vs unset),
through `resolve_library_effective(deduplicate=True)`:

- BEFORE (origin/main): `canonical_configs = 2` (no collapse)
- AFTER (this PR): `canonical_configs = 1` (collapse); `would_dedup = True`

Same shape verified for the engine_params-scoped `all2all_backend` rule
(2 -> 1). Both survive under `deduplicate=False`.

## Validation

- `make lint`: 4 import-linter contracts kept, ruff clean
- `make typecheck`: mypy success, no issues in 284 source files
- `uv run pytest tests/unit -q`: 2593 passed, 45 skipped, 0 failures
- `git diff origin/main... -- 'src/llenergymeasure/engines/*/rules.yaml' 'engine_versions/'`: empty
- Existing synthetic dotted-path resolution tests unchanged and passing

## Deviation from the literal brief

The brief scoped the fix to path resolution. Path resolution alone was
necessary but insufficient: vLLM dormant fields are pydantic extras where
`None != absent` under the strict resolved-config hash, so the seed-dedup
regression would still report `canonical = 2`. Added a narrowly-scoped
strip-to-absent (only the explicit `normalised_fields` path) so the dedup
genuinely fires. The `not_equal` / `present` fallback is untouched, keeping
transformers / tensorrt behaviour identical.