### PR TITLE
feat(tensorrt): annotate build-cache hits and fix cache mount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,9 +96,12 @@ LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP=auto
 # the library default.
 LLEM_TRT_BUILD_CACHE_ENABLED=1
 
-# Optional cache directory. Empty → TRT-LLM's internal default location
-# (~/.cache/tensorrt_llm/). Override when the default location is read-only
-# or full (shared filesystems, scratch dirs, etc.).
+# Optional cache directory. Under docker dispatch this defaults to the
+# bind-mounted cache (/root/.cache/trt-llm, backed by the host ~/.cache/trt-llm)
+# so compiled engines persist across ephemeral containers automatically - leave
+# empty for that. Set a value to override (e.g. a read-only or full default
+# location, scratch dirs); outside docker, empty means TRT-LLM's own default
+# root (/tmp/.cache/tensorrt_llm/llmapi/).
 LLEM_TRT_BUILD_CACHE_PATH=
 
 # ─── Docker GPU selection (llem-launched containers) ─────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Added
 
+- `ExperimentResult.engine_build_cache_hit`: whether the tensorrt trt-backend engine build
+  was served from the on-disk build cache (`true`) or compiled fresh (`false`); `null` when
+  the cache is not in play (pytorch backend, other engines, an `engine_path` override, or the
+  cache disabled). Detected from TRT-LLM's own `llm_build_stats.engine_dir`, which is
+  populated only on the cache-reuse path (the sibling `cache_hitted` flag is unusable - it is
+  `True` on both the reuse and fresh-build paths). Annotates `model_load_time_sec` (a hit
+  skips the compile). Additive optional field; result schema_version stays 4.0. ([#804])
+- `llem doctor` now reports the TensorRT-LLM engine build cache: location, engine-entry count,
+  total size, and the manual clean command. Informational only (never affects the exit code) -
+  the cache lifecycle is manual and visible, and llem never auto-evicts. ([#804])
 - `ExperimentResult.model_load_time_sec`: wall-clock seconds spent in `engine.load_model()`
   (model load plus any engine build/compile performed there - the tensorrt trt backend's
   TRT engine build, vLLM torch.compile / CUDA-graph capture). Captured by the harness
@@ -71,6 +81,22 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- TensorRT-LLM build cache silently died across containers unless
+  `LLEM_TRT_BUILD_CACHE_PATH` was set by hand: the docker runner bind-mounts the host
+  `~/.cache/trt-llm` at `/root/.cache/trt-llm`, but TRT-LLM's own default cache root
+  (`/tmp/.cache/tensorrt_llm/llmapi/`) is unmounted and evaporates with each ephemeral
+  container. The runner now defaults `LLEM_TRT_BUILD_CACHE_PATH` to the mount target (via the
+  mount's `extra_env`, mirroring the `HF_HOME` pattern), so compiled engines persist out of
+  the box; a host-set value still wins (forwarded last, docker `-e` is last-wins). Verified
+  live: upstream `BuildCacheConfig` keying is sound - identical config hits across containers,
+  and tensor-parallel / max-shape / quantisation / dtype changes each key to a distinct
+  engine hash. ([#804])
+- The TRT-LLM pre-quantised-checkpoint preflight message now names what was live-verified at
+  1.2.1: AutoAWQ / AutoGPTQ community-format HF checkpoints load on neither backend (the trt
+  backend raises `NotImplementedError` on the `quant_method`; the pytorch backend rejects the
+  weight layout), and TRT-LLM's supported pre-quantised path is its own ModelOpt export
+  (`hf_quant_config.json`). The rejection stands for both backends; the `engine_path` escape
+  hatch is unchanged. ([#804])
 - vLLM containerized runs at 0.19.1 crashed at engine start with "Cannot re-initialize CUDA
   in forked subprocess": the harness touches torch.cuda (hardware preflight) before the
   plugin constructs the engine, and vLLM's EngineCore worker forks by default. The plugin now
@@ -770,3 +796,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#800]: https://github.com/henrycgbaker/llenergymeasure/pull/800
 [#801]: https://github.com/henrycgbaker/llenergymeasure/pull/801
 [#803]: https://github.com/henrycgbaker/llenergymeasure/pull/803
+[#804]: https://github.com/henrycgbaker/llenergymeasure/pull/804

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -440,10 +440,12 @@ llem doctor
 ```
 
 which reports the cache location, engine-entry count, and total size. Entries
-are large (often 1-15 GB each); clean the cache manually when it grows:
+are large (often 1-15 GB each); clean the cache manually when it grows.
+Entries are written by the container's root process, so removing them from the
+host needs `sudo`:
 
 ```bash
-rm -rf ~/.cache/trt-llm/engine-*
+sudo rm -rf ~/.cache/trt-llm/engine-*
 ```
 
 ### Image labels

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -422,6 +422,30 @@ Operator notes:
 - If the cache is corrupt, recreate it with `make docker-builder-rm && make docker-builder-setup`.
   The remote buildcache ref repopulates on the next local seed.
 
+### TensorRT-LLM engine build cache
+
+Distinct from the Docker layer cache above: the TensorRT engine build cache
+holds compiled `.engine` artefacts so re-running the same experiment config
+skips the multi-minute compile. It lives on the host at `~/.cache/trt-llm` and
+is bind-mounted into every tensorrt container at `/root/.cache/trt-llm`; llem
+defaults the cache location to that mount out of the box (override with
+`LLEM_TRT_BUILD_CACHE_PATH`). TensorRT-LLM keys each entry by the full build
+config (model, dtype, tensor-parallel size, max-shape, quantisation) plus the
+engine version, so distinct configs and version bumps never collide.
+
+The lifecycle is manual and visible - llem never auto-evicts. Inspect it with:
+
+```bash
+llem doctor
+```
+
+which reports the cache location, engine-entry count, and total size. Entries
+are large (often 1-15 GB each); clean the cache manually when it grows:
+
+```bash
+rm -rf ~/.cache/trt-llm/engine-*
+```
+
 ### Image labels
 
 `docker/Dockerfile.transformers` stamps a single OCI label:

--- a/docs/how-to/run-with-tensorrt-llm.md
+++ b/docs/how-to/run-with-tensorrt-llm.md
@@ -110,27 +110,45 @@ What happens:
 3. The container compiles the TensorRT engine from the model weights.
    **First run only - this takes several minutes.** Progress is shown in
    the terminal.
-4. The compiled engine is cached on disk
-   (`~/.cache/tensorrt_llm` inside the container, mounted from the host).
+4. The compiled engine is cached on disk. The host directory
+   `~/.cache/trt-llm` is bind-mounted into the container at
+   `/root/.cache/trt-llm`, and llem defaults the build-cache location to that
+   mount so compiled engines persist across ephemeral containers out of the
+   box (override with `LLEM_TRT_BUILD_CACHE_PATH`).
 5. Inference runs against the compiled engine.
 6. Results are printed to stdout and saved to `results/`.
 
 :::tip Engine caching
-The compiled engine is keyed to your config (model, dtype, max_batch_size,
-tp_size, etc.). Running the same experiment config again skips compilation
-and starts inference immediately. Changing any compile-time parameter
-triggers a new build.
+The compiled engine is keyed by TensorRT-LLM to the full build config -
+model, dtype, tensor-parallel size, max-shape (max_seq_len / max_batch_size /
+max_input_len), and quantisation - plus the TRT-LLM version. Running the same
+config again reuses the cached engine and skips compilation; changing any of
+those inputs (or bumping the engine version) triggers a fresh build. The cache
+is manual and visible: llem never auto-evicts. See its location, entry count,
+total size, and the manual clean command with `llem doctor`.
 :::
 
 ## HF pre-quantised checkpoints
 
-TensorRT-LLM cannot load Hugging Face AWQ or GPTQ checkpoints directly:
-the weight-key layout in HF's serialisation differs from what TensorRT-LLM
-expects, so model load raises `KeyError: 'weight'`.
+TensorRT-LLM's `LLM` API cannot load AutoAWQ / AutoGPTQ community-format
+Hugging Face checkpoints directly on **either** backend (live-verified at
+1.2.1 against `Qwen/Qwen2.5-0.5B-Instruct-AWQ`):
 
-Pre-flight catches this and refuses the run with an actionable error. To
-benchmark a pre-quantised checkpoint, convert it once with `trtllm-build`
-and point the experiment at the build output:
+- the **trt** (compiled) backend raises `NotImplementedError: Unsupported
+  quantization_config` - it only recognises `fp8`/`mxfp4` `quant_method` values
+  from `config.json`;
+- the **pytorch** backend raises an `AssertionError` in the weight loader - it
+  expects the NVIDIA ModelOpt weight layout, not AutoAWQ's `qweight` packing.
+
+TensorRT-LLM's supported pre-quantised path is its own ModelOpt export (a
+checkpoint carrying `hf_quant_config.json`), not the AutoAWQ/AutoGPTQ
+`config.json` `quantization_config` format that Qwen's official `*-AWQ` repos
+ship.
+
+Pre-flight catches AutoAWQ/AutoGPTQ checkpoints and refuses the run with an
+actionable error. To benchmark such a checkpoint, either use a ModelOpt-
+quantised equivalent, or convert it once with `trtllm-build` and point the
+experiment at the build output:
 
 ```bash
 trtllm-build \

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -53,6 +53,7 @@ The scientific record. One JSON file per experiment cell. Schema version `4.0`.
 | `measurement_methodology` | `"total"` &#124; `"steady_state"` &#124; `"windowed"` | Which slice of the run produced the headline metrics |
 | `warmup_excluded_samples` | int &#124; null | Number of warmup iterations run before the measurement window (from `warmup_result.iterations_completed`); `null` when no warmup result is available |
 | `model_load_time_sec` | float &#124; null | Wall-clock seconds spent in `engine.load_model()`: model load plus any engine build/compile performed there (e.g. the tensorrt trt backend's TRT engine build, vLLM torch.compile / CUDA-graph capture). Non-energy metadata: this phase completes before the energy measurement window opens and contributes nothing to `total_energy_j` |
+| `engine_build_cache_hit` | bool &#124; null | Whether the tensorrt trt-backend engine build was served from the on-disk build cache (`true`) or compiled fresh (`false`). `null` when the build cache is not in play: the pytorch backend, other engines, an `engine_path` override, or the cache disabled. Annotates `model_load_time_sec` (a cache hit skips the compile) |
 | `reproducibility_notes` | str | Free-text caveats (default mentions NVML accuracy +/-5 %, thermal drift) |
 
 ### Aggregate metrics

--- a/src/llenergymeasure/api/doctor.py
+++ b/src/llenergymeasure/api/doctor.py
@@ -89,7 +89,9 @@ def run_trt_cache_check() -> TrtCacheHealth:
     skipped so a permission hiccup cannot break ``llem doctor``.
     """
     cache_dir = trt_build_cache_host_dir()
-    clean_hint = f"clean manually (llem never auto-evicts): rm -rf {cache_dir}/engine-*"
+    # Entries are written by the container's root process, so a non-root host
+    # user needs sudo to remove them - reflect that in the documented path.
+    clean_hint = f"clean manually (llem never auto-evicts): sudo rm -rf {cache_dir}/engine-*"
     if not cache_dir.is_dir():
         return TrtCacheHealth(str(cache_dir), False, 0, 0, clean_hint)
 

--- a/src/llenergymeasure/api/doctor.py
+++ b/src/llenergymeasure/api/doctor.py
@@ -16,13 +16,16 @@ from llenergymeasure.infra.version_handshake import (
     rebuild_hint,
     skip_check_enabled,
 )
+from llenergymeasure.utils.env_config import trt_build_cache_host_dir
 from llenergymeasure.utils.exceptions import ConfigError
 
 __all__ = [
     "DoctorReport",
     "EngineDoctorResult",
     "SchemaStatus",
+    "TrtCacheHealth",
     "run_doctor_checks",
+    "run_trt_cache_check",
 ]
 
 SUPPORTED_ENGINES: tuple[Engine, ...] = tuple(Engine)
@@ -48,6 +51,22 @@ class EngineDoctorResult:
 
 
 @dataclass(frozen=True)
+class TrtCacheHealth:
+    """TensorRT-LLM engine build-cache location and footprint.
+
+    Informational only: the cache lifecycle is manual + visible, so this never
+    affects the doctor exit code. llem NEVER auto-evicts entries; ``clean_hint``
+    is the documented manual clean path.
+    """
+
+    path: str
+    exists: bool
+    entry_count: int
+    total_bytes: int
+    clean_hint: str
+
+
+@dataclass(frozen=True)
 class DoctorReport:
     """Full doctor output: per-engine rows plus host-side context."""
 
@@ -55,10 +74,39 @@ class DoctorReport:
     host_fingerprint: str
     skip_check_active: bool
     results: list[EngineDoctorResult]
+    trt_cache: TrtCacheHealth | None = None
 
     @property
     def any_mismatch(self) -> bool:
         return any(r.status is SchemaStatus.MISMATCH for r in self.results)
+
+
+def run_trt_cache_check() -> TrtCacheHealth:
+    """Report the host TRT-LLM engine build-cache location, entries, and size.
+
+    Host-side only (no container / GPU): stats the directory the docker runner
+    bind-mounts as the build cache. Never raises - unreadable entries are
+    skipped so a permission hiccup cannot break ``llem doctor``.
+    """
+    cache_dir = trt_build_cache_host_dir()
+    clean_hint = f"clean manually (llem never auto-evicts): rm -rf {cache_dir}/engine-*"
+    if not cache_dir.is_dir():
+        return TrtCacheHealth(str(cache_dir), False, 0, 0, clean_hint)
+
+    entry_count = 0
+    total_bytes = 0
+    try:
+        entry_count = sum(1 for e in cache_dir.iterdir() if e.name.startswith("engine-"))
+        for path in cache_dir.rglob("*"):
+            try:
+                if path.is_file() and not path.is_symlink():
+                    total_bytes += path.stat().st_size
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+    return TrtCacheHealth(str(cache_dir), True, entry_count, total_bytes, clean_hint)
 
 
 def _detail_for(engine: str, status: SchemaStatus) -> str:
@@ -121,4 +169,5 @@ def run_doctor_checks(
         host_fingerprint=host_fp,
         skip_check_active=skip_check_enabled(),
         results=results,
+        trt_cache=run_trt_cache_check(),
     )

--- a/src/llenergymeasure/cli/doctor_cmd.py
+++ b/src/llenergymeasure/cli/doctor_cmd.py
@@ -51,5 +51,21 @@ def doctor_command() -> None:
             "WARNING: LLEM_SKIP_IMAGE_CHECK=1 is active - runtime schema handshake is bypassed."
         )
 
+    cache = report.trt_cache
+    if cache is not None:
+        from llenergymeasure.utils.formatting import format_bytes
+
+        typer.echo("")
+        typer.echo("TensorRT-LLM engine build cache:")
+        typer.echo(f"  location: {cache.path}")
+        if cache.exists:
+            typer.echo(
+                f"  entries:  {cache.entry_count} engine(s), {format_bytes(cache.total_bytes)} total"
+            )
+            if cache.entry_count:
+                typer.echo(f"  clean:    {cache.clean_hint}")
+        else:
+            typer.echo("  entries:  (none - directory does not exist yet)")
+
     if report.any_mismatch:
         raise typer.Exit(code=1)

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -201,6 +201,14 @@ class ExperimentResult(BaseModel):
         "Non-energy run metadata: this phase completes before the NVML energy "
         "measurement window opens and contributes nothing to total_energy_j.",
     )
+    engine_build_cache_hit: bool | None = Field(
+        default=None,
+        description="Whether the tensorrt trt-backend engine build was served from "
+        "the on-disk build cache (True) or compiled fresh this run (False). None when "
+        "the build cache is not in play: the pytorch backend, other engines, an "
+        "engine_path override, or the cache disabled. Detected from TRT-LLM's own "
+        "build stats; annotates model_load_time_sec (a cache hit skips the compile).",
+    )
     reproducibility_notes: str = Field(
         default=(
             "Energy measured via NVML polling. Accuracy +/-5%. "

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -333,6 +333,11 @@ class TensorRTEngine:
 
         extras: dict[str, Any] = {}
 
+        # Build-cache hit/miss annotation (trt backend only). Read from TRT-LLM's
+        # own build stats; None when the cache is not in play. Harness maps this
+        # to ExperimentResult.engine_build_cache_hit.
+        extras["engine_build_cache_hit"] = self._detect_build_cache_hit(config, llm)
+
         # Per-request latency metrics from RequestOutput.metrics_dict. Populated
         # only when SamplingParams carried return_perf_metrics=True - which
         # _build_sampling_kwargs sets exactly when latency_profiling is enabled -
@@ -368,6 +373,41 @@ class TensorRTEngine:
             padding_tokens=None,  # Not measurable from TRT-LLM RequestOutputs
             kv_cache_stats=None,  # TRT-LLM does not expose paged KV-cache stats here
         )
+
+    @staticmethod
+    def _detect_build_cache_hit(config: ExperimentConfig, llm: Any) -> bool | None:
+        """Return whether the trt engine build was served from the build cache.
+
+        Detection reads TRT-LLM's own ``llm_build_stats.engine_dir``: at 1.2.1 it
+        is populated ONLY on the cache-reuse path (``llm_utils.py`` sets it just
+        before the early return in the ``is_cached()`` branch) and left ``None``
+        on a fresh build. The sibling ``cache_hitted`` flag is deliberately NOT
+        used - it is set ``True`` on BOTH the reuse path AND after a fresh build
+        writes the cache, so it cannot discriminate hit from miss.
+
+        Returns ``None`` (annotation not applicable) when the build cache is not
+        in play: a non-trt backend, an ``engine_path`` override (loads a prebuilt
+        engine, bypassing the cache), or the cache disabled. Also returns ``None``
+        defensively if the stats attribute is unavailable - never raises.
+
+        Failure modes: relies on an internal TRT-LLM attribute (not public API),
+        re-checked each pin; concurrent processes writing the same cache root do
+        not affect this signal (unlike a directory-count delta) because it reads
+        this construction's own stats object.
+        """
+        from llenergymeasure.utils.env_config import trt_build_cache_enabled
+
+        engine_params = config.active_engine_params()
+        backend = getattr(engine_params, "backend", None) if engine_params is not None else None
+        engine_path = (
+            getattr(engine_params, "engine_path", None) if engine_params is not None else None
+        )
+        if backend != "trt" or engine_path or not trt_build_cache_enabled():
+            return None
+        try:
+            return llm.llm_build_stats.engine_dir is not None
+        except Exception:
+            return None
 
     # -------------------------------------------------------------------------
     # Private: observed-params capture (observed_config_hash)

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -1367,4 +1367,5 @@ class MeasurementHarness:
             steady_state_not_detected=steady_state_not_detected,
             warmup_excluded_samples=warmup_excluded_samples,
             model_load_time_sec=model_load_time_sec,
+            engine_build_cache_hit=output.extras.get("engine_build_cache_hit"),
         )

--- a/src/llenergymeasure/harness/preflight.py
+++ b/src/llenergymeasure/harness/preflight.py
@@ -83,11 +83,16 @@ def _check_model_accessible(model_id: str) -> str | None:
         return None
 
 
-# TRT-LLM cannot load HF pre-quantised checkpoints directly; they require
-# trtllm-build conversion first. The detection signal is the HF-declared
-# quant_method value rather than a regex over model ids, so user-renamed
-# checkpoints (e.g. local forks without the conventional suffix) are still
-# caught - extend by adding the canonical quant_method string, not a pattern.
+# TRT-LLM's LLM API cannot load AutoAWQ / AutoGPTQ community-format HF
+# checkpoints directly on EITHER backend at 1.2.1 (live-verified against
+# Qwen2.5-0.5B-Instruct-AWQ): the trt backend raises NotImplementedError on the
+# config.json quant_method (llm_utils.py only handles fp8/mxfp4 there), and the
+# pytorch backend asserts on the weight layout (linear.py expects the ModelOpt
+# packing, not AutoAWQ's qweight). TRT-LLM's supported pre-quantised path is its
+# own ModelOpt export (hf_quant_config.json) or a pre-built engine via
+# engine_path. Detection keys on the HF-declared quant_method rather than a
+# regex over model ids, so user-renamed forks are still caught - extend by
+# adding the canonical quant_method string, not a pattern.
 _TRT_UNSUPPORTED_HF_QUANT_METHODS: tuple[str, ...] = ("awq", "gptq")
 
 
@@ -151,10 +156,13 @@ def _check_tensorrt_checkpoint_compat(config: ExperimentConfig) -> str | None:
         return None
 
     return (
-        f"{config.task.model} is an HF {method.upper()} checkpoint; TRT-LLM cannot "
-        f"load it directly. Pre-build a TRT-LLM engine (`trtllm-build --checkpoint_dir "
-        f"<converted> ...`) and set `tensorrt.engine_params.engine_path` to the build "
-        f"output. See docs/how-to/run-with-tensorrt-llm.md#hf-pre-quantised-checkpoints."
+        f"{config.task.model} is an HF {method.upper()} checkpoint; TRT-LLM's LLM API "
+        f"cannot load it on either backend at 1.2.1 (the trt backend rejects the "
+        f"quant_method, the pytorch backend rejects the weight layout). Use a "
+        f"ModelOpt-quantised checkpoint (with hf_quant_config.json) instead, or "
+        f"pre-build a TRT-LLM engine (`trtllm-build --checkpoint_dir <converted> ...`) "
+        f"and set `tensorrt.engine_params.engine_path` to the build output. See "
+        f"docs/how-to/run-with-tensorrt-llm.md#hf-pre-quantised-checkpoints."
     )
 
 

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -29,7 +29,7 @@ import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import platformdirs
 
@@ -66,7 +66,11 @@ from llenergymeasure.infra.docker_errors import (
     capture_stderr_snippet,
     translate_docker_error,
 )
-from llenergymeasure.utils.env_config import docker_gpus
+from llenergymeasure.utils.env_config import (
+    ENV_TRT_BUILD_CACHE_PATH,
+    docker_gpus,
+    trt_build_cache_host_dir,
+)
 from llenergymeasure.utils.exceptions import DockerError
 from llenergymeasure.utils.io import load_json
 
@@ -93,6 +97,15 @@ _RESERVED_EXCHANGE_ENV: frozenset[str] = frozenset(
         ENV_BASELINE_SPEC_PATH,
     }
 )
+
+# Container-side mount target for the TRT-LLM engine build cache. The host
+# ~/.cache/trt-llm is bind-mounted here; TRT-LLM's own default cache root
+# (/tmp/.cache/tensorrt_llm/llmapi/) is NOT this path and lives on the
+# ephemeral container filesystem, so without pinning the cache to the mount
+# it would silently die with each container. We default
+# LLEM_TRT_BUILD_CACHE_PATH to this mount so the cache works out of the box;
+# a host-set value still wins (forwarded later, docker -e is last-wins).
+_TRT_BUILD_CACHE_CONTAINER_PATH: Final = "/root/.cache/trt-llm"
 
 # Watchdog poll cadence: small enough to surface timeouts promptly, large
 # enough to keep idle CPU near zero. 0.5s gives users at most a half-second
@@ -973,10 +986,18 @@ class DockerRunner:
         if env_path is not None:
             cmd.extend(["--env-file", str(env_path)])
 
-        # TRT-LLM engine cache: persist compiled engines across ephemeral containers
+        # TRT-LLM engine cache: persist compiled engines across ephemeral
+        # containers. Also default LLEM_TRT_BUILD_CACHE_PATH to the mount target
+        # via extra_env so the cache lands on the mount out of the box (TRT-LLM's
+        # own default root is unmounted); a host-set value overrides this because
+        # the blanket LLEM_* forwarding loop below re-emits it last (docker -e is
+        # last-wins).
         if config.engine == Engine.TENSORRT:
             self._mount_if_absent(
-                cmd, str(Path.home() / ".cache" / "trt-llm"), "/root/.cache/trt-llm"
+                cmd,
+                str(trt_build_cache_host_dir()),
+                _TRT_BUILD_CACHE_CONTAINER_PATH,
+                extra_env=f"{ENV_TRT_BUILD_CACHE_PATH}={_TRT_BUILD_CACHE_CONTAINER_PATH}",
             )
 
         # Auto-mount the host HuggingFace cache so model weights persist across

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -90,11 +90,17 @@ via ``.env.example`` - not baked into this helper.
 
 
 ENV_TRT_BUILD_CACHE_PATH: Final = "LLEM_TRT_BUILD_CACHE_PATH"
-"""User-supplied cache directory for TRT-LLM engine build cache.
+"""Cache directory for the TRT-LLM engine build cache.
 
 If set and non-empty, the engine plugin wraps it into TRT-LLM's
 ``BuildCacheConfig.cache_root``. Unset / empty leaves TRT-LLM's internal
-default cache location in place.
+default cache root in place (``/tmp/.cache/tensorrt_llm/llmapi/``).
+
+Under docker dispatch the runner defaults this to the bind-mounted cache
+directory (``/root/.cache/trt-llm``) so the cache persists across ephemeral
+containers out of the box; TRT-LLM's own default root lives on the container
+filesystem and would not survive. A host-set value still overrides the
+docker default.
 """
 
 
@@ -113,7 +119,21 @@ def trt_build_cache_path() -> Path | None:
     """Return the user-supplied TRT-LLM build cache root, if any.
 
     Returns a ``Path`` when set to a non-empty value; otherwise ``None`` so
-    TRT-LLM uses its internal default location (``~/.cache/tensorrt_llm/``).
+    TRT-LLM uses its internal default root (``/tmp/.cache/tensorrt_llm/llmapi/``).
+    Under docker dispatch the runner sets this to the mounted cache directory
+    so the default is the persistent mount, not the ephemeral container path.
     """
     raw = os.environ.get(ENV_TRT_BUILD_CACHE_PATH)
     return Path(raw) if raw else None
+
+
+def trt_build_cache_host_dir() -> Path:
+    """Return the host directory bind-mounted as the TRT-LLM build cache.
+
+    This is the out-of-the-box location the docker runner mounts into the
+    container (``~/.cache/trt-llm``) and the directory ``llem doctor`` reports.
+    A single source of truth so the mount source and the doctor view cannot
+    drift. A user who overrides ``LLEM_TRT_BUILD_CACHE_PATH`` to a custom
+    container path is responsible for their own host mount.
+    """
+    return Path.home() / ".cache" / "trt-llm"

--- a/src/llenergymeasure/utils/formatting.py
+++ b/src/llenergymeasure/utils/formatting.py
@@ -14,6 +14,24 @@ def bytes_to_mb(n: float) -> float:
     return n / (1024 * 1024)
 
 
+def format_bytes(n: int) -> str:
+    """Format a byte count as a human-readable binary size.
+
+    Examples:
+        0            -> "0 B"
+        1536         -> "1.5 KB"
+        1073741824   -> "1.0 GB"
+    """
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"  # pragma: no cover - unreachable, loop returns first
+
+
 def format_elapsed(seconds: float) -> str:
     """Format seconds as human-readable elapsed time.
 

--- a/tests/unit/api/test_doctor.py
+++ b/tests/unit/api/test_doctor.py
@@ -45,3 +45,58 @@ def test_unresolvable_default_becomes_unreachable_row_with_fix():
     assert row.image == "(unresolved)"
     assert 'runners.tensorrt to "docker:' in row.detail
     assert not report.any_mismatch
+
+
+# ---------------------------------------------------------------------------
+# run_trt_cache_check: TRT-LLM build-cache visibility (manual + visible policy)
+# ---------------------------------------------------------------------------
+
+
+def test_trt_cache_check_absent_dir(tmp_path):
+    """A non-existent cache dir reports exists=False, zero entries/bytes."""
+    from llenergymeasure.api.doctor import run_trt_cache_check
+
+    missing = tmp_path / "nope"
+    with patch("llenergymeasure.api.doctor.trt_build_cache_host_dir", return_value=missing):
+        health = run_trt_cache_check()
+
+    assert health.exists is False
+    assert health.entry_count == 0
+    assert health.total_bytes == 0
+    assert "rm -rf" in health.clean_hint
+
+
+def test_trt_cache_check_counts_entries_and_bytes(tmp_path):
+    """Counts engine-* entries and sums file bytes; ignores non-engine files."""
+    from llenergymeasure.api.doctor import run_trt_cache_check
+
+    (tmp_path / "engine-aaa").mkdir()
+    (tmp_path / "engine-aaa" / "content").write_bytes(b"x" * 100)
+    (tmp_path / "engine-bbb").mkdir()
+    (tmp_path / "engine-bbb" / "content").write_bytes(b"y" * 50)
+    (tmp_path / "not-an-engine.txt").write_bytes(b"z" * 7)  # counted in bytes, not entries
+
+    with patch("llenergymeasure.api.doctor.trt_build_cache_host_dir", return_value=tmp_path):
+        health = run_trt_cache_check()
+
+    assert health.exists is True
+    assert health.entry_count == 2
+    assert health.total_bytes == 157
+    assert health.path == str(tmp_path)
+
+
+def test_run_doctor_checks_includes_trt_cache():
+    """The full report carries a trt_cache section (never affects exit code)."""
+    with (
+        patch("llenergymeasure.api.doctor.compute_expconf_fingerprint", return_value="f" * 64),
+        patch(
+            "llenergymeasure.api.doctor.get_default_image",
+            return_value="vllm/vllm-openai:v0.19.1",
+        ),
+        patch("llenergymeasure.api.doctor.image_present_locally", return_value=True),
+        patch("llenergymeasure.api.doctor.inspect_image_stamp", return_value=_EMPTY_STAMP),
+    ):
+        report = run_doctor_checks(engines=("vllm",))
+
+    assert report.trt_cache is not None
+    assert isinstance(report.trt_cache.entry_count, int)

--- a/tests/unit/cli/test_doctor_cmd.py
+++ b/tests/unit/cli/test_doctor_cmd.py
@@ -180,3 +180,43 @@ def test_host_footer_rendered() -> None:
         result = runner.invoke(app, ["doctor"])
     assert "Host llenergymeasure version: 0.9.0" in result.output
     assert "Host ExperimentConfig SHA-256:" in result.output
+
+
+def test_renders_trt_cache_section() -> None:
+    """The doctor output includes the TRT-LLM build-cache location, size, and clean hint."""
+    from llenergymeasure.api.doctor import TrtCacheHealth
+
+    cache = TrtCacheHealth(
+        path="/home/u/.cache/trt-llm",
+        exists=True,
+        entry_count=3,
+        total_bytes=3 * 1024 * 1024 * 1024,
+        clean_hint="clean manually (llem never auto-evicts): rm -rf /home/u/.cache/trt-llm/engine-*",
+    )
+    report = _report(
+        [
+            EngineDoctorResult(
+                engine="tensorrt",
+                image="nvcr.io/nvidia/tensorrt-llm/release:1.2.1",
+                pkg_version="1.2.1",
+                image_fingerprint="a" * 64,
+                status=SchemaStatus.OK,
+            )
+        ]
+    )
+    report = DoctorReport(
+        host_pkg_version=report.host_pkg_version,
+        host_fingerprint=report.host_fingerprint,
+        skip_check_active=report.skip_check_active,
+        results=report.results,
+        trt_cache=cache,
+    )
+    with patch("llenergymeasure.api.doctor.run_doctor_checks", return_value=report):
+        result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "engine build cache" in result.output
+    assert "/home/u/.cache/trt-llm" in result.output
+    assert "3 engine(s)" in result.output
+    assert "3.0 GB" in result.output
+    assert "auto-evicts" in result.output

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -943,6 +943,37 @@ class TestExtraMounts:
 
         assert not any("trt-llm" in arg for arg in cmd)
 
+    def test_tensorrt_cache_path_defaults_to_mount(self, tmp_path, monkeypatch):
+        """Unset LLEM_TRT_BUILD_CACHE_PATH defaults to the mounted cache dir.
+
+        TRT-LLM's own default root is unmounted, so without this the cache would
+        die with each container. The runner pins it to the bind-mount target.
+        """
+        monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_PATH", raising=False)
+        config = make_config(
+            engine="tensorrt", tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+        )
+        runner = DockerRunner(image=IMAGE)
+        cmd = self._build_cmd(config, tmp_path, runner)
+
+        vals = [a for a in cmd if a.startswith("LLEM_TRT_BUILD_CACHE_PATH=")]
+        assert vals == ["LLEM_TRT_BUILD_CACHE_PATH=/root/.cache/trt-llm"]
+
+    def test_tensorrt_cache_path_host_override_wins(self, tmp_path, monkeypatch):
+        """A host-set LLEM_TRT_BUILD_CACHE_PATH is forwarded last (docker -e last-wins)."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_PATH", "/mnt/scratch/trt")
+        config = make_config(
+            engine="tensorrt", tensorrt={"engine_params": {"tensor_parallel_size": 1}}
+        )
+        runner = DockerRunner(image=IMAGE)
+        cmd = self._build_cmd(config, tmp_path, runner)
+
+        # Both the mount default and the forwarded override are present; the
+        # override must come later so docker's last-wins semantics pick it.
+        idx_default = cmd.index("LLEM_TRT_BUILD_CACHE_PATH=/root/.cache/trt-llm")
+        idx_override = cmd.index("LLEM_TRT_BUILD_CACHE_PATH=/mnt/scratch/trt")
+        assert idx_default < idx_override
+
 
 # ---------------------------------------------------------------------------
 # Test: --entrypoint per (engine, tp_size)

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -914,3 +914,64 @@ class TestLoudSubConfigImportErrors:
         engine = TensorRTEngine()
         with pytest.raises(EngineError, match="build cache path was configured"):
             engine._build_llm_kwargs(config)
+
+
+# =============================================================================
+# Test Group 11: build-cache hit/miss detection (_detect_build_cache_hit)
+# =============================================================================
+
+
+def _fake_llm(engine_dir):
+    """Stand-in LLM exposing TRT-LLM's llm_build_stats.engine_dir."""
+    return types.SimpleNamespace(llm_build_stats=types.SimpleNamespace(engine_dir=engine_dir))
+
+
+class TestDetectBuildCacheHit:
+    """_detect_build_cache_hit reads llm_build_stats.engine_dir (set only on reuse)."""
+
+    def _trt_config(self, **engine_params):
+        return make_config(
+            engine="tensorrt",
+            tensorrt={"engine_params": {"backend": "trt", **engine_params}},
+        )
+
+    def test_hit_when_engine_dir_set(self, monkeypatch):
+        """engine_dir populated => served from cache (True)."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        config = self._trt_config()
+        llm = _fake_llm("/root/.cache/trt-llm/engine-abc/content")
+        assert TensorRTEngine._detect_build_cache_hit(config, llm) is True
+
+    def test_miss_when_engine_dir_none(self, monkeypatch):
+        """engine_dir None => built fresh this run (False)."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        config = self._trt_config()
+        llm = _fake_llm(None)
+        assert TensorRTEngine._detect_build_cache_hit(config, llm) is False
+
+    def test_none_for_pytorch_backend(self, monkeypatch):
+        """pytorch backend never uses the trt build cache => None."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        config = make_config(engine="tensorrt", tensorrt={"engine_params": {"backend": "pytorch"}})
+        llm = _fake_llm(None)
+        assert TensorRTEngine._detect_build_cache_hit(config, llm) is None
+
+    def test_none_when_cache_disabled(self, monkeypatch):
+        """Cache disabled => annotation not applicable (None)."""
+        monkeypatch.delenv("LLEM_TRT_BUILD_CACHE_ENABLED", raising=False)
+        config = self._trt_config()
+        llm = _fake_llm("/root/.cache/trt-llm/engine-abc/content")
+        assert TensorRTEngine._detect_build_cache_hit(config, llm) is None
+
+    def test_none_for_engine_path_override(self, monkeypatch):
+        """engine_path loads a prebuilt engine, bypassing the cache => None."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        config = self._trt_config(engine_path="/prebuilt/engine")
+        llm = _fake_llm(None)
+        assert TensorRTEngine._detect_build_cache_hit(config, llm) is None
+
+    def test_none_when_stats_unavailable(self, monkeypatch):
+        """Missing llm_build_stats attribute is swallowed, never raises => None."""
+        monkeypatch.setenv("LLEM_TRT_BUILD_CACHE_ENABLED", "1")
+        config = self._trt_config()
+        assert TensorRTEngine._detect_build_cache_hit(config, types.SimpleNamespace()) is None

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -705,6 +705,43 @@ def test_inference_time_sec_used_in_result(minimal_config):
     )
 
 
+def test_engine_build_cache_hit_mapped_from_extras(minimal_config):
+    """result.engine_build_cache_hit comes from output.extras['engine_build_cache_hit']."""
+    custom_output = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=20,
+        peak_memory_mb=512.0,
+        model_memory_mb=256.0,
+        extras={"engine_build_cache_hit": True},
+    )
+    engine = FakeBackend(inference_output=custom_output)
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, minimal_config)
+
+    assert result.engine_build_cache_hit is True
+
+
+def test_engine_build_cache_hit_defaults_none_without_extra(minimal_config):
+    """No extras key (non-trt run) leaves engine_build_cache_hit None."""
+    custom_output = InferenceOutput(
+        elapsed_time_sec=1.0,
+        input_tokens=10,
+        output_tokens=20,
+        peak_memory_mb=512.0,
+        model_memory_mb=256.0,
+    )
+    engine = FakeBackend(inference_output=custom_output)
+    harness = MeasurementHarness()
+
+    with _apply_patches():
+        result = harness.run(engine, minimal_config)
+
+    assert result.engine_build_cache_hit is None
+
+
 def test_datetime_still_used_for_wall_clock(minimal_config):
     """ExperimentResult.start_time and end_time must be datetime objects, not perf_counter values."""
     from datetime import datetime as dt

--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -1,0 +1,14 @@
+"""Tests for shared formatting helpers."""
+
+from __future__ import annotations
+
+from llenergymeasure.utils.formatting import format_bytes
+
+
+def test_format_bytes_scales_binary_units():
+    assert format_bytes(0) == "0 B"
+    assert format_bytes(512) == "512 B"
+    assert format_bytes(1536) == "1.5 KB"
+    assert format_bytes(1048576) == "1.0 MB"
+    assert format_bytes(3 * 1024**3) == "3.0 GB"
+    assert format_bytes(2 * 1024**4) == "2.0 TB"

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -644,6 +644,10 @@ def test_trt_checkpoint_compat_rejects_awq(monkeypatch: pytest.MonkeyPatch) -> N
     assert "AWQ" in err
     assert "engine_path" in err
     assert "trtllm-build" in err
+    # Names what was tried at 1.2.1: both backends fail, ModelOpt is the path.
+    assert "1.2.1" in err
+    assert "either backend" in err
+    assert "ModelOpt" in err
 
 
 def test_trt_checkpoint_compat_rejects_gptq(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Verifies TensorRT-LLM's engine build-cache keying and closes the follow-ups the F2.2 evidence flagged. Empirically (tiny models, 1.2.1, on-GPU): **upstream `BuildCacheConfig` keying is sound** - an identical config hits across separate container invocations, and tensor-parallel / max-shape / quantisation / dtype changes each key to a distinct engine hash. No wrong reuse; **no config-hash pre-build layer is needed.**

Changes:
- **Cache hit/miss annotation** - new optional `ExperimentResult.engine_build_cache_hit`, detected from TRT-LLM's own `llm_build_stats.engine_dir` (populated only on the cache-reuse path; the `cache_hitted` flag is `True` on both reuse and fresh-build, so it cannot discriminate). Additive; result schema_version stays 4.0. `None` for the pytorch backend, an `engine_path` override, or when the cache is disabled.
- **Mount vs default-location fix** - the docker runner bind-mounts `~/.cache/trt-llm` at `/root/.cache/trt-llm`, but TRT-LLM's own default cache root (`/tmp/.cache/tensorrt_llm/llmapi/`) is unmounted, so the cache silently died per container unless the path was set by hand. The runner now defaults `LLEM_TRT_BUILD_CACHE_PATH` to the mount target (via the mount's `extra_env`, the `HF_HOME` pattern); a host-set value still wins.
- **`llem doctor` cache visibility** - reports the engine build cache location, entry count, total size, and the manual clean command. Manual and visible; llem never auto-evicts. Informational only (never affects the doctor exit code).
- **Pre-quantised preflight message** - live-verified at 1.2.1 that AutoAWQ/AutoGPTQ community-format HF checkpoints load on neither backend (trt raises `NotImplementedError` on the `quant_method`; pytorch rejects the weight layout). ModelOpt export (`hf_quant_config.json`) is the supported path. The rejection stands for both backends; the message now names what was tried. `engine_path` escape hatch unchanged.

Two F2.5 implications are recorded in the evidence report (local, `.product/`): the exit-sweep Qwen2.5-32B AWQ-int4 is AutoAWQ-format so the compiled backend cannot consume it as-is, and a defect where the trt backend TP>1 via the LLM API + build cache fails at multi-rank executor init.

## Test plan

- New mocked host-side unit tests: build-cache hit/miss detection (6 cases), docker cache-path default + host override, `run_trt_cache_check` (absent / counts+bytes / report wiring), doctor cache-section render, `format_bytes`, refreshed preflight assertions, harness extras -> result mapping.
- Full host suite: 2989 passed / 35 skipped. `make lint`, `make typecheck`, `make docs-check` all green.
- On-GPU verification (1.2.1, A100): the keying matrix and quant/backend checks summarised above were run live through the plugin's exact cache construction.

## Doc audit

- `docs/reference/results-schema.md`: new `engine_build_cache_hit` field row.
- `docs/how-to/run-with-tensorrt-llm.md`: corrected cache location, refreshed engine-caching tip, refreshed HF pre-quantised-checkpoints section with the 1.2.1 findings.
- `docs/how-to/docker-setup.md`: new "TensorRT-LLM engine build cache" subsection (location, `llem doctor`, manual clean).
- `.env.example`: corrected `LLEM_TRT_BUILD_CACHE_PATH` guidance (docker default now the mount).
- `CHANGELOG.md`: `[Unreleased]` entries.