### PR TITLE
feat(study): add llem study plan preview command

### DIFF
--- a/src/llenergymeasure/cli/_study_defaults.py
+++ b/src/llenergymeasure/cli/_study_defaults.py
@@ -1,0 +1,56 @@
+"""CLI-layer effective defaults for study execution.
+
+The Pydantic ``StudyExecution`` defaults are deliberately conservative
+(``n_cycles=1``, sequential order). The CLI applies research-appropriate
+effective defaults (``n_cycles=3``, shuffle) unless the study file already sets
+them. Both ``llem run`` and ``llem study plan`` apply these identically, so a
+plan previews exactly what a run executes. This stays at the CLI layer on
+purpose - the library keeps its conservative defaults.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ["build_study_cli_overrides", "study_cli_overrides_for_file"]
+
+
+def build_study_cli_overrides(yaml_execution: dict[str, Any]) -> dict[str, Any]:
+    """Build the CLI-layer effective-default overrides for a study.
+
+    ``n_cycles=3`` and ``experiment_order="shuffle"`` are injected only when the
+    YAML ``study_execution`` block does not set them; the Pydantic model defaults
+    are intentionally more conservative (n_cycles=1). These are unconditional
+    research defaults, not flag overrides - the semantic-override flags were
+    removed and the YAML is the source of truth for anything it declares.
+    """
+    exec_overrides: dict[str, Any] = {}
+    if "n_cycles" not in yaml_execution:
+        exec_overrides["n_cycles"] = 3
+    if "experiment_order" not in yaml_execution:
+        exec_overrides["experiment_order"] = "shuffle"
+    if not exec_overrides:
+        return {}
+    return {"study_execution": exec_overrides}
+
+
+def study_cli_overrides_for_file(study_file: Path) -> dict[str, Any] | None:
+    """Effective-default overrides for a study file, or None if none apply.
+
+    Reads only the ``study_execution`` block to decide which effective defaults
+    to inject. Read or parse errors are ignored here and left for the
+    authoritative ``load_study`` call to report, so callers can pass the result
+    straight into ``load_study(path, cli_overrides=...)``.
+    """
+    import yaml
+
+    try:
+        raw = yaml.safe_load(study_file.read_text())
+    except (OSError, yaml.YAMLError):
+        return None
+    yaml_execution = raw.get("study_execution") if isinstance(raw, dict) else None
+    overrides = build_study_cli_overrides(yaml_execution or {})
+    return overrides or None

--- a/src/llenergymeasure/cli/_study_plan.py
+++ b/src/llenergymeasure/cli/_study_plan.py
@@ -149,9 +149,9 @@ def build_funnel(study: StudyConfig) -> PlanFunnel:
     declared_total = valid + skipped
 
     dedup_enabled = study.dedup_mode == "resolved"
-    n_cycles = execution.n_cycles
+    n_cycles = execution.n_cycles  # ExecutionConfig validates n_cycles >= 1
     runs = len(study.experiments)
-    unique = runs // n_cycles if n_cycles else runs
+    unique = runs // n_cycles
     merged_away = valid - unique if dedup_enabled else 0
 
     attributions, extra_rule_groups = _attributions(study.skipped_configs)

--- a/src/llenergymeasure/cli/_study_plan.py
+++ b/src/llenergymeasure/cli/_study_plan.py
@@ -1,0 +1,258 @@
+"""Read-only preview funnel for ``llem study plan``.
+
+Given a resolved :class:`~llenergymeasure.config.models.StudyConfig` (produced by
+the public ``llenergymeasure.api.load_study`` entry point, which already runs the
+real sweep-expansion, validation, and dedup machinery), this module computes and
+renders a terraform-style preview:
+
+    declared grid points
+      - known-invalid (pruned by engine rules)
+      = valid
+      - duplicates merged away
+      = unique
+      x cycles
+      = runs
+
+plus an honest wall-clock lower bound from the deterministic thermal gaps only.
+
+Nothing here executes experiments, takes locks, touches the GPU, or writes files -
+it only reads counts and metadata off the already-resolved StudyConfig.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.utils.formatting import format_elapsed
+
+if TYPE_CHECKING:
+    from llenergymeasure.config.models import StudyConfig
+
+__all__ = ["PlanFunnel", "RuleAttribution", "build_funnel", "render_funnel"]
+
+# Cap on how many distinct engine-rule attributions get their own line before the
+# tail is folded into a single "+ N more" summary line.
+_MAX_ATTRIBUTIONS = 5
+
+# Leading "[rule_id] " marker(s) that engine rules prepend to their message, and
+# the "Value error, " prefix Pydantic wraps a raised ValueError with. Stripping
+# both leaves the plain, human-readable message. The marker can appear more than
+# once (a known corpus quirk), so match one-or-more.
+_MARKER = re.compile(r"^(?:\[[a-z0-9_]+\]\s*)+")
+_VALUE_ERROR_PREFIX = "Value error, "
+
+# Trailing ", got {placeholder}." clause left behind when a rule's message
+# template was never interpolated (another corpus quirk). Dropping it keeps a
+# stray "{field}" token out of the user-facing preview; a rendered ", got 2.0."
+# has no braces and is preserved.
+_UNRENDERED_TAIL = re.compile(r",?\s*got \{[^}]*\}\.?$")
+
+
+@dataclass(frozen=True)
+class RuleAttribution:
+    """One line of the known-invalid breakdown: a rejecting rule and its count."""
+
+    rule_id: str | None
+    count: int
+    message: str
+
+
+@dataclass(frozen=True)
+class PlanFunnel:
+    """Computed counts for the preview funnel, derived from a resolved StudyConfig."""
+
+    declared_total: int
+    valid: int
+    skipped: int
+    attributions: list[RuleAttribution]
+    extra_rule_groups: int
+    dedup_enabled: bool
+    merged_away: int
+    unique: int
+    n_cycles: int
+    runs: int
+    experiment_gap_seconds: float | None
+    cycle_gap_seconds: float | None
+    n_experiment_gaps: int
+    n_cycle_gaps: int
+
+
+def _plain_message(errors: list[dict[str, Any]], rule_id: str | None) -> str:
+    """Best plain-language message for a skipped config's failure.
+
+    Reads the serialised Pydantic error entries (public data on
+    ``skipped_configs``) and strips the ``Value error,`` wrapper plus the
+    ``[rule_id]`` marker so the researcher sees the underlying human message
+    (e.g. ``max_input_len must be >= 1, got 0.``).
+    """
+    for err in errors:
+        msg = str(err.get("msg", ""))
+        if msg.startswith(_VALUE_ERROR_PREFIX):
+            msg = msg[len(_VALUE_ERROR_PREFIX) :]
+        stripped = _MARKER.sub("", msg).strip()
+        if stripped:
+            cleaned = _UNRENDERED_TAIL.sub("", stripped).strip()
+            return cleaned or stripped
+    if rule_id is not None:
+        return rule_id.replace("_", " ")
+    return "other validation errors"
+
+
+def _attributions(
+    skipped_configs: list[dict[str, Any]],
+) -> tuple[list[RuleAttribution], int]:
+    """Group skipped configs by rejecting rule, top-N with a folded tail.
+
+    Rule-attributed groups are sorted by descending count (ties broken by rule id
+    for determinism); at most ``_MAX_ATTRIBUTIONS`` get their own line and the
+    rest fold into an ``extra_rule_groups`` count. Non-rule failures (rule_id is
+    None) are collapsed into a single trailing "other validation errors" line.
+    """
+    counts: Counter[str | None] = Counter()
+    sample: dict[str | None, str] = {}
+    for cfg in skipped_configs:
+        rule_id = cfg.get("rule_id")
+        counts[rule_id] += 1
+        if rule_id not in sample:
+            sample[rule_id] = _plain_message(cfg.get("errors", []), rule_id)
+
+    rule_items = sorted(
+        ((rid, c) for rid, c in counts.items() if rid is not None),
+        key=lambda item: (-item[1], item[0]),
+    )
+    shown = rule_items[:_MAX_ATTRIBUTIONS]
+    extra_rule_groups = len(rule_items) - len(shown)
+
+    result = [RuleAttribution(rid, c, sample[rid]) for rid, c in shown]
+
+    none_count = counts.get(None, 0)
+    if none_count:
+        result.append(RuleAttribution(None, none_count, "other validation errors"))
+
+    return result, extra_rule_groups
+
+
+def build_funnel(study: StudyConfig) -> PlanFunnel:
+    """Compute the preview funnel from an already-resolved StudyConfig.
+
+    Every number comes straight off ``study`` - the expansion, validation, and
+    dedup already ran inside ``load_study``. Declared valid is the count of
+    per-declared resolved hashes (parallel to the pre-dedup sweep input); unique
+    is the post-dedup, per-cycle experiment count (``runs / n_cycles``).
+    """
+    execution = study.study_execution
+    skipped = len(study.skipped_configs)
+    valid = len(study.declared_resolved_config_hashes)
+    declared_total = valid + skipped
+
+    dedup_enabled = study.dedup_mode == "resolved"
+    n_cycles = execution.n_cycles
+    runs = len(study.experiments)
+    unique = runs // n_cycles if n_cycles else runs
+    merged_away = valid - unique if dedup_enabled else 0
+
+    attributions, extra_rule_groups = _attributions(study.skipped_configs)
+
+    return PlanFunnel(
+        declared_total=declared_total,
+        valid=valid,
+        skipped=skipped,
+        attributions=attributions,
+        extra_rule_groups=extra_rule_groups,
+        dedup_enabled=dedup_enabled,
+        merged_away=merged_away,
+        unique=unique,
+        n_cycles=n_cycles,
+        runs=runs,
+        experiment_gap_seconds=execution.experiment_gap_seconds,
+        cycle_gap_seconds=execution.cycle_gap_seconds,
+        n_experiment_gaps=max(runs - 1, 0),
+        n_cycle_gaps=max(n_cycles - 1, 0),
+    )
+
+
+def _wall_clock_line(funnel: PlanFunnel) -> str:
+    """Honest wall-clock lower bound from the deterministic thermal gaps only.
+
+    The runner waits ``experiment_gap_seconds`` before every experiment after the
+    first (``runs - 1`` gaps) and ``cycle_gap_seconds`` at every cycle boundary
+    (``n_cycles - 1`` gaps). Per-experiment runtime needs the GPU and is never
+    invented here. A gap left unset in the file defers to a machine default we
+    cannot see, so it is reported rather than counted as zero.
+    """
+    if funnel.n_experiment_gaps == 0 and funnel.n_cycle_gaps == 0:
+        return "Wall clock: single run - no gaps; per-experiment runtime unknown."
+
+    known = 0.0
+    counted_any = False
+    deferred: list[str] = []
+
+    if funnel.n_experiment_gaps > 0:
+        if funnel.experiment_gap_seconds is not None:
+            known += funnel.n_experiment_gaps * funnel.experiment_gap_seconds
+            counted_any = True
+        else:
+            deferred.append("experiment gap uses machine default")
+
+    if funnel.n_cycle_gaps > 0:
+        if funnel.cycle_gap_seconds is not None:
+            known += funnel.n_cycle_gaps * funnel.cycle_gap_seconds
+            counted_any = True
+        else:
+            deferred.append("cycle gap uses machine default")
+
+    if not counted_any:
+        return (
+            "Wall clock: no lower bound derivable from this file (gaps unset); "
+            "per-experiment runtime unknown."
+        )
+
+    line = f"Wall clock: gaps alone >= {format_elapsed(known)}; per-experiment runtime unknown"
+    if deferred:
+        line += " (" + "; ".join(deferred) + ")"
+    return line + "."
+
+
+def render_funnel(funnel: PlanFunnel, title: str) -> str:
+    """Render the funnel as a compact plain-text preview block."""
+    nums = [
+        funnel.declared_total,
+        funnel.skipped,
+        funnel.valid,
+        funnel.merged_away,
+        funnel.unique,
+        funnel.n_cycles,
+        funnel.runs,
+    ]
+    width = max(len(str(n)) for n in nums)
+
+    def row(symbol: str, label: str, value: int) -> str:
+        return f"  {symbol} {label:<14}{value:>{width}}"
+
+    lines = [f"Study plan: {title}", ""]
+    lines.append(row(" ", "declared", funnel.declared_total))
+    lines.append(row("-", "known-invalid", funnel.skipped))
+    lines.append(row("=", "valid", funnel.valid))
+    if funnel.dedup_enabled:
+        lines.append(row("-", "dedup-merged", funnel.merged_away))
+        lines.append(row("=", "unique", funnel.unique))
+    else:
+        lines.append("    dedup disabled - every declared config runs")
+    lines.append(row("x", "cycles", funnel.n_cycles))
+    lines.append(row("=", "runs", funnel.runs))
+    lines.append("")
+
+    if funnel.skipped:
+        lines.append(f"Known-invalid breakdown ({funnel.skipped}), by engine rule:")
+        for attribution in funnel.attributions:
+            tag = f"  (rule {attribution.rule_id})" if attribution.rule_id else ""
+            lines.append(f"    {attribution.count}x  {attribution.message}{tag}")
+        if funnel.extra_rule_groups:
+            lines.append(f"    + {funnel.extra_rule_groups} more engine rule(s)")
+        lines.append("")
+
+    lines.append(_wall_clock_line(funnel))
+    return "\n".join(lines)

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -18,6 +18,7 @@ from llenergymeasure.cli._display import (
     print_dry_run,
     print_result_summary,
 )
+from llenergymeasure.cli._study_defaults import build_study_cli_overrides
 from llenergymeasure.cli._vram import estimate_vram, get_gpu_vram_gb
 from llenergymeasure.config.loader import load_experiment_config
 from llenergymeasure.config.ssot import (
@@ -384,25 +385,6 @@ def _resolve_resume_target(
     return resume_dir, resume_manifest, is_resume
 
 
-def _build_study_cli_overrides(yaml_execution: dict[str, Any]) -> dict[str, Any]:
-    """Apply the CLI-layer research-appropriate effective defaults for a study.
-
-    ``n_cycles=3`` and ``experiment_order="shuffle"`` are injected only when the
-    YAML ``study_execution`` block does not set them; the Pydantic model defaults
-    are intentionally more conservative (n_cycles=1). These are unconditional
-    research defaults, not flag overrides - the semantic-override flags were
-    removed and the YAML is the source of truth for anything it declares.
-    """
-    exec_overrides: dict[str, Any] = {}
-    if "n_cycles" not in yaml_execution:
-        exec_overrides["n_cycles"] = 3
-    if "experiment_order" not in yaml_execution:
-        exec_overrides["experiment_order"] = "shuffle"
-    if not exec_overrides:
-        return {}
-    return {"study_execution": exec_overrides}
-
-
 def _print_config_summary(
     console: Any,
     study_config: Any,
@@ -518,7 +500,7 @@ def _run_study_impl(
 
     # Apply the CLI-layer research-appropriate effective defaults (n_cycles=3,
     # shuffle) unless the YAML study_execution block already sets them.
-    study_cli_overrides = _build_study_cli_overrides(yaml_execution)
+    study_cli_overrides = build_study_cli_overrides(yaml_execution)
 
     # Load study config with overrides - show step-format spinner during expansion
     from rich.console import Console as _ExpandConsole

--- a/src/llenergymeasure/cli/study_cmd.py
+++ b/src/llenergymeasure/cli/study_cmd.py
@@ -139,11 +139,15 @@ def study_plan(
     from pydantic import ValidationError
 
     from llenergymeasure.api import load_study
+    from llenergymeasure.cli._study_defaults import study_cli_overrides_for_file
     from llenergymeasure.cli._study_plan import build_funnel, render_funnel
     from llenergymeasure.utils.exceptions import ConfigError
 
+    # Apply the same CLI-layer effective defaults llem run applies, so the
+    # preview matches exactly what a run would execute (e.g. n_cycles=3 when the
+    # file omits it) rather than the conservative Pydantic default.
     try:
-        study = load_study(study_file)
+        study = load_study(study_file, cli_overrides=study_cli_overrides_for_file(study_file))
     except (ConfigError, ValidationError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=2) from None

--- a/src/llenergymeasure/cli/study_cmd.py
+++ b/src/llenergymeasure/cli/study_cmd.py
@@ -118,3 +118,36 @@ def study_init(
         typer.echo(f"Prune the sweep value lists, then run: llem run {out_path}")
     else:
         typer.echo(f"Edit it, then run: llem run {out_path}")
+
+
+@study_app.command("plan")  # type: ignore[misc, untyped-decorator]
+def study_plan(
+    study_file: Annotated[
+        Path,
+        typer.Argument(help="Study YAML file to preview (as llem run would expand it)."),
+    ],
+) -> None:
+    """Preview what ``llem run <study_file>`` would execute, without running it.
+
+    Prints a read-only funnel - declared grid points, then known-invalid points
+    pruned by engine rules, then duplicate configs merged away, then experiments
+    times cycles equals total runs - plus a wall-clock lower bound from the
+    thermal gaps alone. No experiments run, nothing is written, the GPU is never
+    touched. Exit 0 on a valid plan (even with skips); nonzero when the file is
+    missing, unparseable, or produces no experiments.
+    """
+    from pydantic import ValidationError
+
+    from llenergymeasure.api import load_study
+    from llenergymeasure.cli._study_plan import build_funnel, render_funnel
+    from llenergymeasure.utils.exceptions import ConfigError
+
+    try:
+        study = load_study(study_file)
+    except (ConfigError, ValidationError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from None
+
+    funnel = build_funnel(study)
+    title = study.study_name or str(study_file)
+    typer.echo(render_funnel(funnel, title))

--- a/tests/unit/cli/test_study_cmd.py
+++ b/tests/unit/cli/test_study_cmd.py
@@ -152,6 +152,28 @@ def test_plan_happy_path(tmp_path: Path) -> None:
     assert "vllm_samplingparams_raises_top_p_gt_1p0" in result.output
 
 
+def test_plan_previews_run_effective_cycles(tmp_path: Path) -> None:
+    """A study omitting n_cycles previews run's effective 3 cycles, not Pydantic 1."""
+    import re
+
+    study = tmp_path / "study.yaml"
+    study.write_text(
+        f"""
+study_name: default-cycles
+task:
+  model: {MODEL}
+engine: vllm
+sweep:
+  measurement.latency_profiling: [false, true]
+"""
+    )
+    result = runner.invoke(app, ["study", "plan", str(study)])
+    assert result.exit_code == 0
+    # 2 measurement-only configs dedup to 1 unique x 3 cycles = 3 runs.
+    assert re.search(r"cycles\s+3", result.output)
+    assert re.search(r"runs\s+3", result.output)
+
+
 def test_plan_output_has_no_invariant_vocab(tmp_path: Path) -> None:
     """The command output never uses the word 'invariant'."""
     study = tmp_path / "study.yaml"

--- a/tests/unit/cli/test_study_cmd.py
+++ b/tests/unit/cli/test_study_cmd.py
@@ -112,3 +112,68 @@ def test_init_requires_model(tmp_path: Path) -> None:
     """The model option is required."""
     result = runner.invoke(app, ["study", "init", "-o", str(tmp_path / "study.yaml")])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# llem study plan
+# ---------------------------------------------------------------------------
+
+_PLAN_STUDY = f"""
+study_name: plan-smoke
+task:
+  model: {MODEL}
+engine: vllm
+study_execution:
+  n_cycles: 3
+sweep:
+  vllm.sampling_params.top_p: [0.9, 2.0]
+  measurement.latency_profiling: [false, true]
+"""
+
+
+def test_plan_help() -> None:
+    """`llem study plan --help` documents the preview command."""
+    result = runner.invoke(app, ["study", "plan", "--help"])
+    assert result.exit_code == 0
+    assert "plan" in result.output
+    assert "preview" in result.output.lower()
+
+
+def test_plan_happy_path(tmp_path: Path) -> None:
+    """A valid study renders the funnel and exits 0, even with skips."""
+    study = tmp_path / "study.yaml"
+    study.write_text(_PLAN_STUDY)
+    result = runner.invoke(app, ["study", "plan", str(study)])
+    assert result.exit_code == 0
+    assert "Study plan: plan-smoke" in result.output
+    assert "declared" in result.output
+    assert "runs" in result.output
+    # The rejecting engine rule is attributed by id.
+    assert "vllm_samplingparams_raises_top_p_gt_1p0" in result.output
+
+
+def test_plan_output_has_no_invariant_vocab(tmp_path: Path) -> None:
+    """The command output never uses the word 'invariant'."""
+    study = tmp_path / "study.yaml"
+    study.write_text(_PLAN_STUDY)
+    result = runner.invoke(app, ["study", "plan", str(study)])
+    assert result.exit_code == 0
+    assert "invariant" not in result.output.lower()
+
+
+def test_plan_missing_file_exits_nonzero(tmp_path: Path) -> None:
+    """A missing study file exits nonzero with a clean message (no traceback)."""
+    result = runner.invoke(app, ["study", "plan", str(tmp_path / "nope.yaml")])
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+    assert "Traceback" not in result.output
+
+
+def test_plan_zero_experiments_exits_nonzero(tmp_path: Path) -> None:
+    """A study that produces no experiments exits nonzero with a clean message."""
+    study = tmp_path / "empty.yaml"
+    study.write_text("study_name: empty\n")
+    result = runner.invoke(app, ["study", "plan", str(study)])
+    assert result.exit_code != 0
+    assert "no experiments" in result.output.lower()
+    assert "Traceback" not in result.output

--- a/tests/unit/cli/test_study_plan.py
+++ b/tests/unit/cli/test_study_plan.py
@@ -1,0 +1,161 @@
+"""Tests for the ``llem study plan`` funnel (``cli/_study_plan.py``).
+
+These exercise the real machinery: a crafted study YAML is loaded through the
+public ``load_study`` entry point (the same one ``llem run`` uses), so the
+expansion, validation, and dedup are genuine, then the funnel is computed and
+rendered.
+"""
+
+from __future__ import annotations
+
+from math import prod
+from pathlib import Path
+
+import yaml
+
+from llenergymeasure.api import load_study
+from llenergymeasure.cli._study_plan import build_funnel, render_funnel
+
+MODEL = "Qwen/Qwen2.5-0.5B"
+
+# A crafted vLLM study with a known shape:
+#   sweep = top_p(2) x latency_profiling(2) = 4 declared grid points
+#   top_p = 2.0 is rejected by a shipped engine rule (2 points)
+#   the 2 valid points differ only in latency_profiling, a measurement dial
+#     excluded from the resolved-config hash, so they dedup to 1 unique
+#   n_cycles = 3 -> 3 runs; gaps: 2 x 30s experiment + 2 x 120s cycle = 300s
+_CRAFTED = f"""
+study_name: crafted-demo
+task:
+  model: {MODEL}
+engine: vllm
+study_execution:
+  n_cycles: 3
+  experiment_gap_seconds: 30
+  cycle_gap_seconds: 120
+sweep:
+  vllm.sampling_params.top_p: [0.9, 2.0]
+  measurement.latency_profiling: [false, true]
+"""
+
+_TOP_P_RULE = "vllm_samplingparams_raises_top_p_gt_1p0"
+
+
+def _load(tmp_path: Path, text: str) -> object:
+    path = tmp_path / "study.yaml"
+    path.write_text(text)
+    return load_study(path)
+
+
+def test_funnel_arithmetic_full(tmp_path: Path) -> None:
+    """Declared / pruned / dedup / runs all reconcile on a crafted study."""
+    funnel = build_funnel(_load(tmp_path, _CRAFTED))  # type: ignore[arg-type]
+
+    assert funnel.declared_total == 4
+    assert funnel.skipped == 2
+    assert funnel.valid == 2
+    assert funnel.dedup_enabled is True
+    assert funnel.merged_away == 1
+    assert funnel.unique == 1
+    assert funnel.n_cycles == 3
+    assert funnel.runs == 3
+
+
+def test_funnel_rule_attribution(tmp_path: Path) -> None:
+    """The rejecting engine-rule id is attributed with the right count."""
+    funnel = build_funnel(_load(tmp_path, _CRAFTED))  # type: ignore[arg-type]
+
+    by_rule = {a.rule_id: a for a in funnel.attributions}
+    assert _TOP_P_RULE in by_rule
+    assert by_rule[_TOP_P_RULE].count == 2
+    # The rendered value survives; no leftover [rule_id] marker in the message.
+    message = by_rule[_TOP_P_RULE].message
+    assert "top_p" in message
+    assert not message.startswith("[")
+    assert _TOP_P_RULE not in message
+
+
+def test_render_shows_rule_id_and_counts(tmp_path: Path) -> None:
+    """The rendered preview names the rule id and the funnel counts."""
+    out = render_funnel(build_funnel(_load(tmp_path, _CRAFTED)), "crafted-demo")  # type: ignore[arg-type]
+
+    assert "Study plan: crafted-demo" in out
+    assert _TOP_P_RULE in out
+    assert "runs" in out
+    # Gap-only wall-clock lower bound: 2*30 + 2*120 = 300s = 5m 00s.
+    assert "5m 00s" in out
+
+
+def test_non_rule_failures_grouped(tmp_path: Path) -> None:
+    """Pydantic field failures (rule_id None) collapse to one 'other' line."""
+    text = f"""
+task:
+  model: {MODEL}
+engine: vllm
+sweep:
+  vllm.engine_params.max_num_seqs: [4, 0]
+"""
+    funnel = build_funnel(_load(tmp_path, text))  # type: ignore[arg-type]
+    assert funnel.skipped == 1
+    none_lines = [a for a in funnel.attributions if a.rule_id is None]
+    assert len(none_lines) == 1
+    assert none_lines[0].message == "other validation errors"
+
+
+def test_dedup_disabled_skips_stage(tmp_path: Path) -> None:
+    """With deduplicate_equivalent false, the dedup stage is not applied."""
+    text = f"""
+task:
+  model: {MODEL}
+engine: vllm
+study_execution:
+  deduplicate_equivalent: false
+sweep:
+  measurement.latency_profiling: [false, true]
+"""
+    funnel = build_funnel(_load(tmp_path, text))  # type: ignore[arg-type]
+    assert funnel.dedup_enabled is False
+    assert funnel.merged_away == 0
+    assert funnel.valid == 2
+    assert funnel.runs == 2  # both declared configs run, no cycles
+    out = render_funnel(funnel, "no-dedup")
+    assert "dedup disabled" in out
+
+
+def test_bounds_scaffold_round_trip(tmp_path: Path) -> None:
+    """A bounds scaffold's declared count equals the product of its sweep lists."""
+    from llenergymeasure.config.scaffold import render_study_bounds
+
+    text = render_study_bounds(MODEL, ["vllm"])
+    raw = yaml.safe_load(text)
+
+    # The full bounds grid is large; keep two axes so the round-trip stays fast
+    # while still asserting declared == the Cartesian product of the sweep lists.
+    axes = list(raw["sweep"].items())[:2]
+    raw["sweep"] = dict(axes)
+    expected = prod(len(values) for _key, values in axes)
+
+    funnel = build_funnel(_load(tmp_path, yaml.safe_dump(raw)))  # type: ignore[arg-type]
+    # Bounds scaffolds exclude engine-rejected values, so nothing is pruned.
+    assert funnel.skipped == 0
+    assert funnel.declared_total == expected
+    assert funnel.valid == expected
+
+
+def test_vocabulary_no_invariant(tmp_path: Path) -> None:
+    """The user-facing preview never uses the word 'invariant'."""
+    out = render_funnel(build_funnel(_load(tmp_path, _CRAFTED)), "crafted-demo")  # type: ignore[arg-type]
+    assert "invariant" not in out.lower()
+    assert "known-invalid" in out
+    assert "engine rule" in out
+
+
+def test_wall_clock_single_run(tmp_path: Path) -> None:
+    """A one-run study reports no gaps rather than a bogus lower bound."""
+    text = f"""
+task:
+  model: {MODEL}
+engine: vllm
+"""
+    out = render_funnel(build_funnel(_load(tmp_path, text)), "single")  # type: ignore[arg-type]
+    assert "single run" in out

--- a/tests/unit/cli/test_study_plan.py
+++ b/tests/unit/cli/test_study_plan.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from llenergymeasure.api import load_study
+from llenergymeasure.cli._study_defaults import study_cli_overrides_for_file
 from llenergymeasure.cli._study_plan import build_funnel, render_funnel
 
 MODEL = "Qwen/Qwen2.5-0.5B"
@@ -45,6 +46,17 @@ def _load(tmp_path: Path, text: str) -> object:
     path = tmp_path / "study.yaml"
     path.write_text(text)
     return load_study(path)
+
+
+def _load_with_cli_defaults(tmp_path: Path, text: str) -> object:
+    """Load exactly as ``llem run``/``llem study plan`` do - CLI defaults applied.
+
+    Mirrors the command path: the CLI-layer effective defaults (n_cycles=3,
+    shuffle) are injected before ``load_study`` unless the file sets them.
+    """
+    path = tmp_path / "study.yaml"
+    path.write_text(text)
+    return load_study(path, cli_overrides=study_cli_overrides_for_file(path))
 
 
 def test_funnel_arithmetic_full(tmp_path: Path) -> None:
@@ -103,12 +115,17 @@ sweep:
 
 
 def test_dedup_disabled_skips_stage(tmp_path: Path) -> None:
-    """With deduplicate_equivalent false, the dedup stage is not applied."""
+    """With deduplicate_equivalent false, the dedup stage is not applied.
+
+    n_cycles is pinned to 1 to keep the focus on dedup - cycle semantics are
+    covered by ``test_plan_previews_run_cycle_default``.
+    """
     text = f"""
 task:
   model: {MODEL}
 engine: vllm
 study_execution:
+  n_cycles: 1
   deduplicate_equivalent: false
 sweep:
   measurement.latency_profiling: [false, true]
@@ -117,9 +134,45 @@ sweep:
     assert funnel.dedup_enabled is False
     assert funnel.merged_away == 0
     assert funnel.valid == 2
-    assert funnel.runs == 2  # both declared configs run, no cycles
+    assert funnel.runs == 2  # 2 declared configs x 1 cycle, dedup off
     out = render_funnel(funnel, "no-dedup")
     assert "dedup disabled" in out
+
+
+def test_plan_previews_run_cycle_default(tmp_path: Path) -> None:
+    """A file omitting n_cycles previews run's effective 3 cycles, not Pydantic 1.
+
+    The plan mirrors run semantics: the CLI injects n_cycles=3 when the study
+    file leaves it unset, so the funnel must show 3 cycles and 3x the unique
+    experiment count.
+    """
+    text = f"""
+task:
+  model: {MODEL}
+engine: vllm
+sweep:
+  measurement.latency_profiling: [false, true]
+"""
+    funnel = build_funnel(_load_with_cli_defaults(tmp_path, text))  # type: ignore[arg-type]
+    assert funnel.n_cycles == 3
+    assert funnel.unique == 1  # 2 measurement-only configs dedup to 1
+    assert funnel.runs == 3 * funnel.unique
+
+
+def test_plan_respects_pinned_cycles(tmp_path: Path) -> None:
+    """An explicit n_cycles=1 is honoured - the CLI default does not override it."""
+    text = f"""
+task:
+  model: {MODEL}
+engine: vllm
+study_execution:
+  n_cycles: 1
+sweep:
+  measurement.latency_profiling: [false, true]
+"""
+    funnel = build_funnel(_load_with_cli_defaults(tmp_path, text))  # type: ignore[arg-type]
+    assert funnel.n_cycles == 1
+    assert funnel.runs == funnel.unique
 
 
 def test_bounds_scaffold_round_trip(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Adds a read-only `llem study plan <study.yaml>` command: a terraform-style
preview of what `llem run <study.yaml>` would execute. Nothing runs, no lock is
taken, no files are written, the GPU is never touched. `llem run --dry-run` is
untouched (it stays the flag form).

## Funnel

```
declared grid points
  - known-invalid (pruned by engine rules, top attributions by rule id)
  = valid
  - dedup-merged
  = unique
  x cycles
  = runs
```

plus a wall-clock lower bound from the deterministic thermal gaps only.

## Entry points reused per stage

Every number comes off the resolved `StudyConfig` returned by the public
`llenergymeasure.api.load_study(path)`. That single call runs `load_study_config`
(parse + `expand_grid`) then `finalise_study` (the real
`resolve_library_effective` resolved-config-hash dedup + cycle ordering), so the
command reuses the exact machinery `llem run` uses and never reimplements
expansion, validation, or dedup. `load_study` was chosen over calling
`expand_grid` directly because it returns both the valid/skipped split and the
finalised execution block in one resolved object, with no GPU / lock / filesystem
side effects.

- Declared: `len(declared_resolved_config_hashes)` (valid, parallel to the
  pre-dedup sweep input) `+ len(skipped_configs)`.
- Invalid-pruned: `len(skipped_configs)`, grouped by `SkippedConfig.rule_id`
  (serialised onto `skipped_configs`); top 5 rule attributions by count, the
  `rule_id is None` non-rule failures folded into one "other validation errors"
  line, any tail of rules folded into a "+ N more" line. Rule messages are read
  from the serialised Pydantic error entries and cleaned (leading `[rule_id]`
  marker(s) and any un-interpolated `, got {placeholder}.` tail stripped - both
  pre-existing corpus quirks).
- Dedup-merged: read straight off the finalised config - `dedup_mode` plus
  `runs / n_cycles` for unique and `valid - unique` for merged-away. Because
  `load_study` already applied `resolve_library_effective`, this is the exact
  dedup code path, not a fork. When `deduplicate_equivalent` is false the stage
  is skipped with a "dedup disabled" note. Nothing had to be marked "computed at
  run time".
- Runs: `len(study.experiments)` (post-dedup, post-cycle) with the
  `unique x n_cycles` factors shown.

## Wall-clock decision

There is no per-experiment runtime estimate that does not need the GPU. The
existing dry-run VRAM path (`print_study_dry_run`) hits NVML and the HuggingFace
Hub, which this command must not do; `grid.py` only ever computes a
`total_runs * gap_seconds` gap-time floor. So the estimate is an honest LOWER
BOUND from the deterministic thermal gaps alone, matching the runner's own gap
arithmetic (`_run_inter_experiment_gaps`): `experiment_gap_seconds` fires
`runs - 1` times and `cycle_gap_seconds` fires `n_cycles - 1` times. It is
labelled "gaps alone >= ...; per-experiment runtime unknown". A gap left unset
in the file defers to a machine default we cannot see, so it is reported rather
than silently counted as zero; a single-run study reports "no gaps" instead of a
bogus bound. No fake per-experiment duration is ever invented.

## Sample output (bounds-generated vLLM file)

Generated with `llem study init -m Qwen/Qwen2.5-0.5B -e vllm --bounds`:

```
Study plan: qwen2.5-0.5b-vllm

    declared      6144
  - known-invalid    0
  = valid         6144
  - dedup-merged     0
  = unique        6144
  x cycles           1
  = runs          6144

Wall clock: no lower bound derivable from this file (gaps unset); per-experiment runtime unknown.
```

The bounds scaffold pre-excludes engine-rejected values, so it prunes nothing.
A crafted study that exercises every stage (rule rejection, dedup, cycles, gaps):

```
Study plan: crafted-demo

    declared      4
  - known-invalid 2
  = valid         2
  - dedup-merged  1
  = unique        1
  x cycles        3
  = runs          3

Known-invalid breakdown (2), by engine rule:
    2x  top_p must be in [0.0..1.0], got 2.0.  (rule vllm_samplingparams_raises_top_p_gt_1p0)

Wall clock: gaps alone >= 5m 00s; per-experiment runtime unknown.
```

## Tests

`tests/unit/cli/test_study_plan.py` (funnel arithmetic, rule attribution, dedup
on/off, bounds-scaffold round-trip == expansion product, vocabulary guard,
wall-clock single-run) and `tests/unit/cli/test_study_cmd.py` extensions (help,
happy path, missing-file and zero-experiments exit codes, vocabulary guard).

## Validation

- `make lint`: ruff check + ruff format + import-linter (4 kept, 0 broken) green
- `make typecheck`: mypy clean, 295 source files
- `uv run pytest tests/unit -q`: 2800 passed, 45 skipped

## Frozen paths

`run.py`, `config/grid.py`, `scaffold.py`, `series.py`, `sweep_idioms.py`, and
all generated engine artefacts untouched; consumes public APIs only.
