### PR TITLE
feat(rules): add upstream validator coverage check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: test test-unit test-integration test-all
 .PHONY: docs-all docs-check docs-generate docs-serve docs-build docs-clean
 .PHONY: discover-schema discover-schemas-all refresh-invariants refresh-invariants-all
-.PHONY: check-citations probe-candidates analyst-cold-read absorb
+.PHONY: check-citations probe-candidates analyst-cold-read absorb rules-coverage
 .PHONY: package-check
 .PHONY: docker-smoke
 .PHONY: ci ci-all ci-docker
@@ -184,6 +184,14 @@ probe-candidates: ## Probe candidate rules in-engine (ENGINE=vllm|tensorrt|trans
 absorb: ## Absorb one engine-version bump into the shipped rules (ENGINE=vllm SRC=path/to/source [ARGS='--dry-run'])
 	@test -n "$(ENGINE)" && test -n "$(SRC)" || (echo "Usage: make absorb ENGINE=vllm SRC=engine-src/ [ARGS='--dry-run --skip-cold-read']" && exit 1)
 	uv run python scripts/absorb.py --engine $(ENGINE) --source-root "$(SRC)" $(ARGS)
+
+# The completeness counterpart to absorb: after a bump, report validator sites in
+# the engine source that no shipped rule covers (advisory - exit 0 by default).
+# SRC = the same engine package at the pinned version absorb takes. ARGS forwards
+# flags (--fail-on-uncovered to exit non-zero when any gap remains).
+rules-coverage: ## Report uncovered engine validator sites (ENGINE=vllm SRC=path/to/source [ARGS='--fail-on-uncovered'])
+	@test -n "$(ENGINE)" && test -n "$(SRC)" || (echo "Usage: make rules-coverage ENGINE=vllm SRC=engine-src/ [ARGS='--fail-on-uncovered']" && exit 1)
+	uv run python scripts/rules_coverage.py --engine $(ENGINE) --source-root "$(SRC)" $(ARGS)
 
 # Build wheel + validate package install + check version consistency
 package-check: ## Build wheel, validate install, and check pyproject/_version sync

--- a/scripts/rules_coverage.py
+++ b/scripts/rules_coverage.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Rules coverage check: does the shipped corpus still cover the engine's validators?
+
+Run once per engine-version bump, next to the knowledge-refresh conductor. The
+conductor re-confirms rules the maintainer already knows; this check answers the
+complementary question: has upstream grown a NEW config validator that no shipped
+rule speaks to? Such a validator is a coverage gap the maintainer should decide on.
+
+Mechanism (host-only, no engine imports, uniform across engines):
+
+1. Load the shipped rules and collect the leaf name (last dotted segment) of every
+   rule's match path: the config fields the corpus already reasons about.
+2. AST-parse every ``*.py`` under the staged source tree for VALIDATOR SITES:
+   pydantic ``field_validator`` / ``model_validator`` functions (matched by the
+   decorator's last dotted name, so any import alias is caught) and ``__post_init__``
+   methods. For each, collect the config fields it reads - public attributes of the
+   receiver (``self`` / ``cls``) or first data arg, plus any name in a
+   ``field_validator`` decorator. A site counts only if it BOTH raises and reads a
+   field; normalisers and field-less guards are out of the model.
+3. A site is COVERED when its fields intersect the corpus leaves. The grain is
+   deliberately coarse - a shared name, not a proven predicate. Advisory, not a prover.
+4. Report every UNCOVERED site (engine-relative path, line, class.function, fields),
+   sorted for byte-stable output, with a summary count. Exit 0 by default;
+   ``--fail-on-uncovered`` exits 1 when any gap remains, for later opt-in gating.
+
+Sites in the pinned sources that are genuinely not engine-config material (HTTP
+request models, per-request objects, runtime structs, vendored kernels) are listed
+in :data:`IGNORED_SITES` so the uncovered list stays real gaps. This script never
+writes the corpus; proposing new rules is the refresh conductor's job.
+
+Run: python scripts/rules_coverage.py --engine vllm --source-root SRC/
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+import warnings
+from dataclasses import dataclass
+from operator import attrgetter
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from llenergymeasure.config.engine_rules.loader import EngineRulesLoader  # noqa: E402
+
+ENGINES = ("vllm", "transformers", "tensorrt")
+DEFAULT_CORPUS_ROOT = _PROJECT_ROOT / "src" / "llenergymeasure" / "engines"
+
+# Pydantic validator decorators, matched by their last dotted segment so any import
+# alias (``pydantic.field_validator``, ``from pydantic import model_validator``) is
+# caught without following imports.
+_VALIDATOR_DECORATORS = frozenset({"field_validator", "model_validator"})
+_POST_INIT = "__post_init__"
+
+# Validator sites in the pinned sources that are NOT engine-config-rule material,
+# triaged by hand so the uncovered list stays real gaps. Each entry is
+# "engine relative/posix/path Class.function"; the trailing comment is the rationale.
+# A genuinely rule-material gap belongs in a rule (via the conductor), never here.
+_IGNORED_RAW = (
+    # vllm: HTTP API request models, not engine-construction config.
+    "vllm entrypoints/anthropic/protocol.py AnthropicTool.validate_input_schema",
+    "vllm entrypoints/anthropic/protocol.py AnthropicToolChoice.validate_name_required_for_tool",
+    "vllm entrypoints/anthropic/protocol.py AnthropicMessagesRequest.validate_model",
+    "vllm entrypoints/anthropic/protocol.py AnthropicCountTokensRequest.validate_model",
+    "vllm entrypoints/serve/disagg/protocol.py GenerateRequest.validate_token_ids",
+    # vllm: internal RPC weight-transfer payload structs, not user config.
+    "vllm distributed/weight_transfer/ipc_engine.py IPCTrainerSendWeightsArgs.__post_init__",
+    "vllm distributed/weight_transfer/ipc_engine.py IPCWeightTransferUpdateInfo.__post_init__",
+    "vllm distributed/weight_transfer/nccl_engine.py NCCLWeightTransferUpdateInfo.__post_init__",
+    # vllm: per-request / runtime objects and a vendored kernel struct.
+    "vllm lora/request.py LoRARequest.__post_init__",  # per-request adapter handle
+    "vllm renderers/params.py TokenizeParams.__post_init__",  # tokenize request params
+    "vllm model_executor/layers/attention/mla_attention.py MLACommonMetadata.__post_init__",  # runtime metadata
+    "vllm model_executor/model_loader/tensorizer.py TensorizerConfig.__post_init__",  # loader plumbing
+    "vllm third_party/triton_kernels/tensor.py Tensor.__post_init__",  # vendored kernel tensor
+    # tensorrt: the trtllm-bench tool's own dataclasses, not engine llm args.
+    "tensorrt bench/dataclasses/configuration.py DecodingConfig.validate_speculative_decoding",
+    "tensorrt bench/dataclasses/configuration.py ExecutorWorldConfig.validate_world_size",
+    "tensorrt bench/dataclasses/general.py InferenceRequest.verify_prompt_and_logits",
+    # tensorrt: per-request / runtime input objects and a private wrapper.
+    "tensorrt executor/request.py LoRARequest.__post_init__",  # per-request adapter handle
+    "tensorrt executor/request.py PromptAdapterRequest.__post_init__",  # per-request adapter handle
+    "tensorrt inputs/multimodal.py MultimodalInput.__post_init__",  # runtime input struct
+    "tensorrt inputs/multimodal.py MultimodalRuntimeData.__post_init__",  # runtime input struct
+    "tensorrt llmapi/llm_args.py _ModelWrapper.__post_init__",  # private internal wrapper
+)
+# (engine, engine-relative posix path, "Class.function"), parsed from _IGNORED_RAW.
+IGNORED_SITES: frozenset[tuple[str, ...]] = frozenset(tuple(e.split()) for e in _IGNORED_RAW)
+
+
+@dataclass(frozen=True)
+class ValidatorSite:
+    """One material validator function found in the source tree."""
+
+    path: str  # engine-relative posix path
+    line: int  # 1-based line of the ``def``
+    qualname: str  # "Class.function"
+    fields: tuple[str, ...]  # sorted config field names the body reads
+
+
+def _decorator_last_name(node: ast.expr) -> str | None:
+    """Return the last dotted name of a decorator expression (``pydantic.x`` -> ``x``), or None."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _is_validator_site(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    # A pydantic validator or a __post_init__ hook.
+    if fn.name == _POST_INIT:
+        return True
+    names = {_decorator_last_name(d) for d in fn.decorator_list}
+    return bool(names & _VALIDATOR_DECORATORS)
+
+
+def _field_validator_targets(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    # The field names in a @field_validator("a", "b") decorator.
+    targets: set[str] = set()
+    for dec in fn.decorator_list:
+        if not isinstance(dec, ast.Call):
+            continue
+        if _decorator_last_name(dec) != "field_validator":
+            continue
+        for arg in dec.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                targets.add(arg.value)
+    return targets
+
+
+def _read_fields(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Return public config fields ``fn`` reads via receiver / data-arg attributes.
+
+    Receivers are the first two positional params (the receiver self/cls and first
+    data arg). Method calls (``self.foo()``) are excluded - the attribute is a
+    ``Call.func``, not a read. Private / dunder attributes are excluded: the corpus
+    names only public fields, so a leading-underscore read only adds noise.
+    """
+    positional = fn.args.posonlyargs + fn.args.args
+    receivers = {p.arg for p in positional[:2]}
+    called = {
+        id(node.func)
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    fields: set[str] = set()
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Attribute)
+            and id(node) not in called
+            and not node.attr.startswith("_")
+            and isinstance(node.value, ast.Name)
+            and node.value.id in receivers
+        ):
+            fields.add(node.attr)
+    return fields
+
+
+def _iter_class_sites(cls: ast.ClassDef, relpath: str) -> list[ValidatorSite]:
+    # Material validator sites defined directly in cls's body.
+    sites: list[ValidatorSite] = []
+    for stmt in cls.body:
+        if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not _is_validator_site(stmt):
+            continue
+        fields = _read_fields(stmt) | _field_validator_targets(stmt)
+        raises = any(isinstance(node, ast.Raise) for node in ast.walk(stmt))
+        if not (fields and raises):
+            continue  # a coverage target must both raise and read a field
+        sites.append(
+            ValidatorSite(
+                path=relpath,
+                line=stmt.lineno,
+                qualname=f"{cls.name}.{stmt.name}",
+                fields=tuple(sorted(fields)),
+            )
+        )
+    return sites
+
+
+def scan_source(source_root: Path) -> list[ValidatorSite]:
+    """Parse every ``*.py`` under ``source_root`` and collect material validator sites.
+
+    Each validator method is enumerated once, at its own definition; scanning the
+    whole tree covers in-tree base-class validators at their own location without an
+    import graph. Files that fail to parse are skipped.
+    """
+    sites: list[ValidatorSite] = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # upstream files may have bad escape sequences
+        for py in sorted(source_root.rglob("*.py")):
+            try:
+                tree = ast.parse(py.read_text())
+            except (SyntaxError, ValueError, UnicodeDecodeError):
+                continue
+            relpath = py.relative_to(source_root).as_posix()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    sites.extend(_iter_class_sites(node, relpath))
+    return sites
+
+
+def corpus_leaf_names(engine: str, corpus_root: Path) -> tuple[str, set[str]]:
+    """Return (engine_version, set of leaf field names) for the shipped corpus."""
+    rules = EngineRulesLoader(corpus_root).load_rules(engine)
+    leaves = {path.rsplit(".", 1)[-1] for rule in rules.rules for path in rule.match_fields}
+    return rules.engine_version, leaves
+
+
+def classify(
+    engine: str, sites: list[ValidatorSite], leaves: set[str]
+) -> tuple[list[ValidatorSite], list[ValidatorSite], int]:
+    """Split sites into (covered, uncovered_reported, ignored_count).
+
+    Covered = fields intersect the corpus leaves; the rest are uncovered, minus any
+    :data:`IGNORED_SITES` entry for this engine (counted separately).
+    """
+    covered: list[ValidatorSite] = []
+    uncovered: list[ValidatorSite] = []
+    ignored = 0
+    ignored_keys = {(e[1], e[2]) for e in IGNORED_SITES if e[0] == engine}
+    for site in sites:
+        if set(site.fields) & leaves:
+            covered.append(site)
+        elif (site.path, site.qualname) in ignored_keys:
+            ignored += 1
+        else:
+            uncovered.append(site)
+    order = attrgetter("path", "line", "qualname")
+    return sorted(covered, key=order), sorted(uncovered, key=order), ignored
+
+
+def render_report(
+    engine: str,
+    engine_version: str,
+    covered: list[ValidatorSite],
+    uncovered: list[ValidatorSite],
+    ignored: int,
+) -> str:
+    """Render a deterministic, path-relative coverage report."""
+    total = len(covered) + len(uncovered) + ignored
+    lines = [
+        f"Rules coverage check: {engine} (corpus engine_version {engine_version})",
+        f"validator sites: {total} | covered: {len(covered)} | "
+        f"uncovered: {len(uncovered)} | ignored: {ignored}",
+        "",
+    ]
+    if uncovered:
+        lines.append("Uncovered validator sites (no shipped rule names a field they read):")
+        for site in uncovered:
+            lines.append(
+                f"  {site.path}:{site.line}  {site.qualname}  reads: {', '.join(site.fields)}"
+            )
+    else:
+        lines.append("All validator sites are covered by the shipped rules.")
+    return "\n".join(lines) + "\n"
+
+
+def run(engine: str, source_root: Path, corpus_root: Path) -> tuple[str, int]:
+    """Compute the report and the count of uncovered sites."""
+    engine_version, leaves = corpus_leaf_names(engine, corpus_root)
+    sites = scan_source(source_root)
+    covered, uncovered, ignored = classify(engine, sites, leaves)
+    report = render_report(engine, engine_version, covered, uncovered, ignored)
+    return report, len(uncovered)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--engine", required=True, choices=ENGINES)
+    parser.add_argument(
+        "--source-root",
+        required=True,
+        type=Path,
+        help="Staged engine package directory (the same tree the refresh conductor takes).",
+    )
+    parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        default=DEFAULT_CORPUS_ROOT,
+        help="Root holding <engine>/rules.yaml (default: the shipped corpus).",
+    )
+    parser.add_argument(
+        "--fail-on-uncovered",
+        action="store_true",
+        help="Exit 1 when any uncovered site remains (default: advisory, exit 0).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.source_root.is_dir():
+        print(f"source root not found: {args.source_root}", file=sys.stderr)
+        return 2
+    report, uncovered_count = run(args.engine, args.source_root, args.corpus_root)
+    sys.stdout.write(report)
+    if args.fail_on_uncovered and uncovered_count:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_rules_coverage.py
+++ b/tests/unit/scripts/test_rules_coverage.py
@@ -1,0 +1,209 @@
+"""Host-side tests for scripts/rules_coverage.py (the validator coverage check).
+
+No engine import, no container: each test builds a tiny source tree and a tiny
+rules corpus on disk and exercises the check's own logic - validator-site
+detection (pydantic decorators by any alias, plus __post_init__), the public
+field-read extraction (method calls and private attributes excluded), the
+materiality gate (raise AND a field), the field-name coverage intersection,
+IGNORED_SITES suppression, deterministic path-relative reporting, and CLI codes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[3] / "scripts"))
+
+import rules_coverage as rc
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def _pi(cls: str, field: str) -> str:
+    """A minimal class whose __post_init__ raises on one field read."""
+    return f"class {cls}:\n    def __post_init__(self):\n        if self.{field}:\n            raise ValueError('x')\n"
+
+
+def _corpus(root: Path, engine: str, fields: list[str]) -> Path:
+    rules = "".join(
+        f"- id: r{i}\n  engine: {engine}\n  severity: error\n"
+        f"  match:\n    fields:\n      {engine}.engine_params.{leaf}:\n        <: 1\n"
+        f"  provenance:\n    source: manual\n    verified: human\n"
+        for i, leaf in enumerate(fields)
+    )
+    corpus_root = root / "corpus"
+    (corpus_root / engine).mkdir(parents=True, exist_ok=True)
+    (corpus_root / engine / "rules.yaml").write_text(
+        f"schema_version: 1.0.0\nengine: {engine}\nengine_version: 9.9.9\n"
+        f"rules:{chr(10) + rules if rules else ' []'}\n"
+    )
+    return corpus_root
+
+
+def _cli(tmp: Path, engine: str, fields: list[str], *extra: str) -> list[str]:
+    return [
+        "--engine",
+        engine,
+        "--source-root",
+        str(tmp),
+        "--corpus-root",
+        str(_corpus(tmp, engine, fields)),
+        *extra,
+    ]
+
+
+def test_detects_pydantic_and_post_init(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cfg.py",
+        "from pydantic import field_validator, model_validator\n"
+        "class Cfg:\n"
+        "    @field_validator('alpha')\n"
+        "    def _v(cls, v):\n"
+        "        if v < 0:\n            raise ValueError('bad')\n        return v\n"
+        "    @model_validator(mode='after')\n"
+        "    def _m(self):\n"
+        "        if self.beta:\n            raise ValueError('bad')\n        return self\n"
+        "    def __post_init__(self):\n"
+        "        if self.gamma < 1:\n            raise ValueError('bad')\n",
+    )
+    quals = {s.qualname: s.fields for s in rc.scan_source(tmp_path)}
+    assert quals == {"Cfg._v": ("alpha",), "Cfg._m": ("beta",), "Cfg.__post_init__": ("gamma",)}
+
+
+def test_decorator_alias_matched_by_last_name(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cfg.py",
+        "import pydantic as pyd\n"
+        "class Cfg:\n"
+        "    @pyd.field_validator('alpha')\n"
+        "    def _v(cls, v):\n        if v:\n            raise ValueError('x')\n",
+    )
+    (site,) = rc.scan_source(tmp_path)
+    assert site.qualname == "Cfg._v" and site.fields == ("alpha",)
+
+
+def test_field_extraction_excludes_calls_and_private(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cfg.py",
+        "class Cfg:\n"
+        "    def __post_init__(self):\n"
+        "        self.helper()\n"  # method call, not a field
+        "        _ = self._private\n"  # private attr, excluded
+        "        _ = self.__dict__\n"  # dunder attr, excluded
+        "        if self.public and self.other:\n            raise ValueError('x')\n",
+    )
+    (site,) = rc.scan_source(tmp_path)
+    assert site.fields == ("other", "public")
+
+
+def test_data_arg_attribute_read(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cfg.py",
+        "from pydantic import model_validator\n"
+        "class Cfg:\n"
+        "    @model_validator(mode='before')\n"
+        "    def _m(cls, data):\n        if data.knob:\n            raise ValueError('x')\n        return data\n",
+    )
+    (site,) = rc.scan_source(tmp_path)
+    assert site.fields == ("knob",)
+
+
+def test_materiality_requires_raise_and_field(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cfg.py",
+        # normaliser: reads a field, never raises -> skipped
+        "class Norm:\n    def __post_init__(self):\n        self.x = self.y or 1\n"
+        # guard: raises but reads no field -> skipped
+        "class Guard:\n    def __post_init__(self):\n        raise ValueError('always')\n"
+        # real: raises and reads a field -> material
+        + _pi("Real", "z"),
+    )
+    assert {s.qualname for s in rc.scan_source(tmp_path)} == {"Real.__post_init__"}
+
+
+def test_unparseable_file_skipped(tmp_path: Path) -> None:
+    _write(tmp_path, "broken.py", "def (:\n")
+    _write(tmp_path, "ok.py", _pi("Cfg", "z"))
+    assert [s.qualname for s in rc.scan_source(tmp_path)] == ["Cfg.__post_init__"]
+
+
+def test_coverage_intersection() -> None:
+    sites = [
+        rc.ValidatorSite("a.py", 1, "A.f", ("covered_field",)),
+        rc.ValidatorSite("b.py", 2, "B.g", ("unknown_field",)),
+    ]
+    covered, uncovered, ignored = rc.classify("vllm", sites, {"covered_field"})
+    assert [s.qualname for s in covered] == ["A.f"]
+    assert [s.qualname for s in uncovered] == ["B.g"]
+    assert ignored == 0
+
+
+def test_ignored_sites_suppressed(monkeypatch) -> None:
+    monkeypatch.setattr(rc, "IGNORED_SITES", frozenset({("vllm", "b.py", "B.g")}))
+    sites = [
+        rc.ValidatorSite("a.py", 1, "A.f", ("x",)),
+        rc.ValidatorSite("b.py", 2, "B.g", ("x",)),
+    ]
+    covered, uncovered, ignored = rc.classify("vllm", sites, set())
+    assert not covered
+    assert [s.qualname for s in uncovered] == ["A.f"]
+    assert ignored == 1
+    # the same site under a different engine is NOT ignored
+    _, unc2, ig2 = rc.classify("tensorrt", sites, set())
+    assert ig2 == 0 and len(unc2) == 2
+
+
+def test_corpus_leaf_names(tmp_path: Path) -> None:
+    version, leaves = rc.corpus_leaf_names(
+        "vllm", _corpus(tmp_path, "vllm", ["max_model_len", "seed"])
+    )
+    assert version == "9.9.9"
+    assert leaves == {"max_model_len", "seed"}
+
+
+def test_report_sorted_relative_and_deterministic(tmp_path: Path) -> None:
+    _write(tmp_path, "z_last.py", _pi("Z", "q"))
+    _write(tmp_path, "a_first.py", _pi("A", "p"))
+    corpus_root = _corpus(tmp_path, "vllm", [])
+    report_a, n_a = rc.run("vllm", tmp_path, corpus_root)
+    report_b, n_b = rc.run("vllm", tmp_path, corpus_root)
+    assert report_a == report_b  # byte-identical
+    assert n_a == n_b == 2
+    assert str(tmp_path) not in report_a  # no absolute paths leak
+    assert report_a.index("a_first.py") < report_a.index("z_last.py")  # sorted
+
+
+def test_main_advisory_default_and_fail_flag(tmp_path: Path, capsys) -> None:
+    _write(tmp_path, "cfg.py", _pi("Cfg", "x"))
+    args = _cli(tmp_path, "vllm", [])
+    assert rc.main(args) == 0  # advisory by default even with an uncovered site
+    assert "uncovered: 1" in capsys.readouterr().out
+    assert rc.main([*args, "--fail-on-uncovered"]) == 1
+
+
+def test_main_clean_source_exit_zero(tmp_path: Path) -> None:
+    _write(tmp_path, "cfg.py", _pi("Cfg", "covered"))
+    assert rc.main(_cli(tmp_path, "vllm", ["covered"], "--fail-on-uncovered")) == 0
+
+
+def test_main_missing_source_root(tmp_path: Path) -> None:
+    corpus_root = _corpus(tmp_path, "vllm", [])
+    args = [
+        "--engine",
+        "vllm",
+        "--source-root",
+        str(tmp_path / "nope"),
+        "--corpus-root",
+        str(corpus_root),
+    ]
+    assert rc.main(args) == 2


### PR DESCRIPTION
## What and why

After an engine-version bump, the refresh conductor re-confirms the rules a maintainer already ships. It cannot, by construction, tell you about a validator that has *just appeared* upstream and has no rule yet. This PR adds the completeness counterpart: a standalone, host-only check that answers "does the shipped rules corpus still cover the engine's validator surface?" A new upstream config validator that no shipped rule speaks to is surfaced as a coverage gap the maintainer can then decide on.

The check is deliberately coarse and advisory. It is a completeness signal, not a prover: it flags validator sites whose config fields no rule names, not sites whose predicate is unproven. It never touches the corpus (proposing rules stays the conductor's job), it imports no engine (pure `ast` over staged source), and it runs uniformly across all three engines with no per-engine manifest. Exit is 0 by default; `--fail-on-uncovered` flips it to 1 for opt-in gating later.

## Mechanism

1. Load the shipped rules for the engine and collect the leaf name (last dotted segment) of every rule's match path: the config fields the corpus already reasons about.
2. AST-parse every `*.py` under the staged source tree and collect VALIDATOR SITES: pydantic `field_validator` / `model_validator` functions (matched by the decorator's last dotted name, so any import alias is caught without following imports) and `__post_init__` methods. For each site, collect the config fields it reads: public attribute access on the receiver (`self` / `cls`) or first data argument, plus any field named in a `field_validator` decorator. Method calls and private/dunder attributes are not field reads. A site is material only if it BOTH raises and reads at least one field.
3. A site is COVERED when its field set intersects the corpus leaf names.
4. Emit a deterministic, path-relative report of every UNCOVERED site (engine-relative path, line, `Class.function`, fields read), sorted by path then line, with a summary count line. Output is byte-identical run to run (no timestamps, no absolute paths).

Sites in the pinned sources that are genuinely not engine-config material (HTTP request models, per-request objects, runtime structs, vendored kernels) are listed in a small hand-triaged `IGNORED_SITES` constant with a rationale each, so the uncovered list stays real gaps.

Run: `make rules-coverage ENGINE=vllm SRC=path/to/staged/source` (mirrors the absorb target's `ENGINE`/`SRC` argument style).

## Dogfood against real staged sources (host-only, no GPU)

| engine | corpus version | validator sites | covered | uncovered | ignored |
| --- | --- | --- | --- | --- | --- |
| vllm | 0.19.1 | 41 | 5 | 23 | 13 |
| transformers | 5.7.0 | 22 | 0 | 22 | 0 |
| tensorrt | 1.0.0 | 24 | 4 | 12 | 8 |

Triage:

- **vllm** - the 23 uncovered are all genuine engine-config validators under `config/*` (CompilationConfig, DeviceConfig, KVTransferConfig, LoRAConfig, ModelConfig, MultiModalConfig, ObservabilityConfig, OffloadConfig, EPLBConfig, PoolerConfig, ProfilerConfig, SpeculativeConfig, StructuredOutputsConfig, VllmConfig) plus two `sampling_params` structs. These are config-surface sites outside the corpus's curated exposure subset - expected, not corpus bugs. The check's value is catching a *new* one appearing on a bump. No corpus change is proposed. The 13 ignored are non-config: five HTTP API request models (`entrypoints/anthropic`, disagg protocol), three internal RPC weight-transfer payload structs, four per-request/runtime objects, and one vendored triton kernel struct.
- **tensorrt** - the 12 uncovered are all real engine-args validators in `llmapi/llm_args.py` (LookaheadDecodingConfig, BaseLlmArgs, TrtLlmArgs, TorchLlmArgs, TorchCompileConfig), again outside the curated subset. The 8 ignored are the trtllm-bench tool's own dataclasses, per-request adapter/input objects, and one private wrapper.
- **transformers** - 22 uncovered, 0 covered. Every site is model-architecture config (`models/*/configuration_*.py`), training (`training_args.py`, `trainer_callback.py`), a data collator, or `PreTrainedConfig` - none is the generation/quantization runtime-config surface the corpus targets. This is a design-fit limitation (see below), deferred to E1. These are deliberately NOT parked in `IGNORED_SITES`: it is a whole-category mismatch, not a handful of stray non-config sites.

## Design decisions to flag for review

- **Materiality = raise AND read a field.** A site counts only if it both raises and reads at least one public config field - the minimal condition under which a field-named rule could cover it. The looser "raise OR reads fields" form floods the report (~120 uncovered for vllm) with pure normalisers and field-less guards that no field-named rule can ever match, which cannot fit a small hand-triaged ignore list. The tighter AND rule drops normalisers (no raise) and field-less raise-guards from the coverage model.
- **transformers fit.** transformers validates its runtime config through imperative idioms (`GenerationConfig.validate()`, `BitsAndBytesConfig.post_init()`) that the current site model (pydantic decorators + `__post_init__`) does not match, and the scan is not scoped to the runtime-config surface. The result is 0 coverage against out-of-scope model-architecture/training sites. Recommend E1 broaden site matching and add a config-surface scope for transformers before this check is treated as authoritative there.

## Size accounting

- `scripts/rules_coverage.py`: 312 raw lines (about 197 code; of those roughly 24 are the `IGNORED_SITES` triage data, so pure logic is about 173).
- `tests/unit/scripts/test_rules_coverage.py`: 209 raw lines (about 156 code), 13 tests.
- Raw total 521; logic-only total about 353, within the 250-400 target.
- Raw sits 21 over the 500 ceiling. The overage is the module docstring that explains purpose and mechanism (about 30 lines) plus the hand-triaged `IGNORED_SITES` data (24 entries). The design is intentionally flat (name-based base lookup within scanned files, no import graph), so there is no inheritance-resolution sophistication left to trade away. If a strict raw-500 is required, the module docstring is the only lever; flagging rather than gutting the explanation unilaterally.

## Deferred to E1

- CI wiring (workflow integration) is intentionally out of scope here. The check is advisory today (exit 0) and already exposes `--fail-on-uncovered` for the opt-in gate E1 will add.
- Broaden transformers site matching and add a config-surface scope (per the fit note above).
