### PR TITLE
refactor(cli)!: reduce llem run to session flags only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Post-v0.9.0 work: engine-coupling restructure, engine-invariants pipeline, Docus
 
   Retained session flags: `--output`, `--quiet`, `--verbose`, `--resume`, `--resume-dir`,
   `--dry-run`, `--no-lock`, `--skip-preflight`. Passing a removed flag now gives Typer's standard
-  "No such option" (exit 2). ([#PRNUM])
+  "No such option" (exit 2). ([#749])
 
 - **`engine: pytorch` renamed to `engine: transformers`** throughout YAML, CLI, and Python API.
   The `pytorch` identifier has been renamed to `transformers` - the engine runs HuggingFace
@@ -488,3 +488,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#570]: https://github.com/henrycgbaker/llenergymeasure/pull/570
 [#573]: https://github.com/henrycgbaker/llenergymeasure/pull/573
 [#575]: https://github.com/henrycgbaker/llenergymeasure/pull/575
+[#749]: https://github.com/henrycgbaker/llenergymeasure/pull/749

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ Post-v0.9.0 work: engine-coupling restructure, engine-invariants pipeline, Docus
 
 ### Breaking Changes
 
+- **`llem run` reduced to session flags only.** The semantic-override flags were removed;
+  experiment parameters now live in the YAML config (author one with `llem study init`), and a
+  config path is now required. Flags describe the session; YAML describes the experiment. Removed
+  flags and their YAML equivalents:
+  - `--model` / `-m` -> `task.model`
+  - `--engine` / `-e` -> `engine`
+  - `--dataset` / `-d` -> `task.dataset.source`
+  - `--n-prompts` / `-n` -> `task.dataset.n_prompts`
+  - `--cycles` -> `study_execution.n_cycles`
+  - `--order` -> `study_execution.experiment_order`
+  - `--no-gaps` -> `study_execution.experiment_gap_seconds: 0` (and `cycle_gap_seconds: 0`)
+  - `--timeout` -> `study_execution.wall_clock_timeout_hours`
+  - `--no-circuit-breaker` -> `study_execution.max_consecutive_failures: 0`
+  - `--fail-fast` -> `study_execution.max_consecutive_failures: 1`
+  - `--no-dedup` -> `study_execution.deduplicate_equivalent: false`
+
+  Migrate the quick single-run path:
+  ```bash
+  # before
+  llem run --model gpt2 --engine transformers
+  # after
+  llem study init -m gpt2 --defaults
+  llem run study.yaml
+  ```
+
+  Retained session flags: `--output`, `--quiet`, `--verbose`, `--resume`, `--resume-dir`,
+  `--dry-run`, `--no-lock`, `--skip-preflight`. Passing a removed flag now gives Typer's standard
+  "No such option" (exit 2). ([#PRNUM])
+
 - **`engine: pytorch` renamed to `engine: transformers`** throughout YAML, CLI, and Python API.
   The `pytorch` identifier has been renamed to `transformers` - the engine runs HuggingFace
   Transformers `.generate()`. PyTorch is the tensor substrate, not the engine, and renaming aligns

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Engine code (Transformers, vLLM, TensorRT-LLM) runs inside per-engine Docker ima
 Run your first measurement (host dispatches the appropriate engine container):
 
 ```bash
-llem run --model gpt2 --engine transformers
+llem study init -m gpt2 --defaults   # author a runnable study.yaml
+llem run study.yaml
 ```
 
 See the [documentation site](https://henrycgbaker.github.io/llenergymeasure/) for the full guide - tutorials, how-to recipes, reference (CLI, study config, library API, engines), conceptual explanation (methodology, energy measurement, architecture), and a contributing guide for internals.

--- a/docs/contributing/roadmap.md
+++ b/docs/contributing/roadmap.md
@@ -63,8 +63,9 @@ without a deprecation notice:
 - **Study config top-level keys** - `task`, `sweep`, `experiments`,
   `study_execution`, `runners`. Key names and their structural role will
   not change.
-- **CLI commands** - `llem run` and `llem config` are stable. Flag names
-  (`--model`, `--engine`, `--dtype`) are stable.
+- **CLI commands** - `llem run` and `llem config` are stable. `llem run` takes
+  a config path plus session flags (`--output`, `--resume`, `--dry-run`);
+  experiment parameters live in the YAML config, not in flags.
 
 Pre-1.0 disclaimer: minor-version bumps (0.10 to 0.11 etc.) may include
 breaking changes to internal APIs, engine plugin interfaces, and sampler

--- a/docs/explanation/methodology/comparison-context.md
+++ b/docs/explanation/methodology/comparison-context.md
@@ -45,7 +45,7 @@ If you have MLPerf throughput results, you can run LLenergyMeasure on the same m
 LLenergyMeasure includes the AI Energy Score benchmark dataset as a built-in option. When you run:
 
 ```bash
-llem run --model gpt2 -e transformers
+llem run study.yaml
 ```
 
 the default dataset used is the AI Energy Score prompt set. This means LLenergyMeasure results are directly comparable to AI Energy Score benchmarks run on the same hardware.

--- a/docs/explanation/methodology/glossary.md
+++ b/docs/explanation/methodology/glossary.md
@@ -126,8 +126,8 @@ LLenergyMeasure currently supports three engines:
 | `vllm` | vLLM | Docker only |
 | `tensorrt` | TensorRT-LLM | Docker only |
 
-The engine is set via `engine:` in the YAML or `--engine` on the CLI. Each
-engine runs inside its own Docker image (except Transformers in local mode).
+The engine is set via `engine:` in the YAML config. Each engine runs inside
+its own Docker image (except Transformers in local mode).
 See also [runner](#runner).
 
 ---

--- a/docs/explanation/methodology/methodology.md
+++ b/docs/explanation/methodology/methodology.md
@@ -323,10 +323,12 @@ repeat; when `n_cycles < k`, the first `n_cycles` rows are used.
 
 Best for studies where carryover effects between experiments are a concern.
 
-Override the experiment order from the CLI:
+Set the cycle count and experiment order in the study YAML:
 
-```bash
-llem run study.yaml --cycles 5 --order interleave
+```yaml
+study_execution:
+  n_cycles: 5
+  experiment_order: interleave
 ```
 
 ---
@@ -342,10 +344,13 @@ By default, LLenergyMeasure inserts thermal gaps between experiments in a study.
 gaps allow the GPU to return toward its baseline temperature before the next experiment
 starts.
 
-Disable thermal gaps for speed-oriented testing (at the cost of measurement quality):
+Disable thermal gaps for speed-oriented testing (at the cost of measurement quality)
+by zeroing the gaps in the study YAML:
 
-```bash
-llem run study.yaml --no-gaps
+```yaml
+study_execution:
+  experiment_gap_seconds: 0
+  cycle_gap_seconds: 0
 ```
 
 LLenergyMeasure also monitors thermal throttle events during measurement. If the GPU

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -14,7 +14,8 @@ import TabItem from '@theme/TabItem';
 <TabItem value="cli" label="CLI">
 
 ```bash
-llem run --model gpt2 --engine transformers
+llem study init -m gpt2 --defaults   # author a runnable study.yaml
+llem run study.yaml
 ```
 
 </TabItem>

--- a/docs/how-to/faq.md
+++ b/docs/how-to/faq.md
@@ -64,13 +64,13 @@ Use `mj_per_tok_adjusted` (energy per token) or `total_inference_time_sec` (wall
 
 `llem` deduplicates measurement-equivalent configs before running. If your sweep generates two cells whose effective `ExperimentConfig` hashes are identical (e.g. a sampling parameter is `dormant` for the active engine), they collapse into one cell. `total_experiments` is the number actually *run* (after dedup x `n_cycles`); `unique_configurations` is the distinct configs.
 
-To inspect what was deduplicated: read `_study-artefacts/equivalence_groups.json` in the study directory. To disable dedup: pass `--no-dedup` to `llem run`.
+To inspect what was deduplicated: read `_study-artefacts/equivalence_groups.json` in the study directory. To disable dedup: set `study_execution.deduplicate_equivalent: false` in the study YAML.
 
 ## Configuration
 
 ### Top-level `n: 50` doesn't work - what's the canonical YAML?
 
-`n` is a CLI flag (`-n / --n-prompts`), not a YAML field. The YAML form is:
+`n` is not a top-level YAML field. Prompt count lives under `task.dataset`:
 
 ```yaml
 task:

--- a/docs/how-to/single-gpu-or-limited-hardware.md
+++ b/docs/how-to/single-gpu-or-limited-hardware.md
@@ -50,12 +50,6 @@ task:
     n_prompts: 10
 ```
 
-Or via the CLI flag:
-
-```bash
-llem run study.yaml --n-prompts 10
-```
-
 Fewer prompts reduces statistical stability. For publication-quality measurements,
 use at least 50-100 prompts and set `study_execution.n_cycles: 3` to run the full
 workload three times and report the median.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -25,8 +25,8 @@ environment, or the system is CPU-only.
 
 ### Engine not available on host
 
-**Symptom:** `llem run -e vllm ...` fails immediately with an import error
-mentioning the engine package.
+**Symptom:** `llem run study.yaml` (with `engine: vllm`) fails immediately with
+an import error mentioning the engine package.
 
 **Cause:** Engines have no host install path - they run inside per-engine
 Docker images. A host import of `transformers`, `vllm`, or `tensorrt_llm`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,31 +20,20 @@ Run an LLM efficiency experiment
 
 | Argument | Type | Required | Description |
 |----------|------|----------|-------------|
-| `config` | path | no | Path to experiment YAML config |
+| `config` | path | no | Path to the experiment or study YAML config |
 
 **Options:**
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--model` | `-m` | str |  | Model name or HuggingFace path |
-| `--engine` | `-e` | str |  | Inference engine (transformers, vllm, tensorrt) |
-| `--dataset` | `-d` | str |  | Dataset name |
-| `--n-prompts` | `-n` | int |  | Number of prompts to run |
 | `--output` | `-o` | str |  | Output directory for results |
 | `--dry-run` |  | flag | `false` | Validate config and estimate VRAM without running |
 | `--quiet` | `-q` | flag | `false` | Suppress progress bars |
 | `--verbose` | `-v` | int | `0` | Increase verbosity (-v=INFO, -vv=DEBUG) |
-| `--cycles` |  | int |  | Number of cycles (study mode) |
-| `--order` |  | str |  | Experiment ordering: sequential, interleave, shuffle, reverse, latin_square (study mode) |
-| `--no-gaps` |  | flag | `false` | Disable thermal gaps between experiments (study mode) |
 | `--skip-preflight` |  | flag | `false` | Skip Docker pre-flight checks (GPU visibility, CUDA/driver compatibility) |
 | `--resume` |  | flag | `false` | Resume most recent interrupted study |
 | `--resume-dir` |  | path |  | Resume a specific study directory |
-| `--fail-fast` |  | flag | `false` | Abort study on first failure (circuit breaker threshold=1) |
-| `--no-circuit-breaker` |  | flag | `false` | Disable circuit breaker entirely |
-| `--timeout` |  | float |  | Study wall-clock timeout in hours (e.g. 24, 1.5) |
 | `--no-lock` |  | flag | `false` | Disable GPU lock files (advanced) |
-| `--no-dedup` |  | flag | `false` | Disable library-resolution mechanism sweep dedup. Every declared config runs regardless of measurement equivalence (study mode). |
 
 ### `llem config`
 
@@ -74,3 +63,7 @@ Propose invariants corpus entries from runtime observations
 | `--out` |  | path |  | Output path for proposed YAML fragments (one YAML document per gap, separated by '---'). |
 | `--include-exceptions` |  | flag | `false` | Also propose rules from runtime exceptions. Disabled by default; exceptions ship through a different review path. |
 | `--verbose` | `-v` | int | `0` | Increase verbosity (-v=INFO, -vv=DEBUG) |
+
+### `llem study`
+
+Write and prepare study files (llem run stays the executor).

--- a/docs/reference/library/StudyConfig.md
+++ b/docs/reference/library/StudyConfig.md
@@ -111,7 +111,7 @@ Controls sequencing, cycles, and failure handling:
 | `wall_clock_timeout_hours` | `float \| None` | `None` | Study-level wall-clock timeout. `None` = no limit. |
 | `experiment_timeout_seconds` | `float` | `600.0` | Per-experiment timeout. Applies to both local and Docker paths. |
 | `stdout_silence_timeout_seconds` | `float` | `300.0` | Docker watchdog: kill the container if it emits no stdout for this many seconds. Raise to 600-900s for TRT-LLM builds with infrequent compile progress output. |
-| `deduplicate_equivalent` | `bool` | `True` | When `True`, configs that are library-equivalent (same resolved config hash after engine-invariants dormant resolution) are deduplicated. `--no-dedup` CLI flag is the override. |
+| `deduplicate_equivalent` | `bool` | `True` | When `True`, configs that are library-equivalent (same resolved config hash after engine-invariants dormant resolution) are deduplicated. Set to `false` to run every declared config regardless of measurement equivalence. |
 
 ### Runner and image overrides
 

--- a/docs/tutorials/first-measurement.md
+++ b/docs/tutorials/first-measurement.md
@@ -41,7 +41,8 @@ if any of the pre-flight checks fail.
 <TabItem value="cli" label="CLI">
 
 ```bash
-llem run --model gpt2 -e transformers
+llem study init -m gpt2 -e transformers --defaults   # writes study.yaml
+llem run study.yaml
 ```
 
 </TabItem>
@@ -116,7 +117,7 @@ config, timestamps, and any measurement warnings. See
 Specify a different output directory with `--output`:
 
 ```bash
-llem run --model gpt2 -e transformers --output /data/experiments
+llem run study.yaml --output /data/experiments
 ```
 
 :::tip Reproducibility

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -365,7 +365,7 @@ your question.
 ### Reference
 
 - [Study config](/reference/study-config) - full sweep / runner / measurement field listing
-- [CLI](/reference/cli) - every `llem run` flag (resume, fail-fast, etc.)
+- [CLI](/reference/cli) - every `llem run` session flag (resume, output, etc.)
 - [Engine configuration](/reference/engines/configuration) - per-engine parameter spaces
 
 ### Conceptual depth (Explanation)

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -44,23 +44,7 @@ if TYPE_CHECKING:
 def run(
     config: Annotated[
         Path | None,
-        typer.Argument(help="Path to experiment YAML config"),
-    ] = None,
-    model: Annotated[
-        str | None,
-        typer.Option("--model", "-m", help="Model name or HuggingFace path"),
-    ] = None,
-    engine: Annotated[
-        str | None,
-        typer.Option("--engine", "-e", help="Inference engine (transformers, vllm, tensorrt)"),
-    ] = None,
-    dataset: Annotated[
-        str | None,
-        typer.Option("--dataset", "-d", help="Dataset name"),
-    ] = None,
-    n_prompts: Annotated[
-        int | None,
-        typer.Option("--n-prompts", "-n", help="Number of prompts to run"),
+        typer.Argument(help="Path to the experiment or study YAML config"),
     ] = None,
     output: Annotated[
         str | None,
@@ -78,21 +62,6 @@ def run(
         int,
         typer.Option("--verbose", "-v", count=True, help="Increase verbosity (-v=INFO, -vv=DEBUG)"),
     ] = 0,
-    cycles: Annotated[
-        int | None,
-        typer.Option("--cycles", help="Number of cycles (study mode)"),
-    ] = None,
-    order: Annotated[
-        str | None,
-        typer.Option(
-            "--order",
-            help="Experiment ordering: sequential, interleave, shuffle, reverse, latin_square (study mode)",
-        ),
-    ] = None,
-    no_gaps: Annotated[
-        bool,
-        typer.Option("--no-gaps", help="Disable thermal gaps between experiments (study mode)"),
-    ] = False,
     skip_preflight: Annotated[
         bool,
         typer.Option(
@@ -108,36 +77,17 @@ def run(
         Path | None,
         typer.Option("--resume-dir", help="Resume a specific study directory"),
     ] = None,
-    fail_fast: Annotated[
-        bool,
-        typer.Option(
-            "--fail-fast", help="Abort study on first failure (circuit breaker threshold=1)"
-        ),
-    ] = False,
-    no_circuit_breaker: Annotated[
-        bool,
-        typer.Option("--no-circuit-breaker", help="Disable circuit breaker entirely"),
-    ] = False,
-    timeout: Annotated[
-        float | None,
-        typer.Option("--timeout", help="Study wall-clock timeout in hours (e.g. 24, 1.5)"),
-    ] = None,
     no_lock: Annotated[
         bool,
         typer.Option("--no-lock", help="Disable GPU lock files (advanced)"),
     ] = False,
-    no_dedup: Annotated[
-        bool,
-        typer.Option(
-            "--no-dedup",
-            help=(
-                "Disable library-resolution mechanism sweep dedup. Every declared "
-                "config runs regardless of measurement equivalence (study mode)."
-            ),
-        ),
-    ] = False,
 ) -> None:
-    """Run an LLM efficiency experiment."""
+    """Run an LLM efficiency experiment or study.
+
+    The flags describe the session (output location, verbosity, resume,
+    locking); the YAML config describes the experiment (model, engine, dataset,
+    cycles, ordering, ...). Author a config first with ``llem study init``.
+    """
 
     from llenergymeasure.cli import _setup_logging
 
@@ -154,25 +104,14 @@ def run(
     try:
         _run_impl(
             config=config,
-            model=model,
-            engine=engine,
-            dataset=dataset,
-            n_prompts=n_prompts,
             output=output,
             dry_run=dry_run,
             quiet=quiet,
             verbose=verbose_on,
-            cycles=cycles,
-            order=order,
-            no_gaps=no_gaps,
             skip_preflight=skip_preflight,
             resume=resume,
             resume_dir=resume_dir,
-            fail_fast=fail_fast,
-            no_circuit_breaker=no_circuit_breaker,
-            timeout=timeout,
             no_lock=no_lock,
-            no_dedup=no_dedup,
         )
     except ConfigError as e:
         print(format_error(e, verbose=verbose_on), file=sys.stderr)
@@ -195,68 +134,42 @@ def run(
 
 def _run_impl(
     config: Path | None,
-    model: str | None,
-    engine: str | None,
-    dataset: str | None,
-    n_prompts: int | None,
     output: str | None,
     dry_run: bool,
     quiet: bool,
     verbose: bool,
-    cycles: int | None = None,
-    order: str | None = None,
-    no_gaps: bool = False,
     skip_preflight: bool = False,
     resume: bool = False,
     resume_dir: Path | None = None,
-    fail_fast: bool = False,
-    no_circuit_breaker: bool = False,
-    timeout: float | None = None,
     no_lock: bool = False,
-    no_dedup: bool = False,
 ) -> None:
     """Core implementation - separated for clean error handling in run()."""
-    # Build CLI overrides dict - only include flags the user explicitly passed
-    cli_overrides: dict[str, Any] = {}
-    if model is not None:
-        cli_overrides["task.model"] = model
-    if engine is not None:
-        cli_overrides["engine"] = engine
-    if dataset is not None:
-        cli_overrides["task.dataset.source"] = dataset
-    if n_prompts is not None:
-        cli_overrides["task.dataset.n_prompts"] = n_prompts
-
-    # Validate we have enough information to resolve a config
-    if config is None and model is None:
+    # A config file is required: experiment semantics live in the YAML, not in
+    # flags. Author one with `llem study init` (see the message below).
+    if config is None:
         raise ConfigError(
-            "Provide a config file or --model flag.\n"
-            "  Examples:\n"
-            "    llem run experiment.yaml\n"
-            "    llem run --model gpt2 --engine transformers"
+            "A config file is required.\n"
+            "  Create one with:\n"
+            "    llem study init -m <model> --defaults\n"
+            "  Then run it:\n"
+            "    llem run study.yaml"
         )
 
     # Study detection: YAML with sweep: or experiments: keys is a study
-    is_study = False
-    if config is not None:
-        import yaml
+    import yaml
 
-        try:
-            raw = yaml.safe_load(config.read_text())
-            if isinstance(raw, dict) and ("sweep" in raw or "experiments" in raw):
-                is_study = True
-        except Exception:
-            pass  # Fall through to normal experiment path - loader will raise if invalid
+    is_study = False
+    try:
+        raw = yaml.safe_load(config.read_text())
+        if isinstance(raw, dict) and ("sweep" in raw or "experiments" in raw):
+            is_study = True
+    except Exception:
+        pass  # Fall through to normal experiment path - loader will raise if invalid
 
     # Route to study execution path
     if is_study:
-        assert config is not None  # Guarded by study detection above
         _run_study_impl(
             config=config,
-            cli_overrides=cli_overrides,
-            cycles=cycles,
-            order=order,
-            no_gaps=no_gaps,
             quiet=quiet,
             verbose=verbose,
             skip_preflight=skip_preflight,
@@ -264,35 +177,20 @@ def _run_impl(
             output=output,
             resume=resume,
             resume_dir=resume_dir,
-            fail_fast=fail_fast,
-            no_circuit_breaker=no_circuit_breaker,
-            timeout=timeout,
             no_lock=no_lock,
-            no_dedup=no_dedup,
         )
         return
 
     # Single-experiment path: warn about any study-only flags the user set.
-    # These are parsed by run() for study mode but silently ignored here, so
-    # --cycles 5 on a single experiment would run once with no feedback.
+    # These take effect only in study mode and are silently ignored here.
     _warn_ignored_study_flags(
-        cycles=cycles,
-        order=order,
-        no_gaps=no_gaps,
         resume=resume,
         resume_dir=resume_dir,
-        fail_fast=fail_fast,
-        no_circuit_breaker=no_circuit_breaker,
-        timeout=timeout,
         no_lock=no_lock,
-        no_dedup=no_dedup,
     )
 
     # Load/resolve the experiment config
-    experiment_config = load_experiment_config(
-        path=config,
-        cli_overrides=cli_overrides if cli_overrides else None,
-    )
+    experiment_config = load_experiment_config(path=config)
 
     # --- Dry-run branch ---
     if dry_run:
@@ -358,36 +256,22 @@ def _run_impl(
 
 def _warn_ignored_study_flags(
     *,
-    cycles: int | None,
-    order: str | None,
-    no_gaps: bool,
     resume: bool,
     resume_dir: Path | None,
-    fail_fast: bool,
-    no_circuit_breaker: bool,
-    timeout: float | None,
     no_lock: bool,
-    no_dedup: bool,
 ) -> None:
     """Warn when study-only flags are set on a single-experiment run.
 
     These flags only take effect in study mode (a YAML with ``sweep:`` or
     ``experiments:``). On a single experiment they are silently ignored, which
-    hides mistakes like ``--cycles 5`` on a one-off run.
+    hides mistakes like ``--resume`` on a one-off run.
     """
     set_flags = [
         name
         for name, is_set in (
-            ("--cycles", cycles is not None),
-            ("--order", order is not None),
-            ("--no-gaps", no_gaps),
             ("--resume", resume),
             ("--resume-dir", resume_dir is not None),
-            ("--fail-fast", fail_fast),
-            ("--no-circuit-breaker", no_circuit_breaker),
-            ("--timeout", timeout is not None),
             ("--no-lock", no_lock),
-            ("--no-dedup", no_dedup),
         )
         if is_set
     ]
@@ -500,58 +384,23 @@ def _resolve_resume_target(
     return resume_dir, resume_manifest, is_resume
 
 
-def _build_study_cli_overrides(
-    cli_overrides: dict[str, Any],
-    cycles: int | None,
-    order: str | None,
-    no_gaps: bool,
-    fail_fast: bool,
-    no_circuit_breaker: bool,
-    timeout: float | None,
-    no_dedup: bool,
-    yaml_execution: dict[str, Any],
-) -> dict[str, Any]:
-    """Merge CLI flags into the study override dict passed to load_study.
+def _build_study_cli_overrides(yaml_execution: dict[str, Any]) -> dict[str, Any]:
+    """Apply the CLI-layer research-appropriate effective defaults for a study.
 
-    Applies the CLI-layer effective defaults (n_cycles=3, experiment_order="shuffle")
-    only when neither the YAML study_execution block nor a CLI flag sets them; the
-    Pydantic defaults are intentionally more conservative (n_cycles=1).
+    ``n_cycles=3`` and ``experiment_order="shuffle"`` are injected only when the
+    YAML ``study_execution`` block does not set them; the Pydantic model defaults
+    are intentionally more conservative (n_cycles=1). These are unconditional
+    research defaults, not flag overrides - the semantic-override flags were
+    removed and the YAML is the source of truth for anything it declares.
     """
     exec_overrides: dict[str, Any] = {}
-
-    if cycles is not None:
-        exec_overrides["n_cycles"] = cycles
-    elif "n_cycles" not in yaml_execution:
-        exec_overrides["n_cycles"] = 3  # CLI effective default
-
-    if order is not None:
-        exec_overrides["experiment_order"] = order
-    elif "experiment_order" not in yaml_execution:
-        exec_overrides["experiment_order"] = "shuffle"  # CLI effective default
-
-    if no_gaps:
-        exec_overrides["experiment_gap_seconds"] = 0
-        exec_overrides["cycle_gap_seconds"] = 0
-
-    # Robustness overrides: circuit breaker, timeout
-    if fail_fast:
-        exec_overrides["max_consecutive_failures"] = 1
-        exec_overrides["circuit_breaker_cooldown_seconds"] = 0
-    if no_circuit_breaker:
-        exec_overrides["max_consecutive_failures"] = 0
-    if timeout is not None:
-        exec_overrides["wall_clock_timeout_hours"] = timeout
-
-    # --no-dedup disables library-resolution mechanism sweep dedup (runs every declared config)
-    if no_dedup:
-        exec_overrides["deduplicate_equivalent"] = False
-
-    study_cli_overrides: dict[str, Any] = {}
-    if cli_overrides:
-        study_cli_overrides.update(cli_overrides)
-    if exec_overrides:
-        study_cli_overrides["study_execution"] = exec_overrides
-    return study_cli_overrides
+    if "n_cycles" not in yaml_execution:
+        exec_overrides["n_cycles"] = 3
+    if "experiment_order" not in yaml_execution:
+        exec_overrides["experiment_order"] = "shuffle"
+    if not exec_overrides:
+        return {}
+    return {"study_execution": exec_overrides}
 
 
 def _print_config_summary(
@@ -641,10 +490,6 @@ def _build_historical_rows(resume_manifest: Any) -> list[_CompletedRow]:
 
 def _run_study_impl(
     config: Path,
-    cli_overrides: dict[str, Any],
-    cycles: int | None,
-    order: str | None,
-    no_gaps: bool,
     quiet: bool,
     verbose: bool,
     skip_preflight: bool = False,
@@ -652,11 +497,7 @@ def _run_study_impl(
     output: str | None = None,
     resume: bool = False,
     resume_dir: Path | None = None,
-    fail_fast: bool = False,
-    no_circuit_breaker: bool = False,
-    timeout: float | None = None,
     no_lock: bool = False,
-    no_dedup: bool = False,
 ) -> None:
     """Study execution path - separated for clean error handling."""
     import yaml
@@ -675,18 +516,9 @@ def _run_study_impl(
     raw = yaml.safe_load(config.read_text()) or {}
     yaml_execution = raw.get("study_execution", {}) or {}
 
-    # Merge CLI flags (with CLI-layer effective defaults) into the load_study overrides
-    study_cli_overrides = _build_study_cli_overrides(
-        cli_overrides,
-        cycles,
-        order,
-        no_gaps,
-        fail_fast,
-        no_circuit_breaker,
-        timeout,
-        no_dedup,
-        yaml_execution,
-    )
+    # Apply the CLI-layer research-appropriate effective defaults (n_cycles=3,
+    # shuffle) unless the YAML study_execution block already sets them.
+    study_cli_overrides = _build_study_cli_overrides(yaml_execution)
 
     # Load study config with overrides - show step-format spinner during expansion
     from rich.console import Console as _ExpandConsole
@@ -841,7 +673,6 @@ def _run_study_impl(
             output_dir=Path(output) if output else None,
             no_lock=no_lock,
             config_path=config.resolve(),
-            cli_overrides=cli_overrides or None,
             preresolved=preresolved,
         )
     finally:

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -346,23 +346,6 @@ class TestCLIE2ESingleExperiment:
         assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}:\n{result.output}"
         assert "Result:" in result.output
 
-    def test_cli_e2e_model_flag(self, tmp_path: Path, monkeypatch: Any) -> None:
-        """CLI run --model gpt2 via CliRunner exits 0."""
-        from typer.testing import CliRunner
-
-        import llenergymeasure.cli.run as cli_run_mod
-        from llenergymeasure.cli import app
-
-        mock_result = make_result(experiment_id="cli-flag-001")
-
-        monkeypatch.setattr(cli_run_mod, "run_experiment", lambda config, **kw: mock_result)
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["run", "--model", "gpt2", "--engine", "transformers"])
-
-        assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}:\n{result.output}"
-        assert "Result:" in result.output
-
 
 class TestCLIE2EStudy:
     """Test 6: llem run <study.yaml> via CliRunner with patched run_study."""

--- a/tests/integration/test_gpu_experiment.py
+++ b/tests/integration/test_gpu_experiment.py
@@ -82,20 +82,20 @@ class TestM1ExitCriteria:
         assert len(parquet_files) >= 1
 
     def test_cli_run_produces_valid_output(self, tmp_path):
-        """llem run --model gpt2 --engine transformers via CLI produces valid output."""
+        """llem run <experiment.yaml> via CLI produces valid output."""
         from typer.testing import CliRunner
 
         from llenergymeasure.cli import app
+
+        exp_yaml = tmp_path / "experiment.yaml"
+        exp_yaml.write_text("task:\n  model: gpt2\nengine: transformers\n")
 
         runner = CliRunner()
         result = runner.invoke(
             app,
             [
                 "run",
-                "--model",
-                "gpt2",
-                "--engine",
-                "transformers",
+                str(exp_yaml),
                 "--output",
                 str(tmp_path),
             ],

--- a/tests/unit/cli/test_cli_run.py
+++ b/tests/unit/cli/test_cli_run.py
@@ -76,6 +76,17 @@ def _make_mock_config() -> MagicMock:
     return config
 
 
+def _make_experiment_yaml(tmp_path: Path) -> Path:
+    """Write a minimal single-experiment YAML (no sweep/experiments keys).
+
+    The run command reads the file for study detection before delegating to
+    ``load_experiment_config`` (which callers mock), so the path must exist.
+    """
+    path = tmp_path / "experiment.yaml"
+    path.write_text("task:\n  model: gpt2\nengine: transformers\n")
+    return path
+
+
 def _make_capture_load() -> tuple:
     """Return (capture_fn, captured_overrides) for study routing tests.
 
@@ -154,13 +165,13 @@ def test_build_header_nondefault_fields_shown():
 
 
 def test_run_help():
-    """llem run --help exits 0 and shows expected flags."""
+    """llem run --help exits 0 and shows the retained session flags."""
     result = runner.invoke(app, ["run", "--help"])
     assert result.exit_code == 0
     plain = _strip_ansi(result.output)
-    assert "--model" in plain
-    assert "--engine" in plain
+    assert "--output" in plain
     assert "--dry-run" in plain
+    assert "--resume" in plain
 
 
 def test_run_version():
@@ -197,28 +208,31 @@ def test_run_config_error_exits_2():
     assert "ConfigError" in result.output
 
 
-def test_run_validation_error_exits_2():
+def test_run_validation_error_exits_2(tmp_path):
     """Pydantic ValidationError from a bad field value exits with code 2."""
     # "pytorh" is a misspelled engine - Pydantic will raise ValidationError
-    result = runner.invoke(app, ["run", "--model", "gpt2", "--engine", "pytorh"])
+    bad_yaml = tmp_path / "experiment.yaml"
+    bad_yaml.write_text("task:\n  model: gpt2\nengine: pytorh\n")
+    result = runner.invoke(app, ["run", str(bad_yaml)])
     assert result.exit_code == 2, (
         f"Expected exit 2, got {result.exit_code}. Output: {result.output}"
     )
     assert "Config validation failed" in result.output
 
 
-def test_run_preflight_error_exits_1():
+def test_run_preflight_error_exits_1(tmp_path):
     """PreFlightError raised by run_experiment exits with code 1."""
     from llenergymeasure.utils.exceptions import PreFlightError
 
     mock_config = _make_mock_config()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
         patch.object(cli_run_mod, "run_experiment") as mock_run,
     ):
         mock_run.side_effect = PreFlightError("no GPU available")
-        result = runner.invoke(app, ["run", "--model", "gpt2"])
+        result = runner.invoke(app, ["run", str(exp_yaml)])
 
     assert result.exit_code == 1, (
         f"Expected exit 1, got {result.exit_code}. Output: {result.output}"
@@ -226,18 +240,19 @@ def test_run_preflight_error_exits_1():
     assert "PreFlightError" in result.output
 
 
-def test_run_experiment_error_exits_1():
+def test_run_experiment_error_exits_1(tmp_path):
     """ExperimentError raised during run exits with code 1."""
     from llenergymeasure.utils.exceptions import ExperimentError
 
     mock_config = _make_mock_config()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
         patch.object(cli_run_mod, "run_experiment") as mock_run,
     ):
         mock_run.side_effect = ExperimentError("inference crashed")
-        result = runner.invoke(app, ["run", "--model", "gpt2"])
+        result = runner.invoke(app, ["run", str(exp_yaml)])
 
     assert result.exit_code == 1, (
         f"Expected exit 1, got {result.exit_code}. Output: {result.output}"
@@ -250,9 +265,10 @@ def test_run_experiment_error_exits_1():
 # ---------------------------------------------------------------------------
 
 
-def test_run_dry_run_exits_0():
+def test_run_dry_run_exits_0(tmp_path):
     """--dry-run exits 0 and calls print_dry_run with resolved config."""
     mock_config = _make_mock_config()
+    exp_yaml = _make_experiment_yaml(tmp_path)
     mock_vram = {
         "weights_gb": 0.24,
         "kv_cache_gb": 0.01,
@@ -266,7 +282,7 @@ def test_run_dry_run_exits_0():
         patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None),
         patch.object(cli_run_mod, "print_dry_run") as mock_print_dry,
     ):
-        result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run"])
+        result = runner.invoke(app, ["run", str(exp_yaml), "--dry-run"])
 
     assert result.exit_code == 0, (
         f"Expected exit 0, got {result.exit_code}. Output: {result.output}"
@@ -274,9 +290,10 @@ def test_run_dry_run_exits_0():
     mock_print_dry.assert_called_once()
 
 
-def test_run_dry_run_calls_estimate_vram():
+def test_run_dry_run_calls_estimate_vram(tmp_path):
     """--dry-run calls estimate_vram and get_gpu_vram_gb with the resolved config."""
     mock_config = _make_mock_config()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
@@ -284,7 +301,7 @@ def test_run_dry_run_calls_estimate_vram():
         patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None) as mock_gpu_vram,
         patch.object(cli_run_mod, "print_dry_run"),
     ):
-        result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run"])
+        result = runner.invoke(app, ["run", str(exp_yaml), "--dry-run"])
 
     assert result.exit_code == 0
     mock_vram.assert_called_once_with(mock_config)
@@ -296,9 +313,10 @@ def test_run_dry_run_calls_estimate_vram():
 # ---------------------------------------------------------------------------
 
 
-def test_single_run_warns_on_study_only_flag():
-    """--cycles on a single-experiment run warns that the flag is ignored."""
+def test_single_run_warns_on_study_only_flag(tmp_path):
+    """--resume on a single-experiment run warns that the flag is ignored."""
     mock_config = _make_mock_config()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
@@ -306,17 +324,18 @@ def test_single_run_warns_on_study_only_flag():
         patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None),
         patch.object(cli_run_mod, "print_dry_run"),
     ):
-        result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run", "--cycles", "5"])
+        result = runner.invoke(app, ["run", str(exp_yaml), "--dry-run", "--resume"])
 
     assert result.exit_code == 0
     out = _strip_ansi(result.output).lower()
     assert "study-only" in out
-    assert "--cycles" in out
+    assert "--resume" in out
 
 
-def test_single_run_no_warning_without_study_flags():
+def test_single_run_no_warning_without_study_flags(tmp_path):
     """A clean single-experiment run emits no study-only-flag warning."""
     mock_config = _make_mock_config()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
@@ -324,14 +343,14 @@ def test_single_run_no_warning_without_study_flags():
         patch.object(cli_run_mod, "get_gpu_vram_gb", return_value=None),
         patch.object(cli_run_mod, "print_dry_run"),
     ):
-        result = runner.invoke(app, ["run", "--model", "gpt2", "--dry-run"])
+        result = runner.invoke(app, ["run", str(exp_yaml), "--dry-run"])
 
     assert result.exit_code == 0
     assert "study-only" not in _strip_ansi(result.output).lower()
 
 
 def test_study_run_does_not_warn_on_study_flags(tmp_path):
-    """A study run with --cycles does not emit the single-run ignored-flag warning."""
+    """A study run with --no-lock does not emit the single-run ignored-flag warning."""
     from tests.conftest import make_study_result
 
     study_yaml = tmp_path / "study.yaml"
@@ -350,7 +369,7 @@ def test_study_run_does_not_warn_on_study_flags(tmp_path):
         mock_config.study_execution.n_cycles = 1
         mock_config.skipped_configs = []
         mock_load.return_value = mock_config
-        result = runner.invoke(app, ["run", str(study_yaml), "--cycles", "5"])
+        result = runner.invoke(app, ["run", str(study_yaml), "--no-lock"])
 
     assert result.exit_code == 0, f"Output: {result.output}"
     assert "study-only" not in _strip_ansi(result.output).lower()
@@ -361,17 +380,18 @@ def test_study_run_does_not_warn_on_study_flags(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_run_quiet_flag_accepted():
+def test_run_quiet_flag_accepted(tmp_path):
     """--quiet suppresses step progress display (progress=None passed to run_experiment)."""
     mock_config = _make_mock_config()
     mock_result = _make_mock_result()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
         patch.object(cli_run_mod, "run_experiment", return_value=mock_result) as mock_run,
         patch.object(cli_run_mod, "print_result_summary"),
     ):
-        result = runner.invoke(app, ["run", "--model", "gpt2", "--quiet"])
+        result = runner.invoke(app, ["run", str(exp_yaml), "--quiet"])
 
     assert result.exit_code == 0, (
         f"Expected exit 0, got {result.exit_code}. Output: {result.output}"
@@ -387,17 +407,18 @@ def test_run_quiet_flag_accepted():
 # ---------------------------------------------------------------------------
 
 
-def test_run_success_prints_summary():
+def test_run_success_prints_summary(tmp_path):
     """Successful run calls print_result_summary with the returned result."""
     mock_config = _make_mock_config()
     mock_result = _make_mock_result()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
         patch.object(cli_run_mod, "run_experiment", return_value=mock_result),
         patch.object(cli_run_mod, "print_result_summary") as mock_summary,
     ):
-        result = runner.invoke(app, ["run", "--model", "gpt2"])
+        result = runner.invoke(app, ["run", str(exp_yaml)])
 
     assert result.exit_code == 0, (
         f"Expected exit 0, got {result.exit_code}. Output: {result.output}"
@@ -440,14 +461,35 @@ experiments:
     assert "experiments" in raw
 
 
-def test_cli_flags_present():
-    """llem run --help output includes --cycles, --order, and --no-gaps flags."""
+def test_removed_flags_absent_from_help():
+    """Removed semantic-override flags no longer appear in llem run --help."""
     result = runner.invoke(app, ["run", "--help"])
     assert result.exit_code == 0
     plain = _strip_ansi(result.output)
-    assert "--cycles" in plain
-    assert "--order" in plain
-    assert "--no-gaps" in plain
+    for flag in (
+        "--model",
+        "--engine",
+        "--dataset",
+        "--n-prompts",
+        "--cycles",
+        "--order",
+        "--no-gaps",
+        "--timeout",
+        "--no-circuit-breaker",
+        "--fail-fast",
+        "--no-dedup",
+    ):
+        assert flag not in plain, f"{flag} should have been removed from run --help"
+
+
+def test_removed_flag_exits_2(tmp_path):
+    """A removed flag gets Typer's standard 'No such option' (exit 2), no shim."""
+    exp_yaml = _make_experiment_yaml(tmp_path)
+    result = runner.invoke(app, ["run", str(exp_yaml), "--cycles", "5"])
+    assert result.exit_code == 2, (
+        f"Expected exit 2, got {result.exit_code}. Output: {result.output}"
+    )
+    assert "No such option" in _strip_ansi(result.output)
 
 
 # ---------------------------------------------------------------------------
@@ -519,13 +561,14 @@ def test_run_saves_to_output_dir(tmp_path):
     mock_result = _make_mock_result()
     mock_result.timeseries = None
     output_dir = tmp_path / "out"
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
         patch.object(cli_run_mod, "run_experiment", return_value=mock_result) as mock_run,
         patch.object(cli_run_mod, "print_result_summary"),
     ):
-        result = runner.invoke(app, ["run", "--model", "gpt2", "--output", str(output_dir)])
+        result = runner.invoke(app, ["run", str(exp_yaml), "--output", str(output_dir)])
 
     assert result.exit_code == 0, f"Expected exit 0. Output: {result.output}"
     mock_run.assert_called_once()
@@ -561,25 +604,42 @@ def test_run_study_cli_defaults_applied(tmp_path):
     assert overrides["study_execution"]["experiment_order"] == "shuffle"
 
 
-def test_run_no_model_no_config_error_message():
-    """Error message for missing model/config mentions 'Provide a config file or --model flag'."""
+def test_run_no_config_error_points_to_study_init():
+    """Missing-config error exits 2 and points the user at `llem study init`."""
     result = runner.invoke(app, ["run"])
     assert result.exit_code == 2
-    assert "Provide a config file or --model flag" in result.output
+    out = _strip_ansi(result.output)
+    assert "config file is required" in out
+    assert "llem study init" in out
 
 
-def test_run_engine_error_exits_1():
+def test_run_resume_without_config_requires_config():
+    """--resume without a config still requires a config file (exit 2, study-init hint).
+
+    Resume runs today only when the study YAML is supplied (the resume flow lives
+    in the study path, which is reached only for a real config). This preserves
+    that contract: `llem run --resume` alone points at `llem study init`.
+    """
+    result = runner.invoke(app, ["run", "--resume"])
+    assert result.exit_code == 2
+    out = _strip_ansi(result.output)
+    assert "config file is required" in out
+    assert "llem study init" in out
+
+
+def test_run_engine_error_exits_1(tmp_path):
     """EngineError raised by run_experiment exits with code 1."""
     from llenergymeasure.utils.exceptions import EngineError
 
     mock_config = _make_mock_config()
+    exp_yaml = _make_experiment_yaml(tmp_path)
 
     with (
         patch.object(cli_run_mod, "load_experiment_config", return_value=mock_config),
         patch.object(cli_run_mod, "run_experiment") as mock_run,
     ):
         mock_run.side_effect = EngineError("OOM during forward pass")
-        result = runner.invoke(app, ["run", "--model", "gpt2"])
+        result = runner.invoke(app, ["run", str(exp_yaml)])
 
     assert result.exit_code == 1
     assert "EngineError" in result.output
@@ -605,82 +665,6 @@ def _make_mock_study_result():
     from tests.conftest import make_study_result
 
     return make_study_result()
-
-
-def test_fail_fast_sets_max_consecutive_failures(tmp_path):
-    """--fail-fast sets max_consecutive_failures=1 in study_execution overrides."""
-    study_yaml = _make_study_yaml(tmp_path)
-    mock_study_result = _make_mock_study_result()
-    _capture_load, captured_overrides = _make_capture_load()
-
-    with (
-        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
-        patch("llenergymeasure.run_study", return_value=mock_study_result),
-        patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
-    ):
-        result = runner.invoke(app, ["run", str(study_yaml), "--fail-fast"])
-
-    assert result.exit_code == 0, f"Expected exit 0. Output: {result.output}"
-    overrides = captured_overrides[0]
-    assert overrides is not None
-    assert overrides["study_execution"]["max_consecutive_failures"] == 1
-    assert overrides["study_execution"]["circuit_breaker_cooldown_seconds"] == 0
-
-
-def test_no_circuit_breaker_sets_max_failures_zero(tmp_path):
-    """--no-circuit-breaker sets max_consecutive_failures=0 in study_execution overrides."""
-    study_yaml = _make_study_yaml(tmp_path)
-    mock_study_result = _make_mock_study_result()
-    _capture_load, captured_overrides = _make_capture_load()
-
-    with (
-        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
-        patch("llenergymeasure.run_study", return_value=mock_study_result),
-        patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
-    ):
-        result = runner.invoke(app, ["run", str(study_yaml), "--no-circuit-breaker"])
-
-    assert result.exit_code == 0, f"Expected exit 0. Output: {result.output}"
-    overrides = captured_overrides[0]
-    assert overrides is not None
-    assert overrides["study_execution"]["max_consecutive_failures"] == 0
-
-
-def test_timeout_flag_sets_wall_clock_timeout(tmp_path):
-    """--timeout 24 sets wall_clock_timeout_hours=24.0 in study_execution overrides."""
-    study_yaml = _make_study_yaml(tmp_path)
-    mock_study_result = _make_mock_study_result()
-    _capture_load, captured_overrides = _make_capture_load()
-
-    with (
-        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
-        patch("llenergymeasure.run_study", return_value=mock_study_result),
-        patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
-    ):
-        result = runner.invoke(app, ["run", str(study_yaml), "--timeout", "24"])
-
-    assert result.exit_code == 0, f"Expected exit 0. Output: {result.output}"
-    overrides = captured_overrides[0]
-    assert overrides is not None
-    assert overrides["study_execution"]["wall_clock_timeout_hours"] == 24.0
-
-
-def test_timeout_flag_fractional(tmp_path):
-    """--timeout 1.5 sets wall_clock_timeout_hours=1.5."""
-    study_yaml = _make_study_yaml(tmp_path)
-    mock_study_result = _make_mock_study_result()
-    _capture_load, captured_overrides = _make_capture_load()
-
-    with (
-        patch("llenergymeasure.api.load_study", side_effect=_capture_load),
-        patch("llenergymeasure.run_study", return_value=mock_study_result),
-        patch("llenergymeasure.cli._preflight_display.build_preflight_panel"),
-    ):
-        result = runner.invoke(app, ["run", str(study_yaml), "--timeout", "1.5"])
-
-    assert result.exit_code == 0, f"Expected exit 0. Output: {result.output}"
-    overrides = captured_overrides[0]
-    assert overrides["study_execution"]["wall_clock_timeout_hours"] == 1.5
 
 
 def test_resume_flag_passes_resume_to_api(tmp_path):
@@ -739,13 +723,10 @@ def test_resume_dir_flag_passes_path_to_api(tmp_path):
     assert call_kwargs["resume_dir"] == explicit_dir
 
 
-def test_new_flags_visible_in_help():
-    """--resume, --fail-fast, --no-circuit-breaker, --timeout, --no-lock appear in --help."""
+def test_session_flags_visible_in_help():
+    """The retained session flags appear in llem run --help."""
     result = runner.invoke(app, ["run", "--help"])
     assert result.exit_code == 0
     plain = _strip_ansi(result.output)
-    assert "--resume" in plain
-    assert "--fail-fast" in plain
-    assert "--no-circuit-breaker" in plain
-    assert "--timeout" in plain
-    assert "--no-lock" in plain
+    for flag in ("--resume", "--resume-dir", "--no-lock", "--skip-preflight", "--output"):
+        assert flag in plain, f"{flag} should be present in run --help"


### PR DESCRIPTION
## Principle

Flags describe the **session**; the YAML config describes the **experiment**.
This applies the CLI-leanness principle from the study-authoring-scaffold
design: `llem run` should only carry options that vary per invocation
(output location, verbosity, resume, locking), while everything that defines
*what experiment runs* belongs in the config file. The quick single-run path
is now `llem study init -m <model> --defaults` then `llem run study.yaml`.

This is a breaking change: a config path is now **required**, and passing any
removed flag yields Typer's standard `Error: No such option` with **exit 2**.
There are no compatibility shims. A dedicated test asserts the exit-2
behaviour (`test_removed_flag_exits_2`), and another asserts the missing-config
error points at `llem study init`
(`test_run_no_config_error_points_to_study_init`).

## Removed flags and their YAML equivalents

The first eight are the design doc's explicit removal list. The last three
(`--order`, `--fail-fast`, `--no-dedup`) are coordinator-adjudicated additions:
they are the remaining semantic-override flags with a clean YAML home, removed
for consistency with the same principle.

| Removed flag | YAML equivalent |
|---|---|
| `--model` / `-m` | `task.model` |
| `--engine` / `-e` | `engine` |
| `--dataset` / `-d` | `task.dataset.source` |
| `--n-prompts` / `-n` | `task.dataset.n_prompts` |
| `--cycles` | `study_execution.n_cycles` |
| `--no-gaps` | `study_execution.experiment_gap_seconds: 0` (and `cycle_gap_seconds: 0`) |
| `--timeout` | `study_execution.wall_clock_timeout_hours` |
| `--no-circuit-breaker` | `study_execution.max_consecutive_failures: 0` |
| `--order` (adjudicated) | `study_execution.experiment_order` |
| `--fail-fast` (adjudicated) | `study_execution.max_consecutive_failures: 1` |
| `--no-dedup` (adjudicated) | `study_execution.deduplicate_equivalent: false` |

## Retained session flags

`--output` / `-o`, `--quiet` / `-q`, `--verbose` / `-v`, `--resume`,
`--resume-dir`, `--dry-run`, `--no-lock`, `--skip-preflight`.

## Resume / config mapping

Resume already required a config path before this change: the resume logic
lives inside the study-execution path and is only reached once the config
resolves to a study YAML. Empirically, `llem run --resume` with no config
exits 2 today. This contract is preserved and made explicit: a config path is
required unconditionally, including for resume. A test locks this in
(`test_run_resume_without_config_requires_config`).

## Precedence-plumbing boundary

Two things were often conflated; this PR keeps one and deletes the other:

- **Deleted:** the CLI>config *override* branches (`if cycles is not None: ...`
  and the `model`/`engine`/`dataset`/`n_prompts` -> `cli_overrides` population in
  `run.py`). With no flags to override with, this chain is dead.
- **Kept:** the research-appropriate *effective defaults* not tied to any
  removed flag - `n_cycles=3` and `experiment_order=shuffle`. These were applied
  on flag-absence before; they now apply unconditionally when the YAML omits
  them (`_build_study_cli_overrides`). Documented in `methodology.md` as the
  "CLI effective defaults".

The library-level `cli_overrides` API (loader / resolution / api) is untouched;
`run.py` simply no longer populates it from flags.

## CHANGELOG

Added a Breaking Changes entry under `v0.10.0` listing every removed flag with
its YAML equivalent and the single-run migration snippet.

## Validation

- `make lint`: clean (ruff check + format + import-linter, 4 contracts kept)
- `make typecheck`: `Success: no issues found in 293 source files`
- `uv run pytest tests/unit -q`: **2783 passed, 45 skipped**

## Frozen paths untouched

`config/grid.py`, `cli/study_cmd.py`, `config/scaffold.py`, `config/series.py`
were not modified.
