### PR TITLE
feat(verification): add candidate-rule citation checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,13 @@ refresh-invariants-all: ## Mine invariants for all three engines in sequence
 	./scripts/refresh_invariants.sh tensorrt
 	./scripts/refresh_invariants.sh transformers
 
+# Verification-ladder tier 1: confirm each proposed candidate rule's citation
+# resolves against a pinned engine source tree. Used by the absorb workflow and
+# CI. Obtaining SRC (the engine source tree) is the caller's concern.
+check-citations: ## Verify candidate citations (CANDIDATES=file.yaml SRC=path/to/source)
+	@test -n "$(CANDIDATES)" && test -n "$(SRC)" || (echo "Usage: make check-citations CANDIDATES=candidates.yaml SRC=engine-src/" && exit 1)
+	uv run python scripts/check_citations.py "$(CANDIDATES)" --source-root "$(SRC)"
+
 # Build wheel + validate package install + check version consistency
 package-check: ## Build wheel, validate install, and check pyproject/_version sync
 	uv build --wheel

--- a/scripts/check_citations.py
+++ b/scripts/check_citations.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Citation check: tier 1 of the engine-rule verification ladder.
+
+Proposers emit candidate rules into a per-version workspace, each carrying a
+mandatory citation into the pinned engine source tree (a file, an inclusive
+line range, and the verbatim quoted span). This script verifies each citation
+deterministically and offline, before the construction/identity probes that
+actually run the engine. Against a ``--source-root`` engine source tree it
+confirms, per candidate, that:
+
+- the cited file exists under the source root (and does not escape it);
+- the line range is in bounds;
+- the quoted span matches the file content there (a shifted quote is reported
+  as a drift, naming the line range where the text now lives);
+- the constrained field and value tokens appear in the span, so the span
+  entails the claimed constraint.
+
+Output is machine readable: a JSON report on stdout with a per-candidate
+verdict (``ok`` plus a precise ``reason`` on failure); exit 0 iff all pass. A
+malformed candidate entry raises :class:`CandidateSchemaError` loudly rather
+than being skipped.
+
+The candidate shape is a superset of the shipped ``rules.yaml`` rule (``id``,
+``match.fields``, ...) plus a ``citation`` mapping {``file``, ``lines``:
+[start, end], ``quote``}; the absorb step drops ``citation`` once the ladder
+passes and ships the rest.
+
+Run: python scripts/check_citations.py CANDIDATES.yaml --source-root SRC/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class CandidateSchemaError(ValueError):
+    """A candidate entry is missing required keys or has the wrong shape."""
+
+
+@dataclass(frozen=True)
+class Citation:
+    """A verbatim citation into the pinned engine source tree."""
+
+    file: str
+    line_start: int
+    line_end: int
+    quote: str
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A proposed engine rule awaiting verification, with its citation."""
+
+    id: str
+    fields: dict[str, Any]
+    citation: Citation
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The citation-check outcome for one candidate."""
+
+    candidate_id: str
+    ok: bool
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": self.candidate_id, "ok": self.ok, "reason": self.reason}
+
+
+# --- Candidate loading (malformed entries raise loudly) ---
+
+
+def _require(cond: bool, where: str, msg: str) -> None:
+    if not cond:
+        raise CandidateSchemaError(f"candidate {where}: {msg}")
+
+
+def _parse_candidate(index: int, raw: Any) -> Candidate:
+    where = f"#{index}"
+    _require(isinstance(raw, dict), where, f"must be a mapping, got {type(raw).__name__}")
+    cid = raw.get("id")
+    _require(isinstance(cid, str) and bool(cid), where, "missing string 'id'")
+    where = f"{cid!r}"
+
+    match = raw.get("match")
+    _require(isinstance(match, dict), where, "missing 'match' mapping")
+    fields = match.get("fields")
+    _require(isinstance(fields, dict) and bool(fields), where, "missing non-empty 'match.fields'")
+
+    cite = raw.get("citation")
+    _require(isinstance(cite, dict), where, "missing 'citation' mapping")
+    file = cite.get("file")
+    _require(isinstance(file, str) and bool(file), where, "citation missing string 'file'")
+    lines = cite.get("lines")
+    _require(
+        isinstance(lines, (list, tuple))
+        and len(lines) == 2
+        and all(isinstance(n, int) and not isinstance(n, bool) for n in lines),
+        where,
+        "citation 'lines' must be a two-integer list [start, end]",
+    )
+    quote = cite.get("quote")
+    _require(isinstance(quote, str) and bool(quote.strip()), where, "citation missing 'quote' text")
+
+    return Candidate(
+        id=cid,
+        fields=dict(fields),
+        citation=Citation(file=file, line_start=lines[0], line_end=lines[1], quote=quote),
+    )
+
+
+def load_candidates(path: Path) -> list[Candidate]:
+    """Parse and shape-validate a candidates file; raise on any malformed entry."""
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict):
+        raise CandidateSchemaError("candidates file must be a YAML mapping")
+    raw = data.get("candidates")
+    if not isinstance(raw, list):
+        raise CandidateSchemaError("candidates file must have a 'candidates' list")
+    return [_parse_candidate(i, entry) for i, entry in enumerate(raw)]
+
+
+# --- Claim tokens: what the cited span must entail ---
+
+
+def _leaf(path: str) -> str:
+    """Canonical field path -> the source-level identifier (its last segment)."""
+    return path.rsplit(".", 1)[-1]
+
+
+def _value_tokens(spec: Any) -> list[str]:
+    """Literal value tokens a predicate spec claims must appear in the source.
+
+    Operator keys carry no token; booleans (``present`` / ``absent`` flags) have
+    no source literal; an ``@field_ref`` contributes the referenced field's leaf.
+    """
+    if isinstance(spec, dict):
+        return [t for v in spec.values() for t in _value_tokens(v)]
+    if isinstance(spec, (list, tuple)):
+        return [t for v in spec for t in _value_tokens(v)]
+    if isinstance(spec, bool):
+        return []
+    if isinstance(spec, str):
+        return [_leaf(spec[1:])] if spec.startswith("@") else [spec]
+    if isinstance(spec, (int, float)):
+        return [str(spec)]
+    return []
+
+
+def claim_tokens(candidate: Candidate) -> tuple[list[str], list[str]]:
+    """Return ``(field_tokens, value_tokens)`` the cited span must contain."""
+    field_tokens = [_leaf(p) for p in candidate.fields]
+    value_tokens = [t for spec in candidate.fields.values() for t in _value_tokens(spec)]
+    return field_tokens, value_tokens
+
+
+# --- Span matching ---
+
+
+def _norm_block(text: str) -> list[str]:
+    """Content lines of a span, trailing-stripped and indentation-insensitive.
+
+    The dedent is required, not cosmetic: a YAML block scalar cannot preserve a
+    span's absolute leading indentation (it strips the block's own common indent
+    on parse), so the quoted span is only ever faithful modulo a uniform left
+    shift. Comparing after dedent still catches real content and line drift.
+    """
+    dedented = textwrap.dedent("\n".join(ln.rstrip() for ln in text.splitlines()))
+    lines = dedented.splitlines()
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    return lines
+
+
+def _find_block(file_lines: list[str], quoted: list[str]) -> int | None:
+    """1-based line where the normalised ``quoted`` block first occurs in the file."""
+    if not quoted:
+        return None
+    for i in range(len(file_lines) - len(quoted) + 1):
+        if _norm_block("\n".join(file_lines[i : i + len(quoted)])) == quoted:
+            return i + 1
+    return None
+
+
+# --- Per-candidate check ---
+
+
+def check_candidate(candidate: Candidate, source_root: Path) -> Verdict:
+    """Verify one candidate's citation against the pinned source tree."""
+    cite = candidate.citation
+
+    def fail(reason: str) -> Verdict:
+        return Verdict(candidate.id, ok=False, reason=reason)
+
+    root = source_root.resolve()
+    target = (source_root / cite.file).resolve()
+    if not target.is_relative_to(root):
+        return fail(f"cited file escapes the source root: {cite.file}")
+    if not target.is_file():
+        return fail(f"cited file not found under source root: {cite.file}")
+
+    file_lines = target.read_text().splitlines()
+    n = len(file_lines)
+    if not 1 <= cite.line_start <= cite.line_end <= n:
+        return fail(
+            f"line range [{cite.line_start}, {cite.line_end}] out of bounds (file has {n} lines)"
+        )
+
+    quoted = _norm_block(cite.quote)
+    if _norm_block("\n".join(file_lines[cite.line_start - 1 : cite.line_end])) != quoted:
+        drift = _find_block(file_lines, quoted)
+        if drift is not None:
+            return fail(
+                f"quoted span does not match lines [{cite.line_start}, {cite.line_end}]; "
+                f"verbatim text is at lines [{drift}, {drift + len(quoted) - 1}] (citation drifted)"
+            )
+        return fail(
+            f"quoted span does not match file content at lines [{cite.line_start}, {cite.line_end}]"
+        )
+
+    field_tokens, value_tokens = claim_tokens(candidate)
+    for tok in field_tokens:
+        if tok not in cite.quote:
+            return fail(f"constrained field {tok!r} not present in cited span")
+    for tok in value_tokens:
+        if tok not in cite.quote:
+            return fail(f"constrained value {tok!r} not present in cited span")
+
+    return Verdict(candidate.id, ok=True)
+
+
+# --- CLI ---
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify engine-rule candidate citations (ladder tier 1)."
+    )
+    parser.add_argument("candidates", type=Path, help="Candidates YAML file to check.")
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        required=True,
+        help="Root of the pinned engine source tree that citations resolve against.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.source_root.is_dir():
+        parser.error(f"--source-root is not a directory: {args.source_root}")
+
+    candidates = load_candidates(args.candidates)
+    verdicts = [check_candidate(c, args.source_root) for c in candidates]
+    failed = [v for v in verdicts if not v.ok]
+    report = {
+        "verdicts": [v.to_dict() for v in verdicts],
+        "checked": len(verdicts),
+        "failed": len(failed),
+    }
+    print(json.dumps(report, indent=2))
+    if failed:
+        print(f"\n{len(failed)}/{len(verdicts)} citation checks failed:", file=sys.stderr)
+        for v in failed:
+            print(f"  - {v.candidate_id}: {v.reason}", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_citations.py
+++ b/tests/unit/scripts/test_check_citations.py
@@ -1,0 +1,202 @@
+"""Tests for scripts/check_citations.py (verification-ladder tier 1)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[3] / "scripts"))
+
+from check_citations import (
+    Candidate,
+    CandidateSchemaError,
+    Citation,
+    check_candidate,
+    load_candidates,
+    main,
+)
+
+# A tiny fixture source file. Line numbers are 1-based:
+#   1 class EngineArgs:
+#   2     def __post_init__(self):
+#   3         if self.max_num_seqs < 1:
+#   4             raise ValueError(
+#   5                 "max_num_seqs must be at least 1")
+#   6         self.max_num_seqs = self.max_num_seqs
+#   7         self.done = True
+SRC = (
+    "class EngineArgs:\n"
+    "    def __post_init__(self):\n"
+    "        if self.max_num_seqs < 1:\n"
+    "            raise ValueError(\n"
+    '                "max_num_seqs must be at least 1")\n'
+    "        self.max_num_seqs = self.max_num_seqs\n"
+    "        self.done = True\n"
+)
+
+
+def _src_root(tmp_path: Path) -> Path:
+    (tmp_path / "engine.py").write_text(SRC)
+    return tmp_path
+
+
+def _quote(start: int, end: int) -> str:
+    return "\n".join(SRC.splitlines()[start - 1 : end])
+
+
+def _cand(
+    fields: dict[str, Any],
+    lines: tuple[int, int],
+    *,
+    file: str = "engine.py",
+    quote: str | None = None,
+    cid: str = "c1",
+) -> Candidate:
+    q = quote if quote is not None else _quote(*lines)
+    return Candidate(id=cid, fields=fields, citation=Citation(file, lines[0], lines[1], q))
+
+
+def test_clean_pass(tmp_path: Path) -> None:
+    cand = _cand({"vllm.engine_params.max_num_seqs": {"<": 1}}, (3, 5))
+    verdict = check_candidate(cand, _src_root(tmp_path))
+    assert verdict.ok
+    assert verdict.reason is None
+
+
+def test_quoted_span_mismatch(tmp_path: Path) -> None:
+    cand = _cand(
+        {"vllm.engine_params.max_num_seqs": {"<": 1}},
+        (3, 5),
+        quote="        if self.max_num_seqs < 2:",
+    )
+    verdict = check_candidate(cand, _src_root(tmp_path))
+    assert not verdict.ok
+    assert "does not match file content at lines [3, 5]" in verdict.reason
+
+
+def test_line_range_drifted(tmp_path: Path) -> None:
+    # Cite lines 1-3 but quote the text that actually lives at lines 3-5.
+    cand = _cand({"vllm.engine_params.max_num_seqs": {"<": 1}}, (1, 3), quote=_quote(3, 5))
+    verdict = check_candidate(cand, _src_root(tmp_path))
+    assert not verdict.ok
+    assert "citation drifted" in verdict.reason
+    assert "[3, 5]" in verdict.reason
+
+
+def test_cited_file_missing(tmp_path: Path) -> None:
+    cand = _cand({"vllm.engine_params.max_num_seqs": {"<": 1}}, (3, 5), file="does_not_exist.py")
+    verdict = check_candidate(cand, _src_root(tmp_path))
+    assert not verdict.ok
+    assert "not found under source root" in verdict.reason
+
+
+def test_cited_file_escapes_root(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    (tmp_path / "engine.py").write_text(SRC)
+    cand = _cand({"vllm.engine_params.max_num_seqs": {"<": 1}}, (3, 5), file="../engine.py")
+    verdict = check_candidate(cand, root)
+    assert not verdict.ok
+    assert "escapes the source root" in verdict.reason
+
+
+def test_constrained_field_absent_from_span(tmp_path: Path) -> None:
+    # Field leaf max_num_seqs does not appear at line 7.
+    cand = _cand({"vllm.engine_params.max_num_seqs": {"present": True}}, (7, 7))
+    verdict = check_candidate(cand, _src_root(tmp_path))
+    assert not verdict.ok
+    assert verdict.reason == "constrained field 'max_num_seqs' not present in cited span"
+
+
+def test_constrained_value_absent_from_span(tmp_path: Path) -> None:
+    # Field leaf present at line 6, but the claimed bound 999 is not.
+    cand = _cand({"vllm.engine_params.max_num_seqs": {"<": 999}}, (6, 6))
+    verdict = check_candidate(cand, _src_root(tmp_path))
+    assert not verdict.ok
+    assert verdict.reason == "constrained value '999' not present in cited span"
+
+
+def test_line_range_out_of_bounds(tmp_path: Path) -> None:
+    cand = _cand({"vllm.engine_params.max_num_seqs": {"<": 1}}, (1, 99))
+    verdict = check_candidate(cand, _src_root(tmp_path))
+    assert not verdict.ok
+    assert "out of bounds (file has 7 lines)" in verdict.reason
+
+
+def test_cross_field_ref_token_entailed(tmp_path: Path) -> None:
+    # A cross-field @ref contributes the referenced field's leaf as a token.
+    (tmp_path / "engine.py").write_text(
+        "if num_beams % num_beam_groups != 0:\n    raise ValueError\n"
+    )
+    cand = _cand(
+        {"transformers.generation.num_beams": {"not_divisible_by": "@num_beam_groups"}},
+        (1, 2),
+        quote="if num_beams % num_beam_groups != 0:\n    raise ValueError",
+    )
+    verdict = check_candidate(cand, tmp_path)
+    assert verdict.ok
+
+
+def test_malformed_candidate_raises_loudly(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.yaml"
+    path.write_text(
+        "schema_version: 1.0.0\n"
+        "candidates:\n"
+        "- id: broken\n"
+        "  match:\n"
+        "    fields:\n"
+        "      vllm.x.y: {'<': 1}\n"  # citation block omitted entirely
+    )
+    with pytest.raises(CandidateSchemaError, match=r"'broken'.*citation"):
+        load_candidates(path)
+
+
+def test_missing_candidates_list_raises(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.yaml"
+    path.write_text("schema_version: 1.0.0\n")
+    with pytest.raises(CandidateSchemaError, match="'candidates' list"):
+        load_candidates(path)
+
+
+def _candidates_file(tmp_path: Path, lines: tuple[int, int]) -> Path:
+    path = tmp_path / "candidates.yaml"
+    path.write_text(
+        "schema_version: 1.0.0\n"
+        "candidates:\n"
+        "- id: c1\n"
+        "  match:\n"
+        "    fields:\n"
+        "      vllm.engine_params.max_num_seqs: {'<': 1}\n"
+        "  citation:\n"
+        "    file: engine.py\n"
+        f"    lines: [{lines[0]}, {lines[1]}]\n"
+        "    quote: |\n" + "".join(f"      {ln}\n" for ln in _quote(3, 5).splitlines())
+    )
+    return path
+
+
+def test_main_all_pass(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    root = _src_root(tmp_path)
+    candidates = _candidates_file(tmp_path, (3, 5))
+    code = main([str(candidates), "--source-root", str(root)])
+    assert code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["checked"] == 1
+    assert report["failed"] == 0
+    assert report["verdicts"][0] == {"id": "c1", "ok": True, "reason": None}
+
+
+def test_main_reports_failure_and_exit_1(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _src_root(tmp_path)
+    candidates = _candidates_file(tmp_path, (1, 3))  # wrong lines -> drift
+    code = main([str(candidates), "--source-root", str(root)])
+    assert code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["failed"] == 1
+    assert report["verdicts"][0]["ok"] is False


### PR DESCRIPTION
## What

Adds the citation checker (`scripts/check_citations.py`) - tier 1 of the
engine-rule verification ladder from the engine-knowledge redesign. Given a
candidates file of proposed engine rules, each carrying a mandatory citation
into a pinned engine source tree, it verifies every citation deterministically
and offline.

Per candidate it confirms, against a `--source-root` engine source tree, that:
- the cited file exists under the source root (and does not escape it);
- the line range is in bounds for that file;
- the quoted span matches the file content at those lines (a shifted quote is
  reported as a drift, naming the line range where the text now lives);
- the constrained field and value tokens appear in the span, so the span
  entails the claimed constraint.

Output is machine-readable JSON on stdout (per-candidate `ok` plus a precise
`reason` on failure); exit 0 iff every candidate passes, 1 otherwise. A
malformed candidate entry is a proposer bug, so it raises loudly rather than
being silently skipped.

## Why

Tier 1 is the cheapest, fully deterministic gate before the construction and
identity probes that actually run the engine. The absorb workflow and CI both
call it to reject drifted or unsupported citations early.

## How it fits

- Homed as maintainer tooling under `scripts/` with a `check-citations` make
  target (knowledge production is scripts + make targets, not the `llem` CLI).
- The candidate shape is a superset of the shipped `rules.yaml` rule (`id`,
  `match.fields`, ...) plus a structured `citation` mapping
  {`file`, `lines: [start, end]`, `quote`}; the absorb step drops `citation`
  once the ladder passes and ships the rest. Obtaining the engine source tree
  is the caller's concern; this PR builds no downloaders.
- The parallel observed-collision-miner PR emits this same candidate shape
  independently; nothing is imported across the two.

## Design note

The span comparison is indentation-insensitive (common leading indent is
dedented on both sides before comparing). This is required, not cosmetic: a
YAML block scalar cannot preserve a span's absolute leading indentation, so the
quoted span is only ever faithful modulo a uniform left shift. Content and line
drift are still caught.

## Validated

- `make lint` clean (ruff check + format + import-linter).
- `make typecheck` clean (mypy strict, 297 source files).
- `uv run pytest tests/unit/scripts/` -> 396 passed, 10 skipped; the new
  `test_check_citations.py` contributes 13 tests covering clean pass,
  quoted-span mismatch, line drift, missing file, source-root escape, field
  and value tokens absent, out-of-bounds range, cross-field ref entailment,
  malformed entry (loud error), and the CLI exit codes / JSON shape.
- Manual CLI smoke test: pass case exits 0, drifted-line case exits 1 with the
  drift-located reason.

Sizing: 488 physical authored lines (279 prod + 202 tests + 7 Makefile), under
the 500 ceiling; over the ~250 target because of the 13-test suite and a
maintainer-facing docstring, both judged worth keeping.
