### PR TITLE
fix(infra): quote multi-device --gpus selector for docker run

### DIFF
--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -68,7 +68,7 @@ from llenergymeasure.infra.docker_errors import (
 )
 from llenergymeasure.utils.env_config import (
     ENV_TRT_BUILD_CACHE_PATH,
-    docker_gpus,
+    docker_gpus_arg,
     trt_build_cache_host_dir,
 )
 from llenergymeasure.utils.exceptions import DockerError
@@ -973,7 +973,7 @@ class DockerRunner:
             "run",
             "--rm",
             "--gpus",
-            docker_gpus(),
+            docker_gpus_arg(),
             "-v",
             f"{exchange_dir}:{CONTAINER_EXCHANGE_DIR}",
             "-e",

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -35,7 +35,7 @@ from llenergymeasure.config.ssot import (
 )
 from llenergymeasure.harness.baseline import BaselineCache
 from llenergymeasure.infra.docker_runner import append_package_dispatch
-from llenergymeasure.utils.env_config import docker_gpus
+from llenergymeasure.utils.env_config import docker_gpus_arg
 from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ def build_baseline_docker_cmd(
         "run",
         "--rm",
         "--gpus",
-        docker_gpus(),
+        docker_gpus_arg(),
         "-v",
         f"{exchange_dir}:{CONTAINER_EXCHANGE_DIR}",
         "-e",

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -80,6 +80,26 @@ def docker_gpus() -> str:
     return raw or "all"
 
 
+def docker_gpus_arg() -> str:
+    """Return the ``--gpus`` value formatted for use as a docker-run argument.
+
+    A multi-device ``device=<a>,<b>`` selector MUST be wrapped in literal double
+    quotes: docker parses the ``--gpus`` value as CSV, so an unquoted
+    ``device=1,3`` is split at the comma into a device id (``device=1``) and a
+    trailing GPU *count* (``3``), which docker rejects with "cannot set both
+    Count and DeviceIDs on device request". Quoting keeps the whole list a
+    single device-ids field. ``all``, count forms, and a single-device
+    ``device=N`` (no comma) need no quoting and are returned verbatim.
+
+    ``docker_gpus`` stays the raw selector - :func:`pinned_gpu_lock_ids` parses
+    that form for lock naming and must not see the quotes.
+    """
+    raw = docker_gpus()
+    if raw.startswith("device=") and "," in raw:
+        return f'"{raw}"'
+    return raw
+
+
 _UNSAFE_LOCK_ID_CHARS: Final = re.compile(r"[^A-Za-z0-9._-]")
 
 

--- a/tests/unit/utils/test_env_config.py
+++ b/tests/unit/utils/test_env_config.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import pytest
 
-from llenergymeasure.utils.env_config import ENV_DOCKER_GPUS, pinned_gpu_lock_ids
+from llenergymeasure.utils.env_config import (
+    ENV_DOCKER_GPUS,
+    docker_gpus_arg,
+    pinned_gpu_lock_ids,
+)
 
 
 def test_unset_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -115,3 +119,40 @@ def test_same_device_yields_same_id(monkeypatch: pytest.MonkeyPatch) -> None:
     first = pinned_gpu_lock_ids()
     second = pinned_gpu_lock_ids()
     assert first == second == ["2"]
+
+
+# ---------------------------------------------------------------------------
+# docker_gpus_arg: multi-device selectors must be quoted for `docker run --gpus`
+# ---------------------------------------------------------------------------
+
+
+def test_gpus_arg_multi_device_is_quoted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """device=1,3 -> '"device=1,3"' so docker does not split the comma into a count."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=1,3")
+    assert docker_gpus_arg() == '"device=1,3"'
+
+
+def test_gpus_arg_single_device_unquoted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single device=N has no comma and needs no quoting."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=2")
+    assert docker_gpus_arg() == "device=2"
+
+
+def test_gpus_arg_multi_uuid_is_quoted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A comma-separated UUID device list is quoted too."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "device=GPU-abc,GPU-def")
+    assert docker_gpus_arg() == '"device=GPU-abc,GPU-def"'
+
+
+def test_gpus_arg_all_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    """'all' (and the unset default) is returned verbatim."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "all")
+    assert docker_gpus_arg() == "all"
+    monkeypatch.delenv(ENV_DOCKER_GPUS, raising=False)
+    assert docker_gpus_arg() == "all"
+
+
+def test_gpus_arg_count_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare count is not a device list and is returned verbatim."""
+    monkeypatch.setenv(ENV_DOCKER_GPUS, "2")
+    assert docker_gpus_arg() == "2"


### PR DESCRIPTION
## Summary

`LLEM_DOCKER_GPUS=device=1,3` (the documented way to pin a study to specific GPUs, needed for tensorrt TP>1 on a shared host) was emitted as the bare argv value `device=1,3`. Docker parses the `--gpus` value as CSV, so it split at the comma into a device id (`device=1`) and a trailing GPU count (`3`) and rejected the request: "cannot set both Count and DeviceIDs on device request". Single-device pinning never hit this (no comma), so it was latent until the first multi-GPU pinned run.

This adds `env_config.docker_gpus_arg()`, which wraps a comma-bearing `device=` selector in literal double quotes so docker reads it as one device-ids field. The `all`, count, and single-device selector forms pass through verbatim. The raw `docker_gpus()` is unchanged so `pinned_gpu_lock_ids()` still parses the unquoted form. The experiment and baseline docker dispatches are wired through the new helper.

## Test plan

- `make lint` green.
- `make typecheck` green (no issues in 308 source files).
- Unit tests green: `tests/unit/docker`, `tests/unit/utils`, `tests/unit/study` (801 passed); extended `test_env_config.py` covering the quoting, passthrough, and count/all forms.
- Verified live: a TP=2 trt study pinned with `LLEM_DOCKER_GPUS=device=...` launches successfully and the build cache path stays green cold and warm.
