### PR TITLE
feat(config): add numeric sweep-axis idioms (span, log, pow2)

### DIFF
--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 from llenergymeasure.config._dict_utils import _unflatten, deep_merge
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.config.ssot import ALL_ENGINES
+from llenergymeasure.config.sweep_idioms import expand_axis_idiom
 from llenergymeasure.utils.compat import StrEnum
 from llenergymeasure.utils.exceptions import ConfigError
 
@@ -568,6 +569,11 @@ def _expand_sweep(sweep: dict[str, Any], fixed: dict[str, Any]) -> list[dict[str
       a group are alternatives (unioned, not crossed).
 
     Type-based disambiguation: ``list[scalar]`` = axis, ``list[dict]`` = group.
+
+    An axis value may also be a numeric idiom mapping (see
+    :mod:`llenergymeasure.config.sweep_idioms`); it is expanded to a plain
+    list here, at load time, so downstream consumers only see lists. Any
+    other mapping-valued axis is rejected with ConfigError.
     """
     if not sweep:
         task = fixed.get("task")
@@ -587,7 +593,12 @@ def _expand_sweep(sweep: dict[str, Any], fixed: dict[str, Any]) -> list[dict[str
             groups[key] = _expand_group(values)
             continue
 
-        if not isinstance(values, list):
+        if isinstance(values, dict):
+            try:
+                values = expand_axis_idiom(values)
+            except ValueError as exc:
+                raise ConfigError(f"sweep axis '{key}': {exc}") from exc
+        elif not isinstance(values, list):
             values = [values]
 
         engine_scope = _group_engine_scope(key)

--- a/src/llenergymeasure/config/sweep_idioms.py
+++ b/src/llenergymeasure/config/sweep_idioms.py
@@ -1,0 +1,160 @@
+"""Numeric sweep-axis idioms: mapping notations that expand to value lists.
+
+A sweep axis value is normally an explicit YAML list. Three mapping idioms
+are accepted as alternative notation for such a list. Each idiom is a
+deterministic, versioned notation whose expansion is fixed at load time -
+downstream consumers (dedup, rule pruning, counts) only ever see plain lists:
+
+- ``{min: a, max: b, num: n}`` - n evenly spaced values from a to b inclusive.
+- ``{log: {min: a, max: b, num: n}}`` - n log-spaced values, a > 0, inclusive
+  endpoints.
+- ``{pow2: {min: a, max: b}}`` - ascending powers of two within [a, b].
+
+Number typing: values are ints when all bounds are ints and every produced
+value is integral; otherwise floats. Float values are rounded to
+``_SIGNIFICANT_DIGITS`` significant digits to avoid binary float noise
+(0.30000000000000004 -> 0.3). Duplicates after rounding collapse to unique
+values preserving order.
+
+Any mapping that is not one of the three idiom shapes raises ``ValueError``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+_SIGNIFICANT_DIGITS = 10
+
+_IDIOM_SUMMARY = (
+    "valid idioms are {min: a, max: b, num: n} (evenly spaced), "
+    "{log: {min: a, max: b, num: n}} (log-spaced) and "
+    "{pow2: {min: a, max: b}} (powers of two)"
+)
+
+
+def expand_axis_idiom(mapping: dict[str, Any]) -> list[int] | list[float]:
+    """Expand a mapping-valued sweep axis into a plain list of numbers.
+
+    Raises ``ValueError`` if the mapping is not exactly one of the three
+    idiom shapes, or if an idiom's fields fail validation.
+    """
+    keys = set(mapping)
+    if keys == {"min", "max", "num"}:
+        return _expand_linear(mapping)
+    if keys == {"log"}:
+        return _expand_log(_inner_mapping("log", mapping["log"], {"min", "max", "num"}))
+    if keys == {"pow2"}:
+        return _expand_pow2(_inner_mapping("pow2", mapping["pow2"], {"min", "max"}))
+    raise ValueError(
+        f"mapping with keys {sorted(str(k) for k in keys)} is not a sweep idiom; "
+        f"{_IDIOM_SUMMARY}. Literal mapping values cannot be swept as an axis - "
+        "set them in the base config, or sweep them via a group entry "
+        "(list of dicts)."
+    )
+
+
+# =============================================================================
+# Idiom expansion
+# =============================================================================
+
+
+def _expand_linear(mapping: dict[str, Any]) -> list[int] | list[float]:
+    """``{min, max, num}`` -> n evenly spaced values, endpoints inclusive."""
+    lo, hi = _bounds("min/max/num", mapping)
+    n = _num("min/max/num", mapping["num"])
+    # Integer path: exact divisibility check keeps typing deterministic.
+    if isinstance(lo, int) and isinstance(hi, int) and (hi - lo) % (n - 1) == 0:
+        step = (hi - lo) // (n - 1)
+        return _dedupe([lo + step * i for i in range(n)])
+    values = [lo + (hi - lo) * i / (n - 1) for i in range(1, n - 1)]
+    return _dedupe([float(lo), *(_round_sig(v) for v in values), float(hi)])
+
+
+def _expand_log(mapping: dict[str, Any]) -> list[int] | list[float]:
+    """``{log: {min, max, num}}`` -> n log-spaced values, endpoints inclusive."""
+    lo, hi = _bounds("log", mapping)
+    if lo <= 0:
+        raise ValueError(f"log idiom requires min > 0, got min={lo}")
+    n = _num("log", mapping["num"])
+    ratio = hi / lo
+    values = [lo * ratio ** (i / (n - 1)) for i in range(1, n - 1)]
+    rounded = [float(lo), *(_round_sig(v) for v in values), float(hi)]
+    if isinstance(lo, int) and isinstance(hi, int) and all(v.is_integer() for v in rounded):
+        return _dedupe([int(v) for v in rounded])
+    return _dedupe(rounded)
+
+
+def _expand_pow2(mapping: dict[str, Any]) -> list[int] | list[float]:
+    """``{pow2: {min, max}}`` -> ascending powers of two within [min, max]."""
+    lo, hi = _bounds("pow2", mapping)
+    if lo <= 0:
+        raise ValueError(f"pow2 idiom requires min > 0, got min={lo}")
+    # Scan integer exponents with a +-1 safety margin against log2 rounding.
+    # Negative exponents (0.5, 0.25, ...) are exact binary floats.
+    k_lo = math.floor(math.log2(lo)) - 1
+    k_hi = math.ceil(math.log2(hi)) + 1
+    powers: list[int | float] = [
+        p for k in range(k_lo, k_hi + 1) if lo <= (p := 2**k if k >= 0 else 2.0**k) <= hi
+    ]
+    if not powers:
+        raise ValueError(f"pow2 idiom: no power of two lies within [{lo}, {hi}]")
+    if all(isinstance(p, int) for p in powers):
+        return powers  # type: ignore[return-value]  # narrowed by the all() check
+    return [float(p) for p in powers]
+
+
+# =============================================================================
+# Field validation
+# =============================================================================
+
+
+def _inner_mapping(idiom: str, value: Any, expected_keys: set[str]) -> dict[str, Any]:
+    """Validate the nested mapping of a wrapped idiom (log, pow2)."""
+    keys_desc = ", ".join(sorted(expected_keys))
+    if not isinstance(value, dict) or set(value) != expected_keys:
+        raise ValueError(
+            f"{idiom} idiom requires a nested mapping with exactly the keys "
+            f"{{{keys_desc}}}, got {value!r}; {_IDIOM_SUMMARY}"
+        )
+    return value
+
+
+def _number(idiom: str, name: str, value: Any) -> int | float:
+    """Require a finite int or float (bool excluded)."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value):
+        return value
+    raise ValueError(f"{idiom} idiom: '{name}' must be a finite number, got {value!r}")
+
+
+def _bounds(idiom: str, mapping: dict[str, Any]) -> tuple[int | float, int | float]:
+    """Require numeric min/max with min <= max."""
+    lo = _number(idiom, "min", mapping["min"])
+    hi = _number(idiom, "max", mapping["max"])
+    if lo > hi:
+        raise ValueError(f"{idiom} idiom: min ({lo}) must not exceed max ({hi})")
+    return lo, hi
+
+
+def _num(idiom: str, value: Any) -> int:
+    """Require an integer point count >= 2."""
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 2:
+        return value
+    raise ValueError(f"{idiom} idiom: 'num' must be an integer >= 2, got {value!r}")
+
+
+# =============================================================================
+# Rounding and dedup
+# =============================================================================
+
+
+def _round_sig(value: float) -> float:
+    """Round to ``_SIGNIFICANT_DIGITS`` significant digits (float-noise guard)."""
+    if value == 0.0:
+        return 0.0
+    return float(f"{value:.{_SIGNIFICANT_DIGITS}g}")
+
+
+def _dedupe(values: list[Any]) -> list[Any]:
+    """Collapse duplicates (e.g. after rounding) to unique values, order preserved."""
+    return list(dict.fromkeys(values))

--- a/tests/unit/study/test_sweep_idioms.py
+++ b/tests/unit/study/test_sweep_idioms.py
@@ -1,0 +1,291 @@
+"""Unit tests for numeric sweep-axis idioms (linear span, log, pow2).
+
+Covers expand_axis_idiom directly (values, typing, rounding, endpoints,
+every validation error path) and end-to-end expansion through the public
+expand_grid, plus regression checks that existing list/mapping sweep
+semantics are unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from llenergymeasure.config.grid import (
+    _expand_group_entry,
+    count_sweep_structure,
+    expand_grid,
+)
+from llenergymeasure.config.sweep_idioms import expand_axis_idiom
+from llenergymeasure.utils.exceptions import ConfigError
+
+# =============================================================================
+# Linear span idiom: {min, max, num}
+# =============================================================================
+
+
+class TestLinearIdiom:
+    def test_int_bounds_integral_step_emits_ints(self):
+        values = expand_axis_idiom({"min": 0, "max": 8, "num": 5})
+        assert values == [0, 2, 4, 6, 8]
+        assert all(type(v) is int for v in values)
+
+    def test_int_bounds_non_integral_step_emits_floats(self):
+        values = expand_axis_idiom({"min": 0, "max": 10, "num": 5})
+        assert values == [0.0, 2.5, 5.0, 7.5, 10.0]
+        assert all(type(v) is float for v in values)
+
+    def test_float_bounds_rounding_kills_binary_noise(self):
+        # Naive float arithmetic gives 0.30000000000000004 for the midpoint.
+        values = expand_axis_idiom({"min": 0.1, "max": 0.5, "num": 3})
+        assert values == [0.1, 0.3, 0.5]
+
+    def test_endpoints_inclusive_and_exact(self):
+        values = expand_axis_idiom({"min": 0.7, "max": 1.3, "num": 4})
+        assert values[0] == 0.7
+        assert values[-1] == 1.3
+        assert len(values) == 4
+
+    def test_mixed_int_float_bounds_emit_floats(self):
+        values = expand_axis_idiom({"min": 0, "max": 1.0, "num": 3})
+        assert values == [0.0, 0.5, 1.0]
+        assert all(type(v) is float for v in values)
+
+    def test_num_two_gives_exact_bounds(self):
+        assert expand_axis_idiom({"min": 3, "max": 7, "num": 2}) == [3, 7]
+
+    def test_equal_bounds_collapse_to_single_value(self):
+        assert expand_axis_idiom({"min": 5, "max": 5, "num": 3}) == [5]
+
+    def test_negative_range(self):
+        assert expand_axis_idiom({"min": -4, "max": 4, "num": 3}) == [-4, 0, 4]
+
+
+# =============================================================================
+# Log idiom: {log: {min, max, num}}
+# =============================================================================
+
+
+class TestLogIdiom:
+    def test_int_decades_emit_ints(self):
+        values = expand_axis_idiom({"log": {"min": 1, "max": 100, "num": 3}})
+        assert values == [1, 10, 100]
+        assert all(type(v) is int for v in values)
+
+    def test_float_decades(self):
+        values = expand_axis_idiom({"log": {"min": 0.001, "max": 1.0, "num": 4}})
+        assert values == [0.001, 0.01, 0.1, 1.0]
+
+    def test_non_integral_points_emit_floats(self):
+        values = expand_axis_idiom({"log": {"min": 1, "max": 10, "num": 3}})
+        assert values == [1.0, 3.16227766, 10.0]
+        assert all(type(v) is float for v in values)
+
+    def test_endpoints_inclusive_and_exact(self):
+        values = expand_axis_idiom({"log": {"min": 2, "max": 3, "num": 5}})
+        assert values[0] == 2.0
+        assert values[-1] == 3.0
+        assert len(values) == 5
+
+    def test_rounding_collapse_dedupes_preserving_order(self):
+        # The three interior points all round to 1.0 at 10 significant digits
+        # and collapse into the min endpoint; endpoints stay verbatim.
+        values = expand_axis_idiom({"log": {"min": 1.0, "max": 1.0000000000001, "num": 5}})
+        assert values == [1.0, 1.0000000000001]
+
+
+# =============================================================================
+# pow2 idiom: {pow2: {min, max}}
+# =============================================================================
+
+
+class TestPow2Idiom:
+    def test_bounds_on_powers(self):
+        values = expand_axis_idiom({"pow2": {"min": 4, "max": 32}})
+        assert values == [4, 8, 16, 32]
+        assert all(type(v) is int for v in values)
+
+    def test_bounds_between_powers(self):
+        assert expand_axis_idiom({"pow2": {"min": 3, "max": 33}}) == [4, 8, 16, 32]
+
+    def test_single_power(self):
+        assert expand_axis_idiom({"pow2": {"min": 16, "max": 16}}) == [16]
+
+    def test_float_bounds_integral_powers_emit_ints(self):
+        values = expand_axis_idiom({"pow2": {"min": 3.5, "max": 40.0}})
+        assert values == [4, 8, 16, 32]
+        assert all(type(v) is int for v in values)
+
+    def test_fractional_powers_emit_floats(self):
+        values = expand_axis_idiom({"pow2": {"min": 0.25, "max": 2}})
+        assert values == [0.25, 0.5, 1.0, 2.0]
+        assert all(type(v) is float for v in values)
+
+
+# =============================================================================
+# Validation error paths
+# =============================================================================
+
+
+class TestIdiomErrors:
+    def test_min_greater_than_max(self):
+        with pytest.raises(ValueError, match=r"min .* must not exceed max"):
+            expand_axis_idiom({"min": 5, "max": 1, "num": 3})
+
+    def test_log_min_greater_than_max(self):
+        with pytest.raises(ValueError, match=r"min .* must not exceed max"):
+            expand_axis_idiom({"log": {"min": 10, "max": 1, "num": 3}})
+
+    @pytest.mark.parametrize("num", [1, 0, -3])
+    def test_num_below_two(self, num):
+        with pytest.raises(ValueError, match="'num' must be an integer >= 2"):
+            expand_axis_idiom({"min": 0, "max": 8, "num": num})
+
+    @pytest.mark.parametrize("num", [2.5, "3", True, None])
+    def test_num_not_an_integer(self, num):
+        with pytest.raises(ValueError, match="'num' must be an integer >= 2"):
+            expand_axis_idiom({"min": 0, "max": 8, "num": num})
+
+    @pytest.mark.parametrize("bad", ["a", None, True, [1], float("inf"), float("nan")])
+    def test_non_numeric_bound(self, bad):
+        with pytest.raises(ValueError, match="'min' must be a finite number"):
+            expand_axis_idiom({"min": bad, "max": 8, "num": 3})
+
+    @pytest.mark.parametrize("lo", [0, -1, -0.5])
+    def test_log_requires_positive_min(self, lo):
+        with pytest.raises(ValueError, match="log idiom requires min > 0"):
+            expand_axis_idiom({"log": {"min": lo, "max": 10, "num": 3}})
+
+    @pytest.mark.parametrize("lo", [0, -4])
+    def test_pow2_requires_positive_min(self, lo):
+        with pytest.raises(ValueError, match="pow2 idiom requires min > 0"):
+            expand_axis_idiom({"pow2": {"min": lo, "max": 8}})
+
+    @pytest.mark.parametrize(("lo", "hi"), [(33, 63), (0.3, 0.4)])
+    def test_pow2_no_power_in_range(self, lo, hi):
+        with pytest.raises(ValueError, match="no power of two lies within"):
+            expand_axis_idiom({"pow2": {"min": lo, "max": hi}})
+
+    def test_unknown_key_mixed_into_linear(self):
+        with pytest.raises(ValueError, match=r"not a sweep idiom.*valid idioms"):
+            expand_axis_idiom({"min": 0, "max": 8, "num": 3, "step": 2})
+
+    def test_linear_missing_num(self):
+        with pytest.raises(ValueError, match=r"not a sweep idiom.*valid idioms"):
+            expand_axis_idiom({"min": 0, "max": 8})
+
+    def test_unknown_key_next_to_log(self):
+        with pytest.raises(ValueError, match=r"not a sweep idiom.*valid idioms"):
+            expand_axis_idiom({"log": {"min": 1, "max": 10, "num": 3}, "extra": 1})
+
+    def test_log_inner_missing_num(self):
+        with pytest.raises(ValueError, match="log idiom requires a nested mapping"):
+            expand_axis_idiom({"log": {"min": 1, "max": 10}})
+
+    def test_log_inner_not_a_mapping(self):
+        with pytest.raises(ValueError, match="log idiom requires a nested mapping"):
+            expand_axis_idiom({"log": 5})
+
+    def test_pow2_inner_unknown_key(self):
+        with pytest.raises(ValueError, match="pow2 idiom requires a nested mapping"):
+            expand_axis_idiom({"pow2": {"min": 4, "max": 32, "num": 3}})
+
+    @pytest.mark.parametrize("mapping", [{}, {"foo": 1}, {"values": [1, 2, 3]}])
+    def test_arbitrary_mapping_rejected_loudly(self, mapping):
+        with pytest.raises(ValueError, match=r"not a sweep idiom.*valid idioms"):
+            expand_axis_idiom(mapping)
+
+
+# =============================================================================
+# End-to-end through expand_grid
+# =============================================================================
+
+
+class TestIdiomsThroughExpandGrid:
+    def test_study_yaml_with_all_three_idioms(self):
+        raw = yaml.safe_load(
+            """
+            task: {model: gpt2}
+            engine: transformers
+            sweep:
+              task.dataset.n_prompts: {min: 10, max: 30, num: 3}
+              transformers.sampling_params.temperature: {log: {min: 0.1, max: 1.0, num: 2}}
+              harness.transformers.batch_size: {pow2: {min: 4, max: 16}}
+            """
+        )
+        valid, skipped = expand_grid(raw)
+        assert len(skipped) == 0
+        # 3 n_prompts x 2 temperatures x 3 batch sizes = 18
+        assert len(valid) == 18
+        assert {c.task.dataset.n_prompts for c in valid} == {10, 20, 30}
+        assert {c.transformers.sampling_params.temperature for c in valid} == {0.1, 1.0}
+        assert {c.harness.transformers.batch_size for c in valid} == {4, 8, 16}
+
+    def test_idiom_expands_identically_to_explicit_list(self):
+        base = {"task": {"model": "gpt2"}, "engine": "transformers"}
+        as_list = {**base, "sweep": {"task.dataset.n_prompts": [10, 20, 30]}}
+        as_idiom = {**base, "sweep": {"task.dataset.n_prompts": {"min": 10, "max": 30, "num": 3}}}
+        valid_list, _ = expand_grid(as_list)
+        valid_idiom, _ = expand_grid(as_idiom)
+        assert [c.model_dump() for c in valid_idiom] == [c.model_dump() for c in valid_list]
+
+    def test_non_idiom_mapping_fails_loudly_with_axis_name(self):
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "sweep": {"task.dataset.n_prompts": {"start": 1, "stop": 5}},
+        }
+        with pytest.raises(ConfigError, match=r"sweep axis 'task\.dataset\.n_prompts'"):
+            expand_grid(raw)
+
+    def test_invalid_idiom_fields_fail_loudly(self):
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "sweep": {"task.dataset.n_prompts": {"min": 30, "max": 10, "num": 3}},
+        }
+        with pytest.raises(ConfigError, match=r"min .* must not exceed max"):
+            expand_grid(raw)
+
+    def test_idiom_counts_as_single_axis(self):
+        sweep = {"task.dataset.n_prompts": {"min": 10, "max": 30, "num": 3}}
+        assert count_sweep_structure(sweep) == (1, 0)
+
+
+# =============================================================================
+# Regression: existing sweep semantics unchanged
+# =============================================================================
+
+
+class TestExistingMappingSemanticsUnchanged:
+    def test_explicit_list_axis_unchanged(self):
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "sweep": {"task.dataset.n_prompts": [50, 100]},
+        }
+        valid, skipped = expand_grid(raw)
+        assert len(valid) == 2
+        assert len(skipped) == 0
+        assert {c.task.dataset.n_prompts for c in valid} == {50, 100}
+
+    def test_group_list_of_dicts_still_a_group(self):
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "sweep": {
+                "precision": [
+                    {"transformers.engine_params.dtype": "float16"},
+                    {"transformers.engine_params.dtype": "bfloat16"},
+                ]
+            },
+        }
+        valid, skipped = expand_grid(raw)
+        assert len(valid) == 2
+        assert len(skipped) == 0
+
+    def test_group_entry_dict_value_still_literal(self):
+        """Dict-valued fields inside group entries pass through as literal values."""
+        entry = {"transformers.some_param": {"a": 1}}
+        result = _expand_group_entry(entry)
+        assert result == [{"transformers.some_param": {"a": 1}}]


### PR DESCRIPTION
## What

Adds three deterministic mapping idioms as alternative notation for a sweep-axis
value list in study files. The study file stays fully explicit: an idiom is a
deterministic, versioned notation whose expansion is fixed at load time, exactly
like an explicit list.

- `{min: a, max: b, num: n}` - n evenly spaced values from a to b inclusive (n >= 2)
- `{log: {min: a, max: b, num: n}}` - n log-spaced values, min > 0, inclusive endpoints
- `{pow2: {min: a, max: b}}` - ascending powers of two within [a, b] (min 4, max 32 -> [4, 8, 16, 32])

Expansion happens in `_expand_sweep` (config/grid.py), at the single point where
axis values are read, so every downstream consumer (dedup, rule pruning, swept-field
detection, counts) only ever sees plain lists. The expansion logic lives in a new
sibling module `config/sweep_idioms.py`.

## Semantics decisions

- **Number typing**: values are ints when all bounds are ints AND every produced
  value is integral; otherwise floats. For the linear idiom, integrality is decided
  by exact integer arithmetic (`(max - min) % (num - 1) == 0`), so no float noise
  can leak into the decision. For log, integrality is decided after rounding.
  pow2 emits ints for all integral powers (2^k, k >= 0) regardless of bound type;
  fractional powers (min < 1, e.g. 0.5) make the whole axis float-typed.
- **Rounding**: interior points are rounded to 10 significant digits
  (`float(f"{v:.10g}")`), which eliminates binary float noise
  (0.30000000000000004 -> 0.3). Endpoints are emitted verbatim as written in the
  study file (never rounded), so `min`/`max` always appear exactly. pow2 values
  are exact binary floats/ints and need no rounding.
- **Duplicates**: values that coincide after rounding collapse to unique values
  preserving order (ascending, since both spans are monotone). Rationale: a
  degenerate-but-valid request (e.g. `min == max`, or a span narrower than the
  rounding grain) still expands deterministically instead of failing, and
  duplicate axis values would only create identical experiments that study dedup
  would have to strip anyway.
- **Validation** (all loud, at expansion time): min > max; num < 2 or non-integer
  num; non-numeric / non-finite / boolean fields; log with min <= 0; pow2 with
  min <= 0 or no power of two in range; unknown keys mixed into an idiom mapping;
  wrapped idioms (`log:`, `pow2:`) whose inner value is not a mapping with exactly
  the expected keys. The idiom module raises `ValueError`; `_expand_sweep` wraps it
  as the module-conventional `ConfigError` with the axis key prefixed
  (`sweep axis '<key>': ...`), so CLI error handling behaves as for every other
  sweep-shape error.
- **Scope**: idioms apply only at the top-level sweep axis position (where the
  value would otherwise be a list). They do not apply inside group entries or
  nested inside lists.

## Disambiguation vs existing mapping semantics

How current sweep parsing treats mapping values, verified before implementing:

- **List of dicts** at axis position = dependent group (`_is_group`). Untouched:
  idiom detection only triggers for a *bare* mapping, which `_is_group` never claims.
- **Dict-valued fields inside group entries** pass through as literal values
  (`_expand_group_entry` keeps non-scalar-list values as scalar fields). This is
  the existing, working escape hatch for sweeping literal mapping values, mirroring
  the documented literal-list convention (nested `[[0, 1]]` stays literal).
  Untouched; a regression test now pins it.
- **Bare mapping at axis position** previously fell through
  `if not isinstance(values, list): values = [values]` and became a single-element
  axis carrying the dict as a literal value. This path is undocumented and
  unexercised by any test, doc, tutorial, or example in the repo; fixed mapping
  values belong in the base/fixed config section, and swept ones in group entries.
  It is therefore safe to claim the bare-mapping slot for idioms. A non-idiom bare
  mapping now fails loudly, naming the three valid idioms and pointing at the two
  legitimate homes for literal mappings (base config, group entry) instead of being
  silently treated as a value.

## Validation

- `make lint`: ruff check + format + import-linter all pass (4 contracts kept)
- `make typecheck`: mypy clean, 291 source files
- `uv run pytest tests/unit -q`: 2732 passed, 45 skipped, 0 failed (659s)
- Frozen paths untouched: diff touches only `src/llenergymeasure/config/grid.py`,
  `src/llenergymeasure/config/sweep_idioms.py`,
  `tests/unit/study/test_sweep_idioms.py`

## Tests

- Per idiom: exact values, int/float typing, rounding, inclusive endpoints,
  degenerate spans (min == max, single power)
- Every validation error path (parametrised)
- E2E: a study YAML using all three idioms expands through public `expand_grid`
  to the expected experiment count (18) and exact values; idiom expansion is
  byte-identical to the equivalent explicit list (model_dump comparison)
- Regression: explicit-list axes, list-of-dict groups, and literal dict values
  inside group entries behave exactly as before
