### PR TITLE
fix(docker): repair transformers seed cache hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
-- Transformers image seed cache hygiene: `make docker-seed-transformers` no longer runs a
-  harmful second push that wrote plain `transformers:latest` / `transformers:v<version>`
+- Transformers image seed and dev cache hygiene: `make docker-seed-transformers` no longer runs
+  a harmful second push that wrote plain `transformers:latest` / `transformers:v<version>`
   images and a clobber-prone `mode=max` cache to `:latest`. The `-buildcache` ref is now the
   single cache manifest; the canonical tags are written only by the promotion and release
-  tag-copies. The Dockerfile pins its `ghcr.io/astral-sh/uv` base (was `:latest`, so every uv
+  tag-copies. `docker-compose.yml`'s `cache_from` now targets that per-version buildcache ref
+  (the engine pin is exported as `TRANSFORMERS_VERSION` by the `make docker-build` wrapper and
+  also passed as the build arg, so local builds install the pinned version and actually reuse
+  the seeded FA3 layers), and the dead `LLEM_PKG_VERSION` / `LLEM_EXPCONF_SCHEMA_FINGERPRINT`
+  build-args and Makefile exports are removed (the Dockerfile stopped consuming them in 0.10.0).
+  The Dockerfile pins its `ghcr.io/astral-sh/uv` base (was `:latest`, so every uv
   release invalidated every subsequent builder layer) and records that `MAX_JOBS` must never
   be overridden via build-arg in CI, since it participates in the FA3 layer's cache key. ([#799])
 - Absorb sign-off records now carry the full withheld rule body, so a maintainer's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- Transformers image seed cache hygiene: `make docker-seed-transformers` no longer runs a
+  harmful second push that wrote plain `transformers:latest` / `transformers:v<version>`
+  images and a clobber-prone `mode=max` cache to `:latest`. The `-buildcache` ref is now the
+  single cache manifest; the canonical tags are written only by the promotion and release
+  tag-copies. The Dockerfile pins its `ghcr.io/astral-sh/uv` base (was `:latest`, so every uv
+  release invalidated every subsequent builder layer) and records that `MAX_JOBS` must never
+  be overridden via build-arg in CI, since it participates in the FA3 layer's cache key. ([#PRB])
 - Absorb sign-off records now carry the full withheld rule body, so a maintainer's
   `human_confirmed` mark re-ships a rule even after the withholding run dropped it from the
   corpus; a bodyless mark fails loudly instead of silently skipping. ([#792])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   single cache manifest; the canonical tags are written only by the promotion and release
   tag-copies. The Dockerfile pins its `ghcr.io/astral-sh/uv` base (was `:latest`, so every uv
   release invalidated every subsequent builder layer) and records that `MAX_JOBS` must never
-  be overridden via build-arg in CI, since it participates in the FA3 layer's cache key. ([#PRB])
+  be overridden via build-arg in CI, since it participates in the FA3 layer's cache key. ([#799])
 - Absorb sign-off records now carry the full withheld rule body, so a maintainer's
   `human_confirmed` mark re-ships a rule even after the withholding run dropped it from the
   corpus; a bodyless mark fails loudly instead of silently skipping. ([#792])
@@ -673,3 +673,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#789]: https://github.com/henrycgbaker/llenergymeasure/pull/789
 [#791]: https://github.com/henrycgbaker/llenergymeasure/pull/791
 [#792]: https://github.com/henrycgbaker/llenergymeasure/pull/792
+[#799]: https://github.com/henrycgbaker/llenergymeasure/pull/799

--- a/Makefile
+++ b/Makefile
@@ -328,22 +328,27 @@ docker-build: ## Build first-party engine images (currently: transformers)
 	@echo "First build pulls cache layers from ghcr.io; warm rebuilds < 5 min."
 	scripts/docker_build_with_cache_report.sh transformers
 
-# Seed the transformers images from a local machine with sufficient RAM
+# Seed the transformers image from a local machine with sufficient RAM
 # (the FA3 Hopper compile, ~30 min, needs more memory than CI hosted
 # runners have). Requires: docker login ghcr.io, llem-builder buildx
 # builder. Uses Dockerfile default MAX_JOBS=32 - matches local layer
-# cache so FA3 is not recompiled if already built locally. Two pushes:
+# cache so FA3 is not recompiled if already built locally.
 #
-#   1. The runtime promotion source transformers-cache:transformers-<VER>
-#      (<VER> = library.current_version from
-#      engine_versions/transformers/current.yaml), which
-#      publish-engine-image.yml tag-copies to canonical tags when a bump
-#      lands on main. Run this during a transformers bump session, before
-#      or alongside the bump PR - a missing seed fails the merge-time
-#      promotion run.
-#   2. The GHCR build cache on transformers:latest, reused by
-#      docker-publish.yml for the release-time hosted build.
-docker-seed-transformers: ## Seed transformers runtime image (promotion source) + GHCR build cache
+# One push, producing the two refs the promotion path consumes:
+#   - transformers-cache:transformers-<VER> - the runnable promotion source
+#     (<VER> = library.current_version from
+#     engine_versions/transformers/current.yaml). publish-engine-image.yml
+#     tag-copies it to the canonical tags when a bump lands on main.
+#   - transformers-cache:transformers-<VER>-buildcache - the mode=max
+#     BuildKit cache manifest (includes the FA3 layer). This is THE cache;
+#     warm re-seeds import it via --cache-from.
+#
+# Run this during a transformers bump session, before or alongside the bump
+# PR - a missing seed fails the merge-time promotion run. The seed never
+# writes the canonical transformers:latest or transformers:<version> tags,
+# and never writes cache to them: those are tag-copies owned by
+# publish-engine-image.yml (merge) and docker-publish.yml (release).
+docker-seed-transformers: ## Seed transformers promotion source image + mode=max build cache
 	@engver=$$(python3 -c "import yaml; print(yaml.safe_load(open('engine_versions/transformers/current.yaml'))['library']['current_version'])"); \
 	cacheref=ghcr.io/henrycgbaker/llenergymeasure/transformers-cache; \
 	echo "Seeding promotion source $$cacheref:transformers-$$engver"; \
@@ -358,22 +363,6 @@ docker-seed-transformers: ## Seed transformers runtime image (promotion source) 
 	  --cache-to   type=registry,ref=$$cacheref:transformers-$$engver-buildcache,mode=max \
 	  --push \
 	  --tag $$cacheref:transformers-$$engver \
-	  .
-	@version=$$(python3 -c "from llenergymeasure._version import __version__; print(__version__)" 2>/dev/null || echo "dev"); \
-	fingerprint=$$(python3 scripts/compute_expconf_fingerprint.py 2>/dev/null || echo "unknown"); \
-	ref=ghcr.io/henrycgbaker/llenergymeasure/transformers; \
-	echo "Seeding GHCR cache for transformers (version=$$version)"; \
-	docker buildx build \
-	  --builder $(BUILDER_NAME) \
-	  -f docker/Dockerfile.transformers \
-	  --build-arg LLEM_PKG_VERSION=$$version \
-	  --build-arg LLEM_EXPCONF_SCHEMA_FINGERPRINT=$$fingerprint \
-	  --cache-from type=registry,ref=$$ref:v$$version \
-	  --cache-from type=registry,ref=$$ref:latest \
-	  --cache-to   type=registry,ref=$$ref:latest,mode=max \
-	  --push \
-	  --tag $$ref:v$$version \
-	  --tag $$ref:latest \
 	  .
 
 docker-pull: ## Pull the versioned transformers image from GHCR

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,6 @@
 export PUID := $(shell id -u)
 export PGID := $(shell id -g)
 
-# Host/container schema handshake stamps - surfaced to docker compose build
-# via docker-compose.yml's build.args block so every locally-built image is
-# labelled with the same fingerprint llem computes at runtime. Falls back to
-# "dev"/"unknown" on any error (e.g. missing venv).
-export LLEM_PKG_VERSION := $(shell python3 -c "from llenergymeasure._version import __version__; print(__version__)" 2>/dev/null || echo dev)
-export LLEM_EXPCONF_SCHEMA_FINGERPRINT := $(shell python3 scripts/compute_expconf_fingerprint.py 2>/dev/null || echo unknown)
-
 # =============================================================================
 # Help
 #   Targets with a `## description` suffix are listed by `make help`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@
 # Quick Start:
 #   uv sync                       # Install llenergymeasure + base deps
 #   llem config                   # Check environment
-#   docker compose build transformers  # Build engine image
+#   make docker-build             # Build engine image (wires the GHCR cache;
+#                                 # raw `docker compose build transformers` works
+#                                 # but skips the per-version cache source)
 #
 # Manual Usage:
 #   Transformers (default): docker compose run --rm transformers llem --help
@@ -21,16 +23,21 @@
 
 # BuildKit layer cache for the transformers image.
 # Two sources, in priority order:
-#   1. :v${LLEM_PKG_VERSION} - exact-version image layers from the matching
-#      release. Note the literal `v`: published tags carry a `v` prefix (set by
-#      release.yml) but LLEM_PKG_VERSION is bare semver (from _version.py), so
-#      we have to add the prefix here. On dev versions (`vdev`) this entry
-#      silently misses, which is fine - the next entry catches it.
-#   2. :latest - rolling cache published by docker-publish.yml with mode=max,
-#      which exports intermediate layers (including the flash-attn compile).
+#   1. transformers-cache:transformers-<VER>-buildcache - the mode=max cache
+#      manifest exported by the local seed (make docker-seed-transformers).
+#      The only ref that carries builder-stage layers (the flash-attn FA3
+#      compile). <VER> is the engine pin from
+#      engine_versions/transformers/current.yaml, exported as
+#      TRANSFORMERS_VERSION by scripts/docker_build_with_cache_report.sh
+#      (the `make docker-build` path). When unset (raw `docker compose
+#      build`), the ref resolves to a nonexistent tag and BuildKit skips it
+#      silently - prefer `make docker-build` for the warm path.
+#   2. :latest - the merge-time promotion tag-copy (plain image, final
+#      layers only; nothing publishes build cache to it). Harmless
+#      last-resort reuse.
 x-cache-transformers: &cache-transformers
   cache_from:
-    - ghcr.io/henrycgbaker/llenergymeasure/transformers:v${LLEM_PKG_VERSION:-dev}
+    - ghcr.io/henrycgbaker/llenergymeasure/transformers-cache:transformers-${TRANSFORMERS_VERSION:-unpinned}-buildcache
     - ghcr.io/henrycgbaker/llenergymeasure/transformers:latest
 
 # Shared configuration anchor
@@ -100,8 +107,12 @@ services:
       dockerfile: docker/Dockerfile.transformers
       target: runtime
       args:
-        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
-        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+        # Engine pin from engine_versions/transformers/current.yaml, exported
+        # by scripts/docker_build_with_cache_report.sh. Keeps the local build
+        # byte-aligned with the seed so its cache layers actually apply. The
+        # fallback mirrors the Dockerfile ARG default (raw `docker compose
+        # build` without the make wrapper).
+        TRANSFORMERS_VERSION: ${TRANSFORMERS_VERSION:-4.57.3}
     image: llenergymeasure:transformers
 
   transformers-dev:
@@ -116,8 +127,7 @@ services:
       dockerfile: docker/Dockerfile.transformers
       target: dev
       args:
-        LLEM_PKG_VERSION: ${LLEM_PKG_VERSION:-dev}
-        LLEM_EXPCONF_SCHEMA_FINGERPRINT: ${LLEM_EXPCONF_SCHEMA_FINGERPRINT:-unknown}
+        TRANSFORMERS_VERSION: ${TRANSFORMERS_VERSION:-4.57.3}
     image: llenergymeasure:transformers-dev
     entrypoint: ["/app/scripts/dev-entrypoint.sh"]
     command: []

--- a/docker/Dockerfile.transformers
+++ b/docker/Dockerfile.transformers
@@ -9,8 +9,8 @@
 # guaranteed by the upstream image.
 #
 # The llenergymeasure package itself is NOT installed into this image. The
-# project source is bind-mounted at runtime by the caller - see the engine-
-# invariants/engine-schemas workflows and docs/development.md for the canonical
+# project source is bind-mounted at runtime by the caller - see
+# docs/contributing/development.md for the canonical
 # `docker run -v $(pwd):/llem-src -e PYTHONPATH=/llem-src --entrypoint python3`
 # pattern. Symmetric with the vllm + tensorrt cells, which mount the same way
 # against upstream-direct images. This makes image rebuilds depend only on the
@@ -21,15 +21,17 @@
 #
 # Version pin policy: update PYTORCH_VERSION on each milestone release.
 # Must be compatible with pyproject.toml torch>=2.5 / transformers>=4.49 constraints.
-# TRANSFORMERS_VERSION comes from engine_versions/transformers.yaml SSOT.
+# TRANSFORMERS_VERSION comes from engine_versions/transformers/current.yaml SSOT.
 # ============================================================
 ARG PYTORCH_VERSION=2.5.1-cuda12.4-cudnn9-runtime
 ARG PYTORCH_DEVEL_VERSION=2.5.1-cuda12.4-cudnn9-devel
 
-# Source of truth: engine_versions/transformers.yaml `library.current_version`.
-# Renovate authors that file; CI passes the value via
-# `--build-arg TRANSFORMERS_VERSION=$(yq '.library.current_version' engine_versions/transformers.yaml)`
-# at build time. The ARG default below is a fallback for local manual builds only.
+# Source of truth: engine_versions/transformers/current.yaml `library.current_version`.
+# Renovate authors that file. The local seed (make docker-seed-transformers)
+# passes the value via
+# `--build-arg TRANSFORMERS_VERSION=$(yq '.library.current_version' engine_versions/transformers/current.yaml)`
+# at build time; CI never builds this image - it tag-copies the seeded image.
+# The ARG default below is a fallback for local manual builds only.
 ARG TRANSFORMERS_VERSION=4.57.3
 
 # Build stage: compile flash-attn FA2 + FA3 (needs nvcc from devel image)
@@ -44,7 +46,7 @@ ARG INSTALL_FA3=true
 FROM pytorch/pytorch:${PYTORCH_DEVEL_VERSION} AS builder
 ARG FLASH_ATTN_VERSION
 ARG INSTALL_FA3
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /usr/local/bin/uv
 ENV TORCH_CUDA_ARCH_LIST="8.0;9.0+PTX"
 
 # Make apt resilient to transient Ubuntu mirror flakes (3 build failures
@@ -60,6 +62,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # NVCC_THREADS = threads per nvcc; flash-attention/hopper/setup.py defaults to 2,
 # which silently caps total parallelism even at high MAX_JOBS - set explicitly.
 # Skipped when INSTALL_FA3=false.
+# Never override MAX_JOBS via --build-arg in CI: `ENV MAX_JOBS` below puts it in
+# the FA3 layer's BuildKit cache key, so any value differing from the seed's
+# default (32) forces a cache miss and a cold FA3 recompile (the anti-pattern
+# #529 documented). The seed and any downstream build must share this default.
 ARG MAX_JOBS=32
 ARG NVCC_THREADS=4
 ENV MAX_JOBS=${MAX_JOBS}
@@ -100,7 +106,7 @@ RUN mkdir /flash-attn-staging && \
 # Runtime stage
 FROM pytorch/pytorch:${PYTORCH_VERSION} AS runtime
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /usr/local/bin/uv
 
 # Suppress hardlink warnings when cache mount is on a different filesystem
 ENV UV_LINK_MODE=copy

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -248,9 +248,13 @@ Flow:
    package-versioned release image on a hosted runner, warming off the cache
    the seed exported.
 
-`docker-compose.yml` declares `cache_from: [transformers:v<VERSION>,
-transformers:latest]` for the transformers engine, so a local
-`make docker-build` reuses those published layers; vllm and tensorrt have no
+`docker-compose.yml` declares `cache_from:
+[transformers-cache:transformers-<VER>-buildcache, transformers:latest]` for
+the transformers engine (`<VER>` is the engine pin, exported as
+`TRANSFORMERS_VERSION` by the `make docker-build` wrapper script), so a local
+`make docker-build` imports the seed's `mode=max` cache manifest - the only
+ref carrying the FA3 builder layers - with the plain `:latest` image as a
+last-resort fallback; vllm and tensorrt have no
 first-party `cache_from` chain (they pull upstream directly).
 `make docker-builder-setup` provisions a `docker-container` BuildKit driver
 with a 200 GiB cache limit; the default `docker` driver cannot import

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -265,9 +265,11 @@ of likelihood:
     on the very first build - first-pull cost is paid once).
 (c) You are offline or GHCR is unreachable.
 (d) Your `TRANSFORMERS_VERSION` (from `engine_versions/transformers/current.yaml`)
-    does not match any published cache tag (`cache_from` resolves to
-    `:transformers-<VERSION>` and falls through to `:latest` - if neither has
-    usable layers, BuildKit silently cold-builds).
+    does not match any seeded cache ref (`cache_from` resolves to
+    `transformers-cache:transformers-<VERSION>-buildcache` and falls through
+    to `:latest` - if neither has usable layers, BuildKit silently
+    cold-builds). The buildcache ref only exists after a local
+    `make docker-seed-transformers` at that pin.
 
 The full BuildKit log for the most recent attempt is at
 `/tmp/llem-build-{engine}.log` - grep it for `importing cache manifest` to
@@ -284,9 +286,11 @@ see whether the registry was even reached.
    the registry.
 2. Verify network: `curl -I https://ghcr.io/v2/henrycgbaker/llenergymeasure/transformers/manifests/latest`
    should return 200 or 401 (both fine; 000/timeout means no connectivity).
-3. If you recently bumped the SSOT version but CI hasn't published the
-   per-version tag yet, fall back to `:latest` (which the cache_from chain
-   already lists as a fallback). No env-var override needed.
+3. If you recently bumped the SSOT version but haven't run
+   `make docker-seed-transformers` at the new pin yet, the per-version
+   buildcache ref does not exist and the build falls back to `:latest`
+   (already last in the cache_from chain). Seed locally to create it; no
+   env-var override needed.
 4. If the cache is corrupt, recreate the builder:
    `make docker-builder-rm && make docker-builder-setup`. Note this discards
    all local layer cache; the first subsequent build will repopulate from

--- a/scripts/docker_build_with_cache_report.sh
+++ b/scripts/docker_build_with_cache_report.sh
@@ -19,6 +19,18 @@ log="/tmp/llem-build-${engine}.log"
 # and per-stage "CACHED" markers; auto/tty hides them behind a collapsed UI.
 export BUILDKIT_PROGRESS="${BUILDKIT_PROGRESS:-plain}"
 
+# Resolve the transformers engine pin (engine_versions/transformers/current.yaml)
+# so docker-compose.yml's cache_from can target the seed's per-version mode=max
+# buildcache ref - the only ref that carries the FA3 builder-stage layers - and
+# so the build installs the pinned transformers version. A caller-provided
+# TRANSFORMERS_VERSION wins; on resolution failure the var stays empty and
+# compose's fallbacks kick in (BuildKit skips the unresolvable cache source
+# silently - a cold build, not an error).
+if [[ -z "${TRANSFORMERS_VERSION:-}" ]]; then
+    TRANSFORMERS_VERSION=$(python3 -c "import yaml; print(yaml.safe_load(open('engine_versions/transformers/current.yaml'))['library']['current_version'])" 2>/dev/null || true)
+fi
+export TRANSFORMERS_VERSION
+
 start=$(date +%s)
 # tee preserves the on-screen build log; PIPESTATUS captures compose's exit.
 docker compose build "${engine}" 2>&1 | tee "${log}"


### PR DESCRIPTION
## Summary

Companion to #798 (release publish becomes a tag-copy). This PR repairs the
seed and dev-side caching that #798's diagnosis surfaced. Two of the three
cache defects behind today's v0.10.0 publish OOM live here (the third, the
release rebuild itself, is #798):

- **Defect (1) - clobber-prone seed cache.** `make docker-seed-transformers`
  ran a second `docker buildx build` that pushed plain `transformers:latest`
  and `transformers:v<version>` images (a third, undocumented writer of the
  promotion-owned tags, violating the two-producer contract) and exported a
  `mode=max` cache to `transformers:latest` - which the promotion tag-copy then
  overwrites with a plain image, destroying the cache manifest. That second
  push is deleted. Push 1's `-buildcache` ref
  (`transformers-cache:transformers-<VER>-buildcache`, `mode=max`) is now the
  single cache manifest; `:latest` / `:v<version>` are never cache targets and
  are never written by the seed - they are tag-copies owned by
  `publish-engine-image.yml` (merge) and `docker-publish.yml` (release, #798).
- **Defect (2) - unpinned uv.** `COPY --from=ghcr.io/astral-sh/uv:latest` in
  both build stages meant every uv release invalidated every subsequent builder
  layer (today's failed log shows the cascade starting exactly there). Pinned to
  `:0.11.28` (both COPY lines) so the layer key is stable and Renovate can bump
  it deliberately.
- **Defect (3) - MAX_JOBS in the FA3 cache key.** Added a comment at
  `ARG MAX_JOBS` codifying that it must never be overridden via `--build-arg` in
  CI: `ENV MAX_JOBS` puts it in the FA3 layer's BuildKit cache key, so a value
  differing from the seed's default (32) guarantees a cold recompile - the
  anti-pattern #529 documented.

### Dev-side compose cache wiring (scope extension, second commit)

`docker-compose.yml`'s `cache_from` pointed at `transformers:v<version>` and
`transformers:latest` - both plain tag-copies with no builder-stage layers - so
a local `make docker-build` never reused the seeded FA3 compile; the anchor
comment still claimed `docker-publish.yml` publishes a `mode=max` cache to
`:latest` (false after #798; nothing publishes cache there anymore).

- `cache_from` now targets `transformers-cache:transformers-<VER>-buildcache`
  (the seed's `mode=max` manifest, the only ref with FA3 builder layers), with
  plain `:latest` kept as a harmless last-resort fallback.
- **Plumbing chosen:** the pin is resolved from
  `engine_versions/transformers/current.yaml` and exported as
  `TRANSFORMERS_VERSION` inside `scripts/docker_build_with_cache_report.sh` -
  the script `make docker-build` already runs and where the
  `docker compose build` command actually lives. This keeps the resolution out
  of global Makefile exports (zero cost on unrelated make targets) and also
  covers direct script invocation. A caller-provided `TRANSFORMERS_VERSION`
  wins; on resolution failure the var stays empty and compose falls back
  (`transformers-...-unpinned-buildcache` does not exist, BuildKit skips it
  silently - documented graceful degradation).
- The same var is passed as the `TRANSFORMERS_VERSION` build arg, so a local
  `make docker-build` now installs the pinned engine version (previously
  compose passed no such arg and local builds silently used the Dockerfile ARG
  default, 4.57.3 vs pin 5.7.0) and layer-aligns with the seed for full cache
  reuse. The compose fallback mirrors the Dockerfile ARG default, so raw
  `docker compose build` behavior is unchanged.
- **Dead residue deleted:** the `LLEM_PKG_VERSION` and
  `LLEM_EXPCONF_SCHEMA_FINGERPRINT` compose build-args and their Makefile
  exports. The Dockerfile stopped declaring both ARGs in 0.10.0 (c17ced0c), so
  the args were no-ops; grep-verified no other consumer (src/ never reads
  either env var; `make docker-pull` resolves its version inline;
  `scripts/compute_expconf_fingerprint.py` stays - its underlying library
  function has live runtime consumers in doctor/image-prep/handshake).

Also fixes stale Dockerfile header comments (flagged finding 13): the
pre-migration flat `engine_versions/transformers.yaml` path (now
`engine_versions/transformers/current.yaml`), references to the deleted
`engine-invariants`/`engine-schemas` workflows, and the false "CI passes the
value" claim for `TRANSFORMERS_VERSION` (it is a local-seed responsibility;
CI never builds this image).

The Makefile comment block is rewritten for the single-push model. Docs
aligned with the new compose chain: install.md compose-cache paragraph,
troubleshoot.md cache-miss cause (d) and fix step 3. CHANGELOG `[Unreleased]`
Fixed entry (one entry, extended).

**Not stacked on #798** - branched independently from `main`. File overlap
with #798: `CHANGELOG.md` (one Fixed entry each, trivial both-sides keep) plus
disjoint-hunk edits in `install.md` / `troubleshoot.md` (#798 edits the
release-leg passages, this PR edits the adjacent local-cache passages; a
merge-tree trial shows CHANGELOG as the only textual conflict). All code files
are disjoint.

## Renovate

`renovate.json` enables the `dockerfile` manager with
`managerFilePatterns: ["/docker/Dockerfile\\..*/"]`, which matches
`docker/Dockerfile.transformers`. Renovate's dockerfile manager extracts image
refs from `COPY --from=` lines, so the new `ghcr.io/astral-sh/uv:0.11.28` pin
will be tracked and bumped automatically (no packageRule excludes it). Verified
`ghcr.io/astral-sh/uv:0.11.28` resolves in the registry.

## Test plan

- `docker buildx build --check` on the Dockerfile: clean, no warnings; the
  pinned `uv:0.11.28` tag resolves.
- `make -n docker-seed-transformers`: parses; the single push (runtime target,
  promotion-source tag + `-buildcache` `mode=max` cache) is intact.
- `shellcheck` clean on the modified build script.
- `docker compose config` verified three ways: parses with the pin unset
  (fallbacks render: `unpinned` cache ref + `4.57.3` build arg); with
  `TRANSFORMERS_VERSION=5.7.0` renders
  `transformers-cache:transformers-5.7.0-buildcache` + build arg `5.7.0`;
  `make docker-check` passes. The 5.7.0 buildcache ref exists in GHCR
  (imagetools inspect OK), so the retargeted chain is warm today.
- Script pin resolution exercised standalone: resolves `5.7.0` from
  current.yaml.
- `make lint` (ruff + import-linter) clean; `make typecheck` clean (mypy, 304
  files); `make test` green (2927 passed, 35 skipped).
- No em/en-dashes in any changed file; no AI attribution.

Do not merge yet: the orchestrator sequences #798 + this, then re-publishes
v0.10.0.
