### PR TITLE
fix(ci): disable renovate stability status POST the app token cannot make

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,6 +12,12 @@ name: Renovate
 # opened with GITHUB_TOKEN would not (GitHub suppresses workflow runs on commits
 # it pushed itself, to avoid recursion). Update PRs must run CI to be reviewable.
 #
+# The App token has no Commit-statuses permission, so renovate.json sets
+# statusCheckNames.minimumReleaseAge to null: Renovate would otherwise POST a
+# stability commit status to each bump branch, 403, and abort the whole run
+# before opening the PR (observed 2026-07-12). Nothing consumes that status;
+# the 14-day minimumReleaseAge cooling itself still applies.
+#
 # The in-config `schedule` in renovate.json ("before 9am on Monday") still gates
 # when update PRs are actually created, so this cron does not change bump
 # cadence. This workflow runs daily so the dependency dashboard stays fresh:

--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,9 @@
       "rangeStrategy": "replace"
     }
   ],
+  "statusCheckNames": {
+    "minimumReleaseAge": null
+  },
   "schedule": ["before 9am on Monday"],
   "prConcurrentLimit": 3,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Self-hosted Renovate runs abort with "Repository has changed during renovation" before opening any update PR. Debug logs show the real failure: Renovate POSTs its `minimumReleaseAge` stability commit status to the bump branch, the `llem-ci-bot` App token lacks the Commit-statuses permission (`403`, `x-accepted-github-permissions: statuses=write`), and the status-set error is mapped to a repository-changed abort.
- Fix: `statusCheckNames.minimumReleaseAge: null` in `renovate.json` - skips the status POST entirely. Nothing consumes that status (branch protection never referenced it); the 14-day cooling policy itself still applies to update eligibility.
- Rationale recorded in the `renovate.yml` header comment since JSON carries no comments.

Alternative considered: granting the App `statuses: write`. Rejected as unnecessary surface - the status is purely informational and nothing gates on it.

## Test plan

- [x] Renovate debug run 29192491385 pinpoints the 403 on `POST /statuses/e6635a23`
- [ ] CI passes (actionlint validates the workflow comment change)
- [ ] Post-merge: `gh workflow run renovate.yml` opens the queued `tensorrt-llm 1.2.1` PR without aborting

## Doc audit

- Behavior documented in the `renovate.yml` header block; no user-facing docs cover Renovate internals.