### PR TITLE
feat(infra): cache engine-version probe by image digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Changed
 
+- The upstream-image engine-version handshake probe (a ~60s cold `docker run` per engine
+  per study) is now cached on disk keyed by the image content digest, under
+  `platformdirs.user_cache_dir("llem")/image-probe/`. A warm image resolves from the cache
+  (a `docker image inspect`) instead of re-probing, so the per-study cost the F2 plan flagged
+  drops to near zero. The in-process memo remains the first tier; a corrupt, unreadable, or
+  unwritable cache degrades to a fresh probe and never crashes. Entries never go stale: a
+  rebuilt or re-pulled image gets a new digest and a fresh probe, so no TTL is needed.
 - TensorRT-LLM backends are now selected by constructor class, not a kwarg: `backend='trt'`
   resolves `tensorrt_llm._tensorrt_engine.LLM` and `pytorch`/unset resolves `tensorrt_llm.LLM`,
   validated live at 1.2.1 (the base `LLM` rejects `backend='trt'` at model load). `backend` is

--- a/src/llenergymeasure/infra/version_handshake.py
+++ b/src/llenergymeasure/infra/version_handshake.py
@@ -30,12 +30,18 @@ Bypass with ``LLEM_SKIP_IMAGE_CHECK=1`` when the skew is known harmless.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
+import os
 import subprocess
+import tempfile
 from dataclasses import dataclass
-from functools import cache, lru_cache
+from functools import cache
+from pathlib import Path
+
+import platformdirs
 
 from llenergymeasure.config.ssot import ENGINE_PACKAGES, TIMEOUT_DOCKER_INSPECT, Engine
 from llenergymeasure.infra.image_registry import inspect_image
@@ -57,6 +63,7 @@ __all__ = [
     "probe_image_engine_version",
     "read_bundled_engine_version",
     "rebuild_hint",
+    "resolve_image_engine_version",
     "skip_check_enabled",
 ]
 
@@ -141,7 +148,6 @@ def classify_stamp(stamp: ImageStamp, host_fingerprint: str) -> SchemaStatus:
     return SchemaStatus.MISMATCH
 
 
-@lru_cache(maxsize=32)
 def probe_image_engine_version(
     image: str,
     engine: str,
@@ -151,9 +157,13 @@ def probe_image_engine_version(
     """Probe the engine library's ``__version__`` inside *image*.
 
     Runs ``docker run --rm`` against *image* with an inline ``import X;
-    print(...)`` for the engine module mapped from *engine*. The result
-    is cached per (image, engine) because an image's content is fixed by
-    its digest - the version inside doesn't change without a new tag.
+    print(...)`` for the engine module mapped from *engine*. This is the
+    cold probe: one container start (~60s on the TRT-LLM NGC image). It is
+    intentionally uncached - :func:`resolve_image_engine_version` owns the
+    caching tiers (an in-process memo and a persistent digest-keyed cache)
+    so a repeat probe of the same image content never pays the container
+    cost twice. Callers that want the cached path use that function; this
+    one is the primitive it falls back to on a cache miss.
 
     Engine-conditional entrypoint: TRT-LLM needs
     ``/opt/nvidia/nvidia_entrypoint.sh`` to set up ``LD_LIBRARY_PATH``
@@ -217,6 +227,175 @@ def probe_image_engine_version(
         if line.startswith(_ENGINE_VERSION_MARKER):
             return line[len(_ENGINE_VERSION_MARKER) :].strip() or None
     return None
+
+
+# ---------------------------------------------------------------------------
+# Digest-keyed persistent probe cache
+# ---------------------------------------------------------------------------
+#
+# The cold container probe above is a ~60s ``docker run`` per image, run once
+# per engine per study at study start. Its answer is a pure function of the
+# image *content* (the installed engine library version never changes without
+# a new image), so it is safe to memoise keyed by the image's content digest.
+#
+# Three tiers, cheapest first:
+#   1. in-process memo (this process, keyed by the image reference);
+#   2. persistent on-disk cache keyed by the image DIGEST (survives across
+#      processes / studies - the win the F2 plan asked for);
+#   3. the cold container probe (:func:`probe_image_engine_version`).
+#
+# Invalidation is automatic and total: the key is the content digest, so a
+# rebuilt or re-pulled image gets a fresh key and a fresh probe. Entries for a
+# given digest never go stale - the same digest is byte-identical content, so
+# its engine version cannot change. No TTL is needed or wanted.
+
+_PROBE_CACHE_SUBDIR = "image-probe"
+_PROBE_CACHE_FILENAME = "engine-versions.json"
+
+# Sentinel distinguishing "cached as a real miss" from "not in cache". The
+# cold probe can legitimately return None (probe failed); we do not persist
+# that (a transient failure should be retried next run), so a None here always
+# means "absent from the persistent cache".
+_CACHE_ABSENT = object()
+
+# Tier 1: in-process memo keyed by the image reference (not the digest, so a
+# repeat call skips even the ``docker image inspect`` digest resolution).
+_probe_memo: dict[tuple[str, str], str | None] = {}
+
+
+def _probe_cache_path() -> Path:
+    """Return the on-disk path of the persistent probe cache file.
+
+    Lives under the same XDG cache root the docker runner uses for its deps
+    cache (``platformdirs.user_cache_dir("llem")``), in an ``image-probe``
+    subdirectory, so all llem host caches sit together.
+    """
+    return Path(platformdirs.user_cache_dir("llem")) / _PROBE_CACHE_SUBDIR / _PROBE_CACHE_FILENAME
+
+
+def _resolve_image_digest(image: str, *, timeout: float = TIMEOUT_DOCKER_INSPECT) -> str | None:
+    """Return the local content digest (``Id``) of *image*, or None.
+
+    Reads ``docker image inspect``'s ``Id`` field (the image config digest,
+    e.g. ``sha256:abc...``) via the local daemon. This is always present once
+    an image is pulled and is stable per image content, which is exactly the
+    cache-key property we want.
+
+    Returns None when the digest cannot be resolved - docker missing, the
+    inspect timing out, a non-zero exit (image not pulled yet), or malformed
+    JSON. A None digest means the caller skips the persistent cache and falls
+    back to the cold probe (which pulls the image if absent); it never crashes.
+    RepoDigests (the registry digest) is deliberately not used: it is absent
+    for locally-built images, whereas ``Id`` is always available locally.
+    """
+    result = inspect_image(image, timeout=timeout)
+    if result is None or result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not data:
+        return None
+    image_id = data[0].get("Id")
+    return image_id if isinstance(image_id, str) and image_id else None
+
+
+def _read_probe_cache() -> dict[str, dict[str, str]]:
+    """Load the persistent probe cache, degrading to empty on any error.
+
+    A missing, unreadable, or corrupt cache file yields an empty mapping so
+    the caller re-probes rather than crashing - the file is a pure performance
+    optimisation and is always safe to discard.
+    """
+    path = _probe_cache_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return {}
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        logger.debug("Probe cache at %s is corrupt; ignoring", path)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _read_probe_cache_entry(digest: str, engine: str) -> object:
+    """Return the cached version for (*digest*, *engine*), or ``_CACHE_ABSENT``."""
+    by_engine = _read_probe_cache().get(digest)
+    if not isinstance(by_engine, dict):
+        return _CACHE_ABSENT
+    version = by_engine.get(engine)
+    return version if isinstance(version, str) else _CACHE_ABSENT
+
+
+def _write_probe_cache_entry(digest: str, engine: str, version: str) -> None:
+    """Persist (*digest*, *engine*) -> *version*, swallowing any write error.
+
+    Read-merge-write with an atomic ``os.replace`` so a reader never sees a
+    half-written file. No lock is taken: a concurrent writer racing on a
+    different digest could clobber this entry, but the only consequence is a
+    redundant re-probe next run (correctness is preserved), so the simplicity
+    is worth it. Any failure (read-only cache dir, disk full) is logged at
+    debug and swallowed - the probe result is already in hand.
+    """
+    path = _probe_cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        cache = _read_probe_cache()
+        cache.setdefault(digest, {})[engine] = version
+        fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(cache, handle, indent=2, sort_keys=True)
+            os.replace(tmp_name, path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise
+    except OSError as exc:
+        logger.debug("Could not persist probe cache to %s: %s", path, exc)
+
+
+def resolve_image_engine_version(image: str, engine: str) -> str | None:
+    """Return the engine library version inside *image*, using the cache tiers.
+
+    This is the cached entry point that callers should use instead of
+    :func:`probe_image_engine_version` directly. Tiers, cheapest first:
+
+    1. **in-process memo** - a repeat call in the same process returns
+       immediately (no docker calls at all);
+    2. **persistent digest cache** - keyed by the image content digest; a hit
+       skips the cold container probe entirely, even across processes /
+       studies;
+    3. **cold container probe** - :func:`probe_image_engine_version`, the
+       ~60s ``docker run``, run only on a full miss. Its result is written to
+       both caches (the persistent one only when a digest is resolvable and
+       the probe actually succeeded).
+
+    Never raises for cache reasons: an unresolvable digest, a corrupt cache
+    file, or an unwritable cache dir all degrade to a fresh probe.
+    """
+    memo_key = (image, engine)
+    if memo_key in _probe_memo:
+        return _probe_memo[memo_key]
+
+    digest = _resolve_image_digest(image)
+    if digest is not None:
+        cached = _read_probe_cache_entry(digest, engine)
+        if cached is not _CACHE_ABSENT:
+            assert isinstance(cached, str)
+            _probe_memo[memo_key] = cached
+            return cached
+
+    version = probe_image_engine_version(image, engine)
+    if digest is not None and version is not None:
+        _write_probe_cache_entry(digest, engine, version)
+    _probe_memo[memo_key] = version
+    return version
 
 
 class BundledEngineVersionMismatchError(RuntimeError):

--- a/src/llenergymeasure/study/image_prep.py
+++ b/src/llenergymeasure/study/image_prep.py
@@ -38,9 +38,9 @@ from llenergymeasure.infra.version_handshake import (
     classify_stamp,
     compute_expconf_fingerprint,
     parse_image_stamp,
-    probe_image_engine_version,
     read_bundled_engine_version,
     rebuild_hint,
+    resolve_image_engine_version,
     skip_check_enabled,
 )
 
@@ -306,14 +306,15 @@ class _ImageMixin:
             return "mismatch", error
 
         # label_status is UNVERIFIED or UNREACHABLE: fall back to engine-
-        # version probe. The probe takes one docker-run (a few seconds)
-        # and is cached per (image, engine). The "expected" version comes
-        # from the bundled invariants/schema envelopes (the artefacts llem
-        # actually applies at experiment time), not from current.yaml -
-        # current.yaml isn't shipped in the wheel, so an SSOT-based check
-        # is silently UNREACHABLE for installed users. The bundled envelope
-        # works in both wheel and editable installs.
-        probed = probe_image_engine_version(image, engine_name)
+        # version probe. The cold probe is one ~60s docker-run, but
+        # resolve_image_engine_version serves it from a digest-keyed cache on
+        # a warm image so the steady-state cost is a docker-inspect. The
+        # "expected" version comes from the bundled invariants/schema
+        # envelopes (the artefacts llem actually applies at experiment time),
+        # not from current.yaml - current.yaml isn't shipped in the wheel, so
+        # an SSOT-based check is silently UNREACHABLE for installed users. The
+        # bundled envelope works in both wheel and editable installs.
+        probed = resolve_image_engine_version(image, engine_name)
         try:
             expected = read_bundled_engine_version(engine_name)
         except BundledEngineVersionMismatchError as exc:

--- a/tests/unit/infra/test_version_handshake.py
+++ b/tests/unit/infra/test_version_handshake.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llenergymeasure.config.ssot import ALL_ENGINES
+from llenergymeasure.infra import version_handshake
 from llenergymeasure.infra.version_handshake import (
     ENV_SKIP_IMAGE_CHECK,
     LABEL_IMAGE_VERSION,
@@ -16,12 +17,16 @@ from llenergymeasure.infra.version_handshake import (
     BundledEngineVersionMismatchError,
     ImageStamp,
     SchemaStatus,
+    _read_probe_cache_entry,
+    _resolve_image_digest,
+    _write_probe_cache_entry,
     classify_engine_version,
     classify_stamp,
     compute_expconf_fingerprint,
     inspect_image_stamp,
     probe_image_engine_version,
     read_bundled_engine_version,
+    resolve_image_engine_version,
     skip_check_enabled,
 )
 
@@ -349,3 +354,185 @@ class TestProbeImageEngineVersion:
         called_cmd = mock_run.call_args[0][0]
         ep_idx = called_cmd.index("--entrypoint")
         assert called_cmd[ep_idx + 1] == "python3"
+
+
+# ---------------------------------------------------------------------------
+# Digest-keyed persistent probe cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def probe_cache(tmp_path, monkeypatch):
+    """Point the persistent probe cache at a temp file and reset the in-process memo."""
+    cache_file = tmp_path / "image-probe" / "engine-versions.json"
+    monkeypatch.setattr(version_handshake, "_probe_cache_path", lambda: cache_file)
+    version_handshake._probe_memo.clear()
+    yield cache_file
+    version_handshake._probe_memo.clear()
+
+
+def _inspect_ok(image_id: str) -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = json.dumps([{"Id": image_id}]).encode("utf-8")
+    return result
+
+
+class TestResolveImageDigest:
+    def test_parses_id_from_inspect(self) -> None:
+        with patch(
+            "llenergymeasure.infra.version_handshake.inspect_image",
+            return_value=_inspect_ok("sha256:deadbeef"),
+        ):
+            assert _resolve_image_digest("img:tag") == "sha256:deadbeef"
+
+    def test_none_when_inspect_unavailable(self) -> None:
+        with patch("llenergymeasure.infra.version_handshake.inspect_image", return_value=None):
+            assert _resolve_image_digest("img:tag") is None
+
+    def test_none_on_nonzero_exit(self) -> None:
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = b""
+        with patch("llenergymeasure.infra.version_handshake.inspect_image", return_value=result):
+            assert _resolve_image_digest("missing:tag") is None
+
+    def test_none_on_malformed_json(self) -> None:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = b"not json"
+        with patch("llenergymeasure.infra.version_handshake.inspect_image", return_value=result):
+            assert _resolve_image_digest("img:tag") is None
+
+    def test_none_on_empty_array(self) -> None:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = b"[]"
+        with patch("llenergymeasure.infra.version_handshake.inspect_image", return_value=result):
+            assert _resolve_image_digest("img:tag") is None
+
+
+class TestProbeCacheFile:
+    def test_round_trip(self, probe_cache) -> None:
+        _write_probe_cache_entry("sha256:aaa", "vllm", "0.19.1")
+        assert _read_probe_cache_entry("sha256:aaa", "vllm") == "0.19.1"
+
+    def test_miss_when_absent(self, probe_cache) -> None:
+        assert _read_probe_cache_entry("sha256:absent", "vllm") is version_handshake._CACHE_ABSENT
+
+    def test_distinct_engines_same_digest(self, probe_cache) -> None:
+        _write_probe_cache_entry("sha256:aaa", "vllm", "0.19.1")
+        _write_probe_cache_entry("sha256:aaa", "tensorrt", "1.2.1")
+        assert _read_probe_cache_entry("sha256:aaa", "vllm") == "0.19.1"
+        assert _read_probe_cache_entry("sha256:aaa", "tensorrt") == "1.2.1"
+
+    def test_corrupt_file_degrades_to_miss(self, probe_cache) -> None:
+        probe_cache.parent.mkdir(parents=True, exist_ok=True)
+        probe_cache.write_text("{ this is not valid json", encoding="utf-8")
+        assert _read_probe_cache_entry("sha256:aaa", "vllm") is version_handshake._CACHE_ABSENT
+        # A subsequent write still succeeds (overwrites the corrupt file).
+        _write_probe_cache_entry("sha256:aaa", "vllm", "0.19.1")
+        assert _read_probe_cache_entry("sha256:aaa", "vllm") == "0.19.1"
+
+    def test_write_failure_is_swallowed(self, probe_cache, monkeypatch) -> None:
+        # An unwritable cache dir must not raise - the probe result is in hand.
+        monkeypatch.setattr(
+            version_handshake.Path,
+            "mkdir",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("read-only fs")),
+        )
+        _write_probe_cache_entry("sha256:aaa", "vllm", "0.19.1")  # no exception
+
+
+class TestResolveImageEngineVersion:
+    def test_full_miss_probes_and_persists(self, probe_cache) -> None:
+        with (
+            patch(
+                "llenergymeasure.infra.version_handshake._resolve_image_digest",
+                return_value="sha256:aaa",
+            ),
+            patch(
+                "llenergymeasure.infra.version_handshake.probe_image_engine_version",
+                return_value="0.19.1",
+            ) as probe,
+        ):
+            assert resolve_image_engine_version("vllm:img", "vllm") == "0.19.1"
+            probe.assert_called_once()
+        # Persisted under the digest.
+        assert _read_probe_cache_entry("sha256:aaa", "vllm") == "0.19.1"
+
+    def test_persistent_hit_skips_cold_probe(self, probe_cache) -> None:
+        _write_probe_cache_entry("sha256:aaa", "vllm", "0.19.1")
+        with (
+            patch(
+                "llenergymeasure.infra.version_handshake._resolve_image_digest",
+                return_value="sha256:aaa",
+            ),
+            patch(
+                "llenergymeasure.infra.version_handshake.probe_image_engine_version",
+            ) as probe,
+        ):
+            assert resolve_image_engine_version("vllm:img", "vllm") == "0.19.1"
+            probe.assert_not_called()
+
+    def test_in_process_memo_skips_docker_on_repeat(self, probe_cache) -> None:
+        with (
+            patch(
+                "llenergymeasure.infra.version_handshake._resolve_image_digest",
+                return_value="sha256:aaa",
+            ) as digest,
+            patch(
+                "llenergymeasure.infra.version_handshake.probe_image_engine_version",
+                return_value="0.19.1",
+            ),
+        ):
+            assert resolve_image_engine_version("vllm:img", "vllm") == "0.19.1"
+            assert resolve_image_engine_version("vllm:img", "vllm") == "0.19.1"
+            # Digest resolved only on the first call; the memo serves the second.
+            digest.assert_called_once()
+
+    def test_unresolvable_digest_probes_without_persisting(self, probe_cache) -> None:
+        with (
+            patch(
+                "llenergymeasure.infra.version_handshake._resolve_image_digest",
+                return_value=None,
+            ),
+            patch(
+                "llenergymeasure.infra.version_handshake.probe_image_engine_version",
+                return_value="0.19.1",
+            ) as probe,
+        ):
+            assert resolve_image_engine_version("vllm:img", "vllm") == "0.19.1"
+            probe.assert_called_once()
+        # Nothing persisted (no digest to key on).
+        assert not probe_cache.exists()
+
+    def test_failed_probe_not_persisted(self, probe_cache) -> None:
+        with (
+            patch(
+                "llenergymeasure.infra.version_handshake._resolve_image_digest",
+                return_value="sha256:aaa",
+            ),
+            patch(
+                "llenergymeasure.infra.version_handshake.probe_image_engine_version",
+                return_value=None,
+            ),
+        ):
+            assert resolve_image_engine_version("vllm:img", "vllm") is None
+        assert _read_probe_cache_entry("sha256:aaa", "vllm") is version_handshake._CACHE_ABSENT
+
+    def test_corrupt_cache_falls_through_to_probe(self, probe_cache) -> None:
+        probe_cache.parent.mkdir(parents=True, exist_ok=True)
+        probe_cache.write_text("garbage", encoding="utf-8")
+        with (
+            patch(
+                "llenergymeasure.infra.version_handshake._resolve_image_digest",
+                return_value="sha256:aaa",
+            ),
+            patch(
+                "llenergymeasure.infra.version_handshake.probe_image_engine_version",
+                return_value="0.19.1",
+            ) as probe,
+        ):
+            assert resolve_image_engine_version("vllm:img", "vllm") == "0.19.1"
+            probe.assert_called_once()

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -1595,22 +1595,23 @@ class TestPrepareImages:
     def _bypass_engine_version_probe(self):
         """Short-circuit the SSOT engine-version probe for image-prep tests.
 
-        ``_verify_image_fingerprint`` falls back to ``probe_image_engine_version``
-        whenever the OCI label is UNVERIFIED/UNREACHABLE, which adds a second
-        ``subprocess.run`` call beyond the ``docker image inspect``. These tests
-        check image-prep behaviour (cache hit, pull fall-through), not handshake
-        behaviour, so patching the probe to return ``None`` (probe-inconclusive)
-        keeps assertions about subprocess call counts and side_effect lists
-        stable. Probe behaviour itself is exercised in TestSchemaFingerprintHandshake.
+        ``_verify_image_fingerprint`` falls back to ``resolve_image_engine_version``
+        whenever the OCI label is UNVERIFIED/UNREACHABLE, which adds a digest
+        lookup plus a container probe beyond the ``docker image inspect``. These
+        tests check image-prep behaviour (cache hit, pull fall-through), not
+        handshake behaviour, so patching the resolver to return ``None``
+        (probe-inconclusive) keeps assertions about subprocess call counts and
+        side_effect lists stable. Resolver behaviour itself is exercised in
+        TestSchemaFingerprintHandshake and the version_handshake unit tests.
 
-        Also clears the module-level lru_cache so test ordering across the
-        xdist worker doesn't leak cached probe results between tests.
+        Also clears the resolver's in-process memo so test ordering across the
+        xdist worker doesn't leak cached results between tests.
         """
         from llenergymeasure.infra import version_handshake
 
-        version_handshake.probe_image_engine_version.cache_clear()
+        version_handshake._probe_memo.clear()
         with patch(
-            "llenergymeasure.study.image_prep.probe_image_engine_version",
+            "llenergymeasure.study.image_prep.resolve_image_engine_version",
             return_value=None,
         ):
             yield
@@ -2087,19 +2088,19 @@ class TestSchemaFingerprintHandshake:
         import logging as _logging
 
         # The unlabelled-image path falls through to the SSOT engine-version
-        # probe; this test asserts soft-warn behaviour, which is the same
+        # resolver; this test asserts soft-warn behaviour, which is the same
         # whether the probe returns None because docker is unreachable or
-        # because the output is unparseable. Patch the probe to None
+        # because the output is unparseable. Patch the resolver to None
         # directly so we exercise just the handshake-fallback logic without
         # depending on subprocess output shape.
         from llenergymeasure.infra import version_handshake as vh
 
-        vh.probe_image_engine_version.cache_clear()
+        vh._probe_memo.clear()
         with (
             caplog.at_level(_logging.WARNING, logger="llenergymeasure.study.image_prep"),
             patch("subprocess.run", return_value=ok),
             patch(
-                "llenergymeasure.study.image_prep.probe_image_engine_version",
+                "llenergymeasure.study.image_prep.resolve_image_engine_version",
                 return_value=None,
             ),
         ):


### PR DESCRIPTION
## Summary

The upstream-image engine-version handshake probe (`probe_image_engine_version`) is a
cold `docker run` that imports the engine library inside the pinned image to read its
`__version__`. It runs once per engine per study at study start and was memoised
per-process only, so every fresh study (and every CI dispatch) paid the full container
cost again. The F2 plan flagged this: on the TRT-LLM NGC image the probe is ~60s, and it
degrades to a soft-warn for exactly the upstream images F2 targets.

This persists the probe result on disk keyed by the image **content digest**, so a warm
image resolves from the cache instead of re-probing.

## Design

- **Key**: the image content digest (`docker image inspect` -> `Id`, e.g. `sha256:...`),
  resolved via the local daemon. `Id` is always present once an image is pulled and is
  stable per content, which is exactly the cache-key property we want. `RepoDigests` is
  deliberately not used (absent for locally-built images).
- **Location**: `platformdirs.user_cache_dir("llem")/image-probe/engine-versions.json`,
  next to the docker runner's existing `deps` cache, so all llem host caches sit together.
  Structure: `{"<digest>": {"<engine>": "<version>"}}`.
- **Tiers** (cheapest first), in `resolve_image_engine_version()`:
  1. in-process memo (a repeat call in the same process does no docker calls at all);
  2. persistent digest-keyed cache (a hit skips the cold container probe entirely, even
     across processes / studies);
  3. the cold container probe (`probe_image_engine_version`, now uncached), run only on a
     full miss. Its result is written to both caches (persistent only when a digest is
     resolvable and the probe succeeded).
- **Invalidation**: automatic and total. The key is the content digest, so a rebuilt or
  re-pulled image gets a fresh key and a fresh probe. A given digest is byte-identical
  content, so its engine version cannot change; entries never go stale and no TTL is
  needed or wanted.
- **Failure modes** (never crash): a missing / unreadable / corrupt cache file degrades to
  an empty mapping (fresh probe); an unwritable cache dir logs at debug and proceeds (the
  probe result is already in hand); an unresolvable digest (image not pulled, docker
  missing) skips the persistent cache and falls back to the cold probe. Writes are atomic
  (`os.replace`); the only cost of the lockless read-merge-write race is a redundant
  re-probe next run.

`image_prep` now calls `resolve_image_engine_version` instead of the raw probe.

## Measured skip win (live, this host)

Against the pinned `vllm/vllm-openai:v0.19.1` image:

| path | wall time |
|---|---|
| cold probe (`docker run` + import) | 8.36s |
| digest-cache hit (`docker image inspect`) | 0.065s |

The TRT-LLM NGC image is the ~60s cold case (banner + CUDA compat layer + `import
tensorrt_llm`); the cache hit is the same ~0.065s inspect there.

## Tests

Unit tests in `tests/unit/infra/test_version_handshake.py`: digest derivation (Id parse /
inspect-unavailable / nonzero / malformed / empty), persistent get/put round-trip, distinct
engines under one digest, corrupt-file -> miss, unwritable-dir swallowed, and the
orchestrator's hit / miss / in-process-memo / unresolvable-digest / failed-probe /
corrupt-cache paths (all docker calls mocked). Updated `test_study_runner.py` image-prep
tests that patched the old probe name. Full host suite 3006 passed / 35 skipped; make lint +
make typecheck clean.

## GPU-lock vs LLEM_DOCKER_GPUS index mismatch (investigated, reported not fixed)

The F2.2 evidence report flagged the study GPU-lock keying on host index 0 regardless of
`LLEM_DOCKER_GPUS` pinning. Root cause: `study/gpu_locks.py` names lock files by the
LOGICAL indices from `_resolve_gpu_indices` (counted from 0), but the PHYSICAL device is
chosen by `LLEM_DOCKER_GPUS=device=N`, invisible to that function. Consequences: a study
pinned to `device=2` locks `gpu-0.lock` (wrong device); two studies pinned to different
physical devices both contend for `gpu-0.lock` and spuriously serialise. Cosmetic at TP=1
single-study (F2.2), a real correctness bug under concurrency / TP>1.

Proposal (a separate small PR, kept out of this one for scope hygiene): parse
`docker_gpus()` into physical indices (`device=<id>[,<id>]`; `None` for `all`/UUID -> fall
back to the logical indices) and name the lock files by those. CI single-experiment smoke
runs are unaffected (single experiments take no study-level lock). Full write-up appended to
`.product/research/trt-measured-activation-parity-2026-07-14.md` (section 11).
