### PR TITLE
feat(mining): observed-collision miner plus declared-config sidecar

### DIFF
--- a/scripts/mine_observed_collisions.py
+++ b/scripts/mine_observed_collisions.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Observed-collision miner (proposer S3).
+
+Scans a completed study results directory and proposes dormant-rule CANDIDATES
+from observed collisions: experiments whose declared configs DIFFER yet whose
+engine-effective (observed) state is identical.
+
+Per experiment ``config.json`` sidecar: group by
+``(engine, library_version, observed_config_hash)`` (a shared observed hash
+means the engine resolved every member to the same effective config); within
+any group whose DECLARED configs differ, diff them field-by-field to name the
+fields whose variation left the observed state identical. Each such field is a
+dormancy candidate. When several fields vary together (a multi-field diff),
+each candidate lists the others as ``co_occurring_fields`` - the miner cannot
+attribute dormancy to one field alone; the verification ladder settles that.
+
+Candidates go to the VERSION-SCOPED pool
+(``<pool-root>/<engine>/v<version>/candidates/observed_collisions.yaml``) as
+UNVERIFIED proposals. This script NEVER writes to the shipped
+``src/llenergymeasure/engines/<engine>/rules.yaml`` corpora, which are frozen.
+
+Usage: ``python scripts/mine_observed_collisions.py <study_dir> [--pool-root DIR]``
+Exit codes: 0 = scan completed; 2 = study directory does not exist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger("mine_observed_collisions")
+
+SCHEMA_VERSION = "1.0.0"
+
+# Sentinel for "field absent in this declared config" - distinct from a declared
+# null so absence and an explicit None never compare equal.
+_MISSING = object()
+
+
+@dataclass
+class _Sidecar:
+    """The fields of one experiment ``config.json`` the miner needs."""
+
+    experiment_dir: str
+    engine: str
+    library_version: str
+    observed_config_hash: str
+    declared_config: dict[str, Any]
+
+
+@dataclass
+class ScanStats:
+    """Counters surfaced in the run summary (never raise, always report)."""
+
+    experiments_scanned: int = 0
+    skipped_missing_declared: int = 0
+    skipped_missing_observed_hash: int = 0
+    skipped_unreadable: int = 0
+    collision_groups: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Declared-config diffing
+# ---------------------------------------------------------------------------
+
+
+def _flatten(config: dict[str, Any], prefix: str = "") -> dict[str, Any]:
+    """Flatten a nested declared config to dotted leaf paths.
+
+    ``{"vllm": {"engine_params": {"enforce_eager": True}}}`` becomes
+    ``{"vllm.engine_params.enforce_eager": True}``. Lists and scalars are
+    leaves; only dicts are descended.
+    """
+    flat: dict[str, Any] = {}
+    for key, value in config.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            flat.update(_flatten(value, path))
+        else:
+            flat[path] = value
+    return flat
+
+
+def _value_key(value: Any) -> str:
+    """Stable comparison key for a declared value (handles lists/dicts)."""
+    if value is _MISSING:
+        return "\x00__missing__"
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def _distinct_values(field_path: str, flats: list[dict[str, Any]]) -> list[Any]:
+    """Distinct declared values for ``field_path`` across a group, first-seen order."""
+    seen: set[str] = set()
+    out: list[Any] = []
+    for flat in flats:
+        value = flat.get(field_path, _MISSING)
+        vkey = _value_key(value)
+        if vkey not in seen:
+            seen.add(vkey)
+            out.append("<absent>" if value is _MISSING else value)
+    return out
+
+
+def _differing_fields(flats: list[dict[str, Any]]) -> list[str]:
+    """Leaf paths whose value is not identical across every config in the group."""
+    all_paths = set().union(*(flat.keys() for flat in flats)) if flats else set()
+    differing: list[str] = []
+    for path in sorted(all_paths):
+        values = {_value_key(flat.get(path, _MISSING)) for flat in flats}
+        if len(values) > 1:
+            differing.append(path)
+    return differing
+
+
+def _slug(field_path: str) -> str:
+    """Filesystem/id-safe slug for a dotted field path."""
+    return re.sub(r"_+", "_", re.sub(r"[^0-9a-zA-Z]+", "_", field_path)).strip("_")
+
+
+# ---------------------------------------------------------------------------
+# Loading + mining
+# ---------------------------------------------------------------------------
+
+
+def load_sidecars(study_dir: Path) -> tuple[list[_Sidecar], ScanStats]:
+    """Read every ``config.json`` under ``study_dir`` into sidecar records.
+
+    Experiments whose sidecar predates the declared-config field, or that lack
+    an observed hash, are SKIPPED with a counted warning - never a crash.
+    """
+    stats = ScanStats()
+    sidecars: list[_Sidecar] = []
+    for config_path in sorted(study_dir.rglob("config.json")):
+        stats.experiments_scanned += 1
+        rel_dir = str(config_path.parent.relative_to(study_dir))
+        try:
+            payload = json.loads(config_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            stats.skipped_unreadable += 1
+            logger.warning("skipping %s: unreadable config.json", rel_dir)
+            continue
+        declared = payload.get("declared_config")
+        if not isinstance(declared, dict):
+            stats.skipped_missing_declared += 1
+            logger.warning("skipping %s: legacy sidecar without declared_config", rel_dir)
+            continue
+        observed_hash = payload.get("observed_config_hash")
+        if not observed_hash:
+            stats.skipped_missing_observed_hash += 1
+            logger.warning("skipping %s: no observed_config_hash", rel_dir)
+            continue
+        sidecars.append(
+            _Sidecar(
+                experiment_dir=rel_dir,
+                engine=str(payload.get("engine", "unknown")),
+                library_version=str(payload.get("library_version", "unknown")),
+                observed_config_hash=str(observed_hash),
+                declared_config=declared,
+            )
+        )
+    return sidecars, stats
+
+
+def _make_candidate(
+    field_path: str,
+    co_occurring: list[str],
+    members: list[_Sidecar],
+    flats: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build one dormant-rule candidate for a single differing field."""
+    engine = members[0].engine
+    version = members[0].library_version
+    observed_hash = members[0].observed_config_hash
+    experiment_dirs = sorted(m.experiment_dir for m in members)
+    return {
+        "id": f"{engine}_collision_dormant_{_slug(field_path)}_{observed_hash[:8]}",
+        "engine": engine,
+        "engine_version": version,
+        "severity": "dormant",
+        "fields": [field_path],
+        "predicate": "value_variation_inert",
+        "condition": (
+            f"Declared field '{field_path}' varied across experiments that "
+            "resolved to an identical observed configuration; the variation "
+            "left the engine-effective state unchanged."
+        ),
+        "co_occurring_fields": co_occurring,
+        "provenance": {
+            "source": "observed_collision",
+            "engine": engine,
+            "engine_version": version,
+            "observed_config_hash": observed_hash,
+            "colliding_experiments": experiment_dirs,
+            "declared_values": _distinct_values(field_path, flats),
+        },
+        "verdict": "unverified",
+    }
+
+
+def mine_collisions(sidecars: list[_Sidecar], stats: ScanStats) -> list[dict[str, Any]]:
+    """Group by observed identity and emit dormant-rule candidates for diffs."""
+    groups: dict[tuple[str, str, str], list[_Sidecar]] = defaultdict(list)
+    for sidecar in sidecars:
+        key = (sidecar.engine, sidecar.library_version, sidecar.observed_config_hash)
+        groups[key].append(sidecar)
+
+    candidates: list[dict[str, Any]] = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        flats = [_flatten(m.declared_config) for m in members]
+        differing = _differing_fields(flats)
+        if not differing:
+            # Declared configs identical (e.g. repeat cycles) - dedup, not a collision.
+            continue
+        stats.collision_groups += 1
+        for field_path in differing:
+            co_occurring = [other for other in differing if other != field_path]
+            candidates.append(_make_candidate(field_path, co_occurring, members, flats))
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Writing to the version-scoped candidate pool
+# ---------------------------------------------------------------------------
+
+_POOL_HEADER = (
+    "# Observed-collision candidate rules (proposer S3).\n"
+    "# Emitted by scripts/mine_observed_collisions.py from a completed study.\n"
+    "# UNVERIFIED candidates for the verification ladder. Do NOT hand-copy into\n"
+    "# the shipped src/llenergymeasure/engines/<engine>/rules.yaml corpora.\n"
+)
+
+
+def _pool_path(pool_root: Path, engine: str, version: str) -> Path:
+    version_dir = "v" + re.sub(r"[^0-9a-zA-Z]+", "_", version).strip("_")
+    return pool_root / engine / version_dir / "candidates" / "observed_collisions.yaml"
+
+
+def write_candidates(
+    candidates: list[dict[str, Any]],
+    pool_root: Path,
+    *,
+    generated_at: str | None = None,
+) -> list[Path]:
+    """Write candidates to per-(engine, version) files under the pool root."""
+    generated_at = generated_at or date.today().isoformat()
+    by_pool: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for candidate in candidates:
+        by_pool[(candidate["engine"], candidate["engine_version"])].append(candidate)
+
+    written: list[Path] = []
+    for (engine, version), group in sorted(by_pool.items()):
+        document = {
+            "schema_version": SCHEMA_VERSION,
+            "source": "observed_collision",
+            "engine": engine,
+            "engine_version": version,
+            "generated_at": generated_at,
+            "candidates": group,
+        }
+        path = _pool_path(pool_root, engine, version)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        body = yaml.safe_dump(document, sort_keys=False, default_flow_style=False)
+        path.write_text(_POOL_HEADER + body)
+        written.append(path)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(stats: ScanStats, candidates: list[dict[str, Any]], written: list[Path]) -> None:
+    lines = [
+        "observed-collision miner summary:",
+        f"  experiments scanned      : {stats.experiments_scanned}",
+        f"  skipped (no declared cfg): {stats.skipped_missing_declared}",
+        f"  skipped (no observed hash): {stats.skipped_missing_observed_hash}",
+        f"  skipped (unreadable)     : {stats.skipped_unreadable}",
+        f"  collision groups         : {stats.collision_groups}",
+        f"  candidates emitted       : {len(candidates)}",
+    ]
+    for path in written:
+        lines.append(f"  wrote {path}")
+    print("\n".join(lines), file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("study_dir", type=Path, help="Completed study results directory")
+    parser.add_argument(
+        "--pool-root",
+        type=Path,
+        default=Path("engine_versions"),
+        help="Root of the version-scoped candidate pool (default: engine_versions)",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+    if not args.study_dir.is_dir():
+        print(f"error: study directory not found: {args.study_dir}", file=sys.stderr)
+        return 2
+
+    sidecars, stats = load_sidecars(args.study_dir)
+    candidates = mine_collisions(sidecars, stats)
+    written = write_candidates(candidates, args.pool_root)
+    _print_summary(stats, candidates, written)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -770,6 +770,15 @@ class MeasurementHarness:
             )
             obs_hash = hash_config(observed_view)
 
+            # Full user-declared config, recorded so the observed-collision
+            # miner can attribute a shared observed_config_hash to the declared
+            # fields that varied. Guarded separately: a declared-dump failure
+            # must not cost us the observed hash written below.
+            try:
+                declared_config: dict[str, object] | None = config.model_dump(mode="json")
+            except Exception:  # pragma: no cover - declared dump is best-effort
+                declared_config = None
+
             save_config_sidecar(
                 output_dir,
                 experiment_id=result.experiment_id,
@@ -779,6 +788,7 @@ class MeasurementHarness:
                 observed_engine_params=obs_engine if obs_engine else None,
                 observed_sampling_params=obs_sampling if obs_sampling else None,
                 observed_config_hash=obs_hash,
+                declared_config=declared_config,
             )
         except Exception as exc:
             logger.debug("Config sidecar write failed (non-fatal): %s", exc)

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -105,6 +105,7 @@ def save_config_sidecar(
     resolved_config_hash: str | None = None,
     observed_config_hash: str | None = None,
     config_validation_observations: list[dict[str, object]] | None = None,
+    declared_config: dict[str, object] | None = None,
 ) -> Path:
     """Write the per-experiment ``config.json`` sidecar with resolved/observed config-hash payload.
 
@@ -120,6 +121,13 @@ def save_config_sidecar(
       params at sidecar-write time.
     - ``config_validation_observations`` - DormantField entries that
       ``_apply_rules`` attached at load time.
+    - ``declared_config`` - the full user-declared ``ExperimentConfig``
+      (JSON model dump). Every other config field in this sidecar is a hash;
+      this is the only place the declared state is recorded in full. Named
+      consumer: the observed-collision miner
+      (``scripts/mine_observed_collisions.py``), which groups experiments by
+      ``observed_config_hash`` and diffs their declared configs to find fields
+      whose variation left the engine-effective state identical.
 
     Any missing optional field is omitted from the sidecar (not written as
     null) so downstream consumers distinguish "not available" from
@@ -142,6 +150,8 @@ def save_config_sidecar(
         payload["observed_config_hash"] = observed_config_hash
     if config_validation_observations is not None:
         payload["config_validation_observations"] = config_validation_observations
+    if declared_config is not None:
+        payload["declared_config"] = declared_config
 
     path = experiment_dir / "config.json"
     _atomic_write(json.dumps(payload, indent=2, default=str), path)

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -763,6 +763,13 @@ def test_write_config_sidecar_creates_config_json(minimal_config, tmp_path: Path
     )
     assert len(payload["observed_config_hash"]) == 64
 
+    # The full declared config must be recorded so the observed-collision miner
+    # can attribute a shared observed hash to declared field differences.
+    declared = payload.get("declared_config")
+    assert isinstance(declared, dict), "declared_config must be recorded in full"
+    assert declared["engine"] == "transformers"
+    assert declared["task"]["model"] == "fake/model"
+
 
 # ---------------------------------------------------------------------------
 # Bug 3 fix: capture_observed_params called post-window

--- a/tests/unit/scripts/test_mine_observed_collisions.py
+++ b/tests/unit/scripts/test_mine_observed_collisions.py
@@ -1,0 +1,163 @@
+"""Tests for :mod:`scripts.mine_observed_collisions`."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts import mine_observed_collisions as miner  # noqa: E402
+
+
+def _declared(eager: bool, seed: int | None = None) -> dict[str, Any]:
+    """A small declared ExperimentConfig varying enforce_eager (and maybe seed)."""
+    cfg: dict[str, Any] = {"engine": "vllm", "vllm": {"engine_params": {"enforce_eager": eager}}}
+    if seed is not None:
+        cfg["task"] = {"seed": seed}
+    return cfg
+
+
+def _write_sidecar(
+    study_dir: Path,
+    name: str,
+    *,
+    observed_hash: str | None = "a" * 64,
+    declared: dict[str, Any] | None = None,
+) -> None:
+    """Fabricate one experiment directory with a config.json sidecar."""
+    exp_dir = study_dir / name
+    exp_dir.mkdir(parents=True)
+    payload: dict[str, Any] = {"experiment_id": name, "engine": "vllm", "library_version": "0.19.1"}
+    if observed_hash is not None:
+        payload["observed_config_hash"] = observed_hash
+    if declared is not None:
+        payload["declared_config"] = declared
+    (exp_dir / "config.json").write_text(json.dumps(payload, indent=2))
+
+
+def _mine(study_dir: Path) -> tuple[list[dict[str, Any]], miner.ScanStats]:
+    sidecars, stats = miner.load_sidecars(study_dir)
+    return miner.mine_collisions(sidecars, stats), stats
+
+
+def test_clean_two_way_collision_names_the_field(tmp_path: Path) -> None:
+    """Declared differs on one field, observed identical -> that field is emitted."""
+    _write_sidecar(tmp_path, "001_exp", declared=_declared(eager=True))
+    _write_sidecar(tmp_path, "002_exp", declared=_declared(eager=False))
+
+    candidates, stats = _mine(tmp_path)
+
+    assert stats.collision_groups == 1
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["fields"] == ["vllm.engine_params.enforce_eager"]
+    assert candidate["severity"] == "dormant"
+    assert candidate["co_occurring_fields"] == []
+    assert candidate["verdict"] == "unverified"
+    prov = candidate["provenance"]
+    assert prov["source"] == "observed_collision"
+    assert prov["colliding_experiments"] == ["001_exp", "002_exp"]
+    assert sorted(prov["declared_values"], key=str) == [False, True]
+
+
+def test_non_collision_emits_nothing(tmp_path: Path) -> None:
+    """Different observed hashes never group, so no candidate is proposed."""
+    _write_sidecar(tmp_path, "001_exp", observed_hash="a" * 64, declared=_declared(eager=True))
+    _write_sidecar(tmp_path, "002_exp", observed_hash="b" * 64, declared=_declared(eager=False))
+
+    candidates, stats = _mine(tmp_path)
+
+    assert candidates == []
+    assert stats.collision_groups == 0
+
+
+def test_multi_field_diff_flags_co_occurrence(tmp_path: Path) -> None:
+    """Two fields varying together yield one candidate each, cross-referenced."""
+    _write_sidecar(tmp_path, "001_exp", declared=_declared(eager=True, seed=1))
+    _write_sidecar(tmp_path, "002_exp", declared=_declared(eager=False, seed=2))
+
+    candidates, stats = _mine(tmp_path)
+
+    assert stats.collision_groups == 1
+    by_field = {c["fields"][0]: c for c in candidates}
+    assert set(by_field) == {"task.seed", "vllm.engine_params.enforce_eager"}
+    assert by_field["task.seed"]["co_occurring_fields"] == ["vllm.engine_params.enforce_eager"]
+    assert by_field["vllm.engine_params.enforce_eager"]["co_occurring_fields"] == ["task.seed"]
+
+
+def test_identical_declared_configs_are_not_a_collision(tmp_path: Path) -> None:
+    """Repeat runs (same declared config, same observed hash) emit nothing."""
+    _write_sidecar(tmp_path, "001_c1", declared=_declared(eager=True))
+    _write_sidecar(tmp_path, "001_c2", declared=_declared(eager=True))
+
+    candidates, stats = _mine(tmp_path)
+
+    assert candidates == []
+    assert stats.collision_groups == 0
+
+
+def test_legacy_sidecar_without_declared_config_is_skipped(tmp_path: Path) -> None:
+    """A pre-field sidecar is counted and skipped, not crashed on."""
+    _write_sidecar(tmp_path, "001_exp", declared=_declared(eager=True))
+    _write_sidecar(tmp_path, "002_legacy", declared=None)
+
+    candidates, stats = _mine(tmp_path)
+
+    assert stats.experiments_scanned == 2
+    assert stats.skipped_missing_declared == 1
+    # Only one usable member remains in the group, so nothing is emitted.
+    assert candidates == []
+
+
+def test_group_of_three_with_single_varying_field(tmp_path: Path) -> None:
+    """A three-member group over one differing field yields one candidate."""
+    for idx, eager in enumerate([True, False, True], start=1):
+        _write_sidecar(tmp_path, f"00{idx}_exp", declared=_declared(eager=eager))
+
+    candidates, stats = _mine(tmp_path)
+
+    assert stats.collision_groups == 1
+    assert len(candidates) == 1
+    assert candidates[0]["fields"] == ["vllm.engine_params.enforce_eager"]
+    assert len(candidates[0]["provenance"]["colliding_experiments"]) == 3
+
+
+def test_write_candidates_targets_version_scoped_pool(tmp_path: Path) -> None:
+    """Candidates land under <pool>/<engine>/v<version>/candidates/, never in src/."""
+    _write_sidecar(tmp_path, "001_exp", declared=_declared(eager=True))
+    _write_sidecar(tmp_path, "002_exp", declared=_declared(eager=False))
+    candidates, _ = _mine(tmp_path)
+
+    pool_root = tmp_path / "pool"
+    written = miner.write_candidates(candidates, pool_root, generated_at="2026-07-06")
+
+    expected = pool_root / "vllm" / "v0_19_1" / "candidates" / "observed_collisions.yaml"
+    assert written == [expected]
+    document = yaml.safe_load(expected.read_text())
+    assert document["source"] == "observed_collision"
+    assert document["engine"] == "vllm"
+    assert document["engine_version"] == "0.19.1"
+    assert len(document["candidates"]) == 1
+
+
+def test_main_end_to_end(tmp_path: Path) -> None:
+    """main() scans, writes to the pool, and returns 0."""
+    study = tmp_path / "study"
+    _write_sidecar(study, "001_exp", declared=_declared(eager=True))
+    _write_sidecar(study, "002_exp", declared=_declared(eager=False))
+    pool_root = tmp_path / "pool"
+
+    assert miner.main([str(study), "--pool-root", str(pool_root)]) == 0
+    assert (pool_root / "vllm" / "v0_19_1" / "candidates" / "observed_collisions.yaml").exists()
+
+
+def test_main_missing_study_dir_returns_2(tmp_path: Path) -> None:
+    """A nonexistent study directory is a usage error, not a crash."""
+    assert miner.main([str(tmp_path / "nope")]) == 2

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -455,3 +455,47 @@ def test_environment_field_excluded_from_result_json(
     # model_dump_json drops the excluded field, so the re-serialised result
     # matches the on-disk result.json (no environment leakage).
     assert "environment" not in loaded.model_dump_json()
+
+
+def test_save_config_sidecar_roundtrips_declared_config(tmp_path: Path) -> None:
+    """The declared config survives a write/read round trip verbatim."""
+    import json
+
+    from llenergymeasure.results.persistence import save_config_sidecar
+
+    declared = {
+        "engine": "vllm",
+        "task": {"model": "fake/model", "seed": 7},
+        "vllm": {"engine_params": {"enforce_eager": True}},
+    }
+    path = save_config_sidecar(
+        tmp_path,
+        experiment_id="exp-1",
+        config_hash="a" * 16,
+        engine="vllm",
+        library_version="0.19.1",
+        observed_config_hash="b" * 64,
+        declared_config=declared,
+    )
+
+    payload = json.loads(path.read_text())
+    assert payload["declared_config"] == declared
+
+
+def test_save_config_sidecar_omits_declared_config_when_absent(tmp_path: Path) -> None:
+    """A call without declared_config omits the key (not written as null)."""
+    import json
+
+    from llenergymeasure.results.persistence import save_config_sidecar
+
+    path = save_config_sidecar(
+        tmp_path,
+        experiment_id="exp-1",
+        config_hash="a" * 16,
+        engine="vllm",
+        library_version="0.19.1",
+        observed_config_hash="b" * 64,
+    )
+
+    payload = json.loads(path.read_text())
+    assert "declared_config" not in payload


### PR DESCRIPTION
## What

Implements the observed-collision miner (proposer S3, phase D4 of the fresh-carve campaign) plus its one prerequisite.

- **Prerequisite (commit 1):** record the full user-declared `ExperimentConfig` in the per-experiment `config.json` sidecar as a new `declared_config` field (JSON model dump). Until now every declared-config field in that sidecar was hash-only, so the declared state lived nowhere on disk.
- **Miner (commit 2):** `scripts/mine_observed_collisions.py`, a maintainer script that scans a completed study results directory and proposes dormant-rule candidates from observed collisions.

## Why

Proposer S3 in the engine-knowledge redesign: distinct declared configs that resolve to an identical `observed_config_hash` are aliasing evidence. Recording the declared config in full is the only piece of state missing to attribute a shared observed hash back to the declared fields that varied. The miner is the named consumer of the new sidecar field (repo rule: no metadata without a named consumer). Every study run now generates S3 evidence at zero marginal cost.

## How it works

Per experiment `config.json`: group by `(engine, library_version, observed_config_hash)`; within any group whose declared configs differ, diff them field-by-field to name exactly the fields whose variation left the engine-effective state identical. Each such field becomes a `severity: dormant` candidate. Multi-field diffs emit one candidate per field, cross-referenced as `co_occurring_fields`. Legacy sidecars without a declared config are skipped with a counted warning, not a crash.

Candidates are written to the version-scoped candidate pool (`<pool-root>/<engine>/v<version>/candidates/observed_collisions.yaml`) as unverified proposals for the verification ladder to judge. The miner never writes to the shipped `src/llenergymeasure/engines/<engine>/rules.yaml` corpora, which are frozen.

## Scope note

This PR and the parallel citation-checker PR (ladder tier 1) each define the candidates-file schema independently per the design doc's shape; no shared code and no cross-imports between them. A Makefile invocation target is deferred to phase E2, which owns Makefile changes; the script is directly runnable and covered by `main()` tests.

## Validated

- `make lint`: all checks pass (ruff check, ruff format --check, import-linter 4/4 contracts kept).
- `make typecheck`: mypy clean on `src/` and `tests/` (297 files); `scripts/mine_observed_collisions.py` also clean.
- `uv run pytest`: 11 new tests (9 miner + 2 sidecar round-trip) plus an extended harness assertion; full affected sweep (persistence, harness, study, scripts) = 996 passed, 10 skipped.
