### PR TITLE
chore(engines): remove stale _staging reference and sweep untracked residue

### DIFF
--- a/src/llenergymeasure/engines/README.md
+++ b/src/llenergymeasure/engines/README.md
@@ -27,7 +27,6 @@ engines/
     plugin.py          # HuggingFace Transformers engine
     rules.yaml         # Shipped validation rules (single runtime source)
     schema.discovered.json      # Introspected parameter schema
-    _staging/          # Per-engine miner staging (gitkeep'd)
 
   vllm/                # Same shape: vLLM engine (Docker-only)
   tensorrt/            # Same shape: TensorRT-LLM engine (NGC Docker)


### PR DESCRIPTION
## Summary

- Delete the three untracked `src/llenergymeasure/engines/*/_staging/` directories - scratch residue from a 2026-06-22 local mining session (byte-identical copies of `/tmp` scratch files; no code reads or writes `_staging` anywhere in the repo).
- Drop the stale `_staging/ # Per-engine miner staging (gitkeep'd)` line from `src/llenergymeasure/engines/README.md`: no `.gitkeep` is tracked and the concept never landed on main.

## Test plan

- [x] `grep -rn "_staging" src/ scripts/ tests/ Makefile .github/` returns no functional references
- [x] `git status` clean of the untracked dirs
- [ ] CI passes

## Doc audit

- The README line removal IS the doc fix; no other surface changed.