### PR TITLE
feat(ci): self-hosted renovate cron

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,7 +44,7 @@ jobs:
   renovate:
     name: Run Renovate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Mint llem-ci-bot App token
         id: app-token
@@ -58,9 +58,8 @@ jobs:
         env:
           # Renovate discovers renovate.json from the target repo itself, so no
           # global configurationFile is set here. RENOVATE_REPOSITORIES scopes
-          # the run to this repo; ONBOARDING is off because renovate.json exists.
+          # the run to this repo.
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ONBOARDING: 'false'
           # LOG_LEVEL is forwarded to the Renovate container by the action's
           # default env-regex allowlist.
           LOG_LEVEL: ${{ inputs.log_level || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,68 @@
+name: Renovate
+
+# Self-hosted Renovate cron. The hosted Mend Renovate app stopped visiting
+# this repo on 2026-04-29 (its last update PR and its last dependency-dashboard
+# refresh both landed that day, and later config edits and a dashboard checkbox
+# request drew no reaction). This workflow replaces that hosted app by running
+# Renovate ourselves on a schedule.
+#
+# Authentication uses the llem-ci-bot GitHub App token (minted from the APP_ID
+# and APP_PRIVATE_KEY repo secrets), not the default GITHUB_TOKEN. This is
+# deliberate: pull requests opened with an App token trigger CI, whereas PRs
+# opened with GITHUB_TOKEN would not (GitHub suppresses workflow runs on commits
+# it pushed itself, to avoid recursion). Update PRs must run CI to be reviewable.
+#
+# The in-config `schedule` in renovate.json ("before 9am on Monday") still gates
+# when update PRs are actually created, so this cron does not change bump
+# cadence. This workflow runs daily so the dependency dashboard stays fresh:
+# dashboard staleness is the liveness signal that diagnosed the hosted app's
+# death, and a daily run also picks up dashboard-checkbox requests and
+# vulnerability alerts within a day rather than only on the weekly bump window.
+
+on:
+  schedule:
+    - cron: '23 5 * * *'  # daily 05:23 UTC (off-peak, avoids the Monday crons)
+  workflow_dispatch:
+    inputs:
+      log_level:
+        description: 'Renovate log level (info or debug)'
+        required: false
+        default: 'info'
+
+concurrency:
+  # One Renovate run at a time; never cancel a run mid-flight (a cancelled run
+  # can leave the dependency dashboard or an in-progress PR half-updated).
+  group: renovate
+  cancel-in-progress: false
+
+# Renovate authenticates with the App token minted below; the default
+# GITHUB_TOKEN needs no permissions here (create-github-app-token reads only
+# the App secrets, not the workflow token).
+permissions: {}
+
+jobs:
+  renovate:
+    name: Run Renovate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Mint llem-ci-bot App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.18
+        env:
+          # Renovate discovers renovate.json from the target repo itself, so no
+          # global configurationFile is set here. RENOVATE_REPOSITORIES scopes
+          # the run to this repo; ONBOARDING is off because renovate.json exists.
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: 'false'
+          # LOG_LEVEL is forwarded to the Renovate container by the action's
+          # default env-regex allowlist.
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}
+        with:
+          token: ${{ steps.app-token.outputs.token }}

--- a/docs/explanation/architecture/architecture-overview.md
+++ b/docs/explanation/architecture/architecture-overview.md
@@ -72,7 +72,7 @@ Deep dive: [parameter discovery and config validation](/explanation/architecture
 
 ## Keeping knowledge current
 
-Upstream engines ship frequently. [Renovate](https://github.com/apps/renovate) watches upstream releases and opens a pull request that bumps the pin in `engine_versions/<engine>/current.yaml`. Detection stays automatic; refreshing the committed knowledge is a local maintainer step on that PR:
+Upstream engines ship frequently. A self-hosted Renovate cron (`renovate.yml`) watches upstream releases and opens a pull request that bumps the pin in `engine_versions/<engine>/current.yaml`. Detection stays automatic; refreshing the committed knowledge is a local maintainer step on that PR:
 
 1. Re-discover the schema: `make discover-schema ENGINE=<engine>`.
 2. Re-absorb the rules against the new source: `make absorb ENGINE=<engine> SRC=<engine-source>`.

--- a/docs/explanation/architecture/ci-architecture.md
+++ b/docs/explanation/architecture/ci-architecture.md
@@ -20,7 +20,7 @@ The repo uses two workflow patterns, picked per-concern:
 | Pattern | When | Examples |
 |---|---|---|
 | **Reusable workflow** (`workflow_call`) | a body invoked by another workflow | `docker-publish.yml`, `gpu-ci.yml` |
-| **Monolithic-direct** | one concern, triggered directly | `ci.yml`, `engine-rules-check.yml`, `security.yml`, `release.yml`, `auto-release.yml`, `ghcr-prune.yml`, `publish-engine-image.yml`, `docs.yml`, `issue-type-labeller.yml` |
+| **Monolithic-direct** | one concern, triggered directly | `ci.yml`, `engine-rules-check.yml`, `security.yml`, `release.yml`, `auto-release.yml`, `ghcr-prune.yml`, `publish-engine-image.yml`, `docs.yml`, `issue-type-labeller.yml`, `renovate.yml` |
 
 A monolithic-direct workflow may still fan out over a matrix (see
 `engine-rules-check.yml`, which runs one concern across the engines). The
@@ -251,10 +251,12 @@ PR checks tab.
   `engine-rules-check.yml` and `docs.yml` set it unconditionally. `ci.yml` sets
   it to `${{ github.event_name == 'pull_request' }}` - cancel superseded PR
   runs, but let merge-queue / push runs on `main` finish.
-- **`cancel-in-progress: false`** for workflows that mutate a registry or run
-  long-cached builds: `publish-engine-image.yml` (grouped per commit SHA) and
-  `ghcr-prune.yml` (a single in-flight sweep; a cancelled prune pass leaves the
-  registry half-pruned).
+- **`cancel-in-progress: false`** for workflows that mutate a registry, open
+  or update PRs, or run long-cached builds: `publish-engine-image.yml` (grouped
+  per commit SHA), `ghcr-prune.yml` (a single in-flight sweep; a cancelled prune
+  pass leaves the registry half-pruned), and `renovate.yml` (a single in-flight
+  Renovate run; a cancelled run can strand a half-updated dependency dashboard
+  or PR).
 - **No `concurrency:` block** on `gpu-ci.yml` and `security.yml`: GPU runs are
   label-gated and rare, and the security scan is cheap, so neither needs
   supersession control.
@@ -290,6 +292,7 @@ Workflows that cannot self-test at runtime:
 - `auto-release.yml` - `pull_request: closed` only.
 - `release.yml` - `push: tags` only.
 - `issue-type-labeller.yml` - `issues` events only.
+- `renovate.yml` - `schedule` cron plus `workflow_dispatch` only.
 
 ## Conventions
 

--- a/docs/explanation/architecture/ci-architecture.md
+++ b/docs/explanation/architecture/ci-architecture.md
@@ -292,7 +292,10 @@ Workflows that cannot self-test at runtime:
 - `auto-release.yml` - `pull_request: closed` only.
 - `release.yml` - `push: tags` only.
 - `issue-type-labeller.yml` - `issues` events only.
-- `renovate.yml` - `schedule` cron plus `workflow_dispatch` only.
+- `renovate.yml` - `schedule` cron plus `workflow_dispatch` only. Its
+  operational health signal is the dependency-dashboard issue: the daily run
+  refreshes it, so a stale dashboard means the cron (or its App credentials)
+  has died - the same staleness signal that exposed the hosted app's death.
 
 ## Conventions
 

--- a/docs/explanation/architecture/pipeline-architecture.md
+++ b/docs/explanation/architecture/pipeline-architecture.md
@@ -59,7 +59,7 @@ flowchart TD
     renovate --> bump --> discover --> absorb --> commit --> ci --> review --> merged
 ```
 
-- **Detection is automatic.** [Renovate](https://github.com/apps/renovate) watches upstream releases and opens a PR that bumps the pin (and, for transformers, the Dockerfile `ARG`).
+- **Detection is automatic.** A self-hosted Renovate cron (`renovate.yml`) watches upstream releases and opens a PR that bumps the pin (and, for transformers, the Dockerfile `ARG`).
 - **Production is local.** Reading the new engine source into an updated schema and rule set needs the engine source - and sometimes a GPU - so it runs on a maintainer's machine, not in CI. See [Schema refresh](/contributing/schema-refresh) and [Local knowledge production](/contributing/knowledge-production).
 - **Verification is CI.** Once the regenerated artifacts are committed, `engine-rules-check.yml` checks they are internally consistent - the generated config matches the committed one, and uncovered validator sites are reported as advisory. No GPU, no containers, no self-hosted runners, and nothing writes back to the branch. See [CI architecture](/explanation/architecture/ci-architecture).
 

--- a/renovate.json
+++ b/renovate.json
@@ -51,14 +51,6 @@
     {
       "matchManagers": ["pep621"],
       "rangeStrategy": "replace"
-    },
-    {
-      "description": "Only auto-PR when Mend merge-confidence is high or very-high. Applied ONLY to transformers and pytorch, which have dense merge-confidence data. vllm and tensorrt-llm have sparse merge-confidence (releases rarely score high), so this gate silently suppressed every PR for them; they are excluded here and rely on the 14-day minimumReleaseAge for stability instead.",
-      "matchPackageNames": [
-        "transformers",
-        "pytorch/pytorch"
-      ],
-      "matchConfidence": ["high", "very high"]
     }
   ],
   "schedule": ["before 9am on Monday"],


### PR DESCRIPTION
## Why

The hosted Mend Renovate app stopped visiting this repo on 2026-04-29: its last
update PR (#489) and its last dependency-dashboard refresh both landed that day,
`renovate.json` carries no kill switch, four config edits after the death date
drew zero reaction, and a liveness probe (ticking the create-config-migration-PR
checkbox on dashboard issue #446 on 2026-07-09) got no response in 24+ hours.
The app is dead. This PR is the decided fallback: run Renovate ourselves on a
cron.

## What

- **`.github/workflows/renovate.yml`** - a `Renovate` workflow that runs the
  `renovatebot/github-action` on a daily off-peak cron (05:23 UTC) plus
  `workflow_dispatch` (with an optional `log_level` input for debug reruns).
  - Authenticates with the **llem-ci-bot** GitHub App token (minted from the
    existing `APP_ID` / `APP_PRIVATE_KEY` secrets via
    `actions/create-github-app-token@v1`). App-created PRs trigger CI;
    `GITHUB_TOKEN`-created PRs would not, so the App token is required for
    update PRs to be reviewable.
  - `concurrency` group `renovate`, `cancel-in-progress: false` (writeback
    workflow, per repo conventions). Default `GITHUB_TOKEN` gets
    `permissions: {}` - Renovate uses only the App token.
  - The in-config `schedule` in `renovate.json` ("before 9am on Monday") still
    gates when update PRs are created, so bump cadence is unchanged. The cron
    runs daily so the dependency dashboard stays fresh (dashboard staleness was
    the signal that diagnosed the death) and dashboard-checkbox requests plus
    vulnerability alerts are picked up within a day.
  - `renovate.json` is the repo config and is discovered by Renovate when it
    clones the target repo, so no global `configurationFile` is set (it is not
    duplicated).

- **`renovate.json`** - removed the final `packageRules` entry
  (`matchConfidence: ["high", "very high"]` for transformers + pytorch/pytorch).
  On self-hosted Renovate, `matchConfidence` requires an authenticated Mend
  merge-confidence API token, which we do not have; leaving the rule in makes
  runs fail with a missing-credentials error. transformers/pytorch remain gated
  by their `minimumReleaseAge: "14 days"` rules like the other engines.

- **Docs** - updated the CI architecture reference (added `renovate.yml` to the
  monolithic-direct catalogue, the `cancel-in-progress: false` list, and the
  no-runtime-self-test list) and corrected the two architecture pages that
  linked bumps to the hosted Mend app so they describe the self-hosted cron.

## Verification

- `renovate-config-validator renovate.json` passes ("Config validated
  successfully").
- The `renovate.yml` action tag is pinned to the exact latest release
  (`v46.1.18`); the current major has no floating tag, so the pin is exact and
  the github-actions manager will keep it bumped (self-maintaining).
- `actionlint` shape-validation runs in `ci.yml` (this workflow is
  cron/dispatch-only and cannot paths-filter itself - the documented convention).

## Post-merge

Dispatch the workflow from the Actions tab. Expect a dependency-dashboard
refresh on issue #446 and, because the create-config-migration-PR checkbox is
already ticked, a config-migration PR on the next run.
