### PR TITLE
fix(infra): forward NCCL_* host env into engine containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,15 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- llem now forwards every `NCCL_*` host environment variable into both the experiment
+  container (`infra.docker_runner`) and the baseline container (`study.baseline_container`),
+  so NCCL tuning/workaround settings set on the host reach the engine process, which runs
+  inside the container. The motivating case is `NCCL_P2P_DISABLE=1` on PCIe multi-GPU hosts
+  whose topology lacks functional peer-to-peer (P2P, e.g. an inter-GPU link reported as `SYS`
+  in `nvidia-smi topo -m`, often because ACS is enabled): without it, tensor-parallel runs
+  hang at the first NCCL collective. Vars are emitted as explicit `-e KEY=VALUE` args
+  (matching the existing `LLEM_*` forwarding idiom) in sorted key order for a deterministic
+  command. ([#814])
 - Study GPU advisory locks are now named by the PHYSICAL device a study occupies, not the
   in-container logical index. Lock names came from `_resolve_gpu_indices` (which enumerates
   from 0), but the physical device is chosen at the docker level by `LLEM_DOCKER_GPUS`
@@ -816,3 +825,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#803]: https://github.com/henrycgbaker/llenergymeasure/pull/803
 [#804]: https://github.com/henrycgbaker/llenergymeasure/pull/804
 [#807]: https://github.com/henrycgbaker/llenergymeasure/pull/807
+[#814]: https://github.com/henrycgbaker/llenergymeasure/pull/814

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -206,7 +206,7 @@ For publication-quality measurements, leave warmup enabled. See
 **Symptom:** `llem run` appears to hang indefinitely - no progress output,
 no error, process does not return.
 
-**Cause:** Most hangs fall into four categories:
+**Cause:** Most hangs fall into five categories:
 
 1. **Docker image pull in progress** - the first run of an engine pulls a
    multi-GB image. Check `docker pull` progress in a separate terminal:
@@ -225,6 +225,13 @@ no error, process does not return.
    `max_new_tokens` with a slow sampler) may legitimately exceed this. Increase
    the timeout in the YAML if needed.
 
+5. **Multi-GPU NCCL collective stuck** - on multi-GPU (tensor-parallel) runs the
+   process can hang at the very first NCCL collective with no output. This is
+   common on PCIe hosts whose GPU topology lacks functional peer-to-peer (P2P)
+   - e.g. boxes where the inter-GPU link is `SYS` in `nvidia-smi topo -m`, often
+   because ACS is enabled in the BIOS. The standard workaround is
+   `NCCL_P2P_DISABLE=1`.
+
 **Fix:**
 
 - For Docker/TRT-LLM hangs: wait, then check `docker logs <container-id>` for progress.
@@ -232,6 +239,11 @@ no error, process does not return.
   to verify GPU access from Docker, then re-run `llem run`.
 - For genuine inference hangs: raise `study_execution.experiment_timeout_seconds` or
   reduce `max_new_tokens`.
+- For a multi-GPU NCCL hang: set the NCCL tuning/workaround var on the host and
+  re-run - llem forwards every `NCCL_*` host variable into both the experiment
+  and baseline containers, so `NCCL_P2P_DISABLE=1 llem run ...` (or exporting it
+  first) applies inside the container. On a PCIe box without working P2P this is
+  the standard fix.
 
 ---
 

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -73,7 +73,7 @@ from llenergymeasure.utils.env_config import (
 from llenergymeasure.utils.exceptions import DockerError
 from llenergymeasure.utils.io import load_json
 
-__all__ = ["DockerRunner", "append_package_dispatch"]
+__all__ = ["DockerRunner", "append_nccl_env", "append_package_dispatch"]
 
 logger = logging.getLogger(__name__)
 
@@ -280,6 +280,32 @@ def append_package_dispatch(
     if entry_module is not None:
         cmd.extend(["-e", f"{ENV_ENTRY_MODULE}={entry_module}"])
     cmd.extend(["--entrypoint", "/llem-entry.sh"])
+
+
+def append_nccl_env(cmd: list[str]) -> None:
+    """Forward host ``NCCL_*`` env vars into the container.
+
+    NCCL tuning/workaround settings must reach the engine process, which runs
+    inside the container rather than on the host. The canonical case is
+    ``NCCL_P2P_DISABLE=1`` on PCIe multi-GPU hosts whose topology lacks
+    functional GPU peer-to-peer (P2P): without it, every tensor-parallel run
+    hangs at the first NCCL collective.
+
+    Uses explicit ``-e KEY=VALUE`` (matching the ``LLEM_*`` forwarding idiom in
+    ``DockerRunner._build_docker_cmd``) and iterates keys in sorted order so the
+    built command is deterministic (tests assert on argv). Shared by the
+    experiment dispatch (``DockerRunner._build_docker_cmd``) and the baseline
+    dispatch (``study.baseline_container.build_baseline_docker_cmd``) so the two
+    env-forwarding setups cannot drift.
+
+    Args:
+        cmd: Docker command list to mutate in place (env appended before the
+            image name, which the caller adds afterwards).
+    """
+    for env_key in sorted(k for k in os.environ if k.startswith("NCCL_")):
+        env_val = os.environ[env_key]
+        if env_val:
+            cmd.extend(["-e", f"{env_key}={env_val}"])
 
 
 class DockerRunner:
@@ -1018,6 +1044,11 @@ class DockerRunner:
         for env_key, env_val in os.environ.items():
             if env_key.startswith("LLEM_") and env_val and env_key not in _RESERVED_EXCHANGE_ENV:
                 cmd.extend(["-e", f"{env_key}={env_val}"])
+
+        # Forward host NCCL_* env vars so multi-GPU tuning/workaround settings
+        # (e.g. NCCL_P2P_DISABLE=1 on PCIe hosts without functional GPU P2P)
+        # reach the engine process, which runs inside the container.
+        append_nccl_env(cmd)
 
         # Extra volume mounts (engine cache, model cache, etc.)
         for host_path, container_path in self.extra_mounts:

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -34,7 +34,7 @@ from llenergymeasure.config.ssot import (
     TEMP_PREFIX_EXCHANGE,
 )
 from llenergymeasure.harness.baseline import BaselineCache
-from llenergymeasure.infra.docker_runner import append_package_dispatch
+from llenergymeasure.infra.docker_runner import append_nccl_env, append_package_dispatch
 from llenergymeasure.utils.env_config import docker_gpus_arg
 from llenergymeasure.utils.io import load_json
 
@@ -96,6 +96,10 @@ def build_baseline_docker_cmd(
         "-e",
         f"CUDA_VISIBLE_DEVICES={cuda_visible}",
     ]
+    # Forward host NCCL_* env vars so multi-GPU tuning/workaround settings
+    # (e.g. NCCL_P2P_DISABLE=1 on PCIe hosts without functional GPU P2P) reach
+    # the baseline process inside the container, matching the experiment path.
+    append_nccl_env(cmd)
     # Mount the package + bootstrap and point --entrypoint at /llem-entry.sh,
     # which makes the package importable and exec's the baseline entry module.
     append_package_dispatch(cmd, engine=engine, entry_module=_BASELINE_ENTRY_MODULE)

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -1579,3 +1579,67 @@ class TestDockerGpusOverride:
         cmd = captured_cmds[0]
         assert cmd[cmd.index("--gpus") + 1] == "device=2"
         assert "all" not in cmd[: cmd.index("--gpus") + 2]
+
+
+# ---------------------------------------------------------------------------
+# Test: NCCL_* host env vars are forwarded into the experiment container
+# ---------------------------------------------------------------------------
+
+
+class TestNcclEnvForwarding:
+    """Host ``NCCL_*`` env vars are forwarded into the container so multi-GPU
+    tuning/workaround settings (e.g. ``NCCL_P2P_DISABLE=1`` on PCIe hosts
+    without functional GPU P2P) reach the engine process inside the container.
+    Non-NCCL host vars are NOT forwarded by this loop.
+    """
+
+    @staticmethod
+    def _e_pairs(cmd: list[str]) -> list[str]:
+        """Return every ``VALUE`` following a ``-e`` flag in *cmd*."""
+        return [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "-e" and i + 1 < len(cmd)]
+
+    def test_nccl_vars_forwarded(self, monkeypatch):
+        """Host NCCL_* vars appear as -e KEY=VALUE args in the docker command."""
+        monkeypatch.setenv("NCCL_P2P_DISABLE", "1")
+        monkeypatch.setenv("NCCL_IB_DISABLE", "1")
+        config = make_config()
+        runner = DockerRunner(image=IMAGE)
+        cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
+
+        pairs = self._e_pairs(cmd)
+        assert "NCCL_P2P_DISABLE=1" in pairs
+        assert "NCCL_IB_DISABLE=1" in pairs
+
+    def test_non_nccl_var_not_forwarded(self, monkeypatch):
+        """A non-NCCL, non-LLEM host var must not be forwarded into the container."""
+        monkeypatch.setenv("SOME_UNRELATED_VAR", "leak")
+        config = make_config()
+        runner = DockerRunner(image=IMAGE)
+        cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
+
+        assert not any("SOME_UNRELATED_VAR" in arg for arg in cmd)
+
+    def test_nccl_vars_sorted_deterministically(self, monkeypatch):
+        """NCCL_* vars are emitted in sorted key order (argv is deterministic)."""
+        # Set in non-alphabetical order; the forward loop must sort them.
+        monkeypatch.setenv("NCCL_SOCKET_IFNAME", "eth0")
+        monkeypatch.setenv("NCCL_DEBUG", "INFO")
+        monkeypatch.setenv("NCCL_P2P_DISABLE", "1")
+        config = make_config()
+        runner = DockerRunner(image=IMAGE)
+        cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
+
+        # Filter to just the three we set so a stray host NCCL_* var can't
+        # perturb the assertion; their relative order must be alphabetical.
+        expected = ["NCCL_DEBUG=INFO", "NCCL_P2P_DISABLE=1", "NCCL_SOCKET_IFNAME=eth0"]
+        mine = [p for p in self._e_pairs(cmd) if p in set(expected)]
+        assert mine == expected
+
+    def test_empty_nccl_var_skipped(self, monkeypatch):
+        """An NCCL_* var set to an empty string is not forwarded (matches LLEM_*)."""
+        monkeypatch.setenv("NCCL_P2P_DISABLE", "")
+        config = make_config()
+        runner = DockerRunner(image=IMAGE)
+        cmd = runner._build_docker_cmd(config, "abc123", "/tmp/llem-test")
+
+        assert not any(arg.startswith("NCCL_P2P_DISABLE") for arg in cmd)

--- a/tests/unit/study/test_baseline_container.py
+++ b/tests/unit/study/test_baseline_container.py
@@ -143,6 +143,48 @@ class TestBuildBaselineDockerCmd:
         )
         assert any("CUDA_VISIBLE_DEVICES=" in part for part in cmd)
 
+    def test_nccl_vars_forwarded(self, tmp_path: Path, monkeypatch):
+        """Host NCCL_* vars are forwarded into the baseline container, matching
+        the experiment path (e.g. NCCL_P2P_DISABLE=1 on PCIe hosts without P2P)."""
+        monkeypatch.setenv("NCCL_P2P_DISABLE", "1")
+        monkeypatch.setenv("NCCL_IB_DISABLE", "1")
+        cmd = baseline_container.build_baseline_docker_cmd(
+            image="img:latest",
+            exchange_dir=str(tmp_path),
+            gpu_indices=[0, 1],
+            engine="vllm",
+        )
+        assert "NCCL_P2P_DISABLE=1" in cmd
+        assert "NCCL_IB_DISABLE=1" in cmd
+
+    def test_non_nccl_var_not_forwarded(self, tmp_path: Path, monkeypatch):
+        """A non-NCCL host var must not be forwarded into the baseline container."""
+        monkeypatch.setenv("SOME_UNRELATED_VAR", "leak")
+        cmd = baseline_container.build_baseline_docker_cmd(
+            image="img:latest",
+            exchange_dir=str(tmp_path),
+            gpu_indices=[0],
+            engine="vllm",
+        )
+        assert not any("SOME_UNRELATED_VAR" in part for part in cmd)
+
+    def test_nccl_vars_sorted(self, tmp_path: Path, monkeypatch):
+        """NCCL_* vars are emitted in sorted key order (deterministic argv)."""
+        monkeypatch.setenv("NCCL_SOCKET_IFNAME", "eth0")
+        monkeypatch.setenv("NCCL_DEBUG", "INFO")
+        monkeypatch.setenv("NCCL_P2P_DISABLE", "1")
+        cmd = baseline_container.build_baseline_docker_cmd(
+            image="img:latest",
+            exchange_dir=str(tmp_path),
+            gpu_indices=[0],
+            engine="vllm",
+        )
+        # Filter to the three we set so a stray host NCCL_* var can't perturb
+        # the assertion; their relative order must be alphabetical.
+        expected = ["NCCL_DEBUG=INFO", "NCCL_P2P_DISABLE=1", "NCCL_SOCKET_IFNAME=eth0"]
+        mine = [p for p in cmd if p in set(expected)]
+        assert mine == expected
+
 
 class TestParseStageLine:
     def test_non_marker_returns_none(self):


### PR DESCRIPTION
## Summary

llem's docker dispatch did not forward `NCCL_*` host environment variables into
engine containers, so NCCL tuning/workaround settings set on the host never
reached the engine process (which runs inside the container).

This adds a shared `append_nccl_env(cmd)` helper in `infra/docker_runner.py` and
calls it from both dispatch paths:

- the experiment container (`DockerRunner._build_docker_cmd`), and
- the baseline container (`study.baseline_container.build_baseline_docker_cmd`).

Every host var matching `NCCL_*` is forwarded as an explicit `-e KEY=VALUE`
argument (matching the existing `LLEM_*` forwarding idiom in these builders).
Keys are iterated in sorted order so the constructed command is deterministic.
Empty-valued vars are skipped, matching the `LLEM_*` loop.

### Why

Live-verified on a PCIe A100 box with broken GPU peer-to-peer (P2P) - the
inter-GPU link reports `SYS` in `nvidia-smi topo -m`, likely because ACS is
enabled. On that host, every TP=2 experiment (14B model) hangs at the first
NCCL collective. The identical workload with `NCCL_P2P_DISABLE=1` set inside
the container completes cleanly. Before this change there was no way to get
that variable into llem's ephemeral containers from the host; now
`NCCL_P2P_DISABLE=1 llem run ...` (or exporting it) is inherited by both the
experiment and baseline containers.

## Test plan

- New unit tests in `tests/unit/docker/test_docker_runner.py`
  (`TestNcclEnvForwarding`) and `tests/unit/study/test_baseline_container.py`:
  set `NCCL_*` via `monkeypatch`, assert they appear as `-e KEY=VALUE` in the
  built argv; assert a non-NCCL host var is NOT forwarded; assert sorted-order
  determinism; assert empty-valued vars are skipped.
- `make lint` - clean (ruff check, ruff format --check, import-linter).
- `make typecheck` - clean (mypy, 308 source files).
- `make test` - 3038 passed, 35 skipped.
- Targeted: `pytest tests/unit/docker/test_docker_runner.py
  tests/unit/study/test_baseline_container.py` - 99 passed.

Documents the workaround under the "Stalls or hangs" section of
`docs/how-to/troubleshoot.md` (multi-GPU NCCL collective hang; `NCCL_P2P_DISABLE=1`
as the standard fix for PCIe hosts without functional P2P).
