### PR TITLE
fix(ci): make bump gates reachable and requireable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
               - 'docker/**'
               - '.dockerignore'
               - 'pyproject.toml'
+              # Version-bump PRs move the pin under engine_versions/ (not
+              # docker/), and schema-version-check exists to gate exactly
+              # those. Without this the job never runs on a bump PR.
+              - 'engine_versions/**'
             workflows:
               - '.github/workflows/**'
             docs_inputs:
@@ -63,8 +67,11 @@ jobs:
               # and this workflow file (self-test). pyproject/uv.lock
               # excluded: env-break would surface in lint / type-check /
               # test / package-validation before docs-freshness anyway.
+              # docs/reference/** holds the generated pages docs-freshness
+              # regenerates and diffs; an edit there must trip the check.
               - 'src/**'
               - 'scripts/**'
+              - 'docs/reference/**'
               - '.github/workflows/ci.yml'
 
   lint:
@@ -248,7 +255,6 @@ jobs:
     if: >-
       always()
       && needs.filter.outputs.docker == 'true'
-      && !contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -256,5 +262,5 @@ jobs:
         engine: [transformers, vllm, tensorrt]
     steps:
       - uses: actions/checkout@v6
-      - name: Check ${{ matrix.engine }} schema version aligns with Dockerfile
+      - name: Check ${{ matrix.engine }} schema version matches current.yaml pin
         run: python3 scripts/check_discovered_schema_versions.py --engine ${{ matrix.engine }}

--- a/.github/workflows/engine-rules-check.yml
+++ b/.github/workflows/engine-rules-check.yml
@@ -59,7 +59,10 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: changes
         with:
-          base: ${{ github.event_name == 'push' && github.ref || '' }}
+          # No base: - this workflow has no push trigger, so on its only
+          # events (pull_request, workflow_dispatch) the action diffs against
+          # the PR base branch by default. A base: expression here would be
+          # dead (ci.yml needs it only because ci.yml also runs on push).
           filters: |
             engine:
               - 'src/llenergymeasure/engines/*/config.py'

--- a/.github/workflows/engine-rules-check.yml
+++ b/.github/workflows/engine-rules-check.yml
@@ -26,19 +26,13 @@ name: Engine rules check
 # covered by the gating codegen check.
 
 on:
+  # No workflow-level paths: filter. The jobs must report a check-run context
+  # on EVERY pull request so branch protection can require them - a workflow
+  # that paths-skips never reports, and a required check that never reports
+  # blocks the PR forever with "Expected - waiting for status". The per-job
+  # filter below skips (not omits) the work on non-engine PRs, and a skipped
+  # required check counts as satisfied. Mirrors the ci.yml filter-job pattern.
   pull_request:
-    paths:
-      - 'src/llenergymeasure/engines/*/config.py'
-      - 'src/llenergymeasure/engines/*/rules.yaml'
-      - 'src/llenergymeasure/config/engine_rules/**'
-      - 'engine_versions/*/current.yaml'
-      - 'engine_versions/*/*/outputs/curated.yaml'
-      - 'engine_versions/*/*/outputs/schema.discovered.json'
-      - 'scripts/engine_producers/**'
-      - 'scripts/rules_coverage.py'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/engine-rules-check.yml'
   workflow_dispatch:
 
 permissions:
@@ -50,7 +44,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  filter:
+    # Always runs (including on workflow_dispatch). Cost is trivial; downstream
+    # jobs depend on its output. `engine` is the union of the paths this
+    # workflow previously used as its workflow-level paths: filter.
+    runs-on: ubuntu-latest
+    outputs:
+      engine: ${{ steps.changes.outputs.engine }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          base: ${{ github.event_name == 'push' && github.ref || '' }}
+          filters: |
+            engine:
+              - 'src/llenergymeasure/engines/*/config.py'
+              - 'src/llenergymeasure/engines/*/rules.yaml'
+              - 'src/llenergymeasure/config/engine_rules/**'
+              - 'engine_versions/*/current.yaml'
+              - 'engine_versions/*/*/outputs/curated.yaml'
+              - 'engine_versions/*/*/outputs/schema.discovered.json'
+              - 'scripts/engine_producers/**'
+              - 'scripts/rules_coverage.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/engine-rules-check.yml'
+
   config-codegen:
+    needs: filter
+    if: >-
+      always()
+      && (
+        github.event_name == 'workflow_dispatch'
+        || needs.filter.outputs.engine == 'true'
+      )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -85,6 +113,13 @@ jobs:
 
   rules-coverage:
     name: rules-coverage (${{ matrix.engine }})
+    needs: filter
+    if: >-
+      always()
+      && (
+        github.event_name == 'workflow_dispatch'
+        || needs.filter.outputs.engine == 'true'
+      )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -132,9 +167,26 @@ jobs:
           # The full source archive for these projects is large (hundreds of MB
           # for the compiled-kernel engine) and is not affordable to pull on
           # every relevant PR; the coverage scan only reads the .py package.
-          rm -rf engine-source
-          git clone --filter=blob:none --no-checkout --depth 1 \
-            --branch "v${VERSION}" "$SOURCE_REPO" engine-source
+          #
+          # Retry the clone: a network flake against the upstream remote would
+          # otherwise read as a red gate on an unrelated PR. Retry only, never
+          # continue-on-error - a genuine clone failure (bad tag, dead repo)
+          # must still hard-fail after the attempts are exhausted.
+          set -euo pipefail
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            rm -rf engine-source
+            if git clone --filter=blob:none --no-checkout --depth 1 \
+              --branch "v${VERSION}" "$SOURCE_REPO" engine-source; then
+              break
+            fi
+            if [ "$attempt" -eq "$attempts" ]; then
+              echo "::error::Failed to clone ${SOURCE_REPO} at v${VERSION} after ${attempts} attempts." >&2
+              exit 1
+            fi
+            echo "Clone attempt ${attempt}/${attempts} failed; retrying in 5s..." >&2
+            sleep 5
+          done
           git -C engine-source sparse-checkout init --cone
           git -C engine-source sparse-checkout set "$PACKAGE_DIR"
           git -C engine-source checkout
@@ -161,6 +213,13 @@ jobs:
 
   seed-image-check:
     name: seed-image-check (transformers)
+    needs: filter
+    if: >-
+      always()
+      && (
+        github.event_name == 'workflow_dispatch'
+        || needs.filter.outputs.engine == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/engine-rules-check.yml
+++ b/.github/workflows/engine-rules-check.yml
@@ -44,7 +44,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  filter:
+  # Named engine-filter (not filter) so its check context is distinguishable
+  # from ci.yml's filter job on the PR checks tab, and so branch protection
+  # can require it unambiguously (fail-closed for the codegen gates).
+  engine-filter:
     # Always runs (including on workflow_dispatch). Cost is trivial; downstream
     # jobs depend on its output. `engine` is the union of the paths this
     # workflow previously used as its workflow-level paths: filter.
@@ -72,12 +75,12 @@ jobs:
               - '.github/workflows/engine-rules-check.yml'
 
   config-codegen:
-    needs: filter
+    needs: engine-filter
     if: >-
       always()
       && (
         github.event_name == 'workflow_dispatch'
-        || needs.filter.outputs.engine == 'true'
+        || needs.engine-filter.outputs.engine == 'true'
       )
     runs-on: ubuntu-latest
     strategy:
@@ -113,12 +116,12 @@ jobs:
 
   rules-coverage:
     name: rules-coverage (${{ matrix.engine }})
-    needs: filter
+    needs: engine-filter
     if: >-
       always()
       && (
         github.event_name == 'workflow_dispatch'
-        || needs.filter.outputs.engine == 'true'
+        || needs.engine-filter.outputs.engine == 'true'
       )
     runs-on: ubuntu-latest
     strategy:
@@ -213,12 +216,12 @@ jobs:
 
   seed-image-check:
     name: seed-image-check (transformers)
-    needs: filter
+    needs: engine-filter
     if: >-
       always()
       && (
         github.event_name == 'workflow_dispatch'
-        || needs.filter.outputs.engine == 'true'
+        || needs.engine-filter.outputs.engine == 'true'
       )
     runs-on: ubuntu-latest
     steps:

--- a/scripts/engine_producers/regen_engine_configs.py
+++ b/scripts/engine_producers/regen_engine_configs.py
@@ -477,30 +477,24 @@ def main(argv: list[str] | None = None) -> int:
     try:
         drift = sync(args.engine, args.version, output, write=args.write)
     except FileNotFoundError:
-        # First thing a version-bump PR hits: current.yaml points at a new pin
-        # whose per-version snapshot has not been mined yet, so the outputs/
-        # directory the codegen reads from does not exist. Name the missing
-        # directory and the ritual that fills it, then exit non-zero cleanly
-        # (a bare traceback here reads as an internal error rather than a
-        # missing-snapshot signal).
+        # A missing snapshot dir is expected right after a bump; turn the bare
+        # traceback (reads as an internal error) into a remediation message.
         outputs = _outputs.outputs_dir(args.engine, args.version)
         if outputs.exists():
-            # The snapshot dir is present, so this FileNotFoundError came from
-            # somewhere else inside sync (e.g. a missing tool or file mid
-            # generation). Attributing it to a missing snapshot would point
-            # the maintainer at a directory that exists; let it propagate.
+            # Snapshot dir is present, so this came from elsewhere in sync (a
+            # file missing mid-generation). Don't misattribute it to a missing
+            # snapshot - that would point the maintainer at a dir that exists.
             raise
         print(
             f"No mined snapshot for {args.engine} {args.version}.\n"
             f"Missing directory: {outputs}\n"
             f"(expected {_outputs.SCHEMA_FILENAME} + {_outputs.CURATED_FILENAME} inside it).\n"
             "\n"
-            "This is normal right after a version bump: current.yaml points at\n"
-            "the new pin but its schema has not been discovered yet. Produce the\n"
-            "snapshot locally (needs Docker, and a GPU for vllm/tensorrt):\n"
+            "Normal right after a version bump: the new pin's schema is not\n"
+            "discovered yet. Produce it locally (needs Docker, and a GPU for\n"
+            "vllm/tensorrt), then place schema.discovered.json and curated.yaml\n"
+            "under that directory and re-run this check:\n"
             f"  make discover-schema ENGINE={args.engine}\n"
-            "then place the resulting schema.discovered.json and a curated.yaml\n"
-            f"under {outputs} and re-run this check.\n"
             "See docs/contributing/schema-refresh.md for the full ritual.",
             file=sys.stderr,
         )

--- a/scripts/engine_producers/regen_engine_configs.py
+++ b/scripts/engine_producers/regen_engine_configs.py
@@ -474,7 +474,31 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     output = args.output if args.output is not None else _shadow_config_path(args.engine)
-    drift = sync(args.engine, args.version, output, write=args.write)
+    try:
+        drift = sync(args.engine, args.version, output, write=args.write)
+    except FileNotFoundError:
+        # First thing a version-bump PR hits: current.yaml points at a new pin
+        # whose per-version snapshot has not been mined yet, so the outputs/
+        # directory the codegen reads from does not exist. Name the missing
+        # directory and the ritual that fills it, then exit non-zero cleanly
+        # (a bare traceback here reads as an internal error rather than a
+        # missing-snapshot signal).
+        outputs = _outputs.outputs_dir(args.engine, args.version)
+        print(
+            f"No mined snapshot for {args.engine} {args.version}.\n"
+            f"Missing directory: {outputs}\n"
+            f"(expected {_outputs.SCHEMA_FILENAME} + {_outputs.CURATED_FILENAME} inside it).\n"
+            "\n"
+            "This is normal right after a version bump: current.yaml points at\n"
+            "the new pin but its schema has not been discovered yet. Produce the\n"
+            "snapshot locally (needs Docker, and a GPU for vllm/tensorrt):\n"
+            f"  make discover-schema ENGINE={args.engine}\n"
+            "then place the resulting schema.discovered.json and a curated.yaml\n"
+            f"under {outputs} and re-run this check.\n"
+            "See docs/contributing/schema-refresh.md for the full ritual.",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.write:
         print(f"[regen-configs] wrote: {output}")

--- a/scripts/engine_producers/regen_engine_configs.py
+++ b/scripts/engine_producers/regen_engine_configs.py
@@ -484,6 +484,12 @@ def main(argv: list[str] | None = None) -> int:
         # (a bare traceback here reads as an internal error rather than a
         # missing-snapshot signal).
         outputs = _outputs.outputs_dir(args.engine, args.version)
+        if outputs.exists():
+            # The snapshot dir is present, so this FileNotFoundError came from
+            # somewhere else inside sync (e.g. a missing tool or file mid
+            # generation). Attributing it to a missing snapshot would point
+            # the maintainer at a directory that exists; let it propagate.
+            raise
         print(
             f"No mined snapshot for {args.engine} {args.version}.\n"
             f"Missing directory: {outputs}\n"

--- a/tests/unit/scripts/engine_producers/test_regen_engine_configs.py
+++ b/tests/unit/scripts/engine_producers/test_regen_engine_configs.py
@@ -311,20 +311,36 @@ def test_generated_shape(fake_snapshot: tuple[Path, Path]) -> None:
         assert cls in text
 
 
-def test_missing_snapshot_dir_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_missing_snapshot_dir_sync_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(rec._outputs, "outputs_dir", lambda engine, version: tmp_path / "absent")
     with pytest.raises(FileNotFoundError, match="snapshot outputs dir not found"):
-        rec.main(
-            [
-                "--engine",
-                "vllm",
-                "--version",
-                "9.9.9",
-                "--check",
-                "--output",
-                str(tmp_path / "c.py"),
-            ]
-        )
+        rec.sync("vllm", "9.9.9", tmp_path / "c.py", write=False)
+
+
+def test_missing_snapshot_dir_main_exits_with_friendly_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A version bump lands current.yaml pointing at a pin whose snapshot has
+    # not been mined yet; main() must exit non-zero with a remediation message
+    # (naming the missing directory and the ritual), not a bare traceback.
+    absent = tmp_path / "absent"
+    monkeypatch.setattr(rec._outputs, "outputs_dir", lambda engine, version: absent)
+    rc = rec.main(
+        [
+            "--engine",
+            "vllm",
+            "--version",
+            "9.9.9",
+            "--check",
+            "--output",
+            str(tmp_path / "c.py"),
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "No mined snapshot for vllm 9.9.9" in err
+    assert str(absent) in err
+    assert "make discover-schema ENGINE=vllm" in err
 
 
 def test_default_output_is_the_src_shadow() -> None:

--- a/tests/unit/scripts/engine_producers/test_regen_engine_configs.py
+++ b/tests/unit/scripts/engine_producers/test_regen_engine_configs.py
@@ -343,6 +343,35 @@ def test_missing_snapshot_dir_main_exits_with_friendly_message(
     assert "make discover-schema ENGINE=vllm" in err
 
 
+def test_unrelated_file_not_found_with_present_snapshot_reraises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The snapshot outputs/ dir exists, but something downstream inside sync
+    # raises FileNotFoundError for an unrelated file. main() must NOT print
+    # the missing-snapshot remediation (it would point at a directory that is
+    # present); the error propagates untouched.
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+    monkeypatch.setattr(rec._outputs, "outputs_dir", lambda engine, version: outputs)
+
+    def _boom(engine: str, version: str, outputs_dir: Path) -> bytes:
+        raise FileNotFoundError("some unrelated file vanished mid-generation")
+
+    monkeypatch.setattr(rec, "generate_config", _boom)
+    with pytest.raises(FileNotFoundError, match="unrelated file vanished"):
+        rec.main(
+            [
+                "--engine",
+                "vllm",
+                "--version",
+                "9.9.9",
+                "--check",
+                "--output",
+                str(tmp_path / "c.py"),
+            ]
+        )
+
+
 def test_default_output_is_the_src_shadow() -> None:
     assert rec._shadow_config_path("vllm") == (
         REPO_ROOT / "src" / "llenergymeasure" / "engines" / "vllm" / "config.py"


### PR DESCRIPTION
## What was broken

The merge gate for engine-version bumps was unenforceable, and several
version-bump checks never ran on the PRs they exist for.

**Gates unreachable / unrequireable**
- `engine-rules-check.yml` used a workflow-level `paths:` filter, so on a
  non-engine PR its jobs never reported a check-run context. A required check
  whose workflow does not trigger blocks the PR forever with
  `Expected - waiting for status`, so the `config-codegen (<engine>)` contexts
  could not be added to branch protection. A job SKIPPED by a job-level
  condition, by contrast, satisfies a required check.
- `ci.yml` `schema-version-check` was doubly unreachable on the bump PRs it
  exists for: the docker paths filter excluded `engine_versions/**` (where a
  bump moves the pin), and the job skipped renovate-labelled PRs (exactly the
  bot bump PRs it is meant to gate).

## Changes

1. **`engine-rules-check.yml` filter-job restructure.** Removed the
   workflow-level `paths:` filter; added a first `engine-filter` job (same
   `dorny/paths-filter` mechanism as `ci.yml`) that runs on every PR and emits
   `engine: true/false` over the exact path list the workflow previously filtered
   on. Every downstream job (`config-codegen`, `rules-coverage`,
   `seed-image-check`) now gates on it via `needs:` + `if:`. On non-engine PRs
   all jobs SKIP (satisfies branch protection); on engine-file PRs they run
   exactly as before. Job ids and the matrix contexts are preserved.
2. **`ci.yml` `schema-version-check` reachability.** Added `engine_versions/**`
   to the `docker` filter, dropped the renovate-label skip, and renamed the
   stale step (it checks `current.yaml`, not a Dockerfile).
3. **`rules-coverage` clone hardening.** The engine-source clone is retried
   (3 attempts, short sleep) so an upstream network flake does not read as a red
   gate. No `continue-on-error` - a genuine failure still hard-fails after the
   attempts are exhausted.
4. **`ci.yml` `docs_inputs` filter.** Added `docs/reference/**` so edits to the
   generated reference pages trip the docs-freshness check.
5. **`regen_engine_configs.py` friendly remediation.** When `--check` hits a
   missing per-version snapshot `outputs/` dir (the first thing a bump PR hits),
   it now exits non-zero with a message naming the missing directory and the
   `make discover-schema ENGINE=<engine>` ritual, instead of a bare traceback.

## Final check-context names (as they appear on the PR checks tab)

From `engine-rules-check.yml`:
- `engine-filter`
- `config-codegen (transformers)`
- `config-codegen (vllm)`
- `config-codegen (tensorrt)`
- `rules-coverage (vllm)`
- `rules-coverage (tensorrt)`
- `seed-image-check (transformers)`

## Follow-up

U2 (from the fitness-review plan) will add the three
`config-codegen (<engine>)` contexts to required status checks now that they
report on every PR.

## Reference

Slice PR-E2 of the reviewed plan at
`.product/designs/workflow-fitness-review-2026-07-08/synthesis.md` (see the
`PR-E2` and `U2` sections).
