### PR TITLE
fix(config): rule message rendering, loader guards, early_stopping fidelity

### DIFF
--- a/src/llenergymeasure/config/engine_rules/loader.py
+++ b/src/llenergymeasure/config/engine_rules/loader.py
@@ -209,12 +209,8 @@ class Rule:
 
         ``matched_fields`` is keyed by full dotted paths
         (``vllm.sampling_params.min_tokens``), which are not valid
-        ``str.format`` placeholder names. Templates conventionally reference the
-        bare leaf name (``{min_tokens}``), so each dotted key is additionally
-        exposed under its leaf name (``path.rsplit('.', 1)[-1]``). On a leaf-name
-        collision between two paths the first-seen path wins (dict-insertion
-        order), so a rule keeps deterministic rendering; author unambiguously by
-        keeping distinct leaf names in a single rule's ``match.fields``.
+        ``str.format`` placeholder names, so each key is also exposed under its
+        bare leaf name (``{min_tokens}``) - the corpus authoring convention.
 
         Uses ``str.format`` with permissive defaults - templates that reference
         a still-missing key fall back to the raw template rather than raising at
@@ -224,11 +220,10 @@ class Rule:
         """
         if self.message_template is None:
             return "<no message template>"
-        # Expose both the full dotted path and its leaf name as format kwargs.
-        # The full paths seed the map first, so a bare (dot-free) path is never
-        # re-added under an identical leaf key (which would make ``.format``
-        # raise "multiple values"); on a leaf collision between two distinct
-        # paths the first-seen path wins.
+        # Seed the full dotted paths first, then add leaf names via setdefault:
+        # a dot-free path is never re-added under its own key (which would make
+        # ``.format`` raise "multiple values"), and on a leaf collision between
+        # two distinct paths the first-seen path wins (deterministic rendering).
         fmt_kwargs: dict[str, Any] = dict(match.matched_fields)
         for path, value in match.matched_fields.items():
             fmt_kwargs.setdefault(path.rsplit(".", 1)[-1], value)

--- a/src/llenergymeasure/config/engine_rules/loader.py
+++ b/src/llenergymeasure/config/engine_rules/loader.py
@@ -207,21 +207,40 @@ class Rule:
     def render_message(self, match: RuleMatch) -> str:
         """Substitute ``{declared_value}`` / ``{effective_value}`` / ``{invariant_id}`` in the template.
 
+        ``matched_fields`` is keyed by full dotted paths
+        (``vllm.sampling_params.min_tokens``), which are not valid
+        ``str.format`` placeholder names. Templates conventionally reference the
+        bare leaf name (``{min_tokens}``), so each dotted key is additionally
+        exposed under its leaf name (``path.rsplit('.', 1)[-1]``). On a leaf-name
+        collision between two paths the first-seen path wins (dict-insertion
+        order), so a rule keeps deterministic rendering; author unambiguously by
+        keeping distinct leaf names in a single rule's ``match.fields``.
+
         Uses ``str.format`` with permissive defaults - templates that reference
-        missing keys fall back to the rule id + raw template rather than
-        raising at user-facing time.
+        a still-missing key fall back to the raw template rather than raising at
+        user-facing time. The fallback does NOT prefix the rule id: the sole
+        caller (:meth:`ExperimentConfig._apply_rules`) already annotates every
+        rendered message with ``[rule.id]``.
         """
         if self.message_template is None:
-            return f"[{self.id}] <no message template>"
+            return "<no message template>"
+        # Expose both the full dotted path and its leaf name as format kwargs.
+        # The full paths seed the map first, so a bare (dot-free) path is never
+        # re-added under an identical leaf key (which would make ``.format``
+        # raise "multiple values"); on a leaf collision between two distinct
+        # paths the first-seen path wins.
+        fmt_kwargs: dict[str, Any] = dict(match.matched_fields)
+        for path, value in match.matched_fields.items():
+            fmt_kwargs.setdefault(path.rsplit(".", 1)[-1], value)
         try:
             return self.message_template.format(
                 declared_value=match.declared_value,
                 effective_value=match.effective_value,
                 invariant_id=self.id,
-                **match.matched_fields,
+                **fmt_kwargs,
             )
         except (KeyError, IndexError):
-            return f"[{self.id}] {self.message_template}"
+            return self.message_template
 
 
 @dataclass(frozen=True)
@@ -362,15 +381,24 @@ def _ordered(a: Any, b: Any, op: Callable[[Any, Any], bool]) -> bool:
     ``a`` may be None when the predicate's field is unset; ``b`` may be None
     when a ``@field_ref`` resolves against a missing target - both yield False.
 
-    A mined numeric bound can land on a field that naturally holds a non-numeric
-    value (e.g. transformers ``compile_config``, a dict / CompileConfig shape).
-    Comparing such a pair with ``<`` / ``<=`` / ``>`` / ``>=`` raises TypeError;
-    that would escape config construction as an uncaught crash. Since the bound
-    is a corpus artifact rather than a user error - the generated pydantic model
-    remains the authority on the field's type validity - the rule simply does
-    not fire (False) on a type-incomparable pair.
+    ``bool`` operands are treated as non-comparable and never fire, mirroring
+    the ``_is_int_pair`` exclusion the divisibility ops apply. Python evaluates
+    ``True > 0`` cleanly (``bool`` subclasses ``int``), so an ordering bound
+    mined against a scalar numeric field would otherwise silently reject a
+    boolean-valued field (e.g. a ``{'>': 0}`` bound firing on
+    ``early_stopping=True``). The generated pydantic model remains the authority
+    on a boolean field's type validity, so the ordering rule stays inert.
+
+    A mined numeric bound can also land on a field that naturally holds a
+    non-numeric value (e.g. transformers ``compile_config``, a dict /
+    CompileConfig shape). Comparing such a pair with ``<`` / ``<=`` / ``>`` /
+    ``>=`` raises TypeError; that would escape config construction as an
+    uncaught crash. Since the bound is a corpus artifact rather than a user
+    error, the rule simply does not fire (False) on a type-incomparable pair.
     """
     if a is None or b is None:
+        return False
+    if isinstance(a, bool) or isinstance(b, bool):
         return False
     try:
         return op(a, b)
@@ -549,6 +577,12 @@ def _parse_rule(raw: dict[str, Any]) -> Rule:
     normalised = raw.get("normalised_fields") or ()
     if isinstance(normalised, str):
         normalised = (normalised,)
+    if normalised and severity != "dormant":
+        raise RuleCorpusError(
+            f"Rule {rule_id!r} has severity={severity!r} but declares normalised_fields; "
+            "normalised_fields drives dedup canonicalisation and is only meaningful on "
+            "'dormant' rules (it is dead data on 'error' rules)."
+        )
     return Rule(
         id=rule_id,
         engine=str(raw["engine"]),

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -759,14 +759,6 @@ class ExperimentConfig(BaseModel):
                     effective_value=match.effective_value,
                     reason=annotated,
                 )
-                continue
-            # Typo in the corpus: loader validation would normally reject this,
-            # but surface it visibly if anything slips past.
-            warnings.warn(
-                f"[{rule.id}] unknown severity {rule.severity!r}",
-                ConfigValidationWarning,
-                stacklevel=2,
-            )
 
         object.__setattr__(self, "_dormant_observations", dormant_observations)
         return self

--- a/tests/unit/config/engine_rules/test_invariant_matching.py
+++ b/tests/unit/config/engine_rules/test_invariant_matching.py
@@ -10,6 +10,7 @@ import pytest
 from llenergymeasure.config.engine_rules import (
     Provenance,
     Rule,
+    RuleMatch,
     evaluate_predicate,
     resolve_field_path,
 )
@@ -341,17 +342,6 @@ def test_render_message_substitutes_declared_value() -> None:
     assert "rule_x" in msg
 
 
-def test_render_message_missing_template_returns_fallback() -> None:
-    rule = _make_rule(
-        match_fields={"transformers.sampling.temperature": {"present": True}},
-        message=None,
-    )
-    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
-    match = rule.try_match(config)
-    assert match is not None
-    assert "rule_x" in rule.render_message(match)
-
-
 def test_render_message_with_missing_format_key_falls_back_gracefully() -> None:
     # Template refers to a field not populated in the match.
     rule = _make_rule(
@@ -361,6 +351,90 @@ def test_render_message_with_missing_format_key_falls_back_gracefully() -> None:
     config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
     match = rule.try_match(config)
     assert match is not None
-    # Should not raise; should fall back to rule-id + raw template.
+    # Should not raise; falls back to the raw template unchanged.
+    assert rule.render_message(match) == "Field {not_in_match_or_declared}"
+
+
+def test_render_message_substitutes_leaf_name_of_dotted_path() -> None:
+    # matched_fields keys are full dotted paths, but templates conventionally
+    # reference the bare leaf name. The leaf must resolve.
+    rule = Rule(
+        id="rule_x",
+        engine="transformers",
+        severity="error",
+        match_fields={"transformers.sampling.temperature": {"present": True}},
+        provenance=_PROVENANCE,
+        message_template="temperature={temperature} is invalid",
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
+    match = rule.try_match(config)
+    assert match is not None
+    assert rule.render_message(match) == "temperature=0.7 is invalid"
+
+
+def test_render_message_multiple_leaf_placeholders() -> None:
+    # Every matched dotted path contributes its leaf name; a template can
+    # reference several at once. (The full dotted path itself is not a usable
+    # placeholder: ``str.format`` reads the dots as attribute access, so only
+    # the injected leaf name resolves - matching the corpus authoring style.)
+    rule = _make_rule(
+        match_fields={
+            "transformers.sampling.top_k": {"present": True},
+            "transformers.sampling.top_p": {"present": True},
+        },
+        message="top_k={top_k} top_p={top_p}",
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(top_k=40, top_p=0.9)))
+    match = rule.try_match(config)
+    assert match is not None
+    assert rule.render_message(match) == "top_k=40 top_p=0.9"
+
+
+def test_render_message_fallback_does_not_prefix_rule_id() -> None:
+    # The sole caller (_apply_rules) prepends [rule.id]; render_message must
+    # NOT prepend it again in the fallback, or users see a doubled id.
+    rule = _make_rule(
+        match_fields={"transformers.sampling.temperature": {"present": True}},
+        message="unresolved {mystery}",
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
+    match = rule.try_match(config)
+    assert match is not None
     out = rule.render_message(match)
-    assert "rule_x" in out
+    assert not out.startswith("[rule_x]")
+    assert "rule_x" not in out
+
+
+def test_render_message_missing_template_omits_id_prefix() -> None:
+    # With no template the placeholder message is id-free too (caller owns it).
+    rule = _make_rule(
+        match_fields={"transformers.sampling.temperature": {"present": True}},
+        message=None,
+    )
+    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
+    match = rule.try_match(config)
+    assert match is not None
+    out = rule.render_message(match)
+    assert "rule_x" not in out
+    assert out == "<no message template>"
+
+
+def test_render_message_leaf_collision_keeps_first_path() -> None:
+    # Two dotted paths share a leaf name; first-seen (insertion order) wins.
+    rule = Rule(
+        id="rule_x",
+        engine="transformers",
+        severity="error",
+        match_fields={},
+        provenance=_PROVENANCE,
+        message_template="max_batch_size={max_batch_size}",
+    )
+    match = RuleMatch(
+        rule=rule,
+        declared_value=1,
+        matched_fields={
+            "engine_params.max_batch_size": 8,
+            "cuda_graph_config.max_batch_size": 16,
+        },
+    )
+    assert rule.render_message(match) == "max_batch_size=8"

--- a/tests/unit/config/engine_rules/test_invariant_matching.py
+++ b/tests/unit/config/engine_rules/test_invariant_matching.py
@@ -343,7 +343,10 @@ def test_render_message_substitutes_declared_value() -> None:
 
 
 def test_render_message_with_missing_format_key_falls_back_gracefully() -> None:
-    # Template refers to a field not populated in the match.
+    # Template refers to a field not populated in the match. The fallback must
+    # not raise, and returns the raw template UNCHANGED - notably without a
+    # ``[rule_x]`` prefix, since the sole caller (_apply_rules) already annotates
+    # every rendered message with the rule id.
     rule = _make_rule(
         match_fields={"transformers.sampling.temperature": {"present": True}},
         message="Field {not_in_match_or_declared}",
@@ -351,20 +354,15 @@ def test_render_message_with_missing_format_key_falls_back_gracefully() -> None:
     config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
     match = rule.try_match(config)
     assert match is not None
-    # Should not raise; falls back to the raw template unchanged.
     assert rule.render_message(match) == "Field {not_in_match_or_declared}"
 
 
 def test_render_message_substitutes_leaf_name_of_dotted_path() -> None:
     # matched_fields keys are full dotted paths, but templates conventionally
     # reference the bare leaf name. The leaf must resolve.
-    rule = Rule(
-        id="rule_x",
-        engine="transformers",
-        severity="error",
+    rule = _make_rule(
         match_fields={"transformers.sampling.temperature": {"present": True}},
-        provenance=_PROVENANCE,
-        message_template="temperature={temperature} is invalid",
+        message="temperature={temperature} is invalid",
     )
     config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
     match = rule.try_match(config)
@@ -390,21 +388,6 @@ def test_render_message_multiple_leaf_placeholders() -> None:
     assert rule.render_message(match) == "top_k=40 top_p=0.9"
 
 
-def test_render_message_fallback_does_not_prefix_rule_id() -> None:
-    # The sole caller (_apply_rules) prepends [rule.id]; render_message must
-    # NOT prepend it again in the fallback, or users see a doubled id.
-    rule = _make_rule(
-        match_fields={"transformers.sampling.temperature": {"present": True}},
-        message="unresolved {mystery}",
-    )
-    config = _Config(transformers=_Transformers(sampling=_Sampling(temperature=0.7)))
-    match = rule.try_match(config)
-    assert match is not None
-    out = rule.render_message(match)
-    assert not out.startswith("[rule_x]")
-    assert "rule_x" not in out
-
-
 def test_render_message_missing_template_omits_id_prefix() -> None:
     # With no template the placeholder message is id-free too (caller owns it).
     rule = _make_rule(
@@ -421,14 +404,7 @@ def test_render_message_missing_template_omits_id_prefix() -> None:
 
 def test_render_message_leaf_collision_keeps_first_path() -> None:
     # Two dotted paths share a leaf name; first-seen (insertion order) wins.
-    rule = Rule(
-        id="rule_x",
-        engine="transformers",
-        severity="error",
-        match_fields={},
-        provenance=_PROVENANCE,
-        message_template="max_batch_size={max_batch_size}",
-    )
+    rule = _make_rule(match_fields={}, message="max_batch_size={max_batch_size}")
     match = RuleMatch(
         rule=rule,
         declared_value=1,

--- a/tests/unit/config/engine_rules/test_loader.py
+++ b/tests/unit/config/engine_rules/test_loader.py
@@ -175,8 +175,12 @@ def test_valid_severity_set_is_closed_two_value() -> None:
 
 @pytest.mark.parametrize("severity", ["error", "dormant"])
 def test_both_severities_round_trip(tmp_path: Path, severity: str) -> None:
-    corpus = _CORPUS_MINIMAL.replace("severity: dormant", f"severity: {severity}")
-    _write_corpus(tmp_path, "transformers", corpus)
+    data = yaml.safe_load(_CORPUS_MINIMAL)
+    data["rules"][0]["severity"] = severity
+    # normalised_fields is dormant-only (rejected at load on error rules).
+    if severity == "error":
+        del data["rules"][0]["normalised_fields"]
+    _write_corpus(tmp_path, "transformers", yaml.safe_dump(data))
     loader = EngineRulesLoader(corpus_root=tmp_path)
     assert loader.load_rules("transformers").rules[0].severity == severity
 
@@ -306,3 +310,27 @@ def test_normalised_fields_string_coerces_to_tuple(tmp_path: Path) -> None:
     loader = EngineRulesLoader(corpus_root=tmp_path)
     rule = loader.load_rules("transformers").rules[0]
     assert rule.normalised_fields == ("transformers.sampling.temperature",)
+
+
+def test_normalised_fields_on_error_rule_rejected_at_load(tmp_path: Path) -> None:
+    # normalised_fields drives dedup canonicalisation and is only meaningful on
+    # dormant rules; on an error rule it is dead data. Reject it at load.
+    data = yaml.safe_load(_CORPUS_MINIMAL)
+    data["rules"][0]["severity"] = "error"
+    # (the minimal corpus already carries a normalised_fields entry)
+    _write_corpus(tmp_path, "transformers", yaml.safe_dump(data))
+    loader = EngineRulesLoader(corpus_root=tmp_path)
+    with pytest.raises(RuleCorpusError, match="normalised_fields"):
+        loader.load_rules("transformers")
+
+
+def test_normalised_fields_omitted_on_error_rule_is_fine(tmp_path: Path) -> None:
+    # An error rule with no normalised_fields loads cleanly.
+    data = yaml.safe_load(_CORPUS_MINIMAL)
+    data["rules"][0]["severity"] = "error"
+    del data["rules"][0]["normalised_fields"]
+    _write_corpus(tmp_path, "transformers", yaml.safe_dump(data))
+    loader = EngineRulesLoader(corpus_root=tmp_path)
+    rule = loader.load_rules("transformers").rules[0]
+    assert rule.severity == "error"
+    assert rule.normalised_fields == ()

--- a/tests/unit/config/engine_rules/test_loader_field_ref_and_divisibility.py
+++ b/tests/unit/config/engine_rules/test_loader_field_ref_and_divisibility.py
@@ -258,6 +258,23 @@ def test_ordering_none_operands_are_no_match(op: str) -> None:
     assert evaluate_predicate(5, {op: None}) is False
 
 
+@pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
+@pytest.mark.parametrize("actual", [True, False])
+def test_ordering_rejects_bool_actual(op: str, actual: bool) -> None:
+    # bool subclasses int, so ``True > 0`` compares cleanly; the ordering ops
+    # must treat a boolean-valued field as non-comparable and never fire (the
+    # generated pydantic model stays the authority on bool-field validity).
+    # This is what keeps a mined ``{'>': 0}`` bound off ``early_stopping=True``.
+    assert evaluate_predicate(actual, {op: 0}) is False
+
+
+@pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
+def test_ordering_rejects_bool_bound(op: str) -> None:
+    # A bool on the bound side (e.g. an @field_ref resolving to a boolean) is
+    # equally non-comparable.
+    assert evaluate_predicate(5, {op: True}) is False
+
+
 def test_ordering_comparable_non_numeric_still_compares() -> None:
     # Same-type ordering (str vs str) stays live - only cross-type pairs no-match.
     assert evaluate_predicate("b", {">": "a"}) is True
@@ -272,6 +289,9 @@ def test_ordered_helper() -> None:
     assert _ordered(0, 5, operator.gt) is False
     assert _ordered(None, 0, operator.gt) is False
     assert _ordered(5, None, operator.gt) is False
+    # bool operands are non-comparable (mirrors the divisibility exclusion).
+    assert _ordered(True, 0, operator.gt) is False
+    assert _ordered(5, True, operator.gt) is False
     # Type-incomparable pair: TypeError swallowed, treated as no-match.
     assert _ordered({"backend": "inductor"}, 0, operator.gt) is False
     assert _ordered("inductor", 0, operator.lt) is False

--- a/tests/unit/config/test_generic_validator.py
+++ b/tests/unit/config/test_generic_validator.py
@@ -246,29 +246,6 @@ def test_error_rule_shortcircuits_later_rules(monkeypatch: pytest.MonkeyPatch) -
 
 
 # ---------------------------------------------------------------------------
-# Unknown severity - inert (closed enum makes it unreachable in production)
-# ---------------------------------------------------------------------------
-
-
-def test_unknown_severity_does_not_raise_or_record(monkeypatch: pytest.MonkeyPatch) -> None:
-    rule = _make_rule(
-        "weird_severity",
-        "not_a_real_severity",
-        {"transformers.engine_params.attn_implementation": "sdpa"},
-    )
-    _install_test_rules(monkeypatch, [rule])
-
-    cfg = ExperimentConfig(
-        task={"model": "gpt2"},
-        engine="transformers",
-        transformers={"engine_params": {"attn_implementation": "sdpa"}},
-    )
-    # An out-of-enum severity matches neither the error nor the dormant arm,
-    # so it is skipped: no raise, no dormant observation.
-    assert cfg._dormant_observations == {}
-
-
-# ---------------------------------------------------------------------------
 # Integration - real corpus on disk exercises every engine path without
 # raising (catches predicate-operator / field-path regressions end-to-end)
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_generic_validator.py
+++ b/tests/unit/config/test_generic_validator.py
@@ -1,8 +1,8 @@
 """Tests for the generic ``_apply_rules`` model validator.
 
-Covers the severity dispatch paths (error / dormant), the out-of-enum
-severity fallback, and the no-match / missing-corpus fallbacks. Rule
-loading is exercised by ``tests/unit/config/engine_rules/test_loader.py``;
+Covers the severity dispatch paths (error / dormant), the inert
+out-of-enum severity case, and the no-match / missing-corpus fallbacks.
+Rule loading is exercised by ``tests/unit/config/engine_rules/test_loader.py``;
 this module focuses on the validator's dispatch and the
 ``_dormant_observations`` contract.
 """
@@ -122,15 +122,18 @@ def test_error_severity_no_raise_when_match_misses(monkeypatch: pytest.MonkeyPat
 
 
 # ---------------------------------------------------------------------------
-# Severity dispatch - out-of-enum fallback
+# Severity dispatch - out-of-enum severity is inert
 # ---------------------------------------------------------------------------
 #
-# The loader's closed ``{error, dormant}`` enum makes any other severity
-# unreachable in production; direct construction bypasses that check so the
-# defensive fallback branch stays covered.
+# ``Severity`` is a closed ``{error, dormant}`` Literal validated at corpus
+# load, so no other value can reach ``_apply_rules`` through the real loader.
+# The dispatch therefore carries no fallback branch: a severity outside the
+# enum (only reachable by bypassing the loader via direct construction) matches
+# neither the error nor the dormant arm and is silently skipped - it does not
+# raise, warn, or record a dormant observation.
 
 
-def test_out_of_enum_severity_emits_config_validation_warning(
+def test_out_of_enum_severity_is_silently_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     rule = _make_rule(
@@ -142,37 +145,16 @@ def test_out_of_enum_severity_emits_config_validation_warning(
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", ConfigValidationWarning)
-        ExperimentConfig(
+        cfg = ExperimentConfig(
             task={"model": "gpt2"},
             engine="transformers",
             transformers={"engine_params": {"attn_implementation": "eager"}},
         )
 
+    # Neither error (would raise) nor dormant (would record an observation).
+    assert cfg._dormant_observations == {}
     matched = [w for w in caught if issubclass(w.category, ConfigValidationWarning)]
-    assert matched, "expected a ConfigValidationWarning"
-    assert "test_bogus_rule" in str(matched[0].message)
-    assert "unknown severity" in str(matched[0].message)
-
-
-def test_out_of_enum_severity_not_fatal_under_simplefilter_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``simplefilter('error', ConfigValidationWarning)`` escalates the fallback to raise."""
-    rule = _make_rule(
-        "test_bogus_rule",
-        "bogus",
-        {"transformers.engine_params.attn_implementation": "eager"},
-    )
-    _install_test_rules(monkeypatch, [rule])
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", ConfigValidationWarning)
-        with pytest.raises((ValidationError, ConfigValidationWarning)):
-            ExperimentConfig(
-                task={"model": "gpt2"},
-                engine="transformers",
-                transformers={"engine_params": {"attn_implementation": "eager"}},
-            )
+    assert not matched, "an out-of-enum severity must not warn"
 
 
 # ---------------------------------------------------------------------------
@@ -264,11 +246,11 @@ def test_error_rule_shortcircuits_later_rules(monkeypatch: pytest.MonkeyPatch) -
 
 
 # ---------------------------------------------------------------------------
-# Unknown severity - fail-safe
+# Unknown severity - inert (closed enum makes it unreachable in production)
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_severity_emits_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_unknown_severity_does_not_raise_or_record(monkeypatch: pytest.MonkeyPatch) -> None:
     rule = _make_rule(
         "weird_severity",
         "not_a_real_severity",
@@ -276,17 +258,14 @@ def test_unknown_severity_emits_warning(monkeypatch: pytest.MonkeyPatch) -> None
     )
     _install_test_rules(monkeypatch, [rule])
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", ConfigValidationWarning)
-        ExperimentConfig(
-            task={"model": "gpt2"},
-            engine="transformers",
-            transformers={"engine_params": {"attn_implementation": "sdpa"}},
-        )
-
-    matched = [w for w in caught if issubclass(w.category, ConfigValidationWarning)]
-    assert matched
-    assert "weird_severity" in str(matched[0].message)
+    cfg = ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="transformers",
+        transformers={"engine_params": {"attn_implementation": "sdpa"}},
+    )
+    # An out-of-enum severity matches neither the error nor the dormant arm,
+    # so it is skipped: no raise, no dormant observation.
+    assert cfg._dormant_observations == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_scaffold.py
+++ b/tests/unit/config/test_scaffold.py
@@ -229,9 +229,12 @@ def test_bounds_emits_both_bool_values_for_early_stopping() -> None:
     """early_stopping is a valid boolean knob, so it sweeps both values.
 
     early_stopping=True is the documented way to enable beam-search early
-    stopping; it must not be pruned from the sweep. (A dormant corpus rule
-    strips early_stopping at resolution time, so the two values collapse at
-    dedup - see the round-trip tests - but the sweep axis itself is emitted.)
+    stopping; it must not be pruned from the sweep. The corpus carries a
+    mis-mined ``{'>': 0}`` bound on the field, but ordering predicates do not
+    fire on booleans (see ``_ordered``), so the value pruner does not drop
+    ``True``. (A dormant corpus rule strips early_stopping at resolution time,
+    so the two values collapse at dedup - see the round-trip tests - but the
+    sweep axis itself is emitted.)
     """
     text = render_study_bounds(MODEL, ["transformers"])
     raw = yaml.safe_load(text)
@@ -252,12 +255,13 @@ def test_bounds_render_is_byte_deterministic() -> None:
 def test_bounds_round_trips_to_series_product(engine: str, tmp_path: Path) -> None:
     """A bounds file expands to the product of its series lengths.
 
-    The full Cartesian product is enumerated pre-dedup (one equivalence group
-    per combination member); measurement-equivalent combinations then collapse
-    via the resolved-config-hash dedup, so the number of executed experiments
-    equals the group count (<= product). For transformers the collapse is
-    strict: a dormant corpus rule strips early_stopping at resolution, so its
-    two swept values resolve to the same config.
+    The declared count equals the full Cartesian product of the series lengths
+    (one declared config per combination member). Resolved-config-hash dedup
+    then folds combinations that resolve to the same effective config, so the
+    executed experiments equal the distinct resolved set, which equals the
+    equivalence-group count (<= product). For transformers the collapse is
+    strict: a dormant corpus rule strips early_stopping at resolution time, so
+    its two swept values resolve to the same config.
     """
     text = render_study_bounds(MODEL, [engine])
     path = tmp_path / "study.yaml"
@@ -266,10 +270,13 @@ def test_bounds_round_trips_to_series_product(engine: str, tmp_path: Path) -> No
     product = math.prod(len(v) for v in sweep.values())
     study = _load_without_config_warnings(path)
     assert product > 1
+    # Declared count is the full cartesian product.
+    assert len(study.declared_resolved_config_hashes) == product
     # Every sweep combination is accounted for in exactly one equivalence group.
     assert sum(g["member_count"] for g in study.pre_run_equivalence_groups) == product
     # Executed experiments are the post-dedup distinct resolved configs.
     assert len(study.experiments) == len(study.pre_run_equivalence_groups)
+    assert len(study.experiments) == len(set(study.declared_resolved_config_hashes))
     assert 1 < len(study.experiments) <= product
     assert all(e.engine == engine for e in study.experiments)
 
@@ -277,8 +284,9 @@ def test_bounds_round_trips_to_series_product(engine: str, tmp_path: Path) -> No
 def test_bounds_all_engines_round_trips_to_sum_of_products(tmp_path: Path) -> None:
     """A multi-engine bounds file expands to the sum of per-engine products.
 
-    As in the single-engine case, the sum-of-products is the pre-dedup member
-    total; executed experiments are the post-dedup group count.
+    As in the single-engine case, the declared count equals the summed product
+    (the pre-dedup member total); executed experiments equal the distinct
+    resolved set after dedup, which is the post-dedup group count.
     """
     text = render_study_bounds(MODEL, all_engine_names())
     path = tmp_path / "study.yaml"
@@ -289,8 +297,10 @@ def test_bounds_all_engines_round_trips_to_sum_of_products(tmp_path: Path) -> No
     assert set(per_engine) == set(all_engine_names())
     expected_members = sum(math.prod(lengths) for lengths in per_engine.values())
     study = _load_without_config_warnings(path)
+    assert len(study.declared_resolved_config_hashes) == expected_members
     assert sum(g["member_count"] for g in study.pre_run_equivalence_groups) == expected_members
     assert len(study.experiments) == len(study.pre_run_equivalence_groups)
+    assert len(study.experiments) == len(set(study.declared_resolved_config_hashes))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_series.py
+++ b/tests/unit/config/test_series.py
@@ -178,8 +178,11 @@ def test_series_collapsing_below_two_values_is_pinned() -> None:
 def test_real_corpus_keeps_early_stopping_true() -> None:
     """early_stopping=true is valid (enables beam-search early stopping).
 
-    The old mis-mined `{'>': 0}` bound rejected True (True > 0 in Python); after
-    its removal the shipped corpus keeps both boolean values.
+    Two independent facts now keep both boolean values. First, the mis-mined
+    ``{'>': 0}`` bound that rejected ``True`` (``True > 0`` is true in Python)
+    was deleted from the shipped transformers corpus. Second, even a re-mined
+    ordering bound could not reject booleans: ordering predicates do not fire on
+    bool operands (see ``_ordered``), so the value pruner never drops ``True``.
     """
     rules = EngineRulesLoader().load_rules("transformers").rules
     kept = drop_known_rejected([False, True], "transformers.engine_params.early_stopping", rules)


### PR DESCRIPTION
PR-C from the engine-update workflow fitness review (findings 5, 10, 12, 13, 14 in `leg3-consumers-docs.md`). Fixes user-facing message garbling and two dead/incorrect loader behaviors. Corpus content fixes are PR-B; CI/gate work is PR-E.

## What and why

**1. `render_message` doubled id + literal braces (finding 5, probe-confirmed)**
`RuleMatch.matched_fields` is keyed by full dotted paths (`vllm.sampling_params.min_tokens`), so a template's bare leaf placeholder (`{min_tokens}`) raised `KeyError` and fell into the raw-template fallback, which itself prepended `[rule_id]` on top of the `[rule.id]` the sole caller (`ExperimentConfig._apply_rules`) already adds. Result: users saw a doubled id and literal `{...}` braces (probe: `[vllm_..._min_tokens_gt_ref_max_tokens] [vllm_..._min_tokens_gt_ref_max_tokens] ... got {min_tokens}`). Affected 12 rules.

Fix: additionally inject each dotted key's leaf name (`path.rsplit('.',1)[-1]`) as a format kwarg (first path wins on a leaf-name collision; full-path keys seed the map first so a dot-free path is never double-supplied); and drop the id prefix from both the fallback and the no-template message. The caller owns prefixing. The `{invariant_id}` / `{declared_value}` / `{effective_value}` placeholders are unchanged (vocabulary rename is a later coordinated change).

**2. `_ordered` accepted bool operands (finding 12)**
`bool` subclasses `int`, so `True > 0` compares cleanly and ordering predicates (`<,<=,>,>=`) silently accepted boolean-valued fields. This is the enabler for the finding-1 bug (`{'>': 0}` on `early_stopping` rejecting `early_stopping=True`). Fix: treat a `bool` operand on either side as non-comparable (no-match), mirroring the existing `_is_int_pair` bool exclusion for the divisibility ops. With this change the corpus's mis-mined `early_stopping` `{'>': 0}` rule simply stops matching bools; it still loads and still fires on genuine numeric misuse. (PR-B owns deleting that rule.)

**3. `normalised_fields` on non-dormant rules (finding 13)**
`normalised_fields` drives dedup canonicalisation and is only meaningful on `dormant` rules; on `error` rules it is silently dead data. Now rejected at corpus load with a clear `RuleCorpusError`. Scanned all three corpora (`engines/*/rules.yaml`): **zero existing violations**, so this is purely a forward guard.

**4. Dead unknown-severity warn branch (finding 14)**
`Severity` is a closed `Literal["error","dormant"]` validated at load, so the warn branch in `_apply_rules` was unreachable. Deleted; an out-of-enum severity (only reachable by bypassing the loader in a test) is now inert (no raise, no observation).

**5. `early_stopping` codegen fidelity (finding 10) - STOPPED, not implemented.**
The generated transformers `config.py` types `early_stopping: bool | None`, narrower than upstream's `bool | "never"`. Per the item's hard requirement the generator cannot invent the `"never"` variant. Investigation:
- `engine_versions/transformers/v5_7_0/outputs/schema.discovered.json` records `early_stopping` as `{"type": "bool"}` - the static discovery method (`inspect.signature(from_pretrained) + GenerationConfig().to_dict() with docstring-Args type recovery`) captures the runtime bool default and docstring type, not the `"never"` string literal accepted only at runtime.
- The curation layer (`curated.yaml`) is exclusively an exposure allowlist (`exposed_fields` -> list of field-name strings, verified across all three engines); it carries **no type-override / widening mechanism** by design.

Neither source carries `"never"` and there is no designed widening mechanism, so per the item's instruction this stops rather than hand-editing generated files or inventing a curation feature. The correct fix belongs upstream in the discovery/mining layer (recording the union type), which is out of this PR's scope. The item-5 model tests were skipped accordingly.

## Tests
- `render_message`: bare leaf placeholder renders for a dotted-path match; multiple leaf placeholders; fallback and no-template message no longer prefix the id; leaf-collision keeps first path.
- `_ordered`: bool actual and bool bound do not satisfy any ordering op; helper unit covers the bool case; numeric/None/type-incomparable behavior unchanged.
- Load-guard: an error-severity rule with `normalised_fields` is rejected at load; omitting it loads fine.
- `_apply_rules`: an out-of-enum severity is silently skipped (no warn, no observation).
- Downstream tests reconciled to corrected behavior: `early_stopping` bools survive series pruning and dedup as dormancy-equivalents at the default `num_beams=1`; bounds round-trip asserts `declared == product` and `experiments == distinct resolved set`.

## Gates
`make lint`, `make typecheck`, full `pytest` (2890 passed / 44 skipped), `regen_engine_configs.py --check` byte-identical for all three engines, `make docs-check` clean.
