### PR TITLE
feat(analyst): add cold-read proposer for engine rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: test test-unit test-integration test-all
 .PHONY: docs-all docs-check docs-generate docs-serve docs-build docs-clean
 .PHONY: discover-schema discover-schemas-all refresh-invariants refresh-invariants-all
-.PHONY: check-citations probe-candidates
+.PHONY: check-citations probe-candidates analyst-cold-read
 .PHONY: package-check
 .PHONY: docker-smoke
 .PHONY: ci ci-all ci-docker
@@ -154,6 +154,14 @@ refresh-invariants-all: ## Mine invariants for all three engines in sequence
 	./scripts/refresh_invariants.sh vllm
 	./scripts/refresh_invariants.sh tensorrt
 	./scripts/refresh_invariants.sh transformers
+
+# Proposer S2: LLM analyst cold read of the pinned engine source into candidate
+# rules for the verification ladder. Needs a local Ollama daemon (owns the GPU)
+# and SRC = the engine package directory at the pinned version. Writes to the
+# version-scoped candidate pool, never to the shipped corpora.
+analyst-cold-read: ## Cold-read one engine's source into candidates (ENGINE=vllm SRC=path/to/source [ARGS=...])
+	@test -n "$(ENGINE)" && test -n "$(SRC)" || (echo "Usage: make analyst-cold-read ENGINE=vllm SRC=engine-src/ [ARGS='--samples 1']" && exit 1)
+	uv run python scripts/analyst_cold_read.py --engine $(ENGINE) --source-root "$(SRC)" $(ARGS)
 
 # Verification-ladder tier 1: confirm each proposed candidate rule's citation
 # resolves against a pinned engine source tree. Used by the absorb workflow and

--- a/engine_versions/vllm/analyst_clusters.yaml
+++ b/engine_versions/vllm/analyst_clusters.yaml
@@ -17,8 +17,6 @@
 #   - a platforms/*.py cluster is ADDED: it removes the 5-entry structural
 #     ceiling (the platform-gated constraints the file-scoped readers otherwise
 #     structurally cannot see) and is ordinary guard code the model reads well.
-schema_version: 1
-engine: vllm
 clusters:
   sampling:
     - sampling_params.py

--- a/engine_versions/vllm/analyst_clusters.yaml
+++ b/engine_versions/vllm/analyst_clusters.yaml
@@ -8,9 +8,9 @@
 # (a path containing `*`) expands against the source root; a plain path names
 # one file.
 #
-# Cluster selection follows the ratified parity experiment
-# (.product/research/oss-analyst-parity-2026-07-02/SYNTHESIS.md, "Recommended
-# production harness deltas"):
+# Cluster selection follows the production-harness deltas ratified by the
+# 2026-07-02 OSS analyst parity experiment (qwen2.5-coder:32b measured against
+# the frontier bump-analyst reference):
 #   - the engine/arg_utils.py cluster is DROPPED: it was a pure noise source
 #     (CLI add_argument blocks produced invented bounds and fabricated enum
 #     members) and contributed zero unique ground-truth matches.

--- a/engine_versions/vllm/analyst_clusters.yaml
+++ b/engine_versions/vllm/analyst_clusters.yaml
@@ -1,0 +1,58 @@
+# Analyst cold-read source clusters for vllm.
+#
+# scripts/analyst_cold_read.py reads these source-file clusters and asks an LLM
+# analyst to extract every config-validation constraint it can see, one cited
+# candidate per constraint. This file is DATA describing the engine version's
+# source layout: paths are relative to --source-root (the vllm package
+# directory, e.g. the `vllm/` folder inside an extracted 0.19.1 sdist). A glob
+# (a path containing `*`) expands against the source root; a plain path names
+# one file.
+#
+# Cluster selection follows the ratified parity experiment
+# (.product/research/oss-analyst-parity-2026-07-02/SYNTHESIS.md, "Recommended
+# production harness deltas"):
+#   - the engine/arg_utils.py cluster is DROPPED: it was a pure noise source
+#     (CLI add_argument blocks produced invented bounds and fabricated enum
+#     members) and contributed zero unique ground-truth matches.
+#   - a platforms/*.py cluster is ADDED: it removes the 5-entry structural
+#     ceiling (the platform-gated constraints the file-scoped readers otherwise
+#     structurally cannot see) and is ordinary guard code the model reads well.
+schema_version: 1
+engine: vllm
+clusters:
+  sampling:
+    - sampling_params.py
+    - pooling_params.py
+  model:
+    - config/model.py
+  parallel_sched:
+    - config/parallel.py
+    - config/scheduler.py
+  vllm:
+    - config/vllm.py
+  compilation:
+    - config/compilation.py
+  speculative:
+    - config/speculative.py
+  rest_config:
+    - config/cache.py
+    - config/lora.py
+    - config/kv_transfer.py
+    - config/ec_transfer.py
+    - config/structured_outputs.py
+    - config/observability.py
+    - config/offload.py
+    - config/pooler.py
+    - config/multimodal.py
+    - config/attention.py
+    - config/kernel.py
+    - config/device.py
+    - config/reasoning.py
+    - config/load.py
+    - config/kv_events.py
+    - config/profiler.py
+    - config/model_arch.py
+    - config/speech_to_text.py
+    - config/weight_transfer.py
+  platforms:
+    - platforms/*.py

--- a/scripts/_candidate_pool.py
+++ b/scripts/_candidate_pool.py
@@ -1,0 +1,77 @@
+"""Shared candidate-pool contract for the engine-rule proposers.
+
+Both proposers - the analyst cold read (S2, ``scripts/analyst_cold_read.py``)
+and the observed-collision miner (S3, ``scripts/mine_observed_collisions.py``) -
+write UNVERIFIED candidates into the same version-scoped pool, in one unified
+schema the verification ladder consumes unchanged. This module owns the shared
+pieces of that contract so the two proposers cannot drift apart:
+
+- :func:`pool_path` - the on-disk layout
+  ``<pool_root>/<engine>/v<mangled-version>/candidates/<filename>``.
+- :func:`write_pool` - the envelope writer (``schema_version`` / ``source`` /
+  ``engine`` / ``engine_version`` / ``generated_at`` / ``candidates`` plus any
+  proposer-specific header keys) with the leading header comment.
+- :func:`slug` - the filesystem/id-safe slug for a field path or free text.
+- :func:`unverified_verdict` - the verdict stub every fresh candidate carries.
+
+Neither proposer writes the shipped ``src/llenergymeasure/engines/<engine>/rules.yaml``
+corpora; those are frozen and the ladder promotes into them separately.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "1.0.0"
+
+
+def slug(text: str) -> str:
+    """Filesystem/id-safe slug for a dotted field path or free text."""
+    return re.sub(r"_+", "_", re.sub(r"[^0-9a-zA-Z]+", "_", text)).strip("_")
+
+
+def unverified_verdict() -> dict[str, Any]:
+    """The verdict stub every freshly-proposed candidate carries."""
+    return {"status": "unverified", "tier": None, "date": None, "evidence": None}
+
+
+def pool_path(pool_root: Path, engine: str, version: str, filename: str) -> Path:
+    """Version-scoped pool path ``<pool_root>/<engine>/v<mangled>/candidates/<filename>``."""
+    version_dir = "v" + re.sub(r"[^0-9a-zA-Z]+", "_", version).strip("_")
+    return pool_root / engine / version_dir / "candidates" / filename
+
+
+def write_pool(
+    path: Path,
+    *,
+    source: str,
+    engine: str,
+    version: str,
+    generated_at: str,
+    candidates: list[dict[str, Any]],
+    header: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Write one candidate-pool file with the shared envelope and header comment.
+
+    ``extra`` carries proposer-specific header keys (e.g. the analyst's ``model``
+    and ``samples``); they slot in after ``engine_version`` and before
+    ``generated_at`` so both proposers' envelopes share a stable key order.
+    """
+    document: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "source": source,
+        "engine": engine,
+        "engine_version": version,
+    }
+    if extra:
+        document.update(extra)
+    document["generated_at"] = generated_at
+    document["candidates"] = candidates
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = yaml.safe_dump(document, sort_keys=False, default_flow_style=False)
+    path.write_text(header + body)

--- a/scripts/analyst_cold_read.py
+++ b/scripts/analyst_cold_read.py
@@ -10,7 +10,8 @@ precision (~77-80% content-correct on the parity experiment) the analyst never
 self-certifies. A pure completion loop over line-numbered source chunks: one
 exhaustive-extraction prompt, self-consistency union across samples, a salvage
 parser for truncated output. No agentic access, no repair loops, no retries.
-Design and ratification: .product/research/oss-analyst-parity-2026-07-02/.
+Design ratified by the 2026-07-02 OSS analyst parity experiment
+(qwen2.5-coder:32b measured against the frontier bump-analyst reference).
 
 --source-root is the engine's top-level package directory at the pinned version
 (for vllm, the ``vllm/`` folder) - an explicit maintainer input, as it is for
@@ -466,15 +467,20 @@ def build_candidate(
     model: str,
     samples: int,
     run_date: str,
-) -> dict[str, Any] | None:
-    """Assemble one unified candidate, or None if the rule is unusable.
+) -> dict[str, Any] | str:
+    """Assemble one unified candidate, or the drop reason when unusable.
 
-    Dropped when it names no field or its citation resolves to no real file:line
-    (a hallucination). All the analyst said is kept under provenance.
+    Returns "no_field" when the rule names no usable field, "unresolved_citation"
+    when its citation points at no real file:line (a hallucination); run_analyst
+    counts these as the per-bump analyst-health signal. All the analyst said is
+    kept under provenance. A "warning" severity_suggestion (logs+continues)
+    deliberately still mints an error claim: recall-preserving, and contained by
+    the ladder - a warn-only guard never raises at construction, so the
+    candidate stays unconfirmed and is never promoted. Do not "fix" it here.
     """
     fields = [f for f in (rule.get("fields") or []) if isinstance(f, str) and _leaf(f)]
     if not fields:
-        return None
+        return "no_field"
     kind = str(rule.get("kind") or "other")
     predicate = str(rule.get("predicate") or "")
     suggestion = str(rule.get("severity_suggestion") or "")
@@ -482,7 +488,7 @@ def build_candidate(
 
     citation = resolve_citation(chunk, sources, str(rule.get("citation") or ""))
     if citation is None:
-        return None
+        return "unresolved_citation"
 
     match_fields, normalised = predicate_to_match(kind, fields, predicate, severity)
     digest = hashlib.sha1(
@@ -574,9 +580,16 @@ def run_analyst(
     model: str,
     samples: int,
     run_date: str,
-) -> list[dict[str, Any]]:
-    """Cold-read every chunk, build candidates, and union-dedup the pool."""
+) -> tuple[list[dict[str, Any]], Counter[str]]:
+    """Cold-read every chunk, build candidates, and union-dedup the pool.
+
+    Also returns the drop counters (no_field / unresolved_citation /
+    dedup_collapsed): the per-bump analyst-health signal - citation-resolution
+    rate is the parity experiment's headline quality metric - which the absorb
+    workflow reads to judge whether a cold read degraded.
+    """
     seen: set[str] = set()
+    drops: Counter[str] = Counter()
     candidates: list[dict[str, Any]] = []
     for position, chunk in enumerate(chunks, start=1):
         logger.info("chunk %d/%d %s", position, len(chunks), chunk.chunk_id)
@@ -593,14 +606,16 @@ def run_analyst(
                 samples=samples,
                 run_date=run_date,
             )
-            if candidate is None:
+            if isinstance(candidate, str):
+                drops[candidate] += 1
                 continue
             key = dedup_key(candidate)
             if key in seen:
+                drops["dedup_collapsed"] += 1
                 continue
             seen.add(key)
             candidates.append(candidate)
-    return candidates
+    return candidates, drops
 
 
 # Manifest, version, source loading, emission.
@@ -738,11 +753,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     try:
         manifest = load_manifest(args.engine)
-    except FileNotFoundError as exc:
+        version = resolve_version(args.engine)
+    except (FileNotFoundError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
-    version = resolve_version(args.engine)
     run_date = args.date or date.today().isoformat()
     cluster_files, sources = load_sources(args.source_root, manifest)
     chunks = build_chunks(cluster_files, sources)
@@ -752,7 +767,7 @@ def main(argv: list[str] | None = None) -> int:
 
     started = time.time()
     generate = ollama_generator(args.ollama_host, args.model)
-    candidates = run_analyst(
+    candidates, drops = run_analyst(
         chunks,
         sources,
         generate,
@@ -772,9 +787,11 @@ def main(argv: list[str] | None = None) -> int:
         run_date=run_date,
     )
     by_kind = Counter(c["provenance"]["kind"] for c in candidates)
+    drop_note = " ".join(f"{reason}={count}" for reason, count in sorted(drops.items())) or "none"
     print(
         f"analyst cold read: {len(candidates)} candidates "
-        f"({dict(sorted(by_kind.items()))}) in {time.time() - started:.0f}s\nwrote {path}",
+        f"({dict(sorted(by_kind.items()))}), drops: {drop_note}, "
+        f"in {time.time() - started:.0f}s\nwrote {path}",
         file=sys.stderr,
     )
     return 0

--- a/scripts/analyst_cold_read.py
+++ b/scripts/analyst_cold_read.py
@@ -491,9 +491,19 @@ def build_candidate(
         return "unresolved_citation"
 
     match_fields, normalised = predicate_to_match(kind, fields, predicate, severity)
-    digest = hashlib.sha1(
-        f"{severity}|{sorted(match_fields)}|{citation['file']}|{predicate}".encode()
-    ).hexdigest()[:8]
+    # The id digests the claim - severity, fields, file, whitespace/case-normalised
+    # predicate, deliberately NOT the line window, which shifts across bumps. The
+    # union dedup keys on this id, so "one candidate per id" is the pool contract:
+    # re-proposals of one claim at shifted windows collapse, first citation wins.
+    claim = "|".join(
+        [
+            severity,
+            ",".join(sorted(match_fields)),
+            citation["file"],
+            re.sub(r"\s+", "", predicate.lower()),
+        ]
+    )
+    digest = hashlib.sha1(claim.encode()).hexdigest()[:8]
     candidate: dict[str, Any] = {
         "id": f"{engine}_analyst_{severity}_{_slug('_'.join(_leaf(f) for f in fields))}_{digest}",
         "engine": engine,
@@ -517,21 +527,6 @@ def build_candidate(
     }
     candidate["verdict"] = {"status": "unverified", "tier": None, "date": None, "evidence": None}
     return candidate
-
-
-def dedup_key(candidate: dict[str, Any]) -> str:
-    """Union key: two samples proposing the same constraint at the same cite collapse."""
-    citation = candidate.get("citation") or {}
-    predicate = (candidate.get("provenance") or {}).get("predicate", "")
-    return "|".join(
-        [
-            candidate["severity"],
-            ",".join(sorted(candidate["match"]["fields"])),
-            str(citation.get("file")),
-            str(citation.get("lines")),
-            re.sub(r"\s+", "", predicate.lower()),
-        ]
-    )
 
 
 # Sampling orchestration.
@@ -609,11 +604,10 @@ def run_analyst(
             if isinstance(candidate, str):
                 drops[candidate] += 1
                 continue
-            key = dedup_key(candidate)
-            if key in seen:
+            if candidate["id"] in seen:
                 drops["dedup_collapsed"] += 1
                 continue
-            seen.add(key)
+            seen.add(candidate["id"])
             candidates.append(candidate)
     return candidates, drops
 

--- a/scripts/analyst_cold_read.py
+++ b/scripts/analyst_cold_read.py
@@ -54,6 +54,8 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts._candidate_pool import pool_path, slug, unverified_verdict, write_pool  # noqa: E402
+from scripts._engine_constructors import leaf_of  # noqa: E402
+from scripts.engine_producers._current import current_path, load_current  # noqa: E402
 
 logger = logging.getLogger("analyst_cold_read")
 
@@ -112,9 +114,12 @@ class Segment:
 
 @dataclass(frozen=True)
 class Chunk:
-    """One prompt's worth of source: one or more segments under a cluster."""
+    """One prompt's worth of source: one or more segments under a cluster.
 
-    cluster: str
+    ``chunk_id`` embeds the cluster name (``"<cluster>.<n>"``); split children
+    keep their parent's id, so the cluster need not be tracked separately.
+    """
+
     chunk_id: str
     segments: list[Segment]
 
@@ -163,12 +168,12 @@ def _pack_cluster(cluster: str, segments: list[Segment]) -> list[Chunk]:
     for seg in segments:
         seg_chars = len(seg.numbered())
         if buf and buf_chars + seg_chars > CHUNK_CHAR_BUDGET:
-            chunks.append(Chunk(cluster, f"{cluster}.{len(chunks)}", buf))
+            chunks.append(Chunk(f"{cluster}.{len(chunks)}", buf))
             buf, buf_chars = [], 0
         buf.append(seg)
         buf_chars += seg_chars
     if buf:
-        chunks.append(Chunk(cluster, f"{cluster}.{len(chunks)}", buf))
+        chunks.append(Chunk(f"{cluster}.{len(chunks)}", buf))
     return chunks
 
 
@@ -204,10 +209,7 @@ def split_chunk(chunk: Chunk) -> list[Chunk] | None:
         right_start = seg.start_line + mid - OVERLAP_LINES
         right = Segment(seg.filename, right_start, seg.lines[mid - OVERLAP_LINES :])
         halves = [[left], [right]]
-    return [
-        Chunk(chunk.cluster, f"{chunk.chunk_id}.{tag}", segs)
-        for tag, segs in zip(("a", "b"), halves, strict=True)
-    ]
+    return [Chunk(chunk.chunk_id, segs) for segs in halves]
 
 
 # Prompt: single exhaustive-extraction instruction with a class-coverage checklist.
@@ -327,7 +329,7 @@ def salvage_rules(text: str) -> list[dict[str, Any]]:
         obj = json.loads(text)
         rules = obj.get("rules", obj) if isinstance(obj, dict) else obj
         return [r for r in rules if isinstance(r, dict)] if isinstance(rules, list) else []
-    except (json.JSONDecodeError, AttributeError):
+    except json.JSONDecodeError:
         pass
 
     # Truncated output: the wrapper object never closes, but the complete rule
@@ -361,10 +363,6 @@ def salvage_rules(text: str) -> list[dict[str, Any]]:
 
 
 # LLM rule -> unified candidate.
-
-
-def _leaf(field: str) -> str:
-    return re.sub(r"^self\.", "", field).rsplit(".", 1)[-1]
 
 
 def _coerce_scalar(token: str) -> Any:
@@ -401,8 +399,8 @@ def predicate_to_match(
     falls back to a ``present`` spec (the field still grounds the citation, the
     raw predicate is kept in provenance). Returns (match_fields, normalised).
     """
-    normalised = [_leaf(f) for f in fields] if severity == "dormant" else []
-    leaves = [_leaf(f) for f in fields]
+    normalised = [leaf_of(f) for f in fields] if severity == "dormant" else []
+    leaves = [leaf_of(f) for f in fields]
 
     if (
         severity == "error"
@@ -481,7 +479,7 @@ def build_candidate(
     the ladder - a warn-only guard never raises at construction, so the
     candidate stays unconfirmed and is never promoted. Do not "fix" it here.
     """
-    fields = [f for f in (rule.get("fields") or []) if isinstance(f, str) and _leaf(f)]
+    fields = [f for f in (rule.get("fields") or []) if isinstance(f, str) and leaf_of(f)]
     if not fields:
         return "no_field"
     kind = str(rule.get("kind") or "other")
@@ -508,7 +506,7 @@ def build_candidate(
     )
     digest = hashlib.sha1(claim.encode()).hexdigest()[:8]
     candidate: dict[str, Any] = {
-        "id": f"{engine}_analyst_{severity}_{slug('_'.join(_leaf(f) for f in fields))}_{digest}",
+        "id": f"{engine}_analyst_{severity}_{slug('_'.join(leaf_of(f) for f in fields))}_{digest}",
         "engine": engine,
         "engine_version": version,
         "severity": severity,
@@ -635,11 +633,11 @@ def load_manifest(engine: str) -> dict[str, list[str]]:
 
 def resolve_version(engine: str) -> str:
     """Resolve the pinned engine version from engine_versions/<engine>/current.yaml."""
-    path = ENGINE_VERSIONS / engine / "current.yaml"
-    document = yaml.safe_load(path.read_text())
-    version = (document.get("library") or {}).get("current_version")
+    document = load_current(engine)
+    library = document.get("library")
+    version = library.get("current_version") if isinstance(library, dict) else None
     if not version:
-        raise ValueError(f"{path} has no library.current_version")
+        raise ValueError(f"{current_path(engine)} has no library.current_version")
     return str(version)
 
 
@@ -666,7 +664,8 @@ def load_sources(
                 rel = path.relative_to(source_root).as_posix()
                 if rel not in sources:
                     sources[rel] = path.read_text().splitlines()
-                resolved.append(rel)
+                if rel not in resolved:  # a file matched by two patterns is read once, chunked once
+                    resolved.append(rel)
         if resolved:
             cluster_files[cluster] = resolved
     return cluster_files, sources

--- a/scripts/analyst_cold_read.py
+++ b/scripts/analyst_cold_read.py
@@ -47,9 +47,16 @@ from typing import Any
 
 import yaml
 
+# Make the top-level ``scripts`` package importable whether this is run as a
+# plain script (``python scripts/analyst_cold_read.py``) or imported as a module.
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts._candidate_pool import pool_path, slug, unverified_verdict, write_pool  # noqa: E402
+
 logger = logging.getLogger("analyst_cold_read")
 
-SCHEMA_VERSION = "1.0.0"
 SOURCE = "analyst_cold_read"
 
 DEFAULT_MODEL = "qwen2.5-coder:32b"
@@ -453,10 +460,6 @@ def resolve_citation(
     return {"file": relpath, "lines": [start, end], "quote": "\n".join(file_lines[start - 1 : end])}
 
 
-def _slug(text: str) -> str:
-    return re.sub(r"_+", "_", re.sub(r"[^0-9a-zA-Z]+", "_", text)).strip("_").lower()
-
-
 def build_candidate(
     chunk: Chunk,
     sources: dict[str, list[str]],
@@ -505,7 +508,7 @@ def build_candidate(
     )
     digest = hashlib.sha1(claim.encode()).hexdigest()[:8]
     candidate: dict[str, Any] = {
-        "id": f"{engine}_analyst_{severity}_{_slug('_'.join(_leaf(f) for f in fields))}_{digest}",
+        "id": f"{engine}_analyst_{severity}_{slug('_'.join(_leaf(f) for f in fields))}_{digest}",
         "engine": engine,
         "engine_version": version,
         "severity": severity,
@@ -525,7 +528,7 @@ def build_candidate(
         "rationale": str(rule.get("rationale") or ""),
         "severity_suggestion": suggestion,
     }
-    candidate["verdict"] = {"status": "unverified", "tier": None, "date": None, "evidence": None}
+    candidate["verdict"] = unverified_verdict()
     return candidate
 
 
@@ -678,11 +681,6 @@ _POOL_HEADER = (
 )
 
 
-def _pool_path(pool_root: Path, engine: str, version: str) -> Path:
-    version_dir = "v" + re.sub(r"[^0-9a-zA-Z]+", "_", version).strip("_")
-    return pool_root / engine / version_dir / "candidates" / "analyst_cold_read.yaml"
-
-
 def write_candidates(
     candidates: list[dict[str, Any]],
     pool_root: Path,
@@ -694,20 +692,17 @@ def write_candidates(
     run_date: str,
 ) -> Path:
     """Write the version-scoped candidate pool file and return its path."""
-    document = {
-        "schema_version": SCHEMA_VERSION,
-        "source": SOURCE,
-        "engine": engine,
-        "engine_version": version,
-        "model": model,
-        "samples": samples,
-        "generated_at": run_date,
-        "candidates": candidates,
-    }
-    path = _pool_path(pool_root, engine, version)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    body = yaml.safe_dump(document, sort_keys=False, default_flow_style=False)
-    path.write_text(_POOL_HEADER + body)
+    path = pool_path(pool_root, engine, version, "analyst_cold_read.yaml")
+    write_pool(
+        path,
+        source=SOURCE,
+        engine=engine,
+        version=version,
+        generated_at=run_date,
+        candidates=candidates,
+        header=_POOL_HEADER,
+        extra={"model": model, "samples": samples},
+    )
     return path
 
 

--- a/scripts/analyst_cold_read.py
+++ b/scripts/analyst_cold_read.py
@@ -387,40 +387,42 @@ def _coerce_scalar(token: str) -> Any:
 _NEGATED_OP = {"<": ">=", "<=": ">", ">": "<=", ">=": "<", "==": "!=", "!=": "=="}
 
 
-def predicate_to_match(
-    kind: str, fields: list[str], predicate: str, severity: str
-) -> tuple[dict[str, Any], list[str]]:
+def predicate_to_match(fields: list[str], predicate: str, severity: str) -> dict[str, Any]:
     """Translate the analyst's free-text predicate into a match.fields spec.
 
-    match.fields encodes the config the rule ACTS on, in the corpus polarity:
-    for an error the VIOLATING side (the valid predicate negated), for a dormant
-    candidate the normalised field(s). Only clean single-field comparison/enum
-    predicates are structured; anything compound, cross-field, or arithmetic
-    falls back to a ``present`` spec (the field still grounds the citation, the
-    raw predicate is kept in provenance). Returns (match_fields, normalised).
+    match.fields encodes the config the rule ACTS on. The comparison is
+    structured once; its polarity then follows the severity: an ``error`` probes
+    the VIOLATING side (the valid predicate negated), while a ``dormant``
+    candidate probes the FIRING side (the normalisation's trigger, positive), so
+    the identity probe has two distinct declared values to compare. Dormancy
+    predicates carry a ``-> RHS`` normalisation suffix (``seed == -1 -> None``);
+    the comparison to structure is the left-hand side. Only clean single-field
+    comparison/enum predicates are structured; anything compound, cross-field,
+    or arithmetic falls back to a ``present`` spec (the field still grounds the
+    citation, the raw predicate is kept in provenance).
     """
-    normalised = [leaf_of(f) for f in fields] if severity == "dormant" else []
     leaves = [leaf_of(f) for f in fields]
+    # A dormancy predicate reads "<comparison> -> <normalised result>"; structure
+    # only the comparison. The arrow is dash-then-gt, absent from >=/<=/negatives.
+    comparison = predicate.split("->", 1)[0].strip()
 
-    if (
-        severity == "error"
-        and len(leaves) == 1
-        and " or " not in predicate
-        and " and " not in predicate
-    ):
+    if len(leaves) == 1:
         leaf = leaves[0]
         cmp = re.fullmatch(
-            rf"\s*{re.escape(leaf)}\s*(<=|>=|==|!=|<|>)\s*(-?\d+(?:\.\d+)?)\s*", predicate
+            rf"\s*{re.escape(leaf)}\s*(<=|>=|==|!=|<|>)\s*(-?\d+(?:\.\d+)?)\s*", comparison
         )
         if cmp:
-            return {leaf: {_NEGATED_OP[cmp.group(1)]: _coerce_scalar(cmp.group(2))}}, normalised
-        enum = re.fullmatch(rf"\s*{re.escape(leaf)}\s+in\s+[\[{{(]([^\]}})]+)[\]}})]\s*", predicate)
+            op = _NEGATED_OP[cmp.group(1)] if severity == "error" else cmp.group(1)
+            return {leaf: {op: _coerce_scalar(cmp.group(2))}}
+        enum = re.fullmatch(
+            rf"\s*{re.escape(leaf)}\s+in\s+[\[{{(]([^\]}})]+)[\]}})]\s*", comparison
+        )
         if enum:
             members = [_coerce_scalar(tok) for tok in enum.group(1).split(",") if tok.strip()]
             if members:
-                return {leaf: {"not_in": members}}, normalised
+                return {leaf: {"not_in" if severity == "error" else "in": members}}
 
-    return {leaf: {"present": True} for leaf in leaves}, normalised
+    return {leaf: {"present": True} for leaf in leaves}
 
 
 def resolve_citation(
@@ -428,22 +430,28 @@ def resolve_citation(
 ) -> dict[str, Any] | None:
     """Resolve ``FILE.py:LINE`` to a {file, lines, quote} citation, or None.
 
-    Basename is matched against the chunk's own segments first, then the whole
-    pool. The quote is a verbatim window from the real file, so span-match
-    passes by construction and tier 1 adjudicates only token entailment.
+    The full cited relative path is matched exactly against the loaded sources
+    first (it disambiguates same-basename files in different directories); the
+    basename fallback then tries the chunk's own segments, then a pool-wide
+    unique match. The quote is a verbatim window from the real file, so
+    span-match passes by construction and tier 1 adjudicates only token entailment.
     """
     match = re.search(r"([\w./-]+\.py)\s*:\s*(\d+)", raw)
     if not match:
         return None
-    basename = Path(match.group(1)).name
+    cited = match.group(1)
+    basename = Path(cited).name
     line = int(match.group(2))
 
     relpath: str | None = None
-    for seg in chunk.segments:
-        if Path(seg.filename).name == basename:
-            relpath = seg.filename
-            break
-    if relpath is None:
+    if cited in sources:  # exact relative-path match wins
+        relpath = cited
+    if relpath is None:  # basename fallback: the chunk's own segments first ...
+        for seg in chunk.segments:
+            if Path(seg.filename).name == basename:
+                relpath = seg.filename
+                break
+    if relpath is None:  # ... then a pool-wide unique basename match
         hits = [path for path in sources if Path(path).name == basename]
         if len(hits) == 1:
             relpath = hits[0]
@@ -491,7 +499,10 @@ def build_candidate(
     if citation is None:
         return "unresolved_citation"
 
-    match_fields, normalised = predicate_to_match(kind, fields, predicate, severity)
+    match_fields = predicate_to_match(fields, predicate, severity)
+    # A dormant claim normalises its own field (a value-alias): the identity
+    # probe reads this to snapshot the resolved state across declared values.
+    normalised = [leaf_of(f) for f in fields] if severity == "dormant" else []
     # The id digests the claim - severity, fields, file, whitespace/case-normalised
     # predicate, deliberately NOT the line window, which shifts across bumps. The
     # union dedup keys on this id, so "one candidate per id" is the pool contract:
@@ -620,9 +631,11 @@ def load_manifest(engine: str) -> dict[str, list[str]]:
     """Read the per-engine cluster manifest; fail clearly when it is absent."""
     path = ENGINE_VERSIONS / engine / MANIFEST_NAME
     if not path.is_file():
+        available = sorted(p.parent.name for p in ENGINE_VERSIONS.glob(f"*/{MANIFEST_NAME}"))
+        have = ", ".join(available) if available else "none"
         raise FileNotFoundError(
             f"no analyst cluster manifest for engine {engine!r} at {path}. "
-            f"Only vllm ships one so far; author {path} before cold-reading {engine}."
+            f"Engines with a manifest: {have}. Author {path} before cold-reading {engine}."
         )
     document = yaml.safe_load(path.read_text())
     clusters = document.get("clusters") if isinstance(document, dict) else None
@@ -710,7 +723,11 @@ def write_candidates(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--engine", required=True, choices=("vllm", "transformers", "tensorrt"))
+    parser.add_argument(
+        "--engine",
+        required=True,
+        help="Engine to cold-read; load_manifest gates on the data files that ship a manifest",
+    )
     parser.add_argument(
         "--source-root",
         type=Path,

--- a/scripts/analyst_cold_read.py
+++ b/scripts/analyst_cold_read.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""Analyst cold read (proposer S2 of the engine-rule verification ladder).
+
+An LLM analyst reads the pinned engine source cold - no prior corpus, no
+seeding - and proposes every config-validation constraint it can see, each a
+candidate carrying a mandatory source citation. This is the recall-maximising
+proposer; the deterministic ladder (citation check -> construction probe ->
+identity probe) earns a candidate its place in the shipped corpus. At this
+precision (~77-80% content-correct on the parity experiment) the analyst never
+self-certifies. A pure completion loop over line-numbered source chunks: one
+exhaustive-extraction prompt, self-consistency union across samples, a salvage
+parser for truncated output. No agentic access, no repair loops, no retries.
+Design and ratification: .product/research/oss-analyst-parity-2026-07-02/.
+
+--source-root is the engine's top-level package directory at the pinned version
+(for vllm, the ``vllm/`` folder) - an explicit maintainer input, as it is for
+scripts/check_citations.py, with no downloader built in. Obtain it the cheapest
+defensible way, e.g. ``pip download --no-binary :all: --no-deps vllm==0.19.1``
+then unpack the sdist, or copy the package out of the pinned engine image.
+
+Output goes to ``<pool-root>/<engine>/v<version>/candidates/analyst_cold_read.yaml``
+in the unified candidate schema, consumable UNCHANGED by check_citations.py
+(tier 1) and probe_candidates.py (tiers 2-3). This NEVER writes the shipped
+``src/llenergymeasure/engines/<engine>/rules.yaml`` corpora.
+
+Run: python scripts/analyst_cold_read.py --engine vllm --source-root SRC/
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+import time
+import urllib.request
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger("analyst_cold_read")
+
+SCHEMA_VERSION = "1.0.0"
+SOURCE = "analyst_cold_read"
+
+DEFAULT_MODEL = "qwen2.5-coder:32b"
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+DEFAULT_SAMPLES = 3
+
+CHUNK_CHAR_BUDGET = 60000  # ~18-20k tokens of source; leaves output room in 32k ctx
+OVERLAP_LINES = 40
+NUM_PREDICT = 8192
+NUM_CTX = 32768
+QUOTE_RADIUS = 3  # lines of context each side of a cited line in the emitted quote
+MAX_SPLIT_DEPTH = 3  # cap-hit chunks are halved and re-run, up to this recursion depth
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENGINE_VERSIONS = REPO_ROOT / "engine_versions"
+MANIFEST_NAME = "analyst_clusters.yaml"
+
+
+@dataclass(frozen=True)
+class GenResult:
+    """One model completion: the raw text plus the stop signals we act on."""
+
+    text: str
+    done_reason: str | None
+    eval_count: int | None
+
+
+# A generator maps (prompt, temperature) -> GenResult. The real one calls
+# Ollama; tests inject a deterministic stub. This IS the only client boundary -
+# there is no frontier-model abstraction layer; the candidate file is the
+# interface a different proposer would produce.
+Generator = Callable[[str, float], GenResult]
+
+
+# Source chunking: line numbers preserved so citations resolve.
+
+
+@dataclass(frozen=True)
+class Segment:
+    """A contiguous window of one source file, tagged with its real start line."""
+
+    filename: str  # source-root-relative path, e.g. "config/parallel.py"
+    start_line: int  # 1-based line number of ``lines[0]`` in the real file
+    lines: list[str]
+
+    @property
+    def end_line(self) -> int:
+        return self.start_line + len(self.lines) - 1
+
+    def numbered(self) -> str:
+        return "\n".join(f"{self.start_line + i:6d}  {line}" for i, line in enumerate(self.lines))
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """One prompt's worth of source: one or more segments under a cluster."""
+
+    cluster: str
+    chunk_id: str
+    segments: list[Segment]
+
+    def numbered_source(self) -> str:
+        return "\n\n".join(seg.numbered() for seg in self.segments)
+
+    def label(self) -> str:
+        return ", ".join(
+            f"{seg.filename} (lines {seg.start_line}-{seg.end_line})" for seg in self.segments
+        )
+
+    def class_names(self) -> list[str]:
+        """Top-level class names declared anywhere in this chunk, first-seen order."""
+        names: list[str] = []
+        for seg in self.segments:
+            for line in seg.lines:
+                match = re.match(r"class\s+(\w+)", line)
+                if match and match.group(1) not in names:
+                    names.append(match.group(1))
+        return names
+
+
+def _window_file(filename: str, lines: list[str]) -> list[Segment]:
+    """Split one file into char-budget-limited overlapping segments."""
+    segments: list[Segment] = []
+    n = len(lines)
+    i = 0
+    while i < n:
+        j, chars = i, 0
+        while j < n and chars < CHUNK_CHAR_BUDGET:
+            chars += len(lines[j]) + 8
+            j += 1
+        segments.append(Segment(filename, i + 1, lines[i:j]))
+        if j >= n:
+            break
+        step = j - OVERLAP_LINES
+        i = step if step > i else j  # overlap, but always make forward progress
+    return segments
+
+
+def _pack_cluster(cluster: str, segments: list[Segment]) -> list[Chunk]:
+    """Pack one cluster's windows into char-budget chunks in order."""
+    chunks: list[Chunk] = []
+    buf: list[Segment] = []
+    buf_chars = 0
+    for seg in segments:
+        seg_chars = len(seg.numbered())
+        if buf and buf_chars + seg_chars > CHUNK_CHAR_BUDGET:
+            chunks.append(Chunk(cluster, f"{cluster}.{len(chunks)}", buf))
+            buf, buf_chars = [], 0
+        buf.append(seg)
+        buf_chars += seg_chars
+    if buf:
+        chunks.append(Chunk(cluster, f"{cluster}.{len(chunks)}", buf))
+    return chunks
+
+
+def build_chunks(cluster_files: dict[str, list[str]], sources: dict[str, list[str]]) -> list[Chunk]:
+    """Pack per-file windows into char-budget chunks, one chunk list per cluster."""
+    chunks: list[Chunk] = []
+    for cluster, files in cluster_files.items():
+        segments: list[Segment] = []
+        for filename in files:
+            file_lines = sources.get(filename)
+            if file_lines is not None:
+                segments += _window_file(filename, file_lines)
+        chunks += _pack_cluster(cluster, segments)
+    return chunks
+
+
+def split_chunk(chunk: Chunk) -> list[Chunk] | None:
+    """Halve a chunk that hit the output cap; real line numbers are preserved.
+
+    Multi-segment chunks split down the segment list; a single-segment chunk
+    splits that segment's lines in half with the standard overlap. Returns None
+    when the chunk is too small to split further (accept truncation then).
+    """
+    if len(chunk.segments) > 1:
+        mid = len(chunk.segments) // 2
+        halves = [chunk.segments[:mid], chunk.segments[mid:]]
+    else:
+        seg = chunk.segments[0]
+        if len(seg.lines) <= 2 * OVERLAP_LINES:
+            return None
+        mid = len(seg.lines) // 2
+        left = Segment(seg.filename, seg.start_line, seg.lines[:mid])
+        right_start = seg.start_line + mid - OVERLAP_LINES
+        right = Segment(seg.filename, right_start, seg.lines[mid - OVERLAP_LINES :])
+        halves = [[left], [right]]
+    return [
+        Chunk(chunk.cluster, f"{chunk.chunk_id}.{tag}", segs)
+        for tag, segs in zip(("a", "b"), halves, strict=True)
+    ]
+
+
+# Prompt: single exhaustive-extraction instruction with a class-coverage checklist.
+PROMPT_TEMPLATE = """You are a meticulous configuration-constraint analyst reading {engine} {version} source.
+
+Your job: from the source file(s) below, extract EVERY validation constraint that {engine}
+enforces on user-supplied configuration fields. Be exhaustive - every guard, bound, enum check,
+cross-field relation, and silent-normalisation counts. Do not skip any.
+
+Constraint kinds (use exactly these strings for "kind"):
+  single_field_bound - one field, numeric/range/type predicate (e.g. n >= 1, temperature >= 0.0)
+  single_field_enum  - one field must be in a set of allowed values (e.g. kv_role in {{producer,consumer}})
+  cross_field        - a relation between two or more fields (e.g. min_tokens <= max_tokens; A requires B)
+  dormancy           - a field is silently normalised/reset/clamped without raising (e.g. seed==-1 -> None)
+  other              - env-var-gated, platform-gated, or requires a live model/hf-config to evaluate
+
+For EACH constraint emit an object with these keys:
+  "kind":                one of the five strings above
+  "fields":              list of the config field name(s) involved (bare names, strip any "self." prefix)
+  "predicate":           a normalised boolean expression for the VALID/legal condition
+                         (e.g. "n >= 1", "-2.0 <= presence_penalty <= 2.0", "min_tokens <= max_tokens").
+                         For dormancy, describe the normalisation (e.g. "seed == -1 -> None").
+  "condition":           the class / method context in which it applies (e.g. "SamplingParams._verify_args")
+  "citation":            "FILENAME.py:LINE" using the exact 1-based line numbers shown in the left margin
+                         below. Cite the line where the guard/raise/assignment actually appears.
+  "severity_suggestion": "error" (raises), "warning" (logs+continues), or "dormant" (silent normalise)
+  "rationale":           one short sentence: what is enforced and what happens on violation.
+
+Rules:
+- Cover ALL classes in the file, not just the first. Include pydantic Field(ge=/gt=/le=/lt=/Literal[...])
+  bounds as single_field_bound / single_field_enum with the field's declared line as citation.
+- Cross-field constraints are the highest priority; do not down-cast a two-field relation into a
+  single-field bound.
+- Include silent normalisations (dormancy) - assignments in __post_init__ that overwrite a user value
+  without raising.
+- Do NOT invent constraints not present in the source. Only emit what the code actually enforces.
+- Output STRICT JSON only, an object of the form {{"rules": [ ... ]}} with no prose before or after.
+
+CLASS COVERAGE CHECKLIST - the following classes are declared in this source:
+{class_checklist}
+Scan EVERY listed class before you finish. For each class emit at least one constraint, or, if a class
+genuinely enforces nothing on user config, emit one entry with "kind": "other", the class name in
+"fields", and rationale "no user-config constraint in <ClassName>". Do not silently skip a class.
+
+SOURCE ({label}):
+{source}
+"""
+
+
+def render_prompt(chunk: Chunk, engine: str, version: str) -> str:
+    classes = chunk.class_names()
+    checklist = (
+        "\n".join(f"  - {name}" for name in classes) if classes else "  (no top-level classes)"
+    )
+    return PROMPT_TEMPLATE.format(
+        engine=engine,
+        version=version,
+        class_checklist=checklist,
+        label=chunk.label(),
+        source=chunk.numbered_source(),
+    )
+
+
+# Ollama client: the single proposer boundary.
+
+
+def ollama_generator(host: str, model: str) -> Generator:
+    """A Generator bound to a live Ollama endpoint (format=json completion)."""
+
+    def generate(prompt: str, temperature: float) -> GenResult:
+        body = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "format": "json",
+            "options": {
+                "num_ctx": NUM_CTX,
+                "temperature": temperature,
+                "num_predict": NUM_PREDICT,
+                "top_p": 0.9,
+            },
+        }
+        request = urllib.request.Request(
+            f"{host.rstrip('/')}/api/generate",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(request, timeout=1800) as response:
+            payload = json.load(response)
+        return GenResult(
+            text=payload.get("response", ""),
+            done_reason=payload.get("done_reason"),
+            eval_count=payload.get("eval_count"),
+        )
+
+    return generate
+
+
+def hit_cap(result: GenResult) -> bool:
+    """True when the completion stopped by exhausting the num_predict budget."""
+    if result.done_reason == "length":
+        return True
+    return result.eval_count is not None and result.eval_count >= NUM_PREDICT
+
+
+# Salvage parser: truncated JSON still yields its complete rule objects.
+
+
+def salvage_rules(text: str) -> list[dict[str, Any]]:
+    """Parse ``{"rules": [...]}``; on truncation, recover the complete objects.
+
+    A clean parse returns the ``rules`` list. When output is cut at the token
+    cap json.loads fails, so we scan for balanced ``{...}`` objects and keep the
+    rule-shaped ones that parse.
+    """
+    try:
+        obj = json.loads(text)
+        rules = obj.get("rules", obj) if isinstance(obj, dict) else obj
+        return [r for r in rules if isinstance(r, dict)] if isinstance(rules, list) else []
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    # Truncated output: the wrapper object never closes, but the complete rule
+    # objects inside it do. Track every balanced {...} with a start-index stack
+    # (respecting string escapes) and keep the rule-shaped ones.
+    rules: list[dict[str, Any]] = []
+    starts: list[int] = []
+    in_string = False
+    escape = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char == "{":
+            starts.append(index)
+        elif char == "}" and starts:
+            start = starts.pop()
+            try:
+                obj = json.loads(text[start : index + 1])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict) and "rules" not in obj and ("fields" in obj or "kind" in obj):
+                rules.append(obj)
+    return rules
+
+
+# LLM rule -> unified candidate.
+
+
+def _leaf(field: str) -> str:
+    return re.sub(r"^self\.", "", field).rsplit(".", 1)[-1]
+
+
+def _coerce_scalar(token: str) -> Any:
+    """Parse a source-verbatim literal token into int/float/bool/None/str."""
+    token = token.strip().strip("'\"")
+    low = token.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    if low in ("none", "null"):
+        return None
+    try:
+        return int(token)
+    except ValueError:
+        pass
+    try:
+        return float(token)
+    except ValueError:
+        return token
+
+
+# valid-predicate operator -> the operator whose match is the VIOLATION we probe.
+_NEGATED_OP = {"<": ">=", "<=": ">", ">": "<=", ">=": "<", "==": "!=", "!=": "=="}
+
+
+def predicate_to_match(
+    kind: str, fields: list[str], predicate: str, severity: str
+) -> tuple[dict[str, Any], list[str]]:
+    """Translate the analyst's free-text predicate into a match.fields spec.
+
+    match.fields encodes the config the rule ACTS on, in the corpus polarity:
+    for an error the VIOLATING side (the valid predicate negated), for a dormant
+    candidate the normalised field(s). Only clean single-field comparison/enum
+    predicates are structured; anything compound, cross-field, or arithmetic
+    falls back to a ``present`` spec (the field still grounds the citation, the
+    raw predicate is kept in provenance). Returns (match_fields, normalised).
+    """
+    normalised = [_leaf(f) for f in fields] if severity == "dormant" else []
+    leaves = [_leaf(f) for f in fields]
+
+    if (
+        severity == "error"
+        and len(leaves) == 1
+        and " or " not in predicate
+        and " and " not in predicate
+    ):
+        leaf = leaves[0]
+        cmp = re.fullmatch(
+            rf"\s*{re.escape(leaf)}\s*(<=|>=|==|!=|<|>)\s*(-?\d+(?:\.\d+)?)\s*", predicate
+        )
+        if cmp:
+            return {leaf: {_NEGATED_OP[cmp.group(1)]: _coerce_scalar(cmp.group(2))}}, normalised
+        enum = re.fullmatch(rf"\s*{re.escape(leaf)}\s+in\s+[\[{{(]([^\]}})]+)[\]}})]\s*", predicate)
+        if enum:
+            members = [_coerce_scalar(tok) for tok in enum.group(1).split(",") if tok.strip()]
+            if members:
+                return {leaf: {"not_in": members}}, normalised
+
+    return {leaf: {"present": True} for leaf in leaves}, normalised
+
+
+def resolve_citation(
+    chunk: Chunk, sources: dict[str, list[str]], raw: str
+) -> dict[str, Any] | None:
+    """Resolve ``FILE.py:LINE`` to a {file, lines, quote} citation, or None.
+
+    Basename is matched against the chunk's own segments first, then the whole
+    pool. The quote is a verbatim window from the real file, so span-match
+    passes by construction and tier 1 adjudicates only token entailment.
+    """
+    match = re.search(r"([\w./-]+\.py)\s*:\s*(\d+)", raw)
+    if not match:
+        return None
+    basename = Path(match.group(1)).name
+    line = int(match.group(2))
+
+    relpath: str | None = None
+    for seg in chunk.segments:
+        if Path(seg.filename).name == basename:
+            relpath = seg.filename
+            break
+    if relpath is None:
+        hits = [path for path in sources if Path(path).name == basename]
+        if len(hits) == 1:
+            relpath = hits[0]
+    if relpath is None:
+        return None
+
+    file_lines = sources.get(relpath)
+    if file_lines is None or not 1 <= line <= len(file_lines):
+        return None
+    start = max(1, line - QUOTE_RADIUS)
+    end = min(len(file_lines), line + QUOTE_RADIUS)
+    return {"file": relpath, "lines": [start, end], "quote": "\n".join(file_lines[start - 1 : end])}
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"_+", "_", re.sub(r"[^0-9a-zA-Z]+", "_", text)).strip("_").lower()
+
+
+def build_candidate(
+    chunk: Chunk,
+    sources: dict[str, list[str]],
+    rule: dict[str, Any],
+    *,
+    engine: str,
+    version: str,
+    model: str,
+    samples: int,
+    run_date: str,
+) -> dict[str, Any] | None:
+    """Assemble one unified candidate, or None if the rule is unusable.
+
+    Dropped when it names no field or its citation resolves to no real file:line
+    (a hallucination). All the analyst said is kept under provenance.
+    """
+    fields = [f for f in (rule.get("fields") or []) if isinstance(f, str) and _leaf(f)]
+    if not fields:
+        return None
+    kind = str(rule.get("kind") or "other")
+    predicate = str(rule.get("predicate") or "")
+    suggestion = str(rule.get("severity_suggestion") or "")
+    severity = "dormant" if kind == "dormancy" or suggestion == "dormant" else "error"
+
+    citation = resolve_citation(chunk, sources, str(rule.get("citation") or ""))
+    if citation is None:
+        return None
+
+    match_fields, normalised = predicate_to_match(kind, fields, predicate, severity)
+    digest = hashlib.sha1(
+        f"{severity}|{sorted(match_fields)}|{citation['file']}|{predicate}".encode()
+    ).hexdigest()[:8]
+    candidate: dict[str, Any] = {
+        "id": f"{engine}_analyst_{severity}_{_slug('_'.join(_leaf(f) for f in fields))}_{digest}",
+        "engine": engine,
+        "engine_version": version,
+        "severity": severity,
+        "match": {"fields": match_fields},
+    }
+    if normalised:
+        candidate["normalised_fields"] = normalised
+    candidate["citation"] = citation
+    candidate["provenance"] = {
+        "source": SOURCE,
+        "model": model,
+        "samples": samples,
+        "date": run_date,
+        "kind": kind,
+        "predicate": predicate,
+        "condition": str(rule.get("condition") or ""),
+        "rationale": str(rule.get("rationale") or ""),
+        "severity_suggestion": suggestion,
+    }
+    candidate["verdict"] = {"status": "unverified", "tier": None, "date": None, "evidence": None}
+    return candidate
+
+
+def dedup_key(candidate: dict[str, Any]) -> str:
+    """Union key: two samples proposing the same constraint at the same cite collapse."""
+    citation = candidate.get("citation") or {}
+    predicate = (candidate.get("provenance") or {}).get("predicate", "")
+    return "|".join(
+        [
+            candidate["severity"],
+            ",".join(sorted(candidate["match"]["fields"])),
+            str(citation.get("file")),
+            str(citation.get("lines")),
+            re.sub(r"\s+", "", predicate.lower()),
+        ]
+    )
+
+
+# Sampling orchestration.
+
+
+def sample_chunk(
+    chunk: Chunk,
+    generate: Generator,
+    samples: int,
+    *,
+    engine: str,
+    version: str,
+    _depth: int = 0,
+) -> list[tuple[Chunk, dict[str, Any]]]:
+    """One temp-0 pass plus (samples-1) temp-0.6 passes; split on a cap hit.
+
+    Returns (chunk, raw-llm-rule) pairs. When the temp-0 pass hits the output
+    cap the chunk is halved and each half re-run in full, not read truncated.
+    """
+    prompt = render_prompt(chunk, engine, version)
+    first = generate(prompt, 0.0)
+    if hit_cap(first) and _depth < MAX_SPLIT_DEPTH:
+        parts = split_chunk(chunk)
+        if parts:
+            collected: list[tuple[Chunk, dict[str, Any]]] = []
+            for part in parts:
+                collected += sample_chunk(
+                    part, generate, samples, engine=engine, version=version, _depth=_depth + 1
+                )
+            return collected
+
+    pairs = [(chunk, rule) for rule in salvage_rules(first.text)]
+    for _ in range(max(0, samples - 1)):
+        extra = generate(prompt, 0.6)
+        pairs += [(chunk, rule) for rule in salvage_rules(extra.text)]
+    return pairs
+
+
+def run_analyst(
+    chunks: list[Chunk],
+    sources: dict[str, list[str]],
+    generate: Generator,
+    *,
+    engine: str,
+    version: str,
+    model: str,
+    samples: int,
+    run_date: str,
+) -> list[dict[str, Any]]:
+    """Cold-read every chunk, build candidates, and union-dedup the pool."""
+    seen: set[str] = set()
+    candidates: list[dict[str, Any]] = []
+    for position, chunk in enumerate(chunks, start=1):
+        logger.info("chunk %d/%d %s", position, len(chunks), chunk.chunk_id)
+        for source_chunk, rule in sample_chunk(
+            chunk, generate, samples, engine=engine, version=version
+        ):
+            candidate = build_candidate(
+                source_chunk,
+                sources,
+                rule,
+                engine=engine,
+                version=version,
+                model=model,
+                samples=samples,
+                run_date=run_date,
+            )
+            if candidate is None:
+                continue
+            key = dedup_key(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(candidate)
+    return candidates
+
+
+# Manifest, version, source loading, emission.
+
+
+def load_manifest(engine: str) -> dict[str, list[str]]:
+    """Read the per-engine cluster manifest; fail clearly when it is absent."""
+    path = ENGINE_VERSIONS / engine / MANIFEST_NAME
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"no analyst cluster manifest for engine {engine!r} at {path}. "
+            f"Only vllm ships one so far; author {path} before cold-reading {engine}."
+        )
+    document = yaml.safe_load(path.read_text())
+    clusters = document.get("clusters") if isinstance(document, dict) else None
+    if not isinstance(clusters, dict) or not clusters:
+        raise ValueError(f"manifest {path} has no non-empty 'clusters' mapping")
+    return {str(name): [str(p) for p in patterns] for name, patterns in clusters.items()}
+
+
+def resolve_version(engine: str) -> str:
+    """Resolve the pinned engine version from engine_versions/<engine>/current.yaml."""
+    path = ENGINE_VERSIONS / engine / "current.yaml"
+    document = yaml.safe_load(path.read_text())
+    version = (document.get("library") or {}).get("current_version")
+    if not version:
+        raise ValueError(f"{path} has no library.current_version")
+    return str(version)
+
+
+def load_sources(
+    source_root: Path, manifest: dict[str, list[str]]
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Expand manifest patterns and read every file into line lists.
+
+    Returns ``(cluster_files, sources)``: cluster -> ordered relative paths, and
+    relative path -> line list. Missing files are warned and skipped, not fatal.
+    """
+    cluster_files: dict[str, list[str]] = {}
+    sources: dict[str, list[str]] = {}
+    for cluster, patterns in manifest.items():
+        resolved: list[str] = []
+        for pattern in patterns:
+            matches = (
+                sorted(source_root.glob(pattern)) if "*" in pattern else [source_root / pattern]
+            )
+            for path in matches:
+                if not path.is_file():
+                    logger.warning("skipping missing source file: %s", pattern)
+                    continue
+                rel = path.relative_to(source_root).as_posix()
+                if rel not in sources:
+                    sources[rel] = path.read_text().splitlines()
+                resolved.append(rel)
+        if resolved:
+            cluster_files[cluster] = resolved
+    return cluster_files, sources
+
+
+_POOL_HEADER = (
+    "# Analyst cold-read candidate rules (proposer S2).\n"
+    "# Emitted by scripts/analyst_cold_read.py: an LLM analyst's exhaustive cold\n"
+    "# read of the pinned engine source, one cited candidate per constraint.\n"
+    "# UNVERIFIED candidates for the verification ladder. Do NOT hand-copy into\n"
+    "# the shipped src/llenergymeasure/engines/<engine>/rules.yaml corpora.\n"
+)
+
+
+def _pool_path(pool_root: Path, engine: str, version: str) -> Path:
+    version_dir = "v" + re.sub(r"[^0-9a-zA-Z]+", "_", version).strip("_")
+    return pool_root / engine / version_dir / "candidates" / "analyst_cold_read.yaml"
+
+
+def write_candidates(
+    candidates: list[dict[str, Any]],
+    pool_root: Path,
+    *,
+    engine: str,
+    version: str,
+    model: str,
+    samples: int,
+    run_date: str,
+) -> Path:
+    """Write the version-scoped candidate pool file and return its path."""
+    document = {
+        "schema_version": SCHEMA_VERSION,
+        "source": SOURCE,
+        "engine": engine,
+        "engine_version": version,
+        "model": model,
+        "samples": samples,
+        "generated_at": run_date,
+        "candidates": candidates,
+    }
+    path = _pool_path(pool_root, engine, version)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = yaml.safe_dump(document, sort_keys=False, default_flow_style=False)
+    path.write_text(_POOL_HEADER + body)
+    return path
+
+
+# CLI.
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", required=True, choices=("vllm", "transformers", "tensorrt"))
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        required=True,
+        help="Engine package directory at the pinned version (citations resolve against it)",
+    )
+    parser.add_argument(
+        "--pool-root",
+        type=Path,
+        default=ENGINE_VERSIONS,
+        help="Root of the version-scoped candidate pool (default: engine_versions)",
+    )
+    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--ollama-host",
+        default=os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
+    )
+    parser.add_argument(
+        "--date", default=None, help="Provenance date (default: today; set for reproducible output)"
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    if not args.source_root.is_dir():
+        print(f"error: --source-root is not a directory: {args.source_root}", file=sys.stderr)
+        return 2
+    try:
+        manifest = load_manifest(args.engine)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    version = resolve_version(args.engine)
+    run_date = args.date or date.today().isoformat()
+    cluster_files, sources = load_sources(args.source_root, manifest)
+    chunks = build_chunks(cluster_files, sources)
+    logger.info(
+        "engine=%s version=%s chunks=%d samples=%d", args.engine, version, len(chunks), args.samples
+    )
+
+    started = time.time()
+    generate = ollama_generator(args.ollama_host, args.model)
+    candidates = run_analyst(
+        chunks,
+        sources,
+        generate,
+        engine=args.engine,
+        version=version,
+        model=args.model,
+        samples=args.samples,
+        run_date=run_date,
+    )
+    path = write_candidates(
+        candidates,
+        args.pool_root,
+        engine=args.engine,
+        version=version,
+        model=args.model,
+        samples=args.samples,
+        run_date=run_date,
+    )
+    by_kind = Counter(c["provenance"]["kind"] for c in candidates)
+    print(
+        f"analyst cold read: {len(candidates)} candidates "
+        f"({dict(sorted(by_kind.items()))}) in {time.time() - started:.0f}s\nwrote {path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mine_observed_collisions.py
+++ b/scripts/mine_observed_collisions.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import re
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
@@ -36,11 +35,16 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-import yaml
+# Make the top-level ``scripts`` package importable whether this is run as a
+# plain script (``python scripts/mine_observed_collisions.py``) or imported as
+# ``scripts.mine_observed_collisions``.
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts._candidate_pool import pool_path, slug, unverified_verdict, write_pool  # noqa: E402
 
 logger = logging.getLogger("mine_observed_collisions")
-
-SCHEMA_VERSION = "1.0.0"
 
 # Sentinel for "field absent in this declared config" - distinct from a declared
 # null so absence and an explicit None never compare equal.
@@ -122,11 +126,6 @@ def _differing_fields(flats: list[dict[str, Any]]) -> list[str]:
     return differing
 
 
-def _slug(field_path: str) -> str:
-    """Filesystem/id-safe slug for a dotted field path."""
-    return re.sub(r"_+", "_", re.sub(r"[^0-9a-zA-Z]+", "_", field_path)).strip("_")
-
-
 # ---------------------------------------------------------------------------
 # Loading + mining
 # ---------------------------------------------------------------------------
@@ -191,7 +190,7 @@ def _make_candidate(
     observed_hash = members[0].observed_config_hash
     experiment_dirs = sorted(m.experiment_dir for m in members)
     return {
-        "id": f"{engine}_collision_dormant_{_slug(field_path)}_{observed_hash[:8]}",
+        "id": f"{engine}_collision_dormant_{slug(field_path)}_{observed_hash[:8]}",
         "engine": engine,
         "engine_version": version,
         "severity": "dormant",
@@ -205,7 +204,7 @@ def _make_candidate(
             "declared_values": _distinct_values(field_path, flats),
             "co_occurring_fields": co_occurring,
         },
-        "verdict": {"status": "unverified", "tier": None, "date": None, "evidence": None},
+        "verdict": unverified_verdict(),
     }
 
 
@@ -244,11 +243,6 @@ _POOL_HEADER = (
 )
 
 
-def _pool_path(pool_root: Path, engine: str, version: str) -> Path:
-    version_dir = "v" + re.sub(r"[^0-9a-zA-Z]+", "_", version).strip("_")
-    return pool_root / engine / version_dir / "candidates" / "observed_collisions.yaml"
-
-
 def write_candidates(
     candidates: list[dict[str, Any]],
     pool_root: Path,
@@ -263,18 +257,16 @@ def write_candidates(
 
     written: list[Path] = []
     for (engine, version), group in sorted(by_pool.items()):
-        document = {
-            "schema_version": SCHEMA_VERSION,
-            "source": "observed_collision",
-            "engine": engine,
-            "engine_version": version,
-            "generated_at": generated_at,
-            "candidates": group,
-        }
-        path = _pool_path(pool_root, engine, version)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        body = yaml.safe_dump(document, sort_keys=False, default_flow_style=False)
-        path.write_text(_POOL_HEADER + body)
+        path = pool_path(pool_root, engine, version, "observed_collisions.yaml")
+        write_pool(
+            path,
+            source="observed_collision",
+            engine=engine,
+            version=version,
+            generated_at=generated_at,
+            candidates=group,
+            header=_POOL_HEADER,
+        )
         written.append(path)
     return written
 

--- a/tests/unit/scripts/test_analyst_cold_read.py
+++ b/tests/unit/scripts/test_analyst_cold_read.py
@@ -95,6 +95,18 @@ def test_build_chunks_is_deterministic(fake_tree: Any) -> None:
     assert chunks[0].class_names() == ["SamplingParams"]
 
 
+def test_load_sources_dedups_overlapping_patterns(tmp_path: Path) -> None:
+    # A file matched by two patterns in one cluster is read once and chunked once,
+    # not cold-read twice.
+    (tmp_path / "sampling_params.py").write_text(_FIXTURE_SRC)
+    cluster_files, sources = acr.load_sources(
+        tmp_path, {"sampling": ["sampling_params.py", "*.py"]}
+    )
+    assert cluster_files["sampling"] == ["sampling_params.py"]
+    assert list(sources) == ["sampling_params.py"]
+    assert [c.chunk_id for c in acr.build_chunks(cluster_files, sources)] == ["sampling.0"]
+
+
 def test_prompt_enumerates_class_checklist(fake_tree: Any) -> None:
     _, _, chunks = fake_tree
     prompt = acr.render_prompt(chunks[0], "vllm", "0.19.1")

--- a/tests/unit/scripts/test_analyst_cold_read.py
+++ b/tests/unit/scripts/test_analyst_cold_read.py
@@ -270,6 +270,23 @@ def test_union_dedups_identical_rules_across_samples(fake_tree: Any) -> None:
     assert drops == {"dedup_collapsed": 4}  # 3 samples x 2 rules -> 2 kept, 4 collapsed
 
 
+def test_same_claim_at_shifted_window_collapses_to_one_id(fake_tree: Any) -> None:
+    # The id digests the claim (fields, file, predicate), not the line window:
+    # one claim re-proposed at a shifted cite is one candidate, first cite kept.
+    _, sources, chunks = fake_tree
+    shifted = dict(_N_RULE, citation="sampling_params.py:6")
+
+    def stub(prompt: str, temperature: float) -> Any:
+        return _gen(_rules_json(_N_RULE, shifted))
+
+    candidates, drops = acr.run_analyst(
+        chunks, sources, stub, engine="vllm", version="0.19.1", model="m", samples=1, run_date="d"
+    )
+    assert len(candidates) == 1
+    assert drops == {"dedup_collapsed": 1}
+    assert candidates[0]["citation"]["lines"] == [1, 6]  # window of the first cite, line 3
+
+
 def test_cap_hit_splits_and_reruns() -> None:
     # One 400-line file: the temp-0 pass on the whole chunk hits the cap, so the
     # chunk is halved and each half re-run instead of accepting truncation.

--- a/tests/unit/scripts/test_analyst_cold_read.py
+++ b/tests/unit/scripts/test_analyst_cold_read.py
@@ -1,0 +1,311 @@
+"""Host-side tests for scripts/analyst_cold_read.py (proposer S2).
+
+No model and no network: the Ollama boundary is a stub Generator, so every test
+exercises the harness's own logic - chunking and line fidelity, the salvage
+parser, predicate translation, citation resolution, cap-hit split-and-rerun,
+union dedup, and the emission that must round-trip through the ladder's tier-1
+(check_citations) and tier-2/3 (probe_candidates) consumers.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[3] / "scripts"))
+
+import analyst_cold_read as acr
+import check_citations as cc
+import probe_candidates as pc
+
+
+def _gen(text: str, done: str = "stop", eval_count: int = 100) -> Any:
+    return acr.GenResult(text=text, done_reason=done, eval_count=eval_count)
+
+
+def _rules_json(*rules: dict[str, Any]) -> str:
+    return json.dumps({"rules": list(rules)})
+
+
+# A rule the LLM might emit for the fixture source below (citation points at line 3):
+#   1 class SamplingParams:
+#   2     def _verify_args(self):
+#   3         if self.n < 1:
+#   4             raise ValueError("n must be >= 1")
+#   5         if self.temperature < 0.0:
+#   6             raise ValueError("temperature must be >= 0")
+_N_RULE = {
+    "kind": "single_field_bound",
+    "fields": ["self.n"],
+    "predicate": "n >= 1",
+    "condition": "SamplingParams._verify_args",
+    "citation": "sampling_params.py:3",
+    "severity_suggestion": "error",
+    "rationale": "n must be a positive integer",
+}
+_FIXTURE_SRC = (
+    "class SamplingParams:\n"
+    "    def _verify_args(self):\n"
+    "        if self.n < 1:\n"
+    '            raise ValueError("n must be >= 1")\n'
+    "        if self.temperature < 0.0:\n"
+    '            raise ValueError("temperature must be >= 0")\n'
+)
+
+
+@pytest.fixture
+def fake_tree(tmp_path: Path) -> tuple[Path, dict[str, list[str]], list[Any]]:
+    """A one-file source root plus its loaded sources and built chunks."""
+    (tmp_path / "sampling_params.py").write_text(_FIXTURE_SRC)
+    cluster_files, sources = acr.load_sources(tmp_path, {"sampling": ["sampling_params.py"]})
+    return tmp_path, sources, acr.build_chunks(cluster_files, sources)
+
+
+def _build(
+    chunk: Any, sources: dict[str, list[str]], rule: dict[str, Any]
+) -> dict[str, Any] | None:
+    return acr.build_candidate(
+        chunk, sources, rule, engine="vllm", version="0.19.1", model="m", samples=3, run_date="d"
+    )
+
+
+# Chunking + line fidelity.
+def test_window_preserves_real_line_numbers() -> None:
+    seg = acr.Segment("f.py", 10, [f"x{i} = {i}" for i in range(1, 6)])
+    numbered = seg.numbered().splitlines()
+    assert numbered[0].strip().startswith("10 ")
+    assert numbered[0].endswith("x1 = 1")
+    assert seg.end_line == 14
+
+
+def test_window_overlap_and_progress() -> None:
+    lines = [f"line-{i}" for i in range(1, 5001)]
+    segs = acr._window_file("big.py", lines)
+    assert len(segs) >= 2  # a 5000-line file exceeds one char budget
+    assert segs[1].start_line == segs[0].end_line + 1 - acr.OVERLAP_LINES  # overlap
+    assert all(segs[i + 1].start_line > segs[i].start_line for i in range(len(segs) - 1))
+    assert segs[0].start_line == 1 and segs[-1].end_line == 5000  # full coverage, none dropped
+
+
+def test_build_chunks_is_deterministic(fake_tree: Any) -> None:
+    _, _, chunks = fake_tree
+    assert [c.chunk_id for c in chunks] == ["sampling.0"]
+    assert chunks[0].class_names() == ["SamplingParams"]
+
+
+def test_prompt_enumerates_class_checklist(fake_tree: Any) -> None:
+    _, _, chunks = fake_tree
+    prompt = acr.render_prompt(chunks[0], "vllm", "0.19.1")
+    assert "CLASS COVERAGE CHECKLIST" in prompt
+    assert "- SamplingParams" in prompt
+    assert "vllm 0.19.1 source" in prompt
+
+
+# Salvage parser.
+def test_salvage_clean_json() -> None:
+    text = _rules_json({"kind": "x", "fields": ["a"]}, {"kind": "y", "fields": ["b"]})
+    assert len(acr.salvage_rules(text)) == 2
+
+
+def test_salvage_recovers_complete_objects_from_truncation() -> None:
+    # Wrapper never closes; one complete rule, one cut off -> recover the complete one.
+    text = (
+        '{"rules": [{"kind":"single_field_bound","fields":["n"],'
+        '"predicate":"n >= 1","citation":"p.py:3"}, {"kind":"cross_fie'
+    )
+    rules = acr.salvage_rules(text)
+    assert len(rules) == 1 and rules[0]["fields"] == ["n"]
+
+
+@pytest.mark.parametrize("text", ["not json at all", ""])
+def test_salvage_garbage_is_empty(text: str) -> None:
+    assert acr.salvage_rules(text) == []
+
+
+# Predicate translation: free-text predicate -> match.fields spec.
+@pytest.mark.parametrize(
+    ("kind", "fields", "predicate", "severity", "match", "normalised"),
+    [
+        ("single_field_bound", ["self.n"], "n >= 1", "error", {"n": {"<": 1}}, []),
+        (
+            "single_field_enum",
+            ["kv_role"],
+            "kv_role in {producer, consumer}",
+            "error",
+            {"kv_role": {"not_in": ["producer", "consumer"]}},
+            [],
+        ),
+        (
+            "cross_field",
+            ["a", "b"],
+            "a <= b",
+            "error",
+            {"a": {"present": True}, "b": {"present": True}},
+            [],
+        ),
+        (
+            "single_field_bound",
+            ["seed"],
+            "seed >= 0 or seed == -1",
+            "error",
+            {"seed": {"present": True}},
+            [],
+        ),
+        (
+            "dormancy",
+            ["seed"],
+            "seed == -1 -> None",
+            "dormant",
+            {"seed": {"present": True}},
+            ["seed"],
+        ),
+    ],
+)
+def test_predicate_translation(
+    kind: str,
+    fields: list[str],
+    predicate: str,
+    severity: str,
+    match: dict[str, Any],
+    normalised: list[str],
+) -> None:
+    assert acr.predicate_to_match(kind, fields, predicate, severity) == (match, normalised)
+
+
+# Citation resolution.
+def test_resolve_citation_extracts_verbatim_window(fake_tree: Any) -> None:
+    _, sources, chunks = fake_tree
+    citation = acr.resolve_citation(chunks[0], sources, "sampling_params.py:3")
+    assert citation is not None
+    assert citation["file"] == "sampling_params.py"
+    assert citation["lines"] == [1, 6]  # line 3 +/- QUOTE_RADIUS, clamped to the 6-line file
+    assert "if self.n < 1:" in citation["quote"]
+
+
+@pytest.mark.parametrize("raw", ["imaginary.py:3", "sampling_params.py:999"])
+def test_resolve_citation_rejects_bad_reference(fake_tree: Any, raw: str) -> None:
+    _, sources, chunks = fake_tree
+    assert acr.resolve_citation(chunks[0], sources, raw) is None
+
+
+# Candidate assembly + emission round-trip through the ladder consumers.
+def test_candidate_has_unified_schema(fake_tree: Any) -> None:
+    _, sources, chunks = fake_tree
+    cand = _build(chunks[0], sources, _N_RULE)
+    assert cand is not None
+    assert cand["engine"] == "vllm" and cand["engine_version"] == "0.19.1"
+    assert cand["severity"] == "error"
+    assert cand["match"]["fields"] == {"n": {"<": 1}}
+    assert set(cand["citation"]) == {"file", "lines", "quote"}
+    assert cand["provenance"]["source"] == "analyst_cold_read"
+    assert cand["verdict"] == {"status": "unverified", "tier": None, "date": None, "evidence": None}
+
+
+@pytest.mark.parametrize(
+    "rule", [{"citation": "sampling_params.py:3"}, dict(_N_RULE, citation="ghost.py:1")]
+)
+def test_candidate_dropped_when_unusable(fake_tree: Any, rule: dict[str, Any]) -> None:
+    _, sources, chunks = fake_tree  # no fields, or an unresolvable citation
+    assert _build(chunks[0], sources, rule) is None
+
+
+@pytest.fixture
+def emitted(fake_tree: Any, tmp_path: Path) -> tuple[Path, Path]:
+    """Build the _N_RULE candidate and write the pool file; return (src_root, pool_path)."""
+    src_root, sources, chunks = fake_tree
+    cand = _build(chunks[0], sources, _N_RULE)
+    assert cand is not None
+    out = acr.write_candidates(
+        [cand],
+        tmp_path / "pool",
+        engine="vllm",
+        version="0.19.1",
+        model="m",
+        samples=3,
+        run_date="d",
+    )
+    assert out == tmp_path / "pool" / "vllm" / "v0_19_1" / "candidates" / "analyst_cold_read.yaml"
+    return src_root, out
+
+
+def test_emission_round_trips_through_check_citations(emitted: tuple[Path, Path]) -> None:
+    src_root, out = emitted
+    verdict = cc.check_candidate(cc.load_candidates(out)[0], src_root)
+    assert verdict.ok, verdict.reason
+
+
+def test_emission_round_trips_through_probe_candidates(emitted: tuple[Path, Path]) -> None:
+    _, out = emitted
+    _document, entries = pc.load_document(out)
+    parsed = pc.parse_candidate(entries[0], 0)
+    assert parsed.severity == "error"
+    assert parsed.fields == {"n": {"<": 1}}
+    assert parsed.engine == "vllm"
+
+
+# Sampling orchestration: union dedup + cap-hit split-and-rerun.
+def test_union_dedups_identical_rules_across_samples(fake_tree: Any) -> None:
+    _, sources, chunks = fake_tree
+    other = dict(
+        _N_RULE,
+        fields=["temperature"],
+        predicate="temperature >= 0.0",
+        citation="sampling_params.py:5",
+    )
+
+    def stub(prompt: str, temperature: float) -> Any:
+        return _gen(_rules_json(_N_RULE, other))  # every sample proposes the same two rules
+
+    candidates = acr.run_analyst(
+        chunks, sources, stub, engine="vllm", version="0.19.1", model="m", samples=3, run_date="d"
+    )
+    assert len(candidates) == 2  # union collapses the duplicates
+    assert {next(iter(c["match"]["fields"])) for c in candidates} == {"n", "temperature"}
+
+
+def test_cap_hit_splits_and_reruns() -> None:
+    # One 400-line file: the temp-0 pass on the whole chunk hits the cap, so the
+    # chunk is halved and each half re-run instead of accepting truncation.
+    sources = {"big.py": "\n".join(f"x{i} = {i}" for i in range(1, 401)).splitlines()}
+    chunks = acr.build_chunks({"c": ["big.py"]}, sources)
+    assert len(chunks) == 1
+    seen_temps: list[float] = []
+
+    def stub(prompt: str, temperature: float) -> Any:
+        seen_temps.append(temperature)
+        if temperature == 0.0 and "x400" in prompt and "x1 = 1" in prompt:  # only the full chunk
+            return _gen('{"rules": []}', done="length", eval_count=acr.NUM_PREDICT)
+        return _gen('{"rules": []}')
+
+    acr.sample_chunk(chunks[0], stub, 1, engine="vllm", version="0.19.1")
+    assert seen_temps.count(0.0) >= 3  # full chunk + the two halves each read at temp-0
+
+
+def test_no_split_when_under_cap(fake_tree: Any) -> None:
+    _, _sources, chunks = fake_tree
+    calls: list[float] = []
+
+    def stub(prompt: str, temperature: float) -> Any:
+        calls.append(temperature)
+        return _gen(_rules_json(_N_RULE))
+
+    acr.sample_chunk(chunks[0], stub, 3, engine="vllm", version="0.19.1")
+    assert calls == [0.0, 0.6, 0.6]  # temp-0 then samples-1 temp-0.6, no split
+
+
+# Manifest loading.
+def test_missing_manifest_fails_clearly() -> None:
+    with pytest.raises(FileNotFoundError) as exc:
+        acr.load_manifest("transformers")
+    assert "no analyst cluster manifest" in str(exc.value)
+    assert "transformers" in str(exc.value)
+
+
+def test_vllm_manifest_loads() -> None:
+    manifest = acr.load_manifest("vllm")
+    assert "sampling" in manifest and "platforms" in manifest
+    assert "engine/arg_utils.py" not in [p for ps in manifest.values() for p in ps]

--- a/tests/unit/scripts/test_analyst_cold_read.py
+++ b/tests/unit/scripts/test_analyst_cold_read.py
@@ -65,9 +65,7 @@ def fake_tree(tmp_path: Path) -> tuple[Path, dict[str, list[str]], list[Any]]:
     return tmp_path, sources, acr.build_chunks(cluster_files, sources)
 
 
-def _build(
-    chunk: Any, sources: dict[str, list[str]], rule: dict[str, Any]
-) -> dict[str, Any] | None:
+def _build(chunk: Any, sources: dict[str, list[str]], rule: dict[str, Any]) -> dict[str, Any] | str:
     return acr.build_candidate(
         chunk, sources, rule, engine="vllm", version="0.19.1", model="m", samples=3, run_date="d"
     )
@@ -196,7 +194,7 @@ def test_resolve_citation_rejects_bad_reference(fake_tree: Any, raw: str) -> Non
 def test_candidate_has_unified_schema(fake_tree: Any) -> None:
     _, sources, chunks = fake_tree
     cand = _build(chunks[0], sources, _N_RULE)
-    assert cand is not None
+    assert isinstance(cand, dict)
     assert cand["engine"] == "vllm" and cand["engine_version"] == "0.19.1"
     assert cand["severity"] == "error"
     assert cand["match"]["fields"] == {"n": {"<": 1}}
@@ -206,11 +204,15 @@ def test_candidate_has_unified_schema(fake_tree: Any) -> None:
 
 
 @pytest.mark.parametrize(
-    "rule", [{"citation": "sampling_params.py:3"}, dict(_N_RULE, citation="ghost.py:1")]
+    ("rule", "reason"),
+    [
+        ({"citation": "sampling_params.py:3"}, "no_field"),
+        (dict(_N_RULE, citation="ghost.py:1"), "unresolved_citation"),
+    ],
 )
-def test_candidate_dropped_when_unusable(fake_tree: Any, rule: dict[str, Any]) -> None:
-    _, sources, chunks = fake_tree  # no fields, or an unresolvable citation
-    assert _build(chunks[0], sources, rule) is None
+def test_candidate_dropped_when_unusable(fake_tree: Any, rule: dict[str, Any], reason: str) -> None:
+    _, sources, chunks = fake_tree
+    assert _build(chunks[0], sources, rule) == reason  # the drop reason run_analyst counts
 
 
 @pytest.fixture
@@ -218,7 +220,7 @@ def emitted(fake_tree: Any, tmp_path: Path) -> tuple[Path, Path]:
     """Build the _N_RULE candidate and write the pool file; return (src_root, pool_path)."""
     src_root, sources, chunks = fake_tree
     cand = _build(chunks[0], sources, _N_RULE)
-    assert cand is not None
+    assert isinstance(cand, dict)
     out = acr.write_candidates(
         [cand],
         tmp_path / "pool",
@@ -260,11 +262,12 @@ def test_union_dedups_identical_rules_across_samples(fake_tree: Any) -> None:
     def stub(prompt: str, temperature: float) -> Any:
         return _gen(_rules_json(_N_RULE, other))  # every sample proposes the same two rules
 
-    candidates = acr.run_analyst(
+    candidates, drops = acr.run_analyst(
         chunks, sources, stub, engine="vllm", version="0.19.1", model="m", samples=3, run_date="d"
     )
     assert len(candidates) == 2  # union collapses the duplicates
     assert {next(iter(c["match"]["fields"])) for c in candidates} == {"n", "temperature"}
+    assert drops == {"dedup_collapsed": 4}  # 3 samples x 2 rules -> 2 kept, 4 collapsed
 
 
 def test_cap_hit_splits_and_reruns() -> None:

--- a/tests/unit/scripts/test_analyst_cold_read.py
+++ b/tests/unit/scripts/test_analyst_cold_read.py
@@ -138,52 +138,32 @@ def test_salvage_garbage_is_empty(text: str) -> None:
 
 # Predicate translation: free-text predicate -> match.fields spec.
 @pytest.mark.parametrize(
-    ("kind", "fields", "predicate", "severity", "match", "normalised"),
+    ("fields", "predicate", "severity", "match"),
     [
-        ("single_field_bound", ["self.n"], "n >= 1", "error", {"n": {"<": 1}}, []),
+        # An error probes the VIOLATING side (the valid predicate negated).
+        (["self.n"], "n >= 1", "error", {"n": {"<": 1}}),
         (
-            "single_field_enum",
             ["kv_role"],
             "kv_role in {producer, consumer}",
             "error",
             {"kv_role": {"not_in": ["producer", "consumer"]}},
-            [],
         ),
-        (
-            "cross_field",
-            ["a", "b"],
-            "a <= b",
-            "error",
-            {"a": {"present": True}, "b": {"present": True}},
-            [],
-        ),
-        (
-            "single_field_bound",
-            ["seed"],
-            "seed >= 0 or seed == -1",
-            "error",
-            {"seed": {"present": True}},
-            [],
-        ),
-        (
-            "dormancy",
-            ["seed"],
-            "seed == -1 -> None",
-            "dormant",
-            {"seed": {"present": True}},
-            ["seed"],
-        ),
+        # Compound / cross-field predicates fall back to a present spec.
+        (["a", "b"], "a <= b", "error", {"a": {"present": True}, "b": {"present": True}}),
+        (["seed"], "seed >= 0 or seed == -1", "error", {"seed": {"present": True}}),
+        # A dormant claim probes the FIRING side: the positive comparison, arrow
+        # suffix stripped, so the identity probe has declared values to compare.
+        (["seed"], "seed == -1 -> None", "dormant", {"seed": {"==": -1}}),
+        (["mode"], "mode in {a, b} -> a", "dormant", {"mode": {"in": ["a", "b"]}}),
     ],
 )
 def test_predicate_translation(
-    kind: str,
     fields: list[str],
     predicate: str,
     severity: str,
     match: dict[str, Any],
-    normalised: list[str],
 ) -> None:
-    assert acr.predicate_to_match(kind, fields, predicate, severity) == (match, normalised)
+    assert acr.predicate_to_match(fields, predicate, severity) == match
 
 
 # Citation resolution.
@@ -200,6 +180,21 @@ def test_resolve_citation_extracts_verbatim_window(fake_tree: Any) -> None:
 def test_resolve_citation_rejects_bad_reference(fake_tree: Any, raw: str) -> None:
     _, sources, chunks = fake_tree
     assert acr.resolve_citation(chunks[0], sources, raw) is None
+
+
+def test_resolve_citation_prefers_exact_relpath(tmp_path: Path) -> None:
+    # Two files share a basename; only the full cited relpath disambiguates
+    # (basename alone would pick the first chunk segment, a/dup.py).
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "dup.py").write_text("x = 1\ny = 2\n")
+    (tmp_path / "b" / "dup.py").write_text("z = 3\nw = 4\n")
+    cluster_files, sources = acr.load_sources(tmp_path, {"c": ["a/dup.py", "b/dup.py"]})
+    chunks = acr.build_chunks(cluster_files, sources)
+    citation = acr.resolve_citation(chunks[0], sources, "b/dup.py:2")
+    assert citation is not None
+    assert citation["file"] == "b/dup.py"
+    assert "w = 4" in citation["quote"]
 
 
 # Candidate assembly + emission round-trip through the ladder consumers.
@@ -259,6 +254,31 @@ def test_emission_round_trips_through_probe_candidates(emitted: tuple[Path, Path
     assert parsed.severity == "error"
     assert parsed.fields == {"n": {"<": 1}}
     assert parsed.engine == "vllm"
+
+
+def test_dormancy_candidate_round_trips_probeable(fake_tree: Any) -> None:
+    # A dormancy rule emits the firing positive comparison, so the identity probe
+    # gets the alias value + resolved default to compare (not a dead present-only
+    # spec that probe_candidates rejects as unprobeable).
+    _, sources, chunks = fake_tree
+    rule = {
+        "kind": "dormancy",
+        "fields": ["seed"],
+        "predicate": "seed == -1 -> None",
+        "citation": "sampling_params.py:3",
+        "severity_suggestion": "dormant",
+    }
+    cand = _build(chunks[0], sources, rule)
+    assert isinstance(cand, dict)
+    assert cand["severity"] == "dormant"
+    assert cand["match"]["fields"] == {"seed": {"==": -1}}
+    assert cand["normalised_fields"] == ["seed"]
+
+    parsed = pc.parse_candidate(cand, 0)
+    subject_path = list(parsed.fields)[-1]
+    values = pc.identity_values(parsed, subject_path)  # must not raise Unprobeable
+    assert values[0] == -1  # the alias value ...
+    assert values[1] is pc._DEFAULT  # ... contrasted against the resolved default
 
 
 # Sampling orchestration: union dedup + cap-hit split-and-rerun.


### PR DESCRIPTION
## What and why

Productionises the OSS-local **analyst cold read**: proposer S2 of the engine-rule
verification ladder. An LLM analyst (default `qwen2.5-coder:32b` via a local Ollama
daemon) reads the pinned engine source cold - no prior corpus, no seeding - and
proposes every config-validation constraint it can see, each a candidate carrying a
mandatory `file:line` citation.

This is deliberately the recall-maximising proposer; it never self-certifies. At its
~77-80% content precision (parity experiment) the deterministic ladder is the gate:
tier 1 `check_citations` (does the citation entail the claim?), tiers 2-3
`probe_candidates` (does the engine actually enforce it?). Output is the version-scoped
candidate pool `<pool-root>/<engine>/v<version>/candidates/analyst_cold_read.yaml` in the
unified candidate schema - **consumable unchanged by both ladder consumers**. It never
writes the shipped `rules.yaml` corpora.

Maintainer tooling in `scripts/`, not part of the `llem` CLI. No `src/` changes.

## Shape

- Pure completion loop over line-numbered source chunks (real line numbers preserved so
  citations resolve). One exhaustive-extraction prompt with a class-coverage checklist.
- Self-consistency **union** across one temp-0 pass plus `samples-1` temp-0.6 passes,
  deduped. No agentic tools, no repair loops, no retries: resample beats refine.
- Salvage parser recovers complete rule objects from cap-truncated JSON; a chunk whose
  temp-0 pass hits the output cap is halved and each half re-run (never read truncated).
- Free-text predicates translate to `match.fields` specs in corpus polarity (an error's
  valid predicate is negated to the violating side that the probe drives); compound or
  cross-field predicates fall back to `present`, with the raw predicate kept in provenance.
- One Ollama HTTP client is the only proposer boundary; the candidate-file contract is the
  interface a frontier-model proposer would satisfy, so there is no fallback abstraction.
- `make analyst-cold-read ENGINE=vllm SRC=engine-src/`. `--source-root` is an explicit
  maintainer input (as for `check_citations`); no downloader is built in.

## Manifest decision trail (vllm)

Ships the vllm cluster manifest only; transformers/tensorrt fail clearly until authored.
Per the ratified parity experiment
(`.product/research/oss-analyst-parity-2026-07-02/SYNTHESIS.md`, "Recommended production
harness deltas"):

- **`engine/arg_utils.py` DROPPED**: pure noise source - CLI `add_argument` blocks
  produced invented bounds and fabricated enum members, zero unique ground-truth matches.
- **`platforms/*.py` ADDED**: removes the file-scoped structural ceiling (platform-gated
  constraints the config-file readers structurally cannot see); ordinary guard code the
  model reads well.

The manifest is a data file (exempt from the line budget).

## Acceptance

**Unit** (stubbed client, no model/network): 26 tests, `uv run pytest` green. Covers chunk
line fidelity + overlap, the salvage parser, predicate translation (all five kinds),
citation resolution + rejection, candidate assembly + drops, union dedup, cap-hit
split-and-rerun, manifest loading, and two round-trip tests proving the emitted pool file
is consumed unchanged by `check_citations` and parsed by `probe_candidates`.

**Live smoke** (one real chunk against live Ollama): wall 386s, one temp-0 pass on the
`sampling` cluster chunk -> 80 parseable, schema-valid candidates, 58/80 resolving tier-1
on this single chunk. The chunk hit the output cap (`done_reason=length`), exercising the
salvage path; in a full run it would be split and re-run.

**Full dogfood** (3-sample union, all clusters, vllm 0.19.1 pinned source): RUNNING in the
background at PR-open time (~2-3h; 15 chunks x 3 samples). Generated pool file is NOT
committed. The dogfood table (deduped count, per-kind distribution, tier-1 resolution rate
vs parity's 872 deduped / 100% file:line / 92.3% strict, wall time) will be posted here on
completion.

## Sizing

Hand-authored production 784 + tests 311 (manifest 58 lines exempt as data).

**Deviation flagged**: production (784) lands inside the 500-800 target and under the 1000
hard ceiling. Combined production+test is 1095, above a strict combined-1000 reading. I
read the budget as production-scoped (784 landed naturally at the target boundary) and kept
full test coverage of the two load-bearing ladder contracts rather than trade coverage
against production completeness in one budget. Prose was already trimmed hard (module
docstring, section banners, function docstrings, test parametrisation + shared fixtures);
further cuts would remove either test coverage or readability. Happy to cut tests to a
combined-1000 target if that was the intent.

## Deviations

- Sizing interpretation, above.
- No other deviations from the D3a brief.
