### PR TITLE
feat(rules): lint plugin kwarg literals against mined schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       docker: ${{ steps.changes.outputs.docker }}
       workflows: ${{ steps.changes.outputs.workflows }}
       docs_inputs: ${{ steps.changes.outputs.docs_inputs }}
+      plugin_kwargs: ${{ steps.changes.outputs.plugin_kwargs }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -72,6 +73,17 @@ jobs:
               - 'src/**'
               - 'scripts/**'
               - 'docs/reference/**'
+              - '.github/workflows/ci.yml'
+            plugin_kwargs:
+              # Inputs to plugin-kwarg-check: the hand-written translation
+              # layers, the mined schema surface they answer to (pin plus
+              # versioned snapshot), the workspace path resolver, the checker
+              # itself, and this workflow file (self-test).
+              - 'src/llenergymeasure/engines/*/plugin.py'
+              - 'engine_versions/_outputs.py'
+              - 'engine_versions/*/current.yaml'
+              - 'engine_versions/*/*/outputs/schema.discovered.json'
+              - 'scripts/check_plugin_kwargs.py'
               - '.github/workflows/ci.yml'
 
   lint:
@@ -264,3 +276,20 @@ jobs:
       - uses: actions/checkout@v6
       - name: Check ${{ matrix.engine }} schema version matches current.yaml pin
         run: python3 scripts/check_discovered_schema_versions.py --engine ${{ matrix.engine }}
+
+  plugin-kwarg-check:
+    # Standing lint between the glue code and the mined knowledge: every
+    # constructor-kwarg name a plugin's translation layer hand-types as a
+    # string literal must exist in that engine's discovered schema at the
+    # current pin (or carry an allowlist rationale in the script). Runs on
+    # the runner's bare python3 like schema-version-check; the script needs
+    # only stdlib + yaml and never imports the package.
+    needs: filter
+    if: >-
+      always()
+      && needs.filter.outputs.plugin_kwargs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check hand-typed plugin kwargs against the mined schema
+        run: python3 scripts/check_plugin_kwargs.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+### Added
+
+- Standing plugin-kwarg lint: `scripts/check_plugin_kwargs.py` cross-checks the literal
+  constructor-kwarg names each engine plugin's translation layer hand-types against that
+  engine's discovered schema at the current pin, with a rationale-carrying allowlist for
+  genuine off-surface kwargs (transformers `from_pretrained` open `**kwargs`). Catches
+  upstream kwarg renames the mined schema already knows about but the hand-written glue
+  code missed (the `quantization` -> `quant_config` case). Wired as
+  `make check-plugin-kwargs` and a `plugin-kwarg-check` job in ci.yml. ([#800])
+
 ### Changed
 
 - TensorRT-LLM backends are now selected by constructor class, not a kwarg: `backend='trt'`
@@ -688,3 +698,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#791]: https://github.com/henrycgbaker/llenergymeasure/pull/791
 [#792]: https://github.com/henrycgbaker/llenergymeasure/pull/792
 [#797]: https://github.com/henrycgbaker/llenergymeasure/pull/797
+[#800]: https://github.com/henrycgbaker/llenergymeasure/pull/800

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 .PHONY: docs-all docs-check docs-generate docs-serve docs-build docs-clean
 .PHONY: discover-schema discover-schemas-all scaffold-snapshot promote-schemas
 .PHONY: check-citations probe-candidates analyst-cold-read absorb rules-coverage check-corpus-literals
+.PHONY: check-plugin-kwargs
 .PHONY: package-check
 .PHONY: docker-smoke
 .PHONY: ci ci-all ci-docker
@@ -205,6 +206,14 @@ rules-coverage: ## Report uncovered engine validator sites (ENGINE=vllm SRC=path
 # means a corpus rule references a value the generated typed config would reject.
 check-corpus-literals: ## Report corpus rule literals inexpressible in discovered schema types
 	uv run python -m scripts.engine_producers._runtime_literals --census
+
+# Standing lint between the glue code and the mined knowledge: every
+# constructor-kwarg name an engine plugin's translation layer hand-types as a
+# string literal must exist in that engine's discovered schema at the current
+# pin (or carry an allowlist rationale in the script). Catches upstream kwarg
+# renames the schema already knows about but the hand-written plugin missed.
+check-plugin-kwargs: ## Lint hand-typed plugin constructor kwargs against the mined schema
+	uv run python scripts/check_plugin_kwargs.py
 
 # Build wheel + validate package install + check version consistency
 package-check: ## Build wheel, validate install, and check pyproject/_version sync

--- a/scripts/check_plugin_kwargs.py
+++ b/scripts/check_plugin_kwargs.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Cross-check hand-typed plugin constructor-kwarg names against the mined schema.
+
+Each engine plugin has a thin translation layer that builds the keyword-argument
+dict passed to the engine's native model constructor (``vllm.LLM(**kwargs)``,
+``tensorrt_llm.LLM(**kwargs)``, ``AutoModelForCausalLM.from_pretrained(model,
+**kwargs)``). Most of that dict is schema-sourced: it comes from
+``model_dump()`` of the generated typed config, so those key names are the mined
+schema field names by construction. But the layer also HAND-TYPES a handful of
+kwarg names as string literals - the ``{"model": ...}`` seed, ``kwargs["X"] =
+...`` assignments, and ``kwargs.update({...})`` merges. A hand-typed name that
+upstream renamed or removed is silent drift: the mined schema knows the correct
+name, but nothing checked the glue code against it. This lint closes that gap.
+The schema is the truth; the translation layer must answer to it.
+
+The motivating case: the tensorrt plugin passed quantisation under the hand-typed
+name ``quantization``, a name upstream removed in favour of ``quant_config``. The
+mined ``TrtLlmArgs`` schema carried ``quant_config`` all along; this check would
+have flagged ``quantization`` as absent from the schema surface.
+
+WHAT IS CHECKED (per engine, scoped to the constructor-kwargs variable(s) inside
+the plugin's kwargs-builder function(s)):
+
+  1. dict-literal keys in the kwargs seed:      ``kwargs = {"model": ...}``
+  2. string-literal subscript assignments:      ``kwargs["quantization"] = ...``
+  3. string-literal keys in a literal update:   ``kwargs.update({"model": ...})``
+
+Each extracted name must be a field in the engine's discovered ``engine_params``
+surface, or carry a rationale in :data:`ALLOWLIST`.
+
+WHAT IS NOT CHECKED (by design):
+
+  - Dynamic keys from ``model_dump()`` loops and ``kwargs.update(<var>)`` with a
+    non-literal argument. These are schema-sourced by construction, so they
+    already answer to the schema and are not hand-typed drift risks.
+  - Kwargs to NESTED sub-config constructors (``QuantConfig``, ``SchedulerConfig``,
+    ``KvCacheConfig``, ``BitsAndBytesConfig``, ``SamplingParams``). Those live on
+    their own local variables (``qc_kwargs``, ``sc_kwargs``, ``bnb_kwargs``, ...),
+    not on the engine-constructor kwargs variable, so scoping to the constructor
+    variable excludes them. The lint targets the top-level engine constructor
+    surface, which is what the discovered ``engine_params`` describes.
+  - Computed / f-string / variable-typed keys, and ``|=`` dict merges.
+
+The transformers surface is a special case: its schema is discovered from
+``inspect.signature(from_pretrained)``, which excludes ``**kwargs`` (the schema's
+own ``discovery_limitations`` documents this). Every kwarg the transformers layer
+hand-types is routed through ``from_pretrained``'s open ``**kwargs``, so none are
+in the signature-based surface; each is enumerated in :data:`ALLOWLIST` with a
+rationale. The check still fires if a NEW hand-typed transformers kwarg appears,
+forcing a conscious decision.
+
+The schema is read at the current pin: ``engine_versions/<engine>/current.yaml``
+gives the pinned version, and the mined snapshot at
+``engine_versions/<engine>/v<safe>/outputs/schema.discovered.json`` supplies the
+field surface (the same resolution the schema-version check uses).
+
+Usage:
+    python scripts/check_plugin_kwargs.py [--engine ENGINE]
+
+Exit codes:
+    0 = every hand-typed kwarg is a schema field or allowlisted
+    1 = a hand-typed kwarg is neither in the schema nor allowlisted
+    2 = error (missing file, parse failure, a configured builder went missing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from engine_versions import _outputs  # noqa: E402
+
+REPO_ROOT = _PROJECT_ROOT
+
+# The engines that ship a mined-schema workspace, from that workspace's own
+# registry (engine_versions/_outputs.py); do not hardcode the list here. The
+# llenergymeasure package is deliberately not imported so hosted CI can run
+# this check on the runner's bare python3, like the sibling schema-version
+# check (a test cross-checks this registry against the config-side Engine enum).
+ENGINES: tuple[str, ...] = _outputs.ENGINES
+
+
+@dataclass(frozen=True)
+class PluginSpec:
+    """Where an engine plugin hand-types its constructor kwargs.
+
+    ``builders`` names the functions in ``plugin.py`` that write the engine
+    constructor's kwargs dict (a method plus any same-module helper it threads
+    the dict through). ``kwargs_vars`` names the local variables that hold that
+    dict; scoping extraction to these names excludes kwargs built for nested
+    sub-config constructors, which use their own variables.
+    """
+
+    builders: tuple[str, ...]
+    kwargs_vars: frozenset[str]
+
+
+# A configured builder that goes missing is a loud error, not a silent pass: the
+# extractor would otherwise find nothing and the lint would go dormant after a
+# rename. ``early_kwargs`` is tensorrt's engine-path early-return dict; it may be
+# absent in a given plugin revision, so an absent kwargs variable is fine, but an
+# absent builder function is not.
+_PLUGIN_SPECS: dict[str, PluginSpec] = {
+    "tensorrt": PluginSpec(
+        builders=("_build_llm_kwargs", "_apply_default_build_cache"),
+        kwargs_vars=frozenset({"kwargs", "early_kwargs"}),
+    ),
+    "vllm": PluginSpec(
+        builders=("_build_llm_kwargs",),
+        kwargs_vars=frozenset({"kwargs"}),
+    ),
+    "transformers": PluginSpec(
+        builders=("_model_load_kwargs",),
+        kwargs_vars=frozenset({"kwargs"}),
+    ),
+}
+
+# Hand-typed kwargs that are legitimately outside the mined engine_params
+# surface. Keyed by (engine, kwarg_name) with a one-line rationale. A name that
+# looks like drift belongs in a plugin fix, never here.
+#
+# transformers: every entry is routed through from_pretrained's open **kwargs.
+# The transformers schema is discovered from inspect.signature(from_pretrained),
+# which the schema's own discovery_limitations record as excluding **kwargs, so
+# none of these appear in engine_params despite being valid constructor kwargs.
+ALLOWLIST: dict[tuple[str, str], str] = {
+    (
+        "transformers",
+        "torch_dtype",
+    ): "from_pretrained **kwargs; HF dtype selector (BC alias of dtype)",
+    ("transformers", "device_map"): "from_pretrained **kwargs; accelerate device placement",
+    ("transformers", "tp_plan"): "from_pretrained **kwargs; tensor-parallel plan",
+    (
+        "transformers",
+        "tp_size",
+    ): "from_pretrained **kwargs; tensor-parallel degree, paired with tp_plan",
+    (
+        "transformers",
+        "trust_remote_code",
+    ): "from_pretrained **kwargs; permits custom modelling code",
+    ("transformers", "attn_implementation"): "from_pretrained **kwargs; attention kernel selector",
+    ("transformers", "quantization_config"): "from_pretrained **kwargs; BitsAndBytesConfig carrier",
+    ("transformers", "max_memory"): "from_pretrained **kwargs; per-device memory cap for offload",
+    (
+        "transformers",
+        "low_cpu_mem_usage",
+    ): "from_pretrained **kwargs; sharded-load memory optimisation",
+}
+
+
+@dataclass(frozen=True)
+class EngineReport:
+    """Result of checking one engine's plugin against its schema."""
+
+    engine: str
+    version: str
+    field_count: int
+    checked: tuple[str, ...]  # every hand-typed name found, sorted
+    violations: tuple[str, ...]  # not in schema and not allowlisted, sorted
+    allowlisted: tuple[str, ...]  # not in schema but allowlisted, sorted
+
+
+def _literal_str(node: ast.expr | None) -> str | None:
+    """Return the value of a string-literal AST node, or None if it is not one."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _dict_literal_keys(node: ast.Dict) -> list[str]:
+    """String-literal keys of a dict literal (``**spread`` keys are None; skipped)."""
+    keys: list[str] = []
+    for key in node.keys:
+        literal = _literal_str(key)
+        if literal is not None:
+            keys.append(literal)
+    return keys
+
+
+def extract_literal_kwargs(source: str, spec: PluginSpec) -> tuple[dict[str, int], frozenset[str]]:
+    """Extract hand-typed constructor-kwarg names from a plugin's source.
+
+    Walks the functions named in ``spec.builders`` and, scoped to assignments and
+    updates of the ``spec.kwargs_vars`` variables, collects string-literal kwarg
+    names from the three emission patterns (dict-literal seed, subscript assign,
+    literal ``.update``). Returns ``(name -> first line seen, missing builders)``.
+    The missing-builders set lets the caller fail loudly on a rename rather than
+    go dormant.
+    """
+    tree = ast.parse(source)
+    builder_fns = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in spec.builders
+    ]
+    missing = frozenset(spec.builders) - {fn.name for fn in builder_fns}
+
+    names: dict[str, int] = {}
+
+    def _record(name: str, lineno: int) -> None:
+        names.setdefault(name, lineno)
+
+    def _is_kwargs_var(node: ast.expr) -> bool:
+        return isinstance(node, ast.Name) and node.id in spec.kwargs_vars
+
+    for fn in builder_fns:
+        for node in ast.walk(fn):
+            # Patterns 1 & 2: dict-literal seed and subscript assignment.
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    if _is_kwargs_var(target) and isinstance(node.value, ast.Dict):
+                        for key in _dict_literal_keys(node.value):
+                            _record(key, node.lineno)
+                    elif isinstance(target, ast.Subscript) and _is_kwargs_var(target.value):
+                        literal = _literal_str(target.slice)
+                        if literal is not None:
+                            _record(literal, node.lineno)
+            # Pattern 3: literal .update({...}).
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "update"
+                and _is_kwargs_var(node.func.value)
+                and node.args
+                and isinstance(node.args[0], ast.Dict)
+            ):
+                for key in _dict_literal_keys(node.args[0]):
+                    _record(key, node.lineno)
+
+    return names, missing
+
+
+def _pinned_version(current_yaml: Path) -> str:
+    """Return ``library.current_version`` from an engine current.yaml."""
+    data = yaml.safe_load(current_yaml.read_text()) or {}
+    library = data.get("library") or {}
+    value = library.get("current_version")
+    if value is None:
+        raise KeyError(f"library.current_version not found in {current_yaml}")
+    return str(value)
+
+
+def check_engine(engine: str, repo_root: Path) -> EngineReport:
+    """Check one engine's plugin translation layer against its mined schema.
+
+    Raises FileNotFoundError / KeyError / SyntaxError for the caller to turn into
+    an exit-2 error, and a RuntimeError if a configured builder went missing or
+    the engine has no registered PluginSpec.
+    """
+    spec = _PLUGIN_SPECS.get(engine)
+    if spec is None:
+        raise RuntimeError(
+            f"{engine}: no PluginSpec registered. A new engine joined the "
+            "mined-schema workspace; add its kwargs-builder spec to _PLUGIN_SPECS."
+        )
+
+    version = _pinned_version(repo_root / "engine_versions" / engine / "current.yaml")
+    schema_path = (
+        repo_root
+        / "engine_versions"
+        / engine
+        / _outputs.safe_version(version)
+        / "outputs"
+        / _outputs.SCHEMA_FILENAME
+    )
+    schema = json.loads(schema_path.read_text())
+    fields = set(schema.get("engine_params") or {})
+
+    plugin_path = repo_root / "src" / "llenergymeasure" / "engines" / engine / "plugin.py"
+    names, missing = extract_literal_kwargs(plugin_path.read_text(), spec)
+    if missing:
+        raise RuntimeError(
+            f"{engine}: configured kwargs-builder function(s) not found in "
+            f"{plugin_path.name}: {', '.join(sorted(missing))}. The plugin was "
+            "refactored; update _PLUGIN_SPECS so the lint does not go dormant."
+        )
+
+    violations: list[str] = []
+    allowlisted: list[str] = []
+    for name in names:
+        if name in fields:
+            continue
+        if (engine, name) in ALLOWLIST:
+            allowlisted.append(name)
+        else:
+            violations.append(name)
+
+    return EngineReport(
+        engine=engine,
+        version=str(schema.get("engine_version", version)),
+        field_count=len(fields),
+        checked=tuple(sorted(names)),
+        violations=tuple(sorted(violations)),
+        allowlisted=tuple(sorted(allowlisted)),
+    )
+
+
+def render_report(report: EngineReport) -> str:
+    """Render a deterministic per-engine report block."""
+    status = "FAIL" if report.violations else "PASS"
+    lines = [
+        f"[{report.engine}] {status}  "
+        f"(engine_params @ {report.version}, {report.field_count} fields; "
+        f"{len(report.checked)} hand-typed kwargs checked)"
+    ]
+    if report.violations:
+        lines.append("  hand-typed kwargs absent from the mined schema:")
+        for name in report.violations:
+            lines.append(
+                f"    {name}  -> not in engine_params; fix the plugin to use the "
+                "mined name, or allowlist it with a rationale if it is a genuine "
+                "off-surface constructor arg"
+            )
+    if report.allowlisted:
+        lines.append(f"  allowlisted off-surface kwargs: {', '.join(report.allowlisted)}")
+    return "\n".join(lines)
+
+
+def main(repo_root: Path | None = None, engines: tuple[str, ...] | None = None) -> int:
+    root = repo_root or REPO_ROOT
+    reports: list[EngineReport] = []
+    for engine in engines or ENGINES:
+        try:
+            reports.append(check_engine(engine, root))
+        except (FileNotFoundError, KeyError, SyntaxError, RuntimeError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    for report in reports:
+        print(render_report(report))
+
+    if any(report.violations for report in reports):
+        print(
+            "\nplugin kwarg lint FAILED: a hand-typed constructor kwarg does not "
+            "match the mined schema.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nAll hand-typed plugin kwargs match the mined engine schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--engine",
+        choices=ENGINES,
+        default=None,
+        help="Check only the named engine. Omit to check all engines.",
+    )
+    args = parser.parse_args()
+    sys.exit(main(engines=(args.engine,) if args.engine else None))

--- a/tests/unit/scripts/test_check_plugin_kwargs.py
+++ b/tests/unit/scripts/test_check_plugin_kwargs.py
@@ -1,0 +1,300 @@
+"""Host-side tests for scripts/check_plugin_kwargs.py.
+
+No engine import, no container. The extractor tests feed synthetic plugin-like
+source to :func:`extract_literal_kwargs` and assert exactly which string-literal
+kwarg names are captured (dict-literal seed, subscript assign, literal update)
+and which are ignored (dynamic update, nested sub-config kwargs on a different
+variable, computed keys). The integration tests build a tiny synthetic repo
+(current.yaml pin + versioned schema snapshot + plugin.py) and drive ``main`` /
+``check_engine`` through it, including the historical regression: the removed
+``quantization`` name checked against a tensorrt 1.2.1 schema must fail. A final
+test asserts the real shipped plugins all pass against their mined schemas.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+import check_plugin_kwargs as cpk
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ---------------------------------------------------------------------------
+# Extractor: which string-literal kwarg names are captured
+# ---------------------------------------------------------------------------
+
+_SPEC = cpk.PluginSpec(builders=("_build",), kwargs_vars=frozenset({"kwargs"}))
+
+
+def _names(source: str, spec: cpk.PluginSpec = _SPEC) -> set[str]:
+    names, missing = cpk.extract_literal_kwargs(source, spec)
+    assert not missing
+    return set(names)
+
+
+def test_captures_dict_literal_seed():
+    src = 'def _build(self):\n    kwargs = {"model": m, "seed": s}\n    return kwargs\n'
+    assert _names(src) == {"model", "seed"}
+
+
+def test_captures_annotated_dict_seed():
+    src = 'def _build(self):\n    kwargs: dict = {"model": m}\n    return kwargs\n'
+    assert _names(src) == {"model"}
+
+
+def test_captures_subscript_assignment():
+    src = 'def _build(self):\n    kwargs = {}\n    kwargs["quantization"] = q\n    return kwargs\n'
+    assert _names(src) == {"quantization"}
+
+
+def test_captures_literal_update():
+    src = 'def _build(self):\n    kwargs = {}\n    kwargs.update({"model": m, "dtype": d})\n'
+    assert _names(src) == {"model", "dtype"}
+
+
+def test_ignores_dynamic_update():
+    """A model_dump()-style ``.update(<var>)`` is schema-sourced, not hand-typed."""
+    src = 'def _build(self):\n    kwargs = {"model": m}\n    kwargs.update(dumped)\n'
+    assert _names(src) == {"model"}
+
+
+def test_ignores_nested_subconfig_kwargs():
+    """Keys on a different variable (a nested sub-config's kwargs) are out of scope."""
+    src = (
+        "def _build(self):\n"
+        '    kwargs = {"model": m}\n'
+        "    qc_kwargs = {}\n"
+        '    qc_kwargs["quant_algo"] = a\n'
+        '    kwargs["quant_config"] = QuantConfig(**qc_kwargs)\n'
+    )
+    assert _names(src) == {"model", "quant_config"}
+
+
+def test_ignores_computed_and_variable_keys():
+    src = (
+        "def _build(self):\n"
+        "    kwargs = {}\n"
+        "    kwargs[name] = v\n"  # variable key
+        '    kwargs[f"x_{i}"] = v\n'  # f-string key
+        "    return kwargs\n"
+    )
+    assert _names(src) == set()
+
+
+def test_scopes_to_multiple_kwargs_vars():
+    """tensorrt threads an early-return ``early_kwargs`` dict too."""
+    spec = cpk.PluginSpec(builders=("_build",), kwargs_vars=frozenset({"kwargs", "early_kwargs"}))
+    src = (
+        "def _build(self):\n"
+        '    early_kwargs = {"model": m}\n'
+        '    early_kwargs["backend"] = b\n'
+        '    kwargs = {"model": m}\n'
+    )
+    assert _names(src, spec) == {"model", "backend"}
+
+
+def test_scans_all_configured_builders():
+    """A helper the kwargs dict is threaded through is scanned too."""
+    spec = cpk.PluginSpec(builders=("_build", "_helper"), kwargs_vars=frozenset({"kwargs"}))
+    src = (
+        "def _build(self):\n"
+        '    kwargs = {"model": m}\n'
+        "def _helper(kwargs):\n"
+        '    kwargs["enable_build_cache"] = True\n'
+    )
+    assert _names(src, spec) == {"model", "enable_build_cache"}
+
+
+def test_reports_missing_builder():
+    """A renamed builder is reported so the lint fails loudly instead of dormant."""
+    _names_out, missing = cpk.extract_literal_kwargs("def other():\n    pass\n", _SPEC)
+    assert missing == frozenset({"_build"})
+
+
+# ---------------------------------------------------------------------------
+# Integration: synthetic repo (pin + versioned schema snapshot + plugin.py)
+# ---------------------------------------------------------------------------
+
+
+def _setup_engine(
+    repo: Path,
+    engine: str,
+    *,
+    version: str,
+    engine_params: list[str],
+    plugin_src: str,
+) -> None:
+    """Write a current.yaml pin, a versioned schema snapshot, and a plugin.py."""
+    from engine_versions._outputs import SCHEMA_FILENAME, safe_version
+
+    current = repo / "engine_versions" / engine
+    current.mkdir(parents=True, exist_ok=True)
+    (current / "current.yaml").write_text(f"library:\n  current_version: {version}\n")
+
+    out_dir = repo / "engine_versions" / engine / safe_version(version) / "outputs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / SCHEMA_FILENAME).write_text(
+        json.dumps(
+            {
+                "engine_version": version,
+                "engine_params": {name: {} for name in engine_params},
+                "sampling_params": {},
+            }
+        )
+    )
+
+    plugin_dir = repo / "src" / "llenergymeasure" / "engines" / engine
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.py").write_text(plugin_src)
+
+
+_TRT_QUANTIZATION_PLUGIN = (
+    "class TensorRTEngine:\n"
+    "    def _build_llm_kwargs(self, config):\n"
+    '        kwargs = {"model": config.task.model}\n'
+    "        qc_kwargs = {}\n"
+    '        qc_kwargs["quant_algo"] = 1\n'
+    '        kwargs["quantization"] = QuantConfig(**qc_kwargs)\n'
+    "        return kwargs\n"
+    "\n\n"
+    "def _apply_default_build_cache(kwargs):\n"
+    '    kwargs["enable_build_cache"] = True\n'
+)
+
+
+def test_regression_quantization_against_trt_1_2_1_fails(tmp_path, capsys):
+    """The historical case: ``quantization`` is not in the tensorrt 1.2.1 schema.
+
+    At 1.2.1 the mined ``TrtLlmArgs`` surface carries ``quant_config`` (the native
+    name), never the removed ``quantization``. A plugin that hand-types
+    ``quantization`` must be caught.
+    """
+    _setup_engine(
+        tmp_path,
+        "tensorrt",
+        version="1.2.1",
+        engine_params=["model", "quant_config", "enable_build_cache"],
+        plugin_src=_TRT_QUANTIZATION_PLUGIN,
+    )
+    code = cpk.main(repo_root=tmp_path, engines=("tensorrt",))
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "quantization" in out
+    assert "tensorrt" in out
+    # The nested QuantConfig kwarg must not be reported as a top-level violation.
+    assert "quant_algo" not in out
+
+
+def test_schema_name_passes(tmp_path):
+    _setup_engine(
+        tmp_path,
+        "tensorrt",
+        version="1.2.1",
+        engine_params=["model", "quant_config"],
+        plugin_src=(
+            "class E:\n"
+            "    def _build_llm_kwargs(self, config):\n"
+            '        kwargs = {"model": config.task.model}\n'
+            '        kwargs["quant_config"] = q\n'
+            "        return kwargs\n"
+            "\n\n"
+            "def _apply_default_build_cache(kwargs):\n"
+            "    return None\n"
+        ),
+    )
+    assert cpk.main(repo_root=tmp_path, engines=("tensorrt",)) == 0
+
+
+def test_bad_name_not_allowlisted_fails(tmp_path, capsys):
+    _setup_engine(
+        tmp_path,
+        "vllm",
+        version="0.19.1",
+        engine_params=["model", "seed"],
+        plugin_src=(
+            "class E:\n"
+            "    def _build_llm_kwargs(self, config):\n"
+            '        kwargs = {"model": m, "made_up_name": x}\n'
+            "        return kwargs\n"
+        ),
+    )
+    code = cpk.main(repo_root=tmp_path, engines=("vllm",))
+    assert code == 1
+    assert "made_up_name" in capsys.readouterr().out
+
+
+def test_allowlisted_offsurface_name_passes(tmp_path, capsys):
+    """A transformers from_pretrained **kwarg is off-surface but allowlisted."""
+    assert ("transformers", "torch_dtype") in cpk.ALLOWLIST
+    _setup_engine(
+        tmp_path,
+        "transformers",
+        version="5.7.0",
+        engine_params=["cache_dir", "revision"],  # signature-only surface
+        plugin_src=(
+            "class E:\n"
+            "    def _model_load_kwargs(self, config):\n"
+            '        kwargs = {"torch_dtype": d}\n'
+            "        return kwargs\n"
+        ),
+    )
+    code = cpk.main(repo_root=tmp_path, engines=("transformers",))
+    assert code == 0
+    assert "torch_dtype" in capsys.readouterr().out  # reported as allowlisted
+
+
+def test_missing_builder_is_exit_2(tmp_path, capsys):
+    _setup_engine(
+        tmp_path,
+        "vllm",
+        version="0.19.1",
+        engine_params=["model"],
+        plugin_src="class E:\n    def some_other_method(self):\n        return {}\n",
+    )
+    code = cpk.main(repo_root=tmp_path, engines=("vllm",))
+    assert code == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_missing_schema_is_exit_2(tmp_path, capsys):
+    (tmp_path / "engine_versions" / "vllm").mkdir(parents=True)
+    (tmp_path / "engine_versions" / "vllm" / "current.yaml").write_text(
+        "library:\n  current_version: 0.19.1\n"
+    )
+    plugin_dir = tmp_path / "src" / "llenergymeasure" / "engines" / "vllm"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.py").write_text(
+        "class E:\n    def _build_llm_kwargs(self, config):\n        return {}\n"
+    )
+    code = cpk.main(repo_root=tmp_path, engines=("vllm",))
+    assert code == 2
+    assert "ERROR" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# The real shipped plugins must pass against their mined schemas
+# ---------------------------------------------------------------------------
+
+
+def test_real_plugins_pass():
+    """Every shipped plugin's hand-typed kwargs match the mined schema at the pin."""
+    assert cpk.main(repo_root=_REPO_ROOT) == 0
+
+
+def test_engine_registry_matches_config_enum():
+    """The workspace registry the script enumerates equals the config-side enum.
+
+    The script reads engine_versions._outputs.ENGINES (stdlib-light, so CI runs
+    it on bare python3); this cross-check pins that registry to the Engine enum
+    so the two SSOT-adjacent lists cannot silently diverge.
+    """
+    from llenergymeasure.config.ssot import Engine
+
+    assert set(cpk.ENGINES) == {e.value for e in Engine}
+    assert all((engine in cpk._PLUGIN_SPECS) for engine in cpk.ENGINES)


### PR DESCRIPTION
## Summary

Standing lint that cross-checks the literal constructor-kwarg names each engine plugin's translation layer hand-types against that engine's mined schema at the current pin. Motivated by the `quantization` -> `quant_config` drift fixed in #797: the mined `TrtLlmArgs` schema knew the correct name all along, but nothing checked the hand-written glue code against it. The schema is the truth; the translation layer now answers to it.

- `scripts/check_plugin_kwargs.py`: AST-extracts string-literal kwarg names from each plugin's kwargs-builder functions (dict-literal seed, `kwargs["X"] = ...` subscript assignments, literal `kwargs.update({...})`), scoped to the constructor-kwargs variables so nested sub-config kwargs (`qc_kwargs`, `bnb_kwargs`, ...) are excluded. Dynamic keys from `model_dump()` loops are out of scope by design: they are schema-sourced by construction. Each extracted name must be in the engine's discovered `engine_params` surface (resolved via `current.yaml` -> versioned snapshot, same as the schema-version check) or carry a one-line rationale in the in-script allowlist.
- Allowlist: 9 transformers entries only, all `from_pretrained` open `**kwargs` that signature-based discovery cannot see (the schema's own `discovery_limitations` documents this). vllm and tensorrt need none.
- Engine enumeration comes from the `engine_versions._outputs.ENGINES` workspace registry (a test cross-checks it against the config-side `Engine` enum). The script never imports the package, so the CI job runs on the runner's bare python3 like `schema-version-check`.
- Fails loudly (exit 2) when a configured builder function disappears, so a plugin refactor cannot leave the lint silently dormant.
- Wiring: `make check-plugin-kwargs` (grouped with the corpus/schema checks) and a `plugin-kwarg-check` job in `ci.yml` with its own paths filter (plugin files, pin, schema snapshots, the checker, the workflow itself).

## Test plan

- [x] 18 unit tests in `tests/unit/scripts/test_check_plugin_kwargs.py`: extractor patterns (captures the three emission forms; ignores dynamic updates, nested sub-config kwargs, computed keys; scopes to multiple kwargs vars and builders; reports missing builders), synthetic-repo integration (bad name fails, schema name passes, allowlisted off-surface name passes, exit-2 error paths), and the historical regression: a hand-typed `quantization` against the tensorrt 1.2.1 schema FAILS while the nested `quant_algo` is not flagged.
- [x] `test_real_plugins_pass`: all three shipped plugins pass against their mined schemas as of post-#797 main (tensorrt validated against the class-dispatch / `quant_config` plugin shape).
- [x] `make lint`, `make typecheck`, full host pytest (2959 passed, 35 skipped).
- [x] Deterministic: double-run output byte-identical; all output sorted.
- [x] Bare-python3 run verified locally (no `uv sync` needed in the CI job).
