### PR TITLE
feat(tensorrt): measured both-backend activation with parity fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,3 +100,10 @@ LLEM_TRT_BUILD_CACHE_ENABLED=1
 # (~/.cache/tensorrt_llm/). Override when the default location is read-only
 # or full (shared filesystems, scratch dirs, etc.).
 LLEM_TRT_BUILD_CACHE_PATH=
+
+# ─── Docker GPU selection (llem-launched containers) ─────────────────────────
+# docker run --gpus value for experiment + baseline containers. Empty → "all"
+# (every visible GPU). On a shared multi-GPU host, pin llem to free devices,
+# e.g. device=2 or device=2,3. Restricting at the docker level keeps CUDA and
+# NVML indices consistent inside the container (both enumerate from 0).
+LLEM_DOCKER_GPUS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   TRT engine build, vLLM torch.compile / CUDA-graph capture). Captured by the harness
   around the load call, so all three engines gain it uniformly. Non-energy run metadata:
   the phase completes before the NVML energy window opens. Additive optional field;
-  result schema_version stays 4.0. ([#PR2])
+  result schema_version stays 4.0. ([#803])
 - `LLEM_DOCKER_GPUS`: docker `--gpus` request for llem-launched experiment and baseline
   containers (default `all`, the historical behaviour). On shared multi-GPU hosts, pin llem
   to free devices (e.g. `device=2`); restricting at the docker level keeps CUDA and NVML
-  indices consistent inside the container. ([#PR2])
+  indices consistent inside the container. ([#803])
 - TensorRT per-request latency metrics under `latency_profiling`: the plugin now sets
   `SamplingParams(return_perf_metrics=True)` when latency profiling is enabled and extracts
   per-request TTFT / E2E / average TPOT from `RequestOutput.metrics_dict` (the TRT-LLM 1.x
@@ -26,7 +26,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `RequestOutput.metrics` namespace does not exist there). Capture mode is
   `per_request_batch`. Default runs are unchanged: the flag is never set without
   latency profiling, and the `latency_profiling_unsupported` degradation warning now
-  fires only when profiling was requested but the engine returned no metrics. ([#PR2])
+  fires only when profiling was requested but the engine returned no metrics. ([#803])
 
 - TensorRT-LLM schema discovery now mines BOTH backend args classes and unions them into
   one discovered engine-params surface (63 -> 95 fields): `TrtLlmArgs` (the `trt` backend)
@@ -76,11 +76,11 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   plugin constructs the engine, and vLLM's EngineCore worker forks by default. The plugin now
   sets `VLLM_WORKER_MULTIPROC_METHOD=spawn` (setdefault, so a user override wins) - vLLM's
   own prescription for embedding contexts. Found by the first live containerized vllm run at
-  this pin. ([#PR2])
+  this pin. ([#803])
 - Container deps-cache stamp is now keyed per engine: the pyproject-verified stamp was shared
   across all images of one python minor, so whichever engine dispatched first suppressed the
   missing-deps probe for the others (the TRT-LLM NGC image, which ships every llem dep,
-  masked the vllm image's missing pyarrow -> parquet write crash). ([#PR2])
+  masked the vllm image's missing pyarrow -> parquet write crash). ([#803])
 - Transformers image seed and dev cache hygiene: `make docker-seed-transformers` no longer runs
   a harmful second push that wrote plain `transformers:latest` / `transformers:v<version>`
   images and a clobber-prone `mode=max` cache to `:latest`. The `-buildcache` ref is now the
@@ -769,3 +769,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#799]: https://github.com/henrycgbaker/llenergymeasure/pull/799
 [#800]: https://github.com/henrycgbaker/llenergymeasure/pull/800
 [#801]: https://github.com/henrycgbaker/llenergymeasure/pull/801
+[#803]: https://github.com/henrycgbaker/llenergymeasure/pull/803

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Added
 
+- `ExperimentResult.model_load_time_sec`: wall-clock seconds spent in `engine.load_model()`
+  (model load plus any engine build/compile performed there - the tensorrt trt backend's
+  TRT engine build, vLLM torch.compile / CUDA-graph capture). Captured by the harness
+  around the load call, so all three engines gain it uniformly. Non-energy run metadata:
+  the phase completes before the NVML energy window opens. Additive optional field;
+  result schema_version stays 4.0. ([#PR2])
+- `LLEM_DOCKER_GPUS`: docker `--gpus` request for llem-launched experiment and baseline
+  containers (default `all`, the historical behaviour). On shared multi-GPU hosts, pin llem
+  to free devices (e.g. `device=2`); restricting at the docker level keeps CUDA and NVML
+  indices consistent inside the container. ([#PR2])
+- TensorRT per-request latency metrics under `latency_profiling`: the plugin now sets
+  `SamplingParams(return_perf_metrics=True)` when latency profiling is enabled and extracts
+  per-request TTFT / E2E / average TPOT from `RequestOutput.metrics_dict` (the TRT-LLM 1.x
+  surface, live-verified on both backend legs at 1.2.1; the vLLM-shaped
+  `RequestOutput.metrics` namespace does not exist there). Capture mode is
+  `per_request_batch`. Default runs are unchanged: the flag is never set without
+  latency profiling, and the `latency_profiling_unsupported` degradation warning now
+  fires only when profiling was requested but the engine returned no metrics. ([#PR2])
+
 - TensorRT-LLM schema discovery now mines BOTH backend args classes and unions them into
   one discovered engine-params surface (63 -> 95 fields): `TrtLlmArgs` (the `trt` backend)
   and `TorchLlmArgs` (the `pytorch` backend). Each field carries a `backends` applicability
@@ -52,6 +71,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- vLLM containerized runs at 0.19.1 crashed at engine start with "Cannot re-initialize CUDA
+  in forked subprocess": the harness touches torch.cuda (hardware preflight) before the
+  plugin constructs the engine, and vLLM's EngineCore worker forks by default. The plugin now
+  sets `VLLM_WORKER_MULTIPROC_METHOD=spawn` (setdefault, so a user override wins) - vLLM's
+  own prescription for embedding contexts. Found by the first live containerized vllm run at
+  this pin. ([#PR2])
+- Container deps-cache stamp is now keyed per engine: the pyproject-verified stamp was shared
+  across all images of one python minor, so whichever engine dispatched first suppressed the
+  missing-deps probe for the others (the TRT-LLM NGC image, which ships every llem dep,
+  masked the vllm image's missing pyarrow -> parquet write crash). ([#PR2])
 - Transformers image seed and dev cache hygiene: `make docker-seed-transformers` no longer runs
   a harmful second push that wrote plain `transformers:latest` / `transformers:v<version>`
   images and a clobber-prone `mode=max` cache to `:latest`. The `-buildcache` ref is now the

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -52,6 +52,7 @@ The scientific record. One JSON file per experiment cell. Schema version `4.0`.
 |-------|------|-------------|
 | `measurement_methodology` | `"total"` &#124; `"steady_state"` &#124; `"windowed"` | Which slice of the run produced the headline metrics |
 | `warmup_excluded_samples` | int &#124; null | Number of warmup iterations run before the measurement window (from `warmup_result.iterations_completed`); `null` when no warmup result is available |
+| `model_load_time_sec` | float &#124; null | Wall-clock seconds spent in `engine.load_model()`: model load plus any engine build/compile performed there (e.g. the tensorrt trt backend's TRT engine build, vLLM torch.compile / CUDA-graph capture). Non-energy metadata: this phase completes before the energy measurement window opens and contributes nothing to `total_energy_j` |
 | `reproducibility_notes` | str | Free-text caveats (default mentions NVML accuracy +/-5 %, thermal drift) |
 
 ### Aggregate metrics

--- a/scripts/container_entrypoint.sh
+++ b/scripts/container_entrypoint.sh
@@ -41,7 +41,15 @@ export PYTHONPATH="/llem-src:${DEPS_TARGET}:${PYTHONPATH:-}"
 # last verified against this cache; matching hash means "deps probe was
 # done, nothing changed, skip it." Mismatch (or absent stamp) triggers a
 # full probe and updates the stamp.
-STAMP="${DEPS_TARGET}/.llem_pyproject_hash"
+#
+# The stamp is keyed by ENGINE as well as python minor: different engines run
+# different images whose site-packages differ, so "verified, nothing missing"
+# is an image-level fact, not a python-minor-level one. With a shared stamp,
+# whichever engine dispatches first would suppress the probe for the others
+# (observed live 2026-07-14: the TRT-LLM NGC image, which ships every llem
+# dep, stamped py3.12 verified; the vllm image, which lacks pyarrow, then
+# skipped the probe and crashed at the parquet write).
+STAMP="${DEPS_TARGET}/.llem_pyproject_hash_${LLEM_ENGINE:-default}"
 PYPROJECT_HASH=$(sha256sum /llem-pyproject.toml | head -c 16)
 
 if [ ! -f "$STAMP" ] || [ "$(cat "$STAMP" 2>/dev/null)" != "$PYPROJECT_HASH" ]; then

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -193,6 +193,14 @@ class ExperimentResult(BaseModel):
         description="Warmup iterations run before the measurement window "
         "(from WarmupResult.iterations_completed). None when no warmup result.",
     )
+    model_load_time_sec: float | None = Field(
+        default=None,
+        description="Wall-clock seconds spent in engine.load_model(): model load plus "
+        "any engine build/compile the engine performs there (e.g. the tensorrt trt "
+        "backend's TRT engine build, vLLM torch.compile/CUDA-graph capture). "
+        "Non-energy run metadata: this phase completes before the NVML energy "
+        "measurement window opens and contributes nothing to total_energy_j.",
+    )
     reproducibility_notes: str = Field(
         default=(
             "Energy measured via NVML polling. Accuracy +/-5%. "

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -77,6 +77,40 @@ def _validate_engine_directory(engine_path: Path, tp_size: int) -> list[str]:
     return errors
 
 
+def _extract_metrics_dict(outputs: Any) -> tuple[list[float], list[float], list[float]]:
+    """Per-request (e2e_ms, ttft_ms, tpot_ms) lists from ``RequestOutput.metrics_dict``.
+
+    TRT-LLM 1.x records per-request perf metrics in ``metrics_dict`` - keyed by
+    ``MetricNames`` enum members whose ``.value`` is the plain metric name, with
+    SECOND-valued timings - when ``return_perf_metrics=True`` was requested.
+    Live-verified at 1.2.1 on both backend legs (pytorch and trt): the
+    ``SamplingParams(return_perf_metrics=True)`` flag alone populates
+    ``ttft`` / ``e2e`` / ``tpot`` (+ ``arrival_timestamp`` /
+    ``request_queue_time`` / ``finished_reason``). Without the flag the dict is
+    empty, so this extraction contributes nothing on default runs.
+
+    ``tpot`` is the engine-computed per-request average time-per-output-token,
+    not a per-token timestamp stream - the caller labels the capture
+    ``per_request_batch`` accordingly.
+    """
+    latencies_ms: list[float] = []
+    ttft_ms: list[float] = []
+    itl_ms: list[float] = []
+    for o in outputs:
+        md = getattr(o, "metrics_dict", None) or {}
+        normalized = {str(getattr(k, "value", k)): v for k, v in md.items()}
+        e2e = normalized.get("e2e")
+        ttft = normalized.get("ttft")
+        tpot = normalized.get("tpot")
+        if isinstance(e2e, (int, float)):
+            latencies_ms.append(float(e2e) * 1000.0)
+        if isinstance(ttft, (int, float)):
+            ttft_ms.append(float(ttft) * 1000.0)
+        if isinstance(tpot, (int, float)):
+            itl_ms.append(float(tpot) * 1000.0)
+    return latencies_ms, ttft_ms, itl_ms
+
+
 def _apply_default_build_cache(kwargs: dict[str, Any]) -> None:
     """Apply the env-var-gated default TRT-LLM build cache to ``kwargs``.
 
@@ -299,21 +333,24 @@ class TensorRTEngine:
 
         extras: dict[str, Any] = {}
 
-        # TRT-LLM does not expose a per-token timing stream here, so latency
-        # profiling is unsupported: signal it so the harness can warn. Latency
-        # fields stay empty/None.
-        if config.measurement.latency_profiling:
+        # Per-request latency metrics from RequestOutput.metrics_dict. Populated
+        # only when SamplingParams carried return_perf_metrics=True - which
+        # _build_sampling_kwargs sets exactly when latency_profiling is enabled -
+        # so default energy runs pay nothing and extract nothing. (The vLLM-shaped
+        # ``RequestOutput.metrics`` namespace does NOT exist at TRT-LLM 1.2.1;
+        # metrics_dict is the 1.x surface, live-verified on both backend legs.)
+        per_request_latencies_ms, ttft_ms, itl_ms = _extract_metrics_dict(outputs)
+        latency_measurement_mode: str | None = None
+        if ttft_ms or per_request_latencies_ms:
+            # Engine-recorded per-request TTFT/E2E plus an engine-computed
+            # average TPOT per request - per-request timing without a
+            # per-token stream.
+            latency_measurement_mode = "per_request_batch"
+        elif config.measurement.latency_profiling:
+            # Profiling was requested but the engine returned no per-request
+            # metrics (e.g. an engine_path run where the flag is not applied,
+            # or an upstream regression): keep the loud degradation flag.
             extras["latency_profiling_unsupported"] = True
-
-        # Defensive per-request metric capture. Live-checked at TRT-LLM 1.2.1
-        # (2026-07-13, both backend legs): RequestOutput carries NO ``metrics``
-        # attribute at all - populating it needs ``return_perf_metrics=True`` at
-        # LLM construction, which llem does not set - so these lists come back
-        # empty. Wiring return_perf_metrics into a first-class latency path is a
-        # deliberate follow-up, not done here.
-        from llenergymeasure.engines._observed import extract_request_metrics
-
-        per_request_latencies_ms, ttft_ms = extract_request_metrics(outputs)
 
         return InferenceOutput(
             elapsed_time_sec=elapsed,
@@ -325,6 +362,8 @@ class TensorRTEngine:
             extras=extras,
             per_request_latencies_ms=per_request_latencies_ms,
             ttft_ms=ttft_ms,
+            itl_ms=itl_ms,
+            latency_measurement_mode=latency_measurement_mode,
             num_batches=1,  # Single batched generate() call
             padding_tokens=None,  # Not measurable from TRT-LLM RequestOutputs
             kv_cache_stats=None,  # TRT-LLM does not expose paged KV-cache stats here
@@ -638,6 +677,15 @@ class TensorRTEngine:
         kwargs["seed"] = config.task.random_seed
         if config.task.max_output_tokens is not None:
             kwargs["max_tokens"] = config.task.max_output_tokens
+        if config.measurement.latency_profiling:
+            # Ask TRT-LLM to record per-request perf metrics
+            # (RequestOutput.metrics_dict: ttft/e2e/tpot). Live-verified at
+            # 1.2.1 on both backend legs: the SamplingParams flag alone
+            # populates the dict; the mined schema carries the field on both
+            # args classes and on SamplingParams. Opt-in only - default energy
+            # runs never set it, so the measured configuration is unchanged
+            # unless the user asked for latency profiling.
+            kwargs["return_perf_metrics"] = True
         return kwargs
 
     def _build_sampling_params(self, config: ExperimentConfig) -> Any:

--- a/src/llenergymeasure/engines/vllm/plugin.py
+++ b/src/llenergymeasure/engines/vllm/plugin.py
@@ -139,7 +139,18 @@ class VLLMEngine:
         Raises:
             EngineError: If vLLM is not installed or model loading fails.
         """
+        import os
+
         from llenergymeasure.engines._errors import require_import
+
+        # The harness touches torch.cuda (hardware preflight, device probes)
+        # before this plugin constructs the engine, so CUDA is already
+        # initialised in this process. vLLM's default fork start method for
+        # its EngineCore worker then dies with "Cannot re-initialize CUDA in
+        # forked subprocess" (observed live at 0.19.1 in the containerized
+        # study path, 2026-07-14). Spawn is vLLM's own prescription for
+        # embedding contexts; setdefault keeps any explicit user override.
+        os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
         _vllm = require_import("vllm")
         LLM = _vllm.LLM

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -302,7 +302,7 @@ class MeasurementHarness:
         baseline = self._measure_or_reuse_baseline(config, baseline, gpu_indices, progress)
 
         # 3-4. Load model, join env snapshot, capture model memory baseline
-        model, snapshot, model_memory_mb = self._load_model_and_snapshot(
+        model, snapshot, model_memory_mb, model_load_time_sec = self._load_model_and_snapshot(
             engine, config, snapshot, snapshot_future, gpu_indices, progress
         )
 
@@ -330,6 +330,7 @@ class MeasurementHarness:
             baseline=baseline,
             warmup_result=warmup_result,
             model_memory_mb=model_memory_mb,
+            model_load_time_sec=model_load_time_sec,
             prompt_count=len(prompts),
             gpu_indices=gpu_indices,
             window=window,
@@ -399,19 +400,23 @@ class MeasurementHarness:
         snapshot_future: Future[EnvironmentSnapshot] | None,
         gpu_indices: list[int] | None,
         progress: ProgressCallback | None,
-    ) -> tuple[Any, EnvironmentSnapshot | None, float]:
+    ) -> tuple[Any, EnvironmentSnapshot | None, float, float]:
         """Load the model, join the background environment snapshot, and capture the
         post-load GPU memory baseline.
 
-        Returns (model, snapshot, model_memory_mb). The memory baseline must be
-        captured here - before warmup allocates KV cache.
+        Returns (model, snapshot, model_memory_mb, load_time_sec). The memory
+        baseline must be captured here - before warmup allocates KV cache.
+        load_time_sec brackets engine.load_model() alone: model load plus any
+        engine build/compile the plugin performs there. It lands on the result
+        as model_load_time_sec (non-energy metadata; this phase precedes the
+        NVML measurement window).
         """
         _p = progress
 
         # 3. Load model via engine plugin
         if _p:
             _p.on_step_start("model", "Loading", f"model {config.task.model}")
-            t0 = time.perf_counter()
+        t0 = time.perf_counter()
 
         # Build model substep callback
         def _on_model_substep(text: str, elapsed: float) -> None:
@@ -419,8 +424,9 @@ class MeasurementHarness:
 
         model = engine.load_model(config, on_substep=_on_model_substep)
 
+        load_time_sec = time.perf_counter() - t0
         if _p:
-            _p.on_step_done("model", time.perf_counter() - t0)
+            _p.on_step_done("model", load_time_sec)
 
         # 3b. Join snapshot future - collection hidden behind model loading
         if snapshot_future is not None:
@@ -432,7 +438,7 @@ class MeasurementHarness:
         if model_memory_mb > 0:
             _emit_substep(_p, "model", f"model memory: {model_memory_mb:.0f}MB")
 
-        return model, snapshot, model_memory_mb
+        return model, snapshot, model_memory_mb, load_time_sec
 
     def _load_prompts(
         self,
@@ -658,6 +664,7 @@ class MeasurementHarness:
         baseline: BaselineCache | None,
         warmup_result: WarmupResult,
         model_memory_mb: float,
+        model_load_time_sec: float | None,
         prompt_count: int,
         gpu_indices: list[int] | None,
         window: _MeasuredWindow,
@@ -714,6 +721,7 @@ class MeasurementHarness:
             measurement_warnings=measurement_warnings,
             warmup_result=warmup_result,
             prompt_count=prompt_count,
+            model_load_time_sec=model_load_time_sec,
         )
         _emit_substep(_p, "save", "result assembled")
 
@@ -1039,6 +1047,7 @@ class MeasurementHarness:
         warmup_result: Any = None,
         timeseries_samples: list[PowerThermalSample] | None = None,
         prompt_count: int = 0,
+        model_load_time_sec: float | None = None,
     ) -> ExperimentResult:
         """Assemble ExperimentResult from measurement data.
 
@@ -1068,6 +1077,9 @@ class MeasurementHarness:
             timeseries_samples: Raw PowerThermalSample list for GPU-utilisation /
                 memory-bandwidth / total-VRAM extraction. None = no samples.
             prompt_count: Number of prompts in the run (for batch effective size).
+            model_load_time_sec: Wall-clock seconds spent in engine.load_model()
+                (model load + any engine build/compile). Non-energy metadata;
+                the phase precedes the NVML measurement window.
 
         Returns:
             Fully assembled ExperimentResult.
@@ -1354,4 +1366,5 @@ class MeasurementHarness:
             measurement_window_discard_fraction=discard_fraction,
             steady_state_not_detected=steady_state_not_detected,
             warmup_excluded_samples=warmup_excluded_samples,
+            model_load_time_sec=model_load_time_sec,
         )

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -66,6 +66,7 @@ from llenergymeasure.infra.docker_errors import (
     capture_stderr_snippet,
     translate_docker_error,
 )
+from llenergymeasure.utils.env_config import docker_gpus
 from llenergymeasure.utils.exceptions import DockerError
 from llenergymeasure.utils.io import load_json
 
@@ -959,7 +960,7 @@ class DockerRunner:
             "run",
             "--rm",
             "--gpus",
-            "all",
+            docker_gpus(),
             "-v",
             f"{exchange_dir}:{CONTAINER_EXCHANGE_DIR}",
             "-e",

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -35,6 +35,7 @@ from llenergymeasure.config.ssot import (
 )
 from llenergymeasure.harness.baseline import BaselineCache
 from llenergymeasure.infra.docker_runner import append_package_dispatch
+from llenergymeasure.utils.env_config import docker_gpus
 from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
@@ -87,7 +88,7 @@ def build_baseline_docker_cmd(
         "run",
         "--rm",
         "--gpus",
-        "all",
+        docker_gpus(),
         "-v",
         f"{exchange_dir}:{CONTAINER_EXCHANGE_DIR}",
         "-e",

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -55,6 +55,30 @@ def default_device_map() -> str | None:
     return os.environ.get(ENV_TRANSFORMERS_DEFAULT_DEVICE_MAP) or None
 
 
+ENV_DOCKER_GPUS: Final = "LLEM_DOCKER_GPUS"
+"""Docker ``--gpus`` request for llem-launched containers (experiment + baseline).
+
+Passed verbatim as the value of ``docker run --gpus``. Unset / empty means
+``all`` (every visible GPU - the historical behaviour). On a shared multi-GPU
+host, set a device selector (e.g. ``device=2`` or ``device=2,3``) to pin
+llem's containers to free GPUs.
+
+Restricting visibility at the DOCKER level keeps measurement indices
+consistent: inside the container the only visible GPU(s) enumerate from 0 for
+BOTH CUDA and NVML, so compute, energy sampling, and thermal monitoring all
+address the same physical device without any index translation.
+"""
+
+
+def docker_gpus() -> str:
+    """Return the ``docker run --gpus`` value for llem-launched containers.
+
+    Pure passthrough with the historical fallback: unset / empty -> ``all``.
+    """
+    raw = os.environ.get(ENV_DOCKER_GPUS, "").strip()
+    return raw or "all"
+
+
 ENV_TRT_BUILD_CACHE_ENABLED: Final = "LLEM_TRT_BUILD_CACHE_ENABLED"
 """Toggle for TRT-LLM on-disk engine build cache.
 

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -1514,3 +1514,35 @@ class TestReservedEnvForwarding:
         cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
 
         assert self._forwarded_value(cmd, "LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP") == "auto"
+
+
+class TestDockerGpusOverride:
+    def test_llem_docker_gpus_overrides_gpus_value(self, tmp_path, monkeypatch):
+        """LLEM_DOCKER_GPUS pins llem containers to specific devices (shared host)."""
+        monkeypatch.setenv("LLEM_DOCKER_GPUS", "device=2")
+        config = make_config()
+        exchange_dir = tmp_path / "llem-gpus"
+        exchange_dir.mkdir()
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["docker", "image", "inspect"]:
+                return make_subprocess_result(0)
+            captured_cmds.append(cmd)
+            return make_subprocess_result(1, stderr="No such image")  # fail fast
+
+        with (
+            patch(
+                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                return_value=str(exchange_dir),
+            ),
+            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+        ):
+            runner = DockerRunner(image=IMAGE)
+            with pytest.raises(DockerImagePullError):
+                runner.run(config)
+
+        cmd = captured_cmds[0]
+        assert cmd[cmd.index("--gpus") + 1] == "device=2"
+        assert "all" not in cmd[: cmd.index("--gpus") + 2]

--- a/tests/unit/engines/test_latency_profiling.py
+++ b/tests/unit/engines/test_latency_profiling.py
@@ -218,3 +218,81 @@ class TestVllmModeSelection:
         itl, mode = self._select_mode(True, outputs)
         assert itl == []
         assert mode is None
+
+
+# ---------------------------------------------------------------------------
+# TensorRT metrics_dict extraction + return_perf_metrics opt-in
+# ---------------------------------------------------------------------------
+
+
+class _FakeMetricName:
+    """Mimics TRT-LLM's MetricNames enum members (str(key.value) is the name)."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def _trt_req(ttft: float | None, e2e: float | None, tpot: float | None) -> SimpleNamespace:
+    """A fake TRT-LLM RequestOutput carrying a metrics_dict (values in seconds)."""
+    md: dict[Any, Any] = {"finished_reason": "length"}
+    if ttft is not None:
+        md[_FakeMetricName("ttft")] = ttft
+    if e2e is not None:
+        md[_FakeMetricName("e2e")] = e2e
+    if tpot is not None:
+        md[_FakeMetricName("tpot")] = tpot
+    return SimpleNamespace(metrics_dict=md, outputs=[])
+
+
+class TestTensorrtMetricsDictExtraction:
+    """_extract_metrics_dict: the TRT-LLM 1.x per-request metrics surface."""
+
+    def test_extracts_seconds_as_ms(self):
+        from llenergymeasure.engines.tensorrt.plugin import _extract_metrics_dict
+
+        outputs = [_trt_req(ttft=0.05, e2e=0.25, tpot=0.01)]
+        lat, ttft, itl = _extract_metrics_dict(outputs)
+        assert lat == pytest.approx([250.0])
+        assert ttft == pytest.approx([50.0])
+        assert itl == pytest.approx([10.0])
+
+    def test_empty_metrics_dict_contributes_nothing(self):
+        from llenergymeasure.engines.tensorrt.plugin import _extract_metrics_dict
+
+        outputs = [SimpleNamespace(metrics_dict={}, outputs=[]), SimpleNamespace(outputs=[])]
+        lat, ttft, itl = _extract_metrics_dict(outputs)
+        assert lat == [] and ttft == [] and itl == []
+
+    def test_partial_keys_are_independent(self):
+        from llenergymeasure.engines.tensorrt.plugin import _extract_metrics_dict
+
+        outputs = [_trt_req(ttft=0.1, e2e=None, tpot=None)]
+        lat, ttft, itl = _extract_metrics_dict(outputs)
+        assert lat == [] and itl == []
+        assert ttft == pytest.approx([100.0])
+
+    def test_plain_string_keys_also_accepted(self):
+        from llenergymeasure.engines.tensorrt.plugin import _extract_metrics_dict
+
+        outputs = [SimpleNamespace(metrics_dict={"ttft": 0.2, "e2e": 0.4}, outputs=[])]
+        lat, ttft, _ = _extract_metrics_dict(outputs)
+        assert ttft == pytest.approx([200.0])
+        assert lat == pytest.approx([400.0])
+
+
+class TestTensorrtReturnPerfMetricsOptIn:
+    """return_perf_metrics rides SamplingParams kwargs only under latency_profiling."""
+
+    def test_profiling_on_sets_flag(self):
+        from llenergymeasure.engines.tensorrt.plugin import TensorRTEngine
+
+        config = make_config(engine="tensorrt", latency_profiling=True)
+        kwargs = TensorRTEngine()._build_sampling_kwargs(config)
+        assert kwargs.get("return_perf_metrics") is True
+
+    def test_profiling_off_does_not_set_flag(self):
+        from llenergymeasure.engines.tensorrt.plugin import TensorRTEngine
+
+        config = make_config(engine="tensorrt", latency_profiling=False)
+        kwargs = TensorRTEngine()._build_sampling_kwargs(config)
+        assert "return_perf_metrics" not in kwargs

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -234,6 +234,26 @@ def test_harness_engine_version_none_when_missing(minimal_config):
     assert result.engine_version is None
 
 
+def test_harness_records_model_load_time(minimal_config):
+    """harness.run() persists the engine.load_model() wall-time on the result.
+
+    model_load_time_sec brackets load_model() alone (model load + any engine
+    build/compile the plugin performs there) and is non-energy metadata: the
+    phase precedes the measurement window. It must always be populated on a
+    successful run, and must be a sane non-negative wall-clock value.
+    """
+    engine = FakeBackend()
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, minimal_config)
+
+    assert result.model_load_time_sec is not None
+    assert result.model_load_time_sec >= 0.0
+    # FakeBackend loads instantly; the bracket must not pick up unrelated phases.
+    assert result.model_load_time_sec < 30.0
+
+
 def test_harness_thermal_floor_wait_set_on_warmup_result(minimal_config):
     """thermal_floor_wait_s on WarmupResult must be set by harness (not by engine).
 
@@ -652,8 +672,10 @@ def test_harness_sets_inference_time_sec(minimal_config):
 def test_inference_time_sec_used_in_result(minimal_config):
     """total_inference_time_sec in ExperimentResult must come from harness perf_counter delta.
 
-    We mock time.perf_counter to return controlled values (100.0 then 105.0 → 5.0s delta).
-    The engine returns elapsed_time_sec=99.0. The result must show 5.0, not 99.0.
+    We mock time.perf_counter with controlled values: the model-load bracket
+    (50.0 then 52.0 -> model_load_time_sec=2.0) followed by the inference
+    bracket (100.0 then 105.0 -> 5.0s delta). The engine returns
+    elapsed_time_sec=99.0. The result must show 5.0, not 99.0.
     """
     custom_output = InferenceOutput(
         elapsed_time_sec=99.0,
@@ -665,7 +687,8 @@ def test_inference_time_sec_used_in_result(minimal_config):
     engine = FakeBackend(inference_output=custom_output)
     harness = MeasurementHarness()
 
-    perf_counter_values = iter([100.0, 105.0])  # start=100, end=105 → delta=5.0
+    # load_model bracket: 50 -> 52; inference bracket: 100 -> 105.
+    perf_counter_values = iter([50.0, 52.0, 100.0, 105.0])
 
     with (
         _apply_patches(),
@@ -676,6 +699,9 @@ def test_inference_time_sec_used_in_result(minimal_config):
 
     assert result.total_inference_time_sec == pytest.approx(5.0), (
         f"Expected 5.0 from perf_counter delta, got {result.total_inference_time_sec}"
+    )
+    assert result.model_load_time_sec == pytest.approx(2.0), (
+        f"Expected 2.0 from the load_model perf_counter bracket, got {result.model_load_time_sec}"
     )
 
 

--- a/tests/unit/study/test_baseline_container.py
+++ b/tests/unit/study/test_baseline_container.py
@@ -86,6 +86,19 @@ class TestBuildBaselineDockerCmd:
         assert any("CUDA_VISIBLE_DEVICES=0,2" in part for part in cmd)
         # image is the LAST arg (the entrypoint script invokes the module itself)
         assert cmd[-1] == "ghcr.io/foo/bar:v1"
+        # default --gpus request is "all"
+        assert cmd[cmd.index("--gpus") + 1] == "all"
+
+    def test_cmd_honours_llem_docker_gpus(self, tmp_path: Path, monkeypatch):
+        """LLEM_DOCKER_GPUS overrides the --gpus value (shared-host pinning)."""
+        monkeypatch.setenv("LLEM_DOCKER_GPUS", "device=2")
+        cmd = baseline_container.build_baseline_docker_cmd(
+            image="ghcr.io/foo/bar:v1",
+            exchange_dir=str(tmp_path),
+            gpu_indices=[0],
+            engine="vllm",
+        )
+        assert cmd[cmd.index("--gpus") + 1] == "device=2"
 
     def test_cmd_makes_package_importable(self, tmp_path: Path):
         """The baseline command must mount the host package + route through the


### PR DESCRIPTION
## Summary

Measured activation of the tensorrt engine: both backend legs (`pytorch`, `trt`) ran as real energy-measured cells through the containerized study runner on the same model, alongside a vLLM reference cell, with the ruled three-part parity audit. The live runs surfaced and fixed two pre-existing container-path defects the mocked suite could not reach.

**MODEL SUBSTITUTION (flagged):** the measured runs used `Qwen/Qwen2.5-7B-Instruct`, NOT the ratified `Llama-3.1-8B-Instruct` - the Llama repo is HF-gated and this host has no usable token (gated download live-verified 401). Full evidence (report + machine-readable YAML) filed locally under `.product/research/trt-measured-activation-parity-2026-07-14.md` with a dated pointer in the F2 plan doc.

## What landed

1. **Build/compile wall-time as non-energy result metadata**: new optional `ExperimentResult.model_load_time_sec`, captured by the harness around `engine.load_model()` (the compile lives inside `LLM(**kwargs)` in the plugin's load path). All three engines gain it uniformly. Additive default-None field; result schema stays 4.0. Observed live: 88.6s (trt/pytorch), 127.7s (trt/trt incl. engine acquisition via build cache), 81.5s (vllm).
2. **TensorRT per-request latency metrics under `latency_profiling`**: investigation found the vLLM-shaped `RequestOutput.metrics` does NOT exist at 1.2.1; the 1.x surface is `RequestOutput.metrics_dict` (ttft/e2e/tpot, seconds - live flag-matrix probed: either flag populates it; overhead within noise). Wired minimally: `SamplingParams(return_perf_metrics=True)` only under `latency_profiling`, tensorrt-local extraction, mode `per_request_batch`. Default runs untouched; the `latency_profiling_unsupported` degradation flag now fires only when profiling was requested and no metrics returned. Live result: full TTFT/ITL percentile stats on BOTH backend legs.
3. **Fix (pre-existing): vLLM 0.19.1 containerized runs crashed** with "Cannot re-initialize CUDA in forked subprocess" (harness preflight initialises CUDA before the plugin constructs the engine; EngineCore forks). Fixed with `VLLM_WORKER_MULTIPROC_METHOD=spawn` setdefault in the plugin - vLLM's own embedding prescription. First live containerized vllm run at this pin found it.
4. **Fix (pre-existing): container deps-cache stamp collision** - the pyproject-verified stamp was keyed per python minor only, so the TRT NGC image (ships all llem deps) suppressed the missing-deps probe for the vllm image (missing pyarrow -> parquet write crash). Stamp now keyed per engine.
5. **`LLEM_DOCKER_GPUS`**: docker `--gpus` request for experiment + baseline containers (default `all`). Needed to run at all on this shared host (foreign 28GB workload on GPU 0); docker-level restriction keeps CUDA and NVML indices consistent inside the container (both enumerate from 0), closing the shared-host pinning gap.

## Parity audit (ruling section 8)

- **(a) populated-ness diff**: 76/93 result fields identical across all 3 cells; every energy/throughput/FLOPs/provenance field populates identically. The only systematic diff now favours tensorrt: `latency_stats` populated on both trt legs (new capture), null on vllm (0.19.1 V1 returns no per-request metrics in this path AND sets no degradation flag - reported below).
- **(b) build outside NVML window - OBSERVED**: per-cell timeline from run artifacts shows load/build ENDED >= 37.5s / 38.8s / 49.8s before the window OPENED (gap = prompts + warmup + 30s thermal floor); windows wrap only the generate call (1.2-1.9s). Magnitude cross-check consistent (150-200W over the window).
- **(c) baseline-cache key audit**: key = runner mode + resolved image tag only; `backend` does not participate - and REASONED correct: the baseline is the idle CUDA-init footprint of the image measured in a separate container before any model exists; backend selects the constructor class inside the experiment container and cannot affect it. Observed: one shared cache entry for both trt cells (44.86W), separate measurement for the vllm image (35.78W). No fix required. Caveat recorded: `gpu_indices` also absent from the key - irrelevant at TP=1, flagged for future TP-mixing sweeps.

## Dedup / identity sanity

`equivalence_groups.json`: 2 groups, distinct resolved-config hashes, `member_count` 1 each, `would_dedup: false` - 2 backend cells = 2 experiments end-to-end through the real runner, no silent collapse.

## F2.1 follow-ups closed

- pytorch-leg generation with an instruct model: CONFIRMED (4985 tokens through the measured path).
- `return_perf_metrics`: investigated (full findings in the evidence report) and wired in the minimal clean form (above).
- Degradation flags behave as designed on tensorrt; a vllm-side gap found (null latency_stats with no flag) - reported, not fixed here.

## Reported, not fixed (candidates for follow-up slices)

1. `config.json` observed-params sidecar absent from experiment dirs on the containerized study path (both engines; the best-effort exchange-dir move is debug-swallowed at `study/runner.py:201`). Affects provenance completeness, not measurement.
2. vllm null latency_stats + no degradation flag under profiling at 0.19.1.
3. TRT build-cache location mismatch: docker mounts `~/.cache/trt-llm` but TRT-LLM's default cache root is `~/.cache/tensorrt_llm`; cross-container cache reuse worked here only because `LLEM_TRT_BUILD_CACHE_PATH` was set to the mount path. Reconcile in F2.3 (cache phase). Build cache itself VERIFIED: host cache gained a 15GB engine entry reused across containers.
4. llem's GPU lock keys host index 0 regardless of `LLEM_DOCKER_GPUS` pinning (cosmetic on this host).
5. The stale bare-tag local image (`llenergymeasure:tensorrt` @ 0.21.0) is preferred by smart image resolution; the version handshake correctly hard-fails it (worked as designed) - consider bare-tag deprecation.

## Measured results (activation proof, not science - n=8 prompts, ~1.5s windows)

| metric | trt/pytorch | trt/trt | vllm |
|---|---|---|---|
| total_energy_j | 301.4 | 377.5 | 252.9 |
| tokens | 4985 | 5049 | 5049 |
| tok/s | 3310.6 | 2703.2 | 4249.7 |
| mJ/tok (adj) | 523.7 | 582.3 | 394.4 |
| model_load_time_sec | 88.6 | 127.7 | 81.5 |
| ttft/itl mean ms | 484 / 13.9 | 369 / 23.0 | null |

## Gates

- Host suite: 2974 passed / 35 skipped; `make lint` + `make typecheck` clean; regen `--check` byte-green; `docs-check` green.
- Result-schema addition is additive (`Optional`, default None); schema_version stays 4.0 per the documented policy.

Draft: for orchestrator review/merge.
