### PR TITLE
docs: fix study-config anchors, stale engine pins, roadmap and curation copy

### DIFF
--- a/docs/contributing/roadmap.md
+++ b/docs/contributing/roadmap.md
@@ -15,9 +15,12 @@ Released milestones:
 | v0.8.0 | Study/sweep: multi-experiment grid sweeps, manifest writer, deduplication, subprocess isolation |
 | v0.9.0 | Docker + vLLM: containerised engine architecture, vLLM engine, Docker CI, logging overhaul |
 
-The TensorRT-LLM release (v0.10.0) is implementation-complete and in
-final UAT before tagging. Run `llem --version` against your installed package
-for the authoritative current version.
+v0.10.0 (in progress) is the engine-knowledge-as-data milestone: each engine's
+config, schema, and validation rules are generated from version-pinned upstream
+snapshots rather than hand-curated, alongside study-authoring improvements.
+TensorRT-LLM activation is the v0.11.0 milestone and still needs live
+end-to-end validation on GPU hardware before tagging. Run `llem --version`
+against your installed package for the authoritative current version.
 
 Pre-1.0 disclaimer: the tool is research-grade for single-machine use. It is
 not yet at the stability and API-stability bar of a 1.0 release.

--- a/docs/explanation/architecture/parameter-curation.md
+++ b/docs/explanation/architecture/parameter-curation.md
@@ -4,7 +4,7 @@
 
 ---
 
-llem exposes engine parameters to users through hand-authored Pydantic models. This document explains how those models stay in sync with the underlying engines.
+llem exposes engine parameters to users through generated Pydantic models. This document explains where the curation decisions live and how the generated models stay in sync with the underlying engines.
 
 ---
 
@@ -13,17 +13,23 @@ llem exposes engine parameters to users through hand-authored Pydantic models. T
 ```mermaid
 flowchart TD
     discovery[programmatic discovery<br/>scripts/engine_producers/]
-    pydantic[Pydantic curation<br/>config/engine_configs.py]
+    curated[curation decisions<br/>engine_versions/&lt;engine&gt;/v&lt;ver&gt;/outputs/curated.yaml]
+    codegen[codegen<br/>scripts/engine_producers/regen_engine_configs.py]
+    pydantic[generated Pydantic models<br/>engines/&lt;engine&gt;/config.py]
     drift[drift checker<br/>scripts/check_pydantic_matches_discovered.py]
     allowlist[LLEM_NATIVE_FIELDS<br/>intentional-divergence allowlist]
 
+    discovery --> codegen
+    curated --> codegen
+    codegen --> pydantic
     discovery --> drift
     pydantic --> drift
     drift --> allowlist
 ```
 
 - **Programmatic discovery** introspects engine APIs and writes `engines/*/schema.discovered.json` (the ground truth for "what parameters does this engine accept").
-- **Pydantic curation** is the hand-authored set of sub-config models that expose typed, documented fields to users.
+- **Curation decisions** are recorded per pinned engine version in `curated.yaml` - which fields the typed surface names explicitly, type narrowing, and user-facing descriptions.
+- **Codegen** projects the discovered schema plus the curation decisions into the committed Pydantic models at `src/llenergymeasure/engines/<engine>/config.py`. The generated files must not be hand-edited (each header says so).
 - **Drift checker** flags Pydantic fields with no corresponding discovered entry.
 - **`LLEM_NATIVE_FIELDS`** is the "yes, this divergence is intentional" allowlist - it suppresses known-good exceptions so the drift checker only reports unexpected divergence.
 
@@ -37,14 +43,17 @@ These JSON files are the ground truth for "what parameters does this engine vers
 
 ---
 
-## Pydantic curation
+## Curation and the generated models
 
-`src/llenergymeasure/config/engine_configs.py` contains hand-authored Pydantic models that llem exposes to users. Curation decisions:
+`src/llenergymeasure/engines/<engine>/config.py` holds the Pydantic models llem exposes to users (`engine_params:` and `sampling_params:` per engine). These files are generated: `scripts/engine_producers/regen_engine_configs.py` produces them from the pinned version's `schema.discovered.json` plus `curated.yaml` under `engine_versions/<engine>/v<version>/outputs/`. To change the exposed surface, edit `curated.yaml` and regenerate - never the generated `config.py`.
+
+The curation principles the generated surface encodes:
 
 - **Field names match native engine names.** A field called `quant_config` maps directly to the engine kwarg `quant_config`. No translation layer, no llem aliases.
-- **Sub-configs group related parameters.** e.g. `TensorRTKvCacheConfig` groups all kv-cache knobs under `tensorrt.kv_cache_config.*`. The sub-config name matches the native engine kwarg name.
+- **Sub-config typing is per-engine.** Where the snapshot models a nested config, it becomes a typed sub-model (e.g. vLLM's `speculative_config` and `compilation_config`); where it does not, the field is a freeform `Any`-typed dict passed through whole (e.g. TensorRT-LLM's `quant_config`, `kv_cache_config`, `scheduler_config` on the current pin).
 - **Types may be narrowed.** A field typed `str` in discovery might become `Literal["bfloat16", "float16", "float32"]` in curation - this is intentional and allowed by the drift checker.
-- **Descriptions are added.** Pydantic `Field(description=...)` docs are user-facing; discovery has none.
+- **Descriptions are added.** Pydantic field docs are user-facing; discovery has none.
+- **Unmodelled parameters still work.** The generated sub-models set `extra="allow"`, so a parameter the snapshot does not name explicitly is forwarded to the engine unchanged.
 
 ---
 
@@ -74,7 +83,7 @@ Some Pydantic fields legitimately have no discovered counterpart. Common reasons
 | Reason | Example |
 |--------|---------|
 | Passed via `**kwargs`, invisible to `inspect.signature` | `transformers.dtype` - `from_pretrained` accepts it as a kwarg alias |
-| llem surfaces a sub-config field that the engine accepts as a flat kwarg at a different nesting level | `tensorrt.quant_algo` inside `TensorRTQuantConfig` |
+| Sub-config nesting differs between llem's surface and the engine API | `tensorrt.max_batch_size` - TRT-LLM accepts it inside a nested build config, not as a flat constructor kwarg |
 | Beam-search or speculative-decoding params from a separate params class | `vllm.beam_width` (from `BeamSearchParams`, not `LLM.__init__`) |
 
 These are listed in `LLEM_NATIVE_FIELDS` in the drift checker. Each entry suppresses one `pydantic_only` warning for a named `(engine, field_name)` pair.

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -83,15 +83,17 @@ To get engine images:
 # Transformers - build from source (one-time, ~30 min cold; seconds from cache)
 make docker-build
 
-# vLLM - pull upstream image
-docker pull vllm/vllm-openai:0.7.3
+# vLLM - pull upstream image (pinned engine version)
+docker pull vllm/vllm-openai:v0.19.1
 
-# TensorRT-LLM - pull upstream NGC image
-docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0
+# TensorRT-LLM - pull upstream NGC image (pinned engine version)
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
 ```
 
-Docker and NVIDIA Container Toolkit must be installed first. See
-[Docker setup](/how-to/docker-setup) for a full walkthrough.
+The upstream tags above track the pinned engine versions
+(`engine_versions/<engine>/current.yaml`); `llem doctor` prints the exact image
+each engine resolves to. Docker and NVIDIA Container Toolkit must be installed
+first. See [Docker setup](/how-to/docker-setup) for a full walkthrough.
 
 ---
 

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -276,7 +276,8 @@ each engine has two possible image sources:
 | Source | Tag pattern | Built by | Use case |
 |--------|------------|----------|----------|
 | **Local build** | `llenergymeasure:{engine}` | `make docker-build-{engine}` | Development - reflects current source tree |
-| **Registry** | `ghcr.io/henrycgbaker/llenergymeasure/{engine}:v{version}` | CI on release tags | Production, CI, pip-install users |
+| **Registry (transformers)** | `ghcr.io/henrycgbaker/llenergymeasure/transformers:v{package_version}` | CI on release tags | Production, CI, pip-install users |
+| **Upstream (vllm, tensorrt)** | `vllm/vllm-openai:v{engine_version}`, `nvcr.io/nvidia/tensorrt-llm/release:{engine_version}` | vLLM / NVIDIA (NGC) | Same - the canonical engine image, project source bind-mounted |
 
 ### Image resolution
 
@@ -290,8 +291,10 @@ follows a precedence chain (highest wins):
 5. **Smart default**: local build image if present, otherwise registry image
 
 In practice, most users rely on the smart default (level 5). If you have built images locally
-with `make docker-build`, those are used. Otherwise, `llem` uses the GHCR registry image
-matching your installed version.
+with `make docker-build`, those are used. Otherwise, `llem` resolves the per-engine default:
+the first-party GHCR image for transformers (at the package version), and the canonical
+upstream image for vLLM / TensorRT-LLM (`vllm/vllm-openai`,
+`nvcr.io/nvidia/tensorrt-llm/release`, at the pinned engine version).
 
 ### Auto-pull on first use
 
@@ -320,16 +323,20 @@ multiple experiments share the same engine image. The CLI shows this as a
 For offline environments or to avoid pull latency during experiments:
 
 ```bash
-# Pull all registry images for your version
+# Pull the first-party transformers image for your installed version
 make docker-pull
 
-# Or pull individually
-docker pull ghcr.io/henrycgbaker/llenergymeasure/vllm:v0.9.0
-docker pull ghcr.io/henrycgbaker/llenergymeasure/tensorrt:v0.9.0
+# Or pull each engine's default image individually. transformers is a
+# first-party GHCR image tagged with the llenergymeasure version; vLLM and
+# TensorRT-LLM are upstream images tagged with the pinned engine version.
 docker pull ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.9.0
+docker pull vllm/vllm-openai:v0.19.1
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
 ```
 
-Replace `0.9.0` with your installed version (`llem --version`).
+Replace the transformers tag with your installed version (`llem --version`); the
+vLLM and TensorRT-LLM tags track the pins in `engine_versions/<engine>/current.yaml`.
+`llem doctor` prints the exact image each engine resolves to.
 
 ### Check current image resolution
 
@@ -343,9 +350,9 @@ Output shows local vs registry source for each engine:
 
 ```
 === Image resolution ===
-  transformers -> llenergymeasure:transformers  (local_build)
-  tensorrt   -> ghcr.io/henrycgbaker/llenergymeasure/tensorrt:v0.9.0  (registry)
-  vllm       -> llenergymeasure:vllm  (local_build)
+  tensorrt   -> nvcr.io/nvidia/tensorrt-llm/release:1.0.0  (registry)
+  transformers -> ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.9.0  (registry)
+  vllm       -> vllm/vllm-openai:v0.19.1  (registry)
 ```
 
 ### Building or pulling images locally
@@ -359,10 +366,10 @@ project source at run time.
 make docker-build
 
 # vLLM - pull upstream
-docker pull vllm/vllm-openai:0.7.3
+docker pull vllm/vllm-openai:v0.19.1
 
 # TensorRT-LLM - pull upstream (NGC)
-docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
 ```
 
 `make docker-build` builds the project's first-party engine images

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -119,15 +119,15 @@ vLLM or TensorRT-LLM.
 make docker-build
 
 # vLLM - pull upstream
-docker pull vllm/vllm-openai:0.7.3
+docker pull vllm/vllm-openai:v0.19.1
 
 # TensorRT-LLM - pull upstream (NGC)
-docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
 ```
 
-The pinned versions are the SSOT in `engine_versions/{vllm,tensorrt}.yaml`
-under `library.current_version`. Renovate bumps them on each upstream
-release.
+The pinned versions are the SSOT in `engine_versions/{vllm,tensorrt}/current.yaml`
+under `library.current_version` (`llem doctor` prints the resolved image).
+Renovate bumps them on each upstream release.
 
 You can also build the Transformers image with plain `docker build` (no
 Compose, no build cache):
@@ -216,8 +216,8 @@ subsequent rebuilds for vLLM/TRT are seconds - the slow part doesn't repeat.
 
 ```bash
 make docker-build                                    # build Transformers from source
-docker pull vllm/vllm-openai:0.7.3                   # pull vLLM upstream
-docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0  # pull TensorRT-LLM upstream
+docker pull vllm/vllm-openai:v0.19.1                 # pull vLLM upstream
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0  # pull TensorRT-LLM upstream
 ```
 
 **How the transformers image is published:**

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -345,8 +345,8 @@ the SSOT bumped transformers but the local image is still on an older tag).
 
 ```bash
 make docker-build                                       # local build, Transformers
-docker pull vllm/vllm-openai:0.7.3                      # repull vLLM upstream
-docker pull nvcr.io/nvidia/tensorrt-llm/release:0.21.0  # repull TensorRT-LLM upstream
+docker pull vllm/vllm-openai:v0.19.1                    # repull vLLM upstream
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0   # repull TensorRT-LLM upstream
 make docker-pull                                        # pull the newest published Transformers tag
 ```
 

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -130,7 +130,7 @@ means it stays `null` for that engine.
 
 | Metric group | vLLM | transformers | tensorrt |
 |--------------|:----:|:------------:|:--------:|
-| `request_latency.*` (per-request E2E) | yes (from RequestOutput metrics) | yes (per-batch approximation) | dash (metrics usually absent in 0.21.0) |
+| `request_latency.*` (per-request E2E) | yes (from RequestOutput metrics) | yes (per-batch approximation) | dash (metrics usually absent from the pinned TensorRT-LLM build) |
 | `latency_stats` TTFT | yes (always-on) | profiling only | dash |
 | `latency_stats` ITL / `tpot_ms` | profiling only (`proportional`) | profiling only (`true_streaming`) | dash (unsupported) |
 | `kv_cache.*` | yes (best-effort) | dash | dash |

--- a/docs/reference/schema-discovered-format.md
+++ b/docs/reference/schema-discovered-format.md
@@ -255,7 +255,7 @@ For the full runtime data flow, see [parameter discovery](/explanation/architect
 
 - The parallel validation-rules artefact is `src/llenergymeasure/engines/<engine>/rules.yaml`, reviewed directly in source
 - [Architecture overview](/explanation/architecture/architecture-overview) - how the discovered schema fits the engine-knowledge products
-- [Parameter curation](/explanation/architecture/parameter-curation) - how the discovered schema relates to the hand-authored Pydantic config models
+- [Parameter curation](/explanation/architecture/parameter-curation) - how the discovered schema relates to the generated Pydantic config models
 - [Parameter discovery](/explanation/architecture/parameter-discovery) - runtime config validation
 - [Schema refresh (operations guide)](/contributing/schema-refresh) - manual refresh procedure
 - [Per-engine schema digests](/reference/engines/schema-transformers) - auto-generated reference rendered from these files

--- a/docs/reference/study-config.md
+++ b/docs/reference/study-config.md
@@ -10,16 +10,16 @@ All fields except `model` are optional and have sensible defaults.
 - [Warmup (`warmup:`)](#warmup-warmup)
 - [Baseline (`baseline:`)](#baseline-baseline)
 - [Transformers Engine (`transformers:`)](#transformers-engine-transformers)
-- [Transformers Engine Params (`transformers.engine_params:`)](#transformers-engine-params-transformers-engine_params)
-- [Transformers Sampling Params (`transformers.sampling_params:`)](#transformers-sampling-params-transformers-sampling_params)
+- [Transformers Engine Params (`transformers.engine_params:`)](#transformers-engine-params-transformersengine_params)
+- [Transformers Sampling Params (`transformers.sampling_params:`)](#transformers-sampling-params-transformerssampling_params)
 - [vLLM Engine (`vllm:`)](#vllm-engine-vllm)
-- [vLLM Engine Params (`vllm.engine_params:`)](#vllm-engine-params-vllm-engine_params)
-- [vLLM Sampling Params (`vllm.sampling_params:`)](#vllm-sampling-params-vllm-sampling_params)
+- [vLLM Engine Params (`vllm.engine_params:`)](#vllm-engine-params-vllmengine_params)
+- [vLLM Sampling Params (`vllm.sampling_params:`)](#vllm-sampling-params-vllmsampling_params)
 - [TensorRT-LLM Engine (`tensorrt:`)](#tensorrt-llm-engine-tensorrt)
-- [TensorRT-LLM Engine Params (`tensorrt.engine_params:`)](#tensorrt-llm-engine-params-tensorrt-engine_params)
-- [TensorRT-LLM Sampling Params (`tensorrt.sampling_params:`)](#tensorrt-llm-sampling-params-tensorrt-sampling_params)
+- [TensorRT-LLM Engine Params (`tensorrt.engine_params:`)](#tensorrt-llm-engine-params-tensorrtengine_params)
+- [TensorRT-LLM Sampling Params (`tensorrt.sampling_params:`)](#tensorrt-llm-sampling-params-tensorrtsampling_params)
 - [Harness Overrides (`harness:`)](#harness-overrides-harness)
-- [Transformers Harness (`harness.transformers:`)](#transformers-harness-harness-transformers)
+- [Transformers Harness (`harness.transformers:`)](#transformers-harness-harnesstransformers)
 
 ### Top-Level Fields
 

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -15,6 +15,7 @@ Output:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,25 @@ from llenergymeasure.config._doc_helpers import default_label, type_label
 
 def _description(prop: dict[str, Any]) -> str:
     return prop.get("description", "")
+
+
+# Anything that is not a lowercase word char, hyphen, or space. github-slugger
+# (which Docusaurus uses to derive heading anchors) removes exactly this
+# punctuation from an ASCII heading and keeps [a-z0-9_-]; spaces map to hyphens.
+_SLUGGER_DROP = re.compile(r"[^a-z0-9_ -]")
+
+
+def _heading_anchor(title: str) -> str:
+    """Slugify a heading the way Docusaurus (github-slugger) does.
+
+    Docusaurus derives heading anchors with github-slugger: lowercase, drop
+    punctuation, then map spaces to hyphens. Punctuation is REMOVED,
+    not hyphenated - so a code span like ``transformers.engine_params`` yields
+    ``transformersengine_params``, not ``transformers-engine_params``. The table
+    of contents must slugify with the same rule or its in-page links resolve to
+    anchors that do not exist.
+    """
+    return _SLUGGER_DROP.sub("", title.lower()).replace(" ", "-")
 
 
 # ---------------------------------------------------------------------------
@@ -155,12 +175,7 @@ def render_markdown(schema: dict[str, Any]) -> str:
     lines.append("**Sections:**")
     for section_key, section_title in _SECTION_ORDER:
         if section_key in sections:
-            anchor = section_title.lower()
-            for ch in " /`.:()`":
-                anchor = anchor.replace(ch, "-")
-            while "--" in anchor:
-                anchor = anchor.replace("--", "-")
-            anchor = anchor.strip("-")
+            anchor = _heading_anchor(section_title)
             lines.append(f"- [{section_title}](#{anchor})")
     lines.append("")
 


### PR DESCRIPTION
## Summary

Close-out slice S5: documentation debt. Five items - broken study-config anchors (fixed at the generator), stale TensorRT-LLM/vLLM version pins in docs, dead GHCR image refs in docker-setup, an inaccurate roadmap milestone claim, and the issue #739 curation-era doc residual.

## Item 1 - seven broken anchors on /reference/study-config

`scripts/generate_config_docs.py` built its table-of-contents slugs by replacing `.` with `-`, but Docusaurus derives heading anchors with github-slugger, which removes punctuation outright. Every ToC entry whose heading contains a dotted code span (`transformers.engine_params:` etc.) therefore linked to a nonexistent anchor.

Fix: the generator now slugifies with the github-slugger rule (drop punctuation, spaces to hyphens) and `docs/reference/study-config.md` is regenerated. Verified against the rendered HTML: all 8 ToC `href`s now match the rendered heading `id`s exactly.

Build output before (7 broken anchors):

```
[WARNING] Docusaurus found broken anchors!
- Broken anchor on source page path = /llenergymeasure/reference/study-config:
   -> linking to #transformers-engine-params-transformers-engine_params
   -> linking to #transformers-sampling-params-transformers-sampling_params
   -> linking to #vllm-engine-params-vllm-engine_params
   -> linking to #vllm-sampling-params-vllm-sampling_params
   -> linking to #tensorrt-llm-engine-params-tensorrt-engine_params
   -> linking to #tensorrt-llm-sampling-params-tensorrt-sampling_params
   -> linking to #transformers-harness-harness-transformers
```

Build output after (no broken-anchor or broken-link warnings; the only remaining WARNING is a pre-existing webpack notice about `node_modules/vscode-languageserver-types`, present before this change):

```
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
```

## Item 2 - stale engine versions in docs

`docker pull` examples across `get-started/install.md`, `how-to/install.md`, `how-to/troubleshoot.md`, and `how-to/docker-setup.md` still showed `tensorrt-llm/release:0.21.0` and `vllm-openai:0.7.3`. Updated to the current pins (`1.0.0`, `v0.19.1` - tag formats match `image_registry.DEFAULT_IMAGE_TEMPLATES`), and the surrounding prose now names the pin source (`engine_versions/<engine>/current.yaml`, `llem doctor`) so the next bump has one less place to rot. `results-schema.md` had a hardcoded "absent in 0.21.0" support-matrix note, now phrased against the pinned build. The two remaining `0.21.0` / `v0.7.3` mentions in `contributing/development.md` are dated historical records (a 2026-05-12 spike finding and the #437 rationale) and are intentionally untouched.

## Item 3 - docker-setup.md dead GHCR refs

The "Pre-fetch images manually" block and the `make docker-images` example output still showed `ghcr.io/.../{vllm,tensorrt}:v0.9.0` - refs CI never publishes (the exact bug #780 fixed in code). Aligned with the per-engine upstream default model: transformers = first-party GHCR at the package version, vllm = `vllm/vllm-openai:v<pin>`, tensorrt = `nvcr.io/nvidia/tensorrt-llm/release:<pin>`. The image-sources table and smart-default prose now state the per-engine split instead of a single GHCR pattern for all three.

## Item 4 - roadmap.md milestone claim

Lines 18-20 claimed "The TensorRT-LLM release (v0.10.0) is implementation-complete and in final UAT" - wrong on both counts. Rewritten: v0.10.0 = engine knowledge as data + study authoring; TensorRT-LLM activation = v0.11.0, pending live end-to-end GPU validation.

## Item 5 - issue #739 adjudication (curation-era docs)

Checked each doc named by #739 against the current generated config surface:

- `docs/reference/engines/configuration.md` - **already fixed by #774**: fully rebuilt on `engine_params:` / `sampling_params:` / `harness.<engine>` with the generated models as oracle. Spot-checked structural claims against source: named validators exist in `models.py`, TRT sub-configs are `Any`-typed dicts, vLLM sampling defaults match `engines/vllm/config.py`, `extra="allow"` confirmed, pins in prose match `current.yaml`.
- `docs/explanation/architecture/pipeline-architecture.md` - **already fixed by #759** (plus #760/#775 touch-ups): no `engine_configs.py` references remain; describes the discover -> absorb -> commit-generated-artifacts -> CI-byte-verification flow. Claims verified: `make absorb`, `engine-rules-check.yml`, `renovate.yml` all exist.
- `docs/explanation/architecture/parameter-curation.md` - **fixed in this PR** (was untouched since #634): the overview diagram and "Pydantic curation" section still described hand-authored models in the deleted `config/engine_configs.py` and the deleted `TensorRTKvCacheConfig`. Rewritten around the actual flow (`curated.yaml` + `schema.discovered.json` -> `regen_engine_configs.py` -> generated `engines/<engine>/config.py`, DO NOT EDIT); the drift-checker and `LLEM_NATIVE_FIELDS` sections were still accurate (script exists, CI-wired in `ci.yml`) and kept, with the dead-class example rows replaced by entries verified against the current allowlist. Also fixed a stale "hand-authored" cross-ref in `docs/reference/schema-discovered-format.md`.

Recommendation: with this PR merged, #739 can be closed (all three named docs are now accurate; two were fixed by earlier PRs, the third here). Not closing it from this PR - leaving that call to the maintainer.

## Test plan

- `make docs-check` - clean (generated docs match their generators post-commit)
- `npm ci && npm run build` in `website/` - green, zero broken-anchor / broken-link warnings
- Rendered-HTML cross-check: all study-config ToC hrefs match heading ids
- `make lint` - clean (ruff + import-linter contracts kept)
- `make typecheck` - clean (309 files)
- `make test` - 2930 passed, 44 skipped (generator script touched, so full host suite run)
