### PR TITLE
refactor(results): fold per-field provenance into config.json sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   declared/observed config and its provenance. Consumers (including `llem report-gaps`)
   read the `provenance` section; the `_resolution.json` file is no longer written or read.
   Pre-1.0, bundles produced by older versions are not backfilled: their `_resolution.json`
-  is simply ignored.
+  is simply ignored. `config.json` now materialises in the experiment directory on every
+  successful run, including the docker (multi-engine) path and runs with
+  `save_timeseries` off: the docker runner rescues `config.json` from the container
+  exchange dir alongside `timeseries.parquet`, and the local path always stages an output
+  dir for the sidecar. If a completed experiment ends without a `config.json`, the runner
+  logs a warning rather than dropping the provenance silently.
 
 ## [v0.11.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+### Added
+
+- The per-experiment `config.json` sidecar now carries its own `schema_version`
+  (`"2.0"`), independent of `result.json`'s schema version. It succeeds the retired
+  `_resolution.json` sidecar (`"1.0"`), whose per-field provenance now lives in this file.
+- `equivalence_groups.json` now records `study_name` alongside `study_id`, so the
+  study-level artefact stays attributable if separated from its parent directory.
+
+### Changed
+
+- Per-field config provenance (which fields were overridden and why: CLI flag, sweep, or
+  YAML) is folded into the `config.json` sidecar under a new `provenance` section instead
+  of a standalone `_resolution.json` file. `config.json` is now the single home for both
+  declared/observed config and its provenance. Consumers (including `llem report-gaps`)
+  read the `provenance` section; the `_resolution.json` file is no longer written or read.
+  Pre-1.0, bundles produced by older versions are not backfilled: their `_resolution.json`
+  is simply ignored.
+
 ## [v0.11.0] - 2026-07-16
 
 ### Added

--- a/docs/reference/library/run_study.md
+++ b/docs/reference/library/run_study.md
@@ -99,7 +99,7 @@ print(f"Total energy: {study_result.summary.total_energy_j:.1f} J")
 | `skip_set` | `set[tuple[str, int]] \| None` | `None` | Set of `(config_hash, cycle)` pairs to skip. Populated automatically when resuming; callers rarely need to set this. |
 | `no_lock` | `bool` | `False` | Skip GPU advisory lock acquisition. Equivalent to the `--no-lock` CLI flag. |
 | `config_path` | `Path \| None` | `None` | Original YAML path for artefact copying when `config` is a `StudyConfig` object. Preserved in `_study-artefacts/` for reproducibility. |
-| `cli_overrides` | `dict[str, Any] \| None` | `None` | Flat dict of CLI flag overrides written to per-experiment `_resolution.json` sidecars. Rarely needed outside the CLI. |
+| `cli_overrides` | `dict[str, Any] \| None` | `None` | Flat dict of CLI flag overrides recorded in the per-experiment `config.json` provenance section. Rarely needed outside the CLI. |
 
 ---
 

--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -218,8 +218,8 @@ def run_study(
             When config is a StudyConfig object, callers should pass the original
             path separately so the YAML is preserved for reproducibility.
         cli_overrides: Flat dict of CLI flag overrides (e.g. {"model": "gpt2"}).
-            Used to build per-experiment ``_resolution.json`` sidecars showing
-            which fields were overridden by CLI flags vs YAML vs sweep.
+            Used to build the per-experiment config.json ``provenance`` section
+            showing which fields were overridden by CLI flags vs YAML vs sweep.
         preresolved: Optional ``(runner_specs, system_overrides)`` already
             computed by a prior ``run_study_preflight`` call (e.g. the CLI runs
             preflight to render the panel). When supplied, ``_run`` reuses it

--- a/src/llenergymeasure/api/report_gaps.py
+++ b/src/llenergymeasure/api/report_gaps.py
@@ -23,9 +23,9 @@ Design:
   ``logger_warning``, ``logger_warning_once``, and ``runtime_exception``
   only - a documented subset of :data:`EmissionChannel`.
 
-Source of config kwargs: per-experiment ``_resolution.json`` sidecars,
-flattened into ``dict[str, Any]`` per ``config_hash``. Located via
-``manifest.json`` when present (keyed on full hash), with an 8-char
+Source of config kwargs: the ``provenance`` section of each per-experiment
+``config.json`` sidecar, flattened into ``dict[str, Any]`` per ``config_hash``.
+Located via ``manifest.json`` when present (keyed on full hash), with an 8-char
 prefix-scan fallback for manifest-less studies.
 """
 
@@ -42,7 +42,7 @@ from typing import Any, Literal
 import yaml
 
 from llenergymeasure.config.ssot import Engine
-from llenergymeasure.domain.bundle_artefacts import MANIFEST_FILENAME, RESOLUTION_FILENAME
+from llenergymeasure.domain.bundle_artefacts import CONFIG_SIDECAR_FILENAME, MANIFEST_FILENAME
 from llenergymeasure.study.runtime_observations import RUNTIME_OBSERVATIONS_FILENAME
 from llenergymeasure.utils.io import load_json
 
@@ -178,7 +178,7 @@ def find_runtime_gaps(
         sidecar_failures += study_failures
     if sidecar_failures:
         logger.warning(
-            "Skipped %d malformed _resolution.json sidecar(s); see prior WARNING log lines.",
+            "Skipped %d malformed config.json sidecar(s); see prior WARNING log lines.",
             sidecar_failures,
         )
 
@@ -364,7 +364,7 @@ def _load_kwargs_by_hash(study_dir: Path) -> tuple[dict[str, dict[str, Any]], in
     Preferred path: read ``manifest.json`` (written by
     :class:`llenergymeasure.study.manifest.ManifestWriter`) which keys
     entries by full ``config_hash`` and records the ``result_file``
-    relative path - ``_resolution.json`` sits in the same directory.
+    relative path - ``config.json`` sits in the same directory.
 
     Fallback path: scan experiment subdirs and key on the 8-char hex
     suffix. Logged as a warning so operators know the preferred lookup
@@ -402,10 +402,10 @@ def _load_kwargs_via_manifest(
         if config_hash in by_hash:
             # Same config can repeat across cycles; one flat dict suffices.
             continue
-        resolution_path = study_dir / Path(result_file).parent / RESOLUTION_FILENAME
-        if not resolution_path.exists():
+        config_path = study_dir / Path(result_file).parent / CONFIG_SIDECAR_FILENAME
+        if not config_path.exists():
             continue
-        flat, failed = _read_resolution_sidecar(resolution_path)
+        flat, failed = _read_provenance_sidecar(config_path)
         if failed:
             failures += 1
             continue
@@ -432,10 +432,10 @@ def _load_kwargs_via_prefix_scan(
             c in "0123456789abcdef" for c in hash_prefix
         ):
             continue
-        resolution_path = entry / RESOLUTION_FILENAME
-        if not resolution_path.exists():
+        config_path = entry / CONFIG_SIDECAR_FILENAME
+        if not config_path.exists():
             continue
-        flat, failed = _read_resolution_sidecar(resolution_path)
+        flat, failed = _read_provenance_sidecar(config_path)
         if failed:
             failures += 1
             continue
@@ -444,20 +444,24 @@ def _load_kwargs_via_prefix_scan(
     return _PrefixHashLookup(by_prefix), failures
 
 
-def _read_resolution_sidecar(
+def _read_provenance_sidecar(
     path: Path,
 ) -> tuple[dict[str, Any] | None, bool]:
-    """Parse ``_resolution.json`` at ``path``; return (flat_dict or None, failed)."""
+    """Parse ``config.json`` at ``path``; return (flat_kwargs or None, failed).
+
+    Reads the ``provenance`` section (per-field ``{source, effective, default}``
+    entries) and flattens it to ``{dotted_path: effective_value}``.
+    """
     try:
         payload = load_json(path)
     except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("Failed to parse _resolution.json at %s: %s", path, exc)
+        logger.warning("Failed to parse config.json at %s: %s", path, exc)
         return None, True
-    overrides = payload.get("overrides") or {}
-    if not isinstance(overrides, dict):
+    provenance = payload.get("provenance") or {}
+    if not isinstance(provenance, dict):
         return None, False
     flat: dict[str, Any] = {}
-    for key, value in overrides.items():
+    for key, value in provenance.items():
         if isinstance(value, dict) and "effective" in value:
             flat[str(key)] = value["effective"]
     return flat, False

--- a/src/llenergymeasure/config/README.md
+++ b/src/llenergymeasure/config/README.md
@@ -76,17 +76,20 @@ These CLI flags **still work** but emit deprecation warnings:
 
 ### Override Tracking
 
-All CLI overrides are recorded in the per-experiment `_resolution.json` sidecar for
-traceability (which fields were overridden and why):
+All overrides are recorded in the `provenance` section of the per-experiment
+`config.json` sidecar for traceability (which fields were overridden, and why -
+CLI flag vs YAML vs sweep):
 
 ```json
 {
-  "batching.batch_size": { "original": 1, "new": 8, "source": "cli" }
+  "provenance": {
+    "batching.batch_size": { "effective": 8, "source": "cli_flag", "default": 1 }
+  }
 }
 ```
 
-The fully resolved configuration (all defaults filled in) is written to the
-`effective_config.json` sidecar next to `result.json`.
+The same `config.json` sidecar also carries the observed engine/sampling params
+and the config hashes next to `result.json`.
 
 ### Workflow Examples
 
@@ -699,16 +702,19 @@ lem config new -o my-config.yaml  # Specify output path
 
 Each experiment directory ships sidecars for full reproducibility next to `result.json`:
 
-- `effective_config.json` - the fully resolved configuration (every parameter value used,
-  including engine defaults that were not explicitly specified).
-- `_resolution.json` - which fields were overridden and why (CLI flag, sweep, YAML).
+- `config.json` - the resolved-config sidecar. Its `provenance` section records which
+  fields were overridden and why (CLI flag, sweep, YAML), alongside the observed
+  engine/sampling params and config hashes.
+- `environment.json` - the hardware/runtime environment snapshot.
 
 ```json
-// effective_config.json
+// config.json (excerpt)
 {
-  "model_name": "meta-llama/Llama-2-7b-hf",
-  "batch_size": 8,
-  "dtype": "float16"
+  "schema_version": "2.0",
+  "provenance": {
+    "task.model": { "effective": "meta-llama/Llama-2-7b-hf", "source": "yaml" },
+    "batching.batch_size": { "effective": 8, "source": "cli_flag", "default": 1 }
+  }
 }
 ```
 

--- a/src/llenergymeasure/config/resolution.py
+++ b/src/llenergymeasure/config/resolution.py
@@ -1,13 +1,14 @@
 """Config resolution log - tracks provenance of each non-default experiment field.
 
-Produces a per-experiment ``_resolution.json`` sidecar that records which config
-values were overridden relative to Pydantic defaults, and *why* (CLI flag, sweep
-expansion, or YAML file).
+Records which config values were overridden relative to Pydantic defaults, and
+*why* (CLI flag, sweep expansion, or YAML file). The result is folded into the
+per-experiment ``config.json`` sidecar as its ``provenance`` section (there is no
+standalone ``_resolution.json`` file).
 
 Usage::
 
     log = build_resolution_log(config, cli_overrides={"dtype": "float16"}, swept_fields={"model"})
-    # -> {"schema_version": "1.0", "overrides": {"dtype": {...}, "model": {...}}}
+    # -> {"dtype": {"effective": "float16", "source": "cli_flag", "default": ...}, "model": {...}}
 """
 
 from __future__ import annotations
@@ -40,7 +41,10 @@ def build_resolution_log(
         swept_fields: Dotted field paths that vary across experiments (from get_swept_field_paths).
 
     Returns:
-        Resolution log dict with ``schema_version`` and ``overrides``.
+        Provenance map keyed by dotted field path: ``{path: {"effective": value,
+        "source": ..., "default": ...}}`` (``default`` present only when the
+        field has a Pydantic default). Consumed as the ``config.json``
+        ``provenance`` section.
     """
     from llenergymeasure.config.models import ExperimentConfig
 
@@ -73,7 +77,7 @@ def build_resolution_log(
 
         overrides[key] = entry
 
-    return {"schema_version": "1.0", "overrides": overrides}
+    return overrides
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/domain/bundle_artefacts.py
+++ b/src/llenergymeasure/domain/bundle_artefacts.py
@@ -20,7 +20,6 @@ STUDY_ARTEFACTS_DIR = "_study-artefacts"
 RESULT_FILENAME = "result.json"
 CONFIG_SIDECAR_FILENAME = "config.json"
 ENVIRONMENT_FILENAME = "environment.json"
-RESOLUTION_FILENAME = "_resolution.json"
 TIMESERIES_FILENAME = "timeseries.parquet"
 
 # Study-level bundle files.

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -57,7 +57,7 @@ from llenergymeasure.config.ssot import (
     TIMEOUT_THREAD_JOIN,
     Engine,
 )
-from llenergymeasure.domain.bundle_artefacts import TIMESERIES_FILENAME
+from llenergymeasure.domain.bundle_artefacts import CONFIG_SIDECAR_FILENAME, TIMESERIES_FILENAME
 from llenergymeasure.infra.docker_errors import (
     DockerContainerError,
     DockerStdoutSilenceError,
@@ -394,11 +394,12 @@ class DockerRunner:
             progress: Optional ProgressCallback for step-by-step progress reporting.
 
         Returns:
-            Tuple of (result, ts_tmpdir):
+            Tuple of (result, artefact_tmpdir):
             - result: ExperimentResult on success, or a dict error payload if the
               container wrote an error JSON.
-            - ts_tmpdir: Path to temp dir containing rescued timeseries.parquet,
-              or None. Caller is responsible for cleanup.
+            - artefact_tmpdir: Path to temp dir containing the rescued artefacts
+              (config.json plus timeseries.parquet when it was written), or None
+              when neither was present. Caller is responsible for cleanup.
 
         Raises:
             DockerTimeoutError:    Container exceeded ``self.timeout`` seconds.
@@ -530,15 +531,22 @@ class DockerRunner:
             # --- Read result ---
             result = self._read_result(exchange_dir, config_hash)
 
-            # --- Rescue timeseries parquet before cleanup ---
-            # The harness inside the container wrote timeseries.parquet to
-            # /run/llem (= exchange_dir on host). Move it to a temp dir so
-            # the caller can copy it into the study directory.
-            ts_parquet = exchange_dir / TIMESERIES_FILENAME
-            ts_tmpdir: Path | None = None
-            if ts_parquet.exists() and not isinstance(result, dict):
-                ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
-                shutil.move(str(ts_parquet), str(ts_tmpdir / TIMESERIES_FILENAME))
+            # --- Rescue artefacts before cleanup ---
+            # The harness inside the container wrote its artefacts to /run/llem
+            # (= exchange_dir on host): config.json always (the sole home of
+            # provenance + engine/model/methodology identity) and
+            # timeseries.parquet when enabled. Move them to a temp dir so the
+            # caller can copy them into the study directory before the exchange
+            # dir is destroyed below. config.json must survive too - otherwise a
+            # successful docker run lands a result.json with no provenance.
+            artefact_tmpdir: Path | None = None
+            if not isinstance(result, dict):
+                for _name in (CONFIG_SIDECAR_FILENAME, TIMESERIES_FILENAME):
+                    _src = exchange_dir / _name
+                    if _src.exists():
+                        if artefact_tmpdir is None:
+                            artefact_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
+                        shutil.move(str(_src), str(artefact_tmpdir / _name))
 
             # --- Success: clean up ---
             self._cleanup_exchange_dir(exchange_dir)
@@ -548,7 +556,7 @@ class DockerRunner:
             if isinstance(result, dict):
                 return result, None
 
-            return result, ts_tmpdir
+            return result, artefact_tmpdir
 
         finally:
             # Exchange dir is set to None when we've handed off or already cleaned up.

--- a/src/llenergymeasure/results/README.md
+++ b/src/llenergymeasure/results/README.md
@@ -26,9 +26,9 @@ collision-free before writing.
 {output_dir}/
   [{index}_]c{cycle}_{model}-{engine}_{hash}/
     result.json          # ExperimentResult, pydantic model_dump_json (the only typed dump)
-    config.json          # resolved-config sidecar (save_config_sidecar)
+    config.json          # resolved-config sidecar (save_config_sidecar); its
+                         # provenance section records per-field override sources
     environment.json     # environment snapshot (save_environment)
-    _resolution.json     # per-field resolution log (written when provided)
     timeseries.parquet   # GPU power/thermal/memory series (copied in when present)
 ```
 

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING
 from llenergymeasure.domain.bundle_artefacts import (
     CONFIG_SIDECAR_FILENAME,
     ENVIRONMENT_FILENAME,
-    RESOLUTION_FILENAME,
     RESULT_FILENAME,
     TIMESERIES_FILENAME,
 )
@@ -29,6 +28,11 @@ if TYPE_CHECKING:
     from llenergymeasure.domain.experiment import ExperimentResult
 
 logger = logging.getLogger(__name__)
+
+# Schema version for the config.json sidecar. Independent of result.json's own
+# schema_version; "2.0" succeeds the retired _resolution.json sidecar ("1.0"),
+# whose per-field provenance now lives in this file's ``provenance`` section.
+CONFIG_SIDECAR_SCHEMA_VERSION = "2.0"
 
 
 def _experiment_dir_name(
@@ -138,12 +142,24 @@ def save_config_sidecar(
       declared configs to find fields whose variation left the engine-effective
       state identical.
 
+    Two further fields are patched into this sidecar later by the study layer
+    (``llenergymeasure.study.runner._save_and_record``) rather than written
+    here, because both need study-level context the harness subprocess lacks:
+
+    - ``resolved_config_hash`` - carried forward from sweep expansion.
+    - ``provenance`` - the per-field resolution log (``{source, effective,
+      default}`` per non-default field) built by
+      :func:`llenergymeasure.config.resolution.build_resolution_log`, whose
+      ``cli_flag``/``sweep``/``yaml`` source labels are only known in the
+      parent process. This replaces the retired ``_resolution.json`` sidecar.
+
     Any missing optional field is omitted from the sidecar (not written as
     null) so downstream consumers distinguish "not available" from
     "explicitly null". The file is small (< 4 KB typical) and atomically
     written.
     """
     payload: dict[str, object] = {
+        "schema_version": CONFIG_SIDECAR_SCHEMA_VERSION,
         "experiment_id": experiment_id,
         "measurement_config_hash": config_hash,
         "engine": engine,
@@ -211,13 +227,14 @@ def save_result(
     timeseries_source: Path | None = None,
     experiment_index: int | None = None,
     cycle: int = 1,
-    resolution_log: dict[str, object] | None = None,
 ) -> Path:
     """Save ExperimentResult to a collision-safe subdirectory of output_dir.
 
     Creates: ``{output_dir}/[{index}_]c{cycle}_{model}-{engine}_{hash}/result.json``
-    Also writes ``_resolution.json`` sidecar when ``resolution_log`` is provided.
     If timeseries_source provided: copies to ``{dir}/timeseries.parquet``.
+
+    Per-field config provenance is no longer written here. It is folded into the
+    ``config.json`` sidecar's ``provenance`` section by the study layer.
 
     Args:
         result: The experiment result to persist.
@@ -226,8 +243,6 @@ def save_result(
         experiment_index: Optional 1-based experiment index for directory prefix
             (used in study context for natural sort ordering).
         cycle: Cycle number (1-based). Embedded in directory name.
-        resolution_log: Per-experiment config resolution log showing which fields
-            were overridden and why (CLI flag, sweep, YAML).
 
     Returns:
         Path to the result.json file (usable with load_result() directly).
@@ -242,12 +257,6 @@ def save_result(
     result_path = target_dir / RESULT_FILENAME
     _atomic_write(result.model_dump_json(indent=2), result_path)
     logger.debug("Saved result to %s", result_path)
-
-    # Write _resolution.json sidecar
-    if resolution_log:
-        res_path = target_dir / RESOLUTION_FILENAME
-        _atomic_write(json.dumps(resolution_log, indent=2, default=str), res_path)
-        logger.debug("Saved resolution log to %s", res_path)
 
     if timeseries_source is not None:
         timeseries_source = Path(timeseries_source)

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -58,6 +58,7 @@ class EquivalenceGroups:
     """Top-level equivalence-groups record written as ``equivalence_groups.json``."""
 
     study_id: str
+    study_name: str
     dedup_mode: Literal["resolved", "off"]
     validated_rules_version: str = ""
     groups: list[PreRunGroup] = field(default_factory=list)
@@ -124,6 +125,7 @@ def write_equivalence_groups(groups: EquivalenceGroups, path: Path) -> None:
     """
     payload = {
         "study_id": groups.study_id,
+        "study_name": groups.study_name,
         "dedup_mode": groups.dedup_mode,
         "validated_rules_version": groups.validated_rules_version,
         "groups": [asdict(g) for g in groups.groups],

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -138,7 +138,8 @@ def _save_and_record(
     Args:
         ts_source_dir: Directory where the harness wrote timeseries.parquet.
         environment_snapshot: EnvironmentSnapshot for per-experiment environment.json sidecar.
-        resolution_log: Pre-built resolution log for this experiment (written as _resolution.json).
+        resolution_log: Pre-built per-field resolution log for this experiment,
+            folded into the config.json sidecar's ``provenance`` section.
         runner_provenance: How the experiment was executed (local vs docker). Attached to the
             frozen result via model_copy before saving so it persists into result.json.
 
@@ -169,7 +170,6 @@ def _save_and_record(
             timeseries_source=ts_source,
             experiment_index=experiment_index,
             cycle=cycle,
-            resolution_log=resolution_log,
         )
 
         # Write per-experiment environment.json sidecar
@@ -182,8 +182,10 @@ def _save_and_record(
             )
 
         # Move config.json sidecar (written by harness to temp dir) to experiment dir.
-        # Also patch in the resolved_config_hash from StudyConfig, which the harness
-        # doesn't have access to at write time.
+        # Patch in two fields the harness subprocess cannot compute: the
+        # resolved_config_hash from StudyConfig, and the per-field provenance
+        # (source + effective + default) from the pre-built resolution log. The
+        # provenance section replaces the retired _resolution.json sidecar.
         if ts_source_dir is not None:
             config_sidecar_src = ts_source_dir / CONFIG_SIDECAR_FILENAME
             if config_sidecar_src.exists():
@@ -191,6 +193,8 @@ def _save_and_record(
                     _payload = load_json(config_sidecar_src)
                     if resolved_config_hash is not None:
                         _payload["resolved_config_hash"] = resolved_config_hash
+                    if resolution_log:
+                        _payload["provenance"] = resolution_log
                     from llenergymeasure.results.persistence import _atomic_write
 
                     _atomic_write(
@@ -264,7 +268,8 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         self._no_lock = no_lock
         # Set of (config_hash, cycle) pairs to skip (resume mode)
         self._skip_set: set[tuple[str, int]] = skip_set or set()
-        # Pre-built resolution logs keyed by config_hash (written as _resolution.json sidecar)
+        # Pre-built resolution logs keyed by config_hash (folded into the
+        # config.json sidecar's provenance section by _save_and_record).
         self._resolution_logs: dict[str, dict[str, Any]] = resolution_logs or {}
         # Declared-config-hash → resolved-config-hash mapping.
         # Built from study.experiments (post-dedup unique configs) so _save_and_record
@@ -593,6 +598,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
 
             study = self.study
             study_id = study.study_design_hash or "unknown"
+            study_name = study.study_name or "unnamed-study"
             raw_mode = getattr(study, "dedup_mode", "off")
             dedup_mode: Literal["resolved", "off"] = "resolved" if raw_mode == "resolved" else "off"
 
@@ -623,6 +629,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
 
             groups = EquivalenceGroups(
                 study_id=study_id,
+                study_name=study_name,
                 dedup_mode=dedup_mode,
                 groups=pre_run_groups,
                 observed_collision_groups=post_run_groups,

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -206,6 +206,19 @@ def _save_and_record(
                 finally:
                     config_sidecar_src.unlink(missing_ok=True)
 
+        # Loudness backstop: config.json is the sole home of provenance and
+        # engine/model/methodology identity. A completed experiment that lands
+        # without one is silent data loss - warn (never fail) so the gap is
+        # visible rather than discovered later at analysis time.
+        if not (result_path.parent / CONFIG_SIDECAR_FILENAME).exists():
+            logger.warning(
+                "No config.json materialised for %s (cycle %d) at %s - provenance "
+                "and engine/model identity are missing from this result.",
+                config_hash,
+                cycle,
+                result_path.parent,
+            )
+
         # Clean up the stale flat parquet file after it has been copied into the
         # experiment subdirectory (mirrors cli/run.py line 288).
         if ts_source is not None:
@@ -759,11 +772,15 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
 
         exp_start = time.monotonic()
 
-        # Create a temp dir for timeseries parquet output. The harness receives
-        # output_dir as a runtime param (not from config). The temp dir is
-        # cleaned up after _handle_result copies the parquet into the study directory.
+        # Create a temp dir for harness artefacts. The harness receives it as
+        # output_dir (a runtime param, not from config) and writes config.json
+        # there always, plus timeseries.parquet when save_timeseries is on. The
+        # staging dir is created regardless of save_timeseries so the config.json
+        # sidecar - the sole home of provenance/identity - always materialises;
+        # it is cleaned up after _handle_result copies the artefacts into the
+        # study directory.
         save_ts = self.study.output.save_timeseries
-        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES)) if save_ts else None
+        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
 
         # Resolve cached snapshot in parent - serialised to subprocess via Pipe
         snapshot = self._get_env_snapshot()
@@ -778,7 +795,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
             target=_run_experiment_worker,
             args=(config, child_conn, progress_queue, snapshot),
             kwargs={
-                "output_dir": str(ts_tmpdir) if ts_tmpdir else None,
+                "output_dir": str(ts_tmpdir),
                 "save_timeseries": save_ts,
                 "baseline": baseline,
                 "study_dir": str(self.study_dir),

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -71,7 +71,9 @@ def run_single_experiment(
     manifest.mark_running(config_hash, cycle)
 
     save_ts = study.output.save_timeseries
-    ts_tmpdir: Path | None = None  # Only set for local path
+    # Artefact staging dir. Local path always creates one (below); docker path
+    # inherits the DockerRunner rescue dir, which may be None.
+    ts_tmpdir: Path | None = None
 
     if spec is not None and spec.mode == RUNNER_DOCKER:
         # Docker path: dispatch to container directly (no subprocess)
@@ -116,8 +118,10 @@ def run_single_experiment(
         from llenergymeasure.harness.preflight import run_preflight
         from llenergymeasure.study.runtime_observations import capture_runtime_observations
 
-        # Create temp dir for timeseries parquet (if enabled)
-        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES)) if save_ts else None
+        # Staging dir for harness artefacts. The harness writes config.json here
+        # always (the sole home of provenance/identity) and timeseries.parquet
+        # when save_timeseries is on, so the dir is created regardless of save_ts.
+        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
 
         # Wrap the in-process body (preflight -> engine import -> harness.run) in
         # capture_runtime_observations so single-experiment studies emit
@@ -148,7 +152,7 @@ def run_single_experiment(
                     snapshot=snapshot,
                     gpu_indices=gpu_indices,
                     progress=progress,
-                    output_dir=str(ts_tmpdir) if ts_tmpdir else None,
+                    output_dir=str(ts_tmpdir),
                     save_timeseries=save_ts,
                 )
         except Exception:

--- a/tests/helpers/runtime_obs.py
+++ b/tests/helpers/runtime_obs.py
@@ -32,19 +32,24 @@ def write_resolution(
     full_hash: str,
     overrides: dict[str, Any],
 ) -> Path:
-    """Create the experiment subdir + ``_resolution.json`` sidecar.
+    """Create the experiment subdir + ``config.json`` sidecar with provenance.
 
-    Returns the experiment subdirectory path so callers can write a
-    matching ``manifest.json`` entry pointing at it.
+    The per-field resolution log now lives in the ``config.json`` sidecar's
+    ``provenance`` section (the standalone ``_resolution.json`` was retired).
+    Returns the experiment subdirectory path so callers can write a matching
+    ``manifest.json`` entry pointing at it.
     """
     dir_name = f"{index:03d}_c{cycle}_gpt2-{engine}_{full_hash[:8]}"
     subdir = study_dir / dir_name
     subdir.mkdir(parents=True, exist_ok=True)
     payload = {
-        "schema_version": "1.0",
-        "overrides": {k: {"effective": v, "source": "sweep"} for k, v in overrides.items()},
+        "schema_version": "2.0",
+        "experiment_id": f"exp-{full_hash[:8]}",
+        "measurement_config_hash": full_hash,
+        "engine": engine,
+        "provenance": {k: {"effective": v, "source": "sweep"} for k, v in overrides.items()},
     }
-    (subdir / "_resolution.json").write_text(json.dumps(payload))
+    (subdir / "config.json").write_text(json.dumps(payload))
     return subdir
 
 

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -1643,3 +1643,173 @@ class TestNcclEnvForwarding:
         cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
 
         assert not any(arg.startswith("NCCL_P2P_DISABLE") for arg in cmd)
+
+
+# ---------------------------------------------------------------------------
+# Test: config.json sidecar rescue before exchange dir cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSidecarRescue:
+    """DockerRunner must rescue config.json from the exchange dir before cleanup.
+
+    config.json is the sole home of provenance and engine/model/methodology
+    identity. The harness inside the container writes it to /run/llem
+    (= exchange_dir on host) on every successful run, independent of
+    save_timeseries. Previously only timeseries.parquet was rescued, so
+    _cleanup_exchange_dir destroyed config.json and a successful docker run
+    landed a result.json with no provenance.
+    """
+
+    def test_config_sidecar_rescued_when_no_timeseries(self, tmp_path):
+        """config.json is rescued even when no timeseries.parquet was written."""
+        config = make_config()
+        result = make_result()
+
+        exchange_dir = tmp_path / "llem-cfg-exchange"
+        exchange_dir.mkdir()
+        rescue_dir = tmp_path / "llem-cfg-rescued"
+        rescue_dir.mkdir()
+
+        # mkdtemp: 1st = exchange dir, 2nd = artefact rescue dir (created lazily
+        # when the first artefact - config.json - is found).
+        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
+
+        with (
+            patch(
+                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                side_effect=lambda **kw: next(mkdtemp_returns),
+            ),
+            patch(
+                "llenergymeasure.infra.docker_runner.subprocess.run",
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
+            ),
+            patch("llenergymeasure.infra.docker_runner.shutil.rmtree") as mock_rmtree,
+        ):
+            config_hash = _docker_config_hash(config)
+            (exchange_dir / f"{config_hash}_result.json").write_text(
+                result.model_dump_json(), encoding="utf-8"
+            )
+            # Container wrote config.json but no timeseries.parquet.
+            (exchange_dir / "config.json").write_text(
+                json.dumps({"schema_version": "2.0", "engine": "transformers"}),
+                encoding="utf-8",
+            )
+
+            runner = DockerRunner(image=IMAGE)
+            _returned, artefact_dir = runner.run(config)
+
+        assert artefact_dir == rescue_dir
+        assert (rescue_dir / "config.json").exists(), (
+            "config.json must be rescued from the exchange dir before cleanup"
+        )
+        # Exchange dir must still be cleaned up on success.
+        mock_rmtree.assert_called_once()
+
+    def test_config_and_timeseries_both_rescued(self, tmp_path):
+        """Both config.json and timeseries.parquet land in the single rescue dir."""
+        config = make_config()
+        result = make_result(timeseries="timeseries.parquet")
+
+        exchange_dir = tmp_path / "llem-both-exchange"
+        exchange_dir.mkdir()
+        rescue_dir = tmp_path / "llem-both-rescued"
+        rescue_dir.mkdir()
+
+        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
+
+        with (
+            patch(
+                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                side_effect=lambda **kw: next(mkdtemp_returns),
+            ),
+            patch(
+                "llenergymeasure.infra.docker_runner.subprocess.run",
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
+            ),
+            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+        ):
+            config_hash = _docker_config_hash(config)
+            (exchange_dir / f"{config_hash}_result.json").write_text(
+                result.model_dump_json(), encoding="utf-8"
+            )
+            (exchange_dir / "config.json").write_text(
+                json.dumps({"schema_version": "2.0"}), encoding="utf-8"
+            )
+            (exchange_dir / "timeseries.parquet").write_bytes(b"PARQUET_CONTENT")
+
+            runner = DockerRunner(image=IMAGE)
+            _returned, artefact_dir = runner.run(config)
+
+        assert artefact_dir == rescue_dir
+        assert (rescue_dir / "config.json").exists()
+        assert (rescue_dir / "timeseries.parquet").read_bytes() == b"PARQUET_CONTENT"
+
+    def test_config_sidecar_lands_in_experiment_dir_with_provenance(self, tmp_path):
+        """End-to-end: a successful docker run lands config.json (with provenance)
+        in the experiment dir.
+
+        Exercises the real DockerRunner rescue feeding the real _save_and_record
+        move - the two halves that together close the docker provenance hole.
+        """
+        from unittest.mock import MagicMock
+
+        from llenergymeasure.study.runner import _save_and_record
+
+        config = make_config()
+        result = make_result()
+
+        exchange_dir = tmp_path / "llem-e2e-exchange"
+        exchange_dir.mkdir()
+        rescue_dir = tmp_path / "llem-e2e-rescued"
+        rescue_dir.mkdir()
+        study_dir = tmp_path / "study"
+        study_dir.mkdir()
+
+        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
+
+        with (
+            patch(
+                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                side_effect=lambda **kw: next(mkdtemp_returns),
+            ),
+            patch(
+                "llenergymeasure.infra.docker_runner.subprocess.run",
+                side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
+            ),
+            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+        ):
+            config_hash = _docker_config_hash(config)
+            (exchange_dir / f"{config_hash}_result.json").write_text(
+                result.model_dump_json(), encoding="utf-8"
+            )
+            (exchange_dir / "config.json").write_text(
+                json.dumps({"schema_version": "2.0", "engine": "transformers"}),
+                encoding="utf-8",
+            )
+
+            runner = DockerRunner(image=IMAGE)
+            returned, artefact_dir = runner.run(config)
+
+        # Feed the rescued dir to _save_and_record exactly as the study runner does.
+        resolution_log = {"task.model": {"effective": "gpt2", "source": "yaml"}}
+        manifest = MagicMock()
+        result_files: list[str] = []
+        _save_and_record(
+            returned,
+            study_dir,
+            manifest,
+            config_hash,
+            1,
+            result_files,
+            ts_source_dir=artefact_dir,
+            resolution_log=resolution_log,
+        )
+
+        assert len(result_files) == 1
+        dest_config = Path(result_files[0]).parent / "config.json"
+        assert dest_config.exists(), "config.json must land in the experiment dir"
+        payload = json.loads(dest_config.read_text())
+        assert payload["provenance"] == resolution_log, (
+            "provenance must be folded into the materialised config.json"
+        )

--- a/tests/unit/study/test_equivalence_groups.py
+++ b/tests/unit/study/test_equivalence_groups.py
@@ -18,6 +18,7 @@ class TestWriteSerialisation:
     def test_write_emits_all_fields(self, tmp_path: Path):
         groups = EquivalenceGroups(
             study_id="study_abc",
+            study_name="gpt2-sweep",
             dedup_mode="resolved",
             validated_rules_version="transformers:4.56.0@deadbee",
             groups=[
@@ -47,6 +48,7 @@ class TestWriteSerialisation:
         loaded = json.loads(path.read_text())
 
         assert loaded["study_id"] == "study_abc"
+        assert loaded["study_name"] == "gpt2-sweep"
         assert loaded["dedup_mode"] == "resolved"
         assert loaded["validated_rules_version"].startswith("transformers:")
         assert len(loaded["groups"]) == 1

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -219,6 +219,67 @@ def test_save_and_record_writes_resolved_config_hash(tmp_path: Path) -> None:
     assert not config_sidecar_src.exists()
 
 
+def test_save_and_record_folds_provenance_into_config(tmp_path: Path) -> None:
+    """A resolution_log is folded into config.json as its provenance section.
+
+    The retired _resolution.json sidecar must not be written; the per-field
+    provenance now rides in the config.json sidecar the harness produced.
+    """
+    import json
+
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+
+    # Minimal config.json in the ts_source_dir (simulates harness output).
+    config_sidecar_src = tmp_path / "config.json"
+    config_sidecar_src.write_text(
+        json.dumps(
+            {
+                "schema_version": "2.0",
+                "experiment_id": "test-prov-001",
+                "measurement_config_hash": "aabb1122ccdd3344",
+                "engine": "transformers",
+                "library_version": "4.50.0",
+            }
+        )
+    )
+
+    resolution_log = {
+        "task.model": {"effective": "gpt2", "source": "yaml"},
+        "batching.batch_size": {"effective": 8, "source": "cli_flag", "default": 1},
+    }
+
+    result = _make_result(with_timeseries=False)
+    manifest = MagicMock()
+    result_files: list[str] = []
+
+    _save_and_record(
+        result,
+        study_dir,
+        manifest,
+        "aabb1122",
+        1,
+        result_files,
+        ts_source_dir=tmp_path,
+        resolution_log=resolution_log,
+    )
+
+    assert len(result_files) == 1
+    result_json_path = Path(result_files[0])
+    dest_config = result_json_path.parent / "config.json"
+    assert dest_config.exists(), "config.json sidecar must be moved to result dir"
+
+    payload = json.loads(dest_config.read_text())
+    assert payload.get("provenance") == resolution_log, (
+        "resolution_log must be folded into config.json as its provenance section"
+    )
+    # schema_version from the harness sidecar survives the fold.
+    assert payload["schema_version"] == "2.0"
+    # The retired standalone sidecar must not appear.
+    assert not (result_json_path.parent / "_resolution.json").exists()
+    assert not config_sidecar_src.exists()
+
+
 def test_provenance_from_spec_docker() -> None:
     """A docker RunnerSpec maps onto a docker RunnerProvenance."""
     spec = RunnerSpec(mode="docker", image="img:1.0", source="yaml", image_source="registry")

--- a/tests/unit/study/test_single.py
+++ b/tests/unit/study/test_single.py
@@ -190,3 +190,69 @@ def test_single_experiment_writes_runtime_observations(monkeypatch, tmp_path):
     record = json.loads(lines[0])
     assert record["config_hash"]
     assert record["outcome"] == "success"
+
+
+def test_config_sidecar_materialises_without_timeseries(monkeypatch, tmp_path):
+    """Regression: config.json + provenance still materialise when save_timeseries is off.
+
+    config.json is the sole home of provenance and engine/model/methodology
+    identity. Previously the runner passed output_dir=None to the harness when
+    save_timeseries was False, so the harness (which writes config.json only
+    when it has an output dir) wrote nothing and no provenance landed. The
+    staging dir is now created regardless of save_timeseries.
+    """
+    import json as _json
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    import llenergymeasure.engines as engines_module
+    import llenergymeasure.harness as harness_module
+    import llenergymeasure.harness.preflight as pf_module
+    from llenergymeasure.domain.experiment import compute_declared_config_hash
+    from llenergymeasure.study.manifest import ManifestWriter
+
+    mock_result = make_result(experiment_id="no-ts-config-test")
+    mock_engine = _MockBackend(mock_result)
+
+    captured_output_dirs: list[str | None] = []
+
+    def fake_run(self, engine, config, **kw):
+        # Mirror the real harness: write config.json whenever it has an output
+        # dir, independent of save_timeseries.
+        output_dir = kw.get("output_dir")
+        captured_output_dirs.append(output_dir)
+        if output_dir is not None:
+            (Path(output_dir) / "config.json").write_text(
+                _json.dumps({"schema_version": "2.0", "engine": "transformers"}),
+                encoding="utf-8",
+            )
+        return mock_result
+
+    monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
+    monkeypatch.setattr(engines_module, "get_engine", lambda name: mock_engine)
+    monkeypatch.setattr(harness_module.MeasurementHarness, "run", fake_run)
+    monkeypatch.setattr(
+        "llenergymeasure.study.gpu_memory.check_gpu_memory_residual", lambda *a, **k: None
+    )
+
+    mock_manifest = MagicMock(spec=ManifestWriter)
+    config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
+    study = StudyConfig(experiments=[config], output={"save_timeseries": False})
+    resolution_log = {"task.model": {"effective": "gpt2", "source": "yaml"}}
+    resolution_logs = {compute_declared_config_hash(config): resolution_log}
+
+    result_files, _results, _warnings = run_single_experiment(
+        study, mock_manifest, tmp_path, runner_specs=None, resolution_logs=resolution_logs
+    )
+
+    # save_timeseries is off, yet the harness still received a staging dir.
+    assert captured_output_dirs and captured_output_dirs[0] is not None, (
+        "harness must receive an output dir for the config.json sidecar even when "
+        "save_timeseries is off"
+    )
+    # config.json materialised in the experiment dir with provenance folded in.
+    assert len(result_files) == 1
+    dest_config = Path(result_files[0]).parent / "config.json"
+    assert dest_config.exists(), "config.json must materialise even without timeseries"
+    payload = _json.loads(dest_config.read_text())
+    assert payload["provenance"] == resolution_log

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -499,3 +499,36 @@ def test_save_config_sidecar_omits_declared_config_when_absent(tmp_path: Path) -
 
     payload = json.loads(path.read_text())
     assert "declared_config" not in payload
+
+
+def test_save_config_sidecar_includes_schema_version(tmp_path: Path) -> None:
+    """The config.json sidecar carries its own schema_version (independent of result.json)."""
+    import json
+
+    from llenergymeasure.results.persistence import (
+        CONFIG_SIDECAR_SCHEMA_VERSION,
+        save_config_sidecar,
+    )
+
+    path = save_config_sidecar(
+        tmp_path,
+        experiment_id="exp-1",
+        config_hash="a" * 16,
+        engine="vllm",
+        library_version="0.19.1",
+    )
+
+    payload = json.loads(path.read_text())
+    assert payload["schema_version"] == CONFIG_SIDECAR_SCHEMA_VERSION == "2.0"
+
+
+def test_save_result_does_not_write_resolution_sidecar(
+    minimal_result: ExperimentResult, tmp_path: Path
+) -> None:
+    """The retired _resolution.json sidecar is never written by save_result.
+
+    Per-field provenance now lives in the config.json sidecar's provenance
+    section, folded in by the study layer.
+    """
+    result_path = save_result(minimal_result, tmp_path)
+    assert not (result_path.parent / "_resolution.json").exists()


### PR DESCRIPTION
## Summary

First of three consolidation PRs finishing the results-bundle rationalisation. Scope here is the provenance fold (Change A) plus the equivalence-groups `study_name` (Change D). `ExperimentResult` fields, `result.json`'s schema_version (stays 4.0), and the timeseries parquet are untouched (follow-up PRs).

- **Retire the standalone `_resolution.json` sidecar.** Its per-field resolution log (`source` = cli_flag/sweep/yaml, `effective` value, and `default`) is folded into the per-experiment `config.json` sidecar under a new `provenance` section. It is patched in by the study layer (`_save_and_record`) alongside the existing `resolved_config_hash`, because the harness subprocess cannot compute the cli/sweep source labels (they are only known in the parent process).
- **`config.json` gains its own `schema_version` (`"2.0"`)**, independent of `result.json`'s 4.0. The value follows the design doc (successor to `_resolution.json`'s `"1.0"`).
- **`build_resolution_log()` now returns the flat provenance map directly** (the redundant `{schema_version, overrides}` wrapper is dropped, since `config.json` now owns the schema version).
- **`save_result()` no longer writes or accepts a `resolution_log`.**
- **`llem report-gaps`** now reads config kwargs from `config.json`'s `provenance` section instead of `_resolution.json`.
- **`equivalence_groups.json` records `study_name`** alongside `study_id`.

### Design vs code notes

- The design doc's idealized `provenance` shape omits `effective`, but the real `build_resolution_log()` emits it and `report-gaps` depends on it, so `effective` is kept in the persisted provenance entries.
- The instruction suggested extending `save_config_sidecar()` to accept and write the provenance dict, threaded via `_write_config_sidecar`. Because the harness subprocess cannot produce the cli/sweep source labels, provenance is instead patched into `config.json` by the parent (`_save_and_record`), mirroring the established `resolved_config_hash` pattern; `save_config_sidecar()` owns only the always-present `schema_version`. Same on-disk outcome, no dead parameter.

### Compatibility

Pre-1.0: no backfill shim. Bundles from older versions keep their `_resolution.json`, which is simply ignored (never read).

## Test plan

- `make lint` - pass (ruff check + format + import-linter)
- `make typecheck` - pass (mypy, 308 files)
- `make test` - 3029 passed, 35 skipped
- New/updated tests: config.json `schema_version` present; `save_result` writes no `_resolution.json`; `_save_and_record` folds the resolution log into config.json's `provenance` and writes no `_resolution.json`; `study_name` in `equivalence_groups.json`; report-gaps helper + both report-gaps suites migrated to config.json.