### PR TITLE
fix(ci): pin-driven transformers publish and ghcr prune exemption

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,13 +54,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The promotion path (publish-engine-image.yml) owns the `latest` and
+      # `transformers-<engine version>` tags. This release-time build tags
+      # only the package version so the two producers never write the same
+      # tag with different content.
       - id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/transformers
           tags: |
             type=raw,value=${{ inputs.version }}
-            type=raw,value=latest
 
       - uses: actions/setup-python@v5
         with:
@@ -71,11 +74,23 @@ jobs:
         run: |
           value=$(python3 scripts/compute_expconf_fingerprint.py)
           echo "value=${value}" >> "$GITHUB_OUTPUT"
+      # Read the transformers engine pin so the build installs the pinned
+      # version instead of the Dockerfile ARG fallback default. yq ships on
+      # ubuntu-latest runners.
+      - id: pin
+        name: Resolve transformers pin from current.yaml
+        run: |
+          value=$(yq '.library.current_version' engine_versions/transformers/current.yaml)
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.transformers
+          # Build the runtime stage, matching the locally seeded promotion
+          # source. The dev stage layers ruff/mypy/pytest on top and is for
+          # local iteration only, not for a published release image.
+          target: runtime
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -87,6 +102,7 @@ jobs:
           build-args: |
             LLEM_PKG_VERSION=${{ inputs.version }}
             LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
+            TRANSFORMERS_VERSION=${{ steps.pin.outputs.value }}
             MAX_JOBS=2
           # mode=max exports intermediate layers (including the flash-attn
           # compile) so downstream builders can reuse them, not just the final

--- a/.github/workflows/engine-rules-check.yml
+++ b/.github/workflows/engine-rules-check.yml
@@ -14,6 +14,12 @@ name: Engine rules check
 #      validator sites and reports the sites no shipped rule covers. It never
 #      fails the job, so coverage gaps are visible without blocking.
 #
+#   3. seed-image-check (gating): the transformers runtime image is seeded
+#      locally before a bump lands (make docker-seed-transformers) and
+#      tag-copied on merge by publish-engine-image.yml. This checks the seed
+#      for the current pin already exists in GHCR, so a bump PR that forgot to
+#      seed fails at PR time rather than at merge-time promotion.
+#
 # transformers is absent from the coverage report on purpose: its config
 # validation uses imperative post-init idioms that the validator-site model
 # does not recognise, so a coverage number there would be noise. It is still
@@ -37,6 +43,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: engine-rules-check-${{ github.event.pull_request.number || github.ref }}
@@ -151,3 +158,39 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           echo "rules_coverage advisory exit code: $rc (job stays green regardless)"
+
+  seed-image-check:
+    name: seed-image-check (transformers)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+      - name: Resolve pinned version
+        id: pin
+        run: |
+          version=$(yq '.library.current_version' engine_versions/transformers/current.yaml)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Pinned transformers version: $version"
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify transformers seed image exists in GHCR
+        env:
+          VERSION: ${{ steps.pin.outputs.version }}
+          REPO: ghcr.io/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          SOURCE="${REPO}/transformers-cache:transformers-${VERSION}"
+          echo "Checking promotion source: ${SOURCE}"
+          if docker manifest inspect "${SOURCE}" > /dev/null 2>&1; then
+            echo "Seed image found: ${SOURCE}"
+          else
+            echo "::error::Seed image missing: ${SOURCE}"
+            echo "The transformers runtime image for pin ${VERSION} was not seeded." >&2
+            echo "Run 'make docker-seed-transformers' locally before merging this bump," >&2
+            echo "otherwise the merge-time promotion (publish-engine-image.yml) will fail." >&2
+            exit 1
+          fi

--- a/.github/workflows/ghcr-prune.yml
+++ b/.github/workflows/ghcr-prune.yml
@@ -83,6 +83,13 @@ jobs:
           mapfile -t LIVE_SHAS < <(gh pr list --state open --json headRefOid --jq '.[].headRefOid')
           printf 'Live PR HEAD SHAs: %s\n' "${LIVE_SHAS[*]:-<none>}"
 
+          # The current pin's cache tag is the live promotion source that
+          # publish-engine-image.yml tag-copies from; it must never be
+          # pruned regardless of age. Resolve it from current.yaml at run
+          # time so the exemption tracks the pin, never a hardcoded version.
+          PIN=$(yq '.library.current_version' engine_versions/transformers/current.yaml)
+          printf 'Current transformers pin (exempt): %s\n' "${PIN}"
+
           # Page through versions; the API returns up to 100 per page.
           page=1
           delete_ids=()
@@ -106,14 +113,20 @@ jobs:
               fi
 
               # Tag-overlap check: skip if any tag matches a live PR's
-              # HEAD SHA (whole-string match). The buildx-cache tag
-              # convention is `<sha>-buildcache`; the engine-version tag
-              # is `transformers-<version>`. We compare each tag against
-              # each live SHA.
+              # HEAD SHA (whole-string match) or the current pin's cache
+              # tag. The buildx-cache tag convention is `<sha>-buildcache`;
+              # the engine-version tag is `transformers-<version>`. We
+              # compare each tag against each live SHA, and against the
+              # pinned promotion source `transformers-<PIN>` (+ its
+              # `-buildcache` variant).
               skip=0
               if [[ -n "${TAGS}" ]]; then
                 IFS=',' read -ra TAG_ARR <<< "${TAGS}"
                 for tag in "${TAG_ARR[@]}"; do
+                  if [[ "${tag}" == "transformers-${PIN}" || "${tag}" == "transformers-${PIN}-buildcache" ]]; then
+                    skip=1
+                    break
+                  fi
                   for sha in "${LIVE_SHAS[@]}"; do
                     [[ -z "${sha}" ]] && continue
                     if [[ "${tag}" == "${sha}" || "${tag}" == "${sha}-buildcache" ]]; then
@@ -125,7 +138,7 @@ jobs:
               fi
 
               if [[ ${skip} -eq 1 ]]; then
-                echo "Skip (live PR ref): id=${ID} created=${CREATED} tags=[${TAGS}]"
+                echo "Skip (live PR ref or current pin): id=${ID} created=${CREATED} tags=[${TAGS}]"
                 continue
               fi
 


### PR DESCRIPTION
## What / why

Fixes the transformers image publish + prune lifecycle per the workflow-fitness
review (leg1 findings 6, 7, 8). Three time-bomb / correctness issues around the
transformers first-party image contract.

### 1. `docker-publish.yml`: build the release image with the pinned transformers version (leg1 F6)

The release-time build never passed `TRANSFORMERS_VERSION`, so it installed the
stale Dockerfile ARG default (`4.57.3`) instead of the pin (`5.7.0`). It also
set no explicit target (building the `dev` stage, which layers ruff/mypy/pytest)
and double-wrote `:latest`, colliding with the promotion path which writes the
same tag with different content.

- Read the pin from `engine_versions/transformers/current.yaml` (via `yq`, which
  ships on `ubuntu-latest`) and pass `--build-arg TRANSFORMERS_VERSION=<pin>`.
- Set `target: runtime`, matching the locally seeded promotion source. The `dev`
  stage is for local iteration only and does not belong in a published release.
- Drop `type=raw,value=latest` from the pushed tags. `publish-engine-image.yml`
  is the canonical owner of `:latest` and `transformers-<engine version>`; this
  release build now tags only the package version. `cache-to :latest,mode=max`
  is unchanged (a cache manifest export, not the image tag - it is the documented
  build-cache warming).

### 2. `ghcr-prune.yml`: exempt the current pin's cache tag (leg1 F7)

The 30-day retention sweep protected only open-PR HEAD-SHA tags, so
`transformers-cache:transformers-<pin>` (+ `-buildcache`) - the live promotion
source - was on track for deletion ~2026-08-03, which would break the tag-copy
promotion path. The prune loop now resolves the pin from `current.yaml` at run
time and skips any version tagged `transformers-<pin>` or
`transformers-<pin>-buildcache`. The exemption is pin-driven, not a hardcoded
version string, so it tracks bumps automatically.

### 3. Seed-image existence check at PR time (leg1 F8)

A forgotten local seed previously failed only at/after merge (the promotion
tag-copy finds no source manifest). Added a gating `seed-image-check
(transformers)` job to `engine-rules-check.yml` (which already fans out
per-engine on `engine_versions/*/current.yaml` pin changes - the workflow leg1
designates). It resolves the pin, logs in to GHCR, and runs
`docker manifest inspect` on
`ghcr.io/<repo>/transformers-cache:transformers-<pin>`; a missing seed fails the
PR loudly with a remediation message pointing at `make docker-seed-transformers`.
Added `packages: read` to the workflow permissions for the GHCR login.

## Validation performed

- `actionlint` 1.7.12 on all three touched workflows and on the full
  `.github/workflows/` tree: clean (exit 0).
- Python YAML parse of all three touched workflows: clean.
- Verified `yq '.library.current_version' engine_versions/transformers/current.yaml`
  yields `5.7.0` (matches the committed pin); confirmed the seed tag convention
  (`transformers-<ver>` + `transformers-<ver>-buildcache`) against the Makefile
  seed target so the prune exemption matches both.
- `make lint` (ruff + import-linter, 4 contracts kept), `make typecheck`
  (mypy, 0 issues), `make test` (2872 passed, 44 skipped): all green - proving no
  collateral (workflow-only change, no Python touched).

## Conventions conformance (docs/explanation/architecture/ci-architecture.md)

- **Docker pull guard**: N/A - no `docker pull` added; the seed check uses
  `docker manifest inspect` (a registry metadata read, no image pull).
- **Static env hoisting**: pin/version values are step-output-derived, so they
  stay step-scoped (`env:` on the consuming step), per the per-step-ENV rule
  which reserves job-level `env:` for static values only. `REGISTRY` stays at
  job/workflow level as before.
- **Imperative step names**: new steps use imperative verb + object
  (`Resolve transformers pin from current.yaml`,
  `Verify transformers seed image exists in GHCR`, `Log in to GHCR`); reused the
  standardised `Checkout PR branch` form.
- **cancel-in-progress**: untouched. `docker-publish.yml` has no concurrency
  block (workflow_call/dispatch only); `ghcr-prune.yml` stays `false` (long
  writeback sweep); `engine-rules-check.yml` stays `true` (read-only check).
- **`:latest` tag ownership**: aligns docker-publish with the doc's stated split
  (promotion owns `latest`, release-build produces the package-versioned image).

## Out of scope (separate lanes, deliberately untouched)

- ci.yml gate reachability, `schema-version-check` routing, required-checks
  wiring (PR-E2).
- Doc-drift items in leg1 finding 13 (stale step name in ghcr-prune, Dockerfile
  header stale paths, ci-architecture wording).