### PR TITLE
fix(rules): purge false-positive and phantom corpus rules

### DIFF
--- a/src/llenergymeasure/engines/tensorrt/rules.yaml
+++ b/src/llenergymeasure/engines/tensorrt/rules.yaml
@@ -70,14 +70,14 @@ rules:
     verified: human
     engine_version: 1.0.0
     date: '2026-07-02'
-- id: tensorrt_raises_max_batch_size_lt_0_cuda_graph_max_batch_size
+- id: tensorrt_raises_max_batch_size_lt_0
   engine: tensorrt
   severity: error
   match:
     fields:
       tensorrt.engine_params.max_batch_size:
         <: 0
-  message_template: cuda_graph_config.max_batch_size must be non-negative
+  message_template: engine_params.max_batch_size must be non-negative, got {declared_value}.
   provenance:
     source: deterministic_miner
     verified: construction

--- a/src/llenergymeasure/engines/transformers/rules.yaml
+++ b/src/llenergymeasure/engines/transformers/rules.yaml
@@ -5,20 +5,6 @@ schema_version: 1.0.0
 engine: transformers
 engine_version: 5.7.0
 rules:
-- id: transformers_beam_search_num_beams_eq_1
-  engine: transformers
-  severity: dormant
-  match:
-    fields:
-      transformers.engine_params.num_beams: 1
-  message_template: '`num_beams` is set to 1. However, `early_stopping` is set to `True` -- this flag
-    is only used in beam-based generation modes. You should set `num_beams>1` or unset `early_stopping`.'
-  provenance:
-    source: deterministic_miner
-    verified: runtime
-    engine_version: 5.7.0
-    citation: transformers/generation/configuration_utils.py:386
-    date: '2026-06-12T10:04:46+02:00'
 - id: transformers_bnb_load_in_4bit_xor_load_in_8bit
   engine: transformers
   severity: error
@@ -42,8 +28,18 @@ rules:
       transformers.engine_params.cache_implementation:
         present: true
         not_in:
-        - dynamic
         - static
+        - offloaded_static
+        - sliding_window
+        - hybrid
+        - hybrid_chunked
+        - offloaded_hybrid
+        - offloaded_hybrid_chunked
+        - dynamic
+        - dynamic_full
+        - offloaded
+        - quantized
+        - paged
   message_template: 'Invalid `cache_implementation` (nonsense). Choose one of: (''static'', ''offloaded_static'',
     ''sliding_window'', ''hybrid'', ''hybrid_chunked'', ''offloaded_hybrid'', ''offloaded_hybrid_chunked'',
     ''dynamic'', ''dynamic_full'', ''offloaded'', ''quantized'', ''paged'')'
@@ -139,20 +135,6 @@ rules:
     verified: construction
     engine_version: 5.7.0
     citation: transformers/generation/configuration_utils.py:714
-    date: '2026-06-12T10:04:46+02:00'
-- id: transformers_early_stopping_type_early_stopping_exceeds_zero
-  engine: transformers
-  severity: error
-  match:
-    fields:
-      transformers.engine_params.early_stopping:
-        '>': 0
-  message_template: '`early_stopping` must be a boolean or ''never'', but is 1.5.'
-  provenance:
-    source: deterministic_miner
-    verified: runtime
-    engine_version: 5.7.0
-    citation: transformers/generation/configuration_utils.py:380
     date: '2026-06-12T10:04:46+02:00'
 - id: transformers_early_stopping_type_early_stopping_not_in_allowlist
   engine: transformers
@@ -476,14 +458,14 @@ rules:
     engine_version: 5.7.0
     citation: transformers/generation/configuration_utils.py:386
     date: '2026-06-12T10:04:46+02:00'
-- id: transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences
+- id: transformers_num_return_vs_beams_num_return_sequences_gt_num_beams
   engine: transformers
   severity: error
   match:
     fields:
-      transformers.engine_params.num_beams:
-        not_divisible_by: '@transformers.sampling_params.num_return_sequences'
-  message_template: '`num_return_sequences` (4) has to be smaller or equal to `num_beams` (2).'
+      transformers.sampling_params.num_return_sequences:
+        '>': '@transformers.engine_params.num_beams'
+  message_template: '`num_return_sequences` has to be smaller or equal to `num_beams`.'
   provenance:
     source: deterministic_miner
     verified: runtime
@@ -497,23 +479,6 @@ rules:
     fields:
       transformers.sampling_params.max_new_tokens:
         <=: 0
-  message_template: '`max_new_tokens` must be greater than 0, but is -1.'
-  provenance:
-    source: deterministic_miner
-    verified: runtime
-    engine_version: 5.7.0
-    citation: transformers/generation/configuration_utils.py:376
-    date: '2026-06-12T10:04:46+02:00'
-- id: transformers_output_token_ids_max_new_tokens_not_in_allowlist
-  engine: transformers
-  severity: error
-  match:
-    fields:
-      transformers.sampling_params.max_new_tokens:
-        present: true
-        not_in:
-        - 1
-        - 16
   message_template: '`max_new_tokens` must be greater than 0, but is -1.'
   provenance:
     source: deterministic_miner

--- a/src/llenergymeasure/engines/vllm/rules.yaml
+++ b/src/llenergymeasure/engines/vllm/rules.yaml
@@ -108,21 +108,6 @@ rules:
     engine_version: 0.19.1
     citation: parallel.py:353
     date: '2026-06-22'
-- id: vllm_samplingparams_dormant_bad_words_unset_true
-  engine: vllm
-  severity: dormant
-  match:
-    fields:
-      vllm.sampling_params.bad_words:
-        absent: true
-  normalised_fields:
-  - bad_words
-  provenance:
-    source: deterministic_miner
-    verified: construction
-    engine_version: 0.19.1
-    citation: sampling_params.py:396
-    date: '2026-06-22'
 - id: vllm_samplingparams_dormant_seed_eq_neg1
   engine: vllm
   severity: dormant
@@ -136,36 +121,6 @@ rules:
     verified: construction
     engine_version: 0.19.1
     citation: sampling_params.py:385
-    date: '2026-06-22'
-- id: vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true
-  engine: vllm
-  severity: dormant
-  match:
-    fields:
-      vllm.sampling_params.skip_reading_prefix_cache:
-        absent: true
-  normalised_fields:
-  - skip_reading_prefix_cache
-  provenance:
-    source: deterministic_miner
-    verified: construction
-    engine_version: 0.19.1
-    citation: sampling_params.py:425
-    date: '2026-06-22'
-- id: vllm_samplingparams_dormant_stop_token_ids_unset_true
-  engine: vllm
-  severity: dormant
-  match:
-    fields:
-      vllm.sampling_params.stop_token_ids:
-        absent: true
-  normalised_fields:
-  - stop_token_ids
-  provenance:
-    source: deterministic_miner
-    verified: construction
-    engine_version: 0.19.1
-    citation: sampling_params.py:393
     date: '2026-06-22'
 - id: vllm_samplingparams_raises_frequency_penalty_gt_2p0
   engine: vllm

--- a/tests/unit/config/engine_rules/test_corpus_invariants.py
+++ b/tests/unit/config/engine_rules/test_corpus_invariants.py
@@ -133,27 +133,27 @@ def test_cross_section_field_refs_fire(corpora) -> None:
     fired = {inv.id for inv in rules if inv.try_match(violating)}
     assert "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences" in fired
 
-    not_divisible = {
-        "transformers": {
-            "engine_params": {"num_beams": 5},
-            "sampling_params": {"num_return_sequences": 2},
-        }
-    }
-    fired = {inv.id for inv in rules if inv.try_match(not_divisible)}
-    assert (
-        "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences" in fired
-    )
-
-    clean = {
+    return_gt_beams = {
         "transformers": {
             "engine_params": {"num_beams": 4},
-            "sampling_params": {"num_return_sequences": 2},
+            "sampling_params": {"num_return_sequences": 5},
         }
     }
-    fired = {inv.id for inv in rules if inv.try_match(clean)}
+    fired = {inv.id for inv in rules if inv.try_match(return_gt_beams)}
+    assert "transformers_num_return_vs_beams_num_return_sequences_gt_num_beams" in fired
+
+    # num_return_sequences <= num_beams but not a divisor: valid upstream, must
+    # not fire (regression guard for the not_divisible_by -> <= re-encode).
+    non_divisor_ok = {
+        "transformers": {
+            "engine_params": {"num_beams": 4},
+            "sampling_params": {"num_return_sequences": 3},
+        }
+    }
+    fired = {inv.id for inv in rules if inv.try_match(non_divisor_ok)}
     assert not fired & {
         "transformers_num_return_vs_beams_num_beams_lt_num_return_sequences",
-        "transformers_num_return_vs_beams_num_beams_not_divisible_by_num_return_sequences",
+        "transformers_num_return_vs_beams_num_return_sequences_gt_num_beams",
     }
 
 

--- a/tests/unit/config/test_rehomed_rules_fire.py
+++ b/tests/unit/config/test_rehomed_rules_fire.py
@@ -144,6 +144,7 @@ def test_cross_section_non_divisor_return_count_accepted():
         },
     )
     assert cfg.active_engine_params().num_beams == 4
+    assert cfg.active_sampling_params().num_return_sequences == 3
 
 
 # ---------------------------------------------------------------------------
@@ -220,20 +221,6 @@ def test_legitimate_transformers_value_validates_cleanly(section, field, value):
         transformers={section: {field: value}},
     )
     assert getattr(getattr(cfg, "active_" + section)(), field) == value
-
-
-def test_beams_ge_return_sequences_validates_cleanly():
-    """num_beams=4 with num_return_sequences=3 (non-divisor pair) is valid."""
-    cfg = ExperimentConfig(
-        task={"model": "gpt2"},
-        engine="transformers",
-        transformers={
-            "engine_params": {"num_beams": 4},
-            "sampling_params": {"num_return_sequences": 3},
-        },
-    )
-    assert cfg.active_engine_params().num_beams == 4
-    assert cfg.active_sampling_params().num_return_sequences == 3
 
 
 def test_bare_vllm_config_has_no_phantom_dormant_observations():

--- a/tests/unit/config/test_rehomed_rules_fire.py
+++ b/tests/unit/config/test_rehomed_rules_fire.py
@@ -95,27 +95,52 @@ def test_cross_section_num_beams_lt_num_return_sequences_fires():
         )
 
 
-def test_cross_section_num_beams_not_divisible_by_num_return_sequences_fires():
-    """num_beams not divisible by sampling_params.num_return_sequences is rejected."""
-    with pytest.raises(ValueError, match="not_divisible_by_num_return_sequences"):
+def test_cross_section_num_return_sequences_gt_num_beams_fires():
+    """num_return_sequences above engine_params.num_beams is rejected.
+
+    The real upstream constraint is num_return_sequences <= num_beams (not a
+    divisibility check), so a value strictly greater than num_beams must be
+    rejected regardless of divisibility. The re-encoded rule is asserted to
+    fire in isolation (a sibling `num_beams < @num_return_sequences` rule
+    encodes the same constraint and may short-circuit at the ExperimentConfig
+    layer, so the config-path assertion only pins rejection, not which id).
+    """
+    from llenergymeasure.config.engine_rules import EngineRulesLoader
+
+    rules = EngineRulesLoader().load_rules("transformers").rules
+    violating = {
+        "transformers": {
+            "engine_params": {"num_beams": 4},
+            "sampling_params": {"num_return_sequences": 5},
+        }
+    }
+    fired = {r.id for r in rules if r.try_match(violating)}
+    assert "transformers_num_return_vs_beams_num_return_sequences_gt_num_beams" in fired
+
+    with pytest.raises(ValueError, match="num_return_sequences"):
         ExperimentConfig(
             task={"model": "gpt2"},
             engine="transformers",
             transformers={
-                "engine_params": {"num_beams": 5},
-                "sampling_params": {"num_return_sequences": 2},
+                "engine_params": {"num_beams": 4},
+                "sampling_params": {"num_return_sequences": 5},
             },
         )
 
 
-def test_cross_section_compatible_beam_and_return_counts_accepted():
-    """num_beams >= and divisible by num_return_sequences constructs cleanly."""
+def test_cross_section_non_divisor_return_count_accepted():
+    """num_return_sequences <= num_beams but not a divisor constructs cleanly.
+
+    Regression guard for the re-encode: 3 return sequences with 4 beams is not
+    a divisor pair yet is valid upstream, so the old not_divisible_by rule was a
+    false positive here.
+    """
     cfg = ExperimentConfig(
         task={"model": "gpt2"},
         engine="transformers",
         transformers={
             "engine_params": {"num_beams": 4},
-            "sampling_params": {"num_return_sequences": 2},
+            "sampling_params": {"num_return_sequences": 3},
         },
     )
     assert cfg.active_engine_params().num_beams == 4
@@ -163,3 +188,67 @@ def test_numeric_bound_still_fires_after_incomparable_guard():
             engine="transformers",
             transformers={"sampling_params": {"min_new_tokens": 0}},
         )
+
+
+# ---------------------------------------------------------------------------
+# Purged false-positive rules: legitimate configs must now validate cleanly.
+#
+# Each of these values was rejected by a probe-confirmed false-positive corpus
+# rule (an over-fit allowlist or a mis-mined type bound). After the purge they
+# must construct through the public ExperimentConfig path without raising.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "section,field,value",
+    [
+        # early_stopping=True enables beam-search early stopping (was rejected
+        # by the {'>': 0} bound, since True > 0 in Python).
+        ("engine_params", "early_stopping", True),
+        # max_new_tokens=256 (was rejected by an over-fit not_in [1, 16]).
+        ("sampling_params", "max_new_tokens", 256),
+        # cache_implementation="sliding_window" is a documented value (was
+        # rejected by a not_in [dynamic, static] allowlist).
+        ("engine_params", "cache_implementation", "sliding_window"),
+    ],
+)
+def test_legitimate_transformers_value_validates_cleanly(section, field, value):
+    """A documented, valid transformers value constructs without raising."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers={section: {field: value}},
+    )
+    assert getattr(getattr(cfg, "active_" + section)(), field) == value
+
+
+def test_beams_ge_return_sequences_validates_cleanly():
+    """num_beams=4 with num_return_sequences=3 (non-divisor pair) is valid."""
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers={
+            "engine_params": {"num_beams": 4},
+            "sampling_params": {"num_return_sequences": 3},
+        },
+    )
+    assert cfg.active_engine_params().num_beams == 4
+    assert cfg.active_sampling_params().num_return_sequences == 3
+
+
+def test_bare_vllm_config_has_no_phantom_dormant_observations():
+    """The three deleted vllm `absent: true` rules no longer fire on a bare config.
+
+    Each rule matched a field that was simply never set and normalised it to
+    absence - a guaranteed no-op that fired a phantom dormant observation on
+    every config. A bare vllm config must now yield zero dormant observations
+    from those rules.
+    """
+    cfg = ExperimentConfig(task={"model": "gpt2"}, engine="vllm")
+    purged = {
+        "vllm_samplingparams_dormant_bad_words_unset_true",
+        "vllm_samplingparams_dormant_skip_reading_prefix_cache_unset_true",
+        "vllm_samplingparams_dormant_stop_token_ids_unset_true",
+    }
+    assert not (set(cfg._dormant_observations) & purged)
+    assert cfg._dormant_observations == {}

--- a/tests/unit/config/test_scaffold.py
+++ b/tests/unit/config/test_scaffold.py
@@ -225,13 +225,18 @@ def test_bounds_pins_fields_without_derivable_range() -> None:
     assert raw["vllm"]["sampling_params"]["temperature"] == 1.0
 
 
-def test_bounds_drops_known_rejected_values() -> None:
-    """early_stopping's series collapses to [false] via a corpus rule, so it pins."""
+def test_bounds_emits_both_bool_values_for_early_stopping() -> None:
+    """early_stopping is a valid boolean knob, so it sweeps both values.
+
+    early_stopping=True is the documented way to enable beam-search early
+    stopping; it must not be pruned from the sweep. (At the default num_beams=1
+    the two values are measurement-equivalent and collapse at dedup time - see
+    the round-trip tests - but the sweep axis itself is emitted.)
+    """
     text = render_study_bounds(MODEL, ["transformers"])
     raw = yaml.safe_load(text)
     sweep = raw["sweep"]
-    assert "transformers.engine_params.early_stopping" not in sweep
-    assert raw["transformers"]["engine_params"]["early_stopping"] is None
+    assert sweep["transformers.engine_params.early_stopping"] == [False, True]
     assert sweep["transformers.engine_params.use_cache"] == [False, True]
     assert sweep["transformers.sampling_params.do_sample"] == [False, True]
 
@@ -245,20 +250,36 @@ def test_bounds_render_is_byte_deterministic() -> None:
 
 @pytest.mark.parametrize("engine", all_engine_names())
 def test_bounds_round_trips_to_series_product(engine: str, tmp_path: Path) -> None:
-    """A bounds file expands to exactly the product of its series lengths."""
+    """A bounds file expands to the product of its series lengths.
+
+    The full Cartesian product is enumerated pre-dedup (one equivalence group
+    per combination member); measurement-equivalent combinations then collapse
+    via the resolved-config-hash dedup, so the number of executed experiments
+    equals the group count (<= product). For transformers this is a strict
+    collapse: early_stopping is dormant at the default num_beams=1, so its two
+    values are measurement-equivalent.
+    """
     text = render_study_bounds(MODEL, [engine])
     path = tmp_path / "study.yaml"
     path.write_text(text)
     sweep = _sweep_block(text)
-    expected = math.prod(len(v) for v in sweep.values())
+    product = math.prod(len(v) for v in sweep.values())
     study = _load_without_config_warnings(path)
-    assert expected > 1
-    assert len(study.experiments) == expected
+    assert product > 1
+    # Every sweep combination is accounted for in exactly one equivalence group.
+    assert sum(g["member_count"] for g in study.pre_run_equivalence_groups) == product
+    # Executed experiments are the post-dedup distinct resolved configs.
+    assert len(study.experiments) == len(study.pre_run_equivalence_groups)
+    assert 1 < len(study.experiments) <= product
     assert all(e.engine == engine for e in study.experiments)
 
 
 def test_bounds_all_engines_round_trips_to_sum_of_products(tmp_path: Path) -> None:
-    """A multi-engine bounds file expands to the sum of per-engine products."""
+    """A multi-engine bounds file expands to the sum of per-engine products.
+
+    As in the single-engine case, the sum-of-products is the pre-dedup member
+    total; executed experiments are the post-dedup group count.
+    """
     text = render_study_bounds(MODEL, all_engine_names())
     path = tmp_path / "study.yaml"
     path.write_text(text)
@@ -266,9 +287,10 @@ def test_bounds_all_engines_round_trips_to_sum_of_products(tmp_path: Path) -> No
     for key, values in _sweep_block(text).items():
         per_engine.setdefault(key.split(".")[0], []).append(len(values))
     assert set(per_engine) == set(all_engine_names())
-    expected = sum(math.prod(lengths) for lengths in per_engine.values())
+    expected_members = sum(math.prod(lengths) for lengths in per_engine.values())
     study = _load_without_config_warnings(path)
-    assert len(study.experiments) == expected
+    assert sum(g["member_count"] for g in study.pre_run_equivalence_groups) == expected_members
+    assert len(study.experiments) == len(study.pre_run_equivalence_groups)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_scaffold.py
+++ b/tests/unit/config/test_scaffold.py
@@ -229,9 +229,9 @@ def test_bounds_emits_both_bool_values_for_early_stopping() -> None:
     """early_stopping is a valid boolean knob, so it sweeps both values.
 
     early_stopping=True is the documented way to enable beam-search early
-    stopping; it must not be pruned from the sweep. (At the default num_beams=1
-    the two values are measurement-equivalent and collapse at dedup time - see
-    the round-trip tests - but the sweep axis itself is emitted.)
+    stopping; it must not be pruned from the sweep. (A dormant corpus rule
+    strips early_stopping at resolution time, so the two values collapse at
+    dedup - see the round-trip tests - but the sweep axis itself is emitted.)
     """
     text = render_study_bounds(MODEL, ["transformers"])
     raw = yaml.safe_load(text)
@@ -255,9 +255,9 @@ def test_bounds_round_trips_to_series_product(engine: str, tmp_path: Path) -> No
     The full Cartesian product is enumerated pre-dedup (one equivalence group
     per combination member); measurement-equivalent combinations then collapse
     via the resolved-config-hash dedup, so the number of executed experiments
-    equals the group count (<= product). For transformers this is a strict
-    collapse: early_stopping is dormant at the default num_beams=1, so its two
-    values are measurement-equivalent.
+    equals the group count (<= product). For transformers the collapse is
+    strict: a dormant corpus rule strips early_stopping at resolution, so its
+    two swept values resolve to the same config.
     """
     text = render_study_bounds(MODEL, [engine])
     path = tmp_path / "study.yaml"

--- a/tests/unit/config/test_series.py
+++ b/tests/unit/config/test_series.py
@@ -175,11 +175,15 @@ def test_series_collapsing_below_two_values_is_pinned() -> None:
     assert _series("flag", rules=rules) is None
 
 
-def test_real_corpus_rejects_early_stopping_true() -> None:
-    """The shipped transformers corpus knows early_stopping=true raises."""
+def test_real_corpus_keeps_early_stopping_true() -> None:
+    """early_stopping=true is valid (enables beam-search early stopping).
+
+    The old mis-mined `{'>': 0}` bound rejected True (True > 0 in Python); after
+    its removal the shipped corpus keeps both boolean values.
+    """
     rules = EngineRulesLoader().load_rules("transformers").rules
     kept = drop_known_rejected([False, True], "transformers.engine_params.early_stopping", rules)
-    assert kept == [False]
+    assert kept == [False, True]
 
 
 def test_real_corpus_rejects_vllm_top_k_below_neg1() -> None:

--- a/tests/unit/config/test_tensorrt_config.py
+++ b/tests/unit/config/test_tensorrt_config.py
@@ -86,9 +86,9 @@ class TestCompileTimeParams:
     def test_tensorrt_max_batch_size_nonneg(self):
         """max_batch_size=0 is accepted (rule fires at < 0, not < 1).
 
-        The mined rule `tensorrt_raises_max_batch_size_lt_0_cuda_graph_max_batch_size`
-        uses `< 0` (TRT-LLM's ``cuda_graph_config.max_batch_size must be non-negative``),
-        so 0 is valid at parse time. Negative values are rejected.
+        The mined rule `tensorrt_raises_max_batch_size_lt_0` uses `< 0`
+        (``engine_params.max_batch_size must be non-negative``), so 0 is valid
+        at parse time. Negative values are rejected.
         """
         config = _make_trt(max_batch_size=0)
         assert config.tensorrt.engine_params.max_batch_size == 0


### PR DESCRIPTION
## Summary

Purges probe-confirmed false-positive and phantom rules from the shipped engine
rules corpus, and re-encodes two mis-mined constraints. Data-only corpus edits
plus regression tests. All findings are probe-verified in the leg-3 fitness
review; each is confirmed reproduced on origin/main before the fix and resolved
after.

Corpus goes from 98 -> 92 rules (6 deletions; tensorrt count unchanged, one rule
renamed). All three corpora remain byte-round-trip stable through
`serialize_corpus` (enforced by `test_shipped_vllm_corpus_round_trips_byte_identical`),
so provenance rationale lives here rather than as inline YAML comments (the
serializer drops comments, so a per-edit `#` note would break the round-trip
gate).

## Per-rule changes

**transformers**

1. DELETE `transformers_early_stopping_type_early_stopping_exceeds_zero`. Its
   `{'>': 0}` predicate rejected `early_stopping=True` (`True > 0` is true in
   Python), the documented way to enable beam-search early stopping. Mis-mined
   type probe; the type is still guarded by
   `transformers_raises_early_stopping_not_in_set`.
2. DELETE `transformers_output_token_ids_max_new_tokens_not_in_allowlist`. Its
   `not_in [1, 16]` rejected every `max_new_tokens` except the two values seen
   during mining. The real lower bound stays enforced by
   `transformers_output_token_ids_max_new_tokens_le_zero`.
3. FIX `transformers_cache_choice_cache_implementation_not_in_allowlist`. The
   predicate allowed only `[dynamic, static]` while its own message enumerates
   12 valid values; widened the `not_in` allowlist to the full message set
   (sliding_window, offloaded, hybrid, ...). `nonsense` is still rejected.
4. RE-ENCODE the num_beams / num_return_sequences rule. The mined
   `not_divisible_by` predicate contradicted the real upstream constraint
   `num_return_sequences <= num_beams`. Re-encoded as an error when
   `num_return_sequences > num_beams` using the root-dotted `@field_ref` idiom
   (mirrors the vllm min_tokens/max_tokens rule); renamed to
   `transformers_num_return_vs_beams_num_return_sequences_gt_num_beams`.
   `num_beams=4, num_return_sequences=3` (a non-divisor but valid pair) now
   passes; `num_return_sequences=5` still fails.
5. DELETE `transformers_beam_search_num_beams_eq_1`. Fired a phantom dormant
   observation on every default-shaped `num_beams=1` config with a misleading
   `early_stopping` message and produced no normalisation.

**vllm**

6. DELETE the three `absent: true` dormant rules (`bad_words`,
   `skip_reading_prefix_cache`, `stop_token_ids`). Each fired a phantom dormant
   observation on every config that never set the field, and their
   normalisation (strip an already-absent field) was a guaranteed no-op. The
   unrelated `seed=-1` dormant rule is preserved. A bare vllm config now yields
   zero dormant observations.

**tensorrt**

7. `tensorrt_raises_max_batch_size_lt_0_cuda_graph_max_batch_size` matched
   `engine_params.max_batch_size` but its message/citation described
   `cuda_graph_config.max_batch_size`. **Decided fork: KEPT the current match
   path and fixed the message.** The generated tensorrt `EngineParams` model
   exposes only a flat `max_batch_size: int | None`; there is no typed
   `cuda_graph_config` object for the loader's path grammar to resolve the mined
   nested-field semantics against (`cuda_graph_config` could only arrive as an
   untyped pydantic extra, so `resolve_field_path` cannot faithfully represent
   the mined constraint). Re-pointing the path would make the rule unreachable;
   fixing the message keeps a real, enforceable rule with an accurate
   diagnostic. Renamed to `tensorrt_raises_max_batch_size_lt_0`.

## Tests

- `test_rehomed_rules_fire.py`: added `test_legitimate_transformers_value_validates_cleanly`
  (`early_stopping=True`, `max_new_tokens=256`, `cache_implementation="sliding_window"`),
  `test_beams_ge_return_sequences_validates_cleanly` (`num_beams=4, num_return_sequences=3`),
  and `test_bare_vllm_config_has_no_phantom_dormant_observations`. Re-encoded the
  cross-section num_beams test to the `<=` semantics (asserts the re-encoded rule
  fires in isolation, since the sibling `num_beams < @nrs` rule may short-circuit
  the ExperimentConfig path).
- `test_corpus_invariants.py`: re-encoded the cross-section firing assertion to
  the new rule id and `>` semantics.
- `test_series.py`: inverted `test_real_corpus_rejects_early_stopping_true` ->
  `test_real_corpus_keeps_early_stopping_true` (both bool values kept).
- `test_scaffold.py`: `early_stopping` now sweeps `[False, True]` instead of
  pinning; the two round-trip count tests now assert the pre-dedup member total
  equals the sweep product and executed experiments equal the post-dedup group
  count (transformers collapses 8 -> 4 because `early_stopping` is dormant at the
  default `num_beams=1`).
- `test_tensorrt_config.py`: docstring updated to the renamed rule + corrected
  field.

## Gates

`make lint`, `make typecheck`, full `pytest` (2877 passed, 44 skipped),
per-engine `regen_engine_configs.py --check` (byte-identical - no generated
config touched), and `make docs-check` all green.
