### PR TITLE
docs: align stray docs to rules vocabulary and document study command

### DIFF
--- a/docs/contributing/roadmap.md
+++ b/docs/contributing/roadmap.md
@@ -33,8 +33,9 @@ RadixAttention energy profiles. RadixAttention's KV-cache reuse mechanism
 creates an unusual energy signature (lower energy on repeated prefix patterns)
 that requires a dedicated measurement treatment.
 
-Scope includes: SGLang Docker image, engine plugin, parameter miner, and
-methodology documentation for prefix-aware energy measurement.
+Scope includes: SGLang Docker image, engine plugin, config schema and
+validation rules, and methodology documentation for prefix-aware energy
+measurement.
 
 ### Beyond Milestone 5
 

--- a/docs/explanation/ecosystem.md
+++ b/docs/explanation/ecosystem.md
@@ -183,8 +183,8 @@ others) and sweeps configurations for throughput and latency.
 Where the contrast lies: optimum-benchmark is throughput-leaning - the
 default reported metrics are latency and tokens-per-second, with energy
 as a secondary axis (recently added). LLenergyMeasure makes energy a
-first-class output and pairs it with the discovery and invariant-mining
-pipelines that optimum-benchmark does not have. Methodology rigour
+first-class output and pairs it with the config schema-discovery and
+validation-rules pipelines that optimum-benchmark does not have. Methodology rigour
 (baseline subtraction, warmup convergence, thermal stabilisation,
 sampler lifecycle) is more explicit on the LLenergyMeasure side.
 

--- a/docs/explanation/why.md
+++ b/docs/explanation/why.md
@@ -176,8 +176,8 @@ Concrete near-term directions:
   plugin (RadixAttention prefix-cache energy profiles); the
   engine-plugin contract is sized to absorb new entrants as they
   stabilise.
-- **Adaptive sweep sampling.** Programmatic discovery + invariant
-  mining keeps the tractable parameter space large; further reductions
+- **Adaptive sweep sampling.** Programmatic discovery plus validation
+  rules keep the tractable parameter space large; further reductions
   would come from adaptive sampling that prioritises experiments most
   informative about the impl-effect question.
 - **Open-science result database.** A web frontend that lets users

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -442,7 +442,7 @@ docker image inspect llenergymeasure:transformers \
 > `version_handshake.py` does today is a different check: it probes each
 > image's engine library version (`vllm.__version__`,
 > `tensorrt_llm.__version__`, `transformers.__version__`) and compares
-> it against the engine_version envelope on the wheel-bundled invariants
+> it against the engine_version envelope on the wheel-bundled rules
 > + schema artefacts. A real library/artefact mismatch is a hard error;
 > set `LLEM_SKIP_IMAGE_CHECK=1` to bypass if you know the skew is
 > harmless.

--- a/docs/how-to/faq.md
+++ b/docs/how-to/faq.md
@@ -106,7 +106,7 @@ No. FP8 quantisation (per `tensorrt.engine_params.quant_config.quant_algo: FP8`,
 
 ### Does it work on consumer GPUs (RTX 4090 / 4080)?
 
-Yes for Transformers and vLLM. TensorRT-LLM compilation is supported on Ada Lovelace (SM 8.9). Consumer GPUs typically have less VRAM than datacentre cards, so larger models may need quantisation or smaller batch sizes. The reference invariants corpus catches the most common VRAM-vs-config-vs-batch-size mismatches before init.
+Yes for Transformers and vLLM. TensorRT-LLM compilation is supported on Ada Lovelace (SM 8.9). Consumer GPUs typically have less VRAM than datacentre cards, so larger models may need quantisation or smaller batch sizes. The reference rules corpus catches the most common VRAM-vs-config-vs-batch-size mismatches before init.
 
 ### Multi-GPU?
 

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -329,7 +329,7 @@ tell for version skew).
 > always equals the host source). What `StudyRunner._prepare_images` does
 > today is a different check: it probes the in-container engine library
 > version and compares it against the engine_version envelope on the
-> wheel-bundled invariants + schema artefacts. The Pydantic-shape errors
+> wheel-bundled rules + schema artefacts. The Pydantic-shape errors
 > above are exactly the symptom that probe is meant to catch ahead of
 > dispatch, so on current builds the gate should hard-error before the
 > container ever runs. If you reached this section anyway, either the image

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,13 +2,14 @@
 
 ## CLI Reference
 
-llem provides four commands and a version flag.
+llem provides five commands and a version flag.
 
 ```
 llem run [CONFIG] [OPTIONS]   # run an experiment or study
 llem config [OPTIONS]         # show environment and configuration status
 llem doctor [OPTIONS]         # verify Docker images match the host toolchain
-llem report-gaps [OPTIONS]    # propose invariants corpus entries from runtime feedback
+llem report-gaps [OPTIONS]    # propose rules corpus entries from runtime feedback
+llem study [SUBCOMMAND]       # write and prepare study files (init, plan)
 llem --version                # print version and exit
 ```
 
@@ -51,7 +52,7 @@ Verify Docker images match the host ExperimentConfig schema
 
 ### `llem report-gaps`
 
-Propose invariants corpus entries from runtime observations
+Propose rules corpus entries from runtime observations
 
 **Options:**
 
@@ -67,3 +68,41 @@ Propose invariants corpus entries from runtime observations
 ### `llem study`
 
 Write and prepare study files (llem run stays the executor).
+
+### `llem study init`
+
+Write a study file for a model, ready to edit and run with ``llem run``.
+
+Without ``--defaults`` the tuning fields are present but commented out, each
+annotated with its type, range, and default - uncomment the ones you want.
+With ``--defaults`` those fields are filled in at their defaults, giving a
+reproducible baseline you can run as-is. With ``--bounds`` every field with
+a derivable value range becomes an explicit value list under ``sweep:``,
+forming a maximal grid you prune down to the study you want.
+
+**Options:**
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--model` | `-m` | str |  | Model id or HuggingFace path for the study. |
+| `--engine` | `-e` | str |  | Engine to write (transformers, vllm, tensorrt). Omit to write all engines. |
+| `--output` | `-o` | path |  | Where to write the study file (default: study.yaml). Will not overwrite. |
+| `--defaults` |  | flag | `false` | Set every field to its default (a runnable baseline) instead of leaving them commented out. |
+| `--bounds` |  | flag | `false` | Emit every field with a derivable value range as an explicit value list under sweep: - a maximal grid to prune before running. |
+
+### `llem study plan`
+
+Preview what ``llem run <study_file>`` would execute, without running it.
+
+Prints a read-only funnel - declared grid points, then known-invalid points
+pruned by engine rules, then duplicate configs merged away, then experiments
+times cycles equals total runs - plus a wall-clock lower bound from the
+thermal gaps alone. No experiments run, nothing is written, the GPU is never
+touched. Exit 0 on a valid plan (even with skips); nonzero when the file is
+missing, unparseable, or produces no experiments.
+
+**Arguments:**
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `study_file` | path | yes | Study YAML file to preview (as llem run would expand it). |

--- a/docs/reference/library/ExperimentConfig.md
+++ b/docs/reference/library/ExperimentConfig.md
@@ -160,9 +160,12 @@ ExperimentConfig(
 require `dtype="float16"` or `dtype="bfloat16"`. Combining with `dtype="float32"` raises
 `ValidationError`.
 
-**Engine invariants.** The invariants corpus may emit `ConfigValidationWarning` for
-configurations the library will silently override (dormant invariants), or raise
-`ValidationError` for invalid combinations (e.g. FP8 on A100 with `engine="tensorrt"`).
+**Engine rules.** The engine's shipped `rules.yaml` is checked when the config is parsed,
+before the engine starts. A rule at `error` severity raises `ValidationError` for an
+invalid combination; a rule at `dormant` severity records a field the engine silently
+normalises, which the study planner uses to deduplicate configs that resolve to the same
+effective configuration. A separate `ConfigValidationWarning` is emitted for an unknown or
+misspelled engine field, with a suggestion for the closest valid name.
 
 ---
 

--- a/docs/reference/library/StudyConfig.md
+++ b/docs/reference/library/StudyConfig.md
@@ -111,7 +111,7 @@ Controls sequencing, cycles, and failure handling:
 | `wall_clock_timeout_hours` | `float \| None` | `None` | Study-level wall-clock timeout. `None` = no limit. |
 | `experiment_timeout_seconds` | `float` | `600.0` | Per-experiment timeout. Applies to both local and Docker paths. |
 | `stdout_silence_timeout_seconds` | `float` | `300.0` | Docker watchdog: kill the container if it emits no stdout for this many seconds. Raise to 600-900s for TRT-LLM builds with infrequent compile progress output. |
-| `deduplicate_equivalent` | `bool` | `True` | When `True`, configs that are library-equivalent (same resolved config hash after engine-invariants dormant resolution) are deduplicated. Set to `false` to run every declared config regardless of measurement equivalence. |
+| `deduplicate_equivalent` | `bool` | `True` | When `True`, configs that are library-equivalent (same resolved config hash after engine-rules dormant resolution) are deduplicated. Set to `false` to run every declared config regardless of measurement equivalence. |
 
 ### Runner and image overrides
 
@@ -142,7 +142,7 @@ experiments cannot be constructed.
 
 Each item in `experiments` is individually validated as an `ExperimentConfig` (see
 [`ExperimentConfig`](./ExperimentConfig) for per-experiment validation rules, including
-engine-section matching and engine-invariants checking).
+engine-section matching and engine-rules checking).
 
 ---
 

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -53,6 +53,13 @@ def _render_command(name: str, cmd: object) -> list[str]:
         lines.append(help_text)
         lines.append("")
 
+    # Command group (e.g. `llem study`): render each subcommand as `llem <name> <sub>`.
+    subcommands = getattr(cmd, "commands", None)
+    if subcommands:
+        for sub_name, sub_cmd in subcommands.items():
+            lines.extend(_render_command(f"{name} {sub_name}", sub_cmd))
+        return lines
+
     params = getattr(cmd, "params", [])
 
     # Separate positional args from options
@@ -116,20 +123,21 @@ def render_markdown() -> str:
         "",
         "## CLI Reference",
         "",
-        "llem provides four commands and a version flag.",
+        "llem provides five commands and a version flag.",
         "",
         "```",
         "llem run [CONFIG] [OPTIONS]   # run an experiment or study",
         "llem config [OPTIONS]         # show environment and configuration status",
         "llem doctor [OPTIONS]         # verify Docker images match the host toolchain",
-        "llem report-gaps [OPTIONS]    # propose invariants corpus entries from runtime feedback",
+        "llem report-gaps [OPTIONS]    # propose rules corpus entries from runtime feedback",
+        "llem study [SUBCOMMAND]       # write and prepare study files (init, plan)",
         "llem --version                # print version and exit",
         "```",
         "",
     ]
 
     # Render commands in a fixed order; any others follow in declaration order.
-    command_order = ["run", "config", "doctor", "report-gaps"]
+    command_order = ["run", "config", "doctor", "report-gaps", "study"]
     for cmd_name in command_order:
         if cmd_name in commands:
             lines.extend(_render_command(cmd_name, commands[cmd_name]))

--- a/src/llenergymeasure/cli/__init__.py
+++ b/src/llenergymeasure/cli/__init__.py
@@ -106,7 +106,7 @@ from llenergymeasure.cli.report_gaps import report_gaps_cmd as _report_gaps_cmd 
 
 app.command(
     name="report-gaps",
-    help="Propose invariants corpus entries from runtime observations",
+    help="Propose rules corpus entries from runtime observations",
 )(_report_gaps_cmd)
 
 from llenergymeasure.cli.study_cmd import study_app as _study_app  # noqa: E402


### PR DESCRIPTION
## Summary

Post-carve documentation cleanup. The engine-knowledge subsystem ships as one `rules.yaml` per engine, loaded by `EngineRulesLoader`, with a closed `{error, dormant}` severity enum. A handful of user-facing docs still used the pre-rename "invariants corpus" vocabulary, and one reference bullet mis-described dormant rules as emitting a warning. The generated CLI reference also predated the `study` command.

## Changes

- **Vocabulary alignment** (`troubleshoot`, `docker-setup`, `faq`, `ecosystem`, `why`, `roadmap`, `StudyConfig`): "invariants" -> "rules" where the text refers to the shipped corpus.
- **Behavioural fix** (`ExperimentConfig`): the engine-rules note now matches the two-value severity model - `error` raises `ValidationError`; `dormant` records a silently-normalised field for dedup. `ConfigValidationWarning` is emitted only for an unknown or misspelled engine field (verified against `config/models.py`).
- **CLI reference** (`cli.md` + generator): the `study` command (with `init` / `plan` subcommands) is now documented. The generator renders command groups, the intro reflects five commands, and the `report-gaps` help string uses "rules corpus".

## What was deliberately left

- Plain-English uses of "invariant" ("FLOPs are largely invariant across implementations").
- The `{invariant_id}` template placeholder in `parameter-discovery.md` - the loader genuinely substitutes that key (`loader.py:220`), so the doc is accurate.
- Research/methodology docs keep "invariant mining" as the field's literature term.

## Follow-up (not in this PR)

Eleven `invariant` stragglers remain in `src/` (and a few test-side comments). Some are behavioural - serialized field names in `equivalence_groups.json` (`proposed_invariant_id`, `validated_invariants_version`) and the `{invariant_id}` template placeholder - so finishing the rename is a separate, carefully-scoped code PR, not a docs pass. `warnings.py` also carries a doubly-stale docstring (mentions `severity=warn`, which no longer exists).

## Doc audit

Generated-doc drift gate (`make docs-check`) regenerates only `cli.md` from this change; no other generated doc drifts. No em/en-dashes introduced. Docusaurus build validated by CI.