### PR TITLE
feat(rules): add construction and identity probe kernel, tiers 2-3 of verification ladder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: test test-unit test-integration test-all
 .PHONY: docs-all docs-check docs-generate docs-serve docs-build docs-clean
 .PHONY: discover-schema discover-schemas-all refresh-invariants refresh-invariants-all
+.PHONY: check-citations probe-candidates
 .PHONY: package-check
 .PHONY: docker-smoke
 .PHONY: ci ci-all ci-docker
@@ -160,6 +161,12 @@ refresh-invariants-all: ## Mine invariants for all three engines in sequence
 check-citations: ## Verify candidate citations (CANDIDATES=file.yaml SRC=path/to/source)
 	@test -n "$(CANDIDATES)" && test -n "$(SRC)" || (echo "Usage: make check-citations CANDIDATES=candidates.yaml SRC=engine-src/" && exit 1)
 	uv run python scripts/check_citations.py "$(CANDIDATES)" --source-root "$(SRC)"
+
+# Verification-ladder tiers 2-3: run construction/identity probes against the
+# real engine inside its Docker image. ARGS forwards to the kernel (e.g. --out).
+probe-candidates: ## Probe candidate rules in-engine (ENGINE=vllm|tensorrt|transformers CANDIDATES=file.yaml [ARGS=...])
+	@test -n "$(ENGINE)" && test -n "$(CANDIDATES)" || (echo "Usage: make probe-candidates ENGINE={vllm|tensorrt|transformers} CANDIDATES=candidates.yaml [ARGS='--out /tmp/verdicts.yaml']" && exit 1)
+	./scripts/probe_candidates.sh $(ENGINE) --candidates "$(CANDIDATES)" $(ARGS)
 
 # Build wheel + validate package install + check version consistency
 package-check: ## Build wheel, validate install, and check pyproject/_version sync

--- a/scripts/_engine_constructors.py
+++ b/scripts/_engine_constructors.py
@@ -1,0 +1,283 @@
+"""Resolve and build engine-native config classes for probe execution.
+
+The probe kernel (``scripts/probe_candidates.py``) proves candidate rules by
+constructing the offending config inside the real engine and observing whether
+the engine raises. Candidates address fields by CANONICAL dotted path
+(``vllm.sampling_params.frequency_penalty``, ``vllm.engine_params.all2all_backend``,
+``transformers.sampling_params.temperature``). This module answers two questions:
+
+1. Given a canonical path, which native constructor class(es) validate that
+   field? A path's ``(engine, section)`` prefix maps to an ordered list of
+   candidate classes; the kernel picks the first that accepts every leaf.
+2. Given a class and probe kwargs, how do we build an instance so the engine's
+   own field validation fires (msgspec needs ``convert``; tensorrt needs a
+   placeholder model; transformers needs an explicit ``.validate()`` call)?
+
+It runs INSIDE the engine container and imports the live engine library lazily
+(only when a probe actually needs it), so importing this module on a plain host
+- as the unit tests do - pulls in no engine. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import inspect
+import typing
+from typing import Any
+
+# Sentinel returned by :func:`resolved_value` when a field is absent on the
+# constructed instance (distinct from a real ``None`` resolved value).
+MISSING = object()
+
+
+class ConstructorResolutionError(Exception):
+    """No native constructor class could be resolved for a canonical path.
+
+    The kernel treats this as ``unprobeable``: an unknown engine, an unknown
+    section prefix, or a section whose classes cannot be imported in this
+    container. It is never evidence that a rule stopped holding.
+    """
+
+
+# (engine, section) -> ordered (module, class_name) import specs. The kernel
+# tries these in order and keeps the first class that accepts all the rule's
+# leaf names. vllm.engine_params spans several config classes (a field lives on
+# exactly one), so its list is the full config surface; a rule's fields all
+# validate together on one class, so "first class accepting every leaf" wins.
+_CONSTRUCTOR_TABLE: dict[tuple[str, str], tuple[tuple[str, str], ...]] = {
+    ("vllm", "sampling_params"): (("vllm", "SamplingParams"),),
+    ("vllm", "engine_params"): (
+        ("vllm.config.scheduler", "SchedulerConfig"),
+        ("vllm.config.parallel", "ParallelConfig"),
+        ("vllm.config.cache", "CacheConfig"),
+        ("vllm.config.model", "ModelConfig"),
+        ("vllm.config.load", "LoadConfig"),
+        ("vllm.config.device", "DeviceConfig"),
+        ("vllm.config.lora", "LoRAConfig"),
+        ("vllm.config", "SchedulerConfig"),
+    ),
+    ("transformers", "sampling_params"): (("transformers", "GenerationConfig"),),
+    ("transformers", "sampling"): (("transformers", "GenerationConfig"),),
+    ("transformers", "engine_params"): (("transformers", "GenerationConfig"),),
+    ("tensorrt", "sampling_params"): (("tensorrt_llm", "SamplingParams"),),
+    ("tensorrt", "engine_params"): (("tensorrt_llm.llmapi.llm_args", "TrtLlmArgs"),),
+}
+
+# transformers quantization fields are validated by BitsAndBytesConfig, not
+# GenerationConfig - GenerationConfig silently stashes unknown kwargs, so it
+# would falsely "accept" these and never fire their validation.
+_BNB_FIELDS: frozenset[str] = frozenset(
+    {
+        "load_in_4bit",
+        "load_in_8bit",
+        "bnb_4bit_quant_type",
+        "bnb_4bit_use_double_quant",
+        "bnb_4bit_compute_dtype",
+        "llm_int8_threshold",
+    }
+)
+
+# Top-level import module per engine - used to decide whether this container can
+# probe the engine at all (a missing engine is an infra fact, not a rule verdict).
+_ROOT_MODULE = {"vllm": "vllm", "transformers": "transformers", "tensorrt": "tensorrt_llm"}
+
+# *LlmArgs declare ``model`` required; the probe kwargs only carry the field
+# under test, so an injected placeholder lets construction reach the validators
+# under test. It is never resolved to a real checkpoint.
+_TRTLLM_MODEL_PLACEHOLDER = "/tmp/llem-probe-model-placeholder"
+
+# Minimal-valid stand-in per builtin type for scaffolding required constructor
+# args the probe kwargs do not carry (see :func:`_scaffold_required`).
+_SCAFFOLD_TYPE_DEFAULTS: dict[type, Any] = {bool: False, int: 1, float: 1.0, str: "x"}
+
+
+def section_of(canonical_path: str) -> str:
+    """Return the ``section`` segment of ``engine.section.leaf`` (or "")."""
+    parts = canonical_path.split(".")
+    return parts[1] if len(parts) >= 2 else ""
+
+
+def leaf_of(canonical_path: str) -> str:
+    """Return the constructor-kwarg name: the path's last segment."""
+    return canonical_path.rsplit(".", 1)[-1]
+
+
+def _import(module: str, name: str) -> Any:
+    return getattr(importlib.import_module(module), name)
+
+
+def engine_importable(engine: str) -> bool:
+    """True iff this container can import ``engine``'s top-level library.
+
+    A ``False`` here means every candidate is ``infra_error`` (wrong container),
+    which is categorically distinct from an individual field being unprobeable.
+    """
+    module = _ROOT_MODULE.get(engine)
+    if module is None:
+        return False
+    try:
+        importlib.import_module(module)
+        return True
+    except Exception:
+        return False
+
+
+def candidate_classes(engine: str, canonical_path: str, leaves: list[str]) -> list[type]:
+    """Ordered native config classes that might validate ``canonical_path``.
+
+    ``leaves`` is every leaf the rule constrains; used to route transformers
+    quantization fields to ``BitsAndBytesConfig``. Raises
+    :class:`ConstructorResolutionError` when the engine/section is unknown or no
+    class in the table can be imported here.
+    """
+    if engine == "transformers":
+        target = (
+            "BitsAndBytesConfig" if any(x in _BNB_FIELDS for x in leaves) else "GenerationConfig"
+        )
+        try:
+            return [_import("transformers", target)]
+        except (ImportError, AttributeError) as exc:  # pragma: no cover - container-only
+            raise ConstructorResolutionError(f"cannot import transformers.{target}: {exc}") from exc
+
+    specs = _CONSTRUCTOR_TABLE.get((engine, section_of(canonical_path)))
+    if not specs:
+        raise ConstructorResolutionError(
+            f"no constructor table entry for engine {engine!r} section {section_of(canonical_path)!r}"
+        )
+    classes: list[type] = []
+    seen: set[int] = set()
+    for module, name in specs:
+        try:
+            cls = _import(module, name)
+        except (ImportError, AttributeError):
+            continue
+        if id(cls) not in seen:
+            seen.add(id(cls))
+            classes.append(cls)
+    if not classes:
+        raise ConstructorResolutionError(
+            f"none of the {engine}/{section_of(canonical_path)} classes could be imported"
+        )
+    return classes
+
+
+def accepts(cls: type, leaf: str) -> bool:
+    """True iff ``cls(**{leaf: ...})`` is a legal constructor call.
+
+    Uses the constructor signature so dataclass ``InitVar`` params and
+    ``**kwargs`` catch-alls (GenerationConfig) are handled uniformly.
+    """
+    try:
+        params = inspect.signature(cls).parameters
+    except (ValueError, TypeError):  # pragma: no cover - exotic C constructors
+        return True
+    if leaf in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+def construct(engine: str, cls: type, kwargs: dict[str, Any], *, validate: bool) -> Any:
+    """Build a ``cls`` instance from ``kwargs`` so its field validation fires.
+
+    ``validate`` requests the strict/raising path where an engine separates
+    construction from validation (transformers ``GenerationConfig.validate``);
+    the identity probe passes ``validate=False`` to read resolved state without
+    raising. Any exception raised here is the engine's own - the caller
+    interprets it as the probe signal.
+    """
+    if engine == "transformers":
+        obj = cls(**kwargs)
+        if validate and hasattr(obj, "validate"):
+            obj.validate(strict=True)
+        return obj
+    if engine == "tensorrt":
+        kw = dict(kwargs)
+        if cls.__name__.endswith("LlmArgs") and "model" not in kw:
+            kw["model"] = _TRTLLM_MODEL_PLACEHOLDER
+        return _build_config(cls, kw)
+    if _is_msgspec_struct(cls):
+        import msgspec  # type: ignore[import-not-found]
+
+        return msgspec.convert(kwargs, cls)
+    return _build_config(cls, kwargs)
+
+
+def resolved_value(instance: Any, leaf: str) -> Any:
+    """Return the engine-resolved value of ``leaf`` (or :data:`MISSING`)."""
+    return getattr(instance, leaf, MISSING)
+
+
+# ---------------------------------------------------------------------------
+# Construction helpers (msgspec dispatch + required-arg scaffolding)
+# ---------------------------------------------------------------------------
+
+
+def _build_config(cls: type, kwargs: dict[str, Any]) -> Any:
+    scaffold = _scaffold_required(cls, kwargs)
+    return cls(**{**scaffold, **kwargs})
+
+
+def _is_msgspec_struct(cls: Any) -> bool:
+    """True iff ``cls`` is a ``msgspec.Struct`` (validates only on ``convert``).
+
+    Guarded so a non-msgspec engine container never needs msgspec installed.
+    """
+    try:
+        import msgspec  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+    return isinstance(cls, type) and issubclass(cls, msgspec.Struct)
+
+
+def _scaffold_required(cls: type, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Neutral stand-ins for mandatory constructor args ``kwargs`` omits.
+
+    Some config classes declare required args the probe does not name (vLLM's
+    ``SchedulerConfig`` makes ``max_model_len`` a no-default ``InitVar``), so a
+    bare construction raises "field required" before the rule's own validator
+    runs. The scaffold prefers the class's real default_factory over a synthetic
+    value so a sibling a validator reads lands on its true default, and the
+    probe kwargs always win on conflict, so a scaffolded arg never changes which
+    branch the rule tests. Any introspection failure yields an empty scaffold -
+    always safe, since this only ADDS args the probe omitted.
+    """
+    try:
+        scaffold: dict[str, Any] = {}
+        pyd_fields = getattr(cls, "__pydantic_fields__", None)
+        if pyd_fields is not None:
+            for name, info in pyd_fields.items():
+                if name in kwargs or not getattr(info, "is_required", lambda: False)():
+                    continue
+                if getattr(info, "init", True) is False:
+                    continue
+                factory = getattr(info, "default_factory", None)
+                scaffold[name] = (
+                    factory() if callable(factory) else _scaffold_value(info.annotation)
+                )
+            return scaffold
+        if dataclasses.is_dataclass(cls):
+            for f in dataclasses.fields(cls):
+                if not f.init or f.name in kwargs or f.default is not dataclasses.MISSING:
+                    continue
+                if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+                    scaffold[f.name] = f.default_factory()
+                    continue
+                scaffold[f.name] = _scaffold_value(f.type)
+            return scaffold
+    except Exception:
+        return {}
+    return {}
+
+
+def _scaffold_value(annotation: Any) -> Any:
+    """Minimal-valid value for a required field's annotation (fallback ``1``)."""
+    inner = annotation
+    if isinstance(inner, dataclasses.InitVar):
+        inner = inner.type
+    if typing.get_origin(inner) is typing.Literal:
+        members = typing.get_args(inner)
+        return members[0] if members else 1
+    if isinstance(inner, type) and inner in _SCAFFOLD_TYPE_DEFAULTS:
+        return _SCAFFOLD_TYPE_DEFAULTS[inner]
+    return 1

--- a/scripts/check_citations.py
+++ b/scripts/check_citations.py
@@ -16,14 +16,16 @@ confirms, per candidate, that:
   entails the claimed constraint.
 
 Output is machine readable: a JSON report on stdout with a per-candidate
-verdict (``ok`` plus a precise ``reason`` on failure); exit 0 iff all pass. A
-malformed candidate entry raises :class:`CandidateSchemaError` loudly rather
-than being skipped.
+verdict (``ok`` plus a precise ``reason`` on failure); exit 0 iff all checked
+candidates pass. A candidate with NO ``citation`` key (an observed-collision
+proposal cites runtime evidence, not source) is SKIPPED and counted, not
+failed; a candidate whose citation is present but malformed still raises
+:class:`CandidateSchemaError` loudly.
 
 The candidate shape is a superset of the shipped ``rules.yaml`` rule (``id``,
-``match.fields``, ...) plus a ``citation`` mapping {``file``, ``lines``:
-[start, end], ``quote``}; the absorb step drops ``citation`` once the ladder
-passes and ships the rest.
+``match.fields``, ...) plus an optional ``citation`` mapping {``file``,
+``lines``: [start, end], ``quote``}; the absorb step drops ``citation`` once the
+ladder passes and ships the rest.
 
 Run: python scripts/check_citations.py CANDIDATES.yaml --source-root SRC/
 """
@@ -32,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import textwrap
 from dataclasses import dataclass
@@ -57,11 +60,15 @@ class Citation:
 
 @dataclass(frozen=True)
 class Candidate:
-    """A proposed engine rule awaiting verification, with its citation."""
+    """A proposed engine rule awaiting verification.
+
+    ``citation`` is ``None`` for proposals that cite runtime evidence rather than
+    source (observed collisions); such candidates are skipped by the checker.
+    """
 
     id: str
     fields: dict[str, Any]
-    citation: Citation
+    citation: Citation | None
 
 
 @dataclass(frozen=True)
@@ -95,6 +102,9 @@ def _parse_candidate(index: int, raw: Any) -> Candidate:
     _require(isinstance(match, dict), where, "missing 'match' mapping")
     fields = match.get("fields")
     _require(isinstance(fields, dict) and bool(fields), where, "missing non-empty 'match.fields'")
+
+    if "citation" not in raw:
+        return Candidate(id=cid, fields=dict(fields), citation=None)
 
     cite = raw.get("citation")
     _require(isinstance(cite, dict), where, "missing 'citation' mapping")
@@ -193,12 +203,24 @@ def _find_block(file_lines: list[str], quoted: list[str]) -> int | None:
     return None
 
 
+def _entailed(token: str, quote: str) -> bool:
+    """True iff ``token`` occurs in ``quote`` at a word boundary.
+
+    Boundary, not substring: the field token ``max_tokens`` must NOT be counted
+    as present just because ``max_tokens_per_batch`` appears. The lookarounds
+    reject an occurrence flanked by a word character, so a token is only entailed
+    when it stands as its own identifier/literal.
+    """
+    return re.search(rf"(?<!\w){re.escape(token)}(?!\w)", quote) is not None
+
+
 # --- Per-candidate check ---
 
 
 def check_candidate(candidate: Candidate, source_root: Path) -> Verdict:
     """Verify one candidate's citation against the pinned source tree."""
     cite = candidate.citation
+    assert cite is not None, "check_candidate is only called for cited candidates"
 
     def fail(reason: str) -> Verdict:
         return Verdict(candidate.id, ok=False, reason=reason)
@@ -231,10 +253,10 @@ def check_candidate(candidate: Candidate, source_root: Path) -> Verdict:
 
     field_tokens, value_tokens = claim_tokens(candidate)
     for tok in field_tokens:
-        if tok not in cite.quote:
+        if not _entailed(tok, cite.quote):
             return fail(f"constrained field {tok!r} not present in cited span")
     for tok in value_tokens:
-        if tok not in cite.quote:
+        if not _entailed(tok, cite.quote):
             return fail(f"constrained value {tok!r} not present in cited span")
 
     return Verdict(candidate.id, ok=True)
@@ -260,14 +282,23 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"--source-root is not a directory: {args.source_root}")
 
     candidates = load_candidates(args.candidates)
-    verdicts = [check_candidate(c, args.source_root) for c in candidates]
+    cited = [c for c in candidates if c.citation is not None]
+    skipped = [c for c in candidates if c.citation is None]
+    verdicts = [check_candidate(c, args.source_root) for c in cited]
     failed = [v for v in verdicts if not v.ok]
     report = {
         "verdicts": [v.to_dict() for v in verdicts],
         "checked": len(verdicts),
         "failed": len(failed),
+        "skipped_uncited": len(skipped),
+        "skipped_ids": [c.id for c in skipped],
     }
     print(json.dumps(report, indent=2))
+    if skipped:
+        print(
+            f"skipped {len(skipped)} uncited candidate(s) (runtime-evidence proposals)",
+            file=sys.stderr,
+        )
     if failed:
         print(f"\n{len(failed)}/{len(verdicts)} citation checks failed:", file=sys.stderr)
         for v in failed:

--- a/scripts/mine_observed_collisions.py
+++ b/scripts/mine_observed_collisions.py
@@ -177,7 +177,15 @@ def _make_candidate(
     members: list[_Sidecar],
     flats: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build one dormant-rule candidate for a single differing field."""
+    """Build one dormant-rule candidate for a single differing field.
+
+    Shape is the unified candidate schema the verification ladder consumes:
+    the constrained field lives under ``match.fields`` with a ``present`` spec
+    (the identity probe reads the recorded ``declared_values`` from provenance),
+    and the (unverified) ``verdict`` block is filled in by the probe kernel. No
+    ``citation`` key: observed-collision candidates cite runtime evidence, not
+    source, so ``check_citations.py`` skips rather than fails them.
+    """
     engine = members[0].engine
     version = members[0].library_version
     observed_hash = members[0].observed_config_hash
@@ -187,14 +195,7 @@ def _make_candidate(
         "engine": engine,
         "engine_version": version,
         "severity": "dormant",
-        "fields": [field_path],
-        "predicate": "value_variation_inert",
-        "condition": (
-            f"Declared field '{field_path}' varied across experiments that "
-            "resolved to an identical observed configuration; the variation "
-            "left the engine-effective state unchanged."
-        ),
-        "co_occurring_fields": co_occurring,
+        "match": {"fields": {field_path: {"present": True}}},
         "provenance": {
             "source": "observed_collision",
             "engine": engine,
@@ -202,8 +203,9 @@ def _make_candidate(
             "observed_config_hash": observed_hash,
             "colliding_experiments": experiment_dirs,
             "declared_values": _distinct_values(field_path, flats),
+            "co_occurring_fields": co_occurring,
         },
-        "verdict": "unverified",
+        "verdict": {"status": "unverified", "tier": None, "date": None, "evidence": None},
     }
 
 

--- a/scripts/probe_candidates.py
+++ b/scripts/probe_candidates.py
@@ -79,7 +79,7 @@ _BUILTIN_VALUES: dict[str, Any] = {"bool": True, "int": 1, "float": 1.0, "str": 
 
 
 class Unprobeable(Exception):
-    """No deterministic probe can be derived for this candidate's claim."""
+    """No deterministic probe can be derived or run for this candidate's claim."""
 
 
 @dataclass
@@ -330,6 +330,31 @@ def _ref_of(fields: dict[str, Any], referenced: set[str]) -> Any:
     return lambda leaf: env.get(leaf, REF_BASE)
 
 
+def _firing_kwargs(
+    fields: dict[str, Any],
+    ref_of: Any,
+    referenced: set[str],
+    skip_path: str | None = None,
+) -> dict[str, Any]:
+    """Constructor kwargs with every field (except ``skip_path``, if any) firing.
+
+    Fields referenced by an ``@field_ref`` but not named in ``fields`` are
+    scaffolded to :data:`REF_BASE` so a cross-field comparison has both operands.
+    """
+    named = {ec.leaf_of(p) for p in fields}
+    kwargs: dict[str, Any] = {}
+    for path, spec in fields.items():
+        if path == skip_path:
+            continue
+        value = _fire_value(spec, ec.leaf_of(path), ref_of, referenced)
+        if value is not _OMIT:
+            kwargs[ec.leaf_of(path)] = value
+    for rleaf in referenced:
+        if rleaf not in named and rleaf not in kwargs:
+            kwargs[rleaf] = ref_of(rleaf)
+    return kwargs
+
+
 # ---------------------------------------------------------------------------
 # Construction probe (severity: error)
 # ---------------------------------------------------------------------------
@@ -345,19 +370,10 @@ def build_construction_kwargs(fields: dict[str, Any]) -> tuple[dict[str, Any], d
     """
     referenced = _referenced_leaves(fields)
     ref_of = _ref_of(fields, referenced)
-    named = {ec.leaf_of(p) for p in fields}
     subject_path = list(fields)[-1]
     subject_leaf = ec.leaf_of(subject_path)
 
-    violating: dict[str, Any] = {}
-    for path, spec in fields.items():
-        value = _fire_value(spec, ec.leaf_of(path), ref_of, referenced)
-        if value is not _OMIT:
-            violating[ec.leaf_of(path)] = value
-    for rleaf in referenced:
-        if rleaf not in named and rleaf not in violating:
-            violating[rleaf] = ref_of(rleaf)
-
+    violating = _firing_kwargs(fields, ref_of, referenced)
     nofire = _nofire_value(fields[subject_path], subject_leaf, ref_of, referenced)
     satisfying = dict(violating)
     if nofire is _OMIT:
@@ -367,11 +383,21 @@ def build_construction_kwargs(fields: dict[str, Any]) -> tuple[dict[str, Any], d
     return violating, satisfying, subject_leaf
 
 
-def _pick_class(classes: list[type], leaves: list[str]) -> type | None:
+def _resolve_class(cand: Candidate, engine: str, leaves: list[str]) -> type:
+    """The first constructor class accepting every leaf in ``leaves``.
+
+    Raises :class:`Unprobeable` when the engine/section is unknown here or no
+    importable class accepts all the rule's fields; the caller's handler turns
+    that into the tier-appropriate verdict.
+    """
+    try:
+        classes = ec.candidate_classes(engine, next(iter(cand.fields)), leaves)
+    except ec.ConstructorResolutionError as exc:
+        raise Unprobeable(str(exc)) from exc
     for cls in classes:
         if all(ec.accepts(cls, leaf) for leaf in leaves):
             return cls
-    return None
+    raise Unprobeable(f"no constructor accepts fields {leaves}")
 
 
 def _run_leg(engine: str, cls: type, kwargs: dict[str, Any]) -> str | None:
@@ -380,23 +406,16 @@ def _run_leg(engine: str, cls: type, kwargs: dict[str, Any]) -> str | None:
         ec.construct(engine, cls, kwargs, validate=True)
         return None
     except Exception as exc:
-        return f"{type(exc).__name__}: {exc}"[:200]
+        return _clip(f"{type(exc).__name__}: {exc}")
 
 
 def probe_construction(cand: Candidate, engine: str) -> Verdict:
-    try:
-        violating, satisfying, _ = build_construction_kwargs(cand.fields)
-    except Unprobeable as exc:
-        return Verdict("unprobeable", "construction", str(exc))
-
     leaves = [ec.leaf_of(p) for p in cand.fields]
     try:
-        classes = ec.candidate_classes(engine, next(iter(cand.fields)), leaves)
-    except ec.ConstructorResolutionError as exc:
+        violating, satisfying, _ = build_construction_kwargs(cand.fields)
+        cls = _resolve_class(cand, engine, leaves)
+    except Unprobeable as exc:
         return Verdict("unprobeable", "construction", str(exc))
-    cls = _pick_class(classes, leaves)
-    if cls is None:
-        return Verdict("unprobeable", "construction", f"no constructor accepts fields {leaves}")
 
     positive = _run_leg(engine, cls, violating)
     negative = _run_leg(engine, cls, satisfying)
@@ -478,18 +497,7 @@ def build_identity_base(fields: dict[str, Any], subject_path: str | None) -> dic
     """
     referenced = _referenced_leaves(fields)
     ref_of = _ref_of(fields, referenced)
-    named = {ec.leaf_of(p) for p in fields}
-    base: dict[str, Any] = {}
-    for path, spec in fields.items():
-        if path == subject_path:
-            continue
-        value = _fire_value(spec, ec.leaf_of(path), ref_of, referenced)
-        if value is not _OMIT:
-            base[ec.leaf_of(path)] = value
-    for rleaf in referenced:
-        if rleaf not in named and rleaf not in base:
-            base[rleaf] = ref_of(rleaf)
-    return base
+    return _firing_kwargs(fields, ref_of, referenced, skip_path=subject_path)
 
 
 def _inert_subjects(cand: Candidate) -> list[str]:
@@ -503,18 +511,6 @@ def _inert_subjects(cand: Candidate) -> list[str]:
     return [n for n in cand.normalised if ec.leaf_of(n) not in match_leaves]
 
 
-def _resolve_class(cand: Candidate, engine: str, leaves: list[str]) -> type | Verdict:
-    """The first constructor class accepting ``leaves``, or an unprobeable Verdict."""
-    try:
-        classes = ec.candidate_classes(engine, next(iter(cand.fields)), leaves)
-    except ec.ConstructorResolutionError as exc:
-        return Verdict("unprobeable", "identity", str(exc))
-    cls = _pick_class(classes, leaves)
-    if cls is None:
-        return Verdict("unprobeable", "identity", f"no constructor accepts fields {leaves}")
-    return cls
-
-
 def probe_identity(cand: Candidate, engine: str) -> Verdict:
     is_collision = cand.source == "observed_collision" and bool(cand.declared_values)
     subjects = [] if is_collision else _inert_subjects(cand)
@@ -526,17 +522,14 @@ def probe_identity(cand: Candidate, engine: str) -> Verdict:
 def _probe_alias(cand: Candidate, engine: str) -> Verdict:
     """Value-alias dormancy: the (last) match field itself over declared values."""
     subject_path = list(cand.fields)[-1]
+    subject_leaf = ec.leaf_of(subject_path)
+    leaves = [ec.leaf_of(p) for p in cand.fields]
     try:
         values = identity_values(cand, subject_path)
         base = build_identity_base(cand.fields, subject_path)
+        cls = _resolve_class(cand, engine, leaves)
     except Unprobeable as exc:
         return Verdict("unprobeable", "identity", str(exc))
-
-    subject_leaf = ec.leaf_of(subject_path)
-    leaves = [ec.leaf_of(p) for p in cand.fields]
-    cls = _resolve_class(cand, engine, leaves)
-    if isinstance(cls, Verdict):
-        return cls
 
     snap_leaves = _distinct([subject_leaf, *[ec.leaf_of(n) for n in cand.normalised]])
     snapshots: list[tuple[str, ...]] = []
@@ -552,9 +545,9 @@ def _probe_alias(cand: Candidate, engine: str) -> Verdict:
             return Verdict(
                 "infra_error",
                 "identity",
-                f"constructing {subject_leaf}={_show(value)} raised {type(exc).__name__}: {exc}"[
-                    :200
-                ],
+                _clip(
+                    f"constructing {subject_leaf}={_show(value)} raised {type(exc).__name__}: {exc}"
+                ),
             )
         snapshots.append(tuple(_stable(ec.resolved_value(instance, leaf)) for leaf in snap_leaves))
 
@@ -582,16 +575,13 @@ def _probe_inert(cand: Candidate, engine: str, subjects: list[str]) -> Verdict:
     only if EVERY subject collapses; any subject the engine keeps verbatim is
     unconfirmed (inertness may live at a later grain).
     """
-    try:
-        base = build_identity_base(cand.fields, None)
-    except Unprobeable as exc:
-        return Verdict("unprobeable", "identity", str(exc))
-
     subject_leaves = [ec.leaf_of(s) for s in subjects]
     leaves = _distinct([*[ec.leaf_of(p) for p in cand.fields], *subject_leaves])
-    cls = _resolve_class(cand, engine, leaves)
-    if isinstance(cls, Verdict):
-        return cls
+    try:
+        base = build_identity_base(cand.fields, None)
+        cls = _resolve_class(cand, engine, leaves)
+    except Unprobeable as exc:
+        return Verdict("unprobeable", "identity", str(exc))
 
     try:  # one condition-only construction serves every subject's default read
         default_instance = ec.construct(engine, cls, base, validate=False)
@@ -599,8 +589,10 @@ def _probe_inert(cand: Candidate, engine: str, subjects: list[str]) -> Verdict:
         return Verdict(
             "infra_error",
             "identity",
-            f"constructing the condition base {_show_kwargs(base)} raised "
-            f"{type(exc).__name__}: {exc}"[:200],
+            _clip(
+                f"constructing the condition base {_show_kwargs(base)} raised "
+                f"{type(exc).__name__}: {exc}"
+            ),
         )
 
     notes: list[str] = []
@@ -622,8 +614,10 @@ def _probe_inert(cand: Candidate, engine: str, subjects: list[str]) -> Verdict:
             return Verdict(
                 "infra_error",
                 "identity",
-                f"constructing {leaf}={alt!r} under the condition raised "
-                f"{type(exc).__name__}: {exc}"[:200],
+                _clip(
+                    f"constructing {leaf}={alt!r} under the condition raised "
+                    f"{type(exc).__name__}: {exc}"
+                ),
             )
         resolved = ec.resolved_value(instance, leaf)
         if _stable(resolved) == _stable(default):
@@ -725,6 +719,11 @@ def _distinct(seq: list[Any]) -> list[Any]:
             seen.add(key)
             out.append(item)
     return out
+
+
+def _clip(evidence: str) -> str:
+    """Engine exception text can be enormous; cap it for the transcript."""
+    return evidence[:200]
 
 
 def _show(value: Any) -> str:

--- a/scripts/probe_candidates.py
+++ b/scripts/probe_candidates.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+"""Probe kernel: construction and identity checks for engine-rule candidates.
+
+Tiers 2 and 3 of the verification ladder (tier 1 is ``check_citations.py``).
+Given candidate rules that each claim a severity, this proves the claim against
+the REAL engine and writes a verdict back:
+
+- A ``severity: error`` claim earns a CONSTRUCTION PROBE. We build the offending
+  config inside the engine and require both legs: a violating value must raise,
+  and a satisfying value must construct cleanly. Only then is the error real.
+- A ``severity: dormant`` claim earns an IDENTITY PROBE. We construct the config
+  at two or more distinct declared values for the field and compare the
+  engine-resolved state. Identical resolved state means the declared variation
+  was inert - dormant confirmed. No inference runs, no energy is measured.
+
+Probe values are derived DETERMINISTICALLY from the predicate spec (straddle a
+threshold; a member and a non-member of a set; the declared values an observed
+collision recorded). Nothing is guessed: if a satisfying/violating pair or two
+distinct declared values cannot be derived, the verdict is ``unprobeable``.
+
+Closed verdict vocabulary: ``confirmed`` (claim proven), ``refuted`` (probe
+contradicted the claim), ``unprobeable`` (no deterministic probe exists for this
+claim), ``infra_error`` (a probe leg failed for reasons that do not isolate the
+claim - e.g. the satisfying value also raised, or the engine is not importable
+here). Candidates are never dropped; the verdict plus a short transcript is
+written back so a refuted or unprobeable candidate stays visible.
+
+Runs INSIDE the engine container (imports the live engine via
+``_engine_constructors``); stdlib + PyYAML only. Exit 0 when the run completed
+(whatever the per-candidate verdicts), 2 on a hard error (bad args, unreadable
+candidates file).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _engine_constructors as ec
+
+# Deterministic derivation constants. REF_BASE anchors any field referenced by
+# an @field_ref (and any unnamed constructor arg a cross-field probe needs);
+# the steps straddle a threshold to its firing and satisfying sides.
+REF_BASE = 4
+INT_STEP = 1
+FLOAT_STEP = 0.5
+
+# Derivation sentinels: _OMIT = do not set this field (absent); _DEFAULT = build
+# without the field and read its resolved default (the contrast leg of an
+# aliasing dormancy check).
+_OMIT = object()
+_DEFAULT = object()
+
+_FLAG_KEYS = {"present", "absent"}
+_ENGINES = ("vllm", "tensorrt", "transformers")
+_BUILTIN_VALUES: dict[str, Any] = {"bool": True, "int": 1, "float": 1.0, "str": "x"}
+
+
+class Unprobeable(Exception):
+    """No deterministic probe can be derived for this candidate's claim."""
+
+
+@dataclass
+class Candidate:
+    """A parsed candidate: enough to probe, plus its raw dict for writeback."""
+
+    id: str
+    engine: str | None
+    severity: str | None
+    fields: dict[str, Any]
+    normalised: list[str]
+    source: str | None
+    declared_values: list[Any] | None
+    raw: dict[str, Any]
+
+
+@dataclass
+class Verdict:
+    """The probe outcome for one candidate (status + which probe + transcript)."""
+
+    status: str
+    tier: str | None
+    evidence: str
+
+    def __post_init__(self) -> None:
+        # Engine exception messages are often multi-line; collapse whitespace so
+        # the evidence is one line in both the summary table and the YAML writeback.
+        self.evidence = " ".join(self.evidence.split())
+
+
+@dataclass
+class RunStats:
+    """Per-engine verdict tally surfaced in the summary."""
+
+    counts: dict[str, int] = field(default_factory=dict)
+
+    def record(self, status: str) -> None:
+        self.counts[status] = self.counts.get(status, 0) + 1
+
+
+# ---------------------------------------------------------------------------
+# Predicate-spec value derivation
+# ---------------------------------------------------------------------------
+
+
+def _is_ref(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith("@")
+
+
+def _ref_leaf(value: str) -> str:
+    return value[1:].rsplit(".", 1)[-1]
+
+
+def _iter_refs(spec: Any) -> list[str]:
+    """Every ``@field_ref`` string anywhere inside a predicate spec."""
+    if _is_ref(spec):
+        return [spec]
+    if isinstance(spec, dict):
+        return [r for v in spec.values() for r in _iter_refs(v)]
+    if isinstance(spec, (list, tuple)):
+        return [r for v in spec for r in _iter_refs(v)]
+    return []
+
+
+def _referenced_leaves(fields: dict[str, Any]) -> set[str]:
+    return {_ref_leaf(r) for spec in fields.values() for r in _iter_refs(spec)}
+
+
+def _step(threshold: Any) -> Any:
+    return (
+        INT_STEP if isinstance(threshold, int) and not isinstance(threshold, bool) else FLOAT_STEP
+    )
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, (list, tuple)) else [value]
+
+
+def _bump(value: Any, k: int) -> Any:
+    """A value ``k`` steps away from ``value`` (for distinct !=/threshold probes)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise Unprobeable(f"cannot derive a distinct numeric probe from {value!r}")
+    return value + k * _step(value)
+
+
+def _contrast(value: Any) -> Any:
+    """A value that differs from ``value`` (for the satisfying/nofire leg)."""
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, (int, float)):
+        return value + 1
+    if isinstance(value, str):
+        return value + "_alt"
+    raise Unprobeable(f"cannot derive a contrasting value for {value!r}")
+
+
+def _nonmember(members: list[Any]) -> Any:
+    """A single value outside ``members`` (numeric sets -> max+1, else a sentinel)."""
+    numeric = [m for m in members if isinstance(m, (int, float)) and not isinstance(m, bool)]
+    non_null = [m for m in members if m is not None]
+    if numeric and len(numeric) == len(non_null):
+        return max(numeric) + 1
+    return "__llem_probe_nonmember__"
+
+
+def _two_nonmembers(members: list[Any]) -> list[Any]:
+    numeric = [m for m in members if isinstance(m, (int, float)) and not isinstance(m, bool)]
+    non_null = [m for m in members if m is not None]
+    if numeric and len(numeric) == len(non_null):
+        top = max(numeric)
+        return [top + 1, top + 2]
+    raise Unprobeable("cannot derive two distinct non-members of a non-numeric set")
+
+
+def _first_member(members: list[Any]) -> Any:
+    for m in members:
+        if m is not None:
+            return m
+    raise Unprobeable("membership set has no non-null member to satisfy the claim")
+
+
+def _value_of_type(names: Any) -> Any:
+    for name in _as_list(names):
+        if name in _BUILTIN_VALUES:
+            return _BUILTIN_VALUES[name]
+    raise Unprobeable(f"cannot synthesise an instance of type(s) {names!r}")
+
+
+def _value_not_of_type(names: Any) -> Any:
+    excluded = {str(n) for n in _as_list(names)}
+    for candidate in ("x", 1, 1.0):
+        if type(candidate).__name__ not in excluded:
+            return candidate
+    raise Unprobeable(f"cannot synthesise a value outside type(s) {names!r}")
+
+
+def _substantive_op(spec: dict[str, Any]) -> tuple[str, Any] | None:
+    """The one non-present/absent operator in a spec, or None if flag-only."""
+    ops = [(k, v) for k, v in spec.items() if k not in _FLAG_KEYS]
+    if not ops:
+        return None
+    return ops[0]
+
+
+def _resolve(value: Any, ref_of: Any) -> Any:
+    return ref_of(_ref_leaf(value)) if _is_ref(value) else value
+
+
+def _fire_value(spec: Any, leaf: str, ref_of: Any, referenced: set[str]) -> Any:
+    """A value that makes ``spec`` TRUE (so the engine's validator fires)."""
+    if not isinstance(spec, dict):
+        return spec
+    if spec.get("absent"):
+        return _OMIT
+    op = _substantive_op(spec)
+    if op is None:
+        if spec.get("present"):
+            return REF_BASE if leaf in referenced else True
+        return _OMIT
+    name, raw = op
+    if name == "<":
+        t = _resolve(raw, ref_of)
+        return t - _step(t)
+    if name == "<=":
+        return _resolve(raw, ref_of)
+    if name == ">":
+        t = _resolve(raw, ref_of)
+        return t + _step(t)
+    if name == ">=":
+        return _resolve(raw, ref_of)
+    if name == "==":
+        return raw
+    if name == "!=":
+        return _contrast(_resolve(raw, ref_of))
+    if name == "in":
+        return _first_member(_as_list(raw))
+    if name == "not_in":
+        return _nonmember(_as_list(raw))
+    if name == "type_is":
+        return _value_of_type(raw)
+    if name == "type_is_not":
+        return _value_not_of_type(raw)
+    if name == "divisible_by":
+        return 2 * _resolve(raw, ref_of)
+    if name == "not_divisible_by":
+        return _resolve(raw, ref_of) + 1
+    raise Unprobeable(f"no fire-value rule for operator {name!r}")
+
+
+def _nofire_value(spec: Any, leaf: str, ref_of: Any, referenced: set[str]) -> Any:
+    """A value that makes ``spec`` FALSE (so the engine constructs cleanly)."""
+    if not isinstance(spec, dict):
+        return _contrast(spec)
+    if spec.get("absent"):
+        return REF_BASE if leaf in referenced else True
+    op = _substantive_op(spec)
+    if op is None:
+        if spec.get("present"):
+            return _OMIT
+        return REF_BASE if leaf in referenced else True
+    name, raw = op
+    if name == "<":
+        return _resolve(raw, ref_of)
+    if name == "<=":
+        t = _resolve(raw, ref_of)
+        return t + _step(t)
+    if name == ">":
+        return _resolve(raw, ref_of)
+    if name == ">=":
+        t = _resolve(raw, ref_of)
+        return t - _step(t)
+    if name == "==":
+        return _contrast(raw)
+    if name == "!=":
+        return _resolve(raw, ref_of)
+    if name == "in":
+        return _nonmember(_as_list(raw))
+    if name == "not_in":
+        return _first_member(_as_list(raw))
+    if name == "type_is":
+        return _value_not_of_type(raw)
+    if name == "type_is_not":
+        return _value_of_type(raw)
+    if name == "divisible_by":
+        return _resolve(raw, ref_of) + 1
+    if name == "not_divisible_by":
+        return 2 * _resolve(raw, ref_of)
+    raise Unprobeable(f"no nofire-value rule for operator {name!r}")
+
+
+def _ref_env(fields: dict[str, Any], referenced: set[str]) -> dict[str, Any]:
+    """Numeric fire values of ref-free named fields, to resolve @field_ref."""
+    env: dict[str, Any] = {}
+    for path, spec in fields.items():
+        if _iter_refs(spec):
+            continue
+        try:
+            value = _fire_value(spec, ec.leaf_of(path), lambda _leaf: REF_BASE, referenced)
+        except Unprobeable:
+            continue
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            env[ec.leaf_of(path)] = value
+    return env
+
+
+def _ref_of(fields: dict[str, Any], referenced: set[str]) -> Any:
+    env = _ref_env(fields, referenced)
+    return lambda leaf: env.get(leaf, REF_BASE)
+
+
+# ---------------------------------------------------------------------------
+# Construction probe (severity: error)
+# ---------------------------------------------------------------------------
+
+
+def build_construction_kwargs(fields: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], str]:
+    """Violating and satisfying kwargs for a construction probe.
+
+    Violating sets every constrained field to its firing value; satisfying flips
+    the last (subject) field to a value that does not fire, holding the rest.
+    Fields referenced by an ``@field_ref`` but not named are scaffolded to
+    :data:`REF_BASE` so the cross-field comparison has both operands.
+    """
+    referenced = _referenced_leaves(fields)
+    ref_of = _ref_of(fields, referenced)
+    named = {ec.leaf_of(p) for p in fields}
+    subject_path = list(fields)[-1]
+    subject_leaf = ec.leaf_of(subject_path)
+
+    violating: dict[str, Any] = {}
+    for path, spec in fields.items():
+        value = _fire_value(spec, ec.leaf_of(path), ref_of, referenced)
+        if value is not _OMIT:
+            violating[ec.leaf_of(path)] = value
+    for rleaf in referenced:
+        if rleaf not in named and rleaf not in violating:
+            violating[rleaf] = ref_of(rleaf)
+
+    nofire = _nofire_value(fields[subject_path], subject_leaf, ref_of, referenced)
+    satisfying = dict(violating)
+    if nofire is _OMIT:
+        satisfying.pop(subject_leaf, None)
+    else:
+        satisfying[subject_leaf] = nofire
+    return violating, satisfying, subject_leaf
+
+
+def _pick_class(classes: list[type], leaves: list[str]) -> type | None:
+    for cls in classes:
+        if all(ec.accepts(cls, leaf) for leaf in leaves):
+            return cls
+    return None
+
+
+def _run_leg(engine: str, cls: type, kwargs: dict[str, Any]) -> str | None:
+    """Construct one leg; return None if it built cleanly, else the exception."""
+    try:
+        ec.construct(engine, cls, kwargs, validate=True)
+        return None
+    except Exception as exc:
+        return f"{type(exc).__name__}: {exc}"[:200]
+
+
+def probe_construction(cand: Candidate, engine: str) -> Verdict:
+    try:
+        violating, satisfying, _ = build_construction_kwargs(cand.fields)
+    except Unprobeable as exc:
+        return Verdict("unprobeable", "construction", str(exc))
+
+    leaves = [ec.leaf_of(p) for p in cand.fields]
+    try:
+        classes = ec.candidate_classes(engine, next(iter(cand.fields)), leaves)
+    except ec.ConstructorResolutionError as exc:
+        return Verdict("unprobeable", "construction", str(exc))
+    cls = _pick_class(classes, leaves)
+    if cls is None:
+        return Verdict("unprobeable", "construction", f"no constructor accepts fields {leaves}")
+
+    positive = _run_leg(engine, cls, violating)
+    negative = _run_leg(engine, cls, satisfying)
+    v_show, s_show = _show_kwargs(violating), _show_kwargs(satisfying)
+    if positive and not negative:
+        return Verdict(
+            "confirmed",
+            "construction",
+            f"violating {v_show} raised {positive}; satisfying {s_show} constructed",
+        )
+    if not positive:
+        return Verdict(
+            "refuted",
+            "construction",
+            f"violating {v_show} constructed cleanly - offending value accepted",
+        )
+    return Verdict(
+        "infra_error",
+        "construction",
+        f"satisfying {s_show} also raised ({negative}); cannot isolate the claim (violating raised {positive})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity probe (severity: dormant)
+# ---------------------------------------------------------------------------
+
+
+def identity_values(cand: Candidate, subject_path: str) -> list[Any]:
+    """Two or more distinct declared values for the dormant field under test."""
+    if cand.source == "observed_collision" and cand.declared_values:
+        values = _distinct([_DEFAULT if v == "<absent>" else v for v in cand.declared_values])
+        if len(values) >= 2:
+            return values
+        raise Unprobeable(
+            "observed-collision candidate has fewer than two distinct declared values"
+        )
+
+    spec = cand.fields[subject_path]
+    if not isinstance(spec, dict):
+        return [spec, _DEFAULT]
+    op = _substantive_op(spec)
+    if op is None:
+        raise Unprobeable(
+            f"present/absent-only dormant field {subject_path!r} has no declared values to compare"
+        )
+    name, raw = op
+    ref_of = _ref_of(cand.fields, _referenced_leaves(cand.fields))
+    if name == "in":
+        members = _distinct(_as_list(raw))
+        if len(members) >= 2:
+            return members
+        raise Unprobeable("membership set has fewer than two members")
+    if name == "not_in":
+        return _two_nonmembers(_as_list(raw))
+    if name == "!=":
+        return [_bump(_resolve(raw, ref_of), 1), _bump(_resolve(raw, ref_of), 2)]
+    if name == "==":
+        return [raw, _DEFAULT]
+    if name in ("<", "<=", ">", ">="):
+        t = _resolve(raw, ref_of)
+        s = _step(t)
+        return {
+            "<": [t - s, t - 2 * s],
+            "<=": [t, t - s],
+            ">": [t + s, t + 2 * s],
+            ">=": [t, t + s],
+        }[name]
+    raise Unprobeable(f"cannot derive identity values for operator {name!r}")
+
+
+def build_identity_base(fields: dict[str, Any], subject_path: str) -> dict[str, Any]:
+    """Kwargs for every field except the subject, held at firing values."""
+    referenced = _referenced_leaves(fields)
+    ref_of = _ref_of(fields, referenced)
+    named = {ec.leaf_of(p) for p in fields}
+    base: dict[str, Any] = {}
+    for path, spec in fields.items():
+        if path == subject_path:
+            continue
+        value = _fire_value(spec, ec.leaf_of(path), ref_of, referenced)
+        if value is not _OMIT:
+            base[ec.leaf_of(path)] = value
+    for rleaf in referenced:
+        if rleaf not in named and rleaf not in base:
+            base[rleaf] = ref_of(rleaf)
+    return base
+
+
+def probe_identity(cand: Candidate, engine: str) -> Verdict:
+    subject_path = list(cand.fields)[-1]
+    try:
+        values = identity_values(cand, subject_path)
+        base = build_identity_base(cand.fields, subject_path)
+    except Unprobeable as exc:
+        return Verdict("unprobeable", "identity", str(exc))
+
+    subject_leaf = ec.leaf_of(subject_path)
+    leaves = [ec.leaf_of(p) for p in cand.fields]
+    try:
+        classes = ec.candidate_classes(engine, next(iter(cand.fields)), leaves)
+    except ec.ConstructorResolutionError as exc:
+        return Verdict("unprobeable", "identity", str(exc))
+    cls = _pick_class(classes, leaves)
+    if cls is None:
+        return Verdict("unprobeable", "identity", f"no constructor accepts fields {leaves}")
+
+    snap_leaves = _distinct([subject_leaf, *cand.normalised])
+    snapshots: list[tuple[str, ...]] = []
+    for value in values:
+        kwargs = dict(base)
+        if value is _DEFAULT:
+            kwargs.pop(subject_leaf, None)
+        else:
+            kwargs[subject_leaf] = value
+        try:
+            instance = ec.construct(engine, cls, kwargs, validate=False)
+        except Exception as exc:
+            return Verdict(
+                "infra_error",
+                "identity",
+                f"constructing {subject_leaf}={_show(value)} raised {type(exc).__name__}: {exc}"[
+                    :200
+                ],
+            )
+        snapshots.append(tuple(_stable(ec.resolved_value(instance, leaf)) for leaf in snap_leaves))
+
+    shown = [_show(v) for v in values]
+    if len(set(snapshots)) == 1:
+        return Verdict(
+            "confirmed",
+            "identity",
+            f"{subject_leaf} over {shown} -> resolved {list(snapshots[0])} identical",
+        )
+    return Verdict(
+        "refuted", "identity", f"{subject_leaf} over {shown} -> resolved states differ {snapshots}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch + candidate parsing
+# ---------------------------------------------------------------------------
+
+
+def probe_candidate(cand: Candidate, engine: str, engine_ready: bool) -> Verdict:
+    tier = (
+        "construction"
+        if cand.severity == "error"
+        else "identity"
+        if cand.severity == "dormant"
+        else None
+    )
+    if cand.severity not in ("error", "dormant"):
+        return Verdict(
+            "unprobeable",
+            tier,
+            f"severity {cand.severity!r} is not in the closed set {{error, dormant}}",
+        )
+    if not cand.fields:
+        return Verdict("unprobeable", tier, "candidate has no match.fields to probe")
+    if not engine_ready:
+        return Verdict(
+            "infra_error", tier, f"engine {engine!r} is not importable in this container"
+        )
+    if cand.severity == "error":
+        return probe_construction(cand, engine)
+    return probe_identity(cand, engine)
+
+
+def parse_candidate(raw: Any, index: int) -> Candidate:
+    """Lenient parse of a candidate/rule dict (probing tolerates thin entries)."""
+    if not isinstance(raw, dict):
+        raise Unprobeable(f"entry #{index} is not a mapping")
+    match = raw.get("match")
+    fields = match.get("fields") if isinstance(match, dict) else None
+    provenance = raw.get("provenance") if isinstance(raw.get("provenance"), dict) else {}
+    return Candidate(
+        id=str(raw.get("id") or f"#{index}"),
+        engine=raw.get("engine"),
+        severity=raw.get("severity"),
+        fields=dict(fields) if isinstance(fields, dict) else {},
+        normalised=list(raw.get("normalised_fields") or []),
+        source=provenance.get("source"),
+        declared_values=provenance.get("declared_values"),
+        raw=raw,
+    )
+
+
+def load_document(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Load a candidates/rules YAML; return (document, raw-entry list).
+
+    Accepts either a ``candidates`` (pool) or ``rules`` (shipped corpus) list.
+    """
+    document = yaml.safe_load(path.read_text())
+    if not isinstance(document, dict):
+        raise ValueError(f"{path}: top level must be a mapping")
+    entries = document.get("candidates")
+    if entries is None:
+        entries = document.get("rules")
+    if not isinstance(entries, list):
+        raise ValueError(f"{path}: expected a 'candidates' or 'rules' list")
+    return document, entries
+
+
+# ---------------------------------------------------------------------------
+# Rendering + writeback
+# ---------------------------------------------------------------------------
+
+
+def _distinct(seq: list[Any]) -> list[Any]:
+    out: list[Any] = []
+    seen: set[str] = set()
+    for item in seq:
+        key = repr(item)
+        if key not in seen:
+            seen.add(key)
+            out.append(item)
+    return out
+
+
+def _show(value: Any) -> str:
+    if value is _DEFAULT:
+        return "<default>"
+    if value is _OMIT:
+        return "<omit>"
+    return repr(value)
+
+
+def _show_kwargs(kwargs: dict[str, Any]) -> str:
+    return "{" + ", ".join(f"{k}={v!r}" for k, v in kwargs.items()) + "}"
+
+
+def _stable(value: Any) -> str:
+    if value is ec.MISSING:
+        return "<missing>"
+    try:
+        return repr(value)
+    except Exception:
+        return object.__repr__(value)
+
+
+def write_verdicts(
+    document: dict[str, Any],
+    entries: list[dict[str, Any]],
+    verdicts: list[Verdict],
+    run_date: str,
+    out_path: Path,
+) -> None:
+    for raw, verdict in zip(entries, verdicts, strict=True):
+        raw["verdict"] = {
+            "status": verdict.status,
+            "tier": verdict.tier,
+            "date": run_date,
+            "evidence": verdict.evidence,
+        }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(yaml.safe_dump(document, sort_keys=False, default_flow_style=False))
+
+
+def print_summary(rows: list[tuple[str, Verdict]], stats: RunStats) -> None:
+    id_width = max((len(cid) for cid, _ in rows), default=2)
+    id_width = min(max(id_width, 2), 60)
+    print(f"{'id':<{id_width}}  {'tier':<12}  {'verdict':<12}  evidence")
+    print(f"{'-' * id_width}  {'-' * 12}  {'-' * 12}  {'-' * 40}")
+    for cid, verdict in rows:
+        evidence = (
+            verdict.evidence if len(verdict.evidence) <= 100 else verdict.evidence[:97] + "..."
+        )
+        print(f"{cid:<{id_width}}  {verdict.tier or '-':<12}  {verdict.status:<12}  {evidence}")
+    tally = ", ".join(f"{status}={count}" for status, count in sorted(stats.counts.items()))
+    print(f"\n{len(rows)} candidate(s): {tally}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Construction/identity probe kernel for engine-rule candidates."
+    )
+    parser.add_argument(
+        "--engine", required=True, choices=_ENGINES, help="Engine whose container this runs in."
+    )
+    parser.add_argument(
+        "--candidates", required=True, nargs="+", type=Path, help="Candidate/rule YAML file(s)."
+    )
+    parser.add_argument(
+        "--out", type=Path, help="Write verdicts here (default: in place). One input only."
+    )
+    parser.add_argument(
+        "--date",
+        help="Verdict date (default: $LLEM_PROBE_DATE or today, for reproducible writeback).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.out and len(args.candidates) > 1:
+        parser.error("--out accepts a single --candidates file; run per file otherwise")
+    run_date = args.date or os.environ.get("LLEM_PROBE_DATE") or date.today().isoformat()
+
+    engine_ready = ec.engine_importable(args.engine)
+    all_rows: list[tuple[str, Verdict]] = []
+    stats = RunStats()
+    for candidates_path in args.candidates:
+        try:
+            document, entries = load_document(candidates_path)
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        verdicts: list[Verdict] = []
+        for index, raw in enumerate(entries):
+            try:
+                cand = parse_candidate(raw, index)
+            except Unprobeable as exc:
+                verdicts.append(Verdict("unprobeable", None, str(exc)))
+                continue
+            verdict = probe_candidate(cand, args.engine, engine_ready)
+            verdicts.append(verdict)
+            all_rows.append((cand.id, verdict))
+        for verdict in verdicts:
+            stats.record(verdict.status)
+        write_verdicts(document, entries, verdicts, run_date, args.out or candidates_path)
+
+    print_summary(all_rows, stats)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_candidates.py
+++ b/scripts/probe_candidates.py
@@ -7,23 +7,37 @@ the REAL engine and writes a verdict back:
 
 - A ``severity: error`` claim earns a CONSTRUCTION PROBE. We build the offending
   config inside the engine and require both legs: a violating value must raise,
-  and a satisfying value must construct cleanly. Only then is the error real.
-- A ``severity: dormant`` claim earns an IDENTITY PROBE. We construct the config
-  at two or more distinct declared values for the field and compare the
-  engine-resolved state. Identical resolved state means the declared variation
-  was inert - dormant confirmed. No inference runs, no energy is measured.
+  and a satisfying value must construct cleanly. Only then is the error
+  confirmed at this grain.
+- A ``severity: dormant`` claim earns an IDENTITY PROBE, which has two shapes.
+  Value-alias (the match field itself is the normalised subject): construct at
+  two or more distinct declared values and compare the engine-resolved state -
+  identical resolved state confirms the declared variation was inert.
+  Condition-inert (``normalised_fields`` name fields OUTSIDE ``match.fields``):
+  hold every match field at its firing value so the condition is satisfied,
+  then vary each named field against its engine-resolved default - if the
+  engine rewrites every one back to its default, the dormancy is confirmed.
+  No inference runs, no energy is measured.
 
 Probe values are derived DETERMINISTICALLY from the predicate spec (straddle a
 threshold; a member and a non-member of a set; the declared values an observed
-collision recorded). Nothing is guessed: if a satisfying/violating pair or two
-distinct declared values cannot be derived, the verdict is ``unprobeable``.
+collision recorded; an engine-resolved default and its contrast). Nothing is
+guessed: if a satisfying/violating pair or two distinct values cannot be
+derived, the verdict is ``unprobeable``.
 
-Closed verdict vocabulary: ``confirmed`` (claim proven), ``refuted`` (probe
-contradicted the claim), ``unprobeable`` (no deterministic probe exists for this
+Closed verdict vocabulary: ``confirmed`` (the probe proved the claim at
+construction grain), ``unconfirmed`` (the probe RAN, but the construction-grain
+observation neither proves nor disproves the claim - e.g. the violating value
+constructed cleanly because the engine validates at init or generation time),
+``unprobeable`` (no deterministic probe could be derived or run for this
 claim), ``infra_error`` (a probe leg failed for reasons that do not isolate the
 claim - e.g. the satisfying value also raised, or the engine is not importable
-here). Candidates are never dropped; the verdict plus a short transcript is
-written back so a refuted or unprobeable candidate stays visible.
+here). Candidates start ``unverified`` and are never dropped; the verdict plus
+a short transcript is written back so an unconfirmed or unprobeable candidate
+stays visible. There is deliberately NO ``refuted``: a claim is minted at the
+grain where the engine acts (init, generation, the runtime), and pure config
+construction can never prove the engine accepts a config end-to-end, so no
+honest earner of ``refuted`` exists at this tier.
 
 Runs INSIDE the engine container (imports the live engine via
 ``_engine_constructors``); stdlib + PyYAML only. Exit 0 when the run completed
@@ -237,7 +251,7 @@ def _fire_value(spec: Any, leaf: str, ref_of: Any, referenced: set[str]) -> Any:
     if name == ">=":
         return _resolve(raw, ref_of)
     if name == "==":
-        return raw
+        return _resolve(raw, ref_of)
     if name == "!=":
         return _contrast(_resolve(raw, ref_of))
     if name == "in":
@@ -278,7 +292,7 @@ def _nofire_value(spec: Any, leaf: str, ref_of: Any, referenced: set[str]) -> An
         t = _resolve(raw, ref_of)
         return t - _step(t)
     if name == "==":
-        return _contrast(raw)
+        return _contrast(_resolve(raw, ref_of))
     if name == "!=":
         return _resolve(raw, ref_of)
     if name == "in":
@@ -395,9 +409,10 @@ def probe_construction(cand: Candidate, engine: str) -> Verdict:
         )
     if not positive:
         return Verdict(
-            "refuted",
+            "unconfirmed",
             "construction",
-            f"violating {v_show} constructed cleanly - offending value accepted",
+            f"violating {v_show} constructed cleanly at construction grain; "
+            "validation may fire at engine init or generation",
         )
     return Verdict(
         "infra_error",
@@ -441,7 +456,7 @@ def identity_values(cand: Candidate, subject_path: str) -> list[Any]:
     if name == "!=":
         return [_bump(_resolve(raw, ref_of), 1), _bump(_resolve(raw, ref_of), 2)]
     if name == "==":
-        return [raw, _DEFAULT]
+        return [_resolve(raw, ref_of), _DEFAULT]
     if name in ("<", "<=", ">", ">="):
         t = _resolve(raw, ref_of)
         s = _step(t)
@@ -454,8 +469,13 @@ def identity_values(cand: Candidate, subject_path: str) -> list[Any]:
     raise Unprobeable(f"cannot derive identity values for operator {name!r}")
 
 
-def build_identity_base(fields: dict[str, Any], subject_path: str) -> dict[str, Any]:
-    """Kwargs for every field except the subject, held at firing values."""
+def build_identity_base(fields: dict[str, Any], subject_path: str | None) -> dict[str, Any]:
+    """Kwargs holding every field (except the subject, if any) at firing values.
+
+    ``subject_path=None`` keeps all match fields: the condition-inert shape
+    varies fields OUTSIDE ``match.fields``, so the whole match is the held
+    condition.
+    """
     referenced = _referenced_leaves(fields)
     ref_of = _ref_of(fields, referenced)
     named = {ec.leaf_of(p) for p in fields}
@@ -472,7 +492,39 @@ def build_identity_base(fields: dict[str, Any], subject_path: str) -> dict[str, 
     return base
 
 
+def _inert_subjects(cand: Candidate) -> list[str]:
+    """Normalised fields outside ``match.fields``: the condition-inert subjects.
+
+    Value-alias rules normalise the match field itself, so this is empty and the
+    last match field stays the subject. A field that is both normalised and
+    matched belongs to the held condition, so it is never varied here.
+    """
+    match_leaves = {ec.leaf_of(p) for p in cand.fields}
+    return [n for n in cand.normalised if ec.leaf_of(n) not in match_leaves]
+
+
+def _resolve_class(cand: Candidate, engine: str, leaves: list[str]) -> type | Verdict:
+    """The first constructor class accepting ``leaves``, or an unprobeable Verdict."""
+    try:
+        classes = ec.candidate_classes(engine, next(iter(cand.fields)), leaves)
+    except ec.ConstructorResolutionError as exc:
+        return Verdict("unprobeable", "identity", str(exc))
+    cls = _pick_class(classes, leaves)
+    if cls is None:
+        return Verdict("unprobeable", "identity", f"no constructor accepts fields {leaves}")
+    return cls
+
+
 def probe_identity(cand: Candidate, engine: str) -> Verdict:
+    is_collision = cand.source == "observed_collision" and bool(cand.declared_values)
+    subjects = [] if is_collision else _inert_subjects(cand)
+    if subjects:
+        return _probe_inert(cand, engine, subjects)
+    return _probe_alias(cand, engine)
+
+
+def _probe_alias(cand: Candidate, engine: str) -> Verdict:
+    """Value-alias dormancy: the (last) match field itself over declared values."""
     subject_path = list(cand.fields)[-1]
     try:
         values = identity_values(cand, subject_path)
@@ -482,15 +534,11 @@ def probe_identity(cand: Candidate, engine: str) -> Verdict:
 
     subject_leaf = ec.leaf_of(subject_path)
     leaves = [ec.leaf_of(p) for p in cand.fields]
-    try:
-        classes = ec.candidate_classes(engine, next(iter(cand.fields)), leaves)
-    except ec.ConstructorResolutionError as exc:
-        return Verdict("unprobeable", "identity", str(exc))
-    cls = _pick_class(classes, leaves)
-    if cls is None:
-        return Verdict("unprobeable", "identity", f"no constructor accepts fields {leaves}")
+    cls = _resolve_class(cand, engine, leaves)
+    if isinstance(cls, Verdict):
+        return cls
 
-    snap_leaves = _distinct([subject_leaf, *cand.normalised])
+    snap_leaves = _distinct([subject_leaf, *[ec.leaf_of(n) for n in cand.normalised]])
     snapshots: list[tuple[str, ...]] = []
     for value in values:
         kwargs = dict(base)
@@ -518,7 +566,83 @@ def probe_identity(cand: Candidate, engine: str) -> Verdict:
             f"{subject_leaf} over {shown} -> resolved {list(snapshots[0])} identical",
         )
     return Verdict(
-        "refuted", "identity", f"{subject_leaf} over {shown} -> resolved states differ {snapshots}"
+        "unconfirmed",
+        "identity",
+        f"{subject_leaf} over {shown} -> construction-grain resolved states differ {snapshots}; "
+        "identity may still hold at engine init grain",
+    )
+
+
+def _probe_inert(cand: Candidate, engine: str, subjects: list[str]) -> Verdict:
+    """Condition-inert dormancy: hold the match, vary each normalised field.
+
+    Each subject is probed independently (the others stay omitted, i.e. at
+    default) against its engine-resolved default D: set contrast(D) under the
+    condition and check whether the engine rewrites it back to D. Confirmed
+    only if EVERY subject collapses; any subject the engine keeps verbatim is
+    unconfirmed (inertness may live at a later grain).
+    """
+    try:
+        base = build_identity_base(cand.fields, None)
+    except Unprobeable as exc:
+        return Verdict("unprobeable", "identity", str(exc))
+
+    subject_leaves = [ec.leaf_of(s) for s in subjects]
+    leaves = _distinct([*[ec.leaf_of(p) for p in cand.fields], *subject_leaves])
+    cls = _resolve_class(cand, engine, leaves)
+    if isinstance(cls, Verdict):
+        return cls
+
+    try:  # one condition-only construction serves every subject's default read
+        default_instance = ec.construct(engine, cls, base, validate=False)
+    except Exception as exc:
+        return Verdict(
+            "infra_error",
+            "identity",
+            f"constructing the condition base {_show_kwargs(base)} raised "
+            f"{type(exc).__name__}: {exc}"[:200],
+        )
+
+    notes: list[str] = []
+    underivable: list[str] = []
+    kept = False
+    for leaf in subject_leaves:
+        default = ec.resolved_value(default_instance, leaf)
+        if default is ec.MISSING:
+            underivable.append(f"{leaf}: no engine-resolved default to contrast against")
+            continue
+        try:
+            alt = _contrast(default)
+        except Unprobeable as exc:
+            underivable.append(f"{leaf}: {exc}")
+            continue
+        try:
+            instance = ec.construct(engine, cls, {**base, leaf: alt}, validate=False)
+        except Exception as exc:
+            return Verdict(
+                "infra_error",
+                "identity",
+                f"constructing {leaf}={alt!r} under the condition raised "
+                f"{type(exc).__name__}: {exc}"[:200],
+            )
+        resolved = ec.resolved_value(instance, leaf)
+        if _stable(resolved) == _stable(default):
+            notes.append(f"{leaf}: {alt!r} -> {_stable(default)} (collapsed to default)")
+        else:
+            kept = True
+            notes.append(f"{leaf}: kept {_stable(resolved)} vs default {_stable(default)}")
+    detail = "; ".join([*notes, *underivable])
+    if kept:
+        return Verdict(
+            "unconfirmed",
+            "identity",
+            f"constructor keeps declared values under the condition ({detail}); "
+            "inertness may hold at a later grain",
+        )
+    if underivable:
+        return Verdict("unprobeable", "identity", detail)
+    return Verdict(
+        "confirmed", "identity", f"condition held; every inert field collapsed ({detail})"
     )
 
 
@@ -632,6 +756,8 @@ def write_verdicts(
     out_path: Path,
 ) -> None:
     for raw, verdict in zip(entries, verdicts, strict=True):
+        if not isinstance(raw, dict):  # unparseable entry: verdict lives in the summary only
+            continue
         raw["verdict"] = {
             "status": verdict.status,
             "tier": verdict.tier,
@@ -698,7 +824,9 @@ def main(argv: list[str] | None = None) -> int:
             try:
                 cand = parse_candidate(raw, index)
             except Unprobeable as exc:
-                verdicts.append(Verdict("unprobeable", None, str(exc)))
+                verdict = Verdict("unprobeable", None, str(exc))
+                verdicts.append(verdict)
+                all_rows.append((f"#{index}", verdict))
                 continue
             verdict = probe_candidate(cand, args.engine, engine_ready)
             verdicts.append(verdict)

--- a/scripts/probe_candidates.sh
+++ b/scripts/probe_candidates.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Run the probe kernel (scripts/probe_candidates.py) inside the engine's Docker
+# image, so construction/identity probes execute against the real engine.
+#
+# Usage: ./scripts/probe_candidates.sh {transformers|vllm|tensorrt} [KERNEL ARGS...]
+#   e.g. ./scripts/probe_candidates.sh vllm \
+#            --candidates src/llenergymeasure/engines/vllm/rules.yaml \
+#            --out /tmp/verdicts.yaml
+#
+# Everything after the engine is forwarded verbatim to the kernel, resolved
+# against /repo (the mounted repo root, which is the container working dir).
+#
+# Image selection matches the CI engine cells: the pinned version is read from
+# engine_versions/<engine>/current.yaml (the Renovate-writable SSOT), then
+#   vllm         -> pristine vllm/vllm-openai:v<version>
+#   tensorrt     -> pristine nvcr.io/nvidia/tensorrt-llm/release:<version>
+#   transformers -> llenergymeasure:transformers-<version> (built locally if absent)
+# tensorrt binds CUDA at import, so it keeps the NVIDIA entrypoint and is pinned
+# to GPUs 1-3 (device 0 stays free); vllm/transformers need no GPU to construct
+# config objects.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/probe_candidates.sh {transformers|vllm|tensorrt} [KERNEL ARGS...]
+
+Pulls or builds the engine image, then runs scripts/probe_candidates.py inside
+it. Kernel args (--candidates, --out, --date) are forwarded verbatim.
+EOF
+}
+
+if [[ $# -lt 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+    usage >&2
+    exit 1
+fi
+
+ENGINE="$1"
+shift
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Pinned engine version from the per-engine SSOT (same locus the CI cells read).
+_pinned_version() {
+    yq '.library.current_version' "$REPO_ROOT/engine_versions/$1/current.yaml"
+}
+
+# docker pull only when the image is not already cached: gate the remote call
+# on a local inspect (project convention for docker pull guards).
+_ensure_pulled() {
+    if ! docker image inspect "$1" >/dev/null 2>&1; then
+        echo "[$ENGINE] Pulling $1..." >&2
+        docker pull "$1"
+    fi
+}
+
+VER="$(_pinned_version "$ENGINE")"
+if [[ -z "$VER" || "$VER" == "null" ]]; then
+    echo "Could not resolve $ENGINE version from engine_versions/$ENGINE/current.yaml" >&2
+    exit 1
+fi
+
+case "$ENGINE" in
+    transformers)
+        IMAGE="llenergymeasure:transformers-${VER}"
+        if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "[$ENGINE] Image $IMAGE not found; building from docker/Dockerfile.transformers..." >&2
+            docker build --build-arg "TRANSFORMERS_VERSION=${VER}" \
+                -f "$REPO_ROOT/docker/Dockerfile.transformers" -t "$IMAGE" "$REPO_ROOT"
+        fi
+        ;;
+    vllm)
+        IMAGE="vllm/vllm-openai:v${VER}"
+        _ensure_pulled "$IMAGE"
+        ;;
+    tensorrt)
+        IMAGE="nvcr.io/nvidia/tensorrt-llm/release:${VER}"
+        _ensure_pulled "$IMAGE"
+        ;;
+    *)
+        echo "Unknown engine: $ENGINE" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+# --user maps the host uid, which has no /etc/passwd entry in the image; torch
+# calls getpass.getuser() at import and raises "uid not found" without USER set.
+# HOME=/tmp keeps any torch/HF cache writes on a writable ephemeral path.
+DOCKER_ARGS=(
+    --rm --user "$(id -u):$(id -g)"
+    -e HOME=/tmp -e USER=llem-probe
+    -v "$REPO_ROOT:/repo" -w /repo
+)
+
+echo "[$ENGINE] Running probe_candidates.py inside $IMAGE..." >&2
+if [[ "$ENGINE" == "tensorrt" ]]; then
+    # Keep the NVIDIA entrypoint (it sets up the CUDA env before exec); pin GPUs 1-3.
+    docker run "${DOCKER_ARGS[@]}" --gpus '"device=1,2,3"' "$IMAGE" \
+        python3 scripts/probe_candidates.py --engine "$ENGINE" "$@"
+else
+    docker run "${DOCKER_ARGS[@]}" --entrypoint python3 "$IMAGE" \
+        scripts/probe_candidates.py --engine "$ENGINE" "$@"
+fi

--- a/tests/unit/scripts/test_check_citations.py
+++ b/tests/unit/scripts/test_check_citations.py
@@ -141,7 +141,32 @@ def test_cross_field_ref_token_entailed(tmp_path: Path) -> None:
     assert verdict.ok
 
 
-def test_malformed_candidate_raises_loudly(tmp_path: Path) -> None:
+def test_word_boundary_kills_substring_false_positive(tmp_path: Path) -> None:
+    # The field leaf 'max_tokens' must NOT be counted present just because a
+    # different identifier 'max_tokens_per_batch' appears in the span.
+    (tmp_path / "engine.py").write_text("if max_tokens_per_batch < 1:\n    raise ValueError\n")
+    cand = _cand(
+        {"vllm.engine_params.max_tokens": {"<": 1}},
+        (1, 2),
+        quote="if max_tokens_per_batch < 1:\n    raise ValueError",
+    )
+    verdict = check_candidate(cand, tmp_path)
+    assert not verdict.ok
+    assert verdict.reason == "constrained field 'max_tokens' not present in cited span"
+
+
+def test_word_boundary_accepts_standalone_identifier(tmp_path: Path) -> None:
+    (tmp_path / "engine.py").write_text("if max_tokens < 1:\n    raise ValueError\n")
+    cand = _cand(
+        {"vllm.engine_params.max_tokens": {"<": 1}},
+        (1, 2),
+        quote="if max_tokens < 1:\n    raise ValueError",
+    )
+    assert check_candidate(cand, tmp_path).ok
+
+
+def test_malformed_citation_raises_loudly(tmp_path: Path) -> None:
+    # A citation block that is PRESENT but missing its file is a schema error.
     path = tmp_path / "candidates.yaml"
     path.write_text(
         "schema_version: 1.0.0\n"
@@ -149,10 +174,38 @@ def test_malformed_candidate_raises_loudly(tmp_path: Path) -> None:
         "- id: broken\n"
         "  match:\n"
         "    fields:\n"
-        "      vllm.x.y: {'<': 1}\n"  # citation block omitted entirely
+        "      vllm.x.y: {'<': 1}\n"
+        "  citation:\n"
+        "    lines: [1, 2]\n"
+        "    quote: something\n"
     )
-    with pytest.raises(CandidateSchemaError, match=r"'broken'.*citation"):
+    with pytest.raises(CandidateSchemaError, match=r"'broken'.*file"):
         load_candidates(path)
+
+
+def test_uncited_candidate_is_skipped_not_failed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # An observed-collision proposal has no citation key: skipped, counted, exit 0.
+    root = _src_root(tmp_path)
+    path = tmp_path / "candidates.yaml"
+    path.write_text(
+        "schema_version: 1.0.0\n"
+        "candidates:\n"
+        "- id: collision1\n"
+        "  match:\n"
+        "    fields:\n"
+        "      vllm.engine_params.enforce_eager: {present: true}\n"
+    )
+    parsed = load_candidates(path)
+    assert parsed[0].citation is None
+
+    code = main([str(path), "--source-root", str(root)])
+    assert code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["checked"] == 0
+    assert report["skipped_uncited"] == 1
+    assert report["skipped_ids"] == ["collision1"]
 
 
 def test_missing_candidates_list_raises(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_mine_observed_collisions.py
+++ b/tests/unit/scripts/test_mine_observed_collisions.py
@@ -16,6 +16,13 @@ if str(_PROJECT_ROOT) not in sys.path:
 from scripts import mine_observed_collisions as miner  # noqa: E402
 
 
+def _only_field(candidate: dict[str, Any]) -> str:
+    """The single canonical field path a collision candidate constrains."""
+    fields = list(candidate["match"]["fields"])
+    assert len(fields) == 1
+    return fields[0]
+
+
 def _declared(eager: bool, seed: int | None = None) -> dict[str, Any]:
     """A small declared ExperimentConfig varying enforce_eager (and maybe seed)."""
     cfg: dict[str, Any] = {"engine": "vllm", "vllm": {"engine_params": {"enforce_eager": eager}}}
@@ -57,12 +64,13 @@ def test_clean_two_way_collision_names_the_field(tmp_path: Path) -> None:
     assert stats.collision_groups == 1
     assert len(candidates) == 1
     candidate = candidates[0]
-    assert candidate["fields"] == ["vllm.engine_params.enforce_eager"]
+    assert _only_field(candidate) == "vllm.engine_params.enforce_eager"
+    assert candidate["match"]["fields"]["vllm.engine_params.enforce_eager"] == {"present": True}
     assert candidate["severity"] == "dormant"
-    assert candidate["co_occurring_fields"] == []
-    assert candidate["verdict"] == "unverified"
+    assert candidate["verdict"]["status"] == "unverified"
     prov = candidate["provenance"]
     assert prov["source"] == "observed_collision"
+    assert prov["co_occurring_fields"] == []
     assert prov["colliding_experiments"] == ["001_exp", "002_exp"]
     assert sorted(prov["declared_values"], key=str) == [False, True]
 
@@ -86,10 +94,14 @@ def test_multi_field_diff_flags_co_occurrence(tmp_path: Path) -> None:
     candidates, stats = _mine(tmp_path)
 
     assert stats.collision_groups == 1
-    by_field = {c["fields"][0]: c for c in candidates}
+    by_field = {_only_field(c): c for c in candidates}
     assert set(by_field) == {"task.seed", "vllm.engine_params.enforce_eager"}
-    assert by_field["task.seed"]["co_occurring_fields"] == ["vllm.engine_params.enforce_eager"]
-    assert by_field["vllm.engine_params.enforce_eager"]["co_occurring_fields"] == ["task.seed"]
+    assert by_field["task.seed"]["provenance"]["co_occurring_fields"] == [
+        "vllm.engine_params.enforce_eager"
+    ]
+    assert by_field["vllm.engine_params.enforce_eager"]["provenance"]["co_occurring_fields"] == [
+        "task.seed"
+    ]
 
 
 def test_identical_declared_configs_are_not_a_collision(tmp_path: Path) -> None:
@@ -125,7 +137,7 @@ def test_group_of_three_with_single_varying_field(tmp_path: Path) -> None:
 
     assert stats.collision_groups == 1
     assert len(candidates) == 1
-    assert candidates[0]["fields"] == ["vllm.engine_params.enforce_eager"]
+    assert _only_field(candidates[0]) == "vllm.engine_params.enforce_eager"
     assert len(candidates[0]["provenance"]["colliding_experiments"]) == 3
 
 

--- a/tests/unit/scripts/test_probe_candidates.py
+++ b/tests/unit/scripts/test_probe_candidates.py
@@ -1,0 +1,488 @@
+"""Host-side tests for scripts/probe_candidates.py (verification-ladder tiers 2-3).
+
+These run on plain CPU with no engine installed: the engine boundary
+(``_engine_constructors``) is faked, so every test exercises the kernel's own
+logic - deterministic probe-value derivation, kwargs assembly, verdict
+classification, schema parsing, and writeback - never a real container.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parents[3] / "scripts"))
+
+import _engine_constructors as ec
+import probe_candidates as pc
+
+_NO_REFS: set[str] = set()
+
+
+def _REF_OF(leaf: str) -> int:
+    """A fixed @field_ref resolver for unit derivation (every ref -> 4)."""
+    return 4
+
+
+def _fire(spec: Any, *, leaf: str = "f", referenced: set[str] | None = None) -> Any:
+    return pc._fire_value(spec, leaf, _REF_OF, referenced or _NO_REFS)
+
+
+def _nofire(spec: Any, *, leaf: str = "f", referenced: set[str] | None = None) -> Any:
+    return pc._nofire_value(spec, leaf, _REF_OF, referenced or _NO_REFS)
+
+
+# ---------------------------------------------------------------------------
+# Fire / nofire derivation, per operator in the shipped corpus vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_less_than() -> None:
+    assert _fire({"<": 1}) == 0
+    assert _nofire({"<": 1}) == 1
+
+
+def test_threshold_less_equal_float() -> None:
+    assert _fire({"<=": 0.0}) == 0.0
+    assert _nofire({"<=": 0.0}) == 0.5
+
+
+def test_threshold_greater_than_float() -> None:
+    assert _fire({">": 2.0}) == 2.5
+    assert _nofire({">": 2.0}) == 2.0
+
+
+def test_threshold_greater_equal_int() -> None:
+    assert _fire({">=": 4}) == 4
+    assert _nofire({">=": 4}) == 3
+
+
+def test_bare_value_equality() -> None:
+    assert _fire(1) == 1
+    assert _nofire(1) == 2
+    assert _fire(True) is True
+    assert _nofire(True) is False
+
+
+def test_not_equal_with_present() -> None:
+    assert _fire({"!=": 0.0, "present": True}) == 1.0
+    assert _nofire({"!=": 0.0, "present": True}) == 0.0
+
+
+def test_in_membership() -> None:
+    assert _fire({"in": ["pplx", "naive"]}) == "pplx"
+    assert _nofire({"in": ["pplx", "naive"]}) == "__llem_probe_nonmember__"
+
+
+def test_not_in_numeric_members() -> None:
+    assert _fire({"present": True, "not_in": [1, 16]}) == 17
+    assert _nofire({"present": True, "not_in": [1, 16]}) == 1
+
+
+def test_not_in_mixed_members_uses_first_non_null() -> None:
+    spec = {"not_in": [None, True, False, "never"]}
+    assert _fire(spec) == "__llem_probe_nonmember__"
+    assert _nofire(spec) is True  # first non-null member satisfies the claim
+
+
+def test_type_is_not_scalar() -> None:
+    assert _fire({"type_is_not": "int"}) == "x"
+    assert _nofire({"type_is_not": "int"}) == 1
+
+
+def test_type_is_not_list_picks_value_outside_all() -> None:
+    spec = {"present": True, "type_is_not": ["bool", "int", "str"]}
+    assert _fire(spec) == 1.0  # float is outside {bool, int, str}
+    assert _nofire(spec) is True  # bool is inside the allowlist
+
+
+def test_type_is_not_config_class_nofire_is_unprobeable() -> None:
+    spec = {"type_is_not": "CompileConfig", "present": True}
+    assert _fire(spec) == "x"  # any non-CompileConfig fires
+    with pytest.raises(pc.Unprobeable):
+        _nofire(spec)  # cannot synthesise a CompileConfig satisfying value
+
+
+def test_present_only_flag() -> None:
+    assert _fire({"present": True}) is True
+    assert _nofire({"present": True}) is pc._OMIT
+
+
+def test_present_only_when_referenced_uses_ref_base() -> None:
+    assert _fire({"present": True}, leaf="max_tokens", referenced={"max_tokens"}) == pc.REF_BASE
+
+
+def test_absent_flag() -> None:
+    assert _fire({"absent": True}) is pc._OMIT
+    assert _nofire({"absent": True}) is True
+
+
+def test_not_divisible_by_ref() -> None:
+    assert _fire({"not_divisible_by": "@x"}) == 5  # REF_BASE + 1, not a multiple of 4
+    assert _nofire({"not_divisible_by": "@x"}) == 8  # 2 * REF_BASE, a clean multiple
+
+
+def test_threshold_against_field_ref() -> None:
+    assert _fire({">": "@max_tokens"}) == 5  # REF_BASE + step
+    assert _nofire({">": "@max_tokens"}) == 4  # the referenced base itself
+
+
+# ---------------------------------------------------------------------------
+# Construction-probe kwargs assembly
+# ---------------------------------------------------------------------------
+
+
+def test_single_field_construction_kwargs() -> None:
+    violating, satisfying, subject = pc.build_construction_kwargs(
+        {"vllm.sampling_params.n": {"<": 1}}
+    )
+    assert violating == {"n": 0}
+    assert satisfying == {"n": 1}
+    assert subject == "n"
+
+
+def test_cross_field_ref_scaffolds_unnamed_operand() -> None:
+    fields = {"vllm.engine_params.data_parallel_size_local": {">": "@data_parallel_size"}}
+    violating, satisfying, subject = pc.build_construction_kwargs(fields)
+    assert violating == {"data_parallel_size_local": 5, "data_parallel_size": 4}
+    assert satisfying == {"data_parallel_size_local": 4, "data_parallel_size": 4}
+    assert subject == "data_parallel_size_local"
+
+
+def test_cross_field_named_present_operand() -> None:
+    fields = {
+        "vllm.sampling_params.max_tokens": {"present": True},
+        "vllm.sampling_params.min_tokens": {">": "@max_tokens"},
+    }
+    violating, satisfying, _ = pc.build_construction_kwargs(fields)
+    assert violating == {"max_tokens": 4, "min_tokens": 5}
+    assert satisfying == {"max_tokens": 4, "min_tokens": 4}
+
+
+def test_absent_precondition_flips_subject_to_set() -> None:
+    fields = {
+        "vllm.engine_params.max_num_batched_tokens": {"<": "@max_model_len"},
+        "vllm.engine_params.enable_chunked_prefill": {"absent": True},
+    }
+    violating, satisfying, subject = pc.build_construction_kwargs(fields)
+    assert violating == {"max_num_batched_tokens": 3, "max_model_len": 4}
+    assert satisfying == {
+        "max_num_batched_tokens": 3,
+        "max_model_len": 4,
+        "enable_chunked_prefill": True,
+    }
+    assert subject == "enable_chunked_prefill"
+
+
+# ---------------------------------------------------------------------------
+# Identity-probe value derivation
+# ---------------------------------------------------------------------------
+
+
+def _dormant(fields: dict[str, Any], **prov: Any) -> pc.Candidate:
+    return pc.Candidate(
+        id="d",
+        engine="vllm",
+        severity="dormant",
+        fields=fields,
+        normalised=[],
+        source=prov.get("source"),
+        declared_values=prov.get("declared_values"),
+        raw={},
+    )
+
+
+def test_identity_bare_value_contrasts_with_default() -> None:
+    cand = _dormant({"vllm.sampling_params.seed": -1})
+    values = pc.identity_values(cand, "vllm.sampling_params.seed")
+    assert values == [-1, pc._DEFAULT]
+
+
+def test_identity_membership_values() -> None:
+    cand = _dormant({"vllm.engine_params.all2all_backend": {"in": ["pplx", "naive"]}})
+    assert pc.identity_values(cand, "vllm.engine_params.all2all_backend") == ["pplx", "naive"]
+
+
+def test_identity_not_in_numeric_two_nonmembers() -> None:
+    cand = _dormant({"f": {"present": True, "not_in": [0, 50256]}})
+    assert pc.identity_values(cand, "f") == [50257, 50258]
+
+
+def test_identity_threshold_two_firing_values() -> None:
+    cand = _dormant({"f": {"<": 0}})
+    assert pc.identity_values(cand, "f") == [-1, -2]
+
+
+def test_identity_not_equal_two_firing_values() -> None:
+    cand = _dormant({"f": {"!=": 0.0, "present": True}})
+    assert pc.identity_values(cand, "f") == [0.5, 1.0]
+
+
+def test_identity_present_only_is_unprobeable() -> None:
+    cand = _dormant(
+        {
+            "transformers.sampling_params.do_sample": False,
+            "transformers.sampling_params.temperature": {"present": True},
+        }
+    )
+    with pytest.raises(pc.Unprobeable):
+        pc.identity_values(cand, "transformers.sampling_params.temperature")
+
+
+def test_identity_observed_collision_uses_declared_values() -> None:
+    cand = _dormant(
+        {"vllm.engine_params.enforce_eager": {"present": True}},
+        source="observed_collision",
+        declared_values=[True, False],
+    )
+    assert pc.identity_values(cand, "vllm.engine_params.enforce_eager") == [True, False]
+
+
+def test_identity_observed_collision_absent_sentinel_becomes_default() -> None:
+    cand = _dormant(
+        {"f": {"present": True}},
+        source="observed_collision",
+        declared_values=["<absent>", 7],
+    )
+    assert pc.identity_values(cand, "f") == [pc._DEFAULT, 7]
+
+
+# ---------------------------------------------------------------------------
+# Verdict classification (engine boundary faked)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCls:
+    pass
+
+
+@pytest.fixture
+def fake_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ec, "engine_importable", lambda engine: True)
+    monkeypatch.setattr(ec, "candidate_classes", lambda engine, path, leaves: [_FakeCls])
+    monkeypatch.setattr(ec, "accepts", lambda cls, leaf: True)
+
+
+def _error_cand(fields: dict[str, Any]) -> pc.Candidate:
+    return pc.Candidate(
+        id="e",
+        engine="vllm",
+        severity="error",
+        fields=fields,
+        normalised=[],
+        source=None,
+        declared_values=None,
+        raw={},
+    )
+
+
+def test_construction_confirmed(monkeypatch: pytest.MonkeyPatch, fake_engine: None) -> None:
+    def construct(engine: str, cls: type, kwargs: dict[str, Any], *, validate: bool) -> Any:
+        if kwargs.get("n", 99) < 1:  # the violating leg raises, the satisfying leg builds
+            raise ValueError("n must be at least 1")
+        return object()
+
+    monkeypatch.setattr(ec, "construct", construct)
+    verdict = pc.probe_candidate(_error_cand({"vllm.sampling_params.n": {"<": 1}}), "vllm", True)
+    assert verdict.status == "confirmed"
+    assert verdict.tier == "construction"
+
+
+def test_construction_refuted_when_violating_builds(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    monkeypatch.setattr(ec, "construct", lambda *a, **k: object())  # nothing ever raises
+    verdict = pc.probe_candidate(_error_cand({"vllm.sampling_params.n": {"<": 1}}), "vllm", True)
+    assert verdict.status == "refuted"
+
+
+def test_construction_infra_error_when_satisfying_also_raises(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    def construct(*a: Any, **k: Any) -> Any:
+        raise RuntimeError("unrelated boom")
+
+    monkeypatch.setattr(ec, "construct", construct)
+    verdict = pc.probe_candidate(_error_cand({"vllm.sampling_params.n": {"<": 1}}), "vllm", True)
+    assert verdict.status == "infra_error"
+
+
+def test_construction_unprobeable_when_no_satisfying_value(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    # type_is_not a config class: no synthesisable satisfying value -> unprobeable,
+    # decided before any construct call.
+    monkeypatch.setattr(ec, "construct", lambda *a, **k: pytest.fail("construct should not run"))
+    fields = {
+        "transformers.sampling_params.compile_config": {
+            "type_is_not": "CompileConfig",
+            "present": True,
+        }
+    }
+    verdict = pc.probe_candidate(_error_cand(fields), "transformers", True)
+    assert verdict.status == "unprobeable"
+
+
+def test_identity_confirmed_when_resolved_state_identical(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    monkeypatch.setattr(ec, "construct", lambda *a, **k: object())
+    monkeypatch.setattr(ec, "resolved_value", lambda obj, leaf: None)  # every value aliases to None
+    cand = _dormant({"vllm.sampling_params.seed": -1}, source=None)
+    verdict = pc.probe_candidate(cand, "vllm", True)
+    assert verdict.status == "confirmed"
+    assert verdict.tier == "identity"
+
+
+def test_identity_refuted_when_resolved_state_differs(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    class Obj:
+        def __init__(self, kwargs: dict[str, Any]) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(ec, "construct", lambda engine, cls, kwargs, *, validate: Obj(kwargs))
+    monkeypatch.setattr(ec, "resolved_value", lambda obj, leaf: obj.kwargs.get(leaf, "<unset>"))
+    cand = _dormant({"vllm.sampling_params.seed": -1})
+    verdict = pc.probe_candidate(cand, "vllm", True)
+    assert verdict.status == "refuted"
+
+
+def test_identity_infra_error_when_a_leg_raises(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    def construct(engine: str, cls: type, kwargs: dict[str, Any], *, validate: bool) -> Any:
+        if "seed" not in kwargs:  # the default leg blows up
+            raise ValueError("seed required")
+        return object()
+
+    monkeypatch.setattr(ec, "construct", construct)
+    monkeypatch.setattr(ec, "resolved_value", lambda obj, leaf: 0)
+    cand = _dormant({"vllm.sampling_params.seed": -1})
+    verdict = pc.probe_candidate(cand, "vllm", True)
+    assert verdict.status == "infra_error"
+
+
+def test_engine_not_importable_is_infra_error() -> None:
+    cand = _error_cand({"vllm.sampling_params.n": {"<": 1}})
+    verdict = pc.probe_candidate(cand, "vllm", engine_ready=False)
+    assert verdict.status == "infra_error"
+
+
+def test_unknown_severity_is_unprobeable() -> None:
+    cand = pc.Candidate(
+        id="x",
+        engine="vllm",
+        severity="warn",
+        fields={"a": 1},
+        normalised=[],
+        source=None,
+        declared_values=None,
+        raw={},
+    )
+    verdict = pc.probe_candidate(cand, "vllm", True)
+    assert verdict.status == "unprobeable"
+
+
+# ---------------------------------------------------------------------------
+# Schema parsing + verdict writeback
+# ---------------------------------------------------------------------------
+
+
+def test_parse_candidate_reads_unified_and_shipped_shapes() -> None:
+    raw = {
+        "id": "r1",
+        "engine": "vllm",
+        "severity": "error",
+        "match": {"fields": {"vllm.sampling_params.n": {"<": 1}}},
+        "provenance": {"source": "manual"},
+    }
+    cand = pc.parse_candidate(raw, 0)
+    assert cand.id == "r1"
+    assert cand.severity == "error"
+    assert list(cand.fields) == ["vllm.sampling_params.n"]
+    assert cand.source == "manual"
+
+
+def test_load_document_accepts_rules_or_candidates_key(tmp_path: Path) -> None:
+    rules_file = tmp_path / "rules.yaml"
+    rules_file.write_text(
+        "engine: vllm\nrules:\n- id: a\n  severity: error\n  match:\n    fields:\n      vllm.sampling_params.n: {'<': 1}\n"
+    )
+    document, entries = pc.load_document(rules_file)
+    assert document["engine"] == "vllm"
+    assert len(entries) == 1
+
+
+def test_load_document_rejects_missing_list(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("engine: vllm\n")
+    with pytest.raises(ValueError, match="candidates' or 'rules'"):
+        pc.load_document(bad)
+
+
+def test_write_verdicts_roundtrip(tmp_path: Path) -> None:
+    document = {
+        "engine": "vllm",
+        "candidates": [{"id": "a", "severity": "error", "match": {"fields": {}}}],
+    }
+    entries = document["candidates"]
+    verdicts = [pc.Verdict("confirmed", "construction", "violating raised; satisfying built")]
+    out = tmp_path / "verdicts.yaml"
+    pc.write_verdicts(document, entries, verdicts, "2026-07-06", out)
+
+    reloaded = yaml.safe_load(out.read_text())
+    verdict = reloaded["candidates"][0]["verdict"]
+    assert verdict == {
+        "status": "confirmed",
+        "tier": "construction",
+        "date": "2026-07-06",
+        "evidence": "violating raised; satisfying built",
+    }
+
+
+def test_main_writes_to_out_and_returns_zero(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(ec, "engine_importable", lambda engine: True)
+    monkeypatch.setattr(ec, "candidate_classes", lambda engine, path, leaves: [_FakeCls])
+    monkeypatch.setattr(ec, "accepts", lambda cls, leaf: True)
+
+    def construct(engine: str, cls: type, kwargs: dict[str, Any], *, validate: bool) -> Any:
+        if kwargs.get("n", 99) < 1:
+            raise ValueError("n must be at least 1")
+        return object()
+
+    monkeypatch.setattr(ec, "construct", construct)
+
+    candidates = tmp_path / "cands.yaml"
+    candidates.write_text(
+        "engine: vllm\ncandidates:\n- id: n_rule\n  engine: vllm\n  severity: error\n"
+        "  match:\n    fields:\n      vllm.sampling_params.n: {'<': 1}\n"
+    )
+    out = tmp_path / "out.yaml"
+    code = pc.main(
+        [
+            "--engine",
+            "vllm",
+            "--candidates",
+            str(candidates),
+            "--out",
+            str(out),
+            "--date",
+            "2026-07-06",
+        ]
+    )
+    assert code == 0
+    written = yaml.safe_load(out.read_text())
+    assert written["candidates"][0]["verdict"]["status"] == "confirmed"
+
+
+def test_main_hard_error_on_unreadable_returns_two(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.yaml"
+    code = pc.main(["--engine", "vllm", "--candidates", str(missing)])
+    assert code == 2

--- a/tests/unit/scripts/test_probe_candidates.py
+++ b/tests/unit/scripts/test_probe_candidates.py
@@ -131,6 +131,14 @@ def test_threshold_against_field_ref() -> None:
     assert _nofire({">": "@max_tokens"}) == 4  # the referenced base itself
 
 
+def test_equality_against_field_ref_resolves_not_literal() -> None:
+    # The fire value must be the REFERENCED FIELD'S value, never the "@..." string.
+    assert _fire({"==": "@max_tokens"}) == 4
+    assert _nofire({"==": "@max_tokens"}) == 5  # contrast of the resolved value
+    assert _fire({"!=": "@max_tokens"}) == 5
+    assert _nofire({"!=": "@max_tokens"}) == 4
+
+
 # ---------------------------------------------------------------------------
 # Construction-probe kwargs assembly
 # ---------------------------------------------------------------------------
@@ -163,6 +171,17 @@ def test_cross_field_named_present_operand() -> None:
     assert satisfying == {"max_tokens": 4, "min_tokens": 4}
 
 
+def test_cross_field_equality_kwargs_use_resolved_operand() -> None:
+    fields = {
+        "vllm.engine_params.data_parallel_size": {">": 1},
+        "vllm.engine_params.data_parallel_size_local": {"==": "@data_parallel_size"},
+    }
+    violating, satisfying, subject = pc.build_construction_kwargs(fields)
+    assert violating == {"data_parallel_size": 2, "data_parallel_size_local": 2}
+    assert satisfying == {"data_parallel_size": 2, "data_parallel_size_local": 3}
+    assert subject == "data_parallel_size_local"
+
+
 def test_absent_precondition_flips_subject_to_set() -> None:
     fields = {
         "vllm.engine_params.max_num_batched_tokens": {"<": "@max_model_len"},
@@ -183,13 +202,15 @@ def test_absent_precondition_flips_subject_to_set() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _dormant(fields: dict[str, Any], **prov: Any) -> pc.Candidate:
+def _dormant(
+    fields: dict[str, Any], normalised: list[str] | None = None, **prov: Any
+) -> pc.Candidate:
     return pc.Candidate(
         id="d",
         engine="vllm",
         severity="dormant",
         fields=fields,
-        normalised=[],
+        normalised=normalised or [],
         source=prov.get("source"),
         declared_values=prov.get("declared_values"),
         raw={},
@@ -292,12 +313,15 @@ def test_construction_confirmed(monkeypatch: pytest.MonkeyPatch, fake_engine: No
     assert verdict.tier == "construction"
 
 
-def test_construction_refuted_when_violating_builds(
+def test_construction_unconfirmed_when_violating_builds(
     monkeypatch: pytest.MonkeyPatch, fake_engine: None
 ) -> None:
-    monkeypatch.setattr(ec, "construct", lambda *a, **k: object())  # nothing ever raises
+    # Nothing raises at construction: that does NOT contradict the claim (the
+    # engine may validate at init or generation), so the verdict is unconfirmed.
+    monkeypatch.setattr(ec, "construct", lambda *a, **k: object())
     verdict = pc.probe_candidate(_error_cand({"vllm.sampling_params.n": {"<": 1}}), "vllm", True)
-    assert verdict.status == "refuted"
+    assert verdict.status == "unconfirmed"
+    assert "construction grain" in verdict.evidence
 
 
 def test_construction_infra_error_when_satisfying_also_raises(
@@ -338,7 +362,7 @@ def test_identity_confirmed_when_resolved_state_identical(
     assert verdict.tier == "identity"
 
 
-def test_identity_refuted_when_resolved_state_differs(
+def test_identity_unconfirmed_when_resolved_state_differs(
     monkeypatch: pytest.MonkeyPatch, fake_engine: None
 ) -> None:
     class Obj:
@@ -349,7 +373,10 @@ def test_identity_refuted_when_resolved_state_differs(
     monkeypatch.setattr(ec, "resolved_value", lambda obj, leaf: obj.kwargs.get(leaf, "<unset>"))
     cand = _dormant({"vllm.sampling_params.seed": -1})
     verdict = pc.probe_candidate(cand, "vllm", True)
-    assert verdict.status == "refuted"
+    # Differing constructor-grain state does not disprove effective-config
+    # identity at the grain the collision was observed - unconfirmed, not refuted.
+    assert verdict.status == "unconfirmed"
+    assert "differ" in verdict.evidence
 
 
 def test_identity_infra_error_when_a_leg_raises(
@@ -365,6 +392,74 @@ def test_identity_infra_error_when_a_leg_raises(
     cand = _dormant({"vllm.sampling_params.seed": -1})
     verdict = pc.probe_candidate(cand, "vllm", True)
     assert verdict.status == "infra_error"
+
+
+def test_inert_subjects_are_normalised_fields_outside_match() -> None:
+    inert = _dormant({"transformers.engine_params.num_beams": 1}, normalised=["early_stopping"])
+    assert pc._inert_subjects(inert) == ["early_stopping"]
+    alias = _dormant({"vllm.sampling_params.seed": -1}, normalised=["seed"])
+    assert pc._inert_subjects(alias) == []  # normalises the match field: value-alias
+
+
+class _Kwargs:
+    def __init__(self, kwargs: dict[str, Any]) -> None:
+        self.kwargs = kwargs
+
+
+def _inert_cand(normalised: list[str]) -> pc.Candidate:
+    return _dormant({"transformers.engine_params.num_beams": 1}, normalised=normalised)
+
+
+def test_condition_inert_confirmed_when_engine_rewrites_to_default(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    monkeypatch.setattr(ec, "construct", lambda engine, cls, kwargs, *, validate: _Kwargs(kwargs))
+    # The engine normalises early_stopping to False whatever was passed.
+    monkeypatch.setattr(
+        ec, "resolved_value", lambda obj, leaf: False if leaf == "early_stopping" else 1
+    )
+    verdict = pc.probe_candidate(_inert_cand(["early_stopping"]), "transformers", True)
+    assert verdict.status == "confirmed"
+    assert "collapsed" in verdict.evidence
+
+
+def test_condition_inert_unconfirmed_when_constructor_keeps_value(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    monkeypatch.setattr(ec, "construct", lambda engine, cls, kwargs, *, validate: _Kwargs(kwargs))
+    # The constructor stores whatever was passed (default False when omitted).
+    monkeypatch.setattr(ec, "resolved_value", lambda obj, leaf: obj.kwargs.get(leaf, False))
+    verdict = pc.probe_candidate(_inert_cand(["early_stopping"]), "transformers", True)
+    assert verdict.status == "unconfirmed"
+    assert "kept True" in verdict.evidence
+
+
+def test_condition_inert_multiple_subjects_all_must_collapse(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    monkeypatch.setattr(ec, "construct", lambda engine, cls, kwargs, *, validate: _Kwargs(kwargs))
+
+    def resolved(obj: _Kwargs, leaf: str) -> Any:
+        if leaf == "early_stopping":  # rewritten to its default
+            return False
+        return obj.kwargs.get(leaf, 1.0)  # length_penalty stored verbatim
+
+    monkeypatch.setattr(ec, "resolved_value", resolved)
+    verdict = pc.probe_candidate(
+        _inert_cand(["early_stopping", "length_penalty"]), "transformers", True
+    )
+    assert verdict.status == "unconfirmed"
+    assert "early_stopping" in verdict.evidence  # per-subject evidence, both named
+    assert "length_penalty" in verdict.evidence
+
+
+def test_condition_inert_unprobeable_when_default_has_no_contrast(
+    monkeypatch: pytest.MonkeyPatch, fake_engine: None
+) -> None:
+    monkeypatch.setattr(ec, "construct", lambda engine, cls, kwargs, *, validate: _Kwargs(kwargs))
+    monkeypatch.setattr(ec, "resolved_value", lambda obj, leaf: None)  # no contrast for None
+    verdict = pc.probe_candidate(_inert_cand(["early_stopping"]), "transformers", True)
+    assert verdict.status == "unprobeable"
 
 
 def test_engine_not_importable_is_infra_error() -> None:
@@ -480,6 +575,27 @@ def test_main_writes_to_out_and_returns_zero(
     assert code == 0
     written = yaml.safe_load(out.read_text())
     assert written["candidates"][0]["verdict"]["status"] == "confirmed"
+
+
+def test_main_unparseable_entry_appears_in_summary_table(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ec, "engine_importable", lambda engine: False)
+    candidates = tmp_path / "cands.yaml"
+    candidates.write_text(
+        "engine: vllm\ncandidates:\n- not_a_mapping\n"
+        "- id: ok\n  severity: error\n  match:\n    fields:\n      vllm.sampling_params.n: 1\n"
+    )
+    code = pc.main(["--engine", "vllm", "--candidates", str(candidates), "--date", "2026-07-06"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "#0" in out  # the unparseable entry is a visible table row, not silence
+    assert "ok" in out
+    written = yaml.safe_load(candidates.read_text())
+    assert written["candidates"][0] == "not_a_mapping"  # preserved, no verdict to attach
+    assert written["candidates"][1]["verdict"]["status"] == "infra_error"
 
 
 def test_main_hard_error_on_unreadable_returns_two(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Adds tiers 2 and 3 of the engine-rule verification ladder: the construction
and identity probe kernel. It proves candidate rules against the real engine
after the tier-1 citation check (merged in #753).

- **Construction probe** (severity `error`): derives a violating value and a
  satisfying value from the predicate spec, then confirms the rule only when
  the violating value RAISES at construction and the satisfying value
  constructs cleanly. Both legs are required.
- **Identity probe** (severity `dormant`), two shapes:
  - *Value-alias* (`normalised_fields` names the match field itself):
    construct at two or more distinct declared values and compare
    engine-resolved state; identical state confirms the variation inert.
  - *Condition-inert* (`normalised_fields` name fields OUTSIDE
    `match.fields`): hold every match field at its firing value so the
    condition is satisfied, then vary each named field against its
    engine-resolved default; confirmed only when the engine rewrites every
    one back to its default.
- Probe values are derived deterministically from the operator vocabulary
  (`<`, `<=`, `>`, `>=`, `==`, `!=`, `in`, `not_in`, `present`, `absent`,
  `type_is`, `type_is_not`, `divisible_by`, `not_divisible_by`, `@field_ref`).
- Verdicts come from a closed vocabulary and are written back onto the
  candidate document: `confirmed`, `unconfirmed`, `unprobeable`,
  `infra_error` (candidates start `unverified`). The kernel NEVER edits the
  shipped `rules.yaml` corpora.

### Verdict semantics: why there is no `refuted`

The ladder EARNS tiers. A shipped `error` rule claims "the engine rejects
this config" - it does not claim WHERE. Construction-grain observation can
never prove the engine accepts a config end-to-end (tensorrt validates in
the runtime, several transformers rules at generate time, several vllm rules
at engine init), so a violating value that constructs cleanly leaves the
claim `unconfirmed`, not contradicted. Likewise for identity: differing
constructor-grain state does not disprove effective-config identity at the
grain a collision was observed. `unprobeable` remains distinct: no
deterministic probe could be derived or run, whereas `unconfirmed` means the
probe RAN and was not decisive. A future runtime-grain probe can reintroduce
`refuted` with an honest earner.

## Deliverables

1. `scripts/probe_candidates.py` - the kernel (probes, value derivation,
   schema parse/writeback, summary).
2. `scripts/_engine_constructors.py` - per-engine construction table
   (transformers `GenerationConfig` + `BitsAndBytesConfig` routing, vLLM
   msgspec `SamplingParams` + `vllm.config` submodules, tensorrt
   `TrtLlmArgs`) with importability, field-acceptance, construct, and
   resolved-value helpers.
3. Unified candidate schema; migrated `mine_observed_collisions.py` and
   `check_citations.py` (skip-not-fail for uncited candidates, word-boundary
   token entailment).
4. `scripts/probe_candidates.sh` + a `probe-candidates` make target
   (container wrapper).
5. Host-side CPU-only unit tests (52 for the kernel; citation + miner tests
   updated).
6. Dogfood acceptance run over all three engines' shipped `rules.yaml` in
   real containers.

## Dogfood: construction-grain coverage census (corpora byte-frozen)

Each run executed the kernel inside the engine's pinned image against a copy
of the shipped `src/llenergymeasure/engines/<engine>/rules.yaml`. Corpus
bytes verified unchanged (sha256) before and after every run.

| engine | candidates | confirmed | unconfirmed | unprobeable | infra_error |
| --- | --- | --- | --- | --- | --- |
| vllm | 31 | 23 | 3 | 4 | 1 |
| transformers | 52 | 11 | 13 | 18 | 10 |
| tensorrt | 15 | 0 | 15 | 0 | 0 |

Zero `refuted` anywhere - the story is a census of which rules are
confirmable at construction grain, with the rest awaiting runtime-grain
probes in a later phase:

- **vllm (23/31 confirmed).** The engine that validates most at construction.
  3 unconfirmed (`tensor_parallel_size < 1`, `pipeline_parallel_size < 1`,
  `kv_cache_memory_bytes < 1`) validate at LLM-engine init. 4 unprobeable are
  present/absent-only dormant fields with no declared values to compare.
  1 infra_error: the derived satisfying config for a batched-tokens rule
  trips an unrelated scheduler cross-constraint, so the claim cannot be
  isolated by pure construction.
- **transformers (11 confirmed).** 13 unconfirmed: sampling-range bounds that
  fire at `generate()` time, plus condition-based dormancy claims where the
  constructor stores declared values verbatim (the corpus carries
  `normalised_fields: null` for these, so they fall back to the value-alias
  path; the condition-inert path engages once the corpus names the inert
  siblings). 18 unprobeable are present/absent-only dormant fields and a type
  check against a config class that cannot be synthesised. 10 infra_error are
  config-typed fields (`compile_config`, `watermarking_config`) and
  satisfying legs that trip cross-field checks (`early_stopping` requires
  beam search, `top_p`/`top_k` require `do_sample`).
- **tensorrt (0/15 confirmed, 15 unconfirmed).** Verified empirically in the
  container: `tensorrt_llm.SamplingParams` is a plain dataclass with no
  construction-time validation (`SamplingParams(temperature=-0.5, top_p=1.5,
  n=0)` stores those values verbatim), and `TrtLlmArgs` IS a pydantic
  BaseModel - but its probed fields carry no construction-grain range
  constraints (`max_input_len`/`max_seq_len` are `Optional[int]` with empty
  field metadata, so `max_input_len=0` is accepted and stored). tensorrt
  defers range validation to engine build and the C++ runtime, beyond this
  probe's grain.

## Deviations from the brief (with evidence)

1. **Version resolution from `engine_versions/<engine>/current.yaml` via `yq`,
   not a Dockerfile ARG.** The brief specified reading the pinned version from
   a Dockerfile ARG, but per-engine Dockerfiles for vllm/tensorrt do not exist
   (only `docker/Dockerfile.transformers`). `current.yaml` is the SSOT the CI
   engine cells already read, so the wrapper reads it directly.
2. **Container getpass workaround (`-e HOME=/tmp -e USER=llem-probe`).**
   Running `--user <hostuid>` maps a uid with no `/etc/passwd` entry in the
   image; torch calls `getpass.getuser()` at import and raises
   `KeyError: getpwuid()` without `USER` set. Setting `USER` (and `HOME` for
   cache writes) fixes it. Confirmed empirically: the first vllm run reported
   all infra_error until this was added, then 23 confirmed.
3. **Word-boundary token entailment in `check_citations.py`.** Entailment uses
   lookarounds `(?<!\w)TOKEN(?!\w)` so a field token like `max_tokens` is not
   spuriously entailed by `max_tokens_per_batch`.
4. **Verdict evidence single-lining.** Multi-line engine exception messages are
   whitespace-collapsed so they render on one line in both the summary table
   and the YAML writeback.
5. **Condition-inert subjects are the normalised fields OUTSIDE the match.**
   A field that is both normalised and matched belongs to the held condition
   and cannot simultaneously be held at its firing value and varied, so it is
   never selected as an inert subject.

## Checks

- 460 passed, 10 skipped (`tests/unit/scripts/`); 52 are kernel tests.
- `make lint` (ruff + import-linter: 4 contracts kept, 0 broken).
- `make typecheck` (mypy: 299 files, no issues).
- Shipped `rules.yaml` corpora are not in the diff and were byte-frozen across
  every dogfood run.

Does NOT merge. Merge authority comes later once the simplify and verify
gates pass.

## Documentation audit

No doc update needed: tooling-only addition (scripts, make target, tests) -
no runtime `src/` changes, no user-visible strings renamed or removed, and no
existing doc references this surface.
