### PR TITLE
chore: release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,27 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [v0.10.0] - TBD
 
-Post-v0.9.0 work: engine-coupling restructure, engine-invariants pipeline, Docusaurus docs site, Z-engines layout, and CI hardening.
+The engine-knowledge-as-data milestone. Hand-curated per-engine config was replaced by
+typed Pydantic configs code-generated from validation rules mined directly from engine
+source; the engine-coupling restructure, per-engine SSOT version pins, a Docusaurus docs
+site, study-authoring commands (`llem study init` / bounds mode / sweep idioms / plan
+preview), the absorb conductor, and a rewritten hosted-byte-verification CI all landed on
+this line. Engine pins advanced to vLLM 0.19.1, TensorRT-LLM 1.0.0, and Transformers 5.7.0.
 
 ### Breaking Changes
+
+- **Hand-curated `engine_configs.py` deleted; per-engine typed configs are now
+  code-generated.** The ~1100-line hand-maintained `engine_configs.py` was removed. Each
+  engine's typed Pydantic config surface is now code-generated from validation rules mined
+  directly from that engine's source, keyed to the pinned version under `engine_versions/`.
+  A parity gate guarded the deletion. Author-facing YAML is unchanged; only the internal
+  config construction path moved to codegen. ([#733], [#734], [#735], [#736], [#738])
+
+- **Engine validation vocabulary renamed from "invariants" to "rules".** The mined corpus,
+  its loader surface, and the CLI/docs terminology now say "rules". A single shipped rules
+  corpus with a closed severity enum replaces the prior split, and the invariant-era
+  compatibility shims were dropped. YAML that referenced the old `engine_invariants` naming
+  must move to the `rules` vocabulary. ([#480], [#572], [#737], [#740])
 
 - **`llem run` reduced to session flags only.** The semantic-override flags were removed;
   experiment parameters now live in the YAML config (author one with `llem study init`), and a
@@ -109,9 +127,9 @@ Post-v0.9.0 work: engine-coupling restructure, engine-invariants pipeline, Docus
   via `LLEM_SKIP_IMAGE_CHECK=1`. ([#256])
 - `SchemaLoader` class (`llenergymeasure.config.SchemaLoader`) reads vendored engine schemas via
   `importlib.resources` with per-instance caching and major-version envelope validation. ([#268])
-- Engine parameter discovery script (`scripts/discover_engine_schemas.py`) introspects installed
-  engine packages inside their Docker images. Supports `vllm`, `tensorrt`, `transformers`, and
-  `--all`. ([#266])
+- Engine parameter discovery introspects installed engine packages inside their Docker images.
+  The initial standalone script (`scripts/discover_engine_schemas.py`, #266) was later superseded
+  by the `scripts/engine_producers/` codegen toolkit (see Breaking Changes). ([#266])
 - Vendored engine parameter schemas at `src/llenergymeasure/engines/{vllm,tensorrt,transformers}/`.
   Regenerate with `make discover-schema ENGINE=<engine>`. ([#266])
 - Per-engine sub-package layout (`src/llenergymeasure/engines/<engine>/`) co-locating runtime data,
@@ -148,6 +166,30 @@ Post-v0.9.0 work: engine-coupling restructure, engine-invariants pipeline, Docus
   ([#514], [#573])
 - Cloudflare Pages PR preview deploy workflow. ([#575])
 - SSOT audit trail and GHCR image retention policies. ([#546])
+- Engine-knowledge SSOT workspace under `engine_versions/` with per-version mined producer
+  snapshots, a shared schema-extraction substrate, and workspace-driven codegen for the typed
+  engine config models. ([#733], [#734], [#735], [#736])
+- Vendored per-version producer snapshots for all three engines (vLLM 0.7.3 / 0.16.0 / 0.18.1 /
+  0.19.1, TensorRT-LLM 0.21.0 / 1.0.0 / 1.2.0 / 1.2.1, Transformers 4.57.3 / 5.3.0 / 5.6.2 / 5.7.0).
+  ([#599], [#600], [#601], [#636], [#637], [#638], [#639], [#640], [#641], [#642])
+- Schema-vs-source drift tool (coverage and added-direction probes, `EXCLUSIONS.yaml`, sticky-comment
+  gate) replacing the prior probe primitive. ([#635], [#643], [#644], [#649], [#650])
+- `llem study init` scaffold command for authoring a study YAML. ([#745])
+- `llem study plan` preview command showing the expanded experiment grid. ([#750])
+- Numeric sweep-axis idioms (`span`, `log`, `pow2`) for concise study axes. ([#746])
+- Bounds mode with series policies and per-axis overrides. ([#747])
+- Sweep configs record the rejecting rule id when a candidate is skipped. ([#741])
+- Absorb conductor orchestrates engine-rule refresh across all engines. ([#756], [#771])
+- Upstream validator coverage check confirms mined rules cover each engine's validators. ([#757])
+- Cold-read analyst proposer for engine rules. ([#755])
+- Citation checker (tier 1 of the rule verification ladder). ([#753])
+- Construction and identity probe kernel for rule verification. ([#754])
+- Observed-collision miner surfaces dormant rule candidates from runtime observations. ([#752])
+- Self-hosted Renovate cron; engine-version scanning revived and its config migrated. ([#732],
+  [#775], [#776])
+- Generated-doc drift gate in the docs-freshness workflow. ([#760], [#761])
+- Fan-in gate making the engine-rules-check requireable without deadlock; bump gates made
+  reachable and requireable. ([#769], [#772])
 
 ### Changed
 
@@ -165,6 +207,12 @@ Post-v0.9.0 work: engine-coupling restructure, engine-invariants pipeline, Docus
 - Renovate customManager retargeted from Dockerfile ARGs to `engine_versions/` SSOT. ([#481])
 - First-party `Dockerfile.vllm` and `Dockerfile.tensorrt` replaced with upstream-direct images
   plus volume mounts. ([#509])
+- Advanced engine pins to vLLM 0.19.1, TensorRT-LLM 1.0.0, and Transformers 5.7.0, adopting the
+  generated nested configs at those versions. ([#738])
+- Engine pipeline rewritten to hosted byte-verification (the mined corpus and generated configs
+  are verified byte-for-byte against a fresh mine, no human source-diffing). ([#758])
+- Documentation aligned to the byte-verification engine-knowledge flow and the rules vocabulary;
+  stale engine and contributing pages rewritten. ([#759], [#764], [#774])
 
 ### Fixed
 
@@ -188,12 +236,21 @@ Post-v0.9.0 work: engine-coupling restructure, engine-invariants pipeline, Docus
 - Non-matching engine sections stripped correctly during multi-engine grid expansion. ([#171])
 - Docker auto-elevation enforced for multi-engine studies. ([#172])
 - Baseline cache path resolved before Docker bind-mount. ([#248])
+- Purged false-positive and phantom rules from the shipped corpus. ([#767])
+- Rule message rendering and loader guards corrected. ([#768])
+- Study dedup fallback, grid edge cases, and dormant-candidate visibility repaired. ([#770])
+- Schema discovery retargeted at the `current.yaml` pins. ([#765])
+- Pin-driven Transformers publish and GHCR prune exemption. ([#766])
 
 ### Removed
 
 - Internal helper `llenergymeasure.study.runner._calculate_timeout` (replaced by direct config
   reads). ([#529])
 - First-party `Dockerfile.vllm` and `Dockerfile.tensorrt` engine images. ([#509])
+- Dead invariant-mining pipeline and the `refresh-invariants` / `schema-diff` scripts. ([#762],
+  [#763])
+- Orphaned files, dead references, and retired mined-invariants documentation pages. ([#760],
+  [#773])
 - Predecessor CI workflows: `auto-mine.yml`, `vendor-tensorrt.yml`, `vendor-vllm.yml`,
   `parameter-discovery.yml`, and predecessors. ([#483], [#485])
 
@@ -480,6 +537,7 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#444]: https://github.com/henrycgbaker/llenergymeasure/pull/444
 [#447]: https://github.com/henrycgbaker/llenergymeasure/pull/447
 [#477]: https://github.com/henrycgbaker/llenergymeasure/pull/477
+[#480]: https://github.com/henrycgbaker/llenergymeasure/pull/480
 [#481]: https://github.com/henrycgbaker/llenergymeasure/pull/481
 [#482]: https://github.com/henrycgbaker/llenergymeasure/pull/482
 [#483]: https://github.com/henrycgbaker/llenergymeasure/pull/483
@@ -495,7 +553,61 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#560]: https://github.com/henrycgbaker/llenergymeasure/pull/560
 [#566]: https://github.com/henrycgbaker/llenergymeasure/pull/566
 [#570]: https://github.com/henrycgbaker/llenergymeasure/pull/570
+[#572]: https://github.com/henrycgbaker/llenergymeasure/pull/572
 [#573]: https://github.com/henrycgbaker/llenergymeasure/pull/573
 [#575]: https://github.com/henrycgbaker/llenergymeasure/pull/575
+[#599]: https://github.com/henrycgbaker/llenergymeasure/pull/599
+[#600]: https://github.com/henrycgbaker/llenergymeasure/pull/600
+[#601]: https://github.com/henrycgbaker/llenergymeasure/pull/601
+[#635]: https://github.com/henrycgbaker/llenergymeasure/pull/635
+[#636]: https://github.com/henrycgbaker/llenergymeasure/pull/636
+[#637]: https://github.com/henrycgbaker/llenergymeasure/pull/637
+[#638]: https://github.com/henrycgbaker/llenergymeasure/pull/638
+[#639]: https://github.com/henrycgbaker/llenergymeasure/pull/639
+[#640]: https://github.com/henrycgbaker/llenergymeasure/pull/640
+[#641]: https://github.com/henrycgbaker/llenergymeasure/pull/641
+[#642]: https://github.com/henrycgbaker/llenergymeasure/pull/642
+[#643]: https://github.com/henrycgbaker/llenergymeasure/pull/643
+[#644]: https://github.com/henrycgbaker/llenergymeasure/pull/644
+[#649]: https://github.com/henrycgbaker/llenergymeasure/pull/649
+[#650]: https://github.com/henrycgbaker/llenergymeasure/pull/650
+[#732]: https://github.com/henrycgbaker/llenergymeasure/pull/732
+[#733]: https://github.com/henrycgbaker/llenergymeasure/pull/733
+[#734]: https://github.com/henrycgbaker/llenergymeasure/pull/734
+[#735]: https://github.com/henrycgbaker/llenergymeasure/pull/735
+[#736]: https://github.com/henrycgbaker/llenergymeasure/pull/736
+[#737]: https://github.com/henrycgbaker/llenergymeasure/pull/737
+[#738]: https://github.com/henrycgbaker/llenergymeasure/pull/738
+[#740]: https://github.com/henrycgbaker/llenergymeasure/pull/740
+[#741]: https://github.com/henrycgbaker/llenergymeasure/pull/741
+[#745]: https://github.com/henrycgbaker/llenergymeasure/pull/745
+[#746]: https://github.com/henrycgbaker/llenergymeasure/pull/746
+[#747]: https://github.com/henrycgbaker/llenergymeasure/pull/747
 [#749]: https://github.com/henrycgbaker/llenergymeasure/pull/749
+[#750]: https://github.com/henrycgbaker/llenergymeasure/pull/750
+[#752]: https://github.com/henrycgbaker/llenergymeasure/pull/752
+[#753]: https://github.com/henrycgbaker/llenergymeasure/pull/753
+[#754]: https://github.com/henrycgbaker/llenergymeasure/pull/754
+[#755]: https://github.com/henrycgbaker/llenergymeasure/pull/755
+[#756]: https://github.com/henrycgbaker/llenergymeasure/pull/756
+[#757]: https://github.com/henrycgbaker/llenergymeasure/pull/757
+[#758]: https://github.com/henrycgbaker/llenergymeasure/pull/758
+[#759]: https://github.com/henrycgbaker/llenergymeasure/pull/759
+[#760]: https://github.com/henrycgbaker/llenergymeasure/pull/760
+[#761]: https://github.com/henrycgbaker/llenergymeasure/pull/761
+[#762]: https://github.com/henrycgbaker/llenergymeasure/pull/762
+[#763]: https://github.com/henrycgbaker/llenergymeasure/pull/763
+[#764]: https://github.com/henrycgbaker/llenergymeasure/pull/764
+[#765]: https://github.com/henrycgbaker/llenergymeasure/pull/765
+[#766]: https://github.com/henrycgbaker/llenergymeasure/pull/766
+[#767]: https://github.com/henrycgbaker/llenergymeasure/pull/767
+[#768]: https://github.com/henrycgbaker/llenergymeasure/pull/768
+[#769]: https://github.com/henrycgbaker/llenergymeasure/pull/769
+[#770]: https://github.com/henrycgbaker/llenergymeasure/pull/770
+[#771]: https://github.com/henrycgbaker/llenergymeasure/pull/771
+[#772]: https://github.com/henrycgbaker/llenergymeasure/pull/772
+[#773]: https://github.com/henrycgbaker/llenergymeasure/pull/773
+[#774]: https://github.com/henrycgbaker/llenergymeasure/pull/774
+[#775]: https://github.com/henrycgbaker/llenergymeasure/pull/775
+[#776]: https://github.com/henrycgbaker/llenergymeasure/pull/776
 [#783]: https://github.com/henrycgbaker/llenergymeasure/pull/783

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
-## [v0.10.0] - TBD
+## [v0.10.0] - 2026-07-13
 
 The engine-knowledge-as-data milestone. Hand-curated per-engine config was replaced by
 typed Pydantic configs code-generated from validation rules mined directly from engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,13 @@ this line. Engine pins advanced to vLLM 0.19.1, TensorRT-LLM 1.0.0, and Transfor
 - Generated-doc drift gate in the docs-freshness workflow. ([#760], [#761])
 - Fan-in gate making the engine-rules-check requireable without deadlock; bump gates made
   reachable and requireable. ([#769], [#772])
+- Runtime-literal discovery stage: string-literal candidates pooled from corpus cross-refs,
+  upstream AST/docstring scans, LLM proposals, and previous-schema carry-forward, each verified
+  by a two-leg construction probe in the pinned container; confirmed literals are recorded in
+  the discovered schema and code-generated as union types. Standing census via
+  `make check-corpus-literals`. ([#789])
+- Miner final-run recall check with report, a probe-confirmed nested vLLM compilation-config
+  cross-field rule, and nested-path rule firing tests. ([#788])
 
 ### Changed
 
@@ -213,6 +220,13 @@ this line. Engine pins advanced to vLLM 0.19.1, TensorRT-LLM 1.0.0, and Transfor
   are verified byte-for-byte against a fresh mine, no human source-diffing). ([#758])
 - Documentation aligned to the byte-verification engine-knowledge flow and the rules vocabulary;
   stale engine and contributing pages rewritten. ([#759], [#764], [#774])
+- Discovery write path inverted: container discovery writes only under `engine_versions/`, with
+  `make promote-schemas` as the sole writer of the packaged copies. ([#785])
+- Knowledge-production scripts gated by ruff and mypy in Makefile and CI; import-linter layer
+  contracts made honest; bundle artefact filenames centralised as constants. ([#784])
+- Dead code deleted and duplicated helpers folded across study and scripts layers. ([#786])
+- Docs: heading anchors match the live slugifier, version references pinned to `current.yaml`
+  sources, and curation-era drift rewritten. ([#787])
 
 ### Fixed
 
@@ -241,6 +255,17 @@ this line. Engine pins advanced to vLLM 0.19.1, TensorRT-LLM 1.0.0, and Transfor
 - Study dedup fallback, grid edge cases, and dormant-candidate visibility repaired. ([#770])
 - Schema discovery retargeted at the `current.yaml` pins. ([#765])
 - Pin-driven Transformers publish and GHCR prune exemption. ([#766])
+- Rules follow-ups: probe operator canonicalisation, loader operator allowlist, message-template
+  residue, and `{invariant_id}` renamed to `{rule_id}`. ([#779])
+- Per-engine upstream default images resolve from the pinned engine version instead of a
+  never-published GHCR ref; `llem doctor` verifies them. ([#780])
+- Energy-measurement failure is loud instead of a silent zero: sampler auto-selection warns,
+  absent energy stays `None` rather than coercing to `0.0`, sampler failures set a measurement
+  warning, and NVML init failures log debug traces. ([#781])
+- Documented top-level `images:` study key no longer leaks into experiment configs and rejects
+  the whole study; user-facing config copy de-jargonised. ([#782])
+- Self-hosted Renovate aborted before opening update PRs: the stability commit-status POST the
+  App token cannot make is now disabled in config. ([#791])
 
 ### Removed
 
@@ -610,4 +635,15 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#774]: https://github.com/henrycgbaker/llenergymeasure/pull/774
 [#775]: https://github.com/henrycgbaker/llenergymeasure/pull/775
 [#776]: https://github.com/henrycgbaker/llenergymeasure/pull/776
+[#779]: https://github.com/henrycgbaker/llenergymeasure/pull/779
+[#780]: https://github.com/henrycgbaker/llenergymeasure/pull/780
+[#781]: https://github.com/henrycgbaker/llenergymeasure/pull/781
+[#782]: https://github.com/henrycgbaker/llenergymeasure/pull/782
 [#783]: https://github.com/henrycgbaker/llenergymeasure/pull/783
+[#784]: https://github.com/henrycgbaker/llenergymeasure/pull/784
+[#785]: https://github.com/henrycgbaker/llenergymeasure/pull/785
+[#786]: https://github.com/henrycgbaker/llenergymeasure/pull/786
+[#787]: https://github.com/henrycgbaker/llenergymeasure/pull/787
+[#788]: https://github.com/henrycgbaker/llenergymeasure/pull/788
+[#789]: https://github.com/henrycgbaker/llenergymeasure/pull/789
+[#791]: https://github.com/henrycgbaker/llenergymeasure/pull/791

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llenergymeasure"
-version = "0.9.0"
+version = "0.10.0"
 description = "LLenergyMeasure - LLM inference efficiency measurement framework"
 authors = [
     {name = "henrycgbaker", email = "henry.c.g.baker@gmail.com"},

--- a/src/llenergymeasure/_version.py
+++ b/src/llenergymeasure/_version.py
@@ -5,4 +5,4 @@ by modules at every layer to avoid pulling in the full __init__.py
 import chain.
 """
 
-__version__: str = "0.9.0"
+__version__: str = "0.10.0"

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "llenergymeasure"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

Release-prep commit for v0.10.0 (the engine-knowledge-as-data milestone). This is PREP ONLY - the git tag is deliberately NOT created and this PR must NOT be merged until both hold conditions below are cleared.

Changes:
- `CHANGELOG.md`: consolidated the `[v0.10.0]` section so it accurately reflects everything on main since v0.9.0 (313 commits). Reconciled with the pre-existing partial section (kept the `llem run` session-flags-only breaking bullet and its flag-to-YAML table #749 verbatim; fixed one stale script path in the #266 bullet). New coverage: engine config schema + rules code-generated from mined engine source with the hand-curated `engine_configs.py` deleted; pin advance to vLLM 0.19.1 / TensorRT-LLM 1.0.0 / Transformers 5.7.0; the invariant-to-rule terminology rename; `llem study init` / bounds mode / sweep idioms / `llem study plan` preview; absorb conductor + upstream-validator coverage check; the CI rewrite (hosted byte-verification pipeline, engine-rules-check fan-in gate, docs drift gate, self-hosted Renovate cron); and the docs overhaul.
- Version bump 0.9.0 -> 0.10.0 in `pyproject.toml`, `src/llenergymeasure/_version.py` (the SSOT that `__init__.py` re-exports), and `uv.lock`.

Gates run: `make lint` passes (ruff check + format + import-linter); the two version sources match at 0.10.0; no test pins the literal version string (tests reference `__version__` dynamically or use `0.9.0` only as arbitrary fixture data).

## HOLD - do not merge or tag until BOTH gates clear

1. **Renovate proof.** The first live self-hosted Renovate run must prove the update chain end-to-end (mined artefacts -> gate report -> regenerated typed configs with no human source-diffing). This is the F1 functional exit criterion; the self-hosted cron is expected the week of 2026-07-13.

2. **Release close-out slices.** Per the v0.10.0 close-out plan ratified 2026-07-10 (`.product/designs/release-0.10.0-close-out-2026-07-10.md`), the tag also waits on the close-out slices landing - at minimum the correctness slices, foremost S9. S9 fixes a verified HIGH config-identity hashing bug: `build_resolved_view` omits `config.harness`, so a harness sweep such as `harness.transformers.batch_size: [1, 4, 8, 16]` collapses under default dedup to a single experiment (the other three are reported as dedup-merged). S9 also carries the `--no-dedup` duplicate-config crash fix. The release chore slice (S8) is by design the last slice.

## Before merging

Rebase onto main and add `[v0.10.0]` CHANGELOG lines for any PRs that land after this branch was cut. At cut time a `fix/rules-followups` PR was in flight in parallel and is intentionally NOT included here; the release close-out slices (S1-S9) will also merge after this cut and must be folded into the CHANGELOG before the tag.

Do NOT create the `v0.10.0` git tag as part of merging this PR - tagging is a separate, gated step once both hold conditions above are satisfied.
