### PR TITLE
fix(ci): release image publish becomes a registry-side tag-copy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,12 +1,28 @@
 name: Docker Publish
 
+# Release-time publish for the transformers engine image. This is a
+# registry-side TAG-COPY, not a build: it points a new
+# `transformers:<version>` tag ref at the digest the promotion path already
+# published at `transformers:transformers-<pin>`. No rebuild, no compile,
+# seconds to run.
+#
+# Tag contract:
+#   - The promotion path (publish-engine-image.yml) owns `transformers:latest`
+#     and the canonical `transformers:transformers-<pin>` tag. It tag-copies
+#     them at merge from the locally seeded
+#     `transformers-cache:transformers-<pin>` image.
+#   - Release owns `transformers:<version>` as a pointer to that same promoted
+#     digest, so a released version is bit-identical to the promoted seed.
+#
+# CI never compiles flash-attention: the FA3 Hopper build needs far more
+# memory than hosted runners have (a cold compile OOMs / times out), so image
+# production is a LOCAL maintainer task (make docker-seed-transformers),
+# symmetric with rule and schema production. If the promotion source is
+# missing, the tag-copy step fails loudly with recovery instructions.
+#
 # This workflow has no PR-time `paths:` trigger (it's workflow_call /
 # workflow_dispatch only), so edits can't self-test at runtime. Shape
 # validation happens at PR time via the actionlint job in ci.yml.
-#
-# Builds and pushes the transformers engine Docker image to GHCR on
-# release. Called by release.yml after tests pass, or manually via
-# workflow_dispatch.
 #
 # vLLM and TensorRT-LLM are not published here: they run inside upstream
 # images (vllm/vllm-openai, nvcr.io/nvidia/tensorrt-llm/release) with
@@ -40,42 +56,14 @@ jobs:
         with:
           ref: ${{ inputs.version }}
 
-      # The default `docker` buildx driver does not support
-      # cache-to=type=registry. Switching to `docker-container` is required
-      # for the mode=max cache export below to work - without this, the
-      # build-push-action step fails with:
-      #   ERROR: failed to build: Cache export is not supported for the
-      #   docker driver.
-      - uses: docker/setup-buildx-action@v3
-
       - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The promotion path (publish-engine-image.yml) owns the `latest` and
-      # `transformers-<engine version>` tags. This release-time build tags
-      # only the package version so the two producers never write the same
-      # tag with different content.
-      - id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/transformers
-          tags: |
-            type=raw,value=${{ inputs.version }}
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install llenergymeasure (base deps only)
-        run: pip install .
-      - id: fingerprint
-        run: |
-          value=$(python3 scripts/compute_expconf_fingerprint.py)
-          echo "value=${value}" >> "$GITHUB_OUTPUT"
-      # Read the transformers engine pin so the build installs the pinned
-      # version instead of the Dockerfile ARG fallback default. yq ships on
+      # Resolve the transformers engine pin so the release tag copies the
+      # promoted image for exactly the version this release ships. yq ships on
       # ubuntu-latest runners.
       - id: pin
         name: Resolve transformers pin from current.yaml
@@ -83,32 +71,50 @@ jobs:
           value=$(yq '.library.current_version' engine_versions/transformers/current.yaml)
           echo "value=${value}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.transformers
-          # Build the runtime stage, matching the locally seeded promotion
-          # source. The dev stage layers ruff/mypy/pytest on top and is for
-          # local iteration only, not for a published release image.
-          target: runtime
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Cap nvcc parallelism on the 4-core/16 GB hosted runner. The
-          # default MAX_JOBS=32 (set in Dockerfile.transformers for
-          # developer hardware) asks for ~128 GB of peak RAM during the
-          # FA3 hopper compile, which causes the runner agent to lose
-          # its heartbeat under memory pressure.
-          build-args: |
-            LLEM_PKG_VERSION=${{ inputs.version }}
-            LLEM_EXPCONF_SCHEMA_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
-            TRANSFORMERS_VERSION=${{ steps.pin.outputs.value }}
-            MAX_JOBS=2
-          # mode=max exports intermediate layers (including the flash-attn
-          # compile) so downstream builders can reuse them, not just the final
-          # image layers.
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/transformers:latest
-            type=registry,ref=ghcr.io/${{ github.repository }}/transformers:${{ inputs.version }}
-          cache-to: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/transformers:latest,mode=max
+      - name: Publish release tag via tag-copy
+        # `docker buildx imagetools create` is a registry-side metadata
+        # operation: it creates a new tag ref pointing at the existing promoted
+        # digest. No rebuild, no layer copy - the release image is bit-identical
+        # to the promoted seed. The plain docker CLI + buildx plugin on
+        # ubuntu-latest handles imagetools without a docker-container builder
+        # (these operate directly against the registry), so no setup-buildx.
+        env:
+          VERSION: ${{ inputs.version }}
+          PIN: ${{ steps.pin.outputs.value }}
+          REPO: ${{ env.REGISTRY }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          SOURCE="${REPO}/transformers:transformers-${PIN}"
+          if ! docker buildx imagetools inspect "$SOURCE" >/dev/null 2>&1; then
+            {
+              echo "Promotion source ${SOURCE} not found in the registry."
+              echo
+              echo "The release image is a registry-side tag-copy of the promoted"
+              echo "seed, NOT a hosted build. The seed + promotion must exist first:"
+              echo "  1. make docker-seed-transformers  (local; the FA3 Hopper compile"
+              echo "     needs more RAM than hosted runners have)"
+              echo "  2. publish-engine-image.yml tag-copies the seed to"
+              echo "     ${SOURCE} when the bump lands on main"
+              echo "Then re-run this workflow via workflow_dispatch once the source exists."
+            } >&2
+            echo "::error::Release publish aborted: promotion source ${SOURCE} missing (seed + promote first)"
+            exit 1
+          fi
+          docker buildx imagetools create \
+            -t "${REPO}/transformers:${VERSION}" \
+            "$SOURCE"
+
+      - name: Emit publish summary
+        env:
+          VERSION: ${{ inputs.version }}
+          PIN: ${{ steps.pin.outputs.value }}
+        run: |
+          {
+            echo "## Release image publish"
+            echo
+            echo "- Version: \`${VERSION}\`"
+            echo "- Transformers pin: \`${PIN}\`"
+            echo "- Source: \`transformers:transformers-${PIN}\` (promotion-owned)"
+            echo "- Published: \`transformers:${VERSION}\` (release-owned pointer)"
+            echo "- Mechanism: \`docker buildx imagetools create\` (tag-copy; bit-identical)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   hosted rebuild. `docker-publish.yml` points `transformers:<version>` at the already-promoted
   `transformers:transformers-<pin>` via `docker buildx imagetools create`, eliminating the
   flash-attention FA3 compile that OOM'd the hosted runner; the workflow aborts loudly when the
-  seed/promotion source is missing. ([#PRA])
+  seed/promotion source is missing. ([#798])
 - Absorb sign-off records now carry the full withheld rule body, so a maintainer's
   `human_confirmed` mark re-ships a rule even after the withholding run dropped it from the
   corpus; a bodyless mark fails loudly instead of silently skipping. ([#792])
@@ -671,3 +671,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#789]: https://github.com/henrycgbaker/llenergymeasure/pull/789
 [#791]: https://github.com/henrycgbaker/llenergymeasure/pull/791
 [#792]: https://github.com/henrycgbaker/llenergymeasure/pull/792
+[#798]: https://github.com/henrycgbaker/llenergymeasure/pull/798

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- Release image publish is now a registry-side tag-copy of the promoted seed digest, not a
+  hosted rebuild. `docker-publish.yml` points `transformers:<version>` at the already-promoted
+  `transformers:transformers-<pin>` via `docker buildx imagetools create`, eliminating the
+  flash-attention FA3 compile that OOM'd the hosted runner; the workflow aborts loudly when the
+  seed/promotion source is missing. ([#PRA])
 - Absorb sign-off records now carry the full withheld rule body, so a maintainer's
   `human_confirmed` mark re-ships a rule even after the withholding run dropped it from the
   corpus; a bodyless mark fails loudly instead of silently skipping. ([#792])

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -163,8 +163,9 @@ schema and rules follow:
    few minutes).
 2. **Local seed for a bump.** `make docker-seed-transformers` builds the
    runtime image and pushes it to the promotion-source ref
-   `transformers-cache:transformers-<VER>` (plus the build cache on
-   `transformers:latest`). Run it during a transformers bump session.
+   `transformers-cache:transformers-<VER>` (plus the `mode=max` BuildKit cache
+   to `transformers-cache:transformers-<VER>-buildcache`). Run it during a
+   transformers bump session.
 3. **Merge-time promotion.** When the bump lands on main,
    `publish-engine-image.yml` tag-copies the seeded image to the canonical
    `transformers:transformers-<VER>` and `transformers:latest` tags via

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -170,9 +170,10 @@ schema and rules follow:
    `transformers:transformers-<VER>` and `transformers:latest` tags via
    `docker buildx imagetools create` (no rebuild). A missing seed fails the
    promotion loudly.
-4. **Release build.** `docker-publish.yml` (called by `release.yml`) builds
-   the package-versioned release image on a hosted runner, warming off the
-   cache the seed exported.
+4. **Release tag-copy.** `docker-publish.yml` (called by `release.yml`)
+   tag-copies the promoted `transformers:transformers-<VER>` image to the
+   package-versioned `transformers:<VERSION>` release tag via
+   `docker buildx imagetools create` (no rebuild).
 
 See [Pipeline architecture: transformers image lifecycle](/explanation/architecture/pipeline-architecture#transformers-image-lifecycle)
 for the full diagram and [CI architecture](/explanation/architecture/ci-architecture)

--- a/docs/explanation/architecture/ci-architecture.md
+++ b/docs/explanation/architecture/ci-architecture.md
@@ -192,10 +192,12 @@ runners have, so CI never builds this image on the PR or merge path.
    `publish-engine-image.yml` tag-copies the seeded image to the canonical
    `transformers:transformers-<VER>` and `transformers:latest` tags. No
    rebuild: production gets the bit-identical seeded image.
-3. **Release-time build.** `docker-publish.yml` (called by `release.yml`)
-   builds the package-versioned release image on a hosted runner with capped
-   compile parallelism, reusing the registry build cache that the seed target
-   also warms.
+3. **Release-time tag-copy.** `docker-publish.yml` (called by `release.yml`)
+   tag-copies the promoted `transformers:transformers-<VER>` image to the
+   package-versioned `transformers:<VERSION>` release tag via
+   `docker buildx imagetools create`. No rebuild: the released version is a
+   registry-side pointer to the promoted digest, bit-identical to the seed.
+   CI never compiles flash-attention on any path.
 
 A missing seed fails the promotion run loudly: the tag-copy step finds no
 source manifest at `transformers-cache:transformers-<VER>`. Recovery is to run

--- a/docs/explanation/architecture/pipeline-architecture.md
+++ b/docs/explanation/architecture/pipeline-architecture.md
@@ -28,16 +28,18 @@ flowchart TD
     promote[publish-engine-image.yml<br/>tag-copy, no rebuild]
     prod[(transformers:transformers-VER<br/>+ transformers:latest)]
     release[Release tag pushed]
-    relbuild[docker-publish.yml<br/>builds the release image]
+    relcopy[docker-publish.yml<br/>tag-copy, no rebuild]
+    relimg[(transformers:VERSION)]
 
     seed --> cache
     cache --> merge --> promote --> prod
-    release --> relbuild
+    release --> relcopy
+    prod --> relcopy --> relimg
 ```
 
 1. **Local seed.** During a transformers bump session the maintainer runs `make docker-seed-transformers`, which builds the runtime image on a machine with enough memory and pushes it to `transformers-cache:transformers-<VER>` (`<VER>` is `library.current_version` from `engine_versions/transformers/current.yaml`).
 2. **Merge-time promotion.** When the bump lands on main, `publish-engine-image.yml` tag-copies the seeded image to the canonical `transformers:transformers-<VER>` and `transformers:latest` tags. There is no rebuild - production gets the bit-identical seeded image.
-3. **Release-time build.** `docker-publish.yml` (called by `release.yml`) builds the package-versioned release image on a hosted runner with capped compile parallelism, reusing the registry build cache that the seed target warmed.
+3. **Release-time tag-copy.** `docker-publish.yml` (called by `release.yml`) tag-copies the promoted `transformers:transformers-<VER>` image to the package-versioned `transformers:<VERSION>` release tag via `docker buildx imagetools create`. No rebuild: the released version is a registry-side pointer to the promoted digest, bit-identical to the seed.
 
 A missing seed fails promotion loudly: the tag-copy step finds no source manifest at `transformers-cache:transformers-<VER>`. Recovery is to run the seed locally, then re-run the promotion.
 

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -171,9 +171,11 @@ docker-seed-transformers` exports the image's intermediate layers to
 `ghcr.io/henrycgbaker/llenergymeasure/transformers-cache:transformers-<VER>-buildcache`
 alongside a runnable promotion-source image. The canonical
 `transformers:transformers-<VER>` (immutable per engine pin) and
-`transformers:latest` (rolling) tags are produced from that seed: tag-copied
-at merge by `publish-engine-image.yml`, rebuilt at release by
-`docker-publish.yml` (see "How the transformers image is published" below).
+`transformers:latest` (rolling) tags are produced from that seed by tag-copy
+at merge (`publish-engine-image.yml`); the package-versioned
+`transformers:<VERSION>` release tag is a further tag-copy of the promoted
+image at release (`docker-publish.yml`). None of these steps rebuilds (see
+"How the transformers image is published" below).
 This lets fresh machines skip the ~30-min flash-attn FA3 Hopper compile.
 vLLM and TensorRT-LLM are pulled from upstream images (`vllm/vllm-openai`,
 `nvcr.io/nvidia/tensorrt-llm/release`) and need no project-side cache.
@@ -231,7 +233,8 @@ schema and rules follow. The refs involved:
 |---|---|---|
 | `transformers-cache:transformers-<VER>` | Runnable promotion-source image | Local `make docker-seed-transformers` |
 | `transformers-cache:transformers-<VER>-buildcache` | BuildKit cache manifest (`mode=max`; not a runnable image) | Local `make docker-seed-transformers` |
-| `transformers:transformers-<VER>` + `transformers:latest` | Canonical runtime image | `publish-engine-image.yml` tag-copies the seeded image at merge; `docker-publish.yml` rebuilds it at release |
+| `transformers:transformers-<VER>` + `transformers:latest` | Canonical runtime image | `publish-engine-image.yml` tag-copies the seeded image at merge (no rebuild) |
+| `transformers:<VERSION>` | Package-versioned release image | `docker-publish.yml` tag-copies the promoted image at release (no rebuild) |
 
 Flow:
 
@@ -244,9 +247,10 @@ Flow:
    `transformers:latest` tags via `docker buildx imagetools create` - a
    registry-side metadata operation, no rebuild. A missing seed fails the
    promotion loudly.
-3. At release, `docker-publish.yml` (called by `release.yml`) builds the
-   package-versioned release image on a hosted runner, warming off the cache
-   the seed exported.
+3. At release, `docker-publish.yml` (called by `release.yml`) tag-copies the
+   promoted `transformers:transformers-<VER>` image to the package-versioned
+   `transformers:<VERSION>` release tag via `docker buildx imagetools create` -
+   the same registry-side, no-rebuild operation as the merge-time promotion.
 
 `docker-compose.yml` declares `cache_from: [transformers:v<VERSION>,
 transformers:latest]` for the transformers engine, so a local
@@ -272,9 +276,11 @@ If you hit rate limits or are behind a corporate proxy, `docker login ghcr.io` w
 [personal access token](https://github.com/settings/tokens) (scope `read:packages`) may help.
 
 **Push access (contributors).** You do not need push access to develop on this project -
-contributors only ever pull cache. Cache publication on releases is fully automated by
-`docker-publish.yml` using the repo's auto-issued `GITHUB_TOKEN`, so any merged release
-PR ships a fresh cache without human intervention. Manual seeding via
+contributors only ever pull cache. The merge-time promotion (`publish-engine-image.yml`)
+and the release publish (`docker-publish.yml`) are both automated tag-copies using the
+repo's auto-issued `GITHUB_TOKEN`, so they need no human intervention - but neither one
+builds an image or publishes cache; they only point new tags at the already-seeded
+digest. Manual seeding via
 `make docker-seed-transformers` is restricted to the package owner (the packages live
 under the `henrycgbaker` user namespace, not an org); this is the standard OSS pattern
 for solo-maintained projects and reflects the supply-chain principle that manual pushes

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -294,16 +294,25 @@ see whether the registry was even reached.
 5. Offline is expected-slow. BuildKit degrades gracefully to a cold build -
    no errors, just minutes.
 
-**CI can't build the Transformers image (FA3 compile OOM / heartbeat loss):**
-The FA3 Hopper compile requires ~8-16 GB RAM and multiple hours on a 4-core
-runner. Seed the GHCR cache once from a developer machine with more resources:
+**Release publish fails: promotion source missing (`docker-publish.yml`):**
+CI never compiles flash-attention - the FA3 Hopper build needs far more memory
+than hosted runners have. The release publish is a registry-side tag-copy of
+the image the maintainer seeds locally and the promotion path publishes, so its
+only failure mode is a missing source: `docker-publish.yml` aborts loudly when
+`transformers:transformers-<VER>` does not exist in the registry.
+
+Fix - seed locally, then let the promotion tag-copy run:
 
 ```bash
 docker login ghcr.io           # needs write:packages scope
-make docker-seed-transformers  # builds + pushes cache to ghcr.io (~minutes if locally cached)
+make docker-seed-transformers  # local build + push of the promotion source (~minutes if locally cached)
 ```
 
-After seeding, CI warm-rebuilds from the GHCR cache in <5 min.
+On the next push to main touching `engine_versions/transformers/current.yaml`
+or the Dockerfile, `publish-engine-image.yml` tag-copies the seed to
+`transformers:transformers-<VER>` (or trigger it manually via
+`workflow_dispatch`). Once that source exists, re-run `docker-publish.yml`; the
+tag-copy completes in seconds.
 
 ---
 


### PR DESCRIPTION
## Summary

Today's v0.10.0 release died at the docker-publish leg: the hosted runner OOM'd
recompiling flash-attention FA3 after a structural cache miss. Root cause was
three independently fatal cache defects converging on a cold FA3 compile that
ubuntu-latest provably cannot survive (history: MAX_JOBS=2 timed out >150min,
MAX_JOBS=3 OOM'd at 65min):

1. The promotion path overwrites `transformers:latest` with a plain tag-copied
   image (no builder-stage layers), clobbering any `mode=max` cache manifest the
   release build tried to reuse there.
2. The Dockerfile's `COPY --from=ghcr.io/astral-sh/uv:latest` is unpinned, so
   every uv release invalidates every subsequent builder layer (today's failed
   log shows the cascade starting exactly there).
3. `MAX_JOBS` participates in the FA3 layer's BuildKit cache key via `ENV
   MAX_JOBS`; the local seed builds at the default 32 while docker-publish passed
   2, guaranteeing an FA3 miss (the varying-MAX_JOBS anti-pattern #529 itself
   documented).

Per the design ruling, the release leg becomes a registry-side **tag-copy**, the
same mechanism the promotion path (`publish-engine-image.yml`) already uses. CI
never compiles flash-attention on any path; image production stays a local
maintainer task (`make docker-seed-transformers`).

This PR rewrites `docker-publish.yml`:

- Resolves the transformers pin from `engine_versions/transformers/current.yaml`
  (yq, as before), then a single publish step: preflight
  `docker buildx imagetools inspect` on the promotion-owned source
  `transformers:transformers-<pin>` (loud abort with seed+promotion recovery
  instructions if missing), then `docker buildx imagetools create -t
  transformers:<version> <source>`.
- Deletes the whole rebuild apparatus: `build-push-action`, `setup-buildx-action`
  (imagetools is a registry-side op; plain docker CLI + buildx plugin on
  ubuntu-latest handles it, matching `publish-engine-image.yml`), `metadata-action`,
  `setup-python`, `pip install .`, the `compute_expconf_fingerprint.py` step, the
  `MAX_JOBS` build-arg, and all `cache-from`/`cache-to`.
- Drops the two dead build-args (`LLEM_PKG_VERSION`,
  `LLEM_EXPCONF_SCHEMA_FINGERPRINT`): c17ced0c (#529) removed those ARGs/LABELs
  from the Dockerfile (the package source is bind-mounted at runtime), so the
  workflow was passing build-args the Dockerfile no longer consumes. Pure residue.
- Rewrites the header comments to describe the tag-copy contract (release owns
  `transformers:<version>` as a pointer to the promoted digest).

The file is **not** renamed. The underscore-prefix rename for reusable workflows
(`_docker-publish.yml`) is consciously deferred to keep this PR to one logical
change.

Doc corrections (same leg): `ci-architecture.md`, `pipeline-architecture.md`
(prose + mermaid), `install.md` (intro, refs table, flow step, push-access
paragraph), `troubleshoot.md` (the "reseed fixes CI FA3 OOM" prescription is
replaced with the tag-copy story: the failure mode is now "seed/promotion
missing"), and `development.md` step 4 (same false "release builds the image"
claim). CHANGELOG `[Unreleased]` Fixed entry added.

## Test plan

- `actionlint` clean on all workflows (v1.7.7 local run, exit 0).
- `make lint` (ruff + ruff format + import-linter) clean; import-linter 5 kept,
  0 broken.
- `make typecheck` clean (mypy, 304 source files, no issues).
- `make test` green: 2927 passed, 35 skipped. (PR touches only the workflow +
  docs + CHANGELOG; no Python surface changes, proven by a full host run.)
- No em/en-dashes in any changed file; no AI attribution.

Do not merge yet: the orchestrator re-publishes v0.10.0 after merge. Not
dispatching docker-publish from here.
