### PR TITLE
feat(results): tag timeseries parquet with experiment identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Added
 
+- The `timeseries.parquet` sidecar now carries `experiment_id` and
+  `measurement_config_hash` as Parquet file-level key-value metadata (not columns), so the
+  artefact stays attributable if separated from its result directory. This mirrors the
+  identity fields the JSON sidecars already carry and completes the per-experiment bundle
+  identity rationalisation. Data columns and schema are unchanged; readers that ignore file
+  metadata are unaffected.
 - The per-experiment `config.json` sidecar now carries its own `schema_version`
   (`"2.0"`), independent of `result.json`'s schema version. It succeeds the retired
   `_resolution.json` sidecar (`"1.0"`), whose per-field provenance now lives in this file.

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -178,11 +178,20 @@ def estimate_flops_palm_from_config(
 
 
 def write_timeseries_parquet(
-    samples: list[PowerThermalSample], path: Path
+    samples: list[PowerThermalSample],
+    path: Path,
+    *,
+    experiment_id: str | None = None,
+    measurement_config_hash: str | None = None,
 ) -> Path:  # pragma: no cover
     from llenergymeasure.harness.timeseries import write_timeseries_parquet as _wts
 
-    return _wts(samples, path)
+    return _wts(
+        samples,
+        path,
+        experiment_id=experiment_id,
+        measurement_config_hash=measurement_config_hash,
+    )
 
 
 def collect_measurement_warnings(
@@ -690,7 +699,9 @@ class MeasurementHarness:
         """Write the timeseries + config sidecars and assemble the ExperimentResult."""
         _p = progress
 
-        # 14. Write timeseries Parquet sidecar (if output_dir set and save_timeseries enabled)
+        # 14. Decide the timeseries sidecar path. The Parquet file is written after
+        # the result is assembled (step 17) so it can carry the experiment identity
+        # as file-level metadata, mirroring the JSON sidecars.
         resolved_output_dir = Path(output_dir) if output_dir is not None else None
         if _p:
             _p.on_step_start(
@@ -700,14 +711,11 @@ class MeasurementHarness:
             )
             t0_save = time.perf_counter()
 
-        timeseries_path: str | None = None
-        if save_timeseries and resolved_output_dir is not None and window.timeseries_samples:
-            ts_file = write_timeseries_parquet(
-                window.timeseries_samples,
-                resolved_output_dir / TIMESERIES_FILENAME,
-            )
-            timeseries_path = ts_file.name  # relative name in result JSON
-            _emit_substep(_p, "save", "timeseries parquet written")
+        write_timeseries = bool(
+            save_timeseries and resolved_output_dir is not None and window.timeseries_samples
+        )
+        # Relative name recorded in result JSON; the file lands at this basename.
+        timeseries_path: str | None = TIMESERIES_FILENAME if write_timeseries else None
 
         # 15. Collect measurement quality warnings
         duration_sec = (window.end_time - window.start_time).total_seconds()
@@ -738,7 +746,17 @@ class MeasurementHarness:
         )
         _emit_substep(_p, "save", "result assembled")
 
-        # 17. Write config.json sidecar (observed-params + observed_config_hash)
+        # 17. Write timeseries Parquet sidecar, tagged with the assembled identity.
+        if write_timeseries and resolved_output_dir is not None:
+            write_timeseries_parquet(
+                window.timeseries_samples,
+                resolved_output_dir / TIMESERIES_FILENAME,
+                experiment_id=result.experiment_id,
+                measurement_config_hash=result.measurement_config_hash,
+            )
+            _emit_substep(_p, "save", "timeseries parquet written")
+
+        # 18. Write config.json sidecar (observed-params + observed_config_hash)
         # Written to output_dir (temp dir, same as timeseries.parquet) so the
         # runner can move it to the per-experiment directory.
         if resolved_output_dir is not None:

--- a/src/llenergymeasure/harness/timeseries.py
+++ b/src/llenergymeasure/harness/timeseries.py
@@ -43,6 +43,9 @@ def write_timeseries_parquet(
     samples: list[PowerThermalSample],
     output_path: Path,
     gpu_index: int = 0,
+    *,
+    experiment_id: str | None = None,
+    measurement_config_hash: str | None = None,
 ) -> Path:
     """Write 1 Hz downsampled timeseries to a Parquet file.
 
@@ -54,10 +57,17 @@ def write_timeseries_parquet(
     its own row per second. The ``gpu_index`` parameter is kept for backward
     compatibility but is only used as a fallback when samples lack the attribute.
 
+    When ``experiment_id`` and/or ``measurement_config_hash`` are supplied they are
+    written as Parquet file-level key-value metadata (not columns), so the artefact
+    stays attributable if separated from its result directory. This mirrors the
+    identity fields the JSON sidecars carry.
+
     Args:
         samples: Raw PowerThermalSamples from PowerThermalSampler.
         output_path: Destination path for the Parquet file.
         gpu_index: Fallback GPU device index when samples have no gpu_index attribute.
+        experiment_id: Unique experiment identifier, stored as file metadata.
+        measurement_config_hash: Config hash for orphan attribution, stored as file metadata.
 
     Returns:
         The output_path after writing.
@@ -69,6 +79,16 @@ def write_timeseries_parquet(
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     schema = _timeseries_schema()
+    identity = {
+        key: value
+        for key, value in (
+            ("experiment_id", experiment_id),
+            ("measurement_config_hash", measurement_config_hash),
+        )
+        if value is not None
+    }
+    if identity:
+        schema = schema.with_metadata(identity)
 
     if not samples:
         # Write empty Parquet with correct schema

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -1379,6 +1379,11 @@ def test_harness_save_timeseries_true_writes_parquet(tmp_path):
         ) as mock_write_ts,
         patch("llenergymeasure.harness.measurement.collect_measurement_warnings", return_value=[]),
     ):
-        harness.run(engine, config, output_dir=str(tmp_path), save_timeseries=True)
+        result = harness.run(engine, config, output_dir=str(tmp_path), save_timeseries=True)
 
     mock_write_ts.assert_called_once()
+    # The writer is tagged with the assembled result's identity (mirrors the
+    # config.json sidecar), so the parquet stays attributable if orphaned.
+    _, kwargs = mock_write_ts.call_args
+    assert kwargs["experiment_id"] == result.experiment_id
+    assert kwargs["measurement_config_hash"] == result.measurement_config_hash

--- a/tests/unit/harness/test_timeseries.py
+++ b/tests/unit/harness/test_timeseries.py
@@ -1,0 +1,71 @@
+"""Tests for the Parquet timeseries writer, focused on file-level identity metadata.
+
+The writer tags the Parquet artefact with ``experiment_id`` and
+``measurement_config_hash`` as file-level key-value metadata (not columns) so the
+sidecar stays attributable if separated from its result directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+from llenergymeasure.device.power_thermal import PowerThermalSample
+from llenergymeasure.harness.timeseries import write_timeseries_parquet
+
+
+def _sample(**overrides: object) -> PowerThermalSample:
+    defaults = dict(
+        timestamp=0.0,
+        power_w=10.0,
+        temperature_c=40.0,
+        memory_used_mb=1024.0,
+        memory_total_mb=40960.0,
+        sm_utilisation=50.0,
+    )
+    defaults.update(overrides)
+    return PowerThermalSample(**defaults)  # type: ignore[arg-type]
+
+
+def test_identity_metadata_round_trips(tmp_path: Path) -> None:
+    """experiment_id + measurement_config_hash survive a write/read cycle as KV metadata."""
+    path = tmp_path / "timeseries.parquet"
+    write_timeseries_parquet(
+        [_sample()],
+        path,
+        experiment_id="gpt2_20260715_120000",
+        measurement_config_hash="abcdef0123456789",
+    )
+
+    metadata = pq.read_table(path).schema.metadata
+    assert metadata is not None
+    assert metadata[b"experiment_id"] == b"gpt2_20260715_120000"
+    assert metadata[b"measurement_config_hash"] == b"abcdef0123456789"
+
+
+def test_identity_metadata_on_empty_samples(tmp_path: Path) -> None:
+    """Identity metadata is written even when there are no samples (empty parquet)."""
+    path = tmp_path / "timeseries.parquet"
+    write_timeseries_parquet(
+        [],
+        path,
+        experiment_id="gpt2_20260715_120000",
+        measurement_config_hash="abcdef0123456789",
+    )
+
+    metadata = pq.read_table(path).schema.metadata
+    assert metadata is not None
+    assert metadata[b"experiment_id"] == b"gpt2_20260715_120000"
+    assert metadata[b"measurement_config_hash"] == b"abcdef0123456789"
+
+
+def test_no_identity_metadata_when_omitted(tmp_path: Path) -> None:
+    """Without identity args the writer carries no identity keys (unchanged default)."""
+    path = tmp_path / "timeseries.parquet"
+    write_timeseries_parquet([_sample()], path)
+
+    metadata = pq.read_table(path).schema.metadata
+    identity_keys = {b"experiment_id", b"measurement_config_hash"}
+    present = set(metadata.keys()) if metadata else set()
+    assert not (identity_keys & present)


### PR DESCRIPTION
## Summary

Change C of the results-bundle rationalisation (`.product/designs/results-bundle-rationalisation.md`). Adds `experiment_id` and `measurement_config_hash` to the `timeseries.parquet` sidecar as Parquet **file-level key-value metadata** (not columns), so the artefact stays attributable if separated from its result directory. This mirrors the identity fields the JSON sidecars already carry (see `save_config_sidecar` / `save_environment` in `results/persistence.py`) and completes the per-experiment bundle identity rationalisation.

- `harness/timeseries.py`: `write_timeseries_parquet()` gains keyword-only `experiment_id` / `measurement_config_hash`; when supplied they are attached to the Arrow schema via `with_metadata(...)`, which pyarrow writes as file-level KV metadata. Omitted values write no keys (default unchanged). pyarrow lazy-import and error semantics are untouched.
- `harness/measurement.py`: the parquet is now written **after** the `ExperimentResult` is assembled so the writer can reuse `result.experiment_id` / `result.measurement_config_hash`, matching the config.json sidecar path exactly (no duplicated `experiment_id` derivation). Data columns and the locked schema are unchanged.
- `results/persistence.py`: **no change needed** - `save_result()` only copies the already-written parquet (`shutil.copy2`), which preserves the embedded metadata.

## Test plan

- New `tests/unit/harness/test_timeseries.py`: asserts the KV metadata round-trips via `pyarrow.parquet` (with samples, with empty samples, and absent when omitted).
- Extended `test_harness_save_timeseries_true_writes_parquet`: asserts the harness threads the assembled result identity into the writer.
- `make lint`, `make typecheck`, `make test` all green (3021 passed, 35 skipped).

## Stack

Third and final consolidation PR. Stacked on #812 (`refactor/result-schema-slim`), which is stacked on #811. Base this on #812; do not merge before it.