### PR TITLE
fix(scripts): absorb operability for all engines and ritual hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,9 @@ configs/engine_invariants/_staging/
 engine_versions/*.compat.json
 
 # Absorb candidate-pool workspace (version-scoped working files: pool,
-# ladder verdicts, sign-off, review delta - operational, never committed;
-# the only shipped output is the promoted rules corpus in src/).
+# ladder verdicts, review delta - operational, never committed. The human
+# sign-off record lives in the tracked outputs/ snapshot dir, not here; the
+# only other shipped output is the promoted rules corpus in src/).
 engine_versions/**/candidates/
 
 # Local caches (tooling scratch; never committed).

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: format lint lint-fix typecheck check
 .PHONY: test test-unit test-integration test-all
 .PHONY: docs-all docs-check docs-generate docs-serve docs-build docs-clean
-.PHONY: discover-schema discover-schemas-all
+.PHONY: discover-schema discover-schemas-all scaffold-snapshot
 .PHONY: check-citations probe-candidates analyst-cold-read absorb rules-coverage
 .PHONY: package-check
 .PHONY: docker-smoke
@@ -139,6 +139,18 @@ discover-schemas-all: ## Rediscover all three engine schemas in sequence
 	./scripts/refresh_discovered_schemas.sh vllm
 	./scripts/refresh_discovered_schemas.sh tensorrt
 	./scripts/refresh_discovered_schemas.sh transformers
+
+# Scaffold the per-version snapshot outputs dir a bump needs before codegen can
+# go green (engine_versions/<engine>/v<safe>/outputs/). Derives v<safe> from the
+# current.yaml pin via engine_versions/_outputs.py (the one place that mangling
+# lives). Creating the dir is all this does - the maintainer still drops the
+# mined schema.discovered.json + curated.yaml into it.
+scaffold-snapshot: ## Scaffold the snapshot outputs dir from the pin (ENGINE=vllm|tensorrt|transformers)
+	@test -n "$(ENGINE)" || (echo "Usage: make scaffold-snapshot ENGINE={vllm|tensorrt|transformers}" && exit 1)
+	@ver=$$(python3 -c "import yaml; print(yaml.safe_load(open('engine_versions/$(ENGINE)/current.yaml'))['library']['current_version'])"); \
+	outdir=$$(python3 -c "from engine_versions import _outputs; print(_outputs.outputs_dir('$(ENGINE)', '$$ver'))"); \
+	mkdir -p "$$outdir"; \
+	echo "Scaffolded $$outdir (drop schema.discovered.json + curated.yaml here, then run config-codegen)"
 
 # Proposer S2: LLM analyst cold read of the pinned engine source into candidate
 # rules for the verification ladder. Needs a local Ollama daemon (owns the GPU)

--- a/engine_versions/tensorrt/analyst_clusters.yaml
+++ b/engine_versions/tensorrt/analyst_clusters.yaml
@@ -1,0 +1,24 @@
+# Analyst cold-read source clusters for tensorrt.
+#
+# scripts/analyst_cold_read.py reads these source-file clusters and asks an LLM
+# analyst to extract every config-validation constraint it can see, one cited
+# candidate per constraint. This file is DATA describing the engine version's
+# source layout: paths are relative to --source-root (the installed
+# `tensorrt_llm/` package directory, e.g. the `tensorrt_llm/` folder inside an
+# extracted 1.0.0 release tarball). A glob (a path containing `*`) expands
+# against the source root; a plain path names one file.
+#
+# Cluster selection is a MINIMAL citation-grounded starter, NOT an
+# experiment-ratified cluster design like vllm's (no OSS analyst parity
+# experiment has been run for tensorrt). It is derived from where the shipped
+# rule corpus's verified constraints actually live: the single shipped tensorrt
+# citation names llmapi/llm_args.py (TorchLlmArgs, where the @model_validator
+# constraints live); sampling_params.py is the SamplingParams surface the
+# repo's tensorrt schema introspector reads. Refinement happens at the first
+# real cold-read. load_sources warns-and-skips missing paths, so layout drift
+# at a future pin degrades to a warning, not a crash.
+clusters:
+  llm_args:
+    - llmapi/llm_args.py
+  sampling:
+    - sampling_params.py

--- a/engine_versions/transformers/analyst_clusters.yaml
+++ b/engine_versions/transformers/analyst_clusters.yaml
@@ -1,0 +1,26 @@
+# Analyst cold-read source clusters for transformers.
+#
+# scripts/analyst_cold_read.py reads these source-file clusters and asks an LLM
+# analyst to extract every config-validation constraint it can see, one cited
+# candidate per constraint. This file is DATA describing the engine version's
+# source layout: paths are relative to --source-root (the installed
+# `transformers/` package directory, e.g. the `src/transformers/` folder inside
+# an extracted 5.7.0 sdist). A glob (a path containing `*`) expands against the
+# source root; a plain path names one file.
+#
+# Cluster selection is a MINIMAL citation-grounded starter, NOT an
+# experiment-ratified cluster design like vllm's (no OSS analyst parity
+# experiment has been run for transformers). It is derived from where the
+# shipped rule corpus's verified constraints actually live: all 38 shipped
+# transformers rules cite exactly two files - generation/configuration_utils.py
+# (33 rules, GenerationConfig.validate) and utils/quantization_config.py
+# (5 rules, BnB/quant configs). configuration_utils.py (PretrainedConfig) is
+# the main-config analogue of vllm's `model` cluster. Refinement happens at the
+# first real cold-read.
+clusters:
+  generation:
+    - generation/configuration_utils.py
+  quantization:
+    - utils/quantization_config.py
+  model:
+    - configuration_utils.py

--- a/scripts/absorb.py
+++ b/scripts/absorb.py
@@ -48,6 +48,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from engine_versions import _outputs  # noqa: E402
 from scripts._candidate_pool import (  # noqa: E402
     SCHEMA_VERSION,
     pool_path,
@@ -837,7 +838,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Absorb one engine-version bump into the shipped rules corpus."
     )
     parser.add_argument(
-        "--engine", required=True, help="Engine to absorb (vllm, tensorrt, transformers)."
+        "--engine", required=True, choices=_outputs.ENGINES, help="Engine to absorb."
     )
     parser.add_argument(
         "--source-root", type=Path, help="Pinned engine package dir (citations resolve against it)."

--- a/scripts/absorb.py
+++ b/scripts/absorb.py
@@ -396,20 +396,38 @@ def citation_pass_rate(
     eng = str(union[0].get("engine")) if union else ""
     ver = str(union[0].get("engine_version")) if union else ""
     _write_pool(tmp, "absorb_union", eng, ver, "", union)
-    candidates = [c for c in load_candidates(tmp) if c.citation is not None]
-    passed = sum(1 for c in candidates if check_candidate(c, source_root).ok)
-    tmp.unlink()
-    return passed, len(candidates)
+    try:
+        candidates = [c for c in load_candidates(tmp) if c.citation is not None]
+        passed = sum(1 for c in candidates if check_candidate(c, source_root).ok)
+        return passed, len(candidates)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def run_probe(engine: str, probe_input: Path, run_date: str) -> None:
-    """Probe candidates inside the engine container via the shell wrapper."""
+    """Probe candidates inside the engine container via the shell wrapper.
+
+    A non-zero exit is a hard error: the wrapper crashing before it writes any
+    verdict back (docker pull failure, image missing, entrypoint crash) would
+    otherwise leave every candidate ``unverified``, promotion would touch
+    nothing, and the operator would read a clean "corpus unchanged" as a passing
+    probe. Fail loudly naming the wrapper so a bump is never silently a no-op.
+    Verdict-level failure (all ``infra_error``) is still caught separately by the
+    ladder gate; this catches the case where no verdict was written at all.
+    """
+    wrapper = "scripts/probe_candidates.sh"
     rel = _require_under_repo(probe_input)
-    subprocess.run(
-        ["scripts/probe_candidates.sh", engine, "--candidates", str(rel), "--date", run_date],
+    result = subprocess.run(
+        [wrapper, engine, "--candidates", str(rel), "--date", run_date],
         cwd=REPO_ROOT,
         check=False,
     )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"probe failure: {wrapper} {engine} exited {result.returncode} before writing "
+            f"verdicts back to {rel}; nothing was probed. Fix the engine image / wrapper and "
+            "re-run - absorb will not silently skip the probe."
+        )
 
 
 def probe_ladder(
@@ -597,14 +615,19 @@ def promote(
 # --- Residue sign-off + review delta report ---
 
 
-def read_signoff(pool_dir: Path) -> set[str]:
-    """Rule ids the maintainer marked ``human_confirmed: true`` in the sign-off."""
-    entries = _load_yaml_list(pool_dir / _SIGNOFF_FILE, "residue")
+def read_signoff(signoff_dir: Path) -> set[str]:
+    """Rule ids the maintainer marked ``human_confirmed: true`` in the sign-off.
+
+    ``signoff_dir`` is the versioned, git-tracked ``outputs/`` snapshot dir (not
+    the gitignored candidates pool): the human approval record is a durable
+    decision that must survive a fresh clone.
+    """
+    entries = _load_yaml_list(signoff_dir / _SIGNOFF_FILE, "residue")
     return {str(e["id"]) for e in entries if e.get("human_confirmed") is True}
 
 
 def write_signoff(
-    pool_dir: Path, delta: Delta, old_by_id: dict[str, dict[str, Any]], absent: set[str]
+    signoff_dir: Path, delta: Delta, old_by_id: dict[str, dict[str, Any]], absent: set[str]
 ) -> None:
     """Write the residue sign-off file, persisting consumed marks.
 
@@ -621,7 +644,7 @@ def write_signoff(
     """
     prior = {
         str(e["id"]): bool(e.get("human_confirmed"))
-        for e in _load_yaml_list(pool_dir / _SIGNOFF_FILE, "residue")
+        for e in _load_yaml_list(signoff_dir / _SIGNOFF_FILE, "residue")
     }
 
     def entry(rid: str, confirmed: bool) -> dict[str, Any]:
@@ -646,7 +669,8 @@ def write_signoff(
         "# interrogation: absent is a retirement proposal: decline the mark to let the\n"
         "# rule lapse, or mark it to keep shipping it.\n"
     )
-    (pool_dir / _SIGNOFF_FILE).write_text(
+    signoff_dir.mkdir(parents=True, exist_ok=True)
+    (signoff_dir / _SIGNOFF_FILE).write_text(
         header + yaml.safe_dump({"residue": rows}, sort_keys=False)
     )
 
@@ -728,6 +752,10 @@ def absorb(args: argparse.Namespace) -> int:
     run_date = args.date or date.today().isoformat()
     pool_dir = pool_path(args.pool_root, engine, version, _UNION_FILE).parent
     pool_dir.mkdir(parents=True, exist_ok=True)
+    # The sign-off is the durable human approval record, so it lives in the
+    # versioned, git-tracked outputs/ snapshot dir (sibling of the gitignored
+    # candidates/ pool), not in the throwaway pool workspace.
+    signoff_dir = pool_dir.parent / "outputs"
     logger.info(
         "absorb engine=%s version=%s date=%s dry_run=%s", engine, version, run_date, args.dry_run
     )
@@ -776,11 +804,11 @@ def absorb(args: argparse.Namespace) -> int:
             "probe ladder verified nothing this run; every rule kept untouched, corpus unchanged"
         )
 
-    signed_off = read_signoff(pool_dir)
+    signed_off = read_signoff(signoff_dir)
     new_rules, delta = promote(
         engine, version, run_date, old_rules, verdicts, union, signed_off, interrogation_absent
     )
-    write_signoff(pool_dir, delta, old_by_id, set(interrogation_absent))
+    write_signoff(signoff_dir, delta, old_by_id, set(interrogation_absent))
 
     report = render_delta(delta, citations)
     print(report)

--- a/scripts/absorb.py
+++ b/scripts/absorb.py
@@ -755,6 +755,12 @@ def absorb(args: argparse.Namespace) -> int:
     # The sign-off is the durable human approval record, so it lives in the
     # versioned, git-tracked outputs/ snapshot dir (sibling of the gitignored
     # candidates/ pool), not in the throwaway pool workspace.
+    #
+    # Derived relative to pool_root (not via engine_versions._outputs.outputs_dir)
+    # on purpose: _outputs hardcodes the real repo root, so routing through it
+    # would break test isolation and custom pool roots by writing into the real
+    # engine_versions/ tree. With the default pool root this lands exactly in the
+    # git-tracked engine_versions/<engine>/v<safe>/outputs/ dir.
     signoff_dir = pool_dir.parent / "outputs"
     logger.info(
         "absorb engine=%s version=%s date=%s dry_run=%s", engine, version, run_date, args.dry_run

--- a/scripts/check_discovered_schema_versions.py
+++ b/scripts/check_discovered_schema_versions.py
@@ -35,11 +35,18 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from engine_versions import _outputs
 from scripts.engine_producers._common import DEFAULT_SCHEMA_FILENAME
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 _ENGINES = ("vllm", "tensorrt", "transformers")
+
+# The two on-disk copies of a discovered schema whose parameter surfaces must
+# not diverge: the src/ shadow the runtime loader and absorb read, and the
+# versioned outputs/ snapshot codegen reads. Only the version envelope is
+# compared elsewhere; these are the keys that carry the actual config surface.
+_SURFACE_KEYS = ("engine_params", "sampling_params")
 
 
 def _normalize_version(version: str) -> str:
@@ -59,6 +66,12 @@ def _parse_schema_version(schema_path: Path) -> Any:
     """Extract engine_version from a discovered schema JSON."""
     data = json.loads(schema_path.read_text())
     return data.get("engine_version")
+
+
+def _surface(schema_path: Path) -> dict[str, Any]:
+    """Parameter surface (engine + sampling params) of a discovered schema."""
+    data = json.loads(schema_path.read_text())
+    return {key: data.get(key) for key in _SURFACE_KEYS}
 
 
 def main(repo_root: Path | None = None, engines: tuple[str, ...] | None = None) -> int:
@@ -97,6 +110,26 @@ def main(repo_root: Path | None = None, engines: tuple[str, ...] | None = None) 
                 f"MISMATCH: {current_yaml.name} pins library.current_version={pinned_version} "
                 f"but schema was discovered against {schema_version}\n"
                 f"  Run: ./scripts/refresh_discovered_schemas.sh {engine}"
+            )
+            continue  # version already diverged; a surface diff would just be noise
+
+        # Guard the two schema copies against a surface divergence the version
+        # envelope alone cannot catch: the versioned outputs/ snapshot codegen
+        # reads must expose the same parameter surface as the src/ shadow the
+        # runtime loader and absorb read.
+        outputs_schema = (
+            engine_versions_dir / engine / _outputs.safe_version(pinned_version) / "outputs"
+        ) / DEFAULT_SCHEMA_FILENAME
+        try:
+            outputs_surface = _surface(outputs_schema)
+        except FileNotFoundError:
+            errors.append(f"{engine}: versioned schema snapshot not found: {outputs_schema}")
+            continue
+        if _surface(schema_path) != outputs_surface:
+            mismatches.append(
+                f"SURFACE MISMATCH: {schema_path} and {outputs_schema} agree on version "
+                f"{pinned_version} but their parameter surfaces differ\n"
+                f"  Re-run discovery so both copies carry the same surface."
             )
 
     if errors:

--- a/scripts/check_discovered_schema_versions.py
+++ b/scripts/check_discovered_schema_versions.py
@@ -62,10 +62,16 @@ def _current_version(current_yaml: Path) -> str | None:
     return None if value is None else str(value)
 
 
-def _parse_schema_version(schema_path: Path) -> Any:
-    """Extract engine_version from a discovered schema JSON."""
+def _read_schema(schema_path: Path) -> tuple[Any, dict[str, Any]]:
+    """Parse a discovered schema once, returning (engine_version, surface).
+
+    The surface is the parameter-carrying subset (engine + sampling params). One
+    read serves both the version-envelope check and the surface comparison, so a
+    single loop iteration never json.loads the same file twice.
+    """
     data = json.loads(schema_path.read_text())
-    return data.get("engine_version")
+    surface = {key: data.get(key) for key in _SURFACE_KEYS}
+    return data.get("engine_version"), surface
 
 
 def _surface(schema_path: Path) -> dict[str, Any]:
@@ -92,7 +98,7 @@ def main(repo_root: Path | None = None, engines: tuple[str, ...] | None = None) 
 
         schema_path = engines_dir / engine / DEFAULT_SCHEMA_FILENAME
         try:
-            schema_version = _parse_schema_version(schema_path)
+            schema_version, src_surface = _read_schema(schema_path)
         except FileNotFoundError:
             errors.append(f"{engine}: schema not found: {schema_path}")
             continue
@@ -119,13 +125,13 @@ def main(repo_root: Path | None = None, engines: tuple[str, ...] | None = None) 
         # runtime loader and absorb read.
         outputs_schema = (
             engine_versions_dir / engine / _outputs.safe_version(pinned_version) / "outputs"
-        ) / DEFAULT_SCHEMA_FILENAME
+        ) / _outputs.SCHEMA_FILENAME
         try:
             outputs_surface = _surface(outputs_schema)
         except FileNotFoundError:
             errors.append(f"{engine}: versioned schema snapshot not found: {outputs_schema}")
             continue
-        if _surface(schema_path) != outputs_surface:
+        if src_surface != outputs_surface:
             mismatches.append(
                 f"SURFACE MISMATCH: {schema_path} and {outputs_schema} agree on version "
                 f"{pinned_version} but their parameter surfaces differ\n"

--- a/scripts/check_pydantic_matches_discovered.py
+++ b/scripts/check_pydantic_matches_discovered.py
@@ -267,13 +267,6 @@ def _is_intentional_narrowing(discovered: str, pydantic: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-# Root $defs name of an engine's generated Config model. Codegen emits three
-# same-named classes (Config / EngineParams / SamplingParams) per engine, so
-# pydantic disambiguates them by module path; the root Config is the walk entry.
-def _engine_config_def(engine: str) -> str:
-    return f"llenergymeasure__engines__{engine}__config__Config"
-
-
 def _refs_in(prop: dict[str, Any]) -> list[str]:
     """$defs names a property references directly (bare, or inside anyOf/allOf)."""
     refs: list[str] = []
@@ -288,22 +281,51 @@ def _refs_in(prop: dict[str, Any]) -> list[str]:
     return refs
 
 
-def _collect_props(engine: str, defs: dict[str, Any]) -> dict[str, dict[str, Any]]:
+def _engine_config_def(engine: str, schema: dict[str, Any]) -> str:
+    """Root $defs name of an engine's generated Config model, resolved structurally.
+
+    The top-level ``ExperimentConfig`` schema carries one property per engine
+    (``schema["properties"][engine]``) whose $ref (inside an anyOf with null)
+    points at that engine's generated Config def. Following the ref here binds
+    the walk root to the actual schema structure rather than to the codegen
+    module path (``llenergymeasure__engines__<engine>__config__Config``), so a
+    codegen rename cannot silently leave the type check dormant - the exact
+    failure that hit when the pre-codegen names (``VLLMEngineConfig`` ...)
+    stopped matching. A missing property or unresolvable ref is loud, not silent.
+    """
+    prop = (schema.get("properties") or {}).get(engine)
+    if not isinstance(prop, dict):
+        raise SystemExit(
+            f"{engine}: no top-level property on ExperimentConfig; expected a $ref "
+            "to the engine's generated Config def. The type check would otherwise "
+            "go dormant - fix the structural walk root."
+        )
+    refs = [r for r in _refs_in(prop) if r in (schema.get("$defs") or {})]
+    if not refs:
+        raised = _refs_in(prop) or ["(no $ref)"]
+        raise SystemExit(
+            f"{engine}: ExperimentConfig property {engine!r} $ref {raised[0]!r} is "
+            "not in schema $defs; expected a $ref to the engine's generated Config "
+            "def. The type check would otherwise go dormant - fix the structural "
+            "walk root."
+        )
+    return refs[0]
+
+
+def _collect_props(engine: str, schema: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """All leaf property schemas reachable from an engine's Config def.
 
-    Walks $refs from the generated ``...__config__Config`` def (which fans out
-    to EngineParams / SamplingParams and any nested passthrough sub-configs the
-    vllm surface exposes, e.g. CompilationConfig / SpeculativeConfig). Resolving
-    structurally instead of via a hardcoded class-name list keeps this immune to
-    codegen renames - the exact failure that left the type check silently dormant
-    when the pre-codegen names (``VLLMEngineConfig`` ...) stopped matching.
+    Resolves the walk root structurally from the top-level ExperimentConfig
+    property for the engine, then walks $refs from that generated Config def
+    (which fans out to EngineParams / SamplingParams and any nested passthrough
+    sub-configs the vllm surface exposes, e.g. CompilationConfig /
+    SpeculativeConfig). Resolving structurally instead of via a hardcoded
+    class-name list keeps this immune to codegen renames - the exact failure
+    that left the type check silently dormant when the pre-codegen names
+    (``VLLMEngineConfig`` ...) stopped matching.
     """
-    root = _engine_config_def(engine)
-    if root not in defs:
-        raise SystemExit(
-            f"{engine}: config def {root!r} not in schema $defs; the generated "
-            "Config model was renamed - update _engine_config_def."
-        )
+    defs = schema.get("$defs") or {}
+    root = _engine_config_def(engine, schema)
     props: dict[str, dict[str, Any]] = {}
     seen: set[str] = set()
     queue = [root]
@@ -323,13 +345,12 @@ def _get_pydantic_leaves(engine: str, schema: dict[str, Any]) -> dict[str, dict[
 
     Returns dict mapping leaf_name -> JSON schema property dict.
     """
-    defs = schema.get("$defs", {})
     params = get_engine_params(engine)
 
-    all_props = _collect_props(engine, defs)
+    all_props = _collect_props(engine, schema)
     if not all_props:
         raise SystemExit(
-            f"{engine}: no properties reachable from {_engine_config_def(engine)!r}; "
+            f"{engine}: no properties reachable from the generated Config def; "
             "the type-equality check would be silently dormant. Fix the schema walk."
         )
 

--- a/scripts/check_pydantic_matches_discovered.py
+++ b/scripts/check_pydantic_matches_discovered.py
@@ -233,18 +233,25 @@ def _canonicalise_pydantic_type(prop: dict[str, Any], defs: dict[str, Any]) -> s
 
 
 def _is_intentional_narrowing(discovered: str, pydantic: str) -> bool:
-    """Check if Pydantic intentionally narrows a broad engine type.
+    """Check if Pydantic intentionally narrows or opaquely passes a broad engine type.
 
     Allowed patterns:
-    - str → Literal[...] (curating valid string values)
-    - int → Literal[...] (curating valid int values)
-    - Complex class type → simpler Pydantic type (e.g. CompilationConfig → dict)
+    - str -> Literal[...] (curating valid string values)
+    - int -> Literal[...] (curating valid int values)
+    - Complex class type -> simpler Pydantic type (e.g. CompilationConfig -> dict)
+    - anything -> any (opaque passthrough: llem declines to type a complex field
+      and lets it through the extra="allow" surface with soft validation against
+      the discovered schema - a nested sub-config, a set/list container, or a
+      broad str/type union. Widening to Any is the maximal non-narrowing, so it
+      is not drift.)
     """
+    if pydantic == "any":
+        return True
     if pydantic.startswith("Literal["):
-        # Simple base type → Literal (str → Literal['a', 'b'])
+        # Simple base type -> Literal (str -> Literal['a', 'b'])
         if discovered in ("str", "int", "float"):
             return True
-        # Compound type containing str → Literal (str | SomeClass → Literal['a', 'b'])
+        # Compound type containing str -> Literal (str | SomeClass -> Literal['a', 'b'])
         if "|" in discovered and any(p.strip() == "str" for p in discovered.split("|")):
             return True
     # Complex discovered type (class name) mapped to simple Pydantic type
@@ -260,6 +267,57 @@ def _is_intentional_narrowing(discovered: str, pydantic: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+# Root $defs name of an engine's generated Config model. Codegen emits three
+# same-named classes (Config / EngineParams / SamplingParams) per engine, so
+# pydantic disambiguates them by module path; the root Config is the walk entry.
+def _engine_config_def(engine: str) -> str:
+    return f"llenergymeasure__engines__{engine}__config__Config"
+
+
+def _refs_in(prop: dict[str, Any]) -> list[str]:
+    """$defs names a property references directly (bare, or inside anyOf/allOf)."""
+    refs: list[str] = []
+    ref = prop.get("$ref")
+    if isinstance(ref, str):
+        refs.append(ref.split("/")[-1])
+    for key in ("anyOf", "allOf"):
+        for member in prop.get(key) or []:
+            member_ref = member.get("$ref") if isinstance(member, dict) else None
+            if isinstance(member_ref, str):
+                refs.append(member_ref.split("/")[-1])
+    return refs
+
+
+def _collect_props(engine: str, defs: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """All leaf property schemas reachable from an engine's Config def.
+
+    Walks $refs from the generated ``...__config__Config`` def (which fans out
+    to EngineParams / SamplingParams and any nested passthrough sub-configs the
+    vllm surface exposes, e.g. CompilationConfig / SpeculativeConfig). Resolving
+    structurally instead of via a hardcoded class-name list keeps this immune to
+    codegen renames - the exact failure that left the type check silently dormant
+    when the pre-codegen names (``VLLMEngineConfig`` ...) stopped matching.
+    """
+    root = _engine_config_def(engine)
+    if root not in defs:
+        raise SystemExit(
+            f"{engine}: config def {root!r} not in schema $defs; the generated "
+            "Config model was renamed - update _engine_config_def."
+        )
+    props: dict[str, dict[str, Any]] = {}
+    seen: set[str] = set()
+    queue = [root]
+    while queue:
+        name = queue.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        for leaf, prop in (defs.get(name, {}).get("properties", {}) or {}).items():
+            props.setdefault(leaf, prop)
+            queue += _refs_in(prop)
+    return props
+
+
 def _get_pydantic_leaves(engine: str, schema: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Get flattened Pydantic leaves for an engine with their JSON schema props.
 
@@ -267,40 +325,16 @@ def _get_pydantic_leaves(engine: str, schema: dict[str, Any]) -> dict[str, dict[
     """
     defs = schema.get("$defs", {})
     params = get_engine_params(engine)
-    result: dict[str, dict[str, Any]] = {}
 
-    # Build a lookup from the JSON schema for detailed type info
-    engine_config_names = {
-        "transformers": ["TransformersConfig"],
-        "vllm": [
-            "VLLMEngineConfig",
-            "VLLMSamplingConfig",
-            "VLLMBeamSearchConfig",
-            "VLLMAttentionConfig",
-            "VLLMSpeculativeConfig",
-        ],
-        "tensorrt": [
-            "TensorRTConfig",
-            "TensorRTQuantConfig",
-            "TensorRTKvCacheConfig",
-            "TensorRTSamplingConfig",
-            "TensorRTSchedulerConfig",
-        ],
-    }
-
-    # Collect all properties from relevant $defs
-    all_props: dict[str, dict[str, Any]] = {}
-    for config_name in engine_config_names.get(engine, []):
-        if config_name in defs:
-            props = defs[config_name].get("properties", {})
-            all_props.update(props)
+    all_props = _collect_props(engine, defs)
+    if not all_props:
+        raise SystemExit(
+            f"{engine}: no properties reachable from {_engine_config_def(engine)!r}; "
+            "the type-equality check would be silently dormant. Fix the schema walk."
+        )
 
     # Match introspection output to JSON schema props
-    for _path, meta in params.items():
-        leaf_name = meta["name"]
-        result[leaf_name] = all_props.get(leaf_name, {})
-
-    return result
+    return {meta["name"]: all_props.get(meta["name"], {}) for meta in params.values()}
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/probe_candidates.sh
+++ b/scripts/probe_candidates.sh
@@ -15,10 +15,15 @@
 #   vllm         -> pristine vllm/vllm-openai:v<version>
 #   tensorrt     -> pristine nvcr.io/nvidia/tensorrt-llm/release:<version>
 #   transformers -> llenergymeasure:transformers-<version> (built locally if absent)
-# tensorrt binds CUDA at import, so it keeps the NVIDIA entrypoint and is pinned
-# to GPUs 1-3 (device 0 stays free); vllm/transformers need no GPU to construct
-# config objects.
+# tensorrt binds CUDA at import, so it keeps the NVIDIA entrypoint and needs a
+# GPU; vllm/transformers need no GPU to construct config objects. The tensorrt
+# GPU selection defaults to devices 1-3 (device 0 stays free on the reference
+# host) and is overridable via LLEM_PROBE_GPUS for hosts with a different layout
+# (e.g. LLEM_PROBE_GPUS='device=0' on a single-GPU host).
 set -euo pipefail
+
+# Docker --gpus device selector for the tensorrt probe; override for other hosts.
+LLEM_PROBE_GPUS="${LLEM_PROBE_GPUS:-device=1,2,3}"
 
 usage() {
     cat <<'EOF'
@@ -93,8 +98,9 @@ DOCKER_ARGS=(
 
 echo "[$ENGINE] Running probe_candidates.py inside $IMAGE..." >&2
 if [[ "$ENGINE" == "tensorrt" ]]; then
-    # Keep the NVIDIA entrypoint (it sets up the CUDA env before exec); pin GPUs 1-3.
-    docker run "${DOCKER_ARGS[@]}" --gpus '"device=1,2,3"' "$IMAGE" \
+    # Keep the NVIDIA entrypoint (it sets up the CUDA env before exec); GPU
+    # selection from LLEM_PROBE_GPUS (default device=1,2,3, device 0 free).
+    docker run "${DOCKER_ARGS[@]}" --gpus "\"${LLEM_PROBE_GPUS}\"" "$IMAGE" \
         python3 scripts/probe_candidates.py --engine "$ENGINE" "$@"
 else
     docker run "${DOCKER_ARGS[@]}" --entrypoint python3 "$IMAGE" \

--- a/tests/unit/scripts/test_absorb.py
+++ b/tests/unit/scripts/test_absorb.py
@@ -10,6 +10,8 @@ and the skip flags write nothing they should not.
 
 from __future__ import annotations
 
+import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -455,6 +457,40 @@ def test_ladder_memory_skips_already_verdicted(
     assert calls == []  # already carries a verdict; not re-probed
 
 
+def test_citation_pass_rate_cleans_up_temp_on_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The citation gate writes a throwaway input file; an exception mid-check must
+    not leave it behind in the pool dir (try/finally cleanup)."""
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("citation check exploded")
+
+    monkeypatch.setattr(ab, "load_candidates", _boom)
+    union = [_cand("vllm_a", "error", {"vllm.sampling_params.temperature": {"<": 0}})]
+    with pytest.raises(RuntimeError, match="exploded"):
+        ab.citation_pass_rate(union, tmp_path, tmp_path)
+    assert not (tmp_path / "_citation_input.yaml").exists()
+
+
+def test_run_probe_hard_errors_on_nonzero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A probe wrapper that exits non-zero before writing verdicts must be a hard
+    error, not a silent no-op absorb (the operator would otherwise read the empty
+    result as a clean 'nothing to probe')."""
+    probe_input = tmp_path / "_probe_input.yaml"
+    probe_input.write_text("candidates: []\n")
+
+    def _crash(*args: Any, **kwargs: Any) -> Any:
+        return subprocess.CompletedProcess(args=args, returncode=1)
+
+    monkeypatch.setattr(ab.subprocess, "run", _crash)
+    monkeypatch.setattr(ab, "_require_under_repo", lambda p: Path(p.name))
+    with pytest.raises(SystemExit, match=re.escape("probe_candidates.sh")):
+        ab.run_probe("vllm", probe_input, "2026-07-07")
+
+
 # --- Orchestration: --dry-run + skip flags ---
 
 
@@ -548,9 +584,14 @@ def test_signoff_mark_survives_across_reruns(
     pool_root = tmp_path / "pool"
     pool_dir = ab.pool_path(pool_root, "vllm", "0.19.1", "x").parent
     pool_dir.mkdir(parents=True)
+    # The sign-off is the durable approval record: it lives in the versioned,
+    # git-tracked outputs/ snapshot dir (sibling of the gitignored candidates/
+    # pool), so it survives a fresh clone.
+    signoff_dir = pool_dir.parent / "outputs"
+    signoff_dir.mkdir(parents=True)
     # Pre-seed the human sign-off mark. No analyst pool file: the rule is never
     # rediscovered, and with --skip-interrogation it is never proposed for retirement.
-    (pool_dir / ab._SIGNOFF_FILE).write_text(
+    (signoff_dir / ab._SIGNOFF_FILE).write_text(
         yaml.safe_dump({"residue": [{"id": "vllm_signed", "human_confirmed": True}]})
     )
 
@@ -559,13 +600,15 @@ def test_signoff_mark_survives_across_reruns(
     ab.absorb(args)
     first = corpus.read_text()
     assert "vllm_signed" in first  # ships via the sign-off path ...
-    assert ab.read_signoff(pool_dir) == {"vllm_signed"}  # ... and the mark is retained
+    assert ab.read_signoff(signoff_dir) == {"vllm_signed"}  # ... and the mark is retained
+    # The gitignored candidates/ pool must NOT hold the durable approval record.
+    assert not (pool_dir / ab._SIGNOFF_FILE).exists()
 
     ab.absorb(_args(pool_root, skip_cold_read=True, skip_interrogation=True, skip_probe=False))
     second = corpus.read_text()
     assert second == first  # byte-identical: no oscillation across re-runs
     assert "vllm_signed" in second
-    assert ab.read_signoff(pool_dir) == {"vllm_signed"}  # mark still alive after run two
+    assert ab.read_signoff(signoff_dir) == {"vllm_signed"}  # mark still alive after run two
 
 
 def test_skip_flags_bypass_cold_read_and_probe(

--- a/tests/unit/scripts/test_analyst_cold_read.py
+++ b/tests/unit/scripts/test_analyst_cold_read.py
@@ -352,12 +352,33 @@ def test_no_split_when_under_cap(fake_tree: Any) -> None:
 # Manifest loading.
 def test_missing_manifest_fails_clearly() -> None:
     with pytest.raises(FileNotFoundError) as exc:
-        acr.load_manifest("transformers")
+        acr.load_manifest("no-such-engine")
     assert "no analyst cluster manifest" in str(exc.value)
-    assert "transformers" in str(exc.value)
+    assert "no-such-engine" in str(exc.value)
 
 
 def test_vllm_manifest_loads() -> None:
     manifest = acr.load_manifest("vllm")
     assert "sampling" in manifest and "platforms" in manifest
     assert "engine/arg_utils.py" not in [p for ps in manifest.values() for p in ps]
+
+
+@pytest.mark.parametrize("engine", ["transformers", "tensorrt"])
+def test_every_engine_ships_a_manifest(engine: str) -> None:
+    """Cold-read must be operable for every engine: each ships a manifest with
+    non-empty clusters (citation-grounded starters for transformers/tensorrt)."""
+    manifest = acr.load_manifest(engine)
+    assert manifest, f"{engine}: manifest has no clusters"
+    assert all(patterns for patterns in manifest.values())
+
+
+def test_transformers_manifest_covers_cited_sources() -> None:
+    paths = [p for ps in acr.load_manifest("transformers").values() for p in ps]
+    assert "generation/configuration_utils.py" in paths
+    assert "utils/quantization_config.py" in paths
+
+
+def test_tensorrt_manifest_covers_cited_sources() -> None:
+    paths = [p for ps in acr.load_manifest("tensorrt").values() for p in ps]
+    assert "llmapi/llm_args.py" in paths
+    assert "sampling_params.py" in paths

--- a/tests/unit/scripts/test_analyst_cold_read.py
+++ b/tests/unit/scripts/test_analyst_cold_read.py
@@ -372,13 +372,14 @@ def test_every_engine_ships_a_manifest(engine: str) -> None:
     assert all(patterns for patterns in manifest.values())
 
 
-def test_transformers_manifest_covers_cited_sources() -> None:
-    paths = [p for ps in acr.load_manifest("transformers").values() for p in ps]
-    assert "generation/configuration_utils.py" in paths
-    assert "utils/quantization_config.py" in paths
-
-
-def test_tensorrt_manifest_covers_cited_sources() -> None:
-    paths = [p for ps in acr.load_manifest("tensorrt").values() for p in ps]
-    assert "llmapi/llm_args.py" in paths
-    assert "sampling_params.py" in paths
+@pytest.mark.parametrize(
+    "engine,expected",
+    [
+        ("transformers", ["generation/configuration_utils.py", "utils/quantization_config.py"]),
+        ("tensorrt", ["llmapi/llm_args.py", "sampling_params.py"]),
+    ],
+)
+def test_manifest_covers_cited_sources(engine: str, expected: list[str]) -> None:
+    paths = [p for ps in acr.load_manifest(engine).values() for p in ps]
+    for source in expected:
+        assert source in paths

--- a/tests/unit/scripts/test_check_discovered_schema_versions.py
+++ b/tests/unit/scripts/test_check_discovered_schema_versions.py
@@ -34,59 +34,41 @@ def _setup_repo(
 ) -> Path:
     """Create a minimal repo structure for the version check script.
 
-    Each engine gets a current.yaml pin, a src/ shadow schema, and a matching
-    versioned outputs/ snapshot schema. ``vllm_src_surface`` /
-    ``vllm_outputs_surface`` override the two vllm parameter surfaces so a
-    surface divergence can be simulated (they default to the same empty surface).
+    Each engine gets a current.yaml pin, a src/ shadow schema, and a versioned
+    outputs/ snapshot schema. The outputs dir is named by the pin (``*_current``)
+    while the schemas carry ``*_schema_version``, so the two can diverge to drive
+    a version-mismatch test. ``vllm_src_surface`` / ``vllm_outputs_surface``
+    override the two vllm parameter surfaces so a surface divergence can be
+    simulated (they default to the same empty surface).
     """
     repo = tmp_path / "repo"
     engine_versions_dir = repo / "engine_versions"
-
-    for engine, version in [
-        ("vllm", vllm_current),
-        ("tensorrt", trt_current),
-        ("transformers", transformers_current),
-    ]:
-        engine_dir = engine_versions_dir / engine
-        engine_dir.mkdir(parents=True)
-        (engine_dir / "current.yaml").write_text(_current_yaml(version))
-
     engines_dir = repo / "src" / "llenergymeasure" / "engines"
     empty_surface: dict[str, dict] = {"engine_params": {}, "sampling_params": {}}
 
-    def _write_schema(
-        engine: str,
-        version: str,
-        *,
-        src_surface: dict | None = None,
-        outputs_surface: dict | None = None,
-        outputs_version: str | None = None,
-    ) -> None:
+    specs = [
+        ("vllm", vllm_current, vllm_schema_version, vllm_src_surface, vllm_outputs_surface),
+        ("tensorrt", trt_current, trt_schema_version, None, None),
+        ("transformers", transformers_current, transformers_schema_version, None, None),
+    ]
+    for engine, current, schema_version, src_surface, outputs_surface in specs:
+        engine_dir = engine_versions_dir / engine
+        engine_dir.mkdir(parents=True)
+        (engine_dir / "current.yaml").write_text(_current_yaml(current))
+        if engine == "vllm" and skip_vllm_schema:
+            continue
         # src/ shadow (runtime loader + absorb read this copy)
         src_dir = engines_dir / engine
         src_dir.mkdir(parents=True, exist_ok=True)
         (src_dir / "schema.discovered.json").write_text(
-            json.dumps({"engine_version": version, **(src_surface or empty_surface)})
+            json.dumps({"engine_version": schema_version, **(src_surface or empty_surface)})
         )
-        # versioned outputs/ snapshot (codegen reads this copy)
-        out_dir = (
-            engine_versions_dir / engine / _safe_version(outputs_version or version) / "outputs"
-        )
+        # versioned outputs/ snapshot codegen reads (dir named by the pin)
+        out_dir = engine_versions_dir / engine / _safe_version(current) / "outputs"
         out_dir.mkdir(parents=True, exist_ok=True)
         (out_dir / "schema.discovered.json").write_text(
-            json.dumps({"engine_version": version, **(outputs_surface or empty_surface)})
+            json.dumps({"engine_version": schema_version, **(outputs_surface or empty_surface)})
         )
-
-    if not skip_vllm_schema:
-        _write_schema(
-            "vllm",
-            vllm_schema_version,
-            src_surface=vllm_src_surface,
-            outputs_surface=vllm_outputs_surface,
-            outputs_version=vllm_current,
-        )
-    _write_schema("tensorrt", trt_schema_version, outputs_version=trt_current)
-    _write_schema("transformers", transformers_schema_version, outputs_version=transformers_current)
 
     return repo
 

--- a/tests/unit/scripts/test_check_discovered_schema_versions.py
+++ b/tests/unit/scripts/test_check_discovered_schema_versions.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 # Import the script's main function directly.
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 from check_discovered_schema_versions import main
+
+from engine_versions._outputs import safe_version as _safe_version
 
 
 def _current_yaml(version: str) -> str:
@@ -26,8 +29,16 @@ def _setup_repo(
     transformers_current: str = "5.5.4",
     transformers_schema_version: str = "5.5.4",
     skip_vllm_schema: bool = False,
+    vllm_src_surface: dict | None = None,
+    vllm_outputs_surface: dict | None = None,
 ) -> Path:
-    """Create a minimal repo structure for the version check script."""
+    """Create a minimal repo structure for the version check script.
+
+    Each engine gets a current.yaml pin, a src/ shadow schema, and a matching
+    versioned outputs/ snapshot schema. ``vllm_src_surface`` /
+    ``vllm_outputs_surface`` override the two vllm parameter surfaces so a
+    surface divergence can be simulated (they default to the same empty surface).
+    """
     repo = tmp_path / "repo"
     engine_versions_dir = repo / "engine_versions"
 
@@ -41,16 +52,41 @@ def _setup_repo(
         (engine_dir / "current.yaml").write_text(_current_yaml(version))
 
     engines_dir = repo / "src" / "llenergymeasure" / "engines"
+    empty_surface: dict[str, dict] = {"engine_params": {}, "sampling_params": {}}
 
-    def _write_schema(engine: str, version: str) -> None:
-        engine_dir = engines_dir / engine
-        engine_dir.mkdir(parents=True, exist_ok=True)
-        (engine_dir / "schema.discovered.json").write_text(json.dumps({"engine_version": version}))
+    def _write_schema(
+        engine: str,
+        version: str,
+        *,
+        src_surface: dict | None = None,
+        outputs_surface: dict | None = None,
+        outputs_version: str | None = None,
+    ) -> None:
+        # src/ shadow (runtime loader + absorb read this copy)
+        src_dir = engines_dir / engine
+        src_dir.mkdir(parents=True, exist_ok=True)
+        (src_dir / "schema.discovered.json").write_text(
+            json.dumps({"engine_version": version, **(src_surface or empty_surface)})
+        )
+        # versioned outputs/ snapshot (codegen reads this copy)
+        out_dir = (
+            engine_versions_dir / engine / _safe_version(outputs_version or version) / "outputs"
+        )
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "schema.discovered.json").write_text(
+            json.dumps({"engine_version": version, **(outputs_surface or empty_surface)})
+        )
 
     if not skip_vllm_schema:
-        _write_schema("vllm", vllm_schema_version)
-    _write_schema("tensorrt", trt_schema_version)
-    _write_schema("transformers", transformers_schema_version)
+        _write_schema(
+            "vllm",
+            vllm_schema_version,
+            src_surface=vllm_src_surface,
+            outputs_surface=vllm_outputs_surface,
+            outputs_version=vllm_current,
+        )
+    _write_schema("tensorrt", trt_schema_version, outputs_version=trt_current)
+    _write_schema("transformers", transformers_schema_version, outputs_version=transformers_current)
 
     return repo
 
@@ -86,6 +122,19 @@ class TestMismatch:
         captured = capsys.readouterr()
         assert "MISMATCH" in captured.err
         assert "transformers" in captured.err
+
+    def test_surface_divergence_between_copies(self, tmp_path: Path, capsys):
+        """Versions agree, but the src/ and outputs/ parameter surfaces differ."""
+        repo = _setup_repo(
+            tmp_path,
+            vllm_src_surface={"engine_params": {"max_num_seqs": {}}, "sampling_params": {}},
+            vllm_outputs_surface={"engine_params": {}, "sampling_params": {}},
+        )
+        code = main(repo_root=repo)
+        assert code == 1
+        captured = capsys.readouterr()
+        assert "SURFACE MISMATCH" in captured.err
+        assert "vllm" in captured.err
 
 
 class TestErrors:

--- a/tests/unit/scripts/test_check_discovered_schema_versions.py
+++ b/tests/unit/scripts/test_check_discovered_schema_versions.py
@@ -47,15 +47,22 @@ def _setup_repo(
     empty_surface: dict[str, dict] = {"engine_params": {}, "sampling_params": {}}
 
     specs = [
-        ("vllm", vllm_current, vllm_schema_version, vllm_src_surface, vllm_outputs_surface),
-        ("tensorrt", trt_current, trt_schema_version, None, None),
-        ("transformers", transformers_current, transformers_schema_version, None, None),
+        (
+            "vllm",
+            vllm_current,
+            vllm_schema_version,
+            vllm_src_surface,
+            vllm_outputs_surface,
+            skip_vllm_schema,
+        ),
+        ("tensorrt", trt_current, trt_schema_version, None, None, False),
+        ("transformers", transformers_current, transformers_schema_version, None, None, False),
     ]
-    for engine, current, schema_version, src_surface, outputs_surface in specs:
+    for engine, current, schema_version, src_surface, outputs_surface, skip_schema in specs:
         engine_dir = engine_versions_dir / engine
         engine_dir.mkdir(parents=True)
         (engine_dir / "current.yaml").write_text(_current_yaml(current))
-        if engine == "vllm" and skip_vllm_schema:
+        if skip_schema:
             continue
         # src/ shadow (runtime loader + absorb read this copy)
         src_dir = engines_dir / engine

--- a/tests/unit/scripts/test_check_pydantic_matches_discovered.py
+++ b/tests/unit/scripts/test_check_pydantic_matches_discovered.py
@@ -10,7 +10,6 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parents[3] / "scripts"))
 sys.path.insert(0, str(Path(__file__).parents[3] / "src"))
 
-import check_pydantic_matches_discovered as cpm
 from check_pydantic_matches_discovered import (
     _canonicalise_discovered_type,
     _canonicalise_pydantic_type,
@@ -129,22 +128,21 @@ def test_collect_props_reaches_generated_config(engine: str) -> None:
     from llenergymeasure.config.models import ExperimentConfig
 
     schema = ExperimentConfig.model_json_schema()
-    assert _collect_props(engine, schema["$defs"]), f"no props reachable for {engine}"
+    assert _collect_props(engine, schema), f"no props reachable for {engine}"
 
 
-def test_bogus_config_def_fails_loudly() -> None:
-    """A config-def name that matches nothing must raise, not silently compare zero
-    fields - the guard that keeps the type check from going dormant again."""
+def test_bogus_config_def_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A root resolution that matches nothing must raise, not silently compare zero
+    fields - the guard that keeps the type check from going dormant again. Point the
+    engine property at a $defs entry that does not exist and confirm the loud fail."""
     from llenergymeasure.config.models import ExperimentConfig
 
     schema = ExperimentConfig.model_json_schema()
-    original = cpm._engine_config_def
-    cpm._engine_config_def = lambda engine: "NoSuchConfigDef"
-    try:
-        with pytest.raises(SystemExit, match="not in schema"):
-            _collect_props("vllm", schema["$defs"])
-    finally:
-        cpm._engine_config_def = original
+    bogus = {p: dict(v) for p, v in schema["properties"].items()}
+    bogus["vllm"] = {"anyOf": [{"$ref": "#/$defs/NoSuchConfigDef"}, {"type": "null"}]}
+    monkeypatch.setitem(schema, "properties", bogus)
+    with pytest.raises(SystemExit, match="not in schema"):
+        _collect_props("vllm", schema)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_check_pydantic_matches_discovered.py
+++ b/tests/unit/scripts/test_check_pydantic_matches_discovered.py
@@ -10,9 +10,11 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parents[3] / "scripts"))
 sys.path.insert(0, str(Path(__file__).parents[3] / "src"))
 
+import check_pydantic_matches_discovered as cpm
 from check_pydantic_matches_discovered import (
     _canonicalise_discovered_type,
     _canonicalise_pydantic_type,
+    _collect_props,
     _is_intentional_narrowing,
     check_engine,
 )
@@ -107,6 +109,42 @@ class TestIntentionalNarrowing:
 
     def test_widening_not_allowed(self) -> None:
         assert _is_intentional_narrowing("Literal['a']", "str") is False
+
+    def test_opaque_passthrough_allowed(self) -> None:
+        # llem declines to type a complex field and passes it through as Any;
+        # that maximal non-narrowing is intentional, not drift.
+        assert _is_intentional_narrowing("QuantConfig", "any") is True
+        assert _is_intentional_narrowing("set[str]", "any") is True
+
+
+# ---------------------------------------------------------------------------
+# Structural $defs walk (rename-immune; must not go dormant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("engine", ["transformers", "vllm", "tensorrt"])
+def test_collect_props_reaches_generated_config(engine: str) -> None:
+    """The walk resolves the generated ...__config__Config def and reaches its
+    fields - the live comparison the pre-codegen name map silently stopped doing."""
+    from llenergymeasure.config.models import ExperimentConfig
+
+    schema = ExperimentConfig.model_json_schema()
+    assert _collect_props(engine, schema["$defs"]), f"no props reachable for {engine}"
+
+
+def test_bogus_config_def_fails_loudly() -> None:
+    """A config-def name that matches nothing must raise, not silently compare zero
+    fields - the guard that keeps the type check from going dormant again."""
+    from llenergymeasure.config.models import ExperimentConfig
+
+    schema = ExperimentConfig.model_json_schema()
+    original = cpm._engine_config_def
+    cpm._engine_config_def = lambda engine: "NoSuchConfigDef"
+    try:
+        with pytest.raises(SystemExit, match="not in schema"):
+            _collect_props("vllm", schema["$defs"])
+    finally:
+        cpm._engine_config_def = original
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
One slice of the reviewed workflow-fitness fix plan. Makes the absorb
knowledge-refresh pipeline operable on any engine and hardens it so a bump can
never silently no-op, plus durably tracks the human sign-off.

## Fixes (finding ids)

- **L2-2** Sign-off relocation. The residue sign-off (`absorb_signoff.yaml`)
  moves from the gitignored `engine_versions/**/candidates/` pool to the
  versioned, git-tracked `engine_versions/<engine>/v<safe>/outputs/` snapshot
  dir, so the maintainer approval record survives a fresh clone. `read_signoff`
  / `write_signoff` now take the outputs dir; absorb resolves it as the
  candidates-pool sibling. `candidates/` stays gitignored. absorb.py is the sole
  reader/writer, so no other callers needed updating.
- **L2-3** Probe-crash is now a hard error. A probe wrapper that exits non-zero
  before writing verdicts (docker pull failure, missing image, entrypoint crash)
  used to leave every candidate unverified and read as a clean "corpus
  unchanged". It now raises `SystemExit` naming the wrapper and exit code.
- **L2-4** Reactivate `check_pydantic_matches_discovered.py`. The hardcoded
  `engine_config_names` map predated codegen and matched nothing (dormant since
  the SSOT/codegen rename), so the type check silently compared zero fields.
  Replaced with a structural `$defs` walk from the generated
  `llenergymeasure__engines__<engine>__config__Config` def; the walk fans out
  through EngineParams / SamplingParams and nested passthrough sub-configs.
  A config-def name that matches nothing now raises loudly (the dormancy
  tripwire). Opaque `any` passthrough is treated as intentional non-narrowing.
- **L2-5** New `make scaffold-snapshot ENGINE=<engine>` target scaffolds
  `engine_versions/<engine>/v<safe>/outputs/` from the `current.yaml` pin,
  deriving `v<safe>` via the single mangling authority
  (`engine_versions/_outputs.py`). `regen_engine_configs.py` friendly error left
  untouched (it does not tell users to hand-create the dir, so PR #769 wording
  is preserved).
- **L2-6** Parameterize the hardcoded tensorrt probe `--gpus '"device=1,2,3"'`
  via `LLEM_PROBE_GPUS` (default `device=1,2,3`), matching the existing
  `LLEM_PROBE_*` convention.
- **L2-10** `citation_pass_rate` cleans up its temp pool file on exception
  (try/finally + `unlink(missing_ok=True)`).
- **L2-11** `check_discovered_schema_versions.py` asserts the `src/` shadow and
  the versioned `outputs/` snapshot expose the same parameter surface (not just
  the same version envelope).

## Not done (stopped per brief)

- **Absorb cluster manifests for transformers + tensorrt** (item 1). STOPPED:
  requires genuine domain judgment beyond mirroring structure. `analyst_clusters.yaml`
  maps cluster names to upstream source-file glob patterns (e.g. `config/parallel.py`),
  which are not derivable from any repo data - the discovered schema records only
  field type/default, and landmarks are dotted import symbols, not source file
  layouts. Authoring them requires knowing each library's source-tree
  organization. `make absorb` for these two engines still fails clearly at
  `load_manifest` naming the file to author.

## Gates

- `make lint`, `make typecheck` green
- `pytest tests/unit`: 2809 passed, 44 skipped
- Per-engine `regen_engine_configs.py --check` byte-identical (vllm 0.19.1,
  tensorrt 1.0.0, transformers 5.7.0)
- `make docs-check`: up to date (no drift)

Plan: `.product/designs/workflow-fitness-review-2026-07-08/synthesis.md`