### PR TITLE
fix(rules): treat non-comparable predicate values as no-match

### DIFF
--- a/src/llenergymeasure/config/engine_rules/loader.py
+++ b/src/llenergymeasure/config/engine_rules/loader.py
@@ -31,6 +31,8 @@ per-instance caching for test isolation, same lazy load pattern.
 
 from __future__ import annotations
 
+import operator
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, get_args
@@ -309,12 +311,16 @@ _OPERATOR_HANDLERS: dict[str, Any] = {
     # to `False` for any non-None `x`, so they naturally don't fire on None.
     # ``equals`` / ``not_equal`` are word-form aliases of ``==`` / ``!=``
     # and MUST match their symbol forms exactly - corpus authors swap them.
+    # The four ordering operators route through :func:`_ordered`, which also
+    # treats a type-incomparable pair (e.g. a mined numeric bound landing on a
+    # dict-valued field) as no-match instead of letting the raw ``<`` raise a
+    # TypeError out of config construction.
     "==": lambda a, b: a == b,
     "!=": lambda a, b: a is not None and b is not None and a != b,
-    "<": lambda a, b: a is not None and b is not None and a < b,
-    "<=": lambda a, b: a is not None and b is not None and a <= b,
-    ">": lambda a, b: a is not None and b is not None and a > b,
-    ">=": lambda a, b: a is not None and b is not None and a >= b,
+    "<": lambda a, b: _ordered(a, b, operator.lt),
+    "<=": lambda a, b: _ordered(a, b, operator.le),
+    ">": lambda a, b: _ordered(a, b, operator.gt),
+    ">=": lambda a, b: _ordered(a, b, operator.ge),
     "equals": lambda a, b: a == b,
     "not_equal": lambda a, b: a is not None and b is not None and a != b,
     # Membership operators: None-safe on the asymmetric one (``not_in``)
@@ -346,6 +352,28 @@ _OPERATOR_HANDLERS: dict[str, Any] = {
     "divisible_by": lambda a, b: _is_int_pair(a, b) and b != 0 and a % b == 0,
     "not_divisible_by": lambda a, b: _is_int_pair(a, b) and b != 0 and a % b != 0,
 }
+
+
+def _ordered(a: Any, b: Any, op: Callable[[Any, Any], bool]) -> bool:
+    """Apply an ordering comparison, treating None and incomparable types as no-match.
+
+    ``a`` may be None when the predicate's field is unset; ``b`` may be None
+    when a ``@field_ref`` resolves against a missing target - both yield False.
+
+    A mined numeric bound can land on a field that naturally holds a non-numeric
+    value (e.g. transformers ``compile_config``, a dict / CompileConfig shape).
+    Comparing such a pair with ``<`` / ``<=`` / ``>`` / ``>=`` raises TypeError;
+    that would escape config construction as an uncaught crash. Since the bound
+    is a corpus artifact rather than a user error - the generated pydantic model
+    remains the authority on the field's type validity - the rule simply does
+    not fire (False) on a type-incomparable pair.
+    """
+    if a is None or b is None:
+        return False
+    try:
+        return op(a, b)
+    except TypeError:
+        return False
 
 
 def _is_int_pair(a: Any, b: Any) -> bool:

--- a/tests/unit/config/engine_rules/test_loader_field_ref_and_divisibility.py
+++ b/tests/unit/config/engine_rules/test_loader_field_ref_and_divisibility.py
@@ -24,6 +24,7 @@ from llenergymeasure.config.engine_rules import (
 )
 from llenergymeasure.config.engine_rules.loader import (
     _is_int_pair,
+    _ordered,
     _resolve_field_refs_in_spec,
 )
 
@@ -213,6 +214,67 @@ def test_is_int_pair_helper() -> None:
     assert _is_int_pair(1, False) is False
     assert _is_int_pair(6.0, 3) is False
     assert _is_int_pair(None, 3) is False
+
+
+# ---------------------------------------------------------------------------
+# Ordering operators - type-incomparable operands are no-match, not a crash
+#
+# A mined numeric bound can land on a field that naturally holds a non-numeric
+# value (e.g. transformers ``compile_config``, a dict / CompileConfig shape).
+# The raw ``<`` / ``<=`` / ``>`` / ``>=`` comparison raises TypeError on such a
+# pair; the handler must treat it as no-match so config construction never
+# crashes on a corpus artifact. The generated pydantic model stays the
+# authority on the field's type validity.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
+@pytest.mark.parametrize("actual", [{"backend": "inductor"}, "inductor", ["a"], (1,)])
+def test_ordering_incomparable_actual_is_no_match(op: str, actual: Any) -> None:
+    # dict / str / list / tuple vs an int bound: no TypeError, rule does not fire.
+    assert evaluate_predicate(actual, {op: 0}) is False
+
+
+@pytest.mark.parametrize(
+    "op, actual, bound, expected",
+    [
+        (">", 5, 0, True),
+        (">", 0, 5, False),
+        ("<", 0, 5, True),
+        ("<", 5, 0, False),
+        (">=", 5, 5, True),
+        ("<=", 5, 5, True),
+    ],
+)
+def test_ordering_numeric_still_matches(op: str, actual: Any, bound: Any, expected: bool) -> None:
+    # Guarding incomparable types must not weaken real numeric matching.
+    assert evaluate_predicate(actual, {op: bound}) is expected
+
+
+@pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
+def test_ordering_none_operands_are_no_match(op: str) -> None:
+    # None on either side (unset field / unresolved @field_ref) never fires.
+    assert evaluate_predicate(None, {op: 0}) is False
+    assert evaluate_predicate(5, {op: None}) is False
+
+
+def test_ordering_comparable_non_numeric_still_compares() -> None:
+    # Same-type ordering (str vs str) stays live - only cross-type pairs no-match.
+    assert evaluate_predicate("b", {">": "a"}) is True
+    assert evaluate_predicate("a", {">": "b"}) is False
+
+
+def test_ordered_helper() -> None:
+    # Direct unit on the helper for a tight regression guard.
+    import operator
+
+    assert _ordered(5, 0, operator.gt) is True
+    assert _ordered(0, 5, operator.gt) is False
+    assert _ordered(None, 0, operator.gt) is False
+    assert _ordered(5, None, operator.gt) is False
+    # Type-incomparable pair: TypeError swallowed, treated as no-match.
+    assert _ordered({"backend": "inductor"}, 0, operator.gt) is False
+    assert _ordered("inductor", 0, operator.lt) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_rehomed_rules_fire.py
+++ b/tests/unit/config/test_rehomed_rules_fire.py
@@ -119,3 +119,47 @@ def test_cross_section_compatible_beam_and_return_counts_accepted():
         },
     )
     assert cfg.active_engine_params().num_beams == 4
+
+
+# ---------------------------------------------------------------------------
+# Type-incomparable predicate values are no-match, not an uncaught crash
+#
+# The shipped transformers corpus carries a mined numeric bound on
+# ``compile_config`` (rule ``..._compile_config_exceeds_zero`` with predicate
+# ``{">": 0}``). That bound is a corpus artifact: the field naturally holds a
+# dict / CompileConfig shape, not a number. Before the fix, a non-numeric
+# compile_config let a raw TypeError
+# (``'>' not supported between instances of 'dict' and 'int'``) escape config
+# construction. The ordering comparison must instead treat the incomparable
+# pair as no-match, so the ordering rule silently declines. A *separate*,
+# legitimate ``type_is_not: [CompileConfig]`` rule then cleanly rejects the
+# non-CompileConfig value with a ValueError - a clean rule rejection, never a
+# TypeError. The generated pydantic model stays the authority on type validity.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "compile_config",
+    [{"backend": "inductor"}, "inductor", ["inductor"]],
+)
+def test_non_numeric_compile_config_no_uncaught_typeerror(compile_config):
+    """A dict / str / list compile_config yields a clean rejection, not a TypeError."""
+    with pytest.raises(ValueError, match="type_not_in_CompileConfig") as excinfo:
+        ExperimentConfig(
+            task={"model": "gpt2"},
+            engine="transformers",
+            transformers={"sampling_params": {"compile_config": compile_config}},
+        )
+    # The bug was an uncaught TypeError from the mined ``{">": 0}`` bound; the
+    # surviving rejection must be the clean type rule, never a TypeError.
+    assert not isinstance(excinfo.value, TypeError)
+
+
+def test_numeric_bound_still_fires_after_incomparable_guard():
+    """Control: guarding incomparable types must not suppress real numeric matches."""
+    with pytest.raises(ValueError, match="min_new_tokens"):
+        ExperimentConfig(
+            task={"model": "gpt2"},
+            engine="transformers",
+            transformers={"sampling_params": {"min_new_tokens": 0}},
+        )


### PR DESCRIPTION
## The bug

An adversarial review of all 98 shipped rules found that the rule predicate
comparison handlers for `<`, `<=`, `>`, `>=` in
`src/llenergymeasure/config/engine_rules/loader.py` guarded against `None` but
not against type-incomparability.

The shipped transformers corpus carries the rule
`transformers_compile_config_type_compile_config_exceeds_zero` with predicate
`compile_config: {">": 0}`. This is a mined corpus artifact: `compile_config`
naturally holds a dict / `CompileConfig` shape, not a number. A user
constructing a transformers `ExperimentConfig` with `compile_config` set to a
dict / list / str got an uncaught `TypeError` escaping from config
construction.

### Reproduced traceback (pre-fix, public path)

```
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File ".../pydantic/main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
  File ".../src/llenergymeasure/config/models.py", line 750, in _apply_rules
    match = rule.try_match(self)
  File ".../src/llenergymeasure/config/engine_rules/loader.py", line 199, in try_match
    if not evaluate_predicate(actual, resolved_spec):
  File ".../src/llenergymeasure/config/engine_rules/loader.py", line 414, in evaluate_predicate
    if not handler(actual, value):
  File ".../src/llenergymeasure/config/engine_rules/loader.py", line 316, in <lambda>
    ">": lambda a, b: a is not None and b is not None and a > b,
TypeError: '>' not supported between instances of 'dict' and 'int'
```

The same TypeError reproduces for `compile_config='inductor'` (str) and
`compile_config=['inductor']` (list).

## The fix

Route the four ordering operators through a new `_ordered(a, b, op)` helper
that keeps the existing `None` guard and additionally treats a
type-incomparable pair as no-match (attempt the comparison, catch `TypeError`,
return `False`) rather than raising.

### Semantics: why no-match, not a raise

A mined numeric bound landing on a non-numeric value is a corpus artifact, not
a user error. The rule simply does not fire, and the generated pydantic model
remains the authority on the field's type validity. The `try`/`except`
approach (over an `isinstance` numeric check) preserves every currently-valid
comparison, including same-type non-numeric ordering (e.g. `str` vs `str`);
only genuinely cross-type pairs that used to crash now no-match.

In practice, for this corpus the ordering rule now declines and a *separate*,
legitimate `type_is_not: [CompileConfig]` rule cleanly rejects the
non-CompileConfig value with a `ValueError` - a clean rule rejection, never a
`TypeError`.

## Operator audit

Audited every predicate operator for the same hazard; guarded only where a
real crash is reachable.

| Operator(s) | Underlying op | Crash on mixed types? | Reachable via corpus? | Action |
|---|---|---|---|---|
| `<` `<=` `>` `>=` | `a < b` etc | Yes (`TypeError`) | Yes (compile_config `{">": 0}`) | Guarded via `_ordered` |
| `==` `!=` `equals` `not_equal` | `a == b` / `a != b` | No (returns False on mismatch) | n/a | Unchanged |
| `in` `not_in` | `a in b` | Only if spec is a set + `a` unhashable | No - YAML `safe_load` yields lists; list membership uses `==` and never raises | Unchanged |
| `type_is` `type_is_not` | `type(a).__name__ in frozenset[str]` | No (hashable string membership) | n/a | Unchanged |
| `present` `absent` | `a is None` | No | n/a | Unchanged |
| `divisible_by` `not_divisible_by` | `a % b` | Guarded by `_is_int_pair` short-circuit | n/a | Unchanged |

Only the four ordering operators were a reachable crash. Confirmed empirically:
after the fix, every operator is total against dict / list / str / tuple / float
actuals with corpus-realistic specs.

## Tests (written failing first, confirmed red on unguarded code)

- `test_rehomed_rules_fire.py`: transformers `ExperimentConfig` with
  `compile_config` = dict / str / list constructs through the public path with
  no uncaught `TypeError` (clean `ValueError` from the type rule instead); plus
  a numeric control (`min_new_tokens=0`) proving real numeric rules still fire.
- `test_loader_field_ref_and_divisibility.py`: direct `evaluate_predicate` and
  `_ordered` unit tests across all four operators with mixed types (no-match),
  preserved numeric matching, preserved `None` guards, and preserved same-type
  non-numeric ordering.

## Validation

- `make lint`: All checks passed (ruff check + format).
- `make typecheck`: Success, no issues found in 285 source files.
- `uv run pytest tests/unit -q`: `2639 passed, 45 skipped, 180 warnings` (0 failures).
- Byte-frozen: diff touches only `loader.py` + two test files; no
  `rules.yaml` / `engine_versions/**` / `*.discovered.json` staged.