### PR TITLE
refactor(results): slim result.json to measurement-only (schema 5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   exchange dir alongside `timeseries.parquet`, and the local path always stages an output
   dir for the sidecar. If a completed experiment ends without a `config.json`, the runner
   logs a warning rather than dropping the provenance silently.
+- `result.json` schema bumped `4.0` -> `5.0` (breaking). `result.json` is now pure
+  measurement output: the configuration/methodology fields `engine`, `engine_version`,
+  `model_name`, `measurement_methodology`, `steady_state_window`,
+  `measurement_window_discard_fraction`, and `steady_state_not_detected` are removed from it
+  and live in the `config.json` sidecar as top-level fields. Engine identity is no longer
+  duplicated across the two files. In the sidecar, the engine's library version is now named
+  `engine_version` (was `library_version`); the config sidecar schema stays `2.0` because it
+  is still unreleased. Pre-1.0, old bundles are not migrated in place: they load as their own
+  `schema_version` and are unaffected on disk. Consumers read engine/model/methodology from
+  `config.json` (see the results-schema and `run_study` reference docs for the join pattern).
 
 ## [v0.11.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   is still unreleased. Pre-1.0, old bundles are not migrated in place: they load as their own
   `schema_version` and are unaffected on disk. Consumers read engine/model/methodology from
   `config.json` (see the results-schema and `run_study` reference docs for the join pattern).
+  Because engine/model identity now lives only in `config.json`, that sidecar is guaranteed
+  to materialise next to every `result.json` on all successful runs - including the docker
+  (multi-engine) path and runs with `save_timeseries` off - so the join never dangles.
 
 ## [v0.11.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,19 +29,21 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   exchange dir alongside `timeseries.parquet`, and the local path always stages an output
   dir for the sidecar. If a completed experiment ends without a `config.json`, the runner
   logs a warning rather than dropping the provenance silently.
-- `result.json` schema bumped `4.0` -> `5.0` (breaking). `result.json` is now pure
-  measurement output: the configuration/methodology fields `engine`, `engine_version`,
-  `model_name`, `measurement_methodology`, `steady_state_window`,
-  `measurement_window_discard_fraction`, and `steady_state_not_detected` are removed from it
-  and live in the `config.json` sidecar as top-level fields. Engine identity is no longer
-  duplicated across the two files. In the sidecar, the engine's library version is now named
-  `engine_version` (was `library_version`); the config sidecar schema stays `2.0` because it
-  is still unreleased. Pre-1.0, old bundles are not migrated in place: they load as their own
-  `schema_version` and are unaffected on disk. Consumers read engine/model/methodology from
-  `config.json` (see the results-schema and `run_study` reference docs for the join pattern).
-  Because engine/model identity now lives only in `config.json`, that sidecar is guaranteed
-  to materialise next to every `result.json` on all successful runs - including the docker
-  (multi-engine) path and runs with `save_timeseries` off - so the join never dangles.
+- `result.json` schema bumped `4.0` -> `5.0` (breaking). `result.json` is now measurement
+  output: the configuration/methodology fields `engine_version`, `measurement_methodology`,
+  `steady_state_window`, `measurement_window_discard_fraction`, and
+  `steady_state_not_detected` are removed from it and live in the `config.json` sidecar as
+  top-level fields. `result.json` keeps `model_name` and `engine` as convenience copies -
+  deliberate small duplication so a result file stays self-describing when separated from
+  its directory; the authoritative home for both is `config.json`. In the sidecar, the
+  engine's library version is now named `engine_version` (was `library_version`); the config
+  sidecar schema stays `2.0` because it is still unreleased. Pre-1.0, old bundles are not
+  migrated in place: they load as their own `schema_version` and are unaffected on disk.
+  Consumers read methodology and authoritative identity from `config.json` (see the
+  results-schema and `run_study` reference docs for the join pattern). The `config.json`
+  sidecar is guaranteed to materialise next to every `result.json` on all successful runs -
+  including the docker (multi-engine) path and runs with `save_timeseries` off - so the
+  join never dangles.
 
 ## [v0.11.0] - 2026-07-16
 

--- a/docs/explanation/methodology/energy-measurement.md
+++ b/docs/explanation/methodology/energy-measurement.md
@@ -232,13 +232,13 @@ measurement:
   fixed number of seconds) and measure the remainder. Setting `steady_state_auto_detect`
   enables a lightweight sliding-window stability test (coefficient-of-variation /
   variance-ratio) that finds the steady-state onset; on failure it falls back to the fixed
-  discard and sets the `steady_state_not_detected` flag in the result.
+  discard and sets the `steady_state_not_detected` flag in the `config.json` sidecar.
 
 For `windowed` and `steady_state`, energy is **re-integrated** by feeding the trapezoidal
 integrator only the power samples inside the window (after dropping zero / impossible
 samples and median-filtering transient NVML dropouts). The realised window, the
 methodology actually used, the discard fraction, and the `steady_state_not_detected` flag
-are recorded in the result for auditability.
+are recorded in the `config.json` sidecar for auditability.
 
 Tokens and throughput are attributed to the sub-window **proportionally by time**: the
 harness captures per-request and inter-token durations but not absolute per-token

--- a/docs/how-to/interpret-results.md
+++ b/docs/how-to/interpret-results.md
@@ -39,9 +39,11 @@ Result: gpt2_20260507_143208
 
 This is a unique identifier for this specific measurement. It encodes the
 model name and a UTC timestamp in `YYYYMMDD_HHMMSS` form. For full
-configuration provenance, see the `effective_config` block inside
-`result.json` - it records every setting that influenced the measurement,
-including engine choice, dtype, and engine defaults.
+configuration provenance, see the `config.json` sidecar next to
+`result.json` - its `declared_config` block records every setting that
+influenced the measurement (engine choice, dtype, and engine defaults), and
+its `provenance` block records where each non-default value came from (CLI
+flag, sweep, or YAML).
 
 ---
 
@@ -128,9 +130,8 @@ The full result is saved as a JSON file in the `results/` directory. Key fields:
 | `total_inference_time_sec` | Wall-clock inference time in seconds (same as "Duration"). |
 | `total_tokens` | Total tokens processed across all prompts. |
 | `total_flops` | Estimated total floating-point operations. |
-| `effective_config` | The exact configuration used (model, dtype, engine, etc.). |
 
-The `effective_config` section is particularly important for reproducibility - it records every setting that influenced the measurement, including defaults that were not explicitly specified.
+`result.json` is measurement-only (schema 5.0). The exact configuration used - model, dtype, engine, engine version, methodology, and every engine default - lives in the `config.json` sidecar next to it, under `declared_config` plus the top-level `engine` / `model_name` / `measurement_methodology` fields. That sidecar is the reproducibility record: it captures every setting that influenced the measurement, including defaults that were not explicitly specified.
 
 For the full schema, see [Reference: results schema](/reference/results-schema).
 
@@ -144,7 +145,7 @@ Raw numbers only make sense in context. Here is how to compare results fairly:
 
 **Match prompt counts and input lengths.** Output token counts (and therefore energy) vary with input length. Comparing a run with 100 short prompts against a run with 100 long prompts is not a like-for-like comparison.
 
-**Note the hardware.** A result from an A100 GPU is not directly comparable to a result from a consumer GPU. The result file records the GPU model in `effective_config`.
+**Note the hardware.** A result from an A100 GPU is not directly comparable to a result from a consumer GPU. The GPU model is recorded in the `environment.json` sidecar next to each `result.json`.
 
 **Check the dtype setting.** Running at `float16` (16-bit) typically uses less energy than `float32` (32-bit). Results should use the same dtype to be comparable.
 

--- a/docs/how-to/interpret-results.md
+++ b/docs/how-to/interpret-results.md
@@ -131,7 +131,7 @@ The full result is saved as a JSON file in the `results/` directory. Key fields:
 | `total_tokens` | Total tokens processed across all prompts. |
 | `total_flops` | Estimated total floating-point operations. |
 
-`result.json` is measurement-only (schema 5.0). The exact configuration used - model, dtype, engine, engine version, methodology, and every engine default - lives in the `config.json` sidecar next to it, under `declared_config` plus the top-level `engine` / `model_name` / `measurement_methodology` fields. That sidecar is the reproducibility record: it captures every setting that influenced the measurement, including defaults that were not explicitly specified.
+`result.json` is measurement output (schema 5.0), keeping only `model_name` and `engine` as convenience identity copies. The exact configuration used - model, dtype, engine, engine version, methodology, and every engine default - has its authoritative home in the `config.json` sidecar next to it, under `declared_config` plus the top-level `engine` / `model_name` / `measurement_methodology` fields. That sidecar is the reproducibility record: it captures every setting that influenced the measurement, including defaults that were not explicitly specified.
 
 For the full schema, see [Reference: results schema](/reference/results-schema).
 

--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -34,10 +34,12 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 | `experiment_id` | `str` | Unique identifier for this experiment run. |
 | `measurement_config_hash` | `str` | 16-char SHA-256 hex of the `ExperimentConfig` (environment fields excluded). Matches the hash in the result directory name on disk. |
 | `llenergymeasure_version` | `str \| None` | Package version that produced this result. |
+| `engine` | `str` | Inference engine used. Convenience copy; authoritative home is the `config.json` sidecar. |
+| `model_name` | `str` | Model name/path measured. Convenience copy; authoritative home is the `config.json` sidecar. |
 
 ### Engine, model, and methodology
 
-`ExperimentResult` is pure measurement output. Engine identity (`engine`, `engine_version`), `model_name`, and the measurement-methodology fields (`measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected`) are configuration inputs and live in the `config.json` sidecar next to `result.json`, not on this model.
+`ExperimentResult` is measurement output. `engine_version` and the measurement-methodology fields (`measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected`) are configuration inputs and live in the `config.json` sidecar next to `result.json`, not on this model. The model keeps `model_name` and `engine` as convenience copies so a result stays self-describing when separated from its directory; the authoritative home for both is `config.json`.
 
 ### Core metrics
 

--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -30,25 +30,14 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schema_version` | `str` | Result schema version (current: `"4.0"`). |
+| `schema_version` | `str` | Result schema version (current: `"5.0"`). |
 | `experiment_id` | `str` | Unique identifier for this experiment run. |
 | `measurement_config_hash` | `str` | 16-char SHA-256 hex of the `ExperimentConfig` (environment fields excluded). Matches the hash in the result directory name on disk. |
 | `llenergymeasure_version` | `str \| None` | Package version that produced this result. |
 
-### Engine and model
+### Engine, model, and methodology
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `engine` | `str` | Inference engine used: `"transformers"`, `"vllm"`, or `"tensorrt"`. |
-| `engine_version` | `str \| None` | Engine version string for reproducibility (e.g. `"4.47.0"` for Transformers). |
-| `model_name` | `str` | Model name or path used. |
-
-### Measurement methodology
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `measurement_methodology` | `"total" \| "steady_state" \| "windowed"` | What was measured: the full run, the steady-state window after warmup, or an explicit time window. |
-| `steady_state_window` | `tuple[float, float] \| None` | `(start_sec, end_sec)` relative to inference start. The single-process path sets `(0.0, inference_time_sec)`. `None` only when no inference window was recorded. |
+`ExperimentResult` is pure measurement output. Engine identity (`engine`, `engine_version`), `model_name`, and the measurement-methodology fields (`measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected`) are configuration inputs and live in the `config.json` sidecar next to `result.json`, not on this model.
 
 ### Core metrics
 

--- a/docs/reference/library/run_study.md
+++ b/docs/reference/library/run_study.md
@@ -30,13 +30,23 @@ file to its config hash.
 
 ## Simple usage
 
+Engine identity and model name live in the `config.json` sidecar next to each
+`result.json` (they are configuration inputs, not measurement output), so read
+them from disk via `result_files`:
+
 ```python
+import json
+from pathlib import Path
+
 from llenergymeasure import run_study
 
 study_result = run_study("study.yaml")
 
-for r in study_result.experiments:
-    print(f"{r.model_name} / {r.engine}: {r.mj_per_tok_total:.3f} mJ/tok")
+for result_file in study_result.result_files:
+    cell = Path(result_file).parent
+    result = json.loads((cell / "result.json").read_text())
+    config = json.loads((cell / "config.json").read_text())
+    print(f"{config['model_name']} / {config['engine']}: {result['mj_per_tok_total']:.3f} mJ/tok")
 ```
 
 `study.yaml` (minimal multi-experiment form):
@@ -127,20 +137,35 @@ Each item in `experiments` is an [`ExperimentResult`](./ExperimentResult). See
 
 ## Common patterns
 
+These patterns join each `result.json` with its `config.json` sidecar (which
+carries `engine` and `model_name`) via `result_files`.
+
 ### Filter results by engine
 
 ```python
-transformers_results = [r for r in study_result.experiments if r.engine == "transformers"]
+import json
+from pathlib import Path
+
+transformers_cells = [
+    Path(f).parent
+    for f in study_result.result_files
+    if json.loads((Path(f).parent / "config.json").read_text())["engine"] == "transformers"
+]
 ```
 
 ### Compare energy across models
 
 ```python
+import json
 import statistics
+from pathlib import Path
 
 by_model: dict[str, list[float]] = {}
-for r in study_result.experiments:
-    by_model.setdefault(r.model_name, []).append(r.mj_per_tok_total or 0.0)
+for result_file in study_result.result_files:
+    cell = Path(result_file).parent
+    result = json.loads((cell / "result.json").read_text())
+    config = json.loads((cell / "config.json").read_text())
+    by_model.setdefault(config["model_name"], []).append(result["mj_per_tok_total"] or 0.0)
 
 for model, values in by_model.items():
     print(f"{model}: mean {statistics.mean(values):.3f} mJ/tok (n={len(values)})")
@@ -153,16 +178,20 @@ import json
 from pathlib import Path
 import pandas as pd
 
-rows = [
-    {
-        "model": r.model_name,
-        "engine": r.engine,
-        "energy_j": r.total_energy_j,
-        "throughput": r.avg_tokens_per_second,
-        "mj_per_tok": r.mj_per_tok_total,
-    }
-    for r in study_result.experiments
-]
+rows = []
+for result_file in study_result.result_files:
+    cell = Path(result_file).parent
+    result = json.loads((cell / "result.json").read_text())
+    config = json.loads((cell / "config.json").read_text())
+    rows.append(
+        {
+            "model": config["model_name"],
+            "engine": config["engine"],
+            "energy_j": result["total_energy_j"],
+            "throughput": result["avg_tokens_per_second"],
+            "mj_per_tok": result["mj_per_tok_total"],
+        }
+    )
 df = pd.DataFrame(rows)
 ```
 

--- a/docs/reference/library/run_study.md
+++ b/docs/reference/library/run_study.md
@@ -30,9 +30,10 @@ file to its config hash.
 
 ## Simple usage
 
-Engine identity and model name live in the `config.json` sidecar next to each
-`result.json` (they are configuration inputs, not measurement output), so read
-them from disk via `result_files`:
+The authoritative home for engine identity and model name is the `config.json`
+sidecar next to each `result.json` (they are configuration inputs; `result.json`
+keeps `engine` and `model_name` as convenience copies only), so analysis code
+reads them from disk via `result_files`:
 
 ```python
 import json
@@ -137,8 +138,8 @@ Each item in `experiments` is an [`ExperimentResult`](./ExperimentResult). See
 
 ## Common patterns
 
-These patterns join each `result.json` with its `config.json` sidecar (which
-carries `engine` and `model_name`) via `result_files`.
+These patterns join each `result.json` with its `config.json` sidecar (the
+authoritative home of `engine` and `model_name`) via `result_files`.
 
 ### Filter results by engine
 

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -32,25 +32,23 @@ results/
 
 ## `result.json` - per-experiment record
 
-The scientific record. One JSON file per experiment cell. Schema version `4.0`.
+The scientific record. One JSON file per experiment cell. Schema version `5.0`.
+
+`result.json` is pure measurement output. Configuration inputs and methodology - `engine`, `engine_version`, `model_name`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected` - live in the `config.json` sidecar, not here.
 
 ### Identification
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schema_version` | str | Result schema version (currently `"4.0"`) |
+| `schema_version` | str | Result schema version (currently `"5.0"`) |
 | `experiment_id` | str | Unique experiment identifier (`{model}_{YYYYMMDD_HHMMSS}` for single experiments; study-level cells inherit a richer per-cell identifier) |
 | `measurement_config_hash` | str | SHA-256[:16] of `ExperimentConfig` with environment fields excluded; same hash -> logically identical experiments |
 | `llenergymeasure_version` | str &#124; null | Package version that produced this result |
-| `engine` | str | Inference engine: `transformers` &#124; `vllm` &#124; `tensorrt` |
-| `engine_version` | str &#124; null | Engine library version (e.g. `4.57.0` for transformers) |
-| `model_name` | str | Model name or HuggingFace path used |
 
 ### Measurement methodology
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `measurement_methodology` | `"total"` &#124; `"steady_state"` &#124; `"windowed"` | Which slice of the run produced the headline metrics |
 | `warmup_excluded_samples` | int &#124; null | Number of warmup iterations run before the measurement window (from `warmup_result.iterations_completed`); `null` when no warmup result is available |
 | `model_load_time_sec` | float &#124; null | Wall-clock seconds spent in `engine.load_model()`: model load plus any engine build/compile performed there (e.g. the tensorrt trt backend's TRT engine build, vLLM torch.compile / CUDA-graph capture). Non-energy metadata: this phase completes before the energy measurement window opens and contributes nothing to `total_energy_j` |
 | `engine_build_cache_hit` | bool &#124; null | Whether the tensorrt trt-backend engine build was served from the on-disk build cache (`true`) or compiled fresh (`false`). `null` when the build cache is not in play: the pytorch backend, other engines, an `engine_path` override, or the cache disabled. Annotates `model_load_time_sec` (a cache hit skips the compile) |
@@ -106,8 +104,9 @@ For the methodology that motivates baseline subtraction, see [Methodology &gt; B
 (`memory`, `gpu_utilisation`, `batch`, `kv_cache`, `request_latency`) plus two
 scalars (`tpot_ms`, `token_efficiency_index`). Every leaf is `null` when it
 cannot be computed for the engine/run; the harness fills what each engine can
-provide. `latency_stats`, `steady_state_window`, and `warmup_excluded_samples`
-live at the top level of `result.json`.
+provide. `latency_stats` and `warmup_excluded_samples` live at the top level of
+`result.json`; the measurement window itself (`steady_state_window`) lives in the
+`config.json` sidecar.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -123,7 +122,6 @@ live at the top level of `result.json`.
 | `extended_metrics.request_latency.e2e_latency_{mean,median,p95,p99}_ms` | float &#124; null | Per-request end-to-end latency distribution. |
 | `latency_stats` | object &#124; null | TTFT/ITL statistics. vLLM populates per-request TTFT/E2E plus a decode-average ITL only under `measurement.latency_profiling=true`, in `proportional` mode (V1 records `RequestOutput.metrics` only when `disable_log_stats=False`, which profiling sets); `null` otherwise. transformers populates `latency_stats` (TTFT + ITL) only under profiling. tensorrt populates per-request TTFT/E2E plus an average-TPOT-derived ITL only under profiling, in `per_request_batch` mode; `null` otherwise. |
 | `latency_stats.measurement_mode` | str | Provenance of the latency capture: `true_streaming` (real per-token timestamps, transformers under profiling), `proportional` (decode-average ITL estimate, vLLM under profiling), or `per_request_batch` (tensorrt). The mode reflects the weakest signal present. |
-| `steady_state_window` | [float, float] &#124; null | `(0.0, inference_time_sec)` - the measured window relative to inference start. |
 
 #### Per-engine support matrix
 
@@ -270,6 +268,8 @@ For the Python API equivalent (`StudyResult` object), see [Reference &gt; Librar
 ## Schema versioning
 
 `result.json.schema_version` follows semantic versioning: minor bumps add fields without breaking existing readers, major bumps signal breaking changes. Pre-1.0 the policy is conservative - new fields land as `Optional` with `default = null` so existing parsers don't break.
+
+Schema `5.0` is a breaking change: it removes `engine`, `engine_version`, `model_name`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, and `steady_state_not_detected` from `result.json`. Those configuration/methodology fields now live in the `config.json` sidecar. Old bundles remain readable as their own schema version - there is no in-place migration.
 
 ## See also
 

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -18,8 +18,8 @@ results/
 └── <study-name>_<UTC-timestamp>/
     ├── manifest.json                            # study-level checkpoint + summary
     ├── 001_c0_<model>-<engine>_<hash>/          # one experiment cell
-    │   ├── result.json                          # all metrics + resolved config
-    │   ├── effective_config.json                # final config used (post-expansion)
+    │   ├── result.json                          # measurement metrics (schema 5.0)
+    │   ├── config.json                          # engine/model/methodology + resolved config + provenance
     │   └── timeseries.parquet                   # GPU power/thermal/memory samples
     ├── 002_c0_.../
     ├── ...
@@ -180,9 +180,9 @@ batch is attributed `batch_time / batch_size` (the `PER_REQUEST_BATCH` mode in
 |-------|------|-------------|
 | `timeseries` | str &#124; null | Relative filename of the timeseries sidecar (e.g. `"timeseries.parquet"`); `null` when `output.save_timeseries: false` |
 
-### Effective config (sibling file)
+### Config sidecar (sibling file)
 
-`effective_config.json` lives next to `result.json` in each experiment directory. It contains the fully resolved `ExperimentConfig` - every parameter value used, including engine defaults that were not explicitly specified. **This is what reproduces the experiment.**
+`config.json` lives next to `result.json` in each experiment directory. It is the sole home of engine/model/methodology identity (`engine`, `engine_version`, `model_name`, `measurement_methodology`) and carries the full user-declared `ExperimentConfig` under `declared_config` - every parameter value used, including engine defaults that were not explicitly specified - plus per-field `provenance` (where each non-default value came from: CLI flag, sweep, or YAML) and the observed post-construction engine state. **This is what reproduces the experiment.**
 
 ## `manifest.json` - study-level checkpoint
 

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -34,7 +34,7 @@ results/
 
 The scientific record. One JSON file per experiment cell. Schema version `5.0`.
 
-`result.json` is pure measurement output. Configuration inputs and methodology - `engine`, `engine_version`, `model_name`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected` - live in the `config.json` sidecar, not here.
+`result.json` is measurement output. Configuration inputs and methodology - `engine_version`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected` - live in the `config.json` sidecar, not here. The one deliberate duplication: `result.json` keeps `model_name` and `engine` as convenience copies so a result file is self-describing when separated from its directory; the authoritative home for both is `config.json`.
 
 ### Identification
 
@@ -44,6 +44,8 @@ The scientific record. One JSON file per experiment cell. Schema version `5.0`.
 | `experiment_id` | str | Unique experiment identifier (`{model}_{YYYYMMDD_HHMMSS}` for single experiments; study-level cells inherit a richer per-cell identifier) |
 | `measurement_config_hash` | str | SHA-256[:16] of `ExperimentConfig` with environment fields excluded; same hash -> logically identical experiments |
 | `llenergymeasure_version` | str &#124; null | Package version that produced this result |
+| `engine` | str | Inference engine used. Convenience copy; authoritative home is the `config.json` sidecar |
+| `model_name` | str | Model name/path measured. Convenience copy; authoritative home is the `config.json` sidecar |
 
 ### Measurement methodology
 
@@ -182,7 +184,7 @@ batch is attributed `batch_time / batch_size` (the `PER_REQUEST_BATCH` mode in
 
 ### Config sidecar (sibling file)
 
-`config.json` lives next to `result.json` in each experiment directory. It is the sole home of engine/model/methodology identity (`engine`, `engine_version`, `model_name`, `measurement_methodology`) and carries the full user-declared `ExperimentConfig` under `declared_config` - every parameter value used, including engine defaults that were not explicitly specified - plus per-field `provenance` (where each non-default value came from: CLI flag, sweep, or YAML) and the observed post-construction engine state. **This is what reproduces the experiment.**
+`config.json` lives next to `result.json` in each experiment directory. It is the authoritative home of engine/model/methodology identity (`engine`, `engine_version`, `model_name`, `measurement_methodology`; `result.json` carries convenience copies of `engine` and `model_name` only) and carries the full user-declared `ExperimentConfig` under `declared_config` - every parameter value used, including engine defaults that were not explicitly specified - plus per-field `provenance` (where each non-default value came from: CLI flag, sweep, or YAML) and the observed post-construction engine state. **This is what reproduces the experiment.**
 
 ## `manifest.json` - study-level checkpoint
 
@@ -269,7 +271,7 @@ For the Python API equivalent (`StudyResult` object), see [Reference &gt; Librar
 
 `result.json.schema_version` follows semantic versioning: minor bumps add fields without breaking existing readers, major bumps signal breaking changes. Pre-1.0 the policy is conservative - new fields land as `Optional` with `default = null` so existing parsers don't break.
 
-Schema `5.0` is a breaking change: it removes `engine`, `engine_version`, `model_name`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, and `steady_state_not_detected` from `result.json`. Those configuration/methodology fields now live in the `config.json` sidecar. Old bundles remain readable as their own schema version - there is no in-place migration.
+Schema `5.0` is a breaking change: it removes `engine_version`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, and `steady_state_not_detected` from `result.json`. Those configuration/methodology fields now live in the `config.json` sidecar. `result.json` keeps `model_name` and `engine` as convenience copies (authoritative home: `config.json`). Old bundles remain readable as their own schema version - there is no in-place migration.
 
 ## See also
 

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -249,13 +249,16 @@ experiment list, study timing, completion status per cell, and the
 effective study-level config. This is what you load when you want to
 *reason about the study as a whole* rather than one cell.
 
-A single `result.json` is pure measurement output (schema 5.0 - it no
-longer carries engine/model/config keys):
+A single `result.json` is measurement output (schema 5.0). Configuration
+moved to the sidecar; only `engine` and `model_name` remain as convenience
+copies so the file is self-describing when separated from its directory:
 
 ```json
 {
   "experiment_id": "qwen-transformers-bf16-bs16-fa2-2026-05-07T14-32-08",
   "schema_version": "5.0",
+  "engine": "transformers",
+  "model_name": "Qwen/Qwen2.5-0.5B",
   "total_tokens": 7680,
   "total_inference_time_sec": 9.8,
   "avg_tokens_per_second": 783.7,
@@ -269,10 +272,10 @@ longer carries engine/model/config keys):
 }
 ```
 
-Engine, model, and methodology identity are configuration inputs, not
-measurement output, so they live in the `config.json` sidecar next to
-`result.json` in the same cell directory - alongside the fully resolved
-config (`declared_config`) and per-field provenance:
+The authoritative home for engine, model, and methodology identity is the
+`config.json` sidecar next to `result.json` in the same cell directory -
+alongside the fully resolved config (`declared_config`) and per-field
+provenance:
 
 ```json
 {

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -237,8 +237,8 @@ After the run completes, the study directory looks roughly like this:
 results/tutorial-multi-engine_2026-05-07T14-32-08/
 ├── manifest.json                       # study-level: timing, config, completion
 ├── 001_c0_qwen-transformers_a1b2c3.../ # one experiment cell
-│   ├── result.json                     # all metrics + resolved config
-│   ├── effective_config.json           # final config used (after expansion)
+│   ├── result.json                     # measurement metrics only (schema 5.0)
+│   ├── config.json                     # engine/model/methodology + resolved config + provenance
 │   └── timeseries.parquet              # GPU power/thermal/memory samples
 ├── 002_c0_qwen-transformers_d4e5f6.../
 └── ... (36 cells)
@@ -249,13 +249,13 @@ experiment list, study timing, completion status per cell, and the
 effective study-level config. This is what you load when you want to
 *reason about the study as a whole* rather than one cell.
 
-A single `result.json` looks like (truncated for readability):
+A single `result.json` is pure measurement output (schema 5.0 - it no
+longer carries engine/model/config keys):
 
 ```json
 {
   "experiment_id": "qwen-transformers-bf16-bs16-fa2-2026-05-07T14-32-08",
-  "engine": "transformers",
-  "model": "Qwen/Qwen2.5-0.5B",
+  "schema_version": "5.0",
   "total_tokens": 7680,
   "total_inference_time_sec": 9.8,
   "avg_tokens_per_second": 783.7,
@@ -265,8 +265,24 @@ A single `result.json` looks like (truncated for readability):
   "mj_per_tok_adjusted": 100.4,
   "total_flops": 1.18e+12,
   "flops_per_output_token": 1.54e+8,
-  "energy_breakdown": { "...": "..." },
-  "effective_config": { "...": "..." }
+  "energy_breakdown": { "...": "..." }
+}
+```
+
+Engine, model, and methodology identity are configuration inputs, not
+measurement output, so they live in the `config.json` sidecar next to
+`result.json` in the same cell directory - alongside the fully resolved
+config (`declared_config`) and per-field provenance:
+
+```json
+{
+  "schema_version": "2.0",
+  "engine": "transformers",
+  "engine_version": "4.57.1",
+  "model_name": "Qwen/Qwen2.5-0.5B",
+  "measurement_methodology": "total",
+  "declared_config": { "...": "..." },
+  "provenance": { "...": "..." }
 }
 ```
 
@@ -295,17 +311,18 @@ from pathlib import Path
 
 study_dir = Path("results/tutorial-multi-engine_2026-05-07T14-32-08")
 
-# Load every result.json under the study.
-results = []
-for p in study_dir.glob("*/result.json"):
-    with p.open() as f:
-        results.append(json.load(f))
-
-# Group by (engine, dtype) and average mJ/token (adjusted).
+# Each experiment cell holds result.json (metrics) plus a config.json
+# sidecar (engine/model identity + the resolved config). Join them per
+# cell: engine and dtype come from config.json, the metric from result.json.
 groups: dict[tuple[str, str], list[float]] = defaultdict(list)
-for r in results:
-    key = (r["engine"], r["effective_config"][r["engine"]]["dtype"])
-    groups[key].append(r["mj_per_tok_adjusted"])
+for result_path in study_dir.glob("*/result.json"):
+    cell = result_path.parent
+    result = json.loads(result_path.read_text())
+    config = json.loads((cell / "config.json").read_text())
+
+    engine = config["engine"]
+    dtype = config["declared_config"][engine]["engine_params"]["dtype"]
+    groups[(engine, dtype)].append(result["mj_per_tok_adjusted"])
 
 print(f"{'engine':<14} {'dtype':<10} {'mJ/tok (adj, mean)':>20} {'n':>4}")
 for (engine, dtype), values in sorted(groups.items()):
@@ -331,11 +348,11 @@ vllm           float16                   86.5    8
 > for the per-token energy figure - but the gap between dtypes is
 > often within noise for a 0.5B model.
 
-To go further: group by `(engine, batch_size_effective)` and plot
-mJ/token vs batch size, or pivot on `attn_implementation` /
-`attention.backend` to compare attention kernels within each engine.
-The result.json schema makes this kind of analysis a few lines of
-Python.
+To go further: group by batch size and plot mJ/token vs batch size, or
+pivot on `attn_implementation` / `attention.backend` to compare attention
+kernels within each engine - all read from each cell's `config.json`
+(`declared_config`) joined to its `result.json`. The two-file schema makes
+this kind of analysis a few lines of Python.
 
 ## Step 6 - What you've learned and where to go next
 

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -6,7 +6,7 @@ import functools
 import hashlib
 import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
@@ -98,39 +98,13 @@ class ExperimentResult(BaseModel):
     """
 
     # Identity
-    schema_version: str = Field(default="4.0", description="Result schema version")
+    schema_version: str = Field(default="5.0", description="Result schema version")
     experiment_id: str = Field(..., description="Unique experiment identifier")
     measurement_config_hash: str = Field(
         ..., description="SHA-256[:16] of ExperimentConfig (environment excluded)"
     )
     llenergymeasure_version: str | None = Field(
         default=None, description="Package version that produced this result"
-    )
-
-    # Engine
-    engine: str = Field(default="transformers", description="Inference engine used")
-    engine_version: str | None = Field(
-        default=None, description="Engine version string for reproducibility"
-    )
-    model_name: str = Field(default="unknown", description="Model name/path used")
-
-    # Methodology
-    measurement_methodology: Literal["total", "steady_state", "windowed"] = Field(
-        ..., description="What was measured - total run, steady-state window, or explicit window"
-    )
-    steady_state_window: tuple[float, float] | None = Field(
-        default=None,
-        description="(start_sec, end_sec) of measurement window relative to experiment start",
-    )
-    measurement_window_discard_fraction: float | None = Field(
-        default=None,
-        description="Warm-up fraction discarded for steady_state methodology. None for "
-        "total/windowed.",
-    )
-    steady_state_not_detected: bool = Field(
-        default=False,
-        description="True when steady_state auto-detection was requested but found no "
-        "stable region and fell back to the fixed warm-up discard.",
     )
 
     # Core metrics

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -107,6 +107,20 @@ class ExperimentResult(BaseModel):
         default=None, description="Package version that produced this result"
     )
 
+    # Convenience identity copies. Deliberate small duplication so a result.json
+    # stays self-describing when separated from its directory; the authoritative
+    # home for both is the config.json sidecar.
+    engine: str = Field(
+        default="transformers",
+        description="Inference engine used. Convenience copy; authoritative home "
+        "is the config.json sidecar.",
+    )
+    model_name: str = Field(
+        default="unknown",
+        description="Model name/path used. Convenience copy; authoritative home "
+        "is the config.json sidecar.",
+    )
+
     # Core metrics
     total_tokens: int = Field(..., description="Total tokens across all processes")
     total_energy_j: float = Field(..., description="Total energy (sum across processes)")

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -778,8 +778,10 @@ class MeasurementHarness:
         ``_save_and_record`` moves this file to the per-experiment directory alongside
         ``result.json``.
 
-        Engine identity (``engine`` / ``engine_version``), ``model_name``, and the
-        measurement ``methodology`` fields live in this sidecar (not ``result.json``).
+        This sidecar is the authoritative home for engine identity (``engine`` /
+        ``engine_version``), ``model_name``, and the measurement ``methodology``
+        fields. ``result.json`` carries ``engine`` and ``model_name`` as
+        convenience copies only; the rest live here exclusively.
 
         Best-effort - failures are logged at DEBUG to avoid masking measurement results.
         """
@@ -1380,6 +1382,9 @@ class MeasurementHarness:
             experiment_id=experiment_id,
             measurement_config_hash=compute_declared_config_hash(config),
             llenergymeasure_version=__version__,
+            # Convenience identity copies; authoritative home is config.json.
+            engine=engine_name,
+            model_name=config.task.model,
             aggregation=AggregationMetadata(
                 method="single_process",
                 num_processes=1,

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -241,6 +241,21 @@ class _MeasuredWindow:
     end_time: datetime
 
 
+@dataclass(frozen=True)
+class _ConfigMethodology:
+    """Methodology fields that live in the config.json sidecar, not result.json.
+
+    Derived during result assembly (they depend on the resolved measurement
+    window) and threaded out to the config.json sidecar writer, since they are
+    configuration/methodology, not measurement output.
+    """
+
+    measurement_methodology: str
+    steady_state_window: tuple[float, float] | None
+    measurement_window_discard_fraction: float | None
+    steady_state_not_detected: bool
+
+
 # ---------------------------------------------------------------------------
 # MeasurementHarness
 # ---------------------------------------------------------------------------
@@ -701,10 +716,8 @@ class MeasurementHarness:
         )
 
         # 16. Assemble ExperimentResult
-        engine_version = getattr(engine, "version", None)
-        result = self._build_result(
+        result, methodology = self._build_result(
             engine_name=engine.name,
-            engine_version=engine_version,
             config=config,
             output=window.output,
             model_memory_mb=model_memory_mb,
@@ -733,6 +746,8 @@ class MeasurementHarness:
                 output=window.output,
                 config=config,
                 result=result,
+                engine_name=engine.name,
+                methodology=methodology,
                 output_dir=resolved_output_dir,
             )
             _emit_substep(_p, "save", "config sidecar written")
@@ -751,6 +766,8 @@ class MeasurementHarness:
         output: Any,
         config: Any,
         result: Any,
+        engine_name: str,
+        methodology: _ConfigMethodology,
         output_dir: Path,
     ) -> None:
         """Write ``config.json`` sidecar to ``output_dir`` (temp staging area).
@@ -760,6 +777,9 @@ class MeasurementHarness:
         from the observed-config hashing pipeline, and writes the sidecar atomically. The runner's
         ``_save_and_record`` moves this file to the per-experiment directory alongside
         ``result.json``.
+
+        Engine identity (``engine`` / ``engine_version``), ``model_name``, and the
+        measurement ``methodology`` fields live in this sidecar (not ``result.json``).
 
         Best-effort - failures are logged at DEBUG to avoid masking measurement results.
         """
@@ -773,7 +793,6 @@ class MeasurementHarness:
             # Compute observed_config_hash from extracted native-type state.
             # harness + measurement come from the ran config so the observed hash
             # covers the same identity dimensions as the resolved hash.
-            engine_name = result.engine
             task_dict = config.task.model_dump(mode="python")
             active_harness = config.active_harness()
             harness_dump = (
@@ -803,7 +822,12 @@ class MeasurementHarness:
                 experiment_id=result.experiment_id,
                 config_hash=result.measurement_config_hash,
                 engine=engine_name,
-                library_version=lib_ver,
+                engine_version=lib_ver,
+                model_name=config.task.model,
+                measurement_methodology=methodology.measurement_methodology,
+                steady_state_window=methodology.steady_state_window,
+                measurement_window_discard_fraction=methodology.measurement_window_discard_fraction,
+                steady_state_not_detected=methodology.steady_state_not_detected,
                 observed_engine_params=obs_engine if obs_engine else None,
                 observed_sampling_params=obs_sampling if obs_sampling else None,
                 observed_config_hash=obs_hash,
@@ -1044,7 +1068,6 @@ class MeasurementHarness:
     def _build_result(
         self,
         engine_name: str,
-        engine_version: str | None,
         config: ExperimentConfig,
         output: InferenceOutput,
         model_memory_mb: float,
@@ -1062,8 +1085,13 @@ class MeasurementHarness:
         timeseries_samples: list[PowerThermalSample] | None = None,
         prompt_count: int = 0,
         model_load_time_sec: float | None = None,
-    ) -> ExperimentResult:
+    ) -> tuple[ExperimentResult, _ConfigMethodology]:
         """Assemble ExperimentResult from measurement data.
+
+        Returns the result plus the :class:`_ConfigMethodology` derived from the
+        resolved measurement window. The methodology fields belong to the
+        config.json sidecar (configuration/methodology), not result.json, so they
+        are threaded back to the caller rather than stored on the result.
 
         Energy/FLOPs fields carry measured values. The one exception: when no energy
         sampler produced a measurement, total_energy_j keeps a 0.0 placeholder that is
@@ -1073,7 +1101,6 @@ class MeasurementHarness:
 
         Args:
             engine_name: Engine identifier string (from engine.name).
-            engine_version: Engine version string (from engine.version), or None.
             config: Experiment configuration.
             output: InferenceOutput from engine.run_inference().
             model_memory_mb: GPU memory after model load, before inference (MB).
@@ -1096,7 +1123,8 @@ class MeasurementHarness:
                 the phase precedes the NVML measurement window.
 
         Returns:
-            Fully assembled ExperimentResult.
+            Tuple of (assembled ExperimentResult, _ConfigMethodology). The
+            methodology fields are written to the config.json sidecar, not result.json.
         """
         from llenergymeasure.domain.extended_metrics import compute_extended_metrics
         from llenergymeasure.domain.metrics import (
@@ -1348,13 +1376,10 @@ class MeasurementHarness:
             warmup_result.iterations_completed if warmup_result is not None else None
         )
 
-        return ExperimentResult(
+        result = ExperimentResult(
             experiment_id=experiment_id,
             measurement_config_hash=compute_declared_config_hash(config),
             llenergymeasure_version=__version__,
-            measurement_methodology=measurement_methodology,
-            engine=engine_name,
-            engine_version=engine_version,
             aggregation=AggregationMetadata(
                 method="single_process",
                 num_processes=1,
@@ -1372,7 +1397,6 @@ class MeasurementHarness:
             end_time=end_time,
             thermal_throttle=thermal_info,
             energy_breakdown=energy_breakdown,
-            model_name=config.task.model,
             timeseries=timeseries_path,
             mj_per_tok_total=_mj_total,
             mj_per_tok_adjusted=_mj_adjusted,
@@ -1384,10 +1408,13 @@ class MeasurementHarness:
             measurement_warnings=measurement_warnings,
             extended_metrics=extended_metrics,
             latency_stats=latency_stats,
-            steady_state_window=steady_state_window,
-            measurement_window_discard_fraction=discard_fraction,
-            steady_state_not_detected=steady_state_not_detected,
             warmup_excluded_samples=warmup_excluded_samples,
             model_load_time_sec=model_load_time_sec,
             engine_build_cache_hit=output.extras.get("engine_build_cache_hit"),
+        )
+        return result, _ConfigMethodology(
+            measurement_methodology=measurement_methodology,
+            steady_state_window=steady_state_window,
+            measurement_window_discard_fraction=discard_fraction,
+            steady_state_not_detected=steady_state_not_detected,
         )

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -534,7 +534,7 @@ class DockerRunner:
             # --- Rescue artefacts before cleanup ---
             # The harness inside the container wrote its artefacts to /run/llem
             # (= exchange_dir on host): config.json always (the sole home of
-            # provenance + engine/model/methodology identity) and
+            # provenance and the authoritative home of identity) and
             # timeseries.parquet when enabled. Move them to a temp dir so the
             # caller can copy them into the study directory before the exchange
             # dir is destroyed below. config.json must survive too - otherwise a

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -47,9 +47,9 @@ def _experiment_dir_name(
 
     Format: ``[{index:03d}_]c{cycle}_{model_short}-{engine}_{hash[:8]}``
 
-    ``model_name`` and ``engine`` are the identity of what was measured; they
-    live in the ``config.json`` sidecar (not ``result.json``) so the caller
-    supplies them explicitly.
+    ``model_name`` and ``engine`` are the identity of what was measured. Their
+    authoritative home is the ``config.json`` sidecar (``result.json`` carries
+    convenience copies only), so the caller supplies them explicitly.
 
     When ``experiment_index`` is provided (study context), the directory is
     prefixed with a zero-padded index for natural sort ordering.
@@ -135,10 +135,12 @@ def save_config_sidecar(
     §3.3. Fields:
 
     - ``engine`` / ``engine_version`` - the inference engine and its library
-      version. This is the sole on-disk home for engine identity; it is no longer
-      duplicated on ``result.json``.
+      version. This sidecar is the authoritative home for engine identity;
+      ``result.json`` keeps ``engine`` as a convenience copy only, and
+      ``engine_version`` lives here exclusively.
     - ``model_name`` - the model name/path that was measured (a configuration
-      input, not a measurement output).
+      input, not a measurement output). Authoritative here; ``result.json``
+      keeps a convenience copy.
     - ``measurement_methodology`` / ``steady_state_window`` /
       ``measurement_window_discard_fraction`` / ``steady_state_not_detected`` -
       how the measurement window was set up. Methodology choices are configuration,
@@ -270,10 +272,10 @@ def save_result(
     Args:
         result: The experiment result to persist.
         output_dir: Parent directory. Created if missing.
-        model_name: Model name/path (used for the directory slug). Lives in the
-            ``config.json`` sidecar, not on the result.
-        engine: Inference engine name (used for the directory slug). Lives in the
-            ``config.json`` sidecar, not on the result.
+        model_name: Model name/path (used for the directory slug). Authoritative
+            home is the ``config.json`` sidecar; the result carries a convenience copy.
+        engine: Inference engine name (used for the directory slug). Authoritative
+            home is the ``config.json`` sidecar; the result carries a convenience copy.
         timeseries_source: Optional path to existing .parquet file to copy in.
         experiment_index: Optional 1-based experiment index for directory prefix
             (used in study context for natural sort ordering).

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -38,12 +38,18 @@ CONFIG_SIDECAR_SCHEMA_VERSION = "2.0"
 def _experiment_dir_name(
     result: ExperimentResult,
     *,
+    model_name: str,
+    engine: str,
     experiment_index: int | None = None,
     cycle: int = 1,
 ) -> str:
     """Generate a human-readable directory name for an experiment result.
 
     Format: ``[{index:03d}_]c{cycle}_{model_short}-{engine}_{hash[:8]}``
+
+    ``model_name`` and ``engine`` are the identity of what was measured; they
+    live in the ``config.json`` sidecar (not ``result.json``) so the caller
+    supplies them explicitly.
 
     When ``experiment_index`` is provided (study context), the directory is
     prefixed with a zero-padded index for natural sort ordering.
@@ -54,8 +60,7 @@ def _experiment_dir_name(
     """
     from llenergymeasure.utils.formatting import model_short_name
 
-    model_short = model_short_name(result.model_name)
-    engine = result.engine
+    model_short = model_short_name(model_name)
     config_hash = result.measurement_config_hash[:8]
 
     # Build slug: model_short-engine
@@ -111,7 +116,12 @@ def save_config_sidecar(
     experiment_id: str,
     config_hash: str,
     engine: str,
-    library_version: str,
+    engine_version: str,
+    model_name: str,
+    measurement_methodology: str,
+    steady_state_window: tuple[float, float] | None = None,
+    measurement_window_discard_fraction: float | None = None,
+    steady_state_not_detected: bool = False,
     observed_engine_params: dict[str, object] | None = None,
     observed_sampling_params: dict[str, object] | None = None,
     resolved_config_hash: str | None = None,
@@ -124,6 +134,17 @@ def save_config_sidecar(
     Schema lives in ``.product/designs/config-deduplication-dormancy/sweep-dedup.md``
     §3.3. Fields:
 
+    - ``engine`` / ``engine_version`` - the inference engine and its library
+      version. This is the sole on-disk home for engine identity; it is no longer
+      duplicated on ``result.json``.
+    - ``model_name`` - the model name/path that was measured (a configuration
+      input, not a measurement output).
+    - ``measurement_methodology`` / ``steady_state_window`` /
+      ``measurement_window_discard_fraction`` / ``steady_state_not_detected`` -
+      how the measurement window was set up. Methodology choices are configuration,
+      so they live here rather than alongside the metrics in ``result.json``.
+      ``steady_state_window`` and ``measurement_window_discard_fraction`` are
+      omitted when None (total/windowed methodologies).
     - ``observed_engine_params`` / ``observed_sampling_params`` - authoritative
       post-construction library state (populated by
       :func:`llenergymeasure.engines._observed.extract_observed_params`).
@@ -163,8 +184,15 @@ def save_config_sidecar(
         "experiment_id": experiment_id,
         "measurement_config_hash": config_hash,
         "engine": engine,
-        "library_version": library_version,
+        "engine_version": engine_version,
+        "model_name": model_name,
+        "measurement_methodology": measurement_methodology,
+        "steady_state_not_detected": steady_state_not_detected,
     }
+    if steady_state_window is not None:
+        payload["steady_state_window"] = list(steady_state_window)
+    if measurement_window_discard_fraction is not None:
+        payload["measurement_window_discard_fraction"] = measurement_window_discard_fraction
     if observed_engine_params is not None:
         payload["observed_engine_params"] = observed_engine_params
     if observed_sampling_params is not None:
@@ -224,6 +252,9 @@ def save_environment(
 def save_result(
     result: ExperimentResult,
     output_dir: Path,
+    *,
+    model_name: str,
+    engine: str,
     timeseries_source: Path | None = None,
     experiment_index: int | None = None,
     cycle: int = 1,
@@ -239,6 +270,10 @@ def save_result(
     Args:
         result: The experiment result to persist.
         output_dir: Parent directory. Created if missing.
+        model_name: Model name/path (used for the directory slug). Lives in the
+            ``config.json`` sidecar, not on the result.
+        engine: Inference engine name (used for the directory slug). Lives in the
+            ``config.json`` sidecar, not on the result.
         timeseries_source: Optional path to existing .parquet file to copy in.
         experiment_index: Optional 1-based experiment index for directory prefix
             (used in study context for natural sort ordering).
@@ -250,7 +285,13 @@ def save_result(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    dir_name = _experiment_dir_name(result, experiment_index=experiment_index, cycle=cycle)
+    dir_name = _experiment_dir_name(
+        result,
+        model_name=model_name,
+        engine=engine,
+        experiment_index=experiment_index,
+        cycle=cycle,
+    )
     base_dir = output_dir / dir_name
     target_dir = _find_collision_free_dir(base_dir)
 

--- a/src/llenergymeasure/study/equivalence_groups.py
+++ b/src/llenergymeasure/study/equivalence_groups.py
@@ -47,7 +47,7 @@ class ObservedCollisionGroup:
 
     observed_config_hash: str
     engine: str
-    library_version: str
+    engine_version: str
     member_resolved_config_hashes: tuple[str, ...]
     member_experiment_ids: tuple[str, ...]
     gap_detected: bool
@@ -71,12 +71,12 @@ class EquivalenceGroups:
 
 
 def find_observed_collisions(sidecars: list[dict[str, Any]]) -> list[ObservedCollisionGroup]:
-    """Group sidecars by ``(engine, library_version, observed_config_hash)``.
+    """Group sidecars by ``(engine, engine_version, observed_config_hash)``.
 
     Any group with size >= 2 AND distinct ``resolved_config_hash`` across its members is
     flagged as a proven library-resolution mechanism gap - per sweep-dedup.md §4.1.
 
-    Each sidecar dict must carry at minimum ``engine``, ``library_version``,
+    Each sidecar dict must carry at minimum ``engine``, ``engine_version``,
     ``resolved_config_hash``, ``observed_config_hash``, and ``experiment_id`` keys. Sidecars missing any
     of these are silently skipped (pre-50.3a data, or runs with dedup_mode=off
     for which observed-config-hash may be partial).
@@ -87,7 +87,7 @@ def find_observed_collisions(sidecars: list[dict[str, Any]]) -> list[ObservedCol
         if not obs_hash:
             continue
         engine = str(sc.get("engine", ""))
-        version = str(sc.get("library_version", ""))
+        version = str(sc.get("engine_version", ""))
         buckets[(engine, version, obs_hash)].append(sc)
 
     groups: list[ObservedCollisionGroup] = []
@@ -103,7 +103,7 @@ def find_observed_collisions(sidecars: list[dict[str, Any]]) -> list[ObservedCol
             ObservedCollisionGroup(
                 observed_config_hash=obs_hash,
                 engine=engine,
-                library_version=version,
+                engine_version=version,
                 member_resolved_config_hashes=resolved_config_hashes,
                 member_experiment_ids=exp_ids,
                 gap_detected=gap_detected,

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -46,6 +46,7 @@ from llenergymeasure.config.ssot import (
     TIMEOUT_INTERRUPT_POLL,
     TIMEOUT_SIGTERM_GRACE,
     TIMEOUT_THREAD_JOIN,
+    engine_str,
 )
 from llenergymeasure.domain.bundle_artefacts import (
     CONFIG_SIDECAR_FILENAME,
@@ -122,6 +123,9 @@ def _save_and_record(
     config_hash: str,
     cycle: int,
     result_files: list[str],
+    *,
+    model_name: str,
+    engine: str,
     experiment_index: int | None = None,
     ts_source_dir: Path | None = None,
     environment_snapshot: Any | None = None,
@@ -136,6 +140,10 @@ def _save_and_record(
     flat file written by MeasurementHarness is removed after the copy.
 
     Args:
+        model_name: Model name/path for the experiment directory slug (lives in
+            the config.json sidecar, not on the result).
+        engine: Inference engine name for the experiment directory slug (lives in
+            the config.json sidecar, not on the result).
         ts_source_dir: Directory where the harness wrote timeseries.parquet.
         environment_snapshot: EnvironmentSnapshot for per-experiment environment.json sidecar.
         resolution_log: Pre-built per-field resolution log for this experiment,
@@ -167,6 +175,8 @@ def _save_and_record(
         result_path = save_result(
             result,
             study_dir,
+            model_name=model_name,
+            engine=engine,
             timeseries_source=ts_source,
             experiment_index=experiment_index,
             cycle=cycle,
@@ -882,6 +892,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         local_spec = self._runner_specs.get(config.engine) if self._runner_specs else None
         self._handle_result(
             result,
+            config,
             config_hash,
             cycle,
             index,
@@ -901,6 +912,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
     def _handle_result(
         self,
         result: Any,
+        config: ExperimentConfig,
         config_hash: str,
         cycle: int,
         index: int,
@@ -910,6 +922,8 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         runner_provenance: RunnerProvenance | None = None,
     ) -> None:
         """Update manifest and signal study display based on experiment outcome."""
+        model_name = config.task.model
+        engine = engine_str(config.engine)
         if isinstance(result, dict) and "type" in result:
             error_type = result.get("type", "UnknownError")
             error_message = result.get("message", "")
@@ -927,6 +941,8 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
                 config_hash,
                 cycle,
                 self.result_files,
+                model_name=model_name,
+                engine=engine,
                 experiment_index=index,
                 ts_source_dir=ts_source_dir,
                 environment_snapshot=environment_snapshot,
@@ -942,11 +958,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
                     # Docker experiments: show container path first, then host path.
                     # The original container path is /run/llem; by this point output_dir
                     # has been rewritten to the host temp dir, so use the known constant.
-                    spec = (
-                        self._runner_specs.get(getattr(result, "engine", None) or "")
-                        if self._runner_specs
-                        else None
-                    )
+                    spec = self._runner_specs.get(engine) if self._runner_specs else None
                     is_docker = spec is not None and spec.mode == RUNNER_DOCKER
                     if is_docker:
                         self._progress.on_substep("save", f"container: {CONTAINER_EXCHANGE_DIR}")
@@ -1092,6 +1104,7 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         exp_elapsed = time.monotonic() - exp_start
         self._handle_result(
             result,
+            config,
             config_hash,
             cycle,
             index,

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -140,10 +140,10 @@ def _save_and_record(
     flat file written by MeasurementHarness is removed after the copy.
 
     Args:
-        model_name: Model name/path for the experiment directory slug (lives in
-            the config.json sidecar, not on the result).
-        engine: Inference engine name for the experiment directory slug (lives in
-            the config.json sidecar, not on the result).
+        model_name: Model name/path for the experiment directory slug
+            (authoritative home: config.json; the result keeps a convenience copy).
+        engine: Inference engine name for the experiment directory slug
+            (authoritative home: config.json; the result keeps a convenience copy).
         ts_source_dir: Directory where the harness wrote timeseries.parquet.
         environment_snapshot: EnvironmentSnapshot for per-experiment environment.json sidecar.
         resolution_log: Pre-built per-field resolution log for this experiment,
@@ -217,13 +217,13 @@ def _save_and_record(
                     config_sidecar_src.unlink(missing_ok=True)
 
         # Loudness backstop: config.json is the sole home of provenance and
-        # engine/model/methodology identity. A completed experiment that lands
+        # the authoritative home of identity. A completed experiment that lands
         # without one is silent data loss - warn (never fail) so the gap is
         # visible rather than discovered later at analysis time.
         if not (result_path.parent / CONFIG_SIDECAR_FILENAME).exists():
             logger.warning(
                 "No config.json materialised for %s (cycle %d) at %s - provenance "
-                "and engine/model identity are missing from this result.",
+                "and authoritative engine/model identity are missing from this result.",
                 config_hash,
                 cycle,
                 result_path.parent,
@@ -786,7 +786,8 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         # output_dir (a runtime param, not from config) and writes config.json
         # there always, plus timeseries.parquet when save_timeseries is on. The
         # staging dir is created regardless of save_timeseries so the config.json
-        # sidecar - the sole home of provenance/identity - always materialises;
+        # sidecar - sole home of provenance, authoritative home of identity -
+        # always materialises;
         # it is cleaned up after _handle_result copies the artefacts into the
         # study directory.
         save_ts = self.study.output.save_timeseries

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -119,8 +119,9 @@ def run_single_experiment(
         from llenergymeasure.study.runtime_observations import capture_runtime_observations
 
         # Staging dir for harness artefacts. The harness writes config.json here
-        # always (the sole home of provenance/identity) and timeseries.parquet
-        # when save_timeseries is on, so the dir is created regardless of save_ts.
+        # always (sole home of provenance, authoritative home of identity) and
+        # timeseries.parquet when save_timeseries is on, so the dir is created
+        # regardless of save_ts.
         ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
 
         # Wrap the in-process body (preflight -> engine import -> harness.run) in

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from llenergymeasure.config.models import StudyConfig
-from llenergymeasure.config.ssot import RUNNER_DOCKER, TEMP_PREFIX_TIMESERIES
+from llenergymeasure.config.ssot import RUNNER_DOCKER, TEMP_PREFIX_TIMESERIES, engine_str
 from llenergymeasure.device.gpu_info import _resolve_gpu_indices
 from llenergymeasure.domain.experiment import ExperimentResult
 from llenergymeasure.domain.progress import ProgressCallback
@@ -187,6 +187,8 @@ def run_single_experiment(
         config_hash,
         cycle,
         result_files,
+        model_name=config.task.model,
+        engine=engine_str(config.engine),
         ts_source_dir=ts_tmpdir,
         environment_snapshot=snapshot,
         resolution_log=(resolution_logs or {}).get(config_hash),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,13 +84,12 @@ def make_config(**overrides) -> ExperimentConfig:
 def make_result(**overrides) -> ExperimentResult:
     """Return a valid ExperimentResult with sensible defaults.
 
-    Includes all required fields (measurement_config_hash,
-    measurement_methodology, start_time, end_time) to prevent ValidationError.
+    Includes all required fields (measurement_config_hash, start_time, end_time)
+    to prevent ValidationError.
     """
     defaults: dict = {
         "experiment_id": TEST_EXPERIMENT_ID,
         "measurement_config_hash": TEST_MEASUREMENT_HASH,
-        "measurement_methodology": "total",
         "aggregation": AggregationMetadata(num_processes=1),
         "total_tokens": 1000,
         "total_energy_j": 10.0,

--- a/tests/fixtures/replay/gpt2_transformers_v5.0.json
+++ b/tests/fixtures/replay/gpt2_transformers_v5.0.json
@@ -1,12 +1,7 @@
 {
-  "schema_version": "4.0",
+  "schema_version": "5.0",
   "experiment_id": "gpt2_20260313_142111",
   "measurement_config_hash": "9944baab4dabe390",
-  "engine": "transformers",
-  "engine_version": null,
-  "model_name": "gpt2",
-  "measurement_methodology": "total",
-  "steady_state_window": null,
   "total_tokens": 1920,
   "total_energy_j": 228.03882500813023,
   "total_inference_time_sec": 4.294965875800699,

--- a/tests/fixtures/replay/gpt2_transformers_v5.0.json
+++ b/tests/fixtures/replay/gpt2_transformers_v5.0.json
@@ -2,6 +2,8 @@
   "schema_version": "5.0",
   "experiment_id": "gpt2_20260313_142111",
   "measurement_config_hash": "9944baab4dabe390",
+  "engine": "transformers",
+  "model_name": "gpt2",
   "total_tokens": 1920,
   "total_energy_j": 228.03882500813023,
   "total_inference_time_sec": 4.294965875800699,

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -1103,7 +1103,6 @@ class TestTimeseriesParquetRescue:
         config = make_config()
         result = make_result(
             timeseries="timeseries.parquet",
-            model_name="gpt2",
         )
 
         exchange_dir = tmp_path / "llem-ts-rescue"

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -1801,6 +1801,8 @@ class TestConfigSidecarRescue:
             config_hash,
             1,
             result_files,
+            model_name="gpt2",
+            engine="transformers",
             ts_source_dir=artefact_dir,
             resolution_log=resolution_log,
         )

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -184,7 +184,7 @@ def test_harness_cleanup_called_on_inference_error(minimal_config):
 
 
 def test_harness_returns_experiment_result(minimal_config):
-    """harness.run() must return an ExperimentResult with the correct engine field."""
+    """harness.run() must return an ExperimentResult (engine identity lives in config.json)."""
     from llenergymeasure.domain.experiment import ExperimentResult
 
     engine = FakeBackend(engine_name="fake")
@@ -194,7 +194,7 @@ def test_harness_returns_experiment_result(minimal_config):
         result = harness.run(engine, minimal_config)
 
     assert isinstance(result, ExperimentResult)
-    assert result.engine == "fake"
+    assert result.experiment_id
 
 
 def test_harness_sets_llenergymeasure_version(minimal_config):
@@ -208,30 +208,6 @@ def test_harness_sets_llenergymeasure_version(minimal_config):
         result = harness.run(engine, minimal_config)
 
     assert result.llenergymeasure_version == __version__
-
-
-def test_harness_sets_engine_version_from_engine(minimal_config):
-    """harness.run() populates engine_version via getattr(engine, 'version')."""
-    engine = FakeBackend()
-    engine.version = "1.2.3"  # type: ignore[attr-defined]
-    harness = MeasurementHarness()
-
-    with _apply_patches():
-        result = harness.run(engine, minimal_config)
-
-    assert result.engine_version == "1.2.3"
-
-
-def test_harness_engine_version_none_when_missing(minimal_config):
-    """engine_version is None when engine has no version property."""
-    engine = FakeBackend()
-    # FakeBackend has no .version attribute by default
-    harness = MeasurementHarness()
-
-    with _apply_patches():
-        result = harness.run(engine, minimal_config)
-
-    assert result.engine_version is None
 
 
 def test_harness_records_model_load_time(minimal_config):
@@ -785,15 +761,12 @@ def test_write_config_sidecar_creates_config_json(minimal_config, tmp_path: Path
     result = ExperimentResult(
         experiment_id="test-sidecar-001",
         measurement_config_hash="aabb1122ccdd3344",
-        measurement_methodology="total",
-        model_name="fake/model",
         total_tokens=10,
         total_energy_j=1.0,
         total_inference_time_sec=0.5,
         avg_tokens_per_second=20.0,
         avg_energy_per_token_j=0.1,
         total_flops=0,
-        engine="transformers",
         start_time=datetime(2026, 1, 1),
         end_time=datetime(2026, 1, 1),
     )
@@ -810,10 +783,19 @@ def test_write_config_sidecar_creates_config_json(minimal_config, tmp_path: Path
         },
     )
 
+    from llenergymeasure.harness.measurement import _ConfigMethodology
+
     harness._write_config_sidecar(
         output=output,
         config=minimal_config,
         result=result,
+        engine_name="transformers",
+        methodology=_ConfigMethodology(
+            measurement_methodology="total",
+            steady_state_window=(0.0, 0.5),
+            measurement_window_discard_fraction=None,
+            steady_state_not_detected=False,
+        ),
         output_dir=tmp_path,
     )
 
@@ -825,6 +807,12 @@ def test_write_config_sidecar_creates_config_json(minimal_config, tmp_path: Path
         "observed_config_hash must be a non-null SHA-256 hex string"
     )
     assert len(payload["observed_config_hash"]) == 64
+
+    # Engine identity, model_name, and methodology are the sidecar's job now.
+    assert payload["engine"] == "transformers"
+    assert payload["engine_version"] == "4.50.0"
+    assert payload["model_name"] == "fake/model"
+    assert payload["measurement_methodology"] == "total"
 
     # The full declared config must be recorded so the observed-collision miner
     # can attribute a shared observed hash to declared field differences.
@@ -1099,17 +1087,6 @@ def test_harness_energy_none_still_produces_valid_result(minimal_config):
     assert result.energy_breakdown is None or result.energy_breakdown.raw_j == 0.0
 
 
-def test_build_result_includes_model_name(minimal_config):
-    """_build_result() populates model_name from config.model."""
-    engine = FakeBackend()
-    harness = MeasurementHarness()
-
-    with _apply_patches():
-        result = harness.run(engine, minimal_config)
-
-    assert result.model_name == minimal_config.task.model
-
-
 def test_build_result_populates_mj_per_tok(minimal_config):
     """_build_result() sets mj_per_tok_total when total_tokens > 0."""
     engine = FakeBackend()
@@ -1313,10 +1290,7 @@ def test_harness_populates_extended_metrics(minimal_config):
     assert result.latency_stats is not None
     assert result.latency_stats.ttft_mean_ms == pytest.approx(11.0)
     assert result.latency_stats.itl_mean_ms == pytest.approx(2.5)
-    # Steady-state window + warmup exclusion
-    assert result.steady_state_window is not None
-    assert result.steady_state_window[0] == pytest.approx(0.0)
-    assert result.steady_state_window[1] > 0.0
+    # Warmup exclusion (steady-state window now lives in the config.json sidecar)
     assert result.warmup_excluded_samples == 1
 
 

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -184,7 +184,12 @@ def test_harness_cleanup_called_on_inference_error(minimal_config):
 
 
 def test_harness_returns_experiment_result(minimal_config):
-    """harness.run() must return an ExperimentResult (engine identity lives in config.json)."""
+    """harness.run() must return an ExperimentResult with convenience identity copies.
+
+    The authoritative home for identity is the config.json sidecar; the result
+    keeps engine and model_name as convenience copies so result.json stays
+    self-describing when separated from its directory.
+    """
     from llenergymeasure.domain.experiment import ExperimentResult
 
     engine = FakeBackend(engine_name="fake")
@@ -195,6 +200,8 @@ def test_harness_returns_experiment_result(minimal_config):
 
     assert isinstance(result, ExperimentResult)
     assert result.experiment_id
+    assert result.engine == "fake"
+    assert result.model_name == minimal_config.task.model
 
 
 def test_harness_sets_llenergymeasure_version(minimal_config):

--- a/tests/unit/harness/test_measurement_integration.py
+++ b/tests/unit/harness/test_measurement_integration.py
@@ -348,9 +348,8 @@ def test_harness_build_result_uses_real_energy_values() -> None:
         value=1e12, method="palm_formula", confidence="medium", precision="n/a"
     )
     now = datetime.now()
-    result = harness._build_result(
+    result, _ = harness._build_result(
         engine_name="transformers",
-        engine_version=None,
         config=config,
         output=output,
         model_memory_mb=0.0,
@@ -405,9 +404,8 @@ def test_harness_build_result_absent_energy_placeholder_and_warns(
     )
     now = datetime.now()
     with caplog.at_level(logging.WARNING, logger="llenergymeasure.harness.measurement"):
-        result = harness._build_result(
+        result, _ = harness._build_result(
             engine_name="transformers",
-            engine_version=None,
             config=config,
             output=output,
             model_memory_mb=0.0,
@@ -485,9 +483,8 @@ def test_harness_build_result_uses_energy_measurement_duration_for_baseline() ->
     # Baseline adjustment should use 8.0s, not 10.0s.
     energy_measurement = EnergyMeasurement(total_j=100.0, duration_sec=8.0)
     now = datetime.now()
-    result = harness._build_result(
+    result, _ = harness._build_result(
         engine_name="transformers",
-        engine_version=None,
         config=config,
         output=output,
         model_memory_mb=0.0,
@@ -531,9 +528,8 @@ def test_harness_build_result_zero_energy_when_no_engine() -> None:
     flops_result = FlopsResult(value=0.0, method="palm_formula", confidence="low", precision="n/a")
     now = datetime.now()
 
-    result = harness._build_result(
+    result, _ = harness._build_result(
         engine_name="transformers",
-        engine_version=None,
         config=config,
         output=output,
         model_memory_mb=0.0,
@@ -560,7 +556,7 @@ def test_harness_build_result_zero_energy_when_no_engine() -> None:
 
 
 def _methodology_build_result(measurement: dict, *, samples, output_tokens=100):
-    """Run _build_result with a flat-100W timeseries and return the result."""
+    """Run _build_result with a flat-100W timeseries; return (result, methodology)."""
     from datetime import datetime
 
     from llenergymeasure.config.models import ExperimentConfig
@@ -585,7 +581,6 @@ def _methodology_build_result(measurement: dict, *, samples, output_tokens=100):
     now = datetime.now()
     return harness._build_result(
         engine_name="transformers",
-        engine_version=None,
         config=config,
         output=output,
         model_memory_mb=0.0,
@@ -612,26 +607,26 @@ def _flat_samples():
 
 def test_methodology_total_is_unchanged_default() -> None:
     """Default total mode keeps the sampler total and spans the whole run."""
-    result = _methodology_build_result({}, samples=_flat_samples())
-    assert result.measurement_methodology == "total"
+    result, methodology = _methodology_build_result({}, samples=_flat_samples())
+    assert methodology.measurement_methodology == "total"
     assert result.total_energy_j == pytest.approx(100.0)
     assert result.total_inference_time_sec == pytest.approx(1.0)
-    assert result.steady_state_window == (0.0, 1.0)
-    assert result.steady_state_not_detected is False
-    assert result.measurement_window_discard_fraction is None
+    assert methodology.steady_state_window == (0.0, 1.0)
+    assert methodology.steady_state_not_detected is False
+    assert methodology.measurement_window_discard_fraction is None
     # output_tokens=100 over 100 J -> 1.0 J/token, mj 1000.
     assert result.avg_energy_per_token_j == pytest.approx(1.0)
 
 
 def test_methodology_windowed_reintegrates_and_attributes_tokens() -> None:
     """windowed [0.2,0.7] re-integrates 50 J and attributes 50% of tokens."""
-    result = _methodology_build_result(
+    result, methodology = _methodology_build_result(
         {"measurement_methodology": "windowed", "measurement_window": (0.2, 0.7)},
         samples=_flat_samples(),
     )
-    assert result.measurement_methodology == "windowed"
+    assert methodology.measurement_methodology == "windowed"
     assert result.total_energy_j == pytest.approx(50.0)
-    assert result.steady_state_window == (0.2, 0.7)
+    assert methodology.steady_state_window == (0.2, 0.7)
     assert result.total_inference_time_sec == pytest.approx(0.5)
     # 50 J over 50% of 100 output tokens = 50 J / 50 tokens = 1.0 J/token.
     assert result.avg_energy_per_token_j == pytest.approx(1.0)
@@ -642,20 +637,20 @@ def test_methodology_windowed_reintegrates_and_attributes_tokens() -> None:
 
 def test_methodology_steady_state_fixed_discard() -> None:
     """steady_state fixed fraction 0.3 -> window [0.3,1.0], 70 J, discard fraction recorded."""
-    result = _methodology_build_result(
+    result, methodology = _methodology_build_result(
         {"measurement_methodology": "steady_state", "warmup_discard_fraction": 0.3},
         samples=_flat_samples(),
     )
-    assert result.measurement_methodology == "steady_state"
+    assert methodology.measurement_methodology == "steady_state"
     assert result.total_energy_j == pytest.approx(70.0)
-    assert result.steady_state_window[0] == pytest.approx(0.3)
-    assert result.steady_state_window[1] == pytest.approx(1.0)
-    assert result.measurement_window_discard_fraction == pytest.approx(0.3)
-    assert result.steady_state_not_detected is False
+    assert methodology.steady_state_window[0] == pytest.approx(0.3)
+    assert methodology.steady_state_window[1] == pytest.approx(1.0)
+    assert methodology.measurement_window_discard_fraction == pytest.approx(0.3)
+    assert methodology.steady_state_not_detected is False
 
 
 def test_methodology_steady_state_auto_not_detected_flag() -> None:
-    """auto-detect on a never-stable series sets the not-detected flag in the result."""
+    """auto-detect on a never-stable series sets the not-detected flag in the methodology."""
     import math
 
     from llenergymeasure.device.power_thermal import PowerThermalSample
@@ -668,7 +663,7 @@ def test_methodology_steady_state_auto_not_detected_flag() -> None:
         )
         for t in range(60)
     ]
-    result = _methodology_build_result(
+    result, methodology = _methodology_build_result(
         {
             "measurement_methodology": "steady_state",
             "steady_state_auto_detect": True,
@@ -676,19 +671,19 @@ def test_methodology_steady_state_auto_not_detected_flag() -> None:
         },
         samples=noisy,
     )
-    assert result.measurement_methodology == "steady_state"
-    assert result.steady_state_not_detected is True
+    assert methodology.measurement_methodology == "steady_state"
+    assert methodology.steady_state_not_detected is True
     assert any("auto-detection found no stable region" in w for w in result.measurement_warnings)
 
 
 def test_methodology_falls_back_to_total_without_samples() -> None:
     """No timeseries samples -> windowing cannot apply, total figures retained."""
-    result = _methodology_build_result(
+    result, methodology = _methodology_build_result(
         {"measurement_methodology": "windowed", "measurement_window": (0.2, 0.7)},
         samples=[],
     )
     # Keeps the sampler total and reports total methodology (window not applied).
-    assert result.measurement_methodology == "total"
+    assert methodology.measurement_methodology == "total"
     assert result.total_energy_j == pytest.approx(100.0)
 
 
@@ -737,7 +732,6 @@ def _make_build_result_args():
     now = datetime(2026, 1, 1, 12, 0, 0)
     return dict(
         engine_name="transformers",
-        engine_version=None,
         config=config,
         output=output,
         model_memory_mb=0.0,
@@ -762,23 +756,11 @@ def test_harness_build_result_populates_timeseries_field() -> None:
     kwargs = _make_build_result_args()
     kwargs["timeseries_path"] = "timeseries.parquet"
 
-    result = harness._build_result(**kwargs)
+    result, _ = harness._build_result(**kwargs)
 
     assert result.timeseries == "timeseries.parquet", (
         "timeseries field should be populated from timeseries_path argument"
     )
-
-
-def test_harness_build_result_populates_model_name() -> None:
-    """_build_result() populates result.model_name from the config (RES-16)."""
-    from llenergymeasure.harness import MeasurementHarness
-
-    harness = MeasurementHarness()
-    kwargs = _make_build_result_args()
-
-    result = harness._build_result(**kwargs)
-
-    assert result.model_name == "gpt2", "model_name should be 'gpt2' (the configured model name)"
 
 
 def test_harness_build_result_propagates_baseline_fields() -> None:
@@ -796,7 +778,7 @@ def test_harness_build_result_propagates_baseline_fields() -> None:
         duration_sec=30.0,
     )
 
-    result = harness._build_result(**kwargs)
+    result, _ = harness._build_result(**kwargs)
 
     assert result.baseline_power_w == pytest.approx(30.0), (
         "baseline_power_w should be populated from EnergyBreakdown.baseline_power_w"
@@ -827,7 +809,7 @@ def test_mj_per_tok_uses_output_tokens_only() -> None:
         model_memory_mb=0.0,
     )
 
-    result = harness._build_result(**kwargs)
+    result, _ = harness._build_result(**kwargs)
 
     # 100 J / 100 output tokens * 1000 = 1000.0 mJ/output-token.
     # Old (buggy) denominator total_tokens=1000 would give 100.0.

--- a/tests/unit/study/test_equivalence_groups.py
+++ b/tests/unit/study/test_equivalence_groups.py
@@ -36,7 +36,7 @@ class TestWriteSerialisation:
                 ObservedCollisionGroup(
                     observed_config_hash="sha256:def",
                     engine="transformers",
-                    library_version="4.56.0",
+                    engine_version="4.56.0",
                     member_resolved_config_hashes=("sha256:abc", "sha256:xyz"),
                     member_experiment_ids=("exp_0001", "exp_0003"),
                     gap_detected=True,
@@ -63,14 +63,14 @@ class TestFindObservedCollisions:
         sidecars = [
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_a",
                 "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_b",  # Distinct resolved - gap!
                 "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",
@@ -86,14 +86,14 @@ class TestFindObservedCollisions:
         sidecars = [
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_a",
                 "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_a",
                 "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",
@@ -107,14 +107,14 @@ class TestFindObservedCollisions:
         sidecars = [
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_a",
                 "observed_config_hash": "observed_a",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_b",
                 "observed_config_hash": "observed_b",
                 "experiment_id": "exp_b",
@@ -127,14 +127,14 @@ class TestFindObservedCollisions:
         sidecars = [
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_a",
                 "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_a",
             },
             {
                 "engine": "transformers",
-                "library_version": "4.57.0",  # Different version
+                "engine_version": "4.57.0",  # Different version
                 "resolved_config_hash": "resolved_b",
                 "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",
@@ -148,12 +148,12 @@ class TestFindObservedCollisions:
         sidecars = [
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_a",
             },
             {
                 "engine": "transformers",
-                "library_version": "4.56.0",
+                "engine_version": "4.56.0",
                 "resolved_config_hash": "resolved_b",
                 "observed_config_hash": "observed_shared",
                 "experiment_id": "exp_b",

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -30,8 +30,6 @@ def _make_result(
     return ExperimentResult(
         experiment_id="test-save-record-001",
         measurement_config_hash="aabb1122ccdd3344",
-        measurement_methodology="total",
-        model_name="gpt2",
         total_tokens=256,
         total_energy_j=10.0,
         total_inference_time_sec=2.0,
@@ -77,7 +75,15 @@ def test_save_and_record_copies_timeseries_sidecar(tmp_path: Path) -> None:
     result_files: list[str] = []
 
     _save_and_record(
-        result, study_dir, manifest, "aabb1122", 1, result_files, ts_source_dir=tmp_path
+        result,
+        study_dir,
+        manifest,
+        "aabb1122",
+        1,
+        result_files,
+        model_name="gpt2",
+        engine="transformers",
+        ts_source_dir=tmp_path,
     )
 
     # result.json should have been saved into a subdirectory under study_dir
@@ -111,7 +117,16 @@ def test_save_and_record_no_timeseries(tmp_path: Path) -> None:
     manifest = MagicMock()
     result_files: list[str] = []
 
-    _save_and_record(result, study_dir, manifest, "ccdd5566", 1, result_files)
+    _save_and_record(
+        result,
+        study_dir,
+        manifest,
+        "ccdd5566",
+        1,
+        result_files,
+        model_name="gpt2",
+        engine="transformers",
+    )
 
     # result.json still saved
     assert len(result_files) == 1
@@ -146,7 +161,15 @@ def test_save_and_record_missing_source_file(tmp_path: Path) -> None:
 
     # Must not raise
     _save_and_record(
-        result, study_dir, manifest, "eeff7788", 1, result_files, ts_source_dir=tmp_path
+        result,
+        study_dir,
+        manifest,
+        "eeff7788",
+        1,
+        result_files,
+        model_name="gpt2",
+        engine="transformers",
+        ts_source_dir=tmp_path,
     )
 
     # result.json still saved
@@ -185,7 +208,7 @@ def test_save_and_record_writes_resolved_config_hash(tmp_path: Path) -> None:
                 "experiment_id": "test-resolved-001",
                 "config_hash": "aabb1122ccdd3344",
                 "engine": "transformers",
-                "library_version": "4.50.0",
+                "engine_version": "4.50.0",
                 "observed_config_hash": "sha256_h3_stub",
             }
         )
@@ -202,6 +225,8 @@ def test_save_and_record_writes_resolved_config_hash(tmp_path: Path) -> None:
         "aabb1122",
         1,
         result_files,
+        model_name="gpt2",
+        engine="transformers",
         ts_source_dir=tmp_path,
         resolved_config_hash="resolved_sha256_h1_value",
     )
@@ -239,7 +264,7 @@ def test_save_and_record_folds_provenance_into_config(tmp_path: Path) -> None:
                 "experiment_id": "test-prov-001",
                 "measurement_config_hash": "aabb1122ccdd3344",
                 "engine": "transformers",
-                "library_version": "4.50.0",
+                "engine_version": "4.50.0",
             }
         )
     )
@@ -260,6 +285,8 @@ def test_save_and_record_folds_provenance_into_config(tmp_path: Path) -> None:
         "aabb1122",
         1,
         result_files,
+        model_name="gpt2",
+        engine="transformers",
         ts_source_dir=tmp_path,
         resolution_log=resolution_log,
     )
@@ -316,6 +343,8 @@ def test_save_and_record_attaches_runner_provenance(tmp_path: Path) -> None:
         "aabb1122",
         1,
         result_files,
+        model_name="gpt2",
+        engine="transformers",
         runner_provenance=RunnerProvenance(mode="docker", image="img:2.0", source="env"),
     )
 
@@ -347,7 +376,16 @@ def test_save_and_record_calls_mark_failed_on_exception(tmp_path: Path) -> None:
         "llenergymeasure.results.persistence.save_result",
         side_effect=OSError("disk full"),
     ):
-        _save_and_record(result, study_dir, manifest, "aabb1122", 1, result_files)
+        _save_and_record(
+            result,
+            study_dir,
+            manifest,
+            "aabb1122",
+            1,
+            result_files,
+            model_name="gpt2",
+            engine="transformers",
+        )
 
     # mark_failed must be called - NOT mark_completed
     manifest.mark_failed.assert_called_once()

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -1,8 +1,10 @@
 """Unit tests for the ExperimentResult schema.
 
 Tests cover: schema_version, core/energy/quality fields, JSON round-trip,
-config hash utility, MultiGPUMetrics, frozen model enforcement. Engine identity,
-model_name, and methodology fields live in the config.json sidecar, not here.
+config hash utility, MultiGPUMetrics, frozen model enforcement. The config.json
+sidecar is the authoritative home for identity and methodology; the result keeps
+engine and model_name as convenience copies, while engine_version and the
+methodology fields live in the sidecar only.
 """
 
 from datetime import datetime
@@ -80,6 +82,12 @@ def test_methodology_fields_rejected(make_result):
         make_result(measurement_methodology="total")
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         make_result(steady_state_window=(12.3, 67.8))
+
+
+def test_engine_version_rejected(make_result):
+    """engine_version lives in config.json only; ExperimentResult rejects it."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        make_result(engine_version="1.2.3")
 
 
 # ---------------------------------------------------------------------------
@@ -362,14 +370,22 @@ def test_n_prompts_default_matches_dataset_config():
 
 
 # ---------------------------------------------------------------------------
-# model_name moved to the config.json sidecar
+# Convenience identity copies (authoritative home: config.json sidecar)
 # ---------------------------------------------------------------------------
 
 
-def test_model_name_rejected(make_result):
-    """model_name moved to config.json; ExperimentResult rejects it."""
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-        make_result(model_name="gpt2")
+def test_model_name_convenience_copy(make_result):
+    """model_name is kept on the result as a convenience copy."""
+    result = make_result(model_name="gpt2")
+    assert result.model_name == "gpt2"
+    assert make_result().model_name == "unknown"
+
+
+def test_engine_convenience_copy(make_result):
+    """engine is kept on the result as a convenience copy."""
+    result = make_result(engine="vllm")
+    assert result.engine == "vllm"
+    assert make_result().engine == "transformers"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -1,7 +1,8 @@
-"""Unit tests for ExperimentResult v4.0 schema.
+"""Unit tests for the ExperimentResult schema.
 
-Tests cover: schema_version="4.0", all RES-01..RES-11 fields, JSON round-trip,
-config hash utility, MultiGPUMetrics, frozen model enforcement.
+Tests cover: schema_version, core/energy/quality fields, JSON round-trip,
+config hash utility, MultiGPUMetrics, frozen model enforcement. Engine identity,
+model_name, and methodology fields live in the config.json sidecar, not here.
 """
 
 from datetime import datetime
@@ -29,7 +30,6 @@ def make_result():
         defaults = dict(
             experiment_id="test-001",
             measurement_config_hash="abcdef0123456789",
-            measurement_methodology="total",
             total_tokens=1000,
             total_energy_j=50.0,
             total_inference_time_sec=10.0,
@@ -50,8 +50,8 @@ def make_result():
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_default_is_3_0(make_result):
-    """schema_version defaults to '4.0', not '4.0.0'."""
+def test_schema_version_default(make_result):
+    """schema_version defaults to the current single-segment version (e.g. '5.0')."""
     result = make_result()
     from tests.conftest import EXPERIMENT_SCHEMA_VERSION
 
@@ -70,49 +70,16 @@ def test_measurement_config_hash_field(make_result):
 
 
 # ---------------------------------------------------------------------------
-# Tasks 2.3-2.5: measurement_methodology
+# Methodology fields moved to the config.json sidecar
 # ---------------------------------------------------------------------------
 
 
-def test_measurement_methodology_total(make_result):
-    """measurement_methodology='total' validates."""
-    result = make_result(measurement_methodology="total")
-    assert result.measurement_methodology == "total"
-
-
-def test_measurement_methodology_steady_state(make_result):
-    """measurement_methodology='steady_state' validates."""
-    result = make_result(measurement_methodology="steady_state")
-    assert result.measurement_methodology == "steady_state"
-
-
-def test_measurement_methodology_windowed(make_result):
-    """measurement_methodology='windowed' validates."""
-    result = make_result(measurement_methodology="windowed")
-    assert result.measurement_methodology == "windowed"
-
-
-def test_measurement_methodology_invalid(make_result):
-    """measurement_methodology='invalid' raises ValidationError."""
-    with pytest.raises(ValidationError):
-        make_result(measurement_methodology="invalid")
-
-
-# ---------------------------------------------------------------------------
-# Tasks 2.6-2.7: steady_state_window
-# ---------------------------------------------------------------------------
-
-
-def test_steady_state_window_tuple(make_result):
-    """steady_state_window=(12.3, 67.8) validates and round-trips."""
-    result = make_result(steady_state_window=(12.3, 67.8))
-    assert result.steady_state_window == (12.3, 67.8)
-
-
-def test_steady_state_window_none(make_result):
-    """steady_state_window=None validates when methodology=total."""
-    result = make_result(measurement_methodology="total", steady_state_window=None)
-    assert result.steady_state_window is None
+def test_methodology_fields_rejected(make_result):
+    """methodology fields moved to config.json; ExperimentResult rejects them."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        make_result(measurement_methodology="total")
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        make_result(steady_state_window=(12.3, 67.8))
 
 
 # ---------------------------------------------------------------------------
@@ -356,8 +323,6 @@ def test_json_round_trip(make_result):
         energy_per_output_token_j=0.05,
     )
     original = make_result(
-        measurement_methodology="steady_state",
-        steady_state_window=(10.0, 60.0),
         baseline_power_w=42.5,
         energy_adjusted_j=45.2,
         energy_per_device_j=[25.0, 25.0],
@@ -371,8 +336,6 @@ def test_json_round_trip(make_result):
 
     assert restored.schema_version == original.schema_version
     assert restored.experiment_id == original.experiment_id
-    assert restored.measurement_methodology == original.measurement_methodology
-    assert restored.steady_state_window == original.steady_state_window
     assert restored.baseline_power_w == original.baseline_power_w
     assert restored.energy_adjusted_j == original.energy_adjusted_j
     assert restored.energy_per_device_j == original.energy_per_device_j
@@ -399,20 +362,14 @@ def test_n_prompts_default_matches_dataset_config():
 
 
 # ---------------------------------------------------------------------------
-# model_name field on ExperimentResult
+# model_name moved to the config.json sidecar
 # ---------------------------------------------------------------------------
 
 
-def test_model_name_field_exists(make_result):
-    """model_name is accessible and stores the provided value."""
-    result = make_result(model_name="gpt2")
-    assert result.model_name == "gpt2"
-
-
-def test_model_name_defaults_to_unknown(make_result):
-    """model_name defaults to 'unknown' when not supplied."""
-    result = make_result()
-    assert result.model_name == "unknown"
+def test_model_name_rejected(make_result):
+    """model_name moved to config.json; ExperimentResult rejects it."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        make_result(model_name="gpt2")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -27,20 +27,33 @@ from llenergymeasure.domain.environment import (
     GPUEnvironment,
 )
 from llenergymeasure.domain.experiment import ExperimentResult
-from llenergymeasure.results.persistence import load_result, save_environment, save_result
+from llenergymeasure.results.persistence import (
+    load_result,
+    save_environment,
+)
+from llenergymeasure.results.persistence import save_result as _persist_save_result
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
+# model_name/engine now live in the config.json sidecar, so save_result requires
+# them explicitly. This wrapper supplies gpt2/transformers defaults for the
+# fixtures that do not exercise directory-slug specifics; the slug tests pass
+# model_name explicitly.
+_HF_MODEL = "meta-llama/Llama-3.1-8B"
+
+
+def save_result(result, output_dir, *, model_name="gpt2", engine="transformers", **kwargs):
+    return _persist_save_result(result, output_dir, model_name=model_name, engine=engine, **kwargs)
+
 
 @pytest.fixture()
 def minimal_result() -> ExperimentResult:
-    """Minimal valid ExperimentResult with pytorch engine and known model."""
+    """Minimal valid ExperimentResult."""
     return ExperimentResult(
         experiment_id="persist-test-001",
         measurement_config_hash="abcdef0123456789",
-        measurement_methodology="total",
         total_tokens=512,
         total_energy_j=25.6,
         total_inference_time_sec=5.0,
@@ -49,18 +62,15 @@ def minimal_result() -> ExperimentResult:
         total_flops=1e11,
         start_time=datetime(2026, 2, 26, 14, 0, 0),
         end_time=datetime(2026, 2, 26, 14, 0, 5),
-        model_name="gpt2",
     )
 
 
 @pytest.fixture()
 def hf_model_result() -> ExperimentResult:
-    """ExperimentResult with a HuggingFace-style model path containing /."""
+    """ExperimentResult used with a HuggingFace-style model path containing /."""
     return ExperimentResult(
         experiment_id="persist-test-hf",
         measurement_config_hash="fedcba9876543210",
-        measurement_methodology="steady_state",
-        steady_state_window=(1.0, 4.0),
         total_tokens=1024,
         total_energy_j=51.2,
         total_inference_time_sec=10.0,
@@ -69,7 +79,6 @@ def hf_model_result() -> ExperimentResult:
         total_flops=2e11,
         start_time=datetime(2026, 2, 26, 14, 0, 0),
         end_time=datetime(2026, 2, 26, 14, 0, 10),
-        model_name="meta-llama/Llama-3.1-8B",
     )
 
 
@@ -79,7 +88,6 @@ def result_with_timeseries() -> ExperimentResult:
     return ExperimentResult(
         experiment_id="persist-test-ts",
         measurement_config_hash="1122334455667788",
-        measurement_methodology="windowed",
         total_tokens=256,
         total_energy_j=12.8,
         total_inference_time_sec=2.5,
@@ -89,7 +97,6 @@ def result_with_timeseries() -> ExperimentResult:
         timeseries="timeseries.parquet",
         start_time=datetime(2026, 2, 26, 15, 0, 0),
         end_time=datetime(2026, 2, 26, 15, 0, 2, 500000),
-        model_name="gpt2",
     )
 
 
@@ -129,7 +136,7 @@ def test_save_directory_name_format(tmp_path: Path, minimal_result: ExperimentRe
 
 def test_save_model_slug_normalisation(tmp_path: Path, hf_model_result: ExperimentResult) -> None:
     """HuggingFace model path strips org prefix, uses short model name."""
-    result_path = save_result(hf_model_result, tmp_path)
+    result_path = save_result(hf_model_result, tmp_path, model_name=_HF_MODEL)
     dir_name = result_path.parent.name
     # meta-llama/Llama-3.1-8B -> Llama-3.1-8B (short name, no org prefix)
     assert "Llama-3.1-8B-transformers" in dir_name, f"Slug normalisation failed: {dir_name}"
@@ -204,10 +211,8 @@ def test_from_json_loads_correctly(tmp_path: Path, minimal_result: ExperimentRes
     from tests.conftest import EXPERIMENT_SCHEMA_VERSION
 
     assert loaded.schema_version == EXPERIMENT_SCHEMA_VERSION
-    assert loaded.measurement_methodology == minimal_result.measurement_methodology
     assert loaded.total_tokens == minimal_result.total_tokens
     assert loaded.total_energy_j == pytest.approx(minimal_result.total_energy_j)
-    assert loaded.engine == minimal_result.engine
 
 
 def test_from_json_round_trip(tmp_path: Path, minimal_result: ExperimentResult) -> None:
@@ -218,24 +223,6 @@ def test_from_json_round_trip(tmp_path: Path, minimal_result: ExperimentResult) 
     original_json = minimal_result.model_dump_json(indent=2)
     loaded_json = loaded.model_dump_json(indent=2)
     assert original_json == loaded_json
-
-
-def test_model_name_round_trips(tmp_path: Path, minimal_result: ExperimentResult) -> None:
-    """model_name field survives save/load unchanged."""
-    result_path = save_result(minimal_result, tmp_path)
-    loaded = load_result(result_path)
-    assert loaded.model_name == minimal_result.model_name
-
-
-def test_steady_state_window_round_trips(tmp_path: Path, hf_model_result: ExperimentResult) -> None:
-    """steady_state_window tuple (float, float) survives JSON round-trip."""
-    result_path = save_result(hf_model_result, tmp_path)
-    loaded = load_result(result_path)
-
-    assert loaded.steady_state_window is not None
-    assert len(loaded.steady_state_window) == 2
-    assert loaded.steady_state_window[0] == pytest.approx(1.0)
-    assert loaded.steady_state_window[1] == pytest.approx(4.0)
 
 
 # ---------------------------------------------------------------------------
@@ -473,13 +460,18 @@ def test_save_config_sidecar_roundtrips_declared_config(tmp_path: Path) -> None:
         experiment_id="exp-1",
         config_hash="a" * 16,
         engine="vllm",
-        library_version="0.19.1",
+        engine_version="0.19.1",
+        model_name="fake/model",
+        measurement_methodology="total",
         observed_config_hash="b" * 64,
         declared_config=declared,
     )
 
     payload = json.loads(path.read_text())
     assert payload["declared_config"] == declared
+    assert payload["engine_version"] == "0.19.1"
+    assert payload["model_name"] == "fake/model"
+    assert payload["measurement_methodology"] == "total"
 
 
 def test_save_config_sidecar_omits_declared_config_when_absent(tmp_path: Path) -> None:
@@ -493,12 +485,17 @@ def test_save_config_sidecar_omits_declared_config_when_absent(tmp_path: Path) -
         experiment_id="exp-1",
         config_hash="a" * 16,
         engine="vllm",
-        library_version="0.19.1",
+        engine_version="0.19.1",
+        model_name="fake/model",
+        measurement_methodology="total",
         observed_config_hash="b" * 64,
     )
 
     payload = json.loads(path.read_text())
     assert "declared_config" not in payload
+    # steady_state_window/discard_fraction omitted when None (total methodology).
+    assert "steady_state_window" not in payload
+    assert "measurement_window_discard_fraction" not in payload
 
 
 def test_save_config_sidecar_includes_schema_version(tmp_path: Path) -> None:
@@ -515,11 +512,39 @@ def test_save_config_sidecar_includes_schema_version(tmp_path: Path) -> None:
         experiment_id="exp-1",
         config_hash="a" * 16,
         engine="vllm",
-        library_version="0.19.1",
+        engine_version="0.19.1",
+        model_name="fake/model",
+        measurement_methodology="total",
     )
 
     payload = json.loads(path.read_text())
     assert payload["schema_version"] == CONFIG_SIDECAR_SCHEMA_VERSION == "2.0"
+
+
+def test_save_config_sidecar_carries_methodology_window(tmp_path: Path) -> None:
+    """steady_state methodology writes the window + discard fraction + not-detected flag."""
+    import json
+
+    from llenergymeasure.results.persistence import save_config_sidecar
+
+    path = save_config_sidecar(
+        tmp_path,
+        experiment_id="exp-1",
+        config_hash="a" * 16,
+        engine="transformers",
+        engine_version="4.56.0",
+        model_name="gpt2",
+        measurement_methodology="steady_state",
+        steady_state_window=(1.0, 4.0),
+        measurement_window_discard_fraction=0.1,
+        steady_state_not_detected=True,
+    )
+
+    payload = json.loads(path.read_text())
+    assert payload["measurement_methodology"] == "steady_state"
+    assert payload["steady_state_window"] == [1.0, 4.0]
+    assert payload["measurement_window_discard_fraction"] == pytest.approx(0.1)
+    assert payload["steady_state_not_detected"] is True
 
 
 def test_save_result_does_not_write_resolution_sidecar(

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -37,10 +37,10 @@ from llenergymeasure.results.persistence import save_result as _persist_save_res
 # Fixtures
 # ---------------------------------------------------------------------------
 
-# model_name/engine now live in the config.json sidecar, so save_result requires
-# them explicitly. This wrapper supplies gpt2/transformers defaults for the
-# fixtures that do not exercise directory-slug specifics; the slug tests pass
-# model_name explicitly.
+# The authoritative home for model_name/engine is the config.json sidecar
+# (result.json keeps convenience copies), so save_result takes them explicitly.
+# This wrapper supplies gpt2/transformers defaults for the fixtures that do not
+# exercise directory-slug specifics; the slug tests pass model_name explicitly.
 _HF_MODEL = "meta-llama/Llama-3.1-8B"
 
 
@@ -223,6 +223,34 @@ def test_from_json_round_trip(tmp_path: Path, minimal_result: ExperimentResult) 
     original_json = minimal_result.model_dump_json(indent=2)
     loaded_json = loaded.model_dump_json(indent=2)
     assert original_json == loaded_json
+
+
+def test_convenience_identity_copies_round_trip(tmp_path: Path) -> None:
+    """engine and model_name convenience copies survive save/load on result.json.
+
+    Deliberate small duplication: the authoritative home is config.json, but
+    result.json keeps the two fields so it is self-describing when separated
+    from its directory.
+    """
+    result = ExperimentResult(
+        experiment_id="persist-convenience-001",
+        measurement_config_hash="abcdef0123456789",
+        engine="vllm",
+        model_name=_HF_MODEL,
+        total_tokens=512,
+        total_energy_j=25.6,
+        total_inference_time_sec=5.0,
+        avg_tokens_per_second=102.4,
+        avg_energy_per_token_j=0.05,
+        total_flops=1e12,
+        start_time=datetime(2026, 2, 26, 14, 0, 0),
+        end_time=datetime(2026, 2, 26, 14, 0, 5),
+    )
+    result_path = save_result(result, tmp_path, model_name=result.model_name, engine=result.engine)
+    loaded = load_result(result_path)
+
+    assert loaded.engine == "vllm"
+    assert loaded.model_name == _HF_MODEL
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second of three consolidation PRs finishing the results-bundle rationalisation
(`.product/designs/results-bundle-rationalisation.md`, Change B).

**Stacked on #811** (`refactor/results-provenance-fold`). Retarget to `main` once #811 merges.

`result.json` becomes pure measurement output. Configuration/methodology fields move to the `config.json` sidecar, and engine identity is de-duplicated.

- Removed from `ExperimentResult` and relocated to `config.json` top-level:
  `model_name`, `measurement_methodology`, `steady_state_window`,
  `measurement_window_discard_fraction`, `steady_state_not_detected`.
- Deduped engine identity: `config.json` already carried `engine` + the library
  version, so dropped the duplicated `engine`/`engine_version` off the result and
  renamed the sidecar's `library_version` field to `engine_version`. The config
  sidecar schema stays `2.0` (still unreleased) - the rename is noted in the CHANGELOG.
- Bumped `result.json` `schema_version` `4.0` -> `5.0` (breaking; removals).
- No `load_result()` backfill shim (pre-1.0: `schema_version` discriminates; old
  bundles load as their own schema and are unaffected on disk).

### Field relocation map (old ExperimentResult -> new home)

| Field | New home |
|---|---|
| `engine` | `config.json` `engine` (already present; dropped from result) |
| `engine_version` | `config.json` `engine_version` (renamed from `library_version`; dropped from result) |
| `model_name` | `config.json` `model_name` (top-level) |
| `measurement_methodology` | `config.json` `measurement_methodology` (top-level) |
| `steady_state_window` | `config.json` `steady_state_window` (omitted when None) |
| `measurement_window_discard_fraction` | `config.json` (omitted when None) |
| `steady_state_not_detected` | `config.json` (top-level) |

### Consumer call sites changed

- `results/persistence.py`: `save_config_sidecar` renamed `library_version` -> `engine_version`
  and gained `model_name`/methodology params; `save_result`/`_experiment_dir_name` now take
  `model_name`+`engine` explicitly (no longer read off the result).
- `harness/measurement.py`: `_build_result` returns `(result, _ConfigMethodology)`;
  `_write_config_sidecar` writes the relocated fields.
- `study/runner.py` + `study/single.py`: thread `model_name`/`engine` through
  `_handle_result`/`_save_and_record`; the docker-display path uses the threaded engine.
- `study/equivalence_groups.py`: reads `engine_version` from the sidecar; `ObservedCollisionGroup.engine_version` renamed.
- Docs: results-schema, `ExperimentResult`, `run_study`, energy-measurement reference the new home; the replay fixture is regenerated at `v5.0`.

## Test plan

- `make lint`, `make typecheck`, `make test` all green (3018 passed, 35 skipped).
- Report-gaps / runtime-observations were verified out of scope: their `library_version`
  comes from `runtime_observations.jsonl`, not the config.json sidecar.
- CI `schema-version-check` validates the engine discovered-schema pins, not `result.json`, so it is unaffected.