### PR TITLE
fix(ci): fan-in gate so engine rules check is requireable without deadlock

### DIFF
--- a/.github/workflows/engine-rules-check.yml
+++ b/.github/workflows/engine-rules-check.yml
@@ -20,6 +20,10 @@ name: Engine rules check
 #      for the current pin already exists in GHCR, so a bump PR that forgot to
 #      seed fails at PR time rather than at merge-time promotion.
 #
+#   4. engine-rules-gate: matrix-free fan-in over the gating jobs; the only
+#      context from this workflow that branch protection requires. See the
+#      job comment for why the matrix job names cannot be required directly.
+#
 # transformers is absent from the coverage report on purpose: its config
 # validation uses imperative post-init idioms that the validator-site model
 # does not recognise, so a coverage number there would be noise. It is still
@@ -259,3 +263,29 @@ jobs:
             echo "otherwise the merge-time promotion (publish-engine-image.yml) will fail." >&2
             exit 1
           fi
+
+  engine-rules-gate:
+    # Branch protection requires this single context instead of the per-engine
+    # matrix names. When a matrix job is skipped at job level, GitHub reports
+    # ONE check run under the unexpanded job name, so expanded-name required
+    # contexts like "config-codegen (vllm)" never report on non-engine PRs and
+    # the merge waits forever on "Expected". This job is matrix-free and runs
+    # on every PR, so it always reports; it fails iff a gating job failed
+    # (skipped gating jobs on non-engine PRs pass).
+    needs: [config-codegen, seed-image-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail when a gating job failed
+        env:
+          CODEGEN: ${{ needs.config-codegen.result }}
+          SEED: ${{ needs.seed-image-check.result }}
+        run: |
+          echo "config-codegen: ${CODEGEN}"
+          echo "seed-image-check: ${SEED}"
+          for result in "${CODEGEN}" "${SEED}"; do
+            case "${result}" in
+              success|skipped) ;;
+              *) exit 1 ;;
+            esac
+          done


### PR DESCRIPTION
## Problem

Branch protection (set alongside #769) requires the matrix-expanded contexts
config-codegen (transformers|vllm|tensorrt). When a PR touches no engine
paths, the engine-filter job skips config-codegen at JOB level - and GitHub
reports a job-level-skipped matrix job as ONE check run under the unexpanded
job name (config-codegen), never the expanded names. The required contexts
therefore never report and the merge waits forever on Expected. #771 is
deadlocked this way right now - the first PR since the required-checks change
that does not trip the engine filter.

The always-run + per-job filter design (no workflow-level paths) is sound for
non-matrix jobs; the matrix expansion nuance is the gap.

## Fix

Add engine-rules-gate: a matrix-free fan-in job (needs: config-codegen,
seed-image-check; if: always()) that always reports and fails iff a gating
job failed - skipped gating jobs on non-engine PRs pass. Branch protection
swaps the three expanded contexts for this single one (applied after merge).

seed-image-check joins the gate because the workflow header already declares
it gating ("fails at PR time rather than at merge-time promotion"), but it was
absent from the required set, so it could not actually block a merge.

rules-coverage stays out: advisory by design, never fails.

## Verification

- This PR touches the workflow file itself, which is in the engine filter
  paths, so the full matrix runs here and must be green under the CURRENT
  required contexts before merge.
- After merge + protection swap: #771 update-branch exercises the skipped-leg
  path (non-engine PR -> gate passes on skipped results).