### PR TITLE
fix(config): drop phantom baseline when experiments list present

### DIFF
--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -144,7 +144,9 @@ def expand_grid(
     Resolution order:
     1. Load base: file (optional DRY inheritance)
     2. Build fixed dict from non-sweep/non-experiments/non-study_execution/non-base/non-study_name keys
-    3. Expand sweep: block into raw config dicts
+    3. Expand sweep: block into raw config dicts. An empty sweep synthesises one
+       inline-model baseline from a top-level task.model, but only when there is
+       no explicit experiments: list (otherwise it contributes nothing).
     4. Append explicit experiments: list entries
     5. Pydantic-validate each raw dict, collecting valid + skipped
 
@@ -158,15 +160,19 @@ def expand_grid(
     fixed = _extract_fixed(raw_study)
     merged_fixed = {**base_dict, **fixed}  # inline fields override base
 
-    # Step 3: Expand sweep: block into raw config dicts
+    # Step 3: Expand sweep: block into raw config dicts. The inline-model
+    # baseline (an empty sweep synthesising one experiment from a top-level
+    # task.model) fires only when there is no explicit experiments: list.
+    # With explicit entries an empty sweep contributes nothing, so it never
+    # adds a phantom default-engine baseline the user never wrote.
     sweep = raw_study.get("sweep", {})
-    sweep_raw_configs = _expand_sweep(sweep, merged_fixed)
+    explicit_entries = raw_study.get("experiments", [])
+    sweep_raw_configs = _expand_sweep(sweep, merged_fixed, synthesize_baseline=not explicit_entries)
 
     # Step 4: Append explicit experiments: list entries
     # Strip non-matching engine sections *inherited from fixed*, but preserve
     # any the user wrote directly in the experiment entry (those are genuine
     # misconfigurations and should fail Pydantic validation).
-    explicit_entries = raw_study.get("experiments", [])
     explicit_raw_configs = []
     for exp in explicit_entries:
         merged = {**merged_fixed, **exp}
@@ -558,7 +564,11 @@ def _validate_sweep_groups(
 # =============================================================================
 
 
-def _expand_sweep(sweep: dict[str, Any], fixed: dict[str, Any]) -> list[dict[str, Any]]:
+def _expand_sweep(
+    sweep: dict[str, Any],
+    fixed: dict[str, Any],
+    synthesize_baseline: bool = True,
+) -> list[dict[str, Any]]:
     """Expand a sweep: block into a flat list of raw experiment config dicts.
 
     Supports two entry types under ``sweep:``:
@@ -574,8 +584,17 @@ def _expand_sweep(sweep: dict[str, Any], fixed: dict[str, Any]) -> list[dict[str
     :mod:`llenergymeasure.config.sweep_idioms`); it is expanded to a plain
     list here, at load time, so downstream consumers only see lists. Any
     other mapping-valued axis is rejected with ConfigError.
+
+    When ``sweep`` is empty this synthesises a single inline-model baseline from
+    ``fixed`` (the no-sweep, no-experiments study form) using ``fixed``'s engine
+    or a ``transformers`` default. That synthesis fires only when
+    ``synthesize_baseline`` is True; the caller passes False whenever an explicit
+    experiments: list is present, so an empty sweep never adds a phantom
+    default-engine baseline alongside the user's entries.
     """
     if not sweep:
+        if not synthesize_baseline:
+            return []
         task = fixed.get("task")
         has_model = isinstance(task, dict) and task.get("model")
         if has_model:

--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -272,6 +272,41 @@ class TestExpandGridCombined:
 
 
 # =============================================================================
+# expand_grid() - inline-model baseline vs phantom baseline
+# =============================================================================
+
+
+class TestExpandGridInlineBaseline:
+    def test_inline_model_form_yields_single_baseline(self):
+        """No sweep, no experiments, top-level task.model -> exactly one baseline."""
+        raw = {"study_name": "inline", "task": {"model": "gpt2"}}
+        valid, _skipped = expand_grid(raw)
+        assert len(valid) == 1
+        assert valid[0].engine == "transformers"
+        assert valid[0].task.model == "gpt2"
+
+    def test_experiments_with_shared_task_no_phantom_baseline(self):
+        """A shared top-level task: plus an explicit experiments: list (no sweep)
+        must yield exactly the user's entries, not an extra synthesized
+        default-engine baseline.
+        """
+        raw = {
+            "study_name": "shared-task",
+            "task": {"model": "gpt2"},
+            "experiments": [
+                {"engine": "transformers"},
+                {"engine": "vllm"},
+            ],
+        }
+        valid, _skipped = expand_grid(raw)
+        assert len(valid) == 2
+        assert [c.engine for c in valid] == ["transformers", "vllm"]
+        # None of them is a synthesized baseline: every entry carries the engine
+        # the user wrote, and there is no duplicate transformers baseline.
+        assert all(c.task.model == "gpt2" for c in valid)
+
+
+# =============================================================================
 # expand_grid() - base: resolution
 # =============================================================================
 


### PR DESCRIPTION
## The bug

`expand_grid` in `src/llenergymeasure/config/grid.py` computes
`sweep_raw_configs = _expand_sweep(sweep, merged_fixed)` and then appends the
explicit `experiments:` entries. `_expand_sweep` has an empty-sweep branch: when
`sweep` is empty and the fixed dict carries a `task.model`, it synthesises ONE
inline-model baseline (with a silent `engine = fixed.get("engine", "transformers")`
default). That branch exists for the single-experiment inline-model study form
(no sweep, no experiments list).

But it also fired when a file combined an explicit `experiments:` list with a
shared top-level `task:` block and no sweep, producing N+1 experiments: the user's
N plus a phantom default-engine baseline they never wrote. A 2-entry study
expanded to 3 valid experiments.

## The ruling

The empty-sweep baseline synthesis now fires ONLY when BOTH the sweep block AND
the explicit experiments list are absent/empty. `_expand_sweep` gained a
`synthesize_baseline` flag; `expand_grid` passes `synthesize_baseline=not
explicit_entries`, so with explicit entries an empty sweep contributes nothing.
Affected docstrings (the `expand_grid` resolution order and the `_expand_sweep`
docstring) now state the rule in plain words.

## Preserved behaviors (verified by tests)

- Inline-model form (no sweep, no experiments, top-level `task.model`) still
  yields exactly 1 baseline - new `TestExpandGridInlineBaseline::test_inline_model_form_yields_single_baseline`.
- Sweep + experiments together: union of both, unchanged -
  existing `TestExpandGridCombined::test_sweep_plus_explicit`.
- Sweep only: unchanged - existing `TestExpandGridSweep::test_universal_sweep_cartesian_product`.
- Empty file / no model: unchanged `Study produced no experiments...` error -
  existing `TestExpandGridInvalidHandling::test_no_experiments_raises_config_error`.
- Explicit experiments only (no shared task): unchanged -
  existing `TestExpandGridExplicit::test_explicit_experiments_list`.
- `llem study init --bounds` files (non-empty sweep, no experiments list) expand
  identically (vLLM bounds -> 6144) - existing
  `test_scaffold.py::test_bounds_round_trips_to_series_product` and
  `::test_bounds_all_engines_round_trips_to_sum_of_products`.

## Tests added

- `TestExpandGridInlineBaseline::test_experiments_with_shared_task_no_phantom_baseline`
  (failing-first: asserted 3 == 2 on the old code, now passes with exactly 2 and
  no synthesized baseline).
- `TestExpandGridInlineBaseline::test_inline_model_form_yields_single_baseline`
  (regression pinning the inline-model form to 1).

## Validation

- `make lint`: all checks passed (ruff check + format, import-linter 4 kept / 0 broken)
- `make typecheck`: success, no issues in 293 source files
- `uv run pytest tests/unit -q`: 2787 passed, 45 skipped