### PR TITLE
feat(engines): dispatch tensorrt backends by class and validate constructor surface live at 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   resolves `tensorrt_llm._tensorrt_engine.LLM` and `pytorch`/unset resolves `tensorrt_llm.LLM`,
   validated live at 1.2.1 (the base `LLM` rejects `backend='trt'` at model load). `backend` is
   no longer forwarded as a kwarg; an unsupported value raises `ConfigError` naming
-  `{pytorch, trt}`. ([#PRNUM])
+  `{pytorch, trt}`. ([#797])
 - TensorRT-LLM pin advanced 1.0.0 -> 1.2.1 through the full bump pipeline: schema re-mined
   byte-stably, the 20-field curation carried forward with no discovery debt, typed config
   regenerated (`max_num_tokens` default now 8192), and the shipped rules corpus grown 15 -> 29
@@ -23,20 +23,20 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 - TensorRT-LLM quantisation is passed as the native `quant_config` kwarg, not the
   long-removed `quantization` name (`TrtLlmArgs` is `extra='forbid'` at 1.2.1, so the old
-  name crashed any quantised run at construction). ([#PRNUM])
+  name crashed any quantised run at construction). ([#797])
 - The TensorRT-LLM plugin no longer forwards TRT-build-only knobs (`fast_build`,
   `quant_config`, the engine build cache) to the pytorch backend, whose `TorchLlmArgs` rejects
   them under `extra='forbid'` - this crashed the default pytorch-backend config. Declaring
   `quant_config` or `fast_build=True` on the pytorch backend now raises `ConfigError` rather
-  than silently measuring a different configuration. ([#PRNUM])
+  than silently measuring a different configuration. ([#797])
 - The four silent `ImportError` fallbacks for TensorRT-LLM sub-configs (QuantConfig,
   BuildCacheConfig, KvCacheConfig, SchedulerConfig) now raise `EngineError` when the user
   declared that sub-config and the native class cannot be imported, instead of silently
-  dropping it and measuring a different configuration than declared. ([#PRNUM])
+  dropping it and measuring a different configuration than declared. ([#797])
 - Corrected stale TensorRT-LLM version references: the `RequestOutput.metrics` comment (metrics
   are absent at 1.2.1 without `return_perf_metrics`, not "usually absent in 0.21.0") and the
   container entrypoint's engine-version list (now vLLM 0.19.1 / TRT-LLM 1.2.1 / Python 3.12).
-  ([#PRNUM])
+  ([#797])
 - Absorb sign-off records now carry the full withheld rule body, so a maintainer's
   `human_confirmed` mark re-ships a rule even after the withholding run dropped it from the
   corpus; a bodyless mark fails loudly instead of silently skipping. ([#792])
@@ -687,3 +687,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#789]: https://github.com/henrycgbaker/llenergymeasure/pull/789
 [#791]: https://github.com/henrycgbaker/llenergymeasure/pull/791
 [#792]: https://github.com/henrycgbaker/llenergymeasure/pull/792
+[#797]: https://github.com/henrycgbaker/llenergymeasure/pull/797

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Changed
 
+- TensorRT-LLM backends are now selected by constructor class, not a kwarg: `backend='trt'`
+  resolves `tensorrt_llm._tensorrt_engine.LLM` and `pytorch`/unset resolves `tensorrt_llm.LLM`,
+  validated live at 1.2.1 (the base `LLM` rejects `backend='trt'` at model load). `backend` is
+  no longer forwarded as a kwarg; an unsupported value raises `ConfigError` naming
+  `{pytorch, trt}`. ([#PRNUM])
 - TensorRT-LLM pin advanced 1.0.0 -> 1.2.1 through the full bump pipeline: schema re-mined
   byte-stably, the 20-field curation carried forward with no discovery debt, typed config
   regenerated (`max_num_tokens` default now 8192), and the shipped rules corpus grown 15 -> 29
@@ -16,6 +21,22 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- TensorRT-LLM quantisation is passed as the native `quant_config` kwarg, not the
+  long-removed `quantization` name (`TrtLlmArgs` is `extra='forbid'` at 1.2.1, so the old
+  name crashed any quantised run at construction). ([#PRNUM])
+- The TensorRT-LLM plugin no longer forwards TRT-build-only knobs (`fast_build`,
+  `quant_config`, the engine build cache) to the pytorch backend, whose `TorchLlmArgs` rejects
+  them under `extra='forbid'` - this crashed the default pytorch-backend config. Declaring
+  `quant_config` or `fast_build=True` on the pytorch backend now raises `ConfigError` rather
+  than silently measuring a different configuration. ([#PRNUM])
+- The four silent `ImportError` fallbacks for TensorRT-LLM sub-configs (QuantConfig,
+  BuildCacheConfig, KvCacheConfig, SchedulerConfig) now raise `EngineError` when the user
+  declared that sub-config and the native class cannot be imported, instead of silently
+  dropping it and measuring a different configuration than declared. ([#PRNUM])
+- Corrected stale TensorRT-LLM version references: the `RequestOutput.metrics` comment (metrics
+  are absent at 1.2.1 without `return_perf_metrics`, not "usually absent in 0.21.0") and the
+  container entrypoint's engine-version list (now vLLM 0.19.1 / TRT-LLM 1.2.1 / Python 3.12).
+  ([#PRNUM])
 - Absorb sign-off records now carry the full withheld rule body, so a maintainer's
   `human_confirmed` mark re-ships a rule even after the withholding run dropped it from the
   corpus; a bodyless mark fails loudly instead of silently skipping. ([#792])

--- a/engine_versions/tensorrt/v1_2_1/outputs/absorb_signoff.yaml
+++ b/engine_versions/tensorrt/v1_2_1/outputs/absorb_signoff.yaml
@@ -25,8 +25,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_engineparams_raises_max_num_tokens_lt_1
   severity: error
   fields:
@@ -44,8 +44,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_engineparams_raises_max_seq_len_lt_1
   severity: error
   fields:
@@ -63,8 +63,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_engineparams_raises_pipeline_parallel_size_lt_1
   severity: error
   fields:
@@ -82,8 +82,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_engineparams_raises_tensor_parallel_size_lt_1
   severity: error
   fields:
@@ -101,8 +101,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_raises_max_batch_size_lt_0
   severity: error
   fields:
@@ -120,9 +120,9 @@ residue:
     provenance:
       source: deterministic_miner
       verified: construction
-      engine_version: 1.0.0
+      engine_version: 1.2.1
       citation: llmapi/llm_args.py:129
-      date: '2026-06-22T20:11:29.656816+00:00'
+      date: '2026-07-13'
 - id: tensorrt_samplingparams_raises_min_p_gt_1p0
   severity: error
   fields:
@@ -140,8 +140,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_samplingparams_raises_min_p_lt_0p0
   severity: error
   fields:
@@ -159,8 +159,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_samplingparams_raises_min_tokens_lt_0
   severity: error
   fields:
@@ -197,8 +197,8 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'
 - id: tensorrt_samplingparams_raises_repetition_penalty_le_0p0
   severity: error
   fields:
@@ -216,5 +216,5 @@ residue:
     provenance:
       source: manual
       verified: human
-      engine_version: 1.0.0
-      date: '2026-07-02'
+      engine_version: 1.2.1
+      date: '2026-07-13'

--- a/scripts/container_entrypoint.sh
+++ b/scripts/container_entrypoint.sh
@@ -55,8 +55,9 @@ import sys
 try:
     import tomllib
 except ImportError:
-    # Python < 3.11 - fail loudly; current upstream images (vllm 0.7.3,
-    # TRT-LLM 0.21, transformers first-party) all ship Python >= 3.11.
+    # Python < 3.11 - fail loudly; current upstream images (vllm 0.19.1,
+    # TRT-LLM 1.2.1, transformers first-party) all ship Python >= 3.11
+    # (the TRT-LLM 1.2.1 NGC image ships Python 3.12).
     print("FATAL: tomllib unavailable; container Python < 3.11", file=sys.stderr)
     sys.exit(2)
 

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -89,9 +89,9 @@ def _apply_default_build_cache(kwargs: dict[str, Any]) -> None:
     - Disabled by env → ``enable_build_cache`` is not set (TRT-LLM default is
       False, matching the discovered schema).
     - Enabled with a user-supplied path → build a ``BuildCacheConfig`` whose
-      ``cache_root`` is that path. Falls back to bare ``True`` if the
-      ``tensorrt_llm.llmapi`` import is unavailable (mirrors the behaviour of
-      the explicit YAML-driven path).
+      ``cache_root`` is that path. Raises :class:`EngineError` if
+      ``tensorrt_llm.llmapi`` cannot be imported: a measurement instrument must
+      not silently run without a build cache the user configured.
     - Enabled without a path → set ``enable_build_cache = True`` (preserves the
       pre-env-var behaviour).
     """
@@ -104,13 +104,16 @@ def _apply_default_build_cache(kwargs: dict[str, Any]) -> None:
     if cache_root is not None:
         try:
             from tensorrt_llm.llmapi import BuildCacheConfig
-
-            kwargs["enable_build_cache"] = BuildCacheConfig(cache_root=cache_root)
-            return
-        except ImportError:
-            logger.debug(
-                "tensorrt_llm.llmapi not available; falling back to bare enable_build_cache=True"
-            )
+        except ImportError as exc:
+            raise EngineError(
+                f"A build cache path was configured (cache_root={cache_root}) but "
+                "tensorrt_llm.llmapi.BuildCacheConfig could not be imported "
+                f"({exc}). Refusing to silently run without the configured build "
+                "cache. Run inside the tensorrt_llm image, or unset "
+                "LLEM_TRT_BUILD_CACHE_PATH."
+            ) from exc
+        kwargs["enable_build_cache"] = BuildCacheConfig(cache_root=cache_root)
+        return
 
     kwargs["enable_build_cache"] = True
 
@@ -169,7 +172,7 @@ class TensorRTEngine:
         from llenergymeasure.engines._errors import require_import
 
         _trt_mod = require_import("tensorrt_llm")
-        LLM = _trt_mod.LLM
+        LLM = self._resolve_llm_class(config)
 
         kwargs = self._build_llm_kwargs(config)
         logger.info("Loading TRT-LLM model %r (kwargs: %s)", config.task.model, list(kwargs.keys()))
@@ -302,8 +305,12 @@ class TensorRTEngine:
         if config.measurement.latency_profiling:
             extras["latency_profiling_unsupported"] = True
 
-        # Defensive per-request metric capture - RequestOutput.metrics is usually
-        # absent in TRT-LLM 0.21.0, so these lists typically come back empty.
+        # Defensive per-request metric capture. Live-checked at TRT-LLM 1.2.1
+        # (2026-07-13, both backend legs): RequestOutput carries NO ``metrics``
+        # attribute at all - populating it needs ``return_perf_metrics=True`` at
+        # LLM construction, which llem does not set - so these lists come back
+        # empty. Wiring return_perf_metrics into a first-class latency path is a
+        # follow-up (see the F2 activation plan), not done here.
         from llenergymeasure.engines._observed import extract_request_metrics
 
         per_request_latencies_ms, ttft_ms = extract_request_metrics(outputs)
@@ -440,19 +447,54 @@ class TensorRTEngine:
     # Private: model loading helpers
     # -------------------------------------------------------------------------
 
+    @staticmethod
+    def _resolve_llm_class(config: ExperimentConfig) -> Any:
+        """Select the TRT-LLM constructor class from the configured backend.
+
+        At 1.2.1 ``tensorrt_llm.LLM`` is ``_TorchLLM``-based (validates against
+        ``TorchLlmArgs``) and REJECTS ``backend='trt'`` at model load; the
+        compiled-TensorRT path is the distinct
+        ``tensorrt_llm._tensorrt_engine.LLM`` (``_TrtLLM``, validates against
+        ``TrtLlmArgs``). We dispatch on the class rather than forwarding the
+        upstream-deprecated ``backend`` kwarg (which is never passed to either
+        constructor - see :meth:`_build_llm_kwargs`).
+
+        - ``backend`` None or ``'pytorch'`` -> ``tensorrt_llm.LLM``
+        - ``backend`` ``'trt'`` -> ``tensorrt_llm._tensorrt_engine.LLM``
+        - anything else -> :class:`ConfigError` naming the accepted values.
+
+        Raises:
+            ConfigError: If ``backend`` is set to an unsupported value.
+            EngineError: If the required TRT-LLM class cannot be imported.
+        """
+        from llenergymeasure.engines._errors import require_import
+
+        engine_params = config.active_engine_params()
+        backend = getattr(engine_params, "backend", None) if engine_params is not None else None
+        if backend is None or backend == "pytorch":
+            return require_import("tensorrt_llm").LLM
+        if backend == "trt":
+            return require_import("tensorrt_llm._tensorrt_engine").LLM
+        raise ConfigError(
+            f"Unsupported tensorrt backend {backend!r}; accepted values are "
+            "{pytorch, trt}. backend selects the TRT-LLM constructor class "
+            "(pytorch -> tensorrt_llm.LLM, trt -> tensorrt_llm._tensorrt_engine.LLM)."
+        )
+
     def _build_llm_kwargs(self, config: ExperimentConfig) -> dict[str, Any]:
-        """Build kwargs dict for tensorrt_llm.LLM() constructor.
+        """Build kwargs dict for the resolved tensorrt_llm LLM() constructor.
 
         All engine fields live on the generated ``engine_params`` block: typed
-        scalars (tensor_parallel_size, max_batch_size, dtype, backend, ...) and
-        Any-typed sub-config dicts (quant_config, kv_cache_config,
-        scheduler_config). When ``backend`` is unset, TRT-LLM auto-picks
-        (respecting ``TLLM_USE_TRT_ENGINE``).
+        scalars (tensor_parallel_size, max_batch_size, dtype, ...) and Any-typed
+        sub-config dicts (quant_config, kv_cache_config, scheduler_config).
+        ``backend`` is NEVER forwarded as a kwarg: it selects the constructor
+        class instead (see :meth:`_resolve_llm_class`), because at 1.2.1 the
+        kwarg is upstream-deprecated and ``backend='trt'`` is rejected by the
+        base ``LLM``.
 
         When engine_path is set (an extra="allow" passthrough field, not
-        curated), returns early with only {"model": engine_path} plus ``backend``
-        iff supplied. Compile-time kwargs are baked into the engine and must not
-        be re-specified.
+        curated), returns early with only {"model": engine_path}. Compile-time
+        kwargs are baked into the engine and must not be re-specified.
         """
         kwargs: dict[str, Any] = {
             "model": config.task.model,
@@ -473,29 +515,70 @@ class TensorRTEngine:
                 raise ConfigError(f"engine_path validation failed: {'; '.join(errors)}")
             # Pass engine dir as model - TRT-LLM auto-detects TLLM_ENGINE format.
             # Compile-time kwargs are baked into the engine; don't pass them.
-            early_kwargs: dict[str, Any] = {"model": str(raw_engine_path)}
-            if engine_params.backend is not None:
-                early_kwargs["backend"] = engine_params.backend
-            return early_kwargs
+            # backend is not a kwarg - it selects the constructor class.
+            return {"model": str(raw_engine_path)}
+
+        backend = getattr(engine_params, "backend", None) if engine_params is not None else None
+        is_trt = backend == "trt"
 
         if engine_params is None:
-            # No tensorrt section - apply env-var-gated default build cache.
-            _apply_default_build_cache(kwargs)
+            # No tensorrt section -> default (pytorch) backend. The TRT-engine-build
+            # knobs (build cache, fast_build, quant_config) are absent from the
+            # pytorch backend's TorchLlmArgs, so nothing extra is forwarded.
             return kwargs
 
         # Scalar fields and extras: forward non-None values verbatim. The
-        # sub-config dicts are popped and rebuilt into their native classes below.
+        # sub-config dicts and the TRT-build-only knobs are popped and handled
+        # separately below.
         dumped: dict[str, Any] = engine_params.model_dump(exclude_none=True)
         quant_config = dumped.pop("quant_config", None)
         kv_cache_config = dumped.pop("kv_cache_config", None)
         scheduler_config = dumped.pop("scheduler_config", None)
-        kwargs.update(dumped)
+        dumped.pop("backend", None)  # backend selects the class, never a kwarg
+        fast_build = dumped.pop("fast_build", None)  # TRT-build-only; see below
 
-        # Quantisation config
-        if isinstance(quant_config, dict) and quant_config:
-            try:
-                from tensorrt_llm.llmapi import QuantAlgo, QuantConfig
+        # fast_build, quant_config and the on-disk build cache are TRT-engine-build
+        # concepts absent from the pytorch backend's TorchLlmArgs (extra='forbid'),
+        # so forwarding them there crashes construction. On the pytorch backend we
+        # refuse the ones carrying declared measurement intent LOUDLY rather than
+        # silently measure a different configuration, and skip the build cache (a
+        # build-speed knob with no effect on what is measured).
+        if not is_trt:
+            if isinstance(quant_config, dict) and quant_config:
+                raise ConfigError(
+                    "quant_config requires backend='trt'. The pytorch backend does "
+                    "not apply a TRT-LLM quantization config (it loads a "
+                    "pre-quantised checkpoint instead); refusing to silently "
+                    "measure an unquantised model. Set backend='trt' or remove "
+                    "quant_config."
+                )
+            if fast_build:
+                raise ConfigError(
+                    "fast_build requires backend='trt'. There is no TRT engine "
+                    "build on the pytorch backend. Set backend='trt' or remove "
+                    "fast_build."
+                )
 
+        kwargs.update(dumped)  # scalars valid on both backends (tp/pp/max_*/dtype)
+
+        # TRT-build-only surface (guarded above for the pytorch backend).
+        if is_trt:
+            if fast_build is not None:
+                kwargs["fast_build"] = fast_build
+
+            # Quantisation config -> native ``quant_config`` kwarg. NOT
+            # ``quantization``: TrtLlmArgs is extra='forbid' at 1.2.1 and rejects
+            # the old ``quantization`` name.
+            if isinstance(quant_config, dict) and quant_config:
+                try:
+                    from tensorrt_llm.llmapi import QuantAlgo, QuantConfig
+                except ImportError as exc:
+                    raise EngineError(
+                        f"quant_config was declared ({quant_config}) but "
+                        "tensorrt_llm.llmapi QuantConfig/QuantAlgo could not be "
+                        f"imported ({exc}). Refusing to silently measure an "
+                        "unquantised model while the config declares quantisation."
+                    ) from exc
                 qc_kwargs: dict[str, Any] = {}
                 if quant_config.get("quant_algo") is not None:
                     qc_kwargs["quant_algo"] = QuantAlgo[quant_config["quant_algo"]]
@@ -504,39 +587,44 @@ class TensorRTEngine:
                         quant_config["kv_cache_quant_algo"]
                     ]
                 if qc_kwargs:
-                    kwargs["quantization"] = QuantConfig(**qc_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; skipping QuantConfig")
+                    kwargs["quant_config"] = QuantConfig(**qc_kwargs)
 
-        # Build cache - env-var-gated default.
-        # TensorRTBuildCacheConfig was dropped (D1); advanced config via extra="allow".
-        _apply_default_build_cache(kwargs)
+            # On-disk engine build cache - env-var-gated default (trt build only).
+            _apply_default_build_cache(kwargs)
 
-        # KV cache config
+        # KV cache config (a valid field on both backends)
         if isinstance(kv_cache_config, dict) and kv_cache_config:
             try:
                 from tensorrt_llm.llmapi import KvCacheConfig
-
-                kwargs["kv_cache_config"] = KvCacheConfig(
-                    **{k: v for k, v in kv_cache_config.items() if v is not None}
-                )
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; skipping KvCacheConfig")
+            except ImportError as exc:
+                raise EngineError(
+                    f"kv_cache_config was declared ({kv_cache_config}) but "
+                    "tensorrt_llm.llmapi.KvCacheConfig could not be imported "
+                    f"({exc}). Refusing to silently drop a declared KV-cache "
+                    "config that would change what is measured."
+                ) from exc
+            kwargs["kv_cache_config"] = KvCacheConfig(
+                **{k: v for k, v in kv_cache_config.items() if v is not None}
+            )
 
         # Scheduler config
         if isinstance(scheduler_config, dict) and scheduler_config:
             try:
                 from tensorrt_llm.llmapi import CapacitySchedulerPolicy, SchedulerConfig
-
-                sc_kwargs: dict[str, Any] = {}
-                if scheduler_config.get("capacity_scheduling_policy") is not None:
-                    sc_kwargs["capacity_scheduling_policy"] = CapacitySchedulerPolicy[
-                        scheduler_config["capacity_scheduling_policy"]
-                    ]
-                if sc_kwargs:
-                    kwargs["scheduler_config"] = SchedulerConfig(**sc_kwargs)
-            except ImportError:
-                logger.debug("tensorrt_llm.llmapi not available; skipping SchedulerConfig")
+            except ImportError as exc:
+                raise EngineError(
+                    f"scheduler_config was declared ({scheduler_config}) but "
+                    "tensorrt_llm.llmapi SchedulerConfig/CapacitySchedulerPolicy "
+                    f"could not be imported ({exc}). Refusing to silently drop a "
+                    "declared scheduler config that would change what is measured."
+                ) from exc
+            sc_kwargs: dict[str, Any] = {}
+            if scheduler_config.get("capacity_scheduling_policy") is not None:
+                sc_kwargs["capacity_scheduling_policy"] = CapacitySchedulerPolicy[
+                    scheduler_config["capacity_scheduling_policy"]
+                ]
+            if sc_kwargs:
+                kwargs["scheduler_config"] = SchedulerConfig(**sc_kwargs)
 
         return kwargs
 

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -310,7 +310,7 @@ class TensorRTEngine:
         # attribute at all - populating it needs ``return_perf_metrics=True`` at
         # LLM construction, which llem does not set - so these lists come back
         # empty. Wiring return_perf_metrics into a first-class latency path is a
-        # follow-up (see the F2 activation plan), not done here.
+        # deliberate follow-up, not done here.
         from llenergymeasure.engines._observed import extract_request_metrics
 
         per_request_latencies_ms, ttft_ms = extract_request_metrics(outputs)

--- a/tests/unit/engines/test_measurement_contract.py
+++ b/tests/unit/engines/test_measurement_contract.py
@@ -19,9 +19,10 @@ What is locked:
     present so the caller dispatches to the beam path).
   - VLLMEngine._build_beam_search_params: the BeamSearchParams kwargs assembled
     from the Any-typed beam_search sub-dict.
-  - TensorRTEngine._build_llm_kwargs: scalar forwarding, the env-gated build
-    cache staying off, and the Any-typed sub-config dicts (quant_config /
-    kv_cache_config / scheduler_config) being popped out of the scalar dump.
+  - TensorRTEngine._build_llm_kwargs: scalar forwarding, backend selecting the
+    constructor class (never forwarded as a kwarg), the TRT-build-only knobs
+    (fast_build / build cache) staying off the pytorch backend, and a declared
+    sub-config raising loudly on a plain host rather than silently vanishing.
   - TensorRTEngine._build_sampling_kwargs: the effective SamplingParams kwargs
     including the injected seed and max_tokens.
 
@@ -257,7 +258,12 @@ class TestVLLMKwargBuilders:
 
 class TestTensorRTKwargBuilders:
     def test_build_llm_kwargs_scalar_forwarding(self) -> None:
-        """Scalar engine_params forward; the env-gated build cache stays off."""
+        """Scalars forward on the pytorch backend; backend + TRT-build knobs stay off.
+
+        ``backend`` selects the constructor class (never a kwarg) and the
+        TRT-build-only ``fast_build`` (absent from the pytorch TorchLlmArgs) is
+        dropped rather than forwarded.
+        """
         config = make_config(
             model="test-model",
             engine="tensorrt",
@@ -277,28 +283,37 @@ class TestTensorRTKwargBuilders:
             "max_batch_size": 8,
             "max_num_tokens": 8192,
             "dtype": "bfloat16",
-            "fast_build": False,
-            "backend": "pytorch",
         }
 
-    def test_build_llm_kwargs_pops_sub_config_dicts(self) -> None:
-        """Any-typed sub-config dicts are popped from the scalar dump.
+    def test_build_llm_kwargs_sub_config_declared_raises_loud_on_host(self) -> None:
+        """A declared sub-config raises loudly on a plain host, never vanishes silently.
 
-        The native QuantConfig / KvCacheConfig / SchedulerConfig objects are built
-        only when tensorrt_llm is importable (container path); on a plain host the
-        import is skipped, so the raw dicts must not leak into kwargs either way.
+        The Any-typed sub-config dicts are popped from the scalar dump; building
+        the native KvCacheConfig object needs tensorrt_llm, so on a plain host the
+        import fails and _build_llm_kwargs raises EngineError rather than silently
+        measuring a different configuration than the user declared.
         """
+        from llenergymeasure.utils.exceptions import EngineError
+
         config = make_config(
             model="test-model",
             engine="tensorrt",
             tensorrt={
                 "engine_params": {
                     "tensor_parallel_size": 1,
-                    "quant_config": {"quant_algo": "FP8"},
                     "kv_cache_config": {"free_gpu_memory_fraction": 0.8},
-                    "scheduler_config": {"capacity_scheduling_policy": "MAX_UTILIZATION"},
                 }
             },
+        )
+        with pytest.raises(EngineError, match="kv_cache_config was declared"):
+            TensorRTEngine()._build_llm_kwargs(config)
+
+    def test_build_llm_kwargs_scalars_only_no_sub_config_keys(self) -> None:
+        """With no sub-configs declared, only scalars forward (no raw dict leakage)."""
+        config = make_config(
+            model="test-model",
+            engine="tensorrt",
+            tensorrt={"engine_params": {"tensor_parallel_size": 1}},
         )
         built = TensorRTEngine()._build_llm_kwargs(config)
         assert built == {
@@ -307,10 +322,9 @@ class TestTensorRTKwargBuilders:
             "pipeline_parallel_size": 1,
             "max_num_tokens": 8192,
             "dtype": "auto",
-            "fast_build": False,
         }
-        # The raw sub-config dicts never forward under their own names.
-        assert "quant_config" not in built
+        for key in ("quant_config", "kv_cache_config", "scheduler_config", "backend", "fast_build"):
+            assert key not in built
 
     def test_build_sampling_kwargs(self) -> None:
         """Sampling dump plus the injected seed and max_tokens."""

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -102,11 +102,30 @@ class _FakeSamplingParams:
             setattr(self, k, v)
 
 
+class _MockBaseLLM:
+    """Stand-in for tensorrt_llm.LLM (the pytorch backend, _TorchLLM-based)."""
+
+
+class _MockTrtLLM:
+    """Stand-in for tensorrt_llm._tensorrt_engine.LLM (the compiled-TRT backend)."""
+
+
 def _make_fake_tensorrt_llm_module() -> types.ModuleType:
-    """Build a minimal fake tensorrt_llm module for sys.modules injection."""
+    """Build a minimal fake tensorrt_llm module for sys.modules injection.
+
+    Includes the two LLM classes so the backend class-dispatch path
+    (:meth:`TensorRTEngine._resolve_llm_class`) is exercisable without a real
+    tensorrt_llm import. Callers that need dispatch also inject the
+    ``tensorrt_llm._tensorrt_engine`` submodule (see :func:`_inject_trt`).
+    """
     mock_trt = types.ModuleType("tensorrt_llm")
-    mock_trt.__version__ = "0.21.0"  # type: ignore[attr-defined]
+    mock_trt.__version__ = "1.2.1"  # type: ignore[attr-defined]
     mock_trt.SamplingParams = _FakeSamplingParams  # type: ignore[attr-defined]
+    mock_trt.LLM = _MockBaseLLM  # type: ignore[attr-defined]
+
+    mock_engine = types.ModuleType("tensorrt_llm._tensorrt_engine")
+    mock_engine.LLM = _MockTrtLLM  # type: ignore[attr-defined]
+    mock_trt._tensorrt_engine = mock_engine  # type: ignore[attr-defined]
 
     mock_llmapi = types.ModuleType("tensorrt_llm.llmapi")
     mock_llmapi.QuantAlgo = _MockQuantAlgo  # type: ignore[attr-defined]
@@ -118,6 +137,13 @@ def _make_fake_tensorrt_llm_module() -> types.ModuleType:
 
     mock_trt.llmapi = mock_llmapi  # type: ignore[attr-defined]
     return mock_trt
+
+
+def _inject_trt(monkeypatch, mock_trt) -> None:
+    """Register the fake tensorrt_llm module tree in sys.modules for dispatch."""
+    monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
+    monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
+    monkeypatch.setitem(sys.modules, "tensorrt_llm._tensorrt_engine", mock_trt._tensorrt_engine)
 
 
 # =============================================================================
@@ -155,10 +181,11 @@ class TestProtocolCompliance:
 
 class TestBuildLlmKwargs:
     def test_build_llm_kwargs_minimal(self, monkeypatch):
-        """No tensorrt config -> kwargs has model and enable_build_cache; no backend kwarg.
+        """No tensorrt config -> default (pytorch) backend: model only, no build cache.
 
-        Sets LLEM_TRT_BUILD_CACHE_ENABLED=1 to mimic the production .env state,
-        since the helper is now pure passthrough (unset -> False -> kwarg omitted).
+        With no tensorrt section the default backend is pytorch, whose
+        TorchLlmArgs has no ``enable_build_cache`` field, so the build cache is
+        never applied even with LLEM_TRT_BUILD_CACHE_ENABLED=1.
         """
         monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
         config = make_config(**_TRT_DEFAULTS)
@@ -167,33 +194,23 @@ class TestBuildLlmKwargs:
 
         assert kwargs["model"] == "test-model"
         assert "backend" not in kwargs
-        assert kwargs.get("enable_build_cache") is True
+        assert "enable_build_cache" not in kwargs
 
-    def test_build_llm_kwargs_backend_trt(self):
-        """engine_params.backend='trt' -> kwargs['backend'] == 'trt' (AOT-compiled engine path)."""
+    def test_build_llm_kwargs_backend_never_forwarded_trt(self):
+        """backend='trt' selects the class; it is NOT forwarded as a kwarg."""
         config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "trt"}})
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
-        assert kwargs["backend"] == "trt"
+        assert "backend" not in kwargs
 
-    def test_build_llm_kwargs_backend_pytorch(self):
-        """engine_params.backend='pytorch' -> kwargs['backend'] == 'pytorch' (eager runtime)."""
+    def test_build_llm_kwargs_backend_never_forwarded_pytorch(self):
+        """backend='pytorch' selects the class; it is NOT forwarded as a kwarg."""
         config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "pytorch"}})
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
-        assert kwargs["backend"] == "pytorch"
-
-    def test_build_llm_kwargs_backend_autodeploy(self):
-        """engine_params.backend='_autodeploy' -> kwargs['backend'] == '_autodeploy'."""
-        config = make_config(
-            **_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "_autodeploy"}}
-        )
-        engine = TensorRTEngine()
-        kwargs = engine._build_llm_kwargs(config)
-
-        assert kwargs["backend"] == "_autodeploy"
+        assert "backend" not in kwargs
 
     def test_build_llm_kwargs_tensor_parallel_size(self):
         """tensor_parallel_size=2 maps to kwargs tensor_parallel_size=2."""
@@ -222,12 +239,43 @@ class TestBuildLlmKwargs:
         assert kwargs["dtype"] == "float16"
 
     def test_build_llm_kwargs_fast_build(self):
-        """fast_build=True maps directly."""
-        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"fast_build": True}})
+        """backend='trt' + fast_build=True maps directly (trt-build-only knob)."""
+        config = make_config(
+            **_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "trt", "fast_build": True}}
+        )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
         assert kwargs["fast_build"] is True
+
+    def test_build_llm_kwargs_fast_build_true_pytorch_raises(self):
+        """fast_build=True on the pytorch backend raises ConfigError (no TRT engine build)."""
+        import pytest
+
+        from llenergymeasure.utils.exceptions import ConfigError
+
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "pytorch", "fast_build": True}},
+        )
+        engine = TensorRTEngine()
+        with pytest.raises(ConfigError, match="fast_build requires backend='trt'"):
+            engine._build_llm_kwargs(config)
+
+    def test_build_llm_kwargs_fast_build_false_pytorch_dropped(self):
+        """The default fast_build=False on the pytorch backend is dropped, not forwarded.
+
+        TorchLlmArgs has no ``fast_build`` field (extra='forbid'), so forwarding
+        even the harmless default would crash construction.
+        """
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "pytorch", "fast_build": False}},
+        )
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert "fast_build" not in kwargs
 
     def test_build_llm_kwargs_none_values_not_included(self):
         """None fields from engine_params are NOT in kwargs.
@@ -250,48 +298,83 @@ class TestBuildLlmKwargs:
         assert "backend" not in kwargs
 
     def test_build_llm_kwargs_default_build_cache_when_no_build_cache_section(self, monkeypatch):
-        """When no build_cache section and .env ships LLEM_TRT_BUILD_CACHE_ENABLED=1, enable_build_cache=True."""
+        """backend='trt' + LLEM_TRT_BUILD_CACHE_ENABLED=1 -> enable_build_cache=True."""
         monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "trt", "tensor_parallel_size": 1}},
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
         assert kwargs.get("enable_build_cache") is True
 
+    def test_build_llm_kwargs_build_cache_skipped_on_pytorch(self, monkeypatch):
+        """The build cache is a TRT-build knob: skipped on the pytorch backend even if enabled."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "pytorch", "tensor_parallel_size": 1}},
+        )
+        engine = TensorRTEngine()
+        kwargs = engine._build_llm_kwargs(config)
+
+        assert "enable_build_cache" not in kwargs
+
     def test_build_llm_kwargs_quant_config(self, monkeypatch):
-        """quant.quant_algo='INT8' produces QuantConfig with QuantAlgo.INT8."""
+        """backend='trt' + quant.quant_algo='INT8' -> quant_config=QuantConfig(QuantAlgo.INT8).
+
+        The native kwarg is ``quant_config`` (NOT the legacy ``quantization``,
+        which TrtLlmArgs rejects under extra='forbid' at 1.2.1).
+        """
         mock_trt = _make_fake_tensorrt_llm_module()
         monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
         monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
 
         config = make_config(
             **_TRT_DEFAULTS,
-            tensorrt={"engine_params": {"quant_config": {"quant_algo": "INT8"}}},
+            tensorrt={"engine_params": {"backend": "trt", "quant_config": {"quant_algo": "INT8"}}},
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
-        assert "quantization" in kwargs
-        assert isinstance(kwargs["quantization"], _MockQuantConfig)
-        assert kwargs["quantization"]._kwargs["quant_algo"] == "INT8"
+        assert "quantization" not in kwargs
+        assert "quant_config" in kwargs
+        assert isinstance(kwargs["quant_config"], _MockQuantConfig)
+        assert kwargs["quant_config"]._kwargs["quant_algo"] == "INT8"
+
+    def test_build_llm_kwargs_quant_config_pytorch_raises(self):
+        """Declaring quant_config on the pytorch backend raises ConfigError (loud, not silent)."""
+        import pytest
+
+        from llenergymeasure.utils.exceptions import ConfigError
+
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={
+                "engine_params": {"backend": "pytorch", "quant_config": {"quant_algo": "INT8"}}
+            },
+        )
+        engine = TensorRTEngine()
+        with pytest.raises(ConfigError, match="quant_config requires backend='trt'"):
+            engine._build_llm_kwargs(config)
 
     def test_build_llm_kwargs_enable_build_cache_when_env_set(self, monkeypatch):
-        """LLEM_TRT_BUILD_CACHE_ENABLED=1 with tensorrt section -> enable_build_cache=True."""
+        """backend='trt' + LLEM_TRT_BUILD_CACHE_ENABLED=1 -> enable_build_cache=True."""
         monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
-        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {}})
+        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "trt"}})
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
         assert kwargs.get("enable_build_cache") is True
 
     def test_trt_build_cache_absent_when_env_unset(self, monkeypatch):
-        """Pure passthrough: LLEM_TRT_BUILD_CACHE_ENABLED unset -> kwarg absent (TRT-LLM default)."""
+        """backend='trt', LLEM_TRT_BUILD_CACHE_ENABLED unset -> kwarg absent (TRT-LLM default)."""
         monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_ENABLED", raising=False)
         monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_PATH", raising=False)
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "trt", "tensor_parallel_size": 1}},
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -299,24 +382,25 @@ class TestBuildLlmKwargs:
         assert "enable_build_cache" not in kwargs
 
     def test_trt_build_cache_disabled_by_env_var(self, monkeypatch):
-        """LLEM_TRT_BUILD_CACHE_ENABLED=0 -> kwarg absent."""
+        """backend='trt', LLEM_TRT_BUILD_CACHE_ENABLED=0 -> kwarg absent."""
         monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "0")
         monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_PATH", raising=False)
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "trt", "tensor_parallel_size": 1}},
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
 
         assert "enable_build_cache" not in kwargs
 
-        # Also covers the no-tensorrt-section branch.
+        # Also covers the no-tensorrt-section branch (pytorch default).
         config_no_trt = make_config(**_TRT_DEFAULTS)
         kwargs_no_trt = engine._build_llm_kwargs(config_no_trt)
         assert "enable_build_cache" not in kwargs_no_trt
 
     def test_trt_build_cache_path_used_when_both_env_vars_set(self, monkeypatch):
-        """LLEM_TRT_BUILD_CACHE_ENABLED=1 + LLEM_TRT_BUILD_CACHE_PATH=... -> BuildCacheConfig(cache_root=path)."""
+        """backend='trt' + ENABLED=1 + PATH=... -> BuildCacheConfig(cache_root=path)."""
         mock_trt = _make_fake_tensorrt_llm_module()
         monkeypatch.setitem(sys.modules, "tensorrt_llm", mock_trt)
         monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", mock_trt.llmapi)
@@ -324,7 +408,8 @@ class TestBuildLlmKwargs:
         monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_PATH", "/tmp/test")
 
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "trt", "tensor_parallel_size": 1}},
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -336,11 +421,12 @@ class TestBuildLlmKwargs:
         assert kwargs["enable_build_cache"]._kwargs["cache_root"] == _Path("/tmp/test")
 
     def test_trt_build_cache_enabled_alone_is_bare_true(self, monkeypatch):
-        """LLEM_TRT_BUILD_CACHE_ENABLED=1, path unset -> enable_build_cache is bare True."""
+        """backend='trt', ENABLED=1, path unset -> enable_build_cache is bare True."""
         monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
         monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_PATH", raising=False)
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "trt", "tensor_parallel_size": 1}},
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -348,11 +434,12 @@ class TestBuildLlmKwargs:
         assert kwargs["enable_build_cache"] is True
 
     def test_trt_build_cache_path_requires_enabled(self, monkeypatch):
-        """LLEM_TRT_BUILD_CACHE_PATH set but ENABLED unset -> kwarg absent (passthrough invariant)."""
+        """backend='trt', PATH set but ENABLED unset -> kwarg absent (passthrough invariant)."""
         monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_ENABLED", raising=False)
         monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_PATH", "/tmp/test")
         config = make_config(
-            **_TRT_DEFAULTS, tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "trt", "tensor_parallel_size": 1}},
         )
         engine = TensorRTEngine()
         kwargs = engine._build_llm_kwargs(config)
@@ -583,7 +670,7 @@ class TestBuildLlmKwargsEnginePath:
         assert "backend" not in kwargs
 
     def test_build_llm_kwargs_engine_path_with_typed_backend(self, tmp_path):
-        """engine_path + typed backend -> both present in the early-return kwargs."""
+        """engine_path + typed backend -> only model in kwargs; backend selects the class."""
         config_data = {"pretrained_config": {"mapping": {"tp_size": 1}}, "build_config": {}}
         (tmp_path / "config.json").write_text(json.dumps(config_data))
         (tmp_path / "rank0.engine").write_bytes(b"fake")
@@ -596,7 +683,7 @@ class TestBuildLlmKwargsEnginePath:
         kwargs = engine._build_llm_kwargs(config)
 
         assert kwargs["model"] == str(tmp_path)
-        assert kwargs["backend"] == "trt"
+        assert "backend" not in kwargs
 
     def test_build_llm_kwargs_engine_path_skips_compile_kwargs(self, tmp_path):
         """engine_path set -> no compile-time kwargs (tensor_parallel_size, max_batch_size, etc.)."""
@@ -651,4 +738,135 @@ class TestBuildLlmKwargsEnginePath:
         )
         engine = TensorRTEngine()
         with pytest.raises(ConfigError, match="engine_path validation failed"):
+            engine._build_llm_kwargs(config)
+
+
+# =============================================================================
+# Test Group 9: backend class dispatch (D1)
+# =============================================================================
+
+
+class TestResolveLlmClass:
+    def test_backend_none_resolves_base_llm(self, monkeypatch):
+        """backend unset -> tensorrt_llm.LLM (the pytorch backend)."""
+        mock_trt = _make_fake_tensorrt_llm_module()
+        _inject_trt(monkeypatch, mock_trt)
+        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {}})
+        assert TensorRTEngine._resolve_llm_class(config) is _MockBaseLLM
+
+    def test_backend_pytorch_resolves_base_llm(self, monkeypatch):
+        """backend='pytorch' -> tensorrt_llm.LLM."""
+        mock_trt = _make_fake_tensorrt_llm_module()
+        _inject_trt(monkeypatch, mock_trt)
+        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "pytorch"}})
+        assert TensorRTEngine._resolve_llm_class(config) is _MockBaseLLM
+
+    def test_backend_no_section_resolves_base_llm(self, monkeypatch):
+        """No tensorrt section -> default (pytorch) -> tensorrt_llm.LLM."""
+        mock_trt = _make_fake_tensorrt_llm_module()
+        _inject_trt(monkeypatch, mock_trt)
+        config = make_config(**_TRT_DEFAULTS)
+        assert TensorRTEngine._resolve_llm_class(config) is _MockBaseLLM
+
+    def test_backend_trt_resolves_tensorrt_engine_llm(self, monkeypatch):
+        """backend='trt' -> tensorrt_llm._tensorrt_engine.LLM (compiled-TRT class)."""
+        mock_trt = _make_fake_tensorrt_llm_module()
+        _inject_trt(monkeypatch, mock_trt)
+        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "trt"}})
+        assert TensorRTEngine._resolve_llm_class(config) is _MockTrtLLM
+
+    def test_backend_autodeploy_raises_config_error(self, monkeypatch):
+        """_autodeploy is not exposed -> ConfigError naming accepted values {pytorch, trt}."""
+        import pytest
+
+        from llenergymeasure.utils.exceptions import ConfigError
+
+        mock_trt = _make_fake_tensorrt_llm_module()
+        _inject_trt(monkeypatch, mock_trt)
+        config = make_config(
+            **_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "_autodeploy"}}
+        )
+        with pytest.raises(ConfigError, match=r"\{pytorch, trt\}"):
+            TensorRTEngine._resolve_llm_class(config)
+
+    def test_backend_unknown_raises_config_error(self, monkeypatch):
+        """An arbitrary backend value -> ConfigError."""
+        import pytest
+
+        from llenergymeasure.utils.exceptions import ConfigError
+
+        mock_trt = _make_fake_tensorrt_llm_module()
+        _inject_trt(monkeypatch, mock_trt)
+        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "nonsense"}})
+        with pytest.raises(ConfigError, match="Unsupported tensorrt backend"):
+            TensorRTEngine._resolve_llm_class(config)
+
+
+# =============================================================================
+# Test Group 10: loud sub-config import failures (D2)
+# =============================================================================
+
+
+class TestLoudSubConfigImportErrors:
+    """A declared sub-config whose native class cannot be imported must raise
+    EngineError, never silently drop the kwarg (a measurement instrument must
+    not measure a different configuration than declared).
+
+    These tests inject no fake tensorrt_llm, so the real (absent-on-host) import
+    fails and the loud path fires.
+    """
+
+    def test_quant_config_import_failure_raises(self):
+        import pytest
+
+        from llenergymeasure.utils.exceptions import EngineError
+
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"backend": "trt", "quant_config": {"quant_algo": "INT8"}}},
+        )
+        engine = TensorRTEngine()
+        with pytest.raises(EngineError, match="quant_config was declared"):
+            engine._build_llm_kwargs(config)
+
+    def test_kv_cache_config_import_failure_raises(self):
+        import pytest
+
+        from llenergymeasure.utils.exceptions import EngineError
+
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"kv_cache_config": {"free_gpu_memory_fraction": 0.8}}},
+        )
+        engine = TensorRTEngine()
+        with pytest.raises(EngineError, match="kv_cache_config was declared"):
+            engine._build_llm_kwargs(config)
+
+    def test_scheduler_config_import_failure_raises(self):
+        import pytest
+
+        from llenergymeasure.utils.exceptions import EngineError
+
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={
+                "engine_params": {
+                    "scheduler_config": {"capacity_scheduling_policy": "MAX_UTILIZATION"}
+                }
+            },
+        )
+        engine = TensorRTEngine()
+        with pytest.raises(EngineError, match="scheduler_config was declared"):
+            engine._build_llm_kwargs(config)
+
+    def test_build_cache_import_failure_raises(self, monkeypatch):
+        import pytest
+
+        from llenergymeasure.utils.exceptions import EngineError
+
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_PATH", "/tmp/test")
+        config = make_config(**_TRT_DEFAULTS, tensorrt={"engine_params": {"backend": "trt"}})
+        engine = TensorRTEngine()
+        with pytest.raises(EngineError, match="build cache path was configured"):
             engine._build_llm_kwargs(config)

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -742,7 +742,7 @@ class TestBuildLlmKwargsEnginePath:
 
 
 # =============================================================================
-# Test Group 9: backend class dispatch (D1)
+# Test Group 9: backend class dispatch
 # =============================================================================
 
 
@@ -803,7 +803,7 @@ class TestResolveLlmClass:
 
 
 # =============================================================================
-# Test Group 10: loud sub-config import failures (D2)
+# Test Group 10: loud sub-config import failures
 # =============================================================================
 
 


### PR DESCRIPTION
## Summary

First-ever **live** validation of the TensorRT-LLM integration (every prior test mocked `tensorrt_llm`), against the pinned NGC image `nvcr.io/nvidia/tensorrt-llm/release:1.2.1` on A100 (SM 8.0). The live probing revealed real translation-layer drift the mocked suite could never catch; this PR fixes it and class-dispatches the two backends.

- **Backend class dispatch (D1).** At 1.2.1 `tensorrt_llm.LLM` is `_TorchLLM`-based and rejects `backend='trt'` at model load; the compiled path is `tensorrt_llm._tensorrt_engine.LLM`. `TensorRTEngine._resolve_llm_class` now dispatches on `backend` (`trt` -> `_tensorrt_engine.LLM`; `pytorch`/None -> `LLM`; unknown -> `ConfigError {pytorch, trt}`). `backend` is never forwarded as a kwarg. `_autodeploy` stays unexposed.
- **`quantization` -> `quant_config` (D3).** The plugin passed a `quantization=` kwarg that does not exist on the args classes (`extra='forbid'`), so any quantised trt run crashed at construction. Fixed to the native `quant_config` kwarg.
- **pytorch-leg trt-only fields (D3).** `fast_build`, `quant_config` and the build cache are absent from `TorchLlmArgs` and crash the pytorch leg under `extra='forbid'` (the default `fast_build=False` + default build cache crashed it today). The kwarg builder is now backend-aware: it skips build-speed knobs on pytorch and raises `ConfigError` when a declared `quant_config`/`fast_build=True` cannot be honoured.
- **Loud sub-config fallbacks (D2).** The four `except ImportError: logger.debug(...)` fallbacks (QuantConfig/BuildCacheConfig/KvCacheConfig/SchedulerConfig) now raise `EngineError` when the user declared that sub-config and the native import fails, instead of silently measuring a different configuration.
- **Bound re-verification (D4).** All 10 human-signed residue bounds re-verified **HOLD** live at 1.2.1 at the grain each binds (parallel-size at model-load, max-shapes at load/build, min_p/n/repetition_penalty at generation via C++ assertions). Provenance restamped 1.0.0 -> 1.2.1 (byte-stable). No bound refuted; `min_tokens_lt_0` left untouched.
- **Version-skew comments (D5).** `RequestOutput.metrics` is absent at 1.2.1 (needs `return_perf_metrics`; not wired in, follow-up); stale `container_entrypoint.sh` engine-version list corrected.

## Test plan

- Full host suite: **2941 passed, 35 skipped**.
- `make lint` + `make typecheck`: clean.
- `regen_engine_configs.py --engine tensorrt --version 1.2.1 --check`: byte-green (config.py never hand-edited).
- Corpus literal census (tensorrt): OK; rules loader tests green.
- **Live**: both legs construct Qwen2.5-0.5B in the 1.2.1 container - pytorch loads (~42s), trt builds + loads (~46s) and generates.

## Evidence

Local-only (`.product/`, gitignored):
- `.product/research/trt-live-constructor-validation-2026-07-13.md` (acceptance matrix, bound verdicts, drift, follow-ups)
- `.product/research/trt-live-constructor-validation-evidence-2026-07-13.yaml` (machine-readable)
- pointer added near F2.1 in `.product/designs/f2-tensorrt-activation-plan-2026-07-10.md`

## Follow-ups (out of scope, recorded)

- Wire `return_perf_metrics` -> per-request latency (F2.2).
- pytorch-leg generation raised a base-checkpoint tokenizer quirk (trt leg generates fine); re-verify with an instruct model in F2.2.
- Schema-widening of TorchLlmArgs-only fields (`cuda_graph_config`, `moe_config`, `stream_interval`, `batch_wait_*`) deferred by the schema-freeze ruling.

Draft: do not merge - orchestrator merges.