### PR TITLE
docs(tensorrt): document activated engine, backends, build cache, multi-gpu

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -106,10 +106,11 @@ dispatch into a host-mounted persistent cache.
    by docker_runner) so the host can clean it without sudo despite the
    container running as root.
 7. Writes the pyproject hash to the stamp file.
-8. Exec's the framework entrypoint - routing through
-   `nvidia_entrypoint.sh` when `LLEM_ENGINE=tensorrt`, wrapping in
-   `mpirun -n {N} --allow-run-as-root` when `LLEM_MPI_NP` is set
-   (TRT-LLM tensor parallelism > 1).
+8. Exec's the framework entrypoint as a single `python3` process, routing
+   through `nvidia_entrypoint.sh` when `LLEM_ENGINE=tensorrt` (sets up
+   `LD_LIBRARY_PATH` for libnvinfer). Multi-GPU tensorrt is NOT wrapped in
+   `mpirun`: TensorRT-LLM's `LLM` API self-manages tensor parallelism by
+   spawning its own workers, so one process per container is correct.
 
 ### Cache location
 

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -87,7 +87,7 @@ make docker-build
 docker pull vllm/vllm-openai:v0.19.1
 
 # TensorRT-LLM - pull upstream NGC image (pinned engine version)
-docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.2.1
 ```
 
 The upstream tags above track the pinned engine versions

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -261,8 +261,10 @@ Then run it:
 llem run experiment.yaml
 ```
 
-`llem` will pull the TensorRT-LLM Docker image, compile a TensorRT engine (first run only -
-takes several minutes), cache the engine on disk, then run inference. See [Getting Started](/tutorials/first-measurement)
+`llem` will pull the TensorRT-LLM Docker image and run inference. The default
+`pytorch` backend loads the model directly; the compiled `trt` backend instead
+compiles a TensorRT engine (first run of a config only - several minutes) and
+caches it on disk. See [Getting Started](/tutorials/first-measurement)
 for the full TensorRT-LLM walkthrough.
 
 ---
@@ -331,7 +333,7 @@ make docker-pull
 # TensorRT-LLM are upstream images tagged with the pinned engine version.
 docker pull ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.9.0
 docker pull vllm/vllm-openai:v0.19.1
-docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.2.1
 ```
 
 Replace the transformers tag with your installed version (`llem --version`); the
@@ -350,7 +352,7 @@ Output shows local vs registry source for each engine:
 
 ```
 === Image resolution ===
-  tensorrt   -> nvcr.io/nvidia/tensorrt-llm/release:1.0.0  (registry)
+  tensorrt   -> nvcr.io/nvidia/tensorrt-llm/release:1.2.1  (registry)
   transformers -> ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.9.0  (registry)
   vllm       -> vllm/vllm-openai:v0.19.1  (registry)
 ```
@@ -369,7 +371,7 @@ make docker-build
 docker pull vllm/vllm-openai:v0.19.1
 
 # TensorRT-LLM - pull upstream (NGC)
-docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.2.1
 ```
 
 `make docker-build` builds the project's first-party engine images
@@ -424,14 +426,19 @@ Operator notes:
 
 ### TensorRT-LLM engine build cache
 
-Distinct from the Docker layer cache above: the TensorRT engine build cache
-holds compiled `.engine` artefacts so re-running the same experiment config
-skips the multi-minute compile. It lives on the host at `~/.cache/trt-llm` and
-is bind-mounted into every tensorrt container at `/root/.cache/trt-llm`; llem
-defaults the cache location to that mount out of the box (override with
-`LLEM_TRT_BUILD_CACHE_PATH`). TensorRT-LLM keys each entry by the full build
-config (model, dtype, tensor-parallel size, max-shape, quantisation) plus the
-engine version, so distinct configs and version bumps never collide.
+Distinct from the Docker layer cache above, and specific to the compiled `trt`
+backend: the TensorRT engine build cache holds compiled `.engine` artefacts so
+re-running the same experiment config skips the multi-minute compile. It ships
+on out of the box - `.env.example` sets `LLEM_TRT_BUILD_CACHE_ENABLED=1`
+(delete the line to fall back to TensorRT-LLM's disabled default). It lives on
+the host at `~/.cache/trt-llm` and is bind-mounted into every tensorrt
+container at `/root/.cache/trt-llm`; llem defaults the cache location to that
+mount out of the box (override with `LLEM_TRT_BUILD_CACHE_PATH`). TensorRT-LLM
+keys each entry by the full build config (model, dtype, tensor-parallel size,
+max-shape, quantisation) plus the engine version: an identical config hits even
+across separate containers, while a TP / quantisation / max-shape change or a
+version bump keys to a distinct engine and misses. Each result records
+`engine_build_cache_hit` so you can tell a reused engine from a fresh compile.
 
 The lifecycle is manual and visible - llem never auto-evicts. Inspect it with:
 
@@ -533,6 +540,13 @@ The `--gpus all` flag is missing from the `docker run` command.
 `llem` adds `--gpus all` automatically when launching engine containers. If you are running
 Docker commands manually, ensure you include `--gpus all` (or `--gpus device=0` for a specific
 GPU).
+
+To make `llem` itself target specific GPUs on a shared host, set `LLEM_DOCKER_GPUS` to the
+`docker run --gpus` value (empty means every visible GPU). Quote multi-device values so the
+shell keeps the comma, e.g. `LLEM_DOCKER_GPUS="device=2,3"`. Restricting at the docker level
+keeps CUDA and NVML indices consistent inside the container (both enumerate from 0). For
+tensor-parallel runs, `llem` also forwards every `NCCL_*` host variable into the container;
+see [multi-GPU with TensorRT-LLM](/how-to/run-with-tensorrt-llm#multi-gpu-tensor-parallelism).
 
 ---
 

--- a/docs/how-to/faq.md
+++ b/docs/how-to/faq.md
@@ -110,7 +110,7 @@ Yes for Transformers and vLLM. TensorRT-LLM compilation is supported on Ada Love
 
 ### Multi-GPU?
 
-Tensor parallel is supported via engine-native fields (`tensorrt.engine_params.tensor_parallel_size`, `vllm.engine_params.tensor_parallel_size`). `llem` measures aggregate energy across all visible GPUs. Set `CUDA_VISIBLE_DEVICES` to control which GPUs are used. Cross-node distributed is not currently supported.
+Tensor parallel is supported via engine-native fields (`tensorrt.engine_params.tensor_parallel_size`, `vllm.engine_params.tensor_parallel_size`); the engine self-manages the workers inside a single container process (no `mpirun`). `llem` measures aggregate energy across all visible GPUs. To pin which physical GPUs `llem` uses, set `LLEM_DOCKER_GPUS` (the `docker run --gpus` value, e.g. `LLEM_DOCKER_GPUS="device=2,3"`) rather than `CUDA_VISIBLE_DEVICES`, so CUDA and NVML indices stay consistent inside the container. On PCIe hosts without functional peer-to-peer, set `NCCL_P2P_DISABLE=1` (`llem` forwards `NCCL_*` host vars into the container). Cross-node distributed is not currently supported.
 
 ## Citing and reporting
 

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -122,7 +122,7 @@ make docker-build
 docker pull vllm/vllm-openai:v0.19.1
 
 # TensorRT-LLM - pull upstream (NGC)
-docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.2.1
 ```
 
 The pinned versions are the SSOT in `engine_versions/{vllm,tensorrt}/current.yaml`
@@ -219,7 +219,7 @@ subsequent rebuilds for vLLM/TRT are seconds - the slow part doesn't repeat.
 ```bash
 make docker-build                                    # build Transformers from source
 docker pull vllm/vllm-openai:v0.19.1                 # pull vLLM upstream
-docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0  # pull TensorRT-LLM upstream
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.2.1  # pull TensorRT-LLM upstream
 ```
 
 **How the transformers image is published:**

--- a/docs/how-to/run-with-tensorrt-llm.md
+++ b/docs/how-to/run-with-tensorrt-llm.md
@@ -1,6 +1,6 @@
 ---
 title: Run an experiment with TensorRT-LLM (Docker)
-description: Use the TensorRT-LLM engine for compiled-engine inference measurements.
+description: Use the TensorRT-LLM engine (pytorch and trt backends) for inference measurements.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,10 +8,14 @@ import TabItem from '@theme/TabItem';
 
 # Run an experiment with TensorRT-LLM (Docker)
 
-TensorRT-LLM compiles models into optimised TensorRT engines, then runs
-inference against those engines. The first run compiles the engine
-(several minutes); subsequent runs with the same config load the cached
-engine and start inference immediately.
+TensorRT-LLM exposes two runtimes, chosen per experiment by the `backend`
+field. `pytorch` (the default) runs the model through TensorRT-LLM's PyTorch
+runtime with no ahead-of-time build step. `trt` compiles the model into an
+optimised TensorRT engine and runs inference against that engine; the first
+run of a given config pays a one-time compile cost (several minutes), and an
+on-disk build cache lets later runs of the same config skip it. llem measures
+both backends the same way, so `backend` is just another config axis you can
+sweep.
 
 :::caution TensorRT-LLM requires Docker and an Ampere-or-newer GPU
 The engine runs inside a Docker container and requires an NVIDIA GPU with
@@ -23,7 +27,7 @@ Lovelace or newer); on A100 (SM 8.0), use INT8 or W4A16_AWQ instead.
 
 - `llenergymeasure` installed (host-side orchestrator)
 - Docker + NVIDIA Container Toolkit - see [Docker setup](/how-to/docker-setup)
-- TensorRT-LLM upstream image (`nvcr.io/nvidia/tensorrt-llm/release`) - pulled automatically from NVIDIA NGC on first run; pre-fetch per [Docker setup](/how-to/docker-setup)
+- TensorRT-LLM upstream image, pulled automatically from NVIDIA NGC on first run at the pinned version (`nvcr.io/nvidia/tensorrt-llm/release:1.2.1`, resolved from `engine_versions/tensorrt/current.yaml`) - there is no first-party tensorrt image; pre-fetch per [Docker setup](/how-to/docker-setup)
 - NVIDIA GPU with SM >= 7.5 (Turing or newer; e.g. RTX 2000-series, A100, H100)
 
 ## 1. Create a config file
@@ -44,7 +48,7 @@ runners:
   tensorrt: docker
 ```
 
-With explicit quantisation and engine caching:
+With the compiled `trt` backend, explicit quantisation, and a larger batch:
 
 ```yaml
 engine: tensorrt
@@ -56,11 +60,19 @@ task:
 runners:
   tensorrt: docker
 tensorrt:
-  max_batch_size: 8
-  dtype: bfloat16
-  quant_config:
-    quant_algo: W4A16_AWQ
+  engine_params:
+    backend: trt
+    max_batch_size: 8
+    dtype: bfloat16
+    quant_config:
+      quant_algo: W4A16_AWQ
 ```
+
+Engine fields nest under `engine_params:` (and sampling under
+`sampling_params:`); a field placed directly on the `tensorrt:` block is
+rejected. `quant_config` and `fast_build` exist only on the compiled `trt`
+backend, so they require `backend: trt` - see
+[Choosing a backend](#choosing-a-backend).
 
 </TabItem>
 <TabItem value="python" label="Python">
@@ -78,6 +90,33 @@ print(result)
 
 </TabItem>
 </Tabs>
+
+## Choosing a backend
+
+TensorRT-LLM ships two runtimes behind one engine. Select with
+`tensorrt.engine_params.backend`:
+
+| `backend` | Runtime | Build step | Best for |
+|-----------|---------|-----------|----------|
+| `pytorch` (default) | TensorRT-LLM PyTorch runtime | none | quick runs and sweeps, no compile wait |
+| `trt` | compiled TensorRT engine | ahead-of-time compile (cached) | repeated runs of a fixed config, peak throughput |
+
+llem selects the backend by constructor class, not a runtime kwarg: `pytorch`
+resolves `tensorrt_llm.LLM` and `trt` resolves
+`tensorrt_llm._tensorrt_engine.LLM`. Any other value is rejected at config load
+with a `{pytorch, trt}` error.
+
+Some engine parameters exist only on the compiled `trt` backend and are
+rejected under `pytorch`:
+
+- `quant_config` - build-time quantisation config
+- `fast_build` - reduced-optimisation build for faster compiles
+
+Declaring either without `backend: trt` fails at config load with a clear error
+rather than silently measuring a different configuration - the pytorch
+runtime's argument class has no such field. The on-disk build cache likewise
+applies only to the `trt` backend. The full rule set is in
+[invalid parameter combinations](/reference/engines/invalid-combos).
 
 ## 2. Run the experiment
 
@@ -104,29 +143,84 @@ What happens:
 
 1. Pre-flight checks run: Docker CLI, NVIDIA Container Toolkit, GPU
    visibility, SM-version check.
-2. The upstream TensorRT-LLM image (`nvcr.io/nvidia/tensorrt-llm/release`) is
-   pulled from NVIDIA NGC on first run, with the llenergymeasure source
-   bind-mounted into it.
-3. The container compiles the TensorRT engine from the model weights.
-   **First run only - this takes several minutes.** Progress is shown in
-   the terminal.
-4. The compiled engine is cached on disk. The host directory
-   `~/.cache/trt-llm` is bind-mounted into the container at
-   `/root/.cache/trt-llm`, and llem defaults the build-cache location to that
-   mount so compiled engines persist across ephemeral containers out of the
-   box (override with `LLEM_TRT_BUILD_CACHE_PATH`).
-5. Inference runs against the compiled engine.
-6. Results are printed to stdout and saved to `results/`.
+2. The pinned upstream TensorRT-LLM image
+   (`nvcr.io/nvidia/tensorrt-llm/release:1.2.1`) is pulled from NVIDIA NGC on
+   first run, with the llenergymeasure source bind-mounted into it.
+3. The engine loads the model. On the default `pytorch` backend this is a
+   normal model load. On the `trt` backend the container compiles a TensorRT
+   engine from the model weights - **first run of a given config only, several
+   minutes** - and caches it on disk (see below).
+4. Inference runs against the loaded (or compiled) model.
+5. Results are printed to stdout and saved to `results/`.
 
-:::tip Engine caching
-The compiled engine is keyed by TensorRT-LLM to the full build config -
-model, dtype, tensor-parallel size, max-shape (max_seq_len / max_batch_size /
-max_input_len), and quantisation - plus the TRT-LLM version. Running the same
-config again reuses the cached engine and skips compilation; changing any of
-those inputs (or bumping the engine version) triggers a fresh build. The cache
-is manual and visible: llem never auto-evicts. See its location, entry count,
-total size, and the manual clean command with `llem doctor`.
+:::tip Engine build cache (`trt` backend)
+The compiled `trt` engine is keyed by TensorRT-LLM to the full build config -
+model, dtype, tensor-parallel size, max-shape (`max_seq_len` / `max_batch_size`
+/ `max_input_len`), and quantisation - plus the TRT-LLM version. Running the
+same config again reuses the cached engine and skips compilation; changing any
+of those inputs (or bumping the engine version) keys to a distinct engine hash
+and triggers a fresh build. Because the host directory `~/.cache/trt-llm` is
+bind-mounted into the container at `/root/.cache/trt-llm`, an identical config
+also hits across containers.
+
+The cache is on out of the box: `.env.example` ships
+`LLEM_TRT_BUILD_CACHE_ENABLED=1` and llem defaults the build-cache location to
+the mount (override with `LLEM_TRT_BUILD_CACHE_PATH`; delete the enable line to
+fall back to TensorRT-LLM's disabled default). Each result records
+`engine_build_cache_hit` (`true` on a hit, `false` on a fresh compile, `null`
+when the cache is not in play - the pytorch backend, an `engine_path` override,
+or the cache disabled) and `model_load_time_sec`, which covers the build and
+load and sits outside the energy window. The cache lifecycle is manual and
+visible: llem never auto-evicts. See its location, entry count, total size, and
+the manual clean command with `llem doctor`.
 :::
+
+## Multi-GPU (tensor parallelism)
+
+Set `tensorrt.engine_params.tensor_parallel_size` above `1` to shard the model
+across GPUs:
+
+```yaml
+engine: tensorrt
+tensorrt:
+  engine_params:
+    tensor_parallel_size: 2
+```
+
+TensorRT-LLM's `LLM` API self-manages tensor parallelism: setting
+`tensor_parallel_size` makes it spawn and coordinate its own worker processes
+inside a single container process. llem launches one `python3` process and does
+not wrap the run in `mpirun`.
+
+Pin which physical GPUs llem uses with `LLEM_DOCKER_GPUS` (the `docker run
+--gpus` value; empty means every visible GPU). Quote multi-device values so the
+comma is not split by the shell:
+
+```bash
+LLEM_DOCKER_GPUS="device=2,3" llem run experiment.yaml
+```
+
+Restricting at the docker level keeps CUDA and NVML device indices consistent
+inside the container (both enumerate from 0).
+
+**PCIe hosts without functional peer-to-peer (P2P).** On boxes whose GPU
+topology reports `SYS` links in `nvidia-smi topo -m` (often because ACS is
+enabled in the BIOS), tensor-parallel runs can hang at the first NCCL
+collective. llem forwards every `NCCL_*` host environment variable into the
+experiment and baseline containers, so the standard workaround applies straight
+from the host:
+
+```bash
+NCCL_P2P_DISABLE=1 LLEM_DOCKER_GPUS="device=0,1" llem run experiment.yaml
+```
+
+## Quantisation is engine-owned
+
+llem never quantises or converts checkpoints itself. Quantisation is owned end
+to end by TensorRT-LLM: either declare a build-time `quant_config` on the `trt`
+backend and let the engine quantise during compilation, or point the experiment
+at a checkpoint already quantised in a format TensorRT-LLM supports. The next
+section covers which pre-quantised formats load and which do not.
 
 ## HF pre-quantised checkpoints
 
@@ -169,8 +263,9 @@ is already in TensorRT-LLM's native format.
 ## 3. Read the results
 
 The output format matches other engines. The result file includes
-`engine: tensorrt` and a `build_metadata` section with engine compilation
-time, GPU architecture, and TRT-LLM version. See
+`engine: tensorrt`, the resolved `engine_version`, and the load/cache
+annotations described above (`model_load_time_sec`, and
+`engine_build_cache_hit` on the `trt` backend). See
 [How to interpret results](/how-to/interpret-results) for a field-by-field
 walkthrough.
 

--- a/docs/how-to/single-gpu-or-limited-hardware.md
+++ b/docs/how-to/single-gpu-or-limited-hardware.md
@@ -87,17 +87,20 @@ vllm:
 vLLM requires a pre-quantised model checkpoint (e.g. `TheBloke/*-AWQ` on
 HuggingFace Hub). It does not quantise on the fly.
 
-**TensorRT-LLM engine** - build-time quantisation:
+**TensorRT-LLM engine** - build-time quantisation (compiled `trt` backend):
 
 ```yaml
 engine: tensorrt
 tensorrt:
-  quant_config:
-    quant_algo: W4A16_AWQ   # or INT8, W4A16_GPTQ, W8A16
+  engine_params:
+    backend: trt          # quant_config requires the compiled trt backend
+    quant_config:
+      quant_algo: W4A16_AWQ   # or INT8, W4A16_GPTQ, W8A16
 ```
 
-TRT-LLM compiles a quantised engine at build time. FP8 is NOT supported on A100
-or consumer Ada Lovelace below SM 8.9.
+TRT-LLM compiles a quantised engine at build time; `quant_config` is rejected
+under the default `pytorch` backend. FP8 requires SM >= 8.9 (Ada Lovelace or
+Hopper) and is NOT supported on A100 (SM 8.0).
 
 For full quantisation options and valid combinations, see
 [Reference: engine configuration](/reference/engines/configuration).
@@ -154,9 +157,11 @@ vllm:
     max_model_len: 2048   # also cap KV cache size
 ```
 
-**TensorRT-LLM** - highest throughput but requires 5-15 minutes of engine
-compilation on first run. Most beneficial for models you will run repeatedly.
-Less flexible than Transformers for ad-hoc measurement.
+**TensorRT-LLM** - highest throughput. The default `pytorch` backend loads
+directly; the compiled `trt` backend adds 5-15 minutes of engine compilation on
+the first run of a config (cached afterwards), which is most beneficial for
+models you will run repeatedly. Less flexible than Transformers for ad-hoc
+measurement.
 
 Rule of thumb for consumer hardware:
 - Quick model survey: use Transformers with 4-bit quantisation.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -212,9 +212,11 @@ no error, process does not return.
    multi-GB image. Check `docker pull` progress in a separate terminal:
    `docker ps` and `docker images`.
 
-2. **TensorRT-LLM engine compilation** - TRT-LLM compiles a CUDA engine from
-   model weights on first use. For a 7B model this takes 5-15 minutes with no
-   visible progress. Re-run with `LLEM_LOG_LEVEL=DEBUG` to see compilation logs.
+2. **TensorRT-LLM engine compilation (`trt` backend)** - on the compiled `trt`
+   backend, TRT-LLM compiles a CUDA engine from model weights on the first run
+   of a config. For a 7B model this takes 5-15 minutes with no visible
+   progress. Re-run with `LLEM_LOG_LEVEL=DEBUG` to see compilation logs. The
+   default `pytorch` backend has no such compile step.
 
 3. **Pre-flight check stalled** - if the Docker daemon is unreachable or the GPU
    is being held by another process, the pre-flight probe hangs. Run
@@ -371,7 +373,7 @@ the SSOT bumped transformers but the local image is still on an older tag).
 ```bash
 make docker-build                                       # local build, Transformers
 docker pull vllm/vllm-openai:v0.19.1                    # repull vLLM upstream
-docker pull nvcr.io/nvidia/tensorrt-llm/release:1.0.0   # repull TensorRT-LLM upstream
+docker pull nvcr.io/nvidia/tensorrt-llm/release:1.2.1   # repull TensorRT-LLM upstream
 make docker-pull                                        # pull the newest published Transformers tag
 ```
 

--- a/docs/reference/engines/configuration.md
+++ b/docs/reference/engines/configuration.md
@@ -17,7 +17,7 @@ exactly two sub-sections, `engine_params:` and `sampling_params:`, and both
 sub-models set `extra="allow"`, so a parameter the current snapshot does not
 model is still forwarded to the underlying engine. The tables below document
 the fields the generated models name explicitly at the pinned versions
-(transformers 5.7.0, vllm 0.19.1, tensorrt 1.0.0); for the exhaustive
+(transformers 5.7.0, vllm 0.19.1, tensorrt 1.2.1); for the exhaustive
 introspected inventory see the per-engine schema pages, and for which
 parameters are explicitly modelled vs forwarded see the curation pages (both
 linked under [See also](#see-also)).
@@ -295,12 +295,19 @@ Source: `src/llenergymeasure/engines/vllm/config.py`.
 
 ## TensorRT-LLM engine (`tensorrt:`)
 
-TensorRT-LLM compiles a model into an optimised engine on first use;
-subsequent runs reuse the cached engine. Compile-time fields are baked into the
-engine and changing one invalidates the cache. The nested TRT-LLM sub-configs
-(`quant_config`, `kv_cache_config`, `scheduler_config`) are freeform
-(`Any`-typed) dict fields under `engine_params:` on the current pin, so they
-are written as whole dicts (see the worked example).
+TensorRT-LLM exposes two runtimes behind one engine, selected by `backend`:
+`pytorch` (the default) runs the model through TensorRT-LLM's PyTorch runtime
+with no ahead-of-time build, and `trt` compiles the model into an optimised
+TensorRT engine on first use and reuses the cached engine afterwards.
+`backend` is resolved by constructor class (`pytorch` -> `tensorrt_llm.LLM`,
+`trt` -> `tensorrt_llm._tensorrt_engine.LLM`), never forwarded as a kwarg. A
+handful of fields (`quant_config`, `fast_build`) exist only on the `trt`
+backend; declaring them under `pytorch` is a config-load error. On the `trt`
+backend, compile-time fields are baked into the engine and changing one keys to
+a fresh build. The nested TRT-LLM sub-configs (`quant_config`,
+`kv_cache_config`, `scheduler_config`) are freeform (`Any`-typed) dict fields
+under `engine_params:` on the current pin, so they are written as whole dicts
+(see the worked example).
 
 ### `tensorrt.engine_params:`
 
@@ -313,9 +320,9 @@ are written as whole dicts (see the worked example).
 | `max_seq_len` | int \| null | null | Maximum total sequence length (compile-time) |
 | `max_num_tokens` | int \| null | null | Maximum tokens the engine handles per iteration (compile-time) |
 | `dtype` | str \| null | `auto` | Model compute dtype; untyped, forwarded as given |
-| `fast_build` | bool \| null | `false` | Reduced-optimisation build for faster compilation |
-| `backend` | str \| null | null | TRT-LLM runtime selector (e.g. `trt`, `pytorch`, `_autodeploy`); distinct from the top-level `engine:` selector |
-| `quant_config` | any (dict) \| null | null | Quantisation config; freeform dict (e.g. `{quant_algo: W4A16_AWQ}`) |
+| `backend` | `pytorch` \| `trt` \| null | `pytorch` | Runtime selector, resolved by constructor class (see intro); distinct from the top-level `engine:` selector. Any other value is a config-load error |
+| `fast_build` | bool \| null | `false` | Reduced-optimisation build for faster compilation. **`trt` backend only** - rejected under `pytorch` |
+| `quant_config` | any (dict) \| null | null | Quantisation config; freeform dict (e.g. `{quant_algo: W4A16_AWQ}`). **`trt` backend only** - rejected under `pytorch` |
 | `kv_cache_config` | any (dict) \| null | null | KV cache config; freeform dict (e.g. `{enable_block_reuse: true, free_gpu_memory_fraction: 0.9}`) |
 | `scheduler_config` | any (dict) \| null | null | Scheduler config; freeform dict (e.g. `{capacity_scheduling_policy: MAX_UTILIZATION}`) |
 
@@ -480,6 +487,7 @@ engine: tensorrt
 
 tensorrt:
   engine_params:
+    backend: trt          # quant_config requires the compiled trt backend
     dtype: bfloat16
     max_batch_size: 8
     max_input_len: 1024

--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -109,7 +109,7 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 | Field | Type | Description |
 |-------|------|-------------|
 | `timeseries` | `str \| None` | Relative filename of the timeseries Parquet sidecar (e.g. `"timeseries.parquet"`). `None` when timeseries saving is disabled. |
-| `latency_stats` | `LatencyStatistics \| None` | TTFT/ITL statistics from streaming inference. `None` for non-streaming engines. |
+| `latency_stats` | `LatencyStatistics \| None` | TTFT/ITL statistics. `None` when latency capture did not run. vLLM records TTFT on every run; transformers and tensorrt populate stats only under `measurement.latency_profiling`. |
 | `extended_metrics` | `ExtendedEfficiencyMetrics \| None` | Extended efficiency metrics (TPOT, memory, GPU utilisation). Always present when the harness runs successfully; fields within are `None` when not computable. |
 
 ---

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -121,7 +121,7 @@ live at the top level of `result.json`.
 | `extended_metrics.batch.num_batches` / `effective_batch_size` / `batch_utilisation` / `padding_overhead` | int/float &#124; null | Static-batching efficiency. `null` for vLLM (continuous batching). |
 | `extended_metrics.kv_cache.*` | float/int &#124; null | Prefix-cache hit rate and block occupancy (vLLM only). |
 | `extended_metrics.request_latency.e2e_latency_{mean,median,p95,p99}_ms` | float &#124; null | Per-request end-to-end latency distribution. |
-| `latency_stats` | object &#124; null | TTFT/ITL statistics. vLLM populates TTFT-only stats on every run (engine-recorded first-token timestamps); ITL stats are added only when `measurement.latency_profiling=true`. transformers populates `latency_stats` (TTFT + ITL) only under profiling. Always `null` for tensorrt. |
+| `latency_stats` | object &#124; null | TTFT/ITL statistics. vLLM populates TTFT-only stats on every run (engine-recorded first-token timestamps); ITL stats are added only when `measurement.latency_profiling=true`. transformers populates `latency_stats` (TTFT + ITL) only under profiling. tensorrt populates per-request TTFT/E2E plus an average-TPOT-derived ITL only under profiling, in `per_request_batch` mode; `null` otherwise. |
 | `latency_stats.measurement_mode` | str | Provenance of the latency capture: `true_streaming` (real per-token / first-token timestamps), `proportional` (decode-average ITL estimate, vLLM under profiling), or `per_request_batch`. The mode reflects the weakest signal present. |
 | `steady_state_window` | [float, float] &#124; null | `(0.0, inference_time_sec)` - the measured window relative to inference start. |
 
@@ -132,9 +132,9 @@ means it stays `null` for that engine.
 
 | Metric group | vLLM | transformers | tensorrt |
 |--------------|:----:|:------------:|:--------:|
-| `request_latency.*` (per-request E2E) | yes (from RequestOutput metrics) | yes (per-batch approximation) | dash (metrics usually absent from the pinned TensorRT-LLM build) |
-| `latency_stats` TTFT | yes (always-on) | profiling only | dash |
-| `latency_stats` ITL / `tpot_ms` | profiling only (`proportional`) | profiling only (`true_streaming`) | dash (unsupported) |
+| `request_latency.*` (per-request E2E) | yes (from RequestOutput metrics) | yes (per-batch approximation) | profiling only (from `RequestOutput.metrics_dict` at 1.2.1) |
+| `latency_stats` TTFT | yes (always-on) | profiling only | profiling only |
+| `latency_stats` ITL / `tpot_ms` | profiling only (`proportional`) | profiling only (`true_streaming`) | profiling only (`per_request_batch`) |
 | `kv_cache.*` | yes (best-effort) | dash | dash |
 | `gpu_utilisation.*` (SM + mem-bw) | yes | yes | yes |
 | `memory.*` ratios | yes | yes | yes |
@@ -153,8 +153,13 @@ capture inter-token latency (and hence `tpot_ms`). Per-engine semantics:
   Under profiling, a decode-average ITL is derived per request
   (`(finished - first_token) / (n_out - 1)`); because that averages over the
   decode phase rather than timing each token, the mode becomes `proportional`.
-- **tensorrt**: latency profiling is unsupported; the fields stay `null` and a
-  warning is recorded in `measurement_warnings`.
+- **tensorrt**: under profiling the plugin sets
+  `SamplingParams(return_perf_metrics=True)` and extracts per-request TTFT / E2E
+  / average TPOT from `RequestOutput.metrics_dict` (the TRT-LLM 1.x surface,
+  live-verified on both backends at 1.2.1), in mode `per_request_batch`. With
+  profiling off, `latency_stats` is `null`. The `latency_profiling_unsupported`
+  warning now fires only when profiling was requested but the engine returned no
+  metrics.
 
 **Energy caveat.** Per-token timing capture adds overhead that can perturb both
 energy and latency. Energy figures from a profiled run are emitted as-is and are

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -27,9 +27,9 @@ other axis - "given a fixed implementation, how do models compare?"
 That's a useful question too, but it's not this one.
 
 > **Compute time:** ~30 minutes on a single A100-class GPU once Docker
-> images are pulled, plus ~5 minutes of one-time TensorRT-LLM engine
-> compilation on first run. The compiled engine is cached, so subsequent
-> runs of the same TRT-LLM cell skip compilation.
+> images are pulled. TensorRT-LLM runs on its default `pytorch` backend
+> here, so there is no engine-compilation wait; switching a cell to the
+> compiled `trt` backend would add a one-time (cached) engine build.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Brings the TensorRT-LLM user docs in line with the engine as it actually ships at pin `1.2.1` (now a fully measured engine, not config-shape-only). Covers both measured backends, the on-disk build cache, single-process multi-GPU with device pinning and NCCL forwarding, hardware/quantisation constraints, and fixes stale claims that contradicted the code.

All content verified against `src/llenergymeasure/engines/tensorrt/`, `infra/docker_runner.py`, `scripts/container_entrypoint.sh`, `utils/env_config.py`, `api/doctor.py`, and the `[Unreleased]` CHANGELOG. No invented features.

### What is now documented
- **Image**: upstream NGC dispatch at the pinned version (`nvcr.io/nvidia/tensorrt-llm/release:1.2.1`, resolved from `engine_versions/tensorrt/current.yaml`); no first-party tensorrt image.
- **Both backends as a config axis**: `backend: pytorch` (default, `tensorrt_llm.LLM`) vs `backend: trt` (compiled, `_tensorrt_engine.LLM` class dispatch); per-backend field applicability (`fast_build`, `quant_config` are trt-only, rejected loudly under pytorch).
- **Build cache** (trt backend): `LLEM_TRT_BUILD_CACHE_ENABLED=1` default, `~/.cache/trt-llm` host mount, config-hash keying (identical config hits across containers; TP/quant/max-shape changes miss), manual lifecycle via `llem doctor`, `engine_build_cache_hit` + `model_load_time_sec` annotations outside the energy window.
- **Multi-GPU**: single-process launch (no `mpirun`), `LLEM_DOCKER_GPUS` device pinning with quoted multi-device handling, `NCCL_*` host-env forwarding, `NCCL_P2P_DISABLE=1` for PCIe hosts without functional P2P.
- **Hardware/quant**: FP8 requires SM >= 8.9 (not A100); AutoAWQ/AutoGPTQ community checkpoints rejected at preflight (ModelOpt `hf_quant_config.json` is the supported path); quantisation is engine-owned end to end (llem never quantises/converts).

## Doc audit

| Page | Rationale |
|------|-----------|
| `how-to/run-with-tensorrt-llm.md` | Reframed around the two backends; added Choosing-a-backend and Multi-GPU sections; fixed broken flat-layout / no-`backend: trt` YAML examples; documented build-cache env + result annotations; replaced the invented `build_metadata` field with the real `model_load_time_sec` / `engine_build_cache_hit`; pinned image to 1.2.1. |
| `reference/engines/configuration.md` | Fixed stale `backend` field (was `str`/null default listing `_autodeploy`; now `pytorch`/`trt`, default `pytorch`, class-dispatch, no kwarg); marked `fast_build`/`quant_config` trt-only; added `backend: trt` to the AWQ example; pin 1.0.0 -> 1.2.1. |
| `how-to/docker-setup.md` | Backend-aware run description; build-cache section gains the enable flag + backend scope + cross-container hit note; added `LLEM_DOCKER_GPUS` device-pinning note; pin 1.0.0 -> 1.2.1 (x3). |
| `how-to/troubleshoot.md` | Compilation-hang entry scoped to the trt backend; pin 1.0.0 -> 1.2.1. |
| `how-to/faq.md` | Multi-GPU answer: `CUDA_VISIBLE_DEVICES` -> `LLEM_DOCKER_GPUS`, single-process TP, `NCCL_P2P_DISABLE` pointer. |
| `how-to/single-gpu-or-limited-hardware.md` | Fixed broken flat-layout tensorrt quant example (+ `backend: trt`); clarified compile is trt-backend-only. |
| `reference/results-schema.md` + `reference/library/ExperimentResult.md` | `latency_stats` "Always null for tensorrt" / "unsupported" was stale: tensorrt now populates per-request TTFT/E2E + avg-TPOT under profiling (`per_request_batch`); updated the per-engine matrix and semantics. |
| `contributing/development.md` | Removed the stale `mpirun`/`LLEM_MPI_NP` entrypoint claim (that path was removed; entrypoint is single-process for all engines). |
| `get-started/install.md`, `how-to/install.md` | Pin 1.0.0 -> 1.2.1. |
| `tutorials/multi-engine-study.md` | Compute-time note corrected: the tutorial uses the default `pytorch` backend, so there is no compile wait. |

### Stale claims fixed
- `configuration.md` `backend` field: `str`/null default, listed nonexistent `_autodeploy` -> `Literal[pytorch, trt]`, default `pytorch`.
- Broken flat-layout YAML examples (`tensorrt.quant_config` directly on the block) that fail `validate_engine_section_extras` -> nested under `engine_params` with `backend: trt`.
- Invented `build_metadata` result section (no such field in code) -> real load/cache fields.
- `mpirun`/`LLEM_MPI_NP` entrypoint wrapping (removed from the codebase).
- `latency_stats` "Always null / unsupported for tensorrt" (now measured under profiling).
- Five stale `nvcr.io/nvidia/tensorrt-llm/release:1.0.0` pins across install/docker/troubleshoot docs.
- FAQ `CUDA_VISIBLE_DEVICES` multi-GPU guidance (docker dispatch uses `LLEM_DOCKER_GPUS`).

### Gates
- `make lint`: pass (ruff + import-linter, 5/5 contracts kept).
- `make docs-check`: pass ("Generated docs are up to date"); only hand-written pages edited, no generated-doc drift.
- No em/en-dashes, no AI attribution, no milestone codes in the diff.
