### PR TITLE
fix(study): dedup fallback sentinel, grid edge cases, dormant visibility

### DIFF
--- a/src/llenergymeasure/cli/_preflight_display.py
+++ b/src/llenergymeasure/cli/_preflight_display.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from rich.panel import Panel
 from rich.text import Text
 
+from llenergymeasure.cli._study_plan import dormant_observation_lines
 from llenergymeasure.config.introspection import (
     get_display_label,
     get_field_role,
@@ -235,12 +236,10 @@ def build_preflight_panel(
             body.append(f"    {_pl(n_configs, 'unique config')} total\n")
 
     # -- Dormant normalisations (only when a dormant rule fired) --
-    from llenergymeasure.cli._study_plan import dormant_observation_lines
-
-    dormant_lines = dormant_observation_lines(study_config)
+    dormant_lines = dormant_observation_lines(study_config, include_header=False)
     if dormant_lines:
         _section(body, "Dormant normalisations")
-        for line in dormant_lines[1:]:  # drop the shared header; _section titled it
+        for line in dormant_lines:
             body.append(f"  {line}\n", style="dim")
 
     body.append("\n")

--- a/src/llenergymeasure/cli/_preflight_display.py
+++ b/src/llenergymeasure/cli/_preflight_display.py
@@ -234,6 +234,15 @@ def build_preflight_panel(
         if has_both:
             body.append(f"    {_pl(n_configs, 'unique config')} total\n")
 
+    # -- Dormant normalisations (only when a dormant rule fired) --
+    from llenergymeasure.cli._study_plan import dormant_observation_lines
+
+    dormant_lines = dormant_observation_lines(study_config)
+    if dormant_lines:
+        _section(body, "Dormant normalisations")
+        for line in dormant_lines[1:]:  # drop the shared header; _section titled it
+            body.append(f"  {line}\n", style="dim")
+
     body.append("\n")
     # Hash (dimmed)
     body.append("Study design hash:\n ", style="dim")

--- a/src/llenergymeasure/cli/_study_plan.py
+++ b/src/llenergymeasure/cli/_study_plan.py
@@ -31,7 +31,13 @@ from llenergymeasure.utils.formatting import format_elapsed
 if TYPE_CHECKING:
     from llenergymeasure.config.models import StudyConfig
 
-__all__ = ["PlanFunnel", "RuleAttribution", "build_funnel", "render_funnel"]
+__all__ = [
+    "PlanFunnel",
+    "RuleAttribution",
+    "build_funnel",
+    "dormant_observation_lines",
+    "render_funnel",
+]
 
 # Cap on how many distinct engine-rule attributions get their own line before the
 # tail is folded into a single "+ N more" summary line.
@@ -214,6 +220,34 @@ def _wall_clock_line(funnel: PlanFunnel) -> str:
     if deferred:
         line += " (" + "; ".join(deferred) + ")"
     return line + "."
+
+
+def dormant_observation_lines(study: StudyConfig) -> list[str]:
+    """Plain-text lines describing the dormant normalisations that will apply.
+
+    Dormant rules silently rewrite the executed config (e.g. a greedy config
+    strips ``temperature``), so this surfaces them: one grouped block per
+    engine listing the rule id and the field-level effect. Returns ``[]`` when
+    no dormant rule fired, so callers render the section only when non-empty.
+    Shared by ``llem study plan`` and the preflight summary.
+    """
+    observations = study.dormant_observations
+    if not observations:
+        return []
+
+    by_engine: dict[str, list[dict[str, Any]]] = {}
+    for obs in observations:
+        by_engine.setdefault(str(obs.get("engine", "?")), []).append(obs)
+
+    lines = ["Dormant normalisations (applied to the executed config):"]
+    for engine in sorted(by_engine):
+        lines.append(f"  {engine}:")
+        for obs in by_engine[engine]:
+            rule_id = obs.get("rule_id", "?")
+            field_path = obs.get("field_path", "?")
+            effect = obs.get("normalisation", "")
+            lines.append(f"    {field_path} {effect}  (rule {rule_id})")
+    return lines
 
 
 def render_funnel(funnel: PlanFunnel, title: str) -> str:

--- a/src/llenergymeasure/cli/_study_plan.py
+++ b/src/llenergymeasure/cli/_study_plan.py
@@ -222,7 +222,7 @@ def _wall_clock_line(funnel: PlanFunnel) -> str:
     return line + "."
 
 
-def dormant_observation_lines(study: StudyConfig) -> list[str]:
+def dormant_observation_lines(study: StudyConfig, *, include_header: bool = True) -> list[str]:
     """Plain-text lines describing the dormant normalisations that will apply.
 
     Dormant rules silently rewrite the executed config (e.g. a greedy config
@@ -230,6 +230,10 @@ def dormant_observation_lines(study: StudyConfig) -> list[str]:
     engine listing the rule id and the field-level effect. Returns ``[]`` when
     no dormant rule fired, so callers render the section only when non-empty.
     Shared by ``llem study plan`` and the preflight summary.
+
+    ``include_header`` controls the leading "Dormant normalisations ..." line:
+    ``llem study plan`` keeps it, while the preflight panel omits it because the
+    section already carries its own bold title.
     """
     observations = study.dormant_observations
     if not observations:
@@ -239,7 +243,7 @@ def dormant_observation_lines(study: StudyConfig) -> list[str]:
     for obs in observations:
         by_engine.setdefault(str(obs.get("engine", "?")), []).append(obs)
 
-    lines = ["Dormant normalisations (applied to the executed config):"]
+    lines = ["Dormant normalisations (applied to the executed config):"] if include_header else []
     for engine in sorted(by_engine):
         lines.append(f"  {engine}:")
         for obs in by_engine[engine]:

--- a/src/llenergymeasure/cli/study_cmd.py
+++ b/src/llenergymeasure/cli/study_cmd.py
@@ -140,7 +140,11 @@ def study_plan(
 
     from llenergymeasure.api import load_study
     from llenergymeasure.cli._study_defaults import study_cli_overrides_for_file
-    from llenergymeasure.cli._study_plan import build_funnel, render_funnel
+    from llenergymeasure.cli._study_plan import (
+        build_funnel,
+        dormant_observation_lines,
+        render_funnel,
+    )
     from llenergymeasure.utils.exceptions import ConfigError
 
     # Apply the same CLI-layer effective defaults llem run applies, so the
@@ -155,3 +159,8 @@ def study_plan(
     funnel = build_funnel(study)
     title = study.study_name or str(study_file)
     typer.echo(render_funnel(funnel, title))
+
+    dormant_lines = dormant_observation_lines(study)
+    if dormant_lines:
+        typer.echo("")
+        typer.echo("\n".join(dormant_lines))

--- a/src/llenergymeasure/config/engine_rules/loader.py
+++ b/src/llenergymeasure/config/engine_rules/loader.py
@@ -395,6 +395,27 @@ def canonical_operator(op: str) -> str:
     return OPERATOR_ALIASES.get(op, op)
 
 
+def _canonicalise_match_fields(fields: dict[str, Any]) -> dict[str, Any]:
+    """Canonicalise operator keys in every dict-valued field spec at parse time.
+
+    A dict spec's keys are predicate operators; word-form aliases (``equals`` /
+    ``not_equal``) are mapped to their symbol form via :func:`canonical_operator`
+    so every consumer sees one canonical key regardless of how the corpus author
+    wrote the rule. :func:`canonical_operator` passes unknown keys through
+    unchanged, so non-operator keys (``present``, ``not_in``, ...) are untouched.
+    Scalar shorthand specs (bare-value equality) are not dicts, so they pass
+    through unchanged too.
+    """
+    return {
+        path: (
+            {canonical_operator(op): value for op, value in spec.items()}
+            if isinstance(spec, dict)
+            else spec
+        )
+        for path, spec in fields.items()
+    }
+
+
 def _ordered(a: Any, b: Any, op: Callable[[Any, Any], bool]) -> bool:
     """Apply an ordering comparison, treating None and incomparable types as no-match.
 
@@ -607,7 +628,7 @@ def _parse_rule(raw: dict[str, Any]) -> Rule:
         id=rule_id,
         engine=str(raw["engine"]),
         severity=severity,
-        match_fields=dict(match["fields"]),
+        match_fields=_canonicalise_match_fields(dict(match["fields"])),
         provenance=_parse_provenance(rule_id, raw["provenance"]),
         message_template=raw.get("message_template"),
         normalised_fields=tuple(str(p) for p in normalised),

--- a/src/llenergymeasure/config/engine_rules/loader.py
+++ b/src/llenergymeasure/config/engine_rules/loader.py
@@ -370,6 +370,31 @@ _OPERATOR_HANDLERS: dict[str, Any] = {
 }
 
 
+OPERATOR_ALIASES: dict[str, str] = {
+    "equals": "==",
+    "not_equal": "!=",
+}
+"""Word-form operator names mapped to their symbol canonical form.
+
+Corpus authors write ``equals`` / ``not_equal`` interchangeably with ``==`` /
+``!=`` (both resolve to identical handlers in :data:`_OPERATOR_HANDLERS`).
+Consumers that inspect predicate *keys* rather than evaluate them (e.g. the
+sweep library-resolution projection) canonicalise through this map so an alias
+variant and its symbol form are treated as the same operator. The single
+source of truth for which words alias which symbols - do not duplicate.
+"""
+
+
+def canonical_operator(op: str) -> str:
+    """Return the canonical (symbol) form of a predicate operator.
+
+    Word-form aliases (``equals`` / ``not_equal``) map to their symbols
+    (``==`` / ``!=``); every other operator (including symbols already in
+    canonical form) passes through unchanged.
+    """
+    return OPERATOR_ALIASES.get(op, op)
+
+
 def _ordered(a: Any, b: Any, op: Callable[[Any, Any], bool]) -> bool:
     """Apply an ordering comparison, treating None and incomparable types as no-match.
 

--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -166,7 +166,10 @@ def expand_grid(
     # With explicit entries an empty sweep contributes nothing, so it never
     # adds a phantom default-engine baseline the user never wrote.
     sweep = raw_study.get("sweep", {})
-    explicit_entries = raw_study.get("experiments", [])
+    # `experiments:` present but YAML-null yields None from .get(); treat an
+    # explicitly-empty key the same as an absent one rather than TypeError-ing
+    # on the iteration below.
+    explicit_entries = raw_study.get("experiments") or []
     sweep_raw_configs = _expand_sweep(sweep, merged_fixed, synthesize_baseline=not explicit_entries)
 
     # Step 4: Append explicit experiments: list entries
@@ -203,12 +206,19 @@ def expand_grid(
             errors: list[dict[str, Any]] = []
             if isinstance(exc, ValidationError):
                 errors = [dict(e) for e in exc.errors()]
+            rule_id = _extract_rule_id(errors)
+            # Pydantic's error dicts carry a `ctx` mapping that can hold the raw
+            # exception object (non-serialisable). `_extract_rule_id` has read
+            # what it needs from it, so drop `ctx` now - SkippedConfig.errors is
+            # persisted via json.dumps and must stay serialisable.
+            for err in errors:
+                err.pop("ctx", None)
             skipped.append(
                 SkippedConfig(
                     raw_config=raw_config,
                     reason=reason,
                     errors=errors,
-                    rule_id=_extract_rule_id(errors),
+                    rule_id=rule_id,
                 )
             )
 
@@ -652,8 +662,15 @@ def _expand_sweep(
     if isinstance(fixed_engine, list):
         engines = list(fixed_engine)
     elif scoped_dims or scoped_groups:
-        # Engines implied by scoped axes or scoped groups
-        engines = sorted(set(scoped_dims.keys()) | set(scoped_groups.keys()))
+        # Engines implied by scoped axes or scoped groups. A study may ALSO fix
+        # `engine:` explicitly (e.g. `engine: transformers` while sweeping a
+        # vllm.* axis) - that engine gets its own baseline run, so union it in
+        # rather than letting the scoped axes silently drop it. Only an
+        # explicitly-set engine counts; the "transformers" default does not.
+        scope_engines = set(scoped_dims.keys()) | set(scoped_groups.keys())
+        if "engine" in fixed:
+            scope_engines.add(fixed_engine)
+        engines = sorted(scope_engines)
     else:
         engines = [fixed_engine]
 

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -1014,3 +1014,12 @@ class StudyConfig(BaseModel):
             "its equivalence group at sidecar-write time."
         ),
     )
+    dormant_observations: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Distinct dormant-rule normalisations applied during library resolution "
+            "(keys: engine, rule_id, field_path, normalisation). Dormant fields are "
+            "silently rewritten in the executed config, so these are surfaced in "
+            "'llem study plan' and preflight output. Empty when no dormant rule fired."
+        ),
+    )

--- a/src/llenergymeasure/study/library_resolution.py
+++ b/src/llenergymeasure/study/library_resolution.py
@@ -4,8 +4,9 @@ Design: ``.product/designs/config-deduplication-dormancy/sweep-dedup.md`` §2.
 
 The library-resolution mechanism is the host-side, pre-dispatch layer that normalises every
 field the engine-rules corpus marks as ``dormant``. Each rule's fired-state
-projection is taken from its match predicate's "not_equal" / "present"
-operand (the sentinel value the predicate is *deviating from*) - that same
+projection drives its subject field (the one marked ``!=`` / ``present``, or
+named in ``normalised_fields``) back to *absent* via :data:`_STRIP`, so a
+config that set the dormant field collapses with one that never did. That same
 projection is what :mod:`scripts.engine_producers._fixpoint_test` enforces in CI, so
 runtime canonicalisation and CI correctness tests apply an identical
 normalisation.
@@ -27,6 +28,7 @@ from typing import Any
 from llenergymeasure.config.engine_rules.loader import (
     EngineRulesLoader,
     Rule,
+    canonical_operator,
     resolve_field_path,
 )
 from llenergymeasure.config.models import ExperimentConfig
@@ -78,8 +80,27 @@ class LibraryResolutionCycleError(RuntimeError):
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class DormantObservation:
+    """One dormant normalisation the library-resolution mechanism applied.
+
+    Records that a dormant rule fired on a config and drove a field to its
+    canonical form, so ``llem study plan`` / preflight can surface the
+    (otherwise silent) mutation of the executed config.
+    """
+
+    engine: str
+    rule_id: str
+    field_path: str
+    normalisation: str
+    """Human-readable effect: ``"stripped"`` for a strip-to-absent, else
+    ``"-> <value>"`` for a concrete rewrite."""
+
+
 def _apply_rules_fixpoint(
-    config: ExperimentConfig, rules: list[Rule] | tuple[Rule, ...]
+    config: ExperimentConfig,
+    rules: list[Rule] | tuple[Rule, ...],
+    observations: list[DormantObservation] | None = None,
 ) -> ExperimentConfig:
     """Apply every ``dormant``-severity rule to ``config`` repeatedly until stable.
 
@@ -90,6 +111,9 @@ def _apply_rules_fixpoint(
         config: A validated ``ExperimentConfig``.
         rules: The rule list for the config's engine (typically from
             ``EngineRulesLoader.load_rules(engine).rules``).
+        observations: Optional sink; each applied normalisation is appended as a
+            :class:`DormantObservation` for downstream (plan / preflight)
+            display. ``None`` skips the bookkeeping entirely.
 
     Raises:
         LibraryResolutionCycleError: If the fixpoint loop exceeds
@@ -119,6 +143,16 @@ def _apply_rules_fixpoint(
                 if not already_canonical:
                     _assign_field_path(current, field_path, target_value)
                     fired = True
+                    if observations is not None:
+                        norm = "stripped" if target_value is _STRIP else f"-> {target_value!r}"
+                        observations.append(
+                            DormantObservation(
+                                engine=rule.engine,
+                                rule_id=rule.id,
+                                field_path=field_path,
+                                normalisation=norm,
+                            )
+                        )
         if not fired:
             return current
     raise LibraryResolutionCycleError(current, _MAX_ITER)
@@ -156,15 +190,22 @@ def _rule_normalisations(rule: Rule) -> dict[str, Any]:
        config path (see :func:`_resolve_normalised_field`) and collapses to
        :data:`_STRIP` - the field is driven back to *absent* (its library
        default), so a config that set it equals one that never did.
-    2. Otherwise, fall back to the rule's *match* predicate: any field
-       matched with a ``not_equal`` / ``present`` operator is normalised by
-       stripping (setting to ``None`` or the ``not_equal`` sentinel if
-       scalar). This is the fixpoint-test projection - structurally identical
-       to what CI enforces for shuffle-stability.
+    2. Otherwise, fall back to the rule's *match* predicate: any field marked
+       ``!=`` / ``not_equal`` / ``present`` is a *subject* field and is driven
+       to :data:`_STRIP` (absent). Stripping is the only projection that
+       collapses correctly for both declared fields (reset to their ``None``
+       default) and pydantic extras (remove the key) - emitting ``None`` or a
+       concrete sentinel leaves an extra key present, so the resolved-config
+       hash distinguishes it from a config that never set the field and dedup
+       silently no-ops.
+
+    Operator keys are canonicalised (``!=`` and ``not_equal`` are the same
+    operator) so a rule written with a word alias projects identically to one
+    written with the symbol.
 
     Rules that match only on equality (e.g. ``do_sample: false``) do not
     normalise those fields - equality predicates are *triggers*, not
-    *subjects*. Subject fields are the ones marked ``present``/``not_equal``.
+    *subjects*. Subject fields are the ones marked ``present`` / ``!=``.
     """
     out: dict[str, Any] = {}
 
@@ -179,15 +220,13 @@ def _rule_normalisations(rule: Rule) -> dict[str, Any]:
     for path, spec in rule.match_fields.items():
         if not isinstance(spec, dict):
             continue
-        if "not_equal" in spec:
-            # The "canonical" state is the not_equal sentinel - applying the
-            # rule drives the field back to the library-observed default.
-            out[path] = spec["not_equal"]
-        elif spec.get("present") and "in" not in spec:
-            # Subject field marked only as "present" - strip to None (the
-            # library either ignores it, or the effective value is captured
-            # later via observed_config_hash).
-            out[path] = None
+        canon = {canonical_operator(op): value for op, value in spec.items()}
+        is_not_equal = "!=" in canon
+        is_present = bool(canon.get("present")) and "in" not in canon
+        if is_not_equal or is_present:
+            # Subject field - drive it back to *absent* so a config that set it
+            # collapses with one that never did.
+            out[path] = _STRIP
     return out
 
 
@@ -269,6 +308,9 @@ class DedupResult:
             runs even when ``deduplicate=False``).
         deduplicated: ``True`` iff dedup was actually applied to the
             ``canonical_configs`` return slot.
+        dormant_observations: Distinct dormant normalisations applied across the
+            sweep (dedup'd by engine/rule/field/effect, ordered), for plan /
+            preflight display. Empty when no dormant rule fired.
     """
 
     canonical_configs: list[ExperimentConfig]
@@ -276,6 +318,7 @@ class DedupResult:
     declared_resolved_hashes: list[str] = field(default_factory=list)
     would_dedup: bool = False
     deduplicated: bool = False
+    dormant_observations: list[DormantObservation] = field(default_factory=list)
 
 
 def resolve_library_effective(
@@ -322,10 +365,20 @@ def resolve_library_effective(
 
     canonicalised: list[ExperimentConfig] = []
     hashes: list[str] = []
+    observations: list[DormantObservation] = []
     for cfg in configs:
-        canon = _apply_rules_fixpoint(cfg, _rules_for(cfg))
+        canon = _apply_rules_fixpoint(cfg, _rules_for(cfg), observations=observations)
         canonicalised.append(canon)
         hashes.append(hash_config(build_resolved_view(canon)))
+
+    # Distinct observations, first-seen order - the same rule fires on many
+    # sweep points but the display wants one line per (engine, rule, field).
+    distinct_observations: list[DormantObservation] = []
+    seen: set[DormantObservation] = set()
+    for obs in observations:
+        if obs not in seen:
+            seen.add(obs)
+            distinct_observations.append(obs)
 
     groups_by_hash: dict[str, list[int]] = {}
     for idx, h in enumerate(hashes):
@@ -358,6 +411,7 @@ def resolve_library_effective(
         declared_resolved_hashes=hashes,
         would_dedup=would_dedup,
         deduplicated=deduplicate and would_dedup,
+        dormant_observations=distinct_observations,
     )
 
 

--- a/src/llenergymeasure/study/library_resolution.py
+++ b/src/llenergymeasure/study/library_resolution.py
@@ -123,6 +123,13 @@ def _apply_rules_fixpoint(
     if not dormant_rules:
         return config.model_copy(deep=True)
 
+    # A rule's normalisations depend only on the frozen Rule, not on the config
+    # under resolution, so precompute once per rule rather than recomputing on
+    # every fixpoint iteration for every config. Rule carries a dict field
+    # (match_fields), so it is not hashable - key the precompute by object
+    # identity rather than by the Rule itself.
+    normalisations_by_rule = {id(r): _rule_normalisations(r) for r in dormant_rules}
+
     current = config.model_copy(deep=True)
     for _iteration in range(_MAX_ITER):
         fired = False
@@ -130,7 +137,7 @@ def _apply_rules_fixpoint(
             match = rule.try_match(current)
             if match is None:
                 continue
-            updates = _rule_normalisations(rule)
+            updates = normalisations_by_rule[id(rule)]
             if not updates:
                 continue
             for field_path, target_value in updates.items():
@@ -373,12 +380,9 @@ def resolve_library_effective(
 
     # Distinct observations, first-seen order - the same rule fires on many
     # sweep points but the display wants one line per (engine, rule, field).
-    distinct_observations: list[DormantObservation] = []
-    seen: set[DormantObservation] = set()
-    for obs in observations:
-        if obs not in seen:
-            seen.add(obs)
-            distinct_observations.append(obs)
+    # DormantObservation is frozen/hashable and dict preserves insertion order,
+    # so dict.fromkeys gives first-seen dedup in one pass.
+    distinct_observations = list(dict.fromkeys(observations))
 
     groups_by_hash: dict[str, list[int]] = {}
     for idx, h in enumerate(hashes):

--- a/src/llenergymeasure/study/loading.py
+++ b/src/llenergymeasure/study/loading.py
@@ -112,4 +112,13 @@ def finalise_study(raw: LoadedStudyRaw) -> StudyConfig:
         dedup_mode=dedup_mode,
         pre_run_equivalence_groups=pre_run_groups,
         declared_resolved_config_hashes=list(dedup.declared_resolved_hashes),
+        dormant_observations=[
+            {
+                "engine": obs.engine,
+                "rule_id": obs.rule_id,
+                "field_path": obs.field_path,
+                "normalisation": obs.normalisation,
+            }
+            for obs in dedup.dormant_observations
+        ],
     )

--- a/src/llenergymeasure/study/loading.py
+++ b/src/llenergymeasure/study/loading.py
@@ -13,6 +13,7 @@ parses *and* finalises in one call is ``llenergymeasure.api.load_study``.
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import Any, Literal
 
 from llenergymeasure.config.grid import (
@@ -112,13 +113,5 @@ def finalise_study(raw: LoadedStudyRaw) -> StudyConfig:
         dedup_mode=dedup_mode,
         pre_run_equivalence_groups=pre_run_groups,
         declared_resolved_config_hashes=list(dedup.declared_resolved_hashes),
-        dormant_observations=[
-            {
-                "engine": obs.engine,
-                "rule_id": obs.rule_id,
-                "field_path": obs.field_path,
-                "normalisation": obs.normalisation,
-            }
-            for obs in dedup.dormant_observations
-        ],
+        dormant_observations=[asdict(obs) for obs in dedup.dormant_observations],
     )

--- a/tests/unit/cli/test_preflight_display.py
+++ b/tests/unit/cli/test_preflight_display.py
@@ -77,6 +77,28 @@ class TestBuildPreflightPanel:
         output = _render_panel(sc)
         assert "Study: test-study" in output
 
+    def test_panel_shows_dormant_observations_when_present(self):
+        """The preflight panel surfaces dormant normalisations (PR-D change 6)."""
+        sc = _make_panel_study_config()
+        sc.dormant_observations = [
+            {
+                "engine": "transformers",
+                "rule_id": "transformers_dormant_epsilon_cutoff_ne_0_0",
+                "field_path": "transformers.sampling_params.epsilon_cutoff",
+                "normalisation": "stripped",
+            }
+        ]
+        output = _render_panel(sc)
+        assert "Dormant normalisations" in output
+        assert "transformers_dormant_epsilon_cutoff_ne_0_0" in output
+        assert "epsilon_cutoff" in output
+
+    def test_panel_omits_dormant_section_when_empty(self):
+        """No dormant observations -> no section (additive, non-empty only)."""
+        sc = _make_panel_study_config()
+        output = _render_panel(sc)
+        assert "Dormant normalisations" not in output
+
     def test_panel_metadata_experiments_plural(self):
         """Panel shows n configs x n cycles = n runs (plural form)."""
         sc = _make_panel_study_config(

--- a/tests/unit/cli/test_study_plan.py
+++ b/tests/unit/cli/test_study_plan.py
@@ -15,7 +15,11 @@ import yaml
 
 from llenergymeasure.api import load_study
 from llenergymeasure.cli._study_defaults import study_cli_overrides_for_file
-from llenergymeasure.cli._study_plan import build_funnel, render_funnel
+from llenergymeasure.cli._study_plan import (
+    build_funnel,
+    dormant_observation_lines,
+    render_funnel,
+)
 
 MODEL = "Qwen/Qwen2.5-0.5B"
 
@@ -173,6 +177,46 @@ sweep:
     funnel = build_funnel(_load_with_cli_defaults(tmp_path, text))  # type: ignore[arg-type]
     assert funnel.n_cycles == 1
     assert funnel.runs == funnel.unique
+
+
+def test_dormant_observations_rendered_in_plan(tmp_path: Path) -> None:
+    """A dormant-triggering field surfaces its rule id and field in the plan.
+
+    ``epsilon_cutoff`` is a transformers pydantic-extra the engine silently
+    strips; the dormant rule ``transformers_dormant_epsilon_cutoff_ne_0_0``
+    fires and drives it to absent. That normalisation must be visible in
+    ``llem study plan`` rather than mutating the executed config silently.
+    """
+    text = f"""
+task:
+  model: {MODEL}
+engine: transformers
+transformers:
+  sampling_params:
+    do_sample: true
+    epsilon_cutoff: 0.5
+"""
+    study = _load(tmp_path, text)
+    lines = dormant_observation_lines(study)  # type: ignore[arg-type]
+    joined = "\n".join(lines)
+    assert "transformers_dormant_epsilon_cutoff_ne_0_0" in joined
+    assert "epsilon_cutoff" in joined
+    assert "transformers:" in joined
+
+
+def test_dormant_observations_absent_when_none_fire(tmp_path: Path) -> None:
+    """No dormant rule fires -> the section is empty (rendered only when non-empty)."""
+    text = f"""
+task:
+  model: {MODEL}
+engine: transformers
+transformers:
+  sampling_params:
+    do_sample: true
+    temperature: 0.7
+"""
+    study = _load(tmp_path, text)
+    assert dormant_observation_lines(study) == []  # type: ignore[arg-type]
 
 
 def test_bounds_scaffold_round_trip(tmp_path: Path) -> None:

--- a/tests/unit/config/engine_rules/test_loader.py
+++ b/tests/unit/config/engine_rules/test_loader.py
@@ -334,3 +334,20 @@ def test_normalised_fields_omitted_on_error_rule_is_fine(tmp_path: Path) -> None
     rule = loader.load_rules("transformers").rules[0]
     assert rule.severity == "error"
     assert rule.normalised_fields == ()
+
+
+def test_word_form_operator_alias_canonicalised_at_parse(tmp_path: Path) -> None:
+    # A rule authored with the word-form operator ``not_equal`` must load with
+    # its symbol form ``!=`` in the parsed match fields, so every consumer sees
+    # one canonical key regardless of corpus authoring style. Non-operator keys
+    # (``present``) and the field path pass through unchanged.
+    data = yaml.safe_load(_CORPUS_MINIMAL)
+    data["rules"][0]["match"]["fields"] = {
+        "transformers.sampling.temperature": {"present": True, "not_equal": 1.0},
+    }
+    _write_corpus(tmp_path, "transformers", yaml.safe_dump(data))
+    loader = EngineRulesLoader(corpus_root=tmp_path)
+    rule = loader.load_rules("transformers").rules[0]
+    spec = rule.match_fields["transformers.sampling.temperature"]
+    assert "not_equal" not in spec
+    assert spec == {"present": True, "!=": 1.0}

--- a/tests/unit/study/test_library_resolution.py
+++ b/tests/unit/study/test_library_resolution.py
@@ -166,8 +166,11 @@ class TestCanonicalise:
     def test_cycle_detection_guard_raises(self, monkeypatch):
         # The fixpoint guard is defensive against a bad corpus. A strip-only
         # projection is monotone and cannot cycle, so force the non-convergence
-        # path with a monkeypatched projection that alternates the target value
-        # every pass - the guard must surface it rather than hang.
+        # path. The projection is precomputed once per rule, so we cannot flip
+        # it per pass; instead patch the assignment so the field never lands on
+        # its canonical target (it alternates every write). The field stays off
+        # its projected value, so ``fired`` is True on every pass and the guard
+        # must surface the non-convergence rather than hang.
         cfg = _mk_config(transformers={"sampling_params": {"do_sample": True, "top_k": 50}})
         rule = _mk_rule(
             invariant_id="cycler",
@@ -179,11 +182,16 @@ class TestCanonicalise:
         import llenergymeasure.study.library_resolution as lr
 
         flip = itertools.cycle([999, 50])
-        monkeypatch.setattr(
-            lr,
-            "_rule_normalisations",
-            lambda _rule: {"transformers.sampling_params.top_k": next(flip)},
-        )
+
+        # The projection strips top_k, but the patched assign writes an
+        # alternating literal instead, so the field never lands on its projected
+        # target and the loop never converges.
+        real_assign = lr._assign_field_path
+
+        def _assign(config, path, _value):
+            real_assign(config, path, next(flip))
+
+        monkeypatch.setattr(lr, "_assign_field_path", _assign)
         with pytest.raises(LibraryResolutionCycleError):
             _apply_rules_fixpoint(cfg, [rule])
 

--- a/tests/unit/study/test_library_resolution.py
+++ b/tests/unit/study/test_library_resolution.py
@@ -89,11 +89,14 @@ class TestCanonicalise:
             },
         )
         result = _apply_rules_fixpoint(cfg, [rule])
-        # Canonical form is the not_equal sentinel.
-        assert result.transformers.sampling_params.temperature == 1.0
+        # A not_equal subject field is stripped to *absent* (None for a declared
+        # field) so a config that set it collapses with one that never did.
+        assert result.transformers.sampling_params.temperature is None
 
     def test_idempotence_on_already_canonical(self):
-        cfg = _mk_config(transformers={"sampling_params": {"do_sample": False, "temperature": 1.0}})
+        # Already-absent temperature: the rule cannot fire (present: True fails),
+        # so the config is unchanged - the fixpoint is stable on first pass.
+        cfg = _mk_config(transformers={"sampling_params": {"do_sample": False}})
         rule = _mk_rule(
             invariant_id="greedy_normalises_temperature",
             match_fields={
@@ -102,7 +105,7 @@ class TestCanonicalise:
             },
         )
         result = _apply_rules_fixpoint(cfg, [rule])
-        assert result.transformers.sampling_params.temperature == 1.0
+        assert result.transformers.sampling_params.temperature is None
 
     def test_chained_rules_converge(self):
         # Rule A: if temperature > 0.8, strip top_p (simulating greedy-when-hot
@@ -138,12 +141,12 @@ class TestCanonicalise:
         # top_k unchanged: rule_b only fires when top_k != 50, but input is 50.
         assert result.transformers.sampling_params.top_k == 50
 
-    def test_cycle_detection(self):
-        # Synthetic cycle: two rules that flip a field back and forth.
-        # rule_a: if top_k=50, strip it
-        # rule_b: if top_k absent, set to 50 (via not_equal on present)
-        # The real rule shape is constrained; simulate a cycle by assigning a
-        # path that gets reset each iteration.
+    def test_strip_only_projection_is_monotone(self):
+        # Two present/not_equal rules on the same field can no longer cycle:
+        # every dormant projection strips its subject to *absent*, which is
+        # monotone (a stripped field never re-triggers a present: True rule),
+        # so the flip-flop that used to cycle under the old sentinel-restore
+        # projection now converges to a single stripped state.
         cfg = _mk_config(transformers={"sampling_params": {"do_sample": True, "top_k": 50}})
         rule_a = _mk_rule(
             invariant_id="clear_top_k",
@@ -157,8 +160,32 @@ class TestCanonicalise:
                 "transformers.sampling_params.top_k": {"present": True, "not_equal": 50},
             },
         )
+        result = _apply_rules_fixpoint(cfg, [rule_a, rule_b])
+        assert result.transformers.sampling_params.top_k is None
+
+    def test_cycle_detection_guard_raises(self, monkeypatch):
+        # The fixpoint guard is defensive against a bad corpus. A strip-only
+        # projection is monotone and cannot cycle, so force the non-convergence
+        # path with a monkeypatched projection that alternates the target value
+        # every pass - the guard must surface it rather than hang.
+        cfg = _mk_config(transformers={"sampling_params": {"do_sample": True, "top_k": 50}})
+        rule = _mk_rule(
+            invariant_id="cycler",
+            match_fields={"transformers.sampling_params.top_k": {"present": True}},
+        )
+
+        import itertools
+
+        import llenergymeasure.study.library_resolution as lr
+
+        flip = itertools.cycle([999, 50])
+        monkeypatch.setattr(
+            lr,
+            "_rule_normalisations",
+            lambda _rule: {"transformers.sampling_params.top_k": next(flip)},
+        )
         with pytest.raises(LibraryResolutionCycleError):
-            _apply_rules_fixpoint(cfg, [rule_a, rule_b])
+            _apply_rules_fixpoint(cfg, [rule])
 
     def test_non_dormant_rules_ignored(self):
         cfg = _mk_config(transformers={"sampling_params": {"do_sample": True, "temperature": 0.5}})
@@ -280,6 +307,72 @@ class TestDedupSweep:
         # do_sample=True x temps=[0.5, 1.0, 1.5] -> 3 distinct sampling configs
         # do_sample=False x any temp -> 1 canonical greedy
         assert len(result.canonical_configs) == 4
+
+    def test_dormant_extra_collapses_to_one_group(self):
+        # Regression (PR-D change 1): two configs differing only in a dormant
+        # pydantic EXTRA (epsilon_cutoff) must land in ONE equivalence group.
+        # The fallback projection previously emitted None for the present-only
+        # subject, so the extra key survived with value None and the
+        # resolved-config hash distinguished None from missing -> 2 groups.
+        cfg_a = _mk_config(
+            transformers={"sampling_params": {"do_sample": True, "epsilon_cutoff": 0.5}}
+        )
+        cfg_b = _mk_config(
+            transformers={"sampling_params": {"do_sample": True, "epsilon_cutoff": 0.9}}
+        )
+        result = resolve_library_effective([cfg_a, cfg_b], deduplicate=True)
+        assert len(result.groups) == 1
+        assert result.would_dedup is True
+        assert len(result.canonical_configs) == 1
+
+    def test_operator_alias_projects_identically(self):
+        # Regression (PR-D change 2): a rule written with the '!=' symbol and
+        # one written with the 'not_equal' word alias must project the same way
+        # (both strip the subject field), so a corpus-author's choice of alias
+        # cannot change dedup behaviour.
+        cfg = _mk_config(
+            transformers={"sampling_params": {"do_sample": False, "epsilon_cutoff": 0.5}}
+        )
+        rule_symbol = _mk_rule(
+            invariant_id="strip_via_symbol",
+            match_fields={
+                "transformers.sampling_params.do_sample": False,
+                "transformers.sampling_params.epsilon_cutoff": {"present": True, "!=": 0.0},
+            },
+        )
+        rule_word = _mk_rule(
+            invariant_id="strip_via_word",
+            match_fields={
+                "transformers.sampling_params.do_sample": False,
+                "transformers.sampling_params.epsilon_cutoff": {"present": True, "not_equal": 0.0},
+            },
+        )
+        by_symbol = _apply_rules_fixpoint(cfg, [rule_symbol])
+        by_word = _apply_rules_fixpoint(cfg, [rule_word])
+        # Both strip the extra to absent, so both resolved views hash identically.
+        assert hash_config(build_resolved_view(by_symbol)) == hash_config(
+            build_resolved_view(by_word)
+        )
+        # And the extra is gone in both.
+        symbol_extra = by_symbol.transformers.sampling_params.__pydantic_extra__ or {}
+        word_extra = by_word.transformers.sampling_params.__pydantic_extra__ or {}
+        assert "epsilon_cutoff" not in symbol_extra
+        assert "epsilon_cutoff" not in word_extra
+
+    def test_dormant_observations_captured(self):
+        # PR-D change 6 substrate: dedup records the distinct normalisations it
+        # applied so plan / preflight can surface them.
+        cfg = _mk_config(
+            transformers={"sampling_params": {"do_sample": True, "epsilon_cutoff": 0.5}}
+        )
+        result = resolve_library_effective([cfg], deduplicate=True)
+        obs = result.dormant_observations
+        assert any(
+            o.rule_id == "transformers_dormant_epsilon_cutoff_ne_0_0"
+            and o.field_path == "transformers.sampling_params.epsilon_cutoff"
+            and o.normalisation == "stripped"
+            for o in obs
+        )
 
     def test_hashes_stable_across_repeated_dedup(self):
         cfg = _mk_config(transformers={"sampling_params": {"do_sample": False, "temperature": 0.5}})

--- a/tests/unit/study/test_study_grid.py
+++ b/tests/unit/study/test_study_grid.py
@@ -220,6 +220,45 @@ class TestExpandGridSweep:
             assert c.vllm.engine_params is not None
             assert c.vllm.engine_params.max_num_seqs in (64, 256)
 
+    def test_fixed_engine_union_with_scoped_axis(self):
+        """A study fixing engine: transformers while sweeping a vllm axis keeps both.
+
+        Regression (PR-D change 3): the explicit fixed engine used to be silently
+        dropped when scope-derived engines were computed from a differently-scoped
+        sweep axis. It must be unioned in - transformers gets its baseline run and
+        vllm gets its swept grid.
+        """
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "sweep": {
+                "vllm.engine_params.max_num_seqs": [64, 256],
+            },
+        }
+        valid, skipped = expand_grid(raw)
+        assert skipped == []
+        engines = {c.engine for c in valid}
+        assert engines == {"transformers", "vllm"}
+        # transformers: one baseline (no transformers-scoped axis) ; vllm: 2 swept
+        assert len([c for c in valid if c.engine == "transformers"]) == 1
+        assert len([c for c in valid if c.engine == "vllm"]) == 2
+
+    def test_default_engine_not_unioned_with_scoped_axis(self):
+        """An unset engine (defaulting to transformers) is NOT spuriously added.
+
+        Only an *explicitly* set engine is unioned into scope-derived engines;
+        a sweep over only vllm axes with no engine: line stays vllm-only.
+        """
+        raw = {
+            "task": {"model": "gpt2"},
+            "sweep": {
+                "vllm.engine_params.max_num_seqs": [64, 256],
+            },
+        }
+        valid, skipped = expand_grid(raw)
+        assert skipped == []
+        assert {c.engine for c in valid} == {"vllm"}
+
 
 # =============================================================================
 # expand_grid() - explicit experiments mode
@@ -438,6 +477,47 @@ class TestExpandGridInvalidHandling:
         raw = {"study_name": "empty-study"}
         with pytest.raises(ConfigError):
             expand_grid(raw)
+
+    def test_experiments_yaml_null_treated_as_empty(self):
+        """`experiments:` present-but-null must not TypeError.
+
+        Regression (PR-D change 4): YAML `experiments:` with no value yields
+        None, which used to blow up the iteration. It is treated as [] so the
+        sweep (or inline baseline) still produces the study.
+        """
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "experiments": None,
+            "sweep": {"transformers.engine_params.dtype": ["float16", "bfloat16"]},
+        }
+        valid, skipped = expand_grid(raw)
+        assert len(valid) == 2
+        assert skipped == []
+
+    def test_skipped_config_errors_are_json_serialisable(self):
+        """A rule-rejected config's stored error survives json.dumps.
+
+        Regression (PR-D change 5): Pydantic error dicts carry a non-serialisable
+        `ctx` (the raw exception object). `_extract_rule_id` reads it, then it is
+        stripped so SkippedConfig.errors stays json.dumps-able.
+        """
+        import json
+
+        raw = {
+            "task": {"model": "gpt2"},
+            "engine": "transformers",
+            "transformers": {"engine_params": {"num_beams": 2}},
+            "sweep": {"transformers.sampling_params.num_return_sequences": [1, 4]},
+        }
+        _valid, skipped = expand_grid(raw)
+        assert len(skipped) == 1
+        # rule_id was still extracted before ctx was dropped.
+        assert skipped[0].rule_id is not None
+        # errors carry no ctx and round-trip through json.dumps.
+        for err in skipped[0].errors:
+            assert "ctx" not in err
+        json.dumps(skipped[0].to_dict())
 
 
 class TestSkippedConfigRuleAttribution:


### PR DESCRIPTION
Six correctness fixes to sweep dedup, grid expansion, and dormant-rule observability. Each is backed by a regression test; scope and design are per the workflow-fitness-review synthesis at `.product/designs/workflow-fitness-review-2026-07-08/synthesis.md`.

## Changes

### 1. Dedup fallback emits `_STRIP` (not a residual value/sentinel)
`study/library_resolution.py` - the fallback normalisation drove a subject field to a not-equal value / sentinel instead of driving it to *absent*. For a pydantic-extra field the key survived, and the resolved-config hash distinguished it from a config that never set the field, so dedup silently no-oped.

Fix: emit `_STRIP` for both the `!=`/`not_equal` and `present` subject branches. Stripping to absent is the only projection that collapses correctly for **both** declared fields (reset to their `None` default) and pydantic extras (key removed).

Probe: two transformers configs differing only in the dormant extra `epsilon_cutoff` previously produced 2 dedup groups; they now collapse to 1.

### 2. Canonicalise operator aliases (`!=` vs `not_equal`)
`study/library_resolution.py` + `config/engine_rules/loader.py` - subject detection now canonicalises operator keys, so a rule written with the word alias projects identically to one written with the symbol.

**Premise deviation (surfaced per STOP-AND-REPORT):** the synthesis said to reuse the loader's existing operator alias map. No such named map existed - the loader only had per-operator handler lambdas (`_OPERATOR_HANDLERS`), keyed by symbol, with no alias->canonical table. Rather than duplicate a table, `OPERATOR_ALIASES` + `canonical_operator()` were added to the loader as the single source of truth. This realises the intent (one canonicalisation point, no duplication) as an addition rather than a reuse. No shipped rule uses the literal `not_equal` word-form today, so the change is behaviour-preserving for the current corpus while making the two spellings equivalent going forward.

### 3. Union an explicitly-fixed engine with scope-derived engines
`config/grid.py` - when a study fixes `engine:` explicitly AND scope-derived engines are computed from a differently-scoped sweep axis (e.g. `engine: transformers` while sweeping a `vllm.*` axis), the explicit engine was dropped. It is now unioned in so it still gets its baseline run.

The discriminator is `"engine" in fixed` (an explicitly-written key), not the `"transformers"` `.get()` default - so an unset engine is never spuriously added. An engine inherited via `base:` also counts as explicit (the user wrote it), which is correct.

### 4. `experiments:` present-but-YAML-null treated as empty
`config/grid.py` - a YAML `experiments:` with no value yields `None`, which TypeErrored on iteration. It is now treated as `[]`, so baseline synthesis / sweep still produce the study.

### 5. Strip non-serialisable `ctx` from stored SkippedConfig errors
`config/grid.py` - Pydantic error dicts carry a non-serialisable `ctx` (the raw exception object). `_extract_rule_id` reads `ctx["error"]` first, then `ctx` is stripped, so `SkippedConfig.errors` round-trips through `json.dumps` while rule attribution is preserved. (Ordering is load-bearing: extract-then-strip.)

### 6. Dormant-normalisation visibility
`config/models.py`, `study/loading.py`, `cli/_study_plan.py`, `cli/study_cmd.py`, `cli/_preflight_display.py` - dormant-rule normalisations mutate the executed config but were write-only (no consumer). They are now computed host-side during the library-resolution fixpoint, carried on `StudyConfig.dormant_observations`, and rendered as a per-engine section (shown only when non-empty) in both `llem study plan` output and the preflight panel, via a shared `dormant_observation_lines` helper. Additive only; no new CLI flags.

Real-surface demo (`llem study plan` on a transformers study that sets `epsilon_cutoff` and `early_stopping`):

```
Dormant normalisations (applied to the executed config):
  transformers:
    transformers.engine_params.early_stopping stripped  (rule transformers_dormant_early_stopping_set_true)
    transformers.sampling_params.epsilon_cutoff stripped  (rule transformers_dormant_epsilon_cutoff_ne_0_0)
```

## Gates
- `make lint`: pass (4 import-linter contracts kept)
- `make typecheck`: pass (290 files, no issues)
- `python -m pytest tests/unit -q`: 2813 passed, 44 skipped
- Per-engine `regen_engine_configs.py --check`: byte-identical (transformers 5.7.0, vllm 0.19.1, tensorrt 1.0.0) - no corpus files touched
- `make docs-check`: generated docs up to date