### PR TITLE
fix(rules): emit checker-conformant citations from cross-field extractor

### DIFF
--- a/scripts/cross_field_extractor.py
+++ b/scripts/cross_field_extractor.py
@@ -684,10 +684,23 @@ class _Emitter:
     run_date: str
     rel_file: str
     target: Target
+    source_lines: list[str]
     seen_ids: set[str] = field(default_factory=set)
     candidates: list[dict[str, Any]] = field(default_factory=list)
 
-    def emit(self, preds: list[_Predicate], detected: _Detected, line: int) -> None:
+    def _quote(self, line_start: int, line_end: int) -> str:
+        """Verbatim source span [line_start, line_end] (1-based, inclusive).
+
+        This is the exact text the citation checker re-reads and matches against
+        the pinned source: it must contain every constrained field and value the
+        claim asserts, so the span runs from the outermost contributing ``if``
+        test down to the ``raise`` / assignment the walker detected.
+        """
+        return "\n".join(self.source_lines[line_start - 1 : line_end])
+
+    def emit(
+        self, preds: list[_Predicate], detected: _Detected, line_start: int, line_end: int
+    ) -> None:
         effective = list(preds)
         subject = detected.affected_field
         if subject is not None and not any(p.field == subject for p in effective):
@@ -714,7 +727,11 @@ class _Emitter:
         }
         if detected.severity == "dormant":
             candidate["normalised_fields"] = [subject] if subject is not None else []
-        candidate["citation"] = {"file": self.rel_file, "lines": [line]}
+        candidate["citation"] = {
+            "file": self.rel_file,
+            "lines": [line_start, line_end],
+            "quote": self._quote(line_start, line_end),
+        }
         candidate["provenance"] = {
             "source": SOURCE,
             "engine_version": self.version,
@@ -728,34 +745,49 @@ class _Emitter:
         self.candidates.append(candidate)
 
 
-def _walk_body(body: list[ast.stmt], frame: list[_Predicate], emitter: _Emitter) -> None:
-    """Descend statements, accumulating enclosing ``if`` predicates in the frame."""
+def _walk_body(
+    body: list[ast.stmt], frame: list[_Predicate], frame_start: int | None, emitter: _Emitter
+) -> None:
+    """Descend statements, accumulating enclosing ``if`` predicates in the frame.
+
+    ``frame_start`` is the 1-based line of the outermost ``if`` that contributed a
+    predicate to ``frame``; it anchors the start of every citation span emitted
+    below, so the quoted source runs from that guard down to the detected site.
+    """
     for stmt in body:
         if isinstance(stmt, ast.If):
-            _walk_if_chain(stmt, frame, emitter)
+            _walk_if_chain(stmt, frame, frame_start, emitter)
         elif isinstance(stmt, ast.For):
-            _walk_body(stmt.body, frame, emitter)
+            _walk_body(stmt.body, frame, frame_start, emitter)
 
 
-def _walk_if_chain(if_node: ast.If, frame: list[_Predicate], emitter: _Emitter) -> None:
+def _walk_if_chain(
+    if_node: ast.If, frame: list[_Predicate], frame_start: int | None, emitter: _Emitter
+) -> None:
     node: ast.If | None = if_node
     while node is not None:
         preds = extract_predicates(node.test)
         local = [*frame, *preds]
+        # The outermost contributing guard anchors the citation span: an inherited
+        # frame_start wins; else this test opens the span iff it added predicates.
+        local_start = frame_start if frame_start is not None else (node.lineno if preds else None)
         for stmt in node.body:
             detected = _detect(stmt)
             if detected is not None:
-                emitter.emit(local, detected, getattr(stmt, "lineno", node.lineno))
+                stmt_start = getattr(stmt, "lineno", node.lineno)
+                stmt_end = getattr(stmt, "end_lineno", stmt_start)
+                line_start = local_start if local_start is not None else stmt_start
+                emitter.emit(local, detected, line_start, stmt_end)
             if isinstance(stmt, ast.If):
-                _walk_if_chain(stmt, local, emitter)
+                _walk_if_chain(stmt, local, local_start, emitter)
             elif isinstance(stmt, ast.For):
-                _walk_body(stmt.body, local, emitter)
+                _walk_body(stmt.body, local, local_start, emitter)
         # Follow ``elif`` chains with the enclosing (not the if-branch) frame.
         if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
             node = node.orelse[0]
         else:
             if node.orelse:
-                _walk_body(node.orelse, frame, emitter)
+                _walk_body(node.orelse, frame, frame_start, emitter)
             node = None
 
 
@@ -766,13 +798,13 @@ def _walk_target(module: ast.Module, target: Target, rel_file: str, emitter: _Em
     method = find_method(cls, target.method)
     if method is None:
         return
-    _walk_body(method.body, [], emitter)
+    _walk_body(method.body, [], None, emitter)
 
 
 def extract(engine: str, source_root: Path, version: str, run_date: str) -> list[dict[str, Any]]:
     """Walk the pinned source tree and return sorted, deduped pool candidates."""
     candidates: list[dict[str, Any]] = []
-    ast_cache: dict[str, ast.Module] = {}
+    ast_cache: dict[str, tuple[ast.Module, list[str]]] = {}
     for target in TARGETS.get(engine, ()):
         abs_path = source_root / target.rel_file
         if not abs_path.is_file():
@@ -781,16 +813,21 @@ def extract(engine: str, source_root: Path, version: str, run_date: str) -> list
                 file=sys.stderr,
             )
             continue
-        module = ast_cache.get(target.rel_file)
-        if module is None:
-            module = ast.parse(abs_path.read_text())
-            ast_cache[target.rel_file] = module
+        cached = ast_cache.get(target.rel_file)
+        if cached is None:
+            text = abs_path.read_text()
+            # splitlines() matches how the citation checker slices the same file,
+            # so an emitted quote round-trips to byte-identical source there.
+            cached = (ast.parse(text), text.splitlines())
+            ast_cache[target.rel_file] = cached
+        module, source_lines = cached
         emitter = _Emitter(
             engine=engine,
             version=version,
             run_date=run_date,
             rel_file=target.rel_file,
             target=target,
+            source_lines=source_lines,
         )
         _walk_target(module, target, target.rel_file, emitter)
         candidates.extend(emitter.candidates)

--- a/tests/unit/scripts/test_cross_field_extractor.py
+++ b/tests/unit/scripts/test_cross_field_extractor.py
@@ -19,6 +19,8 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 import scripts.cross_field_extractor as cfe  # noqa: E402
+from scripts._candidate_pool import write_pool  # noqa: E402
+from scripts.check_citations import check_candidate, load_candidates  # noqa: E402
 
 _VLLM_SAMPLING_PARAMS = """
 class SamplingParams:
@@ -136,3 +138,52 @@ def test_id_digest_collapses_re_reached_claim(tmp_path: Path) -> None:
     cands = cfe.extract("vllm", _vllm_source(tmp_path), "0.19.1", "2026-07-13")
     ids = [c["id"] for c in cands]
     assert len(ids) == len(set(ids))  # no duplicate ids within one engine run
+
+
+def _citations_pass(cands: list[dict[str, Any]], engine: str, source_root: Path, out: Path) -> int:
+    """Round-trip candidates through the checker exactly as ``absorb`` does.
+
+    Writes the pool, reloads it via :func:`load_candidates` (the shape gate that
+    used to raise on the single-line, quote-less citation), then verifies each
+    cited candidate's span against the same source tree. Returns the pass count.
+    """
+    write_pool(
+        out,
+        source=cfe.SOURCE,
+        engine=engine,
+        version="test",
+        generated_at="2026-07-13",
+        candidates=cands,
+        header="# test pool\n",
+    )
+    loaded = [c for c in load_candidates(out) if c.citation is not None]
+    assert loaded, "extractor emitted no cited candidates to check"
+    for cand in loaded:
+        verdict = check_candidate(cand, source_root)
+        assert verdict.ok, f"{cand.id}: {verdict.reason}"
+    return len(loaded)
+
+
+def test_every_vllm_citation_passes_the_checker(tmp_path: Path) -> None:
+    # Covers the cross-field raise, single-field raise, and self-assign dormancy
+    # shapes: each emitted citation must load (two-int lines + quote) and entail.
+    src = _vllm_source(tmp_path)
+    cands = cfe.extract("vllm", src, "0.19.1", "2026-07-13")
+    assert _citations_pass(cands, "vllm", src, tmp_path / "pool.yaml") >= 3
+
+
+def test_every_transformers_citation_passes_the_checker(tmp_path: Path) -> None:
+    # Covers the isinstance / is-not-None type-guard shape.
+    src = tmp_path / "transformers"
+    _write(src, "utils/quantization_config.py", _TFM_QUANT)
+    cands = cfe.extract("transformers", src, "5.7.0", "2026-07-13")
+    assert _citations_pass(cands, "transformers", src, tmp_path / "pool.yaml") >= 1
+
+
+def test_citation_lines_are_a_two_int_span_with_quote(tmp_path: Path) -> None:
+    cands = cfe.extract("vllm", _vllm_source(tmp_path), "0.19.1", "2026-07-13")
+    for cand in cands:
+        cite = cand["citation"]
+        start, end = cite["lines"]
+        assert isinstance(start, int) and isinstance(end, int) and 1 <= start <= end
+        assert cite["quote"].strip()


### PR DESCRIPTION
## Summary

The standing cross-field extractor (`scripts/cross_field_extractor.py`) emitted
citations shaped `{"file": ..., "lines": [<single line>]}` with no `quote`. The
citation checker (`scripts/check_citations.py`) requires `lines: [start, end]`
(a two-integer span) AND a non-empty `quote`, so `load_candidates` raised
`CandidateSchemaError` on the malformed entry. That crashed `make absorb` at the
`citation_pass_rate` stage whenever the candidate pool held any extractor
candidate. The tensorrt `TorchLlmArgs` targets added in #801 made this reliably
reproducible; a prior lane worked around it with `--skip-extractor`, which this
change removes the need for.

Fixed at the emitter, not the checker: the checker's contract is correct for
machine-mined candidates (verifying that the cited span actually entails the
claimed fields and values is the point of tier 1). The extractor already owns
the AST line numbers and the source text, so emitting a proper span plus the
exact quoted segment is the contract-honouring fix.

The walk now threads the outermost contributing `if` guard's start line down to
the detected `raise` / assignment, so each citation spans `[guard, site]` and
the quote is the verbatim source of that span (containing every constrained
field and value the claim asserts). A single-line guard emits a one-line span.
Determinism is preserved: the claim digest never included the citation, so ids
are byte-identical and re-proposals still collapse on id; the quote is derived
deterministically from source (no timestamps), so output is byte-stable.

No committed file changes: candidate pools are gitignored, and the shipped
`rules.yaml` corpus is only rewritten on probe-confirmed promotion (unchanged
here). This PR changes candidate emission only.

## Test plan

- `tests/unit/scripts/test_cross_field_extractor.py`: the four #795 recall-check
  shapes (cross-field raise, single-field raise, self-assign dormancy,
  isinstance/is-not-None type guard) still re-propose. Added three tests: every
  emitted vLLM citation and every transformers citation pass the checker's own
  `load_candidates` + `check_candidate` directly, and every citation carries a
  two-int span plus a non-empty quote.
- Real pinned tensorrt v1.2.1 source: extractor emits 16 candidates; the actual
  `check_citations.py` reports `checked: 16, failed: 0`; double-run is
  byte-identical.
- End-to-end: `absorb.py --engine tensorrt ... ` WITHOUT `--skip-extractor`
  (skipping only the LLM/GPU stages) runs past the previously-crashing stage and
  reports `citation check: 16/16 cited candidates entailed`; corpus unchanged.
- `make lint`, `make typecheck`, and `ruff check`/`format` on the changed files
  all pass. Full host pytest: the only failures are 4 pre-existing
  `test_tensorrt_engine.py` cases that fail identically on clean `origin/main`
  (unrelated to this diff).
