### PR TITLE
feat(study): add bounds mode with series policies and overrides

### DIFF
--- a/src/llenergymeasure/cli/study_cmd.py
+++ b/src/llenergymeasure/cli/study_cmd.py
@@ -53,16 +53,36 @@ def study_init(
             "leaving them commented out.",
         ),
     ] = False,
+    bounds: Annotated[
+        bool,
+        typer.Option(
+            "--bounds",
+            help="Emit every field with a derivable value range as an explicit "
+            "value list under sweep: - a maximal grid to prune before running.",
+        ),
+    ] = False,
 ) -> None:
     """Write a study file for a model, ready to edit and run with ``llem run``.
 
     Without ``--defaults`` the tuning fields are present but commented out, each
     annotated with its type, range, and default - uncomment the ones you want.
     With ``--defaults`` those fields are filled in at their defaults, giving a
-    reproducible baseline you can run as-is.
+    reproducible baseline you can run as-is. With ``--bounds`` every field with
+    a derivable value range becomes an explicit value list under ``sweep:``,
+    forming a maximal grid you prune down to the study you want.
     """
-    from llenergymeasure.config.scaffold import all_engine_names, render_study_scaffold
+    from llenergymeasure.config.scaffold import (
+        all_engine_names,
+        render_study_bounds,
+        render_study_scaffold,
+    )
     from llenergymeasure.config.ssot import Engine
+
+    if defaults and bounds:
+        raise typer.BadParameter(
+            "--defaults and --bounds are mutually exclusive; pick one.",
+            param_hint="--bounds",
+        )
 
     if not model.strip():
         raise typer.BadParameter("Model must not be empty.", param_hint="--model")
@@ -78,7 +98,10 @@ def study_init(
     else:
         engines = all_engine_names()
 
-    text = render_study_scaffold(model, engines, defaults=defaults)
+    if bounds:
+        text = render_study_bounds(model, engines)
+    else:
+        text = render_study_scaffold(model, engines, defaults=defaults)
 
     out_path = output if output is not None else Path("study.yaml")
     if out_path.exists():
@@ -91,4 +114,7 @@ def study_init(
 
     out_path.write_text(text)
     typer.echo(f"Wrote study file: {out_path}")
-    typer.echo(f"Edit it, then run: llem run {out_path}")
+    if bounds:
+        typer.echo(f"Prune the sweep value lists, then run: llem run {out_path}")
+    else:
+        typer.echo(f"Edit it, then run: llem run {out_path}")

--- a/src/llenergymeasure/config/engine_rules/loader.py
+++ b/src/llenergymeasure/config/engine_rules/loader.py
@@ -242,21 +242,23 @@ class EngineRules:
 _FIELD_REF_PREFIX = "@"
 
 
-def _spec_has_field_ref(spec: Any) -> bool:
+def spec_has_field_ref(spec: Any) -> bool:
     """Return True if ``spec`` contains any ``@field_path`` string anywhere.
 
-    Used to short-circuit :func:`_resolve_field_refs_in_spec` on the hot
-    path: most predicates are literal (no cross-field refs), so paying a
-    cheap pre-scan to skip the substitution-recursion's allocations is
-    a win - every ``Rule.try_match`` runs this on every match_fields
-    spec on every config construction.
+    Public predicate for spotting cross-field specs. Its first use is to
+    short-circuit :func:`_resolve_field_refs_in_spec` on the hot path: most
+    predicates are literal (no cross-field refs), so paying a cheap pre-scan
+    to skip the substitution-recursion's allocations is a win - every
+    ``Rule.try_match`` runs this on every match_fields spec on every config
+    construction. :mod:`llenergymeasure.config.series` reuses it to skip
+    cross-field rules it cannot evaluate against a bare candidate value.
     """
     if isinstance(spec, str):
         return spec.startswith(_FIELD_REF_PREFIX)
     if isinstance(spec, dict):
-        return any(_spec_has_field_ref(v) for v in spec.values())
+        return any(spec_has_field_ref(v) for v in spec.values())
     if isinstance(spec, (list, tuple)):
-        return any(_spec_has_field_ref(v) for v in spec)
+        return any(spec_has_field_ref(v) for v in spec)
     return False
 
 
@@ -269,7 +271,7 @@ def _resolve_field_refs_in_spec(spec: Any, config: Any, predicate_field_path: st
     ``predicate_field_path``; dotted references (``@a.b.c``) resolve from
     the config root.
 
-    Short-circuits via :func:`_spec_has_field_ref` when the spec contains
+    Short-circuits via :func:`spec_has_field_ref` when the spec contains
     no references - returns the original spec unchanged in that case,
     avoiding the dict/list rebuild overhead on the common literal-spec
     path.
@@ -277,7 +279,7 @@ def _resolve_field_refs_in_spec(spec: Any, config: Any, predicate_field_path: st
     Returns a new spec with substitutions applied; the input is not
     mutated. Non-ref strings pass through unchanged.
     """
-    if not _spec_has_field_ref(spec):
+    if not spec_has_field_ref(spec):
         return spec
     if isinstance(spec, str):
         return _resolve_one_ref(spec, config, predicate_field_path)

--- a/src/llenergymeasure/config/scaffold.py
+++ b/src/llenergymeasure/config/scaffold.py
@@ -226,9 +226,7 @@ def _experiment_block(
     engine: str, model: str, *, defaults: bool, overrides_root: Path | None
 ) -> list[str]:
     """Return one ``experiments:`` list entry for a single engine."""
-    overrides = load_study_overrides(engine, overrides_root)
-    sub_models = _sub_models(engine)
-    _check_override_paths(engine, overrides, sub_models)
+    overrides, sub_models = _load_overrides_and_models(engine, overrides_root)
     lines = [
         f"  - engine: {engine}",
         "    task:",
@@ -291,9 +289,7 @@ def _engine_bounds_plan(
     engine: str, rules_loader: EngineRulesLoader, overrides_root: Path | None
 ) -> _EngineBoundsPlan:
     """Derive the pinned/series partition for one engine."""
-    overrides = load_study_overrides(engine, overrides_root)
-    sub_models = _sub_models(engine)
-    _check_override_paths(engine, overrides, sub_models)
+    overrides, sub_models = _load_overrides_and_models(engine, overrides_root)
     rules: tuple[Rule, ...]
     try:
         rules = rules_loader.load_rules(engine).rules
@@ -332,6 +328,16 @@ def _check_override_paths(
         raise StudyOverridesError(
             f"study_overrides.yaml for {engine!r} names unknown field path(s): {sorted(unknown)}."
         )
+
+
+def _load_overrides_and_models(
+    engine: str, overrides_root: Path | None
+) -> tuple[dict[str, FieldOverride], dict[str, type[BaseModel]]]:
+    """Load an engine's curated overrides and sub-models, rejecting stray paths."""
+    overrides = load_study_overrides(engine, overrides_root)
+    sub_models = _sub_models(engine)
+    _check_override_paths(engine, overrides, sub_models)
+    return overrides, sub_models
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/config/scaffold.py
+++ b/src/llenergymeasure/config/scaffold.py
@@ -7,7 +7,7 @@ read straight off the generated Pydantic config models (the same models
 ``ExperimentConfig`` validates against), so the scaffold never drifts from what
 the engine actually accepts.
 
-Two modes:
+Three modes:
 
 - bare (``defaults=False``): the tuning fields are present but commented out,
   each annotated with its type, range, and default. Only ``model`` and
@@ -15,10 +15,17 @@ Two modes:
   opts into fields by uncommenting them.
 - defaults (``defaults=True``): the same fields are uncommented and pinned to
   their model defaults - a reproducible baseline study.
+- bounds (:func:`render_study_bounds`): every field with a derivable finite
+  range becomes an explicit value list under a ``sweep:`` block - a maximal
+  grid the user prunes before running. Fields with no derivable range stay
+  pinned at their defaults. Value derivation (series policies, curated
+  overrides, known-rejected filtering) lives in
+  :mod:`llenergymeasure.config.series`.
 
-The only difference between the two modes is the comment prefix on the field
-lines, so an uncommented bare field lands on exactly the value the defaults
-mode would emit.
+The only difference between bare and defaults is the comment prefix on the
+field lines, so an uncommented bare field lands on exactly the value the
+defaults mode would emit. All modes honour a curated ``study_default``
+override from the engine's optional ``study_overrides.yaml``.
 """
 
 from __future__ import annotations
@@ -26,15 +33,24 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal, get_args, get_origin
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
+from llenergymeasure.config.engine_rules.loader import EngineRulesLoader, Rule
 from llenergymeasure.config.introspection import get_engine_config_model
+from llenergymeasure.config.series import (
+    FieldOverride,
+    StudyOverridesError,
+    derive_series,
+    load_study_overrides,
+)
 from llenergymeasure.config.ssot import Engine
 
-__all__ = ["all_engine_names", "render_study_scaffold"]
+__all__ = ["all_engine_names", "render_study_bounds", "render_study_scaffold"]
 
 # Sub-sections of every engine's generated Config, in emission order.
 _SUB_SECTIONS = ("engine_params", "sampling_params")
@@ -54,6 +70,7 @@ def render_study_scaffold(
     engines: Sequence[str],
     *,
     defaults: bool,
+    overrides_root: Path | None = None,
 ) -> str:
     """Return the study YAML text for a model across one or more engines.
 
@@ -64,6 +81,9 @@ def render_study_scaffold(
             per engine.
         defaults: False emits commented tuning fields (structure only); True
             emits them uncommented at their model defaults (runnable baseline).
+        overrides_root: Directory holding per-engine ``study_overrides.yaml``
+            files; defaults to the shipped package data. Only ``study_default``
+            entries affect this renderer.
 
     Returns:
         Deterministic YAML text (stable field order, no timestamps), ending in a
@@ -78,7 +98,77 @@ def render_study_scaffold(
     lines.append("# experiment is a complete, self-contained specification.")
     lines.append("experiments:")
     for engine in engines:
-        lines.extend(_experiment_block(engine, model, defaults=defaults))
+        lines.extend(
+            _experiment_block(engine, model, defaults=defaults, overrides_root=overrides_root)
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_study_bounds(
+    model: str,
+    engines: Sequence[str],
+    *,
+    overrides_root: Path | None = None,
+) -> str:
+    """Return the bounds-mode study YAML: pinned fields plus a maximal sweep.
+
+    Every field with a derivable finite range (enum members, bools, numerics
+    with both bounds on the model, or a curated ``sweep_values`` override)
+    becomes an explicit value list under ``sweep:``, keyed by its full dotted
+    path so the grid expander consumes it as-is. All other fields stay pinned
+    at their defaults in a top-level engine section. Values the shipped rules
+    corpus already knows the engine rejects are dropped before emission.
+
+    Args:
+        model: HuggingFace model id or local path.
+        engines: Engine names to scaffold, in emission order.
+        overrides_root: Directory holding per-engine ``study_overrides.yaml``
+            files; defaults to the shipped package data.
+
+    Returns:
+        Deterministic YAML text ending in a newline. Identical arguments always
+        produce byte-identical output.
+    """
+    rules_loader = EngineRulesLoader()
+    plans = [_engine_bounds_plan(e, rules_loader, overrides_root) for e in engines]
+    if len(plans) > 1:
+        for plan in plans:
+            if not plan.series:
+                raise ValueError(
+                    f"Engine {plan.engine!r} has no sweepable fields; scaffold it alone "
+                    f"with `llem study init -e {plan.engine} --bounds`."
+                )
+
+    lines: list[str] = list(_bounds_header(engines))
+    lines.append("")
+    lines.append(f"study_name: {_yaml_scalar(_study_name(model, engines))}")
+    lines.append("")
+    lines.append("task:")
+    lines.append(f"  model: {_yaml_scalar(model)}")
+    if len(engines) == 1:
+        lines.append("")
+        lines.append(f"engine: {engines[0]}")
+    lines.append("")
+    lines.append("# Pinned fields - no derivable value range, so each holds one value for")
+    lines.append("# every grid point. Edit freely, or move a field into the sweep: block")
+    lines.append("# as `<engine>.<section>.<field>: [v1, v2]` to sweep it.")
+    for plan in plans:
+        lines.append(f"{plan.engine}:")
+        for sub_name, pinned_fields in plan.pinned:
+            lines.append(f"  {sub_name}:")
+            for field_name, field_info, value in pinned_fields:
+                lines.append(
+                    _field_line(field_name, field_info, defaults=True, value=value, indent="    ")
+                )
+    lines.append("")
+    lines.append("# One list per sweepable field, covering its full valid range (values the")
+    lines.append("# engine is known to reject are already dropped). The study is the")
+    lines.append("# Cartesian product of these lists - prune each list down to what you")
+    lines.append("# want to study before running.")
+    lines.append("sweep:")
+    for plan in plans:
+        for sweep_key, field_info, values in plan.series:
+            lines.append(f"  {sweep_key}: {_yaml_scalar(values)}  # {_annotation(field_info)}")
     return "\n".join(lines) + "\n"
 
 
@@ -114,35 +204,134 @@ def _header(engines: Sequence[str], *, defaults: bool) -> list[str]:
     return lines
 
 
-def _experiment_block(engine: str, model: str, *, defaults: bool) -> list[str]:
+def _bounds_header(engines: Sequence[str]) -> list[str]:
+    """Return the leading comment block for the bounds mode."""
+    scope = engines[0] if len(engines) == 1 else "all engines"
+    return [
+        f"# llem study file - {scope} (bounds mode)",
+        "#",
+        "# Generated by `llem study init --bounds`. This file is the complete,",
+        "# explicit specification of a study: what you read here is exactly what",
+        "# runs. Edit it freely, then run:",
+        "#",
+        "#     llem run <this-file>",
+        "#",
+        "# Every field with a derivable finite range appears under sweep: as an",
+        "# explicit value list; everything else stays pinned in the engine",
+        "# section. Together the lists form a maximal grid - prune before you run.",
+    ]
+
+
+def _experiment_block(
+    engine: str, model: str, *, defaults: bool, overrides_root: Path | None
+) -> list[str]:
     """Return one ``experiments:`` list entry for a single engine."""
+    overrides = load_study_overrides(engine, overrides_root)
+    sub_models = _sub_models(engine)
+    _check_override_paths(engine, overrides, sub_models)
     lines = [
         f"  - engine: {engine}",
         "    task:",
         f"      model: {_yaml_scalar(model)}",
         f"    {engine}:",
     ]
-    sub_models = _sub_models(engine)
     for sub_name in _SUB_SECTIONS:
         sub_model = sub_models.get(sub_name)
         if sub_model is None:
             continue
         lines.append(f"      {sub_name}:")
         for field_name, field_info in sub_model.model_fields.items():
-            lines.append(_field_line(field_name, field_info, defaults=defaults))
+            value = _pinned_value(field_info, overrides.get(f"{sub_name}.{field_name}"))
+            lines.append(_field_line(field_name, field_info, defaults=defaults, value=value))
     return lines
 
 
-def _field_line(field_name: str, field_info: FieldInfo, *, defaults: bool) -> str:
-    """Render one field line: ``<name>: <default>  # <type> <bounds>, default <v>``.
+def _field_line(
+    field_name: str,
+    field_info: FieldInfo,
+    *,
+    defaults: bool,
+    value: Any,
+    indent: str = "        ",
+) -> str:
+    """Render one field line: ``<name>: <value>  # <type> <bounds>, default <v>``.
 
     In bare mode the field is commented out; in defaults mode it is live. Both
     carry the same value and annotation, so uncommenting a bare line yields the
     defaults-mode line verbatim.
     """
-    value = _yaml_scalar(field_info.default)
-    prefix = "        " if defaults else "        # "
-    return f"{prefix}{field_name}: {value}  # {_annotation(field_info)}"
+    prefix = indent if defaults else f"{indent}# "
+    return f"{prefix}{field_name}: {_yaml_scalar(value)}  # {_annotation(field_info)}"
+
+
+def _pinned_value(field_info: FieldInfo, override: FieldOverride | None) -> Any:
+    """The value a non-swept field is pinned to: curated study_default, else model default."""
+    if override is not None and override.has_study_default:
+        return override.study_default
+    return field_info.default
+
+
+# ---------------------------------------------------------------------------
+# Bounds-mode planning (which fields sweep, which stay pinned)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _EngineBoundsPlan:
+    """Partition of one engine's fields into pinned lines and sweep series."""
+
+    engine: str
+    # Per sub-section: (sub_name, [(field_name, field_info, pinned_value), ...])
+    pinned: list[tuple[str, list[tuple[str, FieldInfo, Any]]]]
+    # (full dotted sweep key, field_info, series values)
+    series: list[tuple[str, FieldInfo, list[Any]]]
+
+
+def _engine_bounds_plan(
+    engine: str, rules_loader: EngineRulesLoader, overrides_root: Path | None
+) -> _EngineBoundsPlan:
+    """Derive the pinned/series partition for one engine."""
+    overrides = load_study_overrides(engine, overrides_root)
+    sub_models = _sub_models(engine)
+    _check_override_paths(engine, overrides, sub_models)
+    rules: tuple[Rule, ...]
+    try:
+        rules = rules_loader.load_rules(engine).rules
+    except FileNotFoundError:
+        rules = ()
+    pinned: list[tuple[str, list[tuple[str, FieldInfo, Any]]]] = []
+    series: list[tuple[str, FieldInfo, list[Any]]] = []
+    for sub_name in _SUB_SECTIONS:
+        sub_model = sub_models.get(sub_name)
+        if sub_model is None:
+            continue
+        sub_pinned: list[tuple[str, FieldInfo, Any]] = []
+        for field_name, field_info in sub_model.model_fields.items():
+            override = overrides.get(f"{sub_name}.{field_name}")
+            sweep_key = f"{engine}.{sub_name}.{field_name}"
+            values = derive_series(field_info, field_path=sweep_key, override=override, rules=rules)
+            if values is None:
+                sub_pinned.append((field_name, field_info, _pinned_value(field_info, override)))
+            else:
+                series.append((sweep_key, field_info, values))
+        pinned.append((sub_name, sub_pinned))
+    return _EngineBoundsPlan(engine=engine, pinned=pinned, series=series)
+
+
+def _check_override_paths(
+    engine: str, overrides: dict[str, FieldOverride], sub_models: dict[str, type[BaseModel]]
+) -> None:
+    """Fail loud when an override names a field path the engine model lacks."""
+    known = {
+        f"{sub_name}.{field_name}"
+        for sub_name, sub_model in sub_models.items()
+        for field_name in sub_model.model_fields
+    }
+    unknown = set(overrides) - known
+    if unknown:
+        raise StudyOverridesError(
+            f"study_overrides.yaml for {engine!r} names unknown field path(s): {sorted(unknown)}."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/config/series.py
+++ b/src/llenergymeasure/config/series.py
@@ -58,8 +58,8 @@ from pydantic.fields import FieldInfo
 
 from llenergymeasure.config.engine_rules.loader import (
     Rule,
-    _spec_has_field_ref,
     evaluate_predicate,
+    spec_has_field_ref,
 )
 
 __all__ = [
@@ -210,7 +210,7 @@ def drop_known_rejected(
         for rule in rules
         if rule.severity == "error"
         and set(rule.match_fields) == {field_path}
-        and not _spec_has_field_ref(rule.match_fields[field_path])
+        and not spec_has_field_ref(rule.match_fields[field_path])
     ]
     if not specs:
         return list(candidates)
@@ -335,6 +335,10 @@ def _finish(
         points = points[:-1]
     if lo_strict:
         points = points[1:]
+    # Latent edge: an interior point can round onto a dropped strict bound
+    # (e.g. gt=0 lt=1 as int -> 0 and 1), a value the model would reject. No
+    # shipped field is this narrow, so the round-trip tests stay green; widen
+    # here if one ever appears.
     if as_int:
         ints: list[int] = []
         for p in points:
@@ -342,6 +346,10 @@ def _finish(
             if r not in ints:
                 ints.append(r)
         return ints
+    # Round to decimal places, not significant digits: these land in a
+    # human-facing YAML file as sweep starting points, so clean numbers like
+    # 0.25 read better than the significant-digit form used by the run-time
+    # grid expander (config.sweep_idioms).
     floats: list[float] = []
     for p in points:
         f = round(p, 6)

--- a/src/llenergymeasure/config/series.py
+++ b/src/llenergymeasure/config/series.py
@@ -1,0 +1,357 @@
+"""Value-series derivation for ``llem study init --bounds``.
+
+A series is the explicit list of values the bounds scaffold emits for one
+tuning field. Everything here is a deterministic, documented floor - the same
+field always yields the same series:
+
+- Enum / Literal fields: every member.
+- Bool fields: ``[false, true]``.
+- Numeric fields with BOTH a lower and an upper bound on the generated model:
+  points from a named series policy (default ``span``). Bounds are read off
+  the field's ge/gt/le/lt metadata; nothing is guessed.
+- Everything else (one-sided or unbounded numerics, strings, objects, Any):
+  no series - the field stays pinned at its default. The scaffold never
+  invents values without a finite derivable range or a curated override.
+
+Series policies (named shapes):
+
+- ``span`` (the floor default): 5 points at quantiles 0, 1/4, 1/2, 3/4, 1 of
+  the closed range; an endpoint whose bound is strict (gt/lt) is dropped.
+- ``log``: 5 geometrically spaced points across the range (requires a
+  positive lower bound); same strict-endpoint handling.
+- ``pow2``: every power of two inside the range (requires a lower bound of
+  at least 1); strict bounds exclude an exactly-matching power.
+
+``log`` and ``pow2`` are reachable only through a curated override
+(``sweep_hint``), never as the automatic default.
+
+Curated overrides live in an optional per-engine package-data file
+``src/llenergymeasure/engines/<engine>/study_overrides.yaml`` mapping a
+section-relative field path (``engine_params.gpu_memory_utilization``) to
+any of a closed key set:
+
+- ``study_default``: value the scaffold pins the field to instead of the
+  model default (applies to every ``llem study init`` mode).
+- ``sweep_hint``: series policy name (``span`` / ``log`` / ``pow2``) for a
+  numeric field with both bounds.
+- ``sweep_values``: explicit value list; wins over any policy.
+
+The file is validated on load - unknown keys fail loud. An absent or empty
+file means no overrides.
+
+Before a series is emitted, candidate values the shipped rules corpus
+already knows the engine rejects are dropped: any single-field ``error``
+rule whose match is exactly this field filters the list (cross-field rules
+are out of scope here). If fewer than two candidates survive, the field
+stays pinned instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, get_args, get_origin
+
+import yaml
+from pydantic.fields import FieldInfo
+
+from llenergymeasure.config.engine_rules.loader import (
+    Rule,
+    _spec_has_field_ref,
+    evaluate_predicate,
+)
+
+__all__ = [
+    "SERIES_SHAPES",
+    "FieldOverride",
+    "StudyOverridesError",
+    "derive_series",
+    "drop_known_rejected",
+    "load_study_overrides",
+]
+
+SERIES_SHAPES = ("span", "log", "pow2")
+"""Named series policies. ``span`` is the floor default; the rest are
+reachable only via a curated ``sweep_hint``."""
+
+OVERRIDES_FILENAME = "study_overrides.yaml"
+
+_OVERRIDE_KEYS = frozenset({"study_default", "sweep_hint", "sweep_values"})
+
+_DEFAULT_OVERRIDES_ROOT = Path(__file__).resolve().parents[1] / "engines"
+
+_UNSET: Any = object()
+"""Sentinel distinguishing an absent ``study_default`` from an explicit null."""
+
+
+class StudyOverridesError(ValueError):
+    """A study_overrides.yaml file is malformed or violates the closed schema."""
+
+
+@dataclass(frozen=True)
+class FieldOverride:
+    """Curated per-field override parsed from ``study_overrides.yaml``."""
+
+    study_default: Any = _UNSET
+    sweep_hint: str | None = None
+    sweep_values: list[Any] | None = None
+
+    @property
+    def has_study_default(self) -> bool:
+        return self.study_default is not _UNSET
+
+
+# ---------------------------------------------------------------------------
+# Overrides loading
+# ---------------------------------------------------------------------------
+
+
+def load_study_overrides(engine: str, root: Path | None = None) -> dict[str, FieldOverride]:
+    """Load and validate an engine's optional study overrides file.
+
+    Returns a mapping of section-relative field path (e.g.
+    ``engine_params.gpu_memory_utilization``) to :class:`FieldOverride`.
+    An absent or empty file yields an empty mapping; a malformed file
+    raises :class:`StudyOverridesError`.
+    """
+    base = root if root is not None else _DEFAULT_OVERRIDES_ROOT
+    path = base / engine / OVERRIDES_FILENAME
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text())
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise StudyOverridesError(
+            f"{path}: top level must be a mapping of field paths, got {type(data).__name__}."
+        )
+    overrides: dict[str, FieldOverride] = {}
+    for raw_path, raw_entry in data.items():
+        field_path = str(raw_path)
+        overrides[field_path] = _parse_override(path, field_path, raw_entry)
+    return overrides
+
+
+def _parse_override(path: Path, field_path: str, raw_entry: Any) -> FieldOverride:
+    if not isinstance(raw_entry, dict):
+        raise StudyOverridesError(
+            f"{path}: entry for {field_path!r} must be a mapping, got {type(raw_entry).__name__}."
+        )
+    unknown = set(raw_entry) - _OVERRIDE_KEYS
+    if unknown:
+        raise StudyOverridesError(
+            f"{path}: entry for {field_path!r} has unknown key(s) {sorted(unknown)}; "
+            f"allowed keys: {sorted(_OVERRIDE_KEYS)}."
+        )
+    if not raw_entry:
+        raise StudyOverridesError(
+            f"{path}: entry for {field_path!r} is empty; "
+            f"set at least one of {sorted(_OVERRIDE_KEYS)}."
+        )
+    hint = raw_entry.get("sweep_hint")
+    if hint is not None and hint not in SERIES_SHAPES:
+        raise StudyOverridesError(
+            f"{path}: entry for {field_path!r} has sweep_hint={hint!r}; "
+            f"must be one of {list(SERIES_SHAPES)}."
+        )
+    values = raw_entry.get("sweep_values")
+    if values is not None and (not isinstance(values, list) or not values):
+        raise StudyOverridesError(
+            f"{path}: entry for {field_path!r} has sweep_values={values!r}; "
+            "must be a non-empty list."
+        )
+    return FieldOverride(
+        study_default=raw_entry.get("study_default", _UNSET),
+        sweep_hint=hint,
+        sweep_values=list(values) if values is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Series derivation
+# ---------------------------------------------------------------------------
+
+
+def derive_series(
+    field_info: FieldInfo,
+    *,
+    field_path: str,
+    override: FieldOverride | None,
+    rules: Sequence[Rule],
+) -> list[Any] | None:
+    """Return the value series for one field, or None to keep it pinned.
+
+    Candidates come from the curated override (``sweep_values`` wins, then
+    ``sweep_hint`` picks the policy) or the deterministic floor. Values a
+    single-field error rule in ``rules`` would reject are dropped; if fewer
+    than two candidates survive, the field gets no series.
+    """
+    candidates = _candidates(field_info, field_path=field_path, override=override)
+    if candidates is None:
+        return None
+    kept = drop_known_rejected(candidates, field_path, rules)
+    if len(kept) < 2:
+        return None
+    return kept
+
+
+def drop_known_rejected(
+    candidates: Sequence[Any], field_path: str, rules: Sequence[Rule]
+) -> list[Any]:
+    """Filter out candidates a single-field error rule would reject.
+
+    Only rules whose match is exactly ``{field_path}`` participate; specs
+    carrying ``@field`` references are cross-field in disguise and are
+    skipped (they cannot be evaluated against a bare candidate value).
+    """
+    specs = [
+        rule.match_fields[field_path]
+        for rule in rules
+        if rule.severity == "error"
+        and set(rule.match_fields) == {field_path}
+        and not _spec_has_field_ref(rule.match_fields[field_path])
+    ]
+    if not specs:
+        return list(candidates)
+    return [c for c in candidates if not any(evaluate_predicate(c, s) for s in specs)]
+
+
+def _candidates(
+    field_info: FieldInfo, *, field_path: str, override: FieldOverride | None
+) -> list[Any] | None:
+    """Raw candidate values before known-rejected filtering, or None."""
+    if override is not None and override.sweep_values is not None:
+        return list(override.sweep_values)
+    hint = override.sweep_hint if override is not None else None
+    inner = _unwrap_optional(field_info.annotation)
+    if get_origin(inner) is Literal:
+        _require_no_hint(hint, field_path)
+        return list(get_args(inner))
+    if inner is bool:
+        _require_no_hint(hint, field_path)
+        return [False, True]
+    if inner is int or inner is float:
+        bounds = _closed_bounds(field_info)
+        if bounds is None:
+            _require_no_hint(hint, field_path)
+            return None
+        lo, hi, lo_strict, hi_strict = bounds
+        policy = _POLICIES[hint or "span"]
+        return list(policy(lo, hi, lo_strict=lo_strict, hi_strict=hi_strict, as_int=inner is int))
+    _require_no_hint(hint, field_path)
+    return None
+
+
+def _require_no_hint(hint: str | None, field_path: str) -> None:
+    if hint is not None:
+        raise StudyOverridesError(
+            f"sweep_hint on {field_path!r} needs a numeric field with both a lower and an "
+            "upper bound on the model; use sweep_values to set the list explicitly."
+        )
+
+
+def _closed_bounds(field_info: FieldInfo) -> tuple[float, float, bool, bool] | None:
+    """Return (lo, hi, lo_strict, hi_strict) if both bounds exist, else None."""
+    lo: float | None = None
+    hi: float | None = None
+    lo_strict = False
+    hi_strict = False
+    for constraint in field_info.metadata:
+        gt = getattr(constraint, "gt", None)
+        ge = getattr(constraint, "ge", None)
+        lt = getattr(constraint, "lt", None)
+        le = getattr(constraint, "le", None)
+        if lo is None and gt is not None:
+            lo, lo_strict = float(gt), True
+        if lo is None and ge is not None:
+            lo = float(ge)
+        if hi is None and lt is not None:
+            hi, hi_strict = float(lt), True
+        if hi is None and le is not None:
+            hi = float(le)
+    if lo is None or hi is None:
+        return None
+    return lo, hi, lo_strict, hi_strict
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """Strip a ``| None`` wrapper, returning the inner type (or the annotation)."""
+    args = get_args(annotation)
+    if args and type(None) in args:
+        inner = [a for a in args if a is not type(None)]
+        if inner:
+            return inner[0]
+    return annotation
+
+
+# ---------------------------------------------------------------------------
+# Series policies
+# ---------------------------------------------------------------------------
+
+
+def _span_series(
+    lo: float, hi: float, *, lo_strict: bool, hi_strict: bool, as_int: bool
+) -> list[int] | list[float]:
+    """5 points at quantiles 0, 1/4, 1/2, 3/4, 1 of [lo, hi]."""
+    points = [lo + (hi - lo) * q / 4 for q in range(5)]
+    return _finish(points, lo_strict=lo_strict, hi_strict=hi_strict, as_int=as_int)
+
+
+def _log_series(
+    lo: float, hi: float, *, lo_strict: bool, hi_strict: bool, as_int: bool
+) -> list[int] | list[float]:
+    """5 geometrically spaced points across [lo, hi]; needs lo > 0."""
+    if lo <= 0:
+        raise StudyOverridesError(f"log series needs a positive lower bound, got {lo}.")
+    ratio = hi / lo
+    points = [lo * ratio ** (q / 4) for q in range(5)]
+    return _finish(points, lo_strict=lo_strict, hi_strict=hi_strict, as_int=as_int)
+
+
+def _pow2_series(
+    lo: float, hi: float, *, lo_strict: bool, hi_strict: bool, as_int: bool
+) -> list[int] | list[float]:
+    """Every power of two inside [lo, hi]; needs lo >= 1."""
+    if lo < 1:
+        raise StudyOverridesError(f"pow2 series needs a lower bound of at least 1, got {lo}.")
+    values: list[int] = []
+    v = 1
+    while v < lo or (lo_strict and v == lo):
+        v *= 2
+    while v < hi or (not hi_strict and v == hi):
+        values.append(v)
+        v *= 2
+    if as_int:
+        return values
+    return [float(v) for v in values]
+
+
+def _finish(
+    points: list[float], *, lo_strict: bool, hi_strict: bool, as_int: bool
+) -> list[int] | list[float]:
+    """Drop strict endpoints (positionally: points[0]==lo, points[-1]==hi), round, dedupe."""
+    if hi_strict:
+        points = points[:-1]
+    if lo_strict:
+        points = points[1:]
+    if as_int:
+        ints: list[int] = []
+        for p in points:
+            r = round(p)
+            if r not in ints:
+                ints.append(r)
+        return ints
+    floats: list[float] = []
+    for p in points:
+        f = round(p, 6)
+        if f not in floats:
+            floats.append(f)
+    return floats
+
+
+_POLICIES: dict[str, Callable[..., list[int] | list[float]]] = {
+    "span": _span_series,
+    "log": _log_series,
+    "pow2": _pow2_series,
+}

--- a/src/llenergymeasure/engines/vllm/study_overrides.yaml
+++ b/src/llenergymeasure/engines/vllm/study_overrides.yaml
@@ -1,0 +1,10 @@
+# Curated study-scaffold overrides for vllm, consumed by `llem study init`.
+# Optional package data: an absent or empty file means no overrides. Each
+# entry maps a section-relative field path to any of a closed key set:
+# study_default (pin value), sweep_hint (span | log | pow2), sweep_values
+# (explicit list, wins over any policy).
+
+engine_params.gpu_memory_utilization:
+  # Interior points only: 1.0 leaves no headroom for non-KV allocations (OOM
+  # prone) and the low quantiles of (0, 1] rarely fit a real KV cache.
+  sweep_values: [0.5, 0.7, 0.8, 0.9]

--- a/tests/unit/cli/test_study_cmd.py
+++ b/tests/unit/cli/test_study_cmd.py
@@ -57,6 +57,30 @@ def test_init_defaults_uncomments_fields(tmp_path: Path) -> None:
     assert "        dtype:" in live.read_text()
 
 
+def test_init_bounds_writes_sweep_file(tmp_path: Path) -> None:
+    """--bounds emits a sweep: block of value lists instead of experiments:."""
+    out = tmp_path / "study.yaml"
+    result = runner.invoke(
+        app, ["study", "init", "-m", MODEL, "-e", "vllm", "--bounds", "-o", str(out)]
+    )
+    assert result.exit_code == 0
+    text = out.read_text()
+    assert "sweep:" in text
+    assert "experiments:" not in text
+    assert "vllm.engine_params.dtype:" in text
+
+
+def test_init_bounds_and_defaults_are_mutually_exclusive(tmp_path: Path) -> None:
+    """Combining --bounds with --defaults is a usage error and writes nothing."""
+    out = tmp_path / "study.yaml"
+    result = runner.invoke(
+        app, ["study", "init", "-m", MODEL, "--bounds", "--defaults", "-o", str(out)]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+    assert not out.exists()
+
+
 def test_init_refuses_to_overwrite(tmp_path: Path) -> None:
     """A second write to the same path is refused with a non-zero exit."""
     out = tmp_path / "study.yaml"

--- a/tests/unit/config/test_scaffold.py
+++ b/tests/unit/config/test_scaffold.py
@@ -1,6 +1,6 @@
 """Tests for the study-scaffold renderer (``llem study init`` backend).
 
-Two things are under test:
+Three things are under test:
 
 1. Rendering: annotations are derived only from the generated Pydantic models,
    bare and defaults modes differ solely by a comment prefix, field order is the
@@ -8,19 +8,30 @@ Two things are under test:
 2. Round-trip: every emitted file loads through the public study loader (the
    same path ``llem run`` uses) with the expected experiment count and no
    ``ConfigValidationWarning``.
+3. Bounds mode: sweepable fields become explicit value lists under ``sweep:``,
+   known-rejected values are dropped, curated overrides apply, and the file
+   expands to exactly the product of the emitted series lengths.
 """
 
 from __future__ import annotations
 
+import math
 import re
 import warnings
 from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 
 from llenergymeasure.api import load_study
 from llenergymeasure.config.introspection import get_engine_config_model
-from llenergymeasure.config.scaffold import all_engine_names, render_study_scaffold
+from llenergymeasure.config.scaffold import (
+    all_engine_names,
+    render_study_bounds,
+    render_study_scaffold,
+)
+from llenergymeasure.config.series import OVERRIDES_FILENAME, StudyOverridesError
 from llenergymeasure.config.warnings import ConfigValidationWarning
 
 MODEL = "Qwen/Qwen2.5-0.5B"
@@ -172,3 +183,131 @@ def test_all_engines_round_trips(defaults: bool, tmp_path: Path) -> None:
     path.write_text(text)
     study = _load_without_config_warnings(path)
     assert [e.engine for e in study.experiments] == engines
+
+
+# ---------------------------------------------------------------------------
+# Bounds mode - value lists under sweep:, pinned fields, round-trip counts
+# ---------------------------------------------------------------------------
+
+
+def _sweep_block(text: str) -> dict[str, list[Any]]:
+    """Parse the rendered YAML and return its sweep: mapping."""
+    sweep = yaml.safe_load(text)["sweep"]
+    assert isinstance(sweep, dict)
+    return sweep
+
+
+def test_bounds_emits_series_for_derivable_fields() -> None:
+    """Literals get all members, bools both values, curated lists win."""
+    sweep = _sweep_block(render_study_bounds(MODEL, ["vllm"]))
+    assert sweep["vllm.engine_params.dtype"] == [
+        "auto",
+        "half",
+        "float16",
+        "bfloat16",
+        "float",
+        "float32",
+    ]
+    assert sweep["vllm.engine_params.enforce_eager"] == [False, True]
+    # Curated override (shipped study_overrides.yaml) beats the span floor.
+    assert sweep["vllm.engine_params.gpu_memory_utilization"] == [0.5, 0.7, 0.8, 0.9]
+
+
+def test_bounds_pins_fields_without_derivable_range() -> None:
+    """One-sided/unbounded fields stay pinned at their defaults, not swept."""
+    text = render_study_bounds(MODEL, ["vllm"])
+    raw = yaml.safe_load(text)
+    assert "experiments" not in raw
+    sweep = raw["sweep"]
+    assert "vllm.engine_params.max_num_seqs" not in sweep  # one-sided bound
+    assert "vllm.sampling_params.temperature" not in sweep  # unbounded float
+    assert raw["vllm"]["engine_params"]["max_num_seqs"] is None
+    assert raw["vllm"]["sampling_params"]["temperature"] == 1.0
+
+
+def test_bounds_drops_known_rejected_values() -> None:
+    """early_stopping's series collapses to [false] via a corpus rule, so it pins."""
+    text = render_study_bounds(MODEL, ["transformers"])
+    raw = yaml.safe_load(text)
+    sweep = raw["sweep"]
+    assert "transformers.engine_params.early_stopping" not in sweep
+    assert raw["transformers"]["engine_params"]["early_stopping"] is None
+    assert sweep["transformers.engine_params.use_cache"] == [False, True]
+    assert sweep["transformers.sampling_params.do_sample"] == [False, True]
+
+
+def test_bounds_render_is_byte_deterministic() -> None:
+    a = render_study_bounds(MODEL, all_engine_names())
+    b = render_study_bounds(MODEL, all_engine_names())
+    assert a == b
+    assert a.endswith("\n")
+
+
+@pytest.mark.parametrize("engine", all_engine_names())
+def test_bounds_round_trips_to_series_product(engine: str, tmp_path: Path) -> None:
+    """A bounds file expands to exactly the product of its series lengths."""
+    text = render_study_bounds(MODEL, [engine])
+    path = tmp_path / "study.yaml"
+    path.write_text(text)
+    sweep = _sweep_block(text)
+    expected = math.prod(len(v) for v in sweep.values())
+    study = _load_without_config_warnings(path)
+    assert expected > 1
+    assert len(study.experiments) == expected
+    assert all(e.engine == engine for e in study.experiments)
+
+
+def test_bounds_all_engines_round_trips_to_sum_of_products(tmp_path: Path) -> None:
+    """A multi-engine bounds file expands to the sum of per-engine products."""
+    text = render_study_bounds(MODEL, all_engine_names())
+    path = tmp_path / "study.yaml"
+    path.write_text(text)
+    per_engine: dict[str, list[int]] = {}
+    for key, values in _sweep_block(text).items():
+        per_engine.setdefault(key.split(".")[0], []).append(len(values))
+    assert set(per_engine) == set(all_engine_names())
+    expected = sum(math.prod(lengths) for lengths in per_engine.values())
+    study = _load_without_config_warnings(path)
+    assert len(study.experiments) == expected
+
+
+# ---------------------------------------------------------------------------
+# Curated overrides in the renderers
+# ---------------------------------------------------------------------------
+
+
+def _write_vllm_overrides(tmp_path: Path, text: str) -> Path:
+    engine_dir = tmp_path / "vllm"
+    engine_dir.mkdir()
+    (engine_dir / OVERRIDES_FILENAME).write_text(text)
+    return tmp_path
+
+
+def test_study_default_applies_to_every_mode(tmp_path: Path) -> None:
+    """A curated study_default pins the field in bare, defaults, and bounds."""
+    root = _write_vllm_overrides(
+        tmp_path, "engine_params.tensor_parallel_size:\n  study_default: 2\n"
+    )
+    expected = "tensor_parallel_size: 2  # int, default 1"
+    bare = render_study_scaffold(MODEL, ["vllm"], defaults=False, overrides_root=root)
+    live = render_study_scaffold(MODEL, ["vllm"], defaults=True, overrides_root=root)
+    bounds = render_study_bounds(MODEL, ["vllm"], overrides_root=root)
+    assert f"        # {expected}" in bare
+    assert f"        {expected}" in live
+    assert f"    {expected}" in bounds
+    # The bare/defaults invariant still holds with overrides applied.
+    assert _field_entries(bare, defaults=False) == _field_entries(live, defaults=True)
+
+
+def test_sweep_values_override_wins_in_bounds(tmp_path: Path) -> None:
+    root = _write_vllm_overrides(tmp_path, "engine_params.dtype:\n  sweep_values: [auto, half]\n")
+    sweep = _sweep_block(render_study_bounds(MODEL, ["vllm"], overrides_root=root))
+    assert sweep["vllm.engine_params.dtype"] == ["auto", "half"]
+
+
+def test_unknown_override_path_fails_loud(tmp_path: Path) -> None:
+    root = _write_vllm_overrides(tmp_path, "engine_params.bogus:\n  study_default: 1\n")
+    with pytest.raises(StudyOverridesError, match="unknown field path"):
+        render_study_bounds(MODEL, ["vllm"], overrides_root=root)
+    with pytest.raises(StudyOverridesError, match="unknown field path"):
+        render_study_scaffold(MODEL, ["vllm"], defaults=True, overrides_root=root)

--- a/tests/unit/config/test_series.py
+++ b/tests/unit/config/test_series.py
@@ -1,0 +1,250 @@
+"""Tests for value-series derivation (``llem study init --bounds`` backend).
+
+Covers the deterministic floor (bounded numerics, enums, bools, unbounded
+fields), the named series policies (span / log / pow2), curated override
+loading and precedence, and known-rejected exclusion against both synthetic
+rules and the shipped corpus.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+import pytest
+from pydantic import BaseModel, Field
+
+from llenergymeasure.config.engine_rules.loader import EngineRulesLoader, Provenance, Rule
+from llenergymeasure.config.series import (
+    OVERRIDES_FILENAME,
+    FieldOverride,
+    StudyOverridesError,
+    derive_series,
+    drop_known_rejected,
+    load_study_overrides,
+)
+
+
+class _Probe(BaseModel):
+    open_float: Annotated[float | None, Field(gt=0.0, le=1.0)] = 0.9
+    closed_float: Annotated[float | None, Field(ge=0.0, le=1.0)] = 0.5
+    closed_int: Annotated[int | None, Field(ge=1, le=8)] = 1
+    narrow_int: Annotated[int | None, Field(ge=1, le=2)] = 1
+    log_float: Annotated[float | None, Field(ge=1.0, le=10000.0)] = 1.0
+    pow_int: Annotated[int | None, Field(ge=1, le=32)] = 1
+    strict_pow_int: Annotated[int | None, Field(gt=1, lt=32)] = 2
+    lower_only: Annotated[int | None, Field(ge=1)] = None
+    unbounded: float | None = None
+    flag: bool | None = None
+    choice: Literal["a", "b", "c"] | None = "a"
+    text: str | None = None
+
+
+def _series(
+    name: str, override: FieldOverride | None = None, rules: tuple[Rule, ...] = ()
+) -> list[Any] | None:
+    return derive_series(
+        _Probe.model_fields[name],
+        field_path=f"eng.engine_params.{name}",
+        override=override,
+        rules=rules,
+    )
+
+
+def _rule(match_fields: dict[str, Any], severity: str = "error") -> Rule:
+    return Rule(
+        id="test_rule",
+        engine="eng",
+        severity=severity,
+        match_fields=match_fields,
+        provenance=Provenance(source="manual", verified="human", engine_version="0"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Floor series: bounded numerics, enums, bools; nothing invented otherwise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field_name", "expected"),
+    [
+        ("open_float", [0.25, 0.5, 0.75, 1.0]),  # strict lower endpoint dropped
+        ("closed_float", [0.0, 0.25, 0.5, 0.75, 1.0]),  # closed range keeps endpoints
+        ("closed_int", [1, 3, 4, 6, 8]),  # int quantiles round to ints
+        ("narrow_int", [1, 2]),  # rounding collisions dedupe
+        ("flag", [False, True]),
+        ("choice", ["a", "b", "c"]),
+        ("lower_only", None),  # one-sided bound: no series
+        ("unbounded", None),
+        ("text", None),
+    ],
+)
+def test_floor_series(field_name: str, expected: list[Any] | None) -> None:
+    """The deterministic floor yields the documented series (or none)."""
+    assert _series(field_name) == expected
+
+
+def test_floor_default_policy_is_span() -> None:
+    """Without a hint, a bounded numeric gets linear quantile points."""
+    assert _series("log_float") == [1.0, 2500.75, 5000.5, 7500.25, 10000.0]
+
+
+def test_series_is_deterministic() -> None:
+    """The same field always yields the same series."""
+    assert _series("open_float") == _series("open_float")
+
+
+# ---------------------------------------------------------------------------
+# Named policies via curated sweep_hint
+# ---------------------------------------------------------------------------
+
+
+def test_log_hint_spaces_points_geometrically() -> None:
+    assert _series("log_float", FieldOverride(sweep_hint="log")) == [
+        1.0,
+        10.0,
+        100.0,
+        1000.0,
+        10000.0,
+    ]
+
+
+def test_pow2_hint_emits_all_powers_in_range() -> None:
+    assert _series("pow_int", FieldOverride(sweep_hint="pow2")) == [1, 2, 4, 8, 16, 32]
+
+
+def test_pow2_strict_bounds_exclude_matching_powers() -> None:
+    assert _series("strict_pow_int", FieldOverride(sweep_hint="pow2")) == [2, 4, 8, 16]
+
+
+def test_log_needs_positive_lower_bound() -> None:
+    """open_float's lower bound is 0.0 (strict), which log cannot span."""
+    with pytest.raises(StudyOverridesError, match="positive lower bound"):
+        _series("open_float", FieldOverride(sweep_hint="log"))
+
+
+@pytest.mark.parametrize("field_name", ["flag", "choice", "unbounded", "lower_only", "text"])
+def test_hint_without_derivable_range_fails_loud(field_name: str) -> None:
+    """A sweep_hint on anything but a two-sided numeric is a curation error."""
+    with pytest.raises(StudyOverridesError, match="sweep_hint"):
+        _series(field_name, FieldOverride(sweep_hint="span"))
+
+
+def test_sweep_values_win_over_hint_and_floor() -> None:
+    """Explicit sweep_values beat both the policy hint and the floor."""
+    override = FieldOverride(sweep_hint="log", sweep_values=[2.0, 3.0])
+    assert _series("log_float", override) == [2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# Known-rejected exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_error_rule_drops_matching_candidates() -> None:
+    rules = (_rule({"eng.engine_params.x": {">": 10}}),)
+    assert drop_known_rejected([5, 20], "eng.engine_params.x", rules) == [5]
+
+
+def test_dormant_rule_does_not_drop() -> None:
+    rules = (_rule({"eng.engine_params.x": {">": 10}}, severity="dormant"),)
+    assert drop_known_rejected([5, 20], "eng.engine_params.x", rules) == [5, 20]
+
+
+def test_multi_field_rule_is_ignored() -> None:
+    """Cross-field rules are C2's job; a bare candidate cannot satisfy them."""
+    rules = (_rule({"eng.engine_params.x": {">": 10}, "eng.engine_params.y": {"present": True}}),)
+    assert drop_known_rejected([5, 20], "eng.engine_params.x", rules) == [5, 20]
+
+
+def test_other_field_rule_is_ignored() -> None:
+    rules = (_rule({"eng.engine_params.other": {">": 10}}),)
+    assert drop_known_rejected([5, 20], "eng.engine_params.x", rules) == [5, 20]
+
+
+def test_field_ref_spec_is_skipped() -> None:
+    """A single-key rule whose spec references another field is cross-field."""
+    rules = (_rule({"eng.engine_params.x": {"<": "@sibling"}}),)
+    assert drop_known_rejected([5, 20], "eng.engine_params.x", rules) == [5, 20]
+
+
+def test_series_collapsing_below_two_values_is_pinned() -> None:
+    """When exclusion leaves fewer than two candidates, no series is emitted."""
+    rules = (_rule({"eng.engine_params.flag": True}),)
+    assert _series("flag", rules=rules) is None
+
+
+def test_real_corpus_rejects_early_stopping_true() -> None:
+    """The shipped transformers corpus knows early_stopping=true raises."""
+    rules = EngineRulesLoader().load_rules("transformers").rules
+    kept = drop_known_rejected([False, True], "transformers.engine_params.early_stopping", rules)
+    assert kept == [False]
+
+
+def test_real_corpus_rejects_vllm_top_k_below_neg1() -> None:
+    """The shipped vllm corpus rejects top_k < -1 and nothing else here."""
+    rules = EngineRulesLoader().load_rules("vllm").rules
+    assert drop_known_rejected([-2, -1, 0, 50], "vllm.sampling_params.top_k", rules) == [
+        -1,
+        0,
+        50,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Overrides file loading + validation
+# ---------------------------------------------------------------------------
+
+
+def _write_overrides(tmp_path: Path, text: str) -> Path:
+    engine_dir = tmp_path / "eng"
+    engine_dir.mkdir()
+    (engine_dir / OVERRIDES_FILENAME).write_text(text)
+    return tmp_path
+
+
+def test_absent_overrides_file_is_valid(tmp_path: Path) -> None:
+    assert load_study_overrides("eng", tmp_path) == {}
+
+
+def test_empty_overrides_file_is_valid(tmp_path: Path) -> None:
+    assert load_study_overrides("eng", _write_overrides(tmp_path, "")) == {}
+
+
+def test_valid_overrides_parse(tmp_path: Path) -> None:
+    root = _write_overrides(
+        tmp_path,
+        "a.b:\n  study_default: null\n  sweep_hint: pow2\nc.d:\n  sweep_values: [1, 2]\n",
+    )
+    overrides = load_study_overrides("eng", root)
+    assert overrides["a.b"].has_study_default
+    assert overrides["a.b"].study_default is None
+    assert overrides["a.b"].sweep_hint == "pow2"
+    assert overrides["c.d"].sweep_values == [1, 2]
+    assert not overrides["c.d"].has_study_default
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "a.b:\n  bogus_key: 1\n",  # unknown entry key
+        "a.b: {}\n",  # empty entry
+        "a.b: 3\n",  # entry not a mapping
+        "a.b:\n  sweep_hint: cubic\n",  # unknown series shape
+        "a.b:\n  sweep_values: 5\n",  # sweep_values not a list
+        "a.b:\n  sweep_values: []\n",  # sweep_values empty
+        "- a\n",  # top level not a mapping
+    ],
+)
+def test_malformed_overrides_fail_loud(tmp_path: Path, text: str) -> None:
+    with pytest.raises(StudyOverridesError):
+        load_study_overrides("eng", _write_overrides(tmp_path, text))
+
+
+def test_shipped_vllm_overrides_load() -> None:
+    """The seeded package-data file parses and carries the curated gpu series."""
+    overrides = load_study_overrides("vllm")
+    gpu = overrides["engine_params.gpu_memory_utilization"]
+    assert gpu.sweep_values == [0.5, 0.7, 0.8, 0.9]
+    assert not gpu.has_study_default


### PR DESCRIPTION
## What

Adds a third mode to `llem study init`: `--bounds`. Instead of pinning every
tuning field to one value, every field with a derivable finite range becomes
an explicit value list under a `sweep:` block - a maximal, trim-me grid the
user prunes before running. Mutually exclusive with `--defaults`.

## Design

**Emission shape.** Bounds mode emits `study_name`, a top-level `task:` block,
a top-level per-engine section holding the pinned (non-sweepable) fields at
their defaults, and a `sweep:` block of flat dotted engine-scoped keys
(`vllm.engine_params.dtype: [...]`) - exactly the shape the existing grid
expansion consumes. No `experiments:` list; engines are implied by the scoped
sweep keys (plus an explicit `engine:` key in single-engine files). The
emitted file round-trips through the public `load_study` path.

**Series policies (deterministic floor, in `config/series.py`).**
- Bounded numerics (both ge/gt and le/lt on the generated model): 5 points at
  quantiles 0, 1/4, 1/2, 3/4, 1 of the closed range; an endpoint whose bound
  is strict is dropped; int fields round and dedupe.
- Enums/Literals: all members. Bools: `[false, true]`.
- Unbounded or one-sided numerics, strings, objects, Any: no series - the
  field stays pinned as in `--defaults`. Nothing is invented without a finite
  derivable range or a curated override.
- Named shapes `span | log | pow2`; the floor default is `span`; `log`/`pow2`
  are reachable only via a curated `sweep_hint`.

**Known-rejected exclusion.** Before emitting a series, candidates are
filtered against the shipped rules corpus (`EngineRulesLoader`): any
single-field `error` rule whose match is exactly that field drops matching
values (specs carrying `@field` references are cross-field in disguise and
skipped). A series left with fewer than two values is not emitted - the field
stays pinned. Real effect today: `transformers.engine_params.early_stopping`
collapses to `[false]` via the corpus and stays pinned.

**Curated overrides.** New optional per-engine package-data file
`src/llenergymeasure/engines/<engine>/study_overrides.yaml`, validated on
load with a closed key set (`study_default`, `sweep_hint`, `sweep_values`;
unknown keys and unknown field paths fail loud). Precedence:
`sweep_values > sweep_hint > floor`. `study_default` pins the field in every
init mode (bare, defaults, bounds).

**Seeded override (one entry, vllm only):**
- `engine_params.gpu_memory_utilization: sweep_values [0.5, 0.7, 0.8, 0.9]` -
  interior points only: 1.0 leaves no headroom for non-KV allocations (OOM
  prone) and the low quantiles of (0, 1] rarely fit a real KV cache.
  transformers and tensorrt ship no file (absent file is valid = no
  overrides). No `study_default` is seeded, so bare/defaults output is
  byte-identical to before this PR.

## Sample: `llem study init -m Qwen/Qwen2.5-0.5B -e vllm --bounds`

```yaml
# llem study file - vllm (bounds mode)
#
# Generated by `llem study init --bounds`. This file is the complete,
# explicit specification of a study: what you read here is exactly what
# runs. Edit it freely, then run:
#
#     llem run <this-file>
#
# Every field with a derivable finite range appears under sweep: as an
# explicit value list; everything else stays pinned in the engine
# section. Together the lists form a maximal grid - prune before you run.

study_name: qwen2.5-0.5b-vllm

task:
  model: Qwen/Qwen2.5-0.5B

engine: vllm

# Pinned fields - no derivable value range, so each holds one value for
# every grid point. Edit freely, or move a field into the sweep: block
# as `<engine>.<section>.<field>: [v1, v2]` to sweep it.
vllm:
  engine_params:
    cpu_offload_gb: 0  # float >=0.0, default 0
    block_size: null  # int, default null
    max_num_seqs: null  # int >=1, default null
    max_num_batched_tokens: null  # int >=1, default null
    max_model_len: null  # int >=1, default null
    tensor_parallel_size: 1  # int, default 1
    pipeline_parallel_size: 1  # int, default 1
    distributed_executor_backend: null  # any, default null
    quantization: null  # any, default null
    speculative_config: null  # object, default null
    offload_group_size: 0  # int >=0, default 0
    offload_num_in_group: 1  # int >=1, default 1
    offload_prefetch_step: 1  # int >=0, default 1
    offload_params: []  # any, default []
    kv_cache_memory_bytes: null  # int, default null
    compilation_config: null  # object, default null
    attention: null  # any, default null
    beam_search: null  # any, default null
  sampling_params:
    temperature: 1.0  # float, default 1.0
    top_k: 0  # int, default 0
    top_p: 1.0  # float, default 1.0
    repetition_penalty: 1.0  # float, default 1.0
    min_p: 0.0  # float, default 0.0
    min_tokens: 0  # int, default 0
    presence_penalty: 0.0  # float, default 0.0
    frequency_penalty: 0.0  # float, default 0.0
    n: 1  # int, default 1

# One list per sweepable field, covering its full valid range (values the
# engine is known to reject are already dropped). The study is the
# Cartesian product of these lists - prune each list down to what you
# want to study before running.
sweep:
  vllm.engine_params.dtype: [auto, half, float16, bfloat16, float, float32]  # one of [auto, half, float16, bfloat16, float, float32], default auto
  vllm.engine_params.gpu_memory_utilization: [0.5, 0.7, 0.8, 0.9]  # float >0.0 <=1.0, default 0.9
  vllm.engine_params.kv_cache_dtype: [auto, float16, bfloat16, fp8, fp8_e4m3, fp8_e5m2, fp8_inc, fp8_ds_mla]  # one of [auto, float16, bfloat16, fp8, fp8_e4m3, fp8_e5m2, fp8_inc, fp8_ds_mla], default auto
  vllm.engine_params.enforce_eager: [false, true]  # bool, default false
  vllm.engine_params.enable_chunked_prefill: [false, true]  # bool, default null
  vllm.engine_params.enable_prefix_caching: [false, true]  # bool, default null
  vllm.engine_params.disable_custom_all_reduce: [false, true]  # bool, default false
  vllm.sampling_params.ignore_eos: [false, true]  # bool, default false

```

Round-trips to 6 x 4 x 8 x 2^5 = 6144 experiments (product of the emitted
series lengths; dedup is identity on this grid). transformers and tensorrt
each expand to 4; the all-engines file expands to the sum, 6152.

## Out of scope (parallel/follow-up work)

- Sweep numeric idioms in `grid.py` (parallel PR; `grid.py` untouched here).
- `llem study plan`.
- `llem run` changes.
- Cross-field pruning of the emitted grid (C2).

## Validation

- `make lint`: pass (ruff check, ruff format, import-linter: 4 contracts kept).
- `make typecheck`: pass (mypy strict, 291 source files, no issues).
- `uv run pytest tests/unit -q`: 2728 passed, 45 skipped, 0 failed (3m32s).
- Frozen artefacts untouched: `engines/*/rules.yaml`, generated
  `engines/*/config.py`, `engine_versions/**`, `*.discovered.json`, `grid.py`.
- Round-trip verified per engine and all-engines via public `load_study` with
  `ConfigValidationWarning` escalated to error: counts match the product of
  emitted series lengths exactly.
