### PR TITLE
ci(docs): enforce generated-doc drift gate in docs-freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,8 @@ jobs:
           cache-suffix: docs-3.12
           python-version: "3.12"
       - run: uv sync --dev
-      - name: Verify doc generation scripts
-        run: |
-          uv run python scripts/generate_config_docs.py > /dev/null
-          uv run python scripts/generate_cli_reference.py > /dev/null
-          uv run python scripts/generate_invalid_combos_doc.py > /dev/null
-          uv run python scripts/generate_curation_doc.py > /dev/null
+      - name: Check generated docs are current
+        run: make docs-check
       - name: Check Pydantic-discovered schema alignment
         run: uv run python scripts/check_pydantic_matches_discovered.py > /dev/null
 


### PR DESCRIPTION
## What

The `docs-freshness` job in `ci.yml` ran the SSOT doc generators with output to `/dev/null` and never diffed their output against the committed docs. For the config and CLI generators that redirect even skipped writing the files (they need `--output`), so the committed generated docs could drift while CI stayed green. This is exactly the failure mode the `make docs-check` gate was built to catch (the vLLM schema doc previously sat at 0.7.3 / 104 params against a 0.19.1 pin with CI passing). Found during verification of #760.

## How

The job now runs `make docs-check` in place of the ad-hoc generator invocations. That target regenerates every generated doc via `docs-all` (config, CLI, schema, curation, invalid combos, API) and fails via `git diff --exit-code` scoped to the committed generated files, printing the drifted paths. This is the gate that landed in #760.

The `check_pydantic_matches_discovered.py` step is retained unchanged: it verifies a distinct property (pydantic model vs discovered schema consistency), not doc freshness. Existing environment setup (`uv sync --dev`) is preserved, since `make docs-check` needs the project venv and the generators import from `src/`.

## Evidence

- `ci.yml` self-tests: it lists itself in its `paths` filters, so the modified `docs-freshness` job runs live on this PR. A green `docs-freshness` run here on a clean tree is the primary evidence.
- Verified locally on a clean checkout of `origin/main`: `make docs-check` regenerates all docs byte-identically and exits 0 ("Generated docs are up to date").
- `actionlint` on `ci.yml` passes with no findings.
- The gate failing loud on drift was already proven in #760's PR body via a staged-stale reproduction.