### PR TITLE
fix(engines): stop launching tensorrt under mpirun for TP>1

### DIFF
--- a/scripts/container_entrypoint.sh
+++ b/scripts/container_entrypoint.sh
@@ -13,8 +13,9 @@
 #      runtime-deps cache are discoverable.
 #   3. Exec the framework's in-container entrypoint module. For TensorRT-LLM,
 #      route through the upstream nvidia_entrypoint.sh which sets up
-#      LD_LIBRARY_PATH for libnvinfer (closes #608). For TP > 1, wrap in
-#      mpirun (LLEM_MPI_NP set by docker_runner).
+#      LD_LIBRARY_PATH for libnvinfer (closes #608). Always a single python3
+#      process - multi-GPU tensorrt is NOT wrapped in mpirun (the TRT-LLM LLM
+#      API self-manages tensor parallelism by spawning its own workers).
 #
 # The pyproject-vs-container diff is computed at every dispatch. Cached
 # installs in /llem-runtime-deps shadow the comparison naturally: once a
@@ -119,13 +120,15 @@ PYEOF
     fi
 fi
 
-# Build the final launch command. For TP > 1, mpirun wraps python3 (matches
-# the prior docker_runner.py behaviour where mpirun was the entrypoint).
-if [ -n "${LLEM_MPI_NP:-}" ]; then
-    LAUNCH=(mpirun -n "${LLEM_MPI_NP}" --allow-run-as-root python3)
-else
-    LAUNCH=(python3)
-fi
+# Build the final launch command. Always a single python3 process, for every
+# engine including multi-GPU tensorrt. TensorRT-LLM's LLM API (both the trt and
+# pytorch backends at 1.2.x) self-manages tensor parallelism: setting
+# tensor_parallel_size makes the LLM class spawn its own worker processes
+# internally (MPI/RPC orchestrator). Wrapping the container in mpirun -n N
+# instead ran the WHOLE entrypoint on every rank, so each rank redundantly
+# built the engine and constructed a full LLM - corrupting the on-disk build
+# cache (a rank race in the upstream write_guard) and OOMing on the executor.
+LAUNCH=(python3)
 
 # Framework module to exec. Defaults to the experiment container entrypoint;
 # the baseline dispatch overrides it with LLEM_ENTRY_MODULE so it reuses this

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -113,9 +113,6 @@ deps cache after priming (container runs as root by default, so without
 this the host can't clean the cache without sudo)."""
 ENV_HOST_GID: Final = "LLEM_HOST_GID"
 """Host user GID; paired with ENV_HOST_UID for chown."""
-ENV_MPI_NP: Final = "LLEM_MPI_NP"
-"""TRT-LLM tensor_parallel_size when > 1; signals the entrypoint script to
-wrap the final exec in mpirun -n N --allow-run-as-root."""
 ENV_DEPS_CACHE_DIR: Final = "LLEM_DEPS_CACHE_DIR"
 """Override for the host-side runtime-deps cache directory. Defaults to
 ``platformdirs.user_cache_dir('llem')/deps`` when unset."""
@@ -213,7 +210,6 @@ __all__ = [
     "ENV_HOST_UID",
     "ENV_IMAGE_PREFIX",
     "ENV_LOG_LEVEL",
-    "ENV_MPI_NP",
     "ENV_NO_PROMPT",
     "ENV_OUTPUT_DIR",
     "ENV_RUNNER_PREFIX",

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -48,7 +48,6 @@ from llenergymeasure.config.ssot import (
     ENV_HF_TOKEN,
     ENV_HOST_GID,
     ENV_HOST_UID,
-    ENV_MPI_NP,
     ENV_OUTPUT_DIR,
     ENV_SAVE_TIMESERIES,
     TEMP_PREFIX_ENV_FILE,
@@ -93,7 +92,6 @@ _RESERVED_EXCHANGE_ENV: frozenset[str] = frozenset(
         ENV_ENTRY_MODULE,
         ENV_HOST_UID,
         ENV_HOST_GID,
-        ENV_MPI_NP,
         ENV_BASELINE_SPEC_PATH,
     }
 )
@@ -121,7 +119,7 @@ _NO_DEADLINE = float("inf")
 # pyproject.toml against installed dists, primes any missing runtime deps
 # to the host-mounted cache, then exec's the framework's Python entrypoint
 # module (with engine-conditional routing through nvidia_entrypoint.sh for
-# TRT-LLM and an mpirun wrapper when LLEM_MPI_NP is set).
+# TRT-LLM).
 _CONTAINER_ENTRY_SCRIPT_REL = ("scripts", "container_entrypoint.sh")
 
 
@@ -230,7 +228,6 @@ def append_package_dispatch(
     *,
     engine: str,
     entry_module: str | None = None,
-    mpi_np: int | None = None,
 ) -> None:
     """Append the bind-mounts + env + entrypoint that make the package importable.
 
@@ -254,8 +251,6 @@ def append_package_dispatch(
             through ``nvidia_entrypoint.sh`` for the libnvinfer ``LD_LIBRARY_PATH``.
         entry_module: Override for the module the script exec's. ``None`` leaves
             the script default (``llenergymeasure.entrypoints.container``).
-        mpi_np: When > 1, sets ``LLEM_MPI_NP`` so the script wraps the exec in
-            ``mpirun -n N`` (TRT-LLM tensor parallelism).
     """
     pkg_parent = _resolve_package_parent_dir()
     repo_root = _resolve_repo_root()
@@ -284,8 +279,6 @@ def append_package_dispatch(
     )
     if entry_module is not None:
         cmd.extend(["-e", f"{ENV_ENTRY_MODULE}={entry_module}"])
-    if mpi_np is not None and mpi_np > 1:
-        cmd.extend(["-e", f"{ENV_MPI_NP}={mpi_np}"])
     cmd.extend(["--entrypoint", "/llem-entry.sh"])
 
 
@@ -306,8 +299,7 @@ class DockerRunner:
            The entrypoint script primes any missing runtime deps to the
            bind-mounted cache, then exec's
            ``python3 -m llenergymeasure.entrypoints.container`` (routing
-           through ``/opt/nvidia/nvidia_entrypoint.sh`` for TRT-LLM and
-           wrapping in mpirun when ``LLEM_MPI_NP`` is set).
+           through ``/opt/nvidia/nvidia_entrypoint.sh`` for TRT-LLM).
         4. Read ``{config_hash}_result.json`` from exchange dir
         5. Clean up temp dir on success; preserve on failure with debug path logged
 
@@ -947,13 +939,12 @@ class DockerRunner:
         ``PYTHONPATH`` to include the cache and ``/llem-src``, and (c) exec's
         the framework entrypoint module - routing through
         ``/opt/nvidia/nvidia_entrypoint.sh`` when ``LLEM_ENGINE=tensorrt``
-        (sets up LD_LIBRARY_PATH for libnvinfer) and wrapping in
-        ``mpirun -n {n} --allow-run-as-root`` when ``LLEM_MPI_NP`` is set
-        (TRT-LLM tensor parallelism > 1).
+        (sets up LD_LIBRARY_PATH for libnvinfer).
 
-        MPI worker ranks re-import the framework module but do not call
-        ``main()`` because ``container_entrypoint.py`` is guarded by
-        ``if __name__ == "__main__"``.
+        Multi-GPU tensorrt runs are NOT wrapped in mpirun: TensorRT-LLM's LLM
+        API self-manages tensor parallelism (setting ``tensor_parallel_size``
+        makes the LLM class spawn its own worker processes via its MPI/RPC
+        orchestrator), so a single python3 process is correct.
 
         Args:
             config:       ExperimentConfig for the current experiment. Used to
@@ -1032,12 +1023,6 @@ class DockerRunner:
         for host_path, container_path in self.extra_mounts:
             cmd.extend(["-v", f"{host_path}:{container_path}"])
 
-        # Determine TRT-LLM tensor parallel size for MPI injection
-        tp_size = None
-        if config.engine == Engine.TENSORRT and config.tensorrt is not None:
-            engine_params = config.active_engine_params()
-            tp_size = engine_params.tensor_parallel_size if engine_params is not None else None
-
         # All engines: bind-mount the host package source + bootstrap (so the
         # package is importable in images that don't ship it) and point
         # --entrypoint at the script. Shared with the baseline dispatch via
@@ -1046,7 +1031,7 @@ class DockerRunner:
         # (``llenergymeasure.entrypoints.container``), so entry_module stays None.
         # ``Engine`` is a (str, Enum) so ``f"{config.engine}"`` resolves to the
         # raw value via its ``__str__`` override.
-        append_package_dispatch(cmd, engine=f"{config.engine}", mpi_np=tp_size)
+        append_package_dispatch(cmd, engine=f"{config.engine}")
 
         # Container name and labels for lifecycle management (cleanup, reaper).
         # These must appear before the image name in the docker run command.

--- a/tests/unit/docker/test_container_entrypoint.py
+++ b/tests/unit/docker/test_container_entrypoint.py
@@ -408,17 +408,16 @@ class TestContainerBaselineLoading:
 
 
 # ---------------------------------------------------------------------------
-# __main__ guard - MPI safety contract
+# __main__ guard
 # ---------------------------------------------------------------------------
 
 
 class TestMainGuard:
     def test_main_guard_exists_at_module_level(self):
-        """The __main__ guard prevents MPI workers from re-executing main().
+        """The entrypoint runs main() only under a ``__main__`` guard.
 
-        When mpirun spawns worker ranks, they re-import the module but
-        __name__ is the dotted module path (not "__main__"), so main()
-        is not called. This test documents that contract.
+        Standard hygiene so importing the module (e.g. in tests) never triggers
+        an experiment. This test documents that the guard is present.
         """
         import inspect
 

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -708,16 +708,19 @@ class TestHFTokenSecure:
 
 
 # ---------------------------------------------------------------------------
-# Test 13: TRT-LLM tensor-parallelism (LLEM_MPI_NP env var)
+# Test 13: multi-GPU tensorrt dispatch is NEVER wrapped in mpirun
 # ---------------------------------------------------------------------------
 
 
 class TestEngineDispatchEnvVars:
     """Verify the env vars passed to the in-container entrypoint script
-    (LLEM_ENGINE, LLEM_MPI_NP) and the always-on entrypoint pointer.
+    (LLEM_ENGINE) and the always-on entrypoint pointer.
 
-    The script itself handles the mpirun wrap when LLEM_MPI_NP is set;
-    docker_runner just passes the signal.
+    No engine is launched under mpirun: TensorRT-LLM's LLM API self-manages
+    tensor parallelism (setting tensor_parallel_size spawns its own workers),
+    so LLEM_MPI_NP is never emitted, even at TP>1. Wrapping the container in
+    mpirun -n N previously ran the whole experiment on every rank and corrupted
+    the trt build cache; the signal was removed entirely.
     """
 
     def _capture_cmd(self, config, tmp_path) -> list[str]:
@@ -769,21 +772,21 @@ class TestEngineDispatchEnvVars:
             ep_idx = cmd.index("--entrypoint")
             assert cmd[ep_idx + 1] == "/llem-entry.sh"
 
-    def test_mpi_np_set_for_tensorrt_tp2(self, tmp_path):
-        """TRT-LLM with tensor_parallel_size=2 sets LLEM_MPI_NP=2 for the entry script."""
+    def test_mpi_np_absent_for_tensorrt_tp2(self, tmp_path):
+        """TRT-LLM at tensor_parallel_size=2 does NOT set LLEM_MPI_NP (no mpirun wrap)."""
         config = make_config(
             engine="tensorrt", tensorrt={"engine_params": {"tensor_parallel_size": 2}}
         )
         cmd = self._capture_cmd(config, tmp_path)
-        assert self._env_value(cmd, "LLEM_MPI_NP") == "2"
+        assert self._env_value(cmd, "LLEM_MPI_NP") is None
 
-    def test_mpi_np_set_for_tensorrt_tp4(self, tmp_path):
-        """TRT-LLM with tensor_parallel_size=4 sets LLEM_MPI_NP=4."""
+    def test_mpi_np_absent_for_tensorrt_tp4(self, tmp_path):
+        """TRT-LLM at tensor_parallel_size=4 does NOT set LLEM_MPI_NP (no mpirun wrap)."""
         config = make_config(
             engine="tensorrt", tensorrt={"engine_params": {"tensor_parallel_size": 4}}
         )
         cmd = self._capture_cmd(config, tmp_path)
-        assert self._env_value(cmd, "LLEM_MPI_NP") == "4"
+        assert self._env_value(cmd, "LLEM_MPI_NP") is None
 
     def test_mpi_np_absent_for_tensorrt_tp1(self, tmp_path):
         """TRT-LLM with tensor_parallel_size=1 omits LLEM_MPI_NP (single-GPU path)."""
@@ -983,11 +986,10 @@ class TestExtraMounts:
 class TestEntrypointPerEngine:
     """All engines dispatch through ``/llem-entry.sh`` regardless of tp_size.
 
-    The in-container entrypoint script reads ``LLEM_ENGINE`` and
-    ``LLEM_MPI_NP`` (set per-engine and per-TP-size by docker_runner) and
-    performs the engine-conditional routing internally - mpirun wrap for
-    TP > 1, nvidia_entrypoint.sh wrap for tensorrt - so docker_runner's
-    --entrypoint flag is constant.
+    The in-container entrypoint script reads ``LLEM_ENGINE`` and performs the
+    engine-conditional routing internally - nvidia_entrypoint.sh wrap for
+    tensorrt - so docker_runner's --entrypoint flag is constant. No engine is
+    wrapped in mpirun (the TRT-LLM LLM API self-manages tensor parallelism).
     """
 
     @staticmethod


### PR DESCRIPTION
## Summary

TensorRT-LLM's LLM API (both the trt and pytorch backends at 1.2.x) self-manages tensor parallelism: setting `tensor_parallel_size` makes the `LLM` class spawn its own worker processes via its MPI/RPC orchestrator from a single `python3` process. The docker dispatch previously wrapped the whole container in `mpirun -n {tp}` for tensorrt TP>1, forcing external-MPI mode where every rank re-ran the entire experiment entrypoint. The guiding assumption (that the `__main__` guard would keep worker ranks out of `main()`) is false: under `python -m module` every mpirun rank gets `__name__ == "__main__"`.

The result at TP=2: both ranks independently built the engine and constructed a full LLM. With the on-disk build cache enabled, the two ranks raced in the upstream `BuildCache.write_guard` rename/rmtree, leaving a corrupted `content/` dir (missing `config.json` and `rank0.engine`), so executor init died with "config.json not found". Without the cache, both ranks each spun up a TP=2 executor and OOMed.

This removes the mpirun launch path entirely:
- Drop `LLEM_MPI_NP` from ssot, the docker_runner injection, and the `append_package_dispatch` `mpi_np` argument.
- Drop the entrypoint mpirun branch: `container_entrypoint.sh` now always execs a single `python3`.
- Multi-GPU tensorrt now runs as one process and the LLM API spawns its own ranks.

## Test plan

- `make lint` green.
- `make typecheck` green (no issues in 308 source files).
- Unit tests green: `tests/unit/docker`, `tests/unit/utils`, `tests/unit/study` (796 passed); updated `test_container_entrypoint.py` and `test_docker_runner.py`.
- Verified live: TP=2 trt backend with the on-disk build cache builds a complete engine and generates end to end; cross-run cache reuse works (cold build then warm hit both green).
