### PR TITLE
test(engines): lock plugin measurement contract with goldens

### DIFF
--- a/tests/unit/engines/test_measurement_contract.py
+++ b/tests/unit/engines/test_measurement_contract.py
@@ -1,0 +1,330 @@
+"""Golden characterisation of the engine kwarg-builder / nested-config accessor contract.
+
+These tests freeze the exact dicts produced by the pure kwarg builders on every
+engine plugin. The frozen literals were captured from the current main branch and
+are asserted verbatim: they are a tripwire, not a re-derivation. Refactors that
+rename an accessor, drop a field, or change the shape of the generated nested
+config will break an exact-equality assertion here rather than silently drifting
+the measured behaviour.
+
+What is locked:
+
+  - TransformersEngine._build_generate_kwargs: sampling + generation-control
+    forwarding and the greedy-strip rule (temperature==0 or do_sample==False
+    removes temperature/top_k/top_p/min_p and forces do_sample=False).
+  - VLLMEngine._build_llm_kwargs: model_dump(exclude_none=True) plus the
+    attention-backend flattening and offload_params set-coercion.
+  - VLLMEngine._build_sampling_kwargs: the effective SamplingParams kwargs, and
+    the beam-search preemption contract (returns {} when a beam_search block is
+    present so the caller dispatches to the beam path).
+  - VLLMEngine._build_beam_search_params: the BeamSearchParams kwargs assembled
+    from the Any-typed beam_search sub-dict.
+  - TensorRTEngine._build_llm_kwargs: scalar forwarding, the env-gated build
+    cache staying off, and the Any-typed sub-config dicts (quant_config /
+    kv_cache_config / scheduler_config) being popped out of the scalar dump.
+  - TensorRTEngine._build_sampling_kwargs: the effective SamplingParams kwargs
+    including the injected seed and max_tokens.
+
+These builders import no engine library, so they run on a plain host. The
+transformers generate path (_run_batch), the vLLM/TensorRT observed-capture
+paths, and the native SamplingParams/BeamSearchParams/QuantConfig object
+construction all require the real engine libraries and are exercised by the
+GPU/container suites; the measurement fixes those paths carry (see PR #730) are
+locked by test_transformers_token_counting.py, test_extended_capture.py,
+test_transformers_observed_capture.py, and test_engine_protocol.py.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from llenergymeasure.engines.tensorrt import TensorRTEngine
+from llenergymeasure.engines.transformers import TransformersEngine
+from llenergymeasure.engines.vllm import VLLMEngine
+from tests.conftest import make_config
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise the opinionated env-var defaults the builders read.
+
+    _build_llm_kwargs reads trust_remote_code (vLLM) and the TRT build-cache
+    toggle; leaving ambient env in play would make the golden dicts host
+    dependent. Removing the vars pins them to their library defaults.
+    """
+    for var in (
+        "LLEM_TRUST_REMOTE_CODE",
+        "LLEM_TRT_BUILD_CACHE_ENABLED",
+        "LLEM_TRT_BUILD_CACHE_PATH",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# =============================================================================
+# Transformers: _build_generate_kwargs
+# =============================================================================
+
+
+class TestTransformersGenerateKwargs:
+    def test_greedy_strips_sampling_and_sets_do_sample_false(self) -> None:
+        """temperature==0 removes top_k/top_p/min_p, forces do_sample=False."""
+        config = make_config(
+            model="test-model",
+            engine="transformers",
+            transformers={
+                "sampling_params": {
+                    "temperature": 0.0,
+                    "top_k": 50,
+                    "top_p": 0.9,
+                    "min_p": 0.1,
+                },
+                "engine_params": {"use_cache": True},
+            },
+        )
+        assert TransformersEngine()._build_generate_kwargs(config) == {
+            "use_cache": True,
+            "do_sample": False,
+        }
+
+    def test_do_sample_false_strips_sampling(self) -> None:
+        """do_sample=False (with non-zero temperature) also strips sampling knobs."""
+        config = make_config(
+            model="test-model",
+            engine="transformers",
+            transformers={"sampling_params": {"temperature": 0.7, "top_k": 50, "do_sample": False}},
+        )
+        assert TransformersEngine()._build_generate_kwargs(config) == {"do_sample": False}
+
+    def test_sampling_and_generation_control_forwarded(self) -> None:
+        """Sampling knobs plus every engine_params generation-control field forward."""
+        config = make_config(
+            model="test-model",
+            engine="transformers",
+            transformers={
+                "sampling_params": {
+                    "temperature": 0.7,
+                    "top_k": 40,
+                    "top_p": 0.95,
+                    "min_p": 0.05,
+                },
+                "engine_params": {
+                    "use_cache": True,
+                    "cache_implementation": "static",
+                    "num_beams": 4,
+                    "length_penalty": 1.2,
+                    "no_repeat_ngram_size": 3,
+                    "prompt_lookup_num_tokens": 5,
+                },
+            },
+        )
+        assert TransformersEngine()._build_generate_kwargs(config) == {
+            "temperature": 0.7,
+            "top_k": 40,
+            "top_p": 0.95,
+            "min_p": 0.05,
+            "use_cache": True,
+            "cache_implementation": "static",
+            "num_beams": 4,
+            "length_penalty": 1.2,
+            "no_repeat_ngram_size": 3,
+            "prompt_lookup_num_tokens": 5,
+        }
+
+
+# =============================================================================
+# vLLM: _build_llm_kwargs / _build_sampling_kwargs / _build_beam_search_params
+# =============================================================================
+
+
+class TestVLLMKwargBuilders:
+    def test_build_llm_kwargs_flattens_attention_and_offload(self) -> None:
+        """Attention backend is hoisted, offload_params becomes a set, defaults dump."""
+        config = make_config(
+            model="test-model",
+            engine="vllm",
+            random_seed=1234,
+            vllm={
+                "engine_params": {
+                    "tensor_parallel_size": 2,
+                    "max_model_len": 4096,
+                    "attention": {"backend": "FLASHINFER", "block_size": 16},
+                    "offload_params": ["cpu", "disk"],
+                }
+            },
+        )
+        assert VLLMEngine()._build_llm_kwargs(config) == {
+            "model": "test-model",
+            "trust_remote_code": False,
+            "seed": 1234,
+            "dtype": "auto",
+            "gpu_memory_utilization": 0.9,
+            "cpu_offload_gb": 0,
+            "kv_cache_dtype": "auto",
+            "enforce_eager": False,
+            "tensor_parallel_size": 2,
+            "pipeline_parallel_size": 1,
+            "max_model_len": 4096,
+            "offload_group_size": 0,
+            "offload_num_in_group": 1,
+            "offload_prefetch_step": 1,
+            "disable_custom_all_reduce": False,
+            "offload_params": {"cpu", "disk"},
+            "attention_backend": "FLASHINFER",
+            "block_size": 16,
+        }
+
+    def test_build_sampling_kwargs_non_beam(self) -> None:
+        """Non-beam path dumps the sampling defaults and injects max_tokens."""
+        config = make_config(
+            model="test-model",
+            engine="vllm",
+            max_output_tokens=64,
+            vllm={"sampling_params": {"temperature": 0.7, "top_p": 0.9, "top_k": 40}},
+        )
+        assert VLLMEngine._build_sampling_kwargs(config) == {
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "top_k": 40,
+            "min_p": 0.0,
+            "min_tokens": 0,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "repetition_penalty": 1.0,
+            "ignore_eos": False,
+            "n": 1,
+            "max_tokens": 64,
+        }
+
+    def test_build_sampling_kwargs_beam_active_returns_empty(self) -> None:
+        """A beam_search block preempts the sampling path: returns {}."""
+        config = make_config(
+            model="test-model",
+            engine="vllm",
+            max_output_tokens=64,
+            vllm={
+                "engine_params": {
+                    "beam_search": {"beam_width": 4, "length_penalty": 1.0, "early_stopping": True}
+                },
+                "sampling_params": {"temperature": 0.7},
+            },
+        )
+        assert VLLMEngine._build_sampling_kwargs(config) == {}
+
+    def test_build_beam_search_params_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Beam kwargs come from the Any-typed beam_search dict plus max_tokens.
+
+        vllm is not importable on host, so a capturing stand-in stands in for
+        vllm.BeamSearchParams; the frozen dict is the kwargs it receives.
+        """
+        captured: dict[str, Any] = {}
+
+        class _FakeBeamSearchParams:
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+        fake_vllm = types.ModuleType("vllm")
+        fake_vllm.BeamSearchParams = _FakeBeamSearchParams  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+
+        config = make_config(
+            model="test-model",
+            engine="vllm",
+            max_output_tokens=64,
+            vllm={
+                "engine_params": {
+                    "beam_search": {"beam_width": 4, "length_penalty": 1.0, "early_stopping": True}
+                }
+            },
+        )
+        beam_cfg = config.engine_sub_dict("beam_search")
+        VLLMEngine._build_beam_search_params(config, beam_cfg)
+        assert captured == {
+            "beam_width": 4,
+            "length_penalty": 1.0,
+            "early_stopping": True,
+            "max_tokens": 64,
+        }
+
+
+# =============================================================================
+# TensorRT: _build_llm_kwargs / _build_sampling_kwargs
+# =============================================================================
+
+
+class TestTensorRTKwargBuilders:
+    def test_build_llm_kwargs_scalar_forwarding(self) -> None:
+        """Scalar engine_params forward; the env-gated build cache stays off."""
+        config = make_config(
+            model="test-model",
+            engine="tensorrt",
+            tensorrt={
+                "engine_params": {
+                    "tensor_parallel_size": 2,
+                    "max_batch_size": 8,
+                    "dtype": "bfloat16",
+                    "backend": "pytorch",
+                }
+            },
+        )
+        assert TensorRTEngine()._build_llm_kwargs(config) == {
+            "model": "test-model",
+            "tensor_parallel_size": 2,
+            "pipeline_parallel_size": 1,
+            "max_batch_size": 8,
+            "dtype": "bfloat16",
+            "fast_build": False,
+            "backend": "pytorch",
+        }
+
+    def test_build_llm_kwargs_pops_sub_config_dicts(self) -> None:
+        """Any-typed sub-config dicts are popped from the scalar dump.
+
+        The native QuantConfig / KvCacheConfig / SchedulerConfig objects are built
+        only when tensorrt_llm is importable (container path); on a plain host the
+        import is skipped, so the raw dicts must not leak into kwargs either way.
+        """
+        config = make_config(
+            model="test-model",
+            engine="tensorrt",
+            tensorrt={
+                "engine_params": {
+                    "tensor_parallel_size": 1,
+                    "quant_config": {"quant_algo": "FP8"},
+                    "kv_cache_config": {"free_gpu_memory_fraction": 0.8},
+                    "scheduler_config": {"capacity_scheduling_policy": "MAX_UTILIZATION"},
+                }
+            },
+        )
+        built = TensorRTEngine()._build_llm_kwargs(config)
+        assert built == {
+            "model": "test-model",
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": 1,
+            "dtype": "auto",
+            "fast_build": False,
+        }
+        # The raw sub-config dicts never forward under their own names.
+        assert "quant_config" not in built
+
+    def test_build_sampling_kwargs(self) -> None:
+        """Sampling dump plus the injected seed and max_tokens."""
+        config = make_config(
+            model="test-model",
+            engine="tensorrt",
+            random_seed=99,
+            max_output_tokens=32,
+            tensorrt={"sampling_params": {"temperature": 0.8, "top_k": 20, "top_p": 0.9}},
+        )
+        assert TensorRTEngine()._build_sampling_kwargs(config) == {
+            "temperature": 0.8,
+            "top_k": 20,
+            "top_p": 0.9,
+            "n": 1,
+            "ignore_eos": False,
+            "seed": 99,
+            "max_tokens": 32,
+        }


### PR DESCRIPTION
## What this locks

A test-only characterisation module, `tests/unit/engines/test_measurement_contract.py`,
that freezes the exact dicts produced by the pure kwarg builders on all three engine
plugins. Zero production changes. The frozen literals were captured from main and are
asserted verbatim, so a later refactor that renames a nested-config accessor, drops a
generated field, or reshapes a sub-config breaks an exact-equality assertion here instead
of silently drifting measured behaviour.

Builders locked (all host-runnable, no engine library imported):

- `TransformersEngine._build_generate_kwargs` - sampling plus generation-control
  forwarding and the greedy-strip rule (temperature==0 or do_sample==False removes
  temperature/top_k/top_p/min_p and forces do_sample=False).
- `VLLMEngine._build_llm_kwargs` - `model_dump(exclude_none=True)` plus attention-backend
  flattening and offload_params set-coercion.
- `VLLMEngine._build_sampling_kwargs` - effective sampling kwargs and the beam-search
  preemption contract (returns `{}` when a beam_search block is present).
- `VLLMEngine._build_beam_search_params` - BeamSearchParams kwargs from the Any-typed
  beam_search sub-dict (captured via a stand-in module since vllm is not host-importable).
- `TensorRTEngine._build_llm_kwargs` - scalar forwarding, env-gated build cache staying
  off, and the Any-typed sub-config dicts (quant_config / kv_cache_config /
  scheduler_config) being popped from the scalar dump.
- `TensorRTEngine._build_sampling_kwargs` - sampling kwargs including the injected seed
  and max_tokens.

Determinism: an autouse fixture removes `LLEM_TRUST_REMOTE_CODE` and the TRT build-cache
env vars so the golden dicts do not depend on ambient host env.

## G1-G6 audit (the five #730 measurement fixes)

Per-golden verdict against the existing anchor tests on main. G5 is the mandatory new
coverage above; G1-G4/G6 are audited and only added where an anchor is missing or is a
replica of production logic.

| Golden | Behaviour | Anchor on main | Verdict |
| --- | --- | --- | --- |
| G5 | kwarg-builder / nested-config accessor contract (all 3 engines) | none (this was the gap) | ADDED - the 10 goldens in this PR |
| G1 | output-token count with num_return_sequences>1 (row-aware `j // n_return`) | `test_transformers_token_counting.py::TestNumReturnSequences` freezes concrete literals (12, 12, 10, 4) via a faithful replica | SKIPPED - already frozen; the production path lives inside `_run_batch` (real `model.generate` + torch), not host-isolable, so a production-driving golden would be CI-only and could not be verified in this host-only run. Residual replica-vs-production drift risk noted. |
| G2 | decode ITL for n>1 parallel outputs uses `max(...)` not `sum(...)` | `test_extended_capture.py::TestExtractDecodeItlParallelOutputs` calls production `extract_decode_itl` directly and asserts concrete values, explicitly proving it is not the summed denominator | SKIPPED - already anchored with direct production calls |
| G3 | effective merged generation config (deepcopy + overlay) and resolved-dtype capture | `test_transformers_observed_capture.py::TestEN2MergedGenerationConfig` and `TestD2ResolvedDtypeCapture` call production `_capture_observed_params` and assert concrete merged values | SKIPPED - already anchored |
| G4 | dtype unset yields `torch_dtype="auto"` (not forced bfloat16); `_resolve_torch_dtype` passthrough | `test_engine_protocol.py::test_model_load_kwargs_contains_base_keys` asserts `torch_dtype == "auto"`; `test_resolve_torch_dtype_auto_passthrough` and the fp16/fp32/bf16 cases lock the mapping; a dedicated test asserts unset != bfloat16 | SKIPPED - already anchored with concrete asserts |
| G6 | `version` returns `transformers.__version__`, not torch's; `"unknown"` on import failure | `test_engine_protocol.py::test_transformers_version_returns_transformers_version` mocks the module and asserts the returned string; a companion asserts the unknown fallback | SKIPPED - already anchored |

Outcome: G5-only module, which is the sanctioned result when the G1-G4/G6 audit finds the
behaviours already anchored. Adding replica-duplicate or unverifiable CI-only goldens for
G1-G4/G6 would not increase protection.

## Validation

- `make lint`: ruff check + format clean; import-linter 4 contracts kept, 0 broken.
- `make typecheck`: mypy success, no issues in 285 source files.
- `uv run pytest tests/unit -q`: 2607 passed, 45 skipped, 0 failed.
- New module in isolation: 10 passed.
- `git diff origin/main --stat`: touches only `tests/unit/engines/test_measurement_contract.py`.
