### PR TITLE
fix(study): name gpu locks by physical device under pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,17 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- Study GPU advisory locks are now named by the PHYSICAL device a study occupies, not the
+  in-container logical index. Lock names came from `_resolve_gpu_indices` (which enumerates
+  from 0), but the physical device is chosen at the docker level by `LLEM_DOCKER_GPUS`
+  (`--gpus device=N`), which the lock logic never saw. Under pinning the container always sees
+  its GPU as logical 0, so a study pinned to `device=2` locked `gpu-0.lock`, and two studies
+  pinned to DIFFERENT physical GPUs both contended on `gpu-0.lock` and spuriously serialised.
+  A new `env_config.pinned_gpu_lock_ids()` parses the docker selector into physical lock ids
+  (`device=2` -> `["2"]`, `device=2,3` -> `["2","3"]`, a `GPU-<uuid>` selector used verbatim
+  as a stable per-device id); `all` / unset / unrecognised shapes fall back to the logical
+  indices (logical == physical when every GPU is visible). Lock naming only - measurement-side
+  index resolution is unchanged. ([#807])
 - TensorRT-LLM build cache silently died across containers unless
   `LLEM_TRT_BUILD_CACHE_PATH` was set by hand: the docker runner bind-mounts the host
   `~/.cache/trt-llm` at `/root/.cache/trt-llm`, but TRT-LLM's own default cache root
@@ -804,3 +815,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#801]: https://github.com/henrycgbaker/llenergymeasure/pull/801
 [#803]: https://github.com/henrycgbaker/llenergymeasure/pull/803
 [#804]: https://github.com/henrycgbaker/llenergymeasure/pull/804
+[#807]: https://github.com/henrycgbaker/llenergymeasure/pull/807

--- a/src/llenergymeasure/study/gpu_locks.py
+++ b/src/llenergymeasure/study/gpu_locks.py
@@ -2,7 +2,11 @@
 
 Uses filelock.FileLock (kernel-backed via fcntl.flock on Linux) which
 auto-releases on process death including SIGKILL. Lock files live at
-~/.cache/llem/gpu-{N}.lock.
+~/.cache/llem/gpu-{id}.lock, where ``id`` names the PHYSICAL device the study
+occupies (a device index like ``2`` under ``--gpus device=2``, or a
+``GPU-<uuid>`` string) - never the in-container logical index, which always
+starts at 0 under docker pinning. Callers derive the ids from the docker
+pinning; see ``utils.env_config.pinned_gpu_lock_ids``.
 """
 
 from __future__ import annotations
@@ -18,24 +22,34 @@ __all__ = ["acquire_gpu_locks", "release_gpu_locks"]
 
 
 def acquire_gpu_locks(
-    gpu_indices: list[int],
+    lock_ids: list[str],
     lock_dir: Path | None = None,
 ) -> list[FileLock]:
-    """Acquire advisory file locks for the given GPU indices, in sorted order.
+    """Acquire advisory file locks for the given physical GPU ids, in sorted order.
+
+    Each id names a PHYSICAL GPU the study will occupy - a device index like
+    ``"2"`` (under ``--gpus device=2``) or a ``GPU-<uuid>`` string. Callers
+    derive these from the docker pinning (see
+    ``utils.env_config.pinned_gpu_lock_ids``) so two studies on different
+    physical GPUs never share a lock. The ids are NOT the in-container logical
+    indices, which always start at 0 under pinning and address the energy
+    samplers, not host-side locks.
 
     Sorted acquisition (Dijkstra's resource ordering) prevents deadlocks when
-    multiple studies attempt to acquire overlapping GPU sets concurrently.
+    multiple studies attempt to acquire overlapping GPU sets concurrently. The
+    sort is lexicographic on the id strings; any globally consistent order
+    suffices for deadlock freedom.
 
     The locks are non-blocking (timeout=0). If any GPU is already locked by
     another process, all previously acquired locks are released (atomic all-or-none
     rollback) and a StudyError is raised.
 
     Args:
-        gpu_indices: GPU device indices to lock (e.g. [0, 1]).
+        lock_ids: Physical GPU lock identifiers to lock (e.g. ``["2", "3"]``).
         lock_dir: Directory for lock files. Defaults to ~/.cache/llem.
 
     Returns:
-        List of acquired FileLock objects in sorted index order.
+        List of acquired FileLock objects in sorted id order.
 
     Raises:
         StudyError: If any GPU is locked by another process.
@@ -46,25 +60,25 @@ def acquire_gpu_locks(
     lock_dir.mkdir(parents=True, exist_ok=True)
 
     # Sort to prevent deadlocks (Dijkstra's resource ordering)
-    sorted_indices = sorted(gpu_indices)
+    sorted_ids = sorted(lock_ids)
 
     acquired: list[FileLock] = []
-    failed_indices: list[int] = []
+    failed_ids: list[str] = []
 
-    for idx in sorted_indices:
-        lock_path = lock_dir / f"gpu-{idx}.lock"
+    for lock_id in sorted_ids:
+        lock_path = lock_dir / f"gpu-{lock_id}.lock"
         lock = FileLock(str(lock_path), timeout=0)
         try:
             lock.acquire()
             acquired.append(lock)
         except Timeout:
-            failed_indices.append(idx)
+            failed_ids.append(lock_id)
             # Atomic rollback: release all already-acquired locks
             for held_lock in acquired:
                 with contextlib.suppress(Exception):
                     held_lock.release()
             raise StudyError(
-                f"GPU(s) {failed_indices} locked by another process. Use --no-lock to override."
+                f"GPU(s) {failed_ids} locked by another process. Use --no-lock to override."
             ) from None
 
     return acquired

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -437,14 +437,25 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         original_sigint = signal.signal(signal.SIGINT, self._handle_sigint)
 
         # Acquire per-GPU advisory locks before image preparation.
+        # Lock names use the PHYSICAL device the study occupies, parsed from the
+        # docker --gpus pinning (LLEM_DOCKER_GPUS): two studies on different
+        # physical GPUs must not share a lock. When there is no docker-level
+        # pinning (all / unset), logical == physical, so fall back to the
+        # in-container logical indices. Measurement-side index resolution is
+        # unchanged - _resolve_gpu_indices still yields the logical indices that
+        # address the energy samplers.
         # Sorted acquisition prevents deadlocks when multiple studies share GPUs.
         gpu_locks: list[Any] = []
         if not self._no_lock and ordered:
-            from llenergymeasure.device.gpu_info import _resolve_gpu_indices
             from llenergymeasure.study.gpu_locks import acquire_gpu_locks
+            from llenergymeasure.utils.env_config import pinned_gpu_lock_ids
 
-            gpu_indices = _resolve_gpu_indices(ordered[0])
-            gpu_locks = acquire_gpu_locks(gpu_indices)
+            lock_ids = pinned_gpu_lock_ids()
+            if lock_ids is None:
+                from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+
+                lock_ids = [str(i) for i in _resolve_gpu_indices(ordered[0])]
+            gpu_locks = acquire_gpu_locks(lock_ids)
 
         # Container lifecycle: reap orphaned containers, register cleanup, install SIGTERM bridge.
         # Only activated for studies that use Docker runners.

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -18,6 +18,7 @@ consumed by engine plugins in Layer 2.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Final
 
@@ -77,6 +78,60 @@ def docker_gpus() -> str:
     """
     raw = os.environ.get(ENV_DOCKER_GPUS, "").strip()
     return raw or "all"
+
+
+_UNSAFE_LOCK_ID_CHARS: Final = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _sanitize_lock_id(raw: str) -> str:
+    """Make a docker ``--gpus`` device token safe as a lock-file name component.
+
+    Replaces any character outside ``[A-Za-z0-9._-]`` with ``_`` so the token
+    cannot contain a path separator (no directory escape) and is a valid
+    filename. Real device selectors - integer indices and ``GPU-<uuid>`` /
+    ``MIG-<uuid>`` strings - are already within this set, so this is a no-op for
+    them; it only hardens against pathological ``LLEM_DOCKER_GPUS`` values.
+    """
+    return _UNSAFE_LOCK_ID_CHARS.sub("_", raw)
+
+
+def pinned_gpu_lock_ids() -> list[str] | None:
+    """Return per-physical-device lock identifiers parsed from ``LLEM_DOCKER_GPUS``.
+
+    llem's per-GPU advisory locks (``study/gpu_locks.py``) must be named by the
+    PHYSICAL device a study occupies so that two studies pinned to different
+    physical GPUs never share a lock. Under ``docker run --gpus device=N`` the
+    container sees its granted GPU as LOGICAL index ``0``, so the in-container
+    index (what ``device/gpu_info._resolve_gpu_indices`` returns) is the wrong
+    key for a host-side lock. This parses the docker selector back into the
+    physical identity:
+
+    - ``device=2``          -> ``["2"]``
+    - ``device=2,3``        -> ``["2", "3"]``
+    - ``device=GPU-<uuid>`` -> ``["GPU-<uuid>"]`` - a UUID cannot be mapped to a
+      small integer index without an ``nvidia-smi`` lookup, but the UUID string
+      is itself globally unique and stable, so it serves directly as a
+      collision-correct per-device lock id (same UUID -> same lock, distinct
+      UUIDs -> distinct locks).
+    - ``all`` / unset       -> ``None`` - every visible GPU is granted, so
+      logical == physical and the caller falls back to the in-container logical
+      indices (unchanged historical behaviour).
+    - any other shape (e.g. ``count=2``, a bare count, malformed) -> ``None`` -
+      the physical identity is unknowable, so fall back to logical indices.
+
+    This is a LOCK-NAMING concern only. Measurement-side index resolution is
+    deliberately untouched: NVML / CUDA indices inside the container enumerate
+    from ``0`` under pinning, and ``_resolve_gpu_indices`` still returns those
+    logical indices to address the energy samplers.
+    """
+    raw = docker_gpus()
+    prefix = "device="
+    if not raw.startswith(prefix):
+        # "all", unset (-> "all"), count forms, or anything unrecognised.
+        return None
+    tokens = [tok.strip() for tok in raw[len(prefix) :].split(",")]
+    ids = [_sanitize_lock_id(tok) for tok in tokens if tok]
+    return ids or None
 
 
 ENV_TRT_BUILD_CACHE_ENABLED: Final = "LLEM_TRT_BUILD_CACHE_ENABLED"

--- a/tests/unit/study/test_gpu_locks.py
+++ b/tests/unit/study/test_gpu_locks.py
@@ -16,8 +16,8 @@ from llenergymeasure.utils.exceptions import StudyError
 # =============================================================================
 
 
-def _lock_path(lock_dir: Path, gpu_index: int) -> Path:
-    return lock_dir / f"gpu-{gpu_index}.lock"
+def _lock_path(lock_dir: Path, lock_id: str) -> Path:
+    return lock_dir / f"gpu-{lock_id}.lock"
 
 
 # =============================================================================
@@ -27,13 +27,13 @@ def _lock_path(lock_dir: Path, gpu_index: int) -> Path:
 
 def test_single_gpu_lock_acquired_and_released(tmp_path: Path) -> None:
     """Single GPU lock acquired successfully and released without error."""
-    locks = acquire_gpu_locks([0], lock_dir=tmp_path)
+    locks = acquire_gpu_locks(["0"], lock_dir=tmp_path)
 
     assert len(locks) == 1
-    assert _lock_path(tmp_path, 0).exists()
+    assert _lock_path(tmp_path, "0").exists()
 
     # Verify the lock is actually held (re-acquiring non-blocking should raise Timeout)
-    held_lock = FileLock(str(_lock_path(tmp_path, 0)), timeout=0)
+    held_lock = FileLock(str(_lock_path(tmp_path, "0")), timeout=0)
     with pytest.raises(filelock.Timeout):
         held_lock.acquire()
 
@@ -41,13 +41,58 @@ def test_single_gpu_lock_acquired_and_released(tmp_path: Path) -> None:
 
 
 def test_multi_gpu_locks_acquired_in_sorted_order(tmp_path: Path) -> None:
-    """Multi-GPU locks are acquired in sorted order (lock files for all indices exist)."""
-    # Pass indices in reverse order to verify sorting
-    locks = acquire_gpu_locks([2, 0, 1], lock_dir=tmp_path)
+    """Multi-GPU locks are acquired in sorted order (lock files for all ids exist)."""
+    # Pass ids in reverse order to verify sorting
+    locks = acquire_gpu_locks(["2", "0", "1"], lock_dir=tmp_path)
 
     assert len(locks) == 3
-    for i in range(3):
+    for i in ("0", "1", "2"):
         assert _lock_path(tmp_path, i).exists(), f"Lock file for GPU {i} missing"
+
+    release_gpu_locks(locks)
+
+
+def test_physical_lock_ids_name_the_physical_device(tmp_path: Path) -> None:
+    """A study pinned to physical device 2 locks gpu-2.lock, not gpu-0.lock."""
+    locks = acquire_gpu_locks(["2"], lock_dir=tmp_path)
+
+    assert _lock_path(tmp_path, "2").exists()
+    assert not _lock_path(tmp_path, "0").exists()
+
+    release_gpu_locks(locks)
+
+
+def test_different_physical_devices_do_not_collide(tmp_path: Path) -> None:
+    """Two studies pinned to distinct physical GPUs acquire disjoint locks."""
+    locks_a = acquire_gpu_locks(["2"], lock_dir=tmp_path)
+    # A second acquisition on a DIFFERENT physical device must succeed even while
+    # the first is still held - this is the concurrency bug the fix closes.
+    locks_b = acquire_gpu_locks(["3"], lock_dir=tmp_path)
+
+    assert len(locks_a) == 1
+    assert len(locks_b) == 1
+
+    release_gpu_locks(locks_a)
+    release_gpu_locks(locks_b)
+
+
+def test_same_physical_device_collides(tmp_path: Path) -> None:
+    """Two studies pinned to the SAME physical GPU contend on one lock."""
+    external_lock = FileLock(str(_lock_path(tmp_path, "2")))
+    external_lock.acquire()
+
+    try:
+        with pytest.raises(StudyError, match=r"GPU\(s\).*locked by another process"):
+            acquire_gpu_locks(["2"], lock_dir=tmp_path)
+    finally:
+        external_lock.release()
+
+
+def test_uuid_lock_id(tmp_path: Path) -> None:
+    """A UUID lock id names its own lock file verbatim."""
+    locks = acquire_gpu_locks(["GPU-abc-123"], lock_dir=tmp_path)
+
+    assert _lock_path(tmp_path, "GPU-abc-123").exists()
 
     release_gpu_locks(locks)
 
@@ -55,28 +100,28 @@ def test_multi_gpu_locks_acquired_in_sorted_order(tmp_path: Path) -> None:
 def test_contention_raises_study_error(tmp_path: Path) -> None:
     """Acquiring the same GPU twice raises StudyError with a clear message."""
     # Hold GPU 0 with an external lock
-    external_lock = FileLock(str(_lock_path(tmp_path, 0)))
+    external_lock = FileLock(str(_lock_path(tmp_path, "0")))
     external_lock.acquire()
 
     try:
         with pytest.raises(StudyError, match=r"GPU\(s\).*locked by another process"):
-            acquire_gpu_locks([0], lock_dir=tmp_path)
+            acquire_gpu_locks(["0"], lock_dir=tmp_path)
     finally:
         external_lock.release()
 
 
 def test_atomic_rollback_on_contention(tmp_path: Path) -> None:
-    """If GPU 1 is locked, attempting [0, 1] releases GPU 0 (atomic rollback)."""
+    """If GPU 1 is locked, attempting ["0", "1"] releases GPU 0 (atomic rollback)."""
     # Hold GPU 1 externally
-    external_lock = FileLock(str(_lock_path(tmp_path, 1)))
+    external_lock = FileLock(str(_lock_path(tmp_path, "1")))
     external_lock.acquire()
 
     try:
         with pytest.raises(StudyError):
-            acquire_gpu_locks([0, 1], lock_dir=tmp_path)
+            acquire_gpu_locks(["0", "1"], lock_dir=tmp_path)
 
         # GPU 0 must be released after rollback - we can acquire it again
-        locks = acquire_gpu_locks([0], lock_dir=tmp_path)
+        locks = acquire_gpu_locks(["0"], lock_dir=tmp_path)
         assert len(locks) == 1
         release_gpu_locks(locks)
     finally:
@@ -105,6 +150,6 @@ def test_lock_dir_created_if_missing(tmp_path: Path) -> None:
     new_dir = tmp_path / "nested" / "llem"
     assert not new_dir.exists()
 
-    locks = acquire_gpu_locks([0], lock_dir=new_dir)
+    locks = acquire_gpu_locks(["0"], lock_dir=new_dir)
     assert new_dir.exists()
     release_gpu_locks(locks)

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -2395,6 +2395,8 @@ def test_gpu_locks_acquired_and_released(study_config: StudyConfig, tmp_path: Pa
         patch("multiprocessing.get_context", return_value=ctx),
         patch("llenergymeasure.study.gpu_locks.acquire_gpu_locks", side_effect=fake_acquire),
         patch("llenergymeasure.study.gpu_locks.release_gpu_locks", side_effect=fake_release),
+        # No docker pinning -> fall back to logical indices (measurement-side).
+        patch("llenergymeasure.utils.env_config.pinned_gpu_lock_ids", return_value=None),
         patch("llenergymeasure.device.gpu_info._resolve_gpu_indices", return_value=[0]),
     ):
         runner = StudyRunner(study_config, manifest, tmp_path, no_lock=False)
@@ -2402,6 +2404,33 @@ def test_gpu_locks_acquired_and_released(study_config: StudyConfig, tmp_path: Pa
 
     assert len(acquired_locks) == 1, "Expected exactly one acquire call"
     assert len(released_locks) == 1, "Expected exactly one release call (in finally)"
+
+
+def test_gpu_locks_use_physical_pinning(study_config: StudyConfig, tmp_path: Path) -> None:
+    """When pinned via LLEM_DOCKER_GPUS, locks are named by the physical device."""
+    manifest = MagicMock()
+
+    acquired_ids: list[list[str]] = []
+
+    def fake_acquire(lock_ids, lock_dir=None):
+        acquired_ids.append(list(lock_ids))
+        return [MagicMock()]
+
+    fake_result = {"status": "ok"}
+    proc = _make_mock_process(is_alive_after_join=False, exitcode=0)
+    ctx = _make_mock_context(proc, pipe_data=fake_result)
+
+    with (
+        patch("multiprocessing.get_context", return_value=ctx),
+        patch("llenergymeasure.study.gpu_locks.acquire_gpu_locks", side_effect=fake_acquire),
+        patch("llenergymeasure.study.gpu_locks.release_gpu_locks"),
+        # Physical device 2 pinned -> lock id "2", NOT the logical index "0".
+        patch("llenergymeasure.utils.env_config.pinned_gpu_lock_ids", return_value=["2"]),
+    ):
+        runner = StudyRunner(study_config, manifest, tmp_path, no_lock=False)
+        runner.run()
+
+    assert acquired_ids == [["2"]]
 
 
 def test_no_lock_skips_gpu_lock_acquisition(study_config: StudyConfig) -> None:

--- a/tests/unit/utils/test_env_config.py
+++ b/tests/unit/utils/test_env_config.py
@@ -1,0 +1,117 @@
+"""Tests for utils/env_config.py physical-GPU lock-id parsing.
+
+pinned_gpu_lock_ids() parses the LLEM_DOCKER_GPUS docker --gpus selector into
+per-physical-device lock identifiers so study GPU locks name the physical
+device, not the in-container logical index (which always starts at 0 under
+pinning). See study/gpu_locks.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llenergymeasure.utils.env_config import ENV_DOCKER_GPUS, pinned_gpu_lock_ids
+
+
+def test_unset_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset LLEM_DOCKER_GPUS -> None (every GPU visible; use logical indices)."""
+    monkeypatch.delenv(ENV_DOCKER_GPUS, raising=False)
+    assert pinned_gpu_lock_ids() is None
+
+
+def test_all_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit 'all' -> None (logical == physical fallback)."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "all")
+    assert pinned_gpu_lock_ids() is None
+
+
+def test_empty_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty value falls back to 'all' -> None."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "")
+    assert pinned_gpu_lock_ids() is None
+
+
+def test_single_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """device=2 -> ["2"] (the physical device index)."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=2")
+    assert pinned_gpu_lock_ids() == ["2"]
+
+
+def test_multi_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """device=2,3 -> ["2", "3"]."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=2,3")
+    assert pinned_gpu_lock_ids() == ["2", "3"]
+
+
+def test_whitespace_tolerated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Surrounding whitespace on tokens is stripped."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=2, 3")
+    assert pinned_gpu_lock_ids() == ["2", "3"]
+
+
+def test_empty_tokens_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty tokens from stray commas are dropped."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=2,,3")
+    assert pinned_gpu_lock_ids() == ["2", "3"]
+
+
+def test_empty_body_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """device= with no ids -> None (nothing to pin)."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=")
+    assert pinned_gpu_lock_ids() is None
+
+
+def test_uuid_single(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A GPU-UUID selector is used verbatim as a stable per-device lock id."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=GPU-abc-123")
+    assert pinned_gpu_lock_ids() == ["GPU-abc-123"]
+
+
+def test_uuid_multi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Multiple UUIDs each become their own lock id."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=GPU-abc,GPU-def")
+    assert pinned_gpu_lock_ids() == ["GPU-abc", "GPU-def"]
+
+
+def test_count_form_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """count=N does not name specific devices -> None (fall back to logical)."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "count=2")
+    assert pinned_gpu_lock_ids() is None
+
+
+def test_bare_count_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare integer count (docker's --gpus 2 form) -> None."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "2")
+    assert pinned_gpu_lock_ids() is None
+
+
+def test_unrecognised_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unrecognised selector shape -> None."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "garbage")
+    assert pinned_gpu_lock_ids() is None
+
+
+def test_traversal_sanitized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Path separators in a pathological value cannot escape the lock dir."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=../../etc")
+    ids = pinned_gpu_lock_ids()
+    assert ids is not None
+    assert "/" not in ids[0]
+    assert ids == [".._.._etc"]
+
+
+def test_different_devices_yield_different_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Distinct physical devices produce distinct lock ids (no false collision)."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=2")
+    ids_two = pinned_gpu_lock_ids()
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=3")
+    ids_three = pinned_gpu_lock_ids()
+    assert ids_two != ids_three
+
+
+def test_same_device_yields_same_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The same physical device always maps to the same lock id (real collision)."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=2")
+    first = pinned_gpu_lock_ids()
+    second = pinned_gpu_lock_ids()
+    assert first == second == ["2"]


### PR DESCRIPTION
## Summary

Study GPU advisory locks were named by the in-container **logical** GPU index
(from `device/gpu_info._resolve_gpu_indices`, which enumerates from 0), but the
**physical** device a study occupies is chosen at the docker level by
`LLEM_DOCKER_GPUS` (`--gpus device=N`, landed in #803) - which the lock logic
never saw. Under `--gpus device=N` the container always sees its granted GPU as
logical index 0, so:

- A study pinned to physical `device=2` locked `gpu-0.lock` (wrong device named).
- **False collision:** two concurrent studies pinned to *different* physical
  GPUs (`device=2` and `device=3`) both computed `[0]` and contended on
  `gpu-0.lock`; the second aborted with "GPU(s) [0] locked by another process"
  despite using disjoint hardware.
- **Missed collision:** two studies on the *same* physical GPU reached via
  different logical views would fail to serialise.

Single-study TP=1 runs were unaffected (the lock only ever guarded against
itself), which is why F2.2 saw only a cosmetic mismatch. Full write-up: section
11 of `.product/research/trt-measured-activation-parity-2026-07-14.md`.

## Fix

New `utils/env_config.pinned_gpu_lock_ids() -> list[str] | None` parses
`docker_gpus()` back into per-physical-device lock identifiers; the study runner
prefers them for lock naming and falls back to the logical indices only when
there is no docker-level pinning.

**Parse scheme:**

| `LLEM_DOCKER_GPUS`   | lock ids        | rationale |
|----------------------|-----------------|-----------|
| `device=2`           | `["2"]`         | physical device index |
| `device=2,3`         | `["2", "3"]`    | physical device indices |
| `device=GPU-<uuid>`  | `["GPU-<uuid>"]`| UUID used verbatim (see below) |
| `all` / unset        | `None`          | every GPU visible; logical == physical, caller uses logical indices |
| `count=2`, bare count, malformed | `None` | physical identity unknowable; safe logical fallback |

**UUID fallback rationale:** a GPU UUID cannot be mapped to a small integer
index without an `nvidia-smi` lookup, but the UUID string is itself globally
unique and stable, so it serves *directly* as a collision-correct per-device
lock id (same UUID -> same lock, distinct UUIDs -> distinct locks). This is
strictly better than falling back to logical indices for the UUID case, which
would reintroduce the exact false-collision bug. Tokens are sanitised to
`[A-Za-z0-9._-]` (real device selectors are already in this set) so a
pathological value cannot escape the lock directory.

**Boundary - lock naming only:** this changes *only* the host-side lock file
names. Measurement-side index resolution is deliberately untouched:
`_resolve_gpu_indices` still returns the in-container logical indices (NVML /
CUDA enumerate from 0 under pinning) that address the energy samplers. No
measurement path changes.

## Test plan

- `tests/unit/utils/test_env_config.py` (new): `device=N`, `device=N,M`,
  whitespace/empty-token tolerance, `all`/unset/empty/`count=`/bare/malformed ->
  `None`, UUID single + multi, traversal sanitisation, and the collision
  invariants (different devices -> different ids; same device -> same id).
- `tests/unit/study/test_gpu_locks.py`: physical-id naming (`device 2` locks
  `gpu-2.lock` not `gpu-0.lock`), two distinct physical devices acquire disjoint
  locks concurrently, same device collides, UUID lock id; existing tests moved to
  string ids.
- `tests/unit/study/test_study_runner.py`: runner passes pinned physical id
  `["2"]` (not logical `["0"]`) to `acquire_gpu_locks`; logical fallback path
  made deterministic.
- Full host suite (`-m "not gpu and not docker and not slow"`): 3026 passed,
  35 skipped. `make lint` + `make typecheck` clean.

## Doc audit

No user-facing docs reference lock file naming. `CHANGELOG.md` [Unreleased]
Fixed updated. Behaviour is host-side only - no GPU or container needed to
validate.
