### PR TITLE
fix(metrics): source out-of-process engine memory from NVML instead of silent zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,24 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- Memory metrics are no longer a silent 0.0 for out-of-process engines. vLLM V1 runs its
+  model in the EngineCore child process and TensorRT-LLM in its executor process, so torch's
+  per-process allocator in the driver process saw nothing and `extended_metrics.memory`
+  `peak_memory_mb` / `model_memory_mb` came back as exactly 0.0 on every vLLM and TRT-LLM
+  experiment (real values only for in-process Transformers). Both capture points now fall
+  back to NVML device-used memory when the torch reading is implausible (`== 0.0`): the
+  harness model-memory baseline, and the plugin peak-memory read (vLLM's NVML fallback was
+  previously gated on the already-broken `peak > 0` torch value so it never fired; TRT-LLM
+  had no fallback at all). Transformers keeps its authoritative torch reading and never
+  consults NVML. The cascade fields that were nulled by the zero (`tokens_per_gb_vram`,
+  `model_memory_utilisation`, `kv_cache_memory_ratio`) now populate. NVML `used` is a
+  whole-device reading (it includes this process's CUDA context and any co-tenants), so the
+  absolute peak/model figures are an upper bound; the derived `inference_memory_mb` delta
+  cancels the shared context term and stays meaningful. Under `LLEM_DOCKER_GPUS` pinning the
+  container sees only the pinned device(s), so NVML index resolution matches the experiment's
+  own GPUs. The raw memory fields are now nullable and any residual 0.0 is coerced to null at
+  the domain boundary - the fields are always either a real measurement or null, never a
+  silently-wrong zero.
 - llem now forwards every `NCCL_*` host environment variable into both the experiment
   container (`infra.docker_runner`) and the baseline container (`study.baseline_container`),
   so NCCL tuning/workaround settings set on the host reach the engine process, which runs

--- a/src/llenergymeasure/domain/extended_metrics.py
+++ b/src/llenergymeasure/domain/extended_metrics.py
@@ -104,23 +104,28 @@ def _compute_memory_metrics(
     if not memory_stats:
         return mem
 
-    # Raw values
+    # Raw values. model/peak are 0.0 when neither torch nor NVML could measure
+    # them (out-of-process engine with NVML unavailable, or a CPU run). A 0.0 is
+    # not a real measurement, so coerce it to null here at the model boundary -
+    # the field must be either correct or null, never a silent zero.
     mem.total_vram_mb = memory_stats.get("total_vram_mb", 0.0)
-    mem.model_memory_mb = memory_stats.get("model_mb", 0.0)
-    mem.peak_memory_mb = memory_stats.get("peak_mb", 0.0)
+    model_mb = memory_stats.get("model_mb", 0.0)
+    peak_mb = memory_stats.get("peak_mb", 0.0)
+    mem.model_memory_mb = model_mb if model_mb and model_mb > 0 else None
+    mem.peak_memory_mb = peak_mb if peak_mb and peak_mb > 0 else None
     mem.kv_cache_mb = memory_stats.get("kv_cache_mb")
 
-    # Derived metrics
-    if mem.peak_memory_mb > 0 and output_tokens > 0:
+    # Derived metrics (null when their inputs are unmeasured/null)
+    if mem.peak_memory_mb and output_tokens > 0:
         # Tokens per GB of VRAM used
         peak_gb = mem.peak_memory_mb / 1024
         if peak_gb > 0:
             mem.tokens_per_gb_vram = output_tokens / peak_gb
 
-    if mem.total_vram_mb > 0 and mem.model_memory_mb > 0:
+    if mem.total_vram_mb > 0 and mem.model_memory_mb:
         mem.model_memory_utilisation = mem.model_memory_mb / mem.total_vram_mb
 
-    if mem.kv_cache_mb is not None and mem.peak_memory_mb > 0:
+    if mem.kv_cache_mb is not None and mem.peak_memory_mb:
         mem.kv_cache_memory_ratio = mem.kv_cache_mb / mem.peak_memory_mb
 
     return mem

--- a/src/llenergymeasure/domain/metrics.py
+++ b/src/llenergymeasure/domain/metrics.py
@@ -165,25 +165,36 @@ class MemoryEfficiencyMetrics(BaseModel):
     All fields always present in schema. Values are null when not computable.
     """
 
-    # Raw memory values (always available)
+    # Raw memory values (null when not measured, never a silent 0.0)
     total_vram_mb: float = Field(default=0.0, description="Total GPU VRAM in MB")
-    model_memory_mb: float = Field(default=0.0, description="Model weights memory in MB")
-    peak_memory_mb: float = Field(
-        default=0.0,
+    model_memory_mb: float | None = Field(
+        default=None,
+        description=(
+            "Model weights memory after load, before inference (MB). "
+            "For out-of-process engines (vLLM V1, TRT-LLM) this is an NVML "
+            "whole-device reading (includes CUDA context and co-tenants); for "
+            "in-process Transformers it is the torch per-process allocation. "
+            "null = not measured (no torch/NVML reading available)."
+        ),
+    )
+    peak_memory_mb: float | None = Field(
+        default=None,
         description=(
             "Peak GPU memory during inference measurement window (MB). "
             "Reflects KV cache + activations + batch buffers, not model weights. "
-            "0.0 = not measured."
+            "For out-of-process engines this is an NVML whole-device reading "
+            "(see model_memory_mb). null = not measured."
         ),
     )
-    inference_memory_mb: float = Field(
-        default=0.0,
+    inference_memory_mb: float | None = Field(
+        default=None,
         description=(
             "Inference-only memory: peak minus model baseline (MB). "
-            "Derived: max(0.0, peak_memory_mb - model_memory_mb). "
-            "Represents KV cache + activations + batch buffers allocated during inference. "
-            "Computed by harness _build_result(), not by the caller. "
-            "0.0 = not measured or not computable."
+            "Derived: max(0.0, peak_memory_mb - model_memory_mb), computed by the "
+            "harness only when both peak and model baseline were measured. When "
+            "both come from NVML the shared whole-device context term cancels in "
+            "the subtraction, so the delta is meaningful. "
+            "null = not measured or not computable."
         ),
     )
     kv_cache_mb: float | None = Field(default=None, description="KV cache memory in MB (vLLM only)")

--- a/src/llenergymeasure/engines/_cuda.py
+++ b/src/llenergymeasure/engines/_cuda.py
@@ -32,7 +32,12 @@ def reset_cuda_peak_memory() -> None:
 def get_cuda_peak_memory_mb() -> float:
     """Return peak GPU memory allocated in MB since last reset.
 
-    Returns 0.0 if torch/CUDA is unavailable.
+    torch's allocator tracks only THIS process. Returns 0.0 if torch/CUDA is
+    unavailable, and also - silently - if the model runs out-of-process (vLLM
+    V1's EngineCore, TRT-LLM's executor): the allocator in the calling process
+    never sees the child's allocation. Out-of-process engines must treat a 0.0
+    reading as "not measured here" and fall back to
+    :func:`get_nvml_device_memory_mb`.
     """
     try:
         import torch
@@ -42,6 +47,53 @@ def get_cuda_peak_memory_mb() -> float:
     except Exception:
         pass
     return 0.0
+
+
+def get_nvml_device_memory_mb(gpu_indices: list[int] | None = None) -> float | None:
+    """Return whole-device used GPU memory in MB, max across the given indices.
+
+    Process-agnostic fallback for out-of-process engines. vLLM V1 runs the model
+    in its EngineCore child process and TRT-LLM in its executor process, so
+    torch's per-process allocator in the driver process reports 0 and
+    :func:`get_cuda_peak_memory_mb` / the harness torch baseline read a silent
+    0.0. NVML reports device-level used memory, which counts the child's
+    allocation.
+
+    CAVEAT - whole-device reading: NVML ``used`` is the entire device's occupied
+    memory: this process's CUDA context PLUS any other tenants on the device, not
+    just the model under measurement. It is therefore an upper bound on the
+    model's usage. Under ``LLEM_DOCKER_GPUS`` pinning the container sees only the
+    pinned device(s) - the nvidia container runtime restricts NVML visibility too
+    (not only CUDA), so indices ``0..N`` map to the experiment's own GPUs and
+    contamination is bounded to co-tenants of those pinned devices. The
+    peak/model deltas the harness derives (``inference_memory_mb``) cancel the
+    shared context term, so relative figures stay meaningful even though the
+    absolute values carry the whole-device overhead.
+
+    Args:
+        gpu_indices: NVML device indices to poll (defaults to ``[0]``). The max
+            ``used`` across them is returned, matching the torch convention of
+            peaking across tensor-parallel ranks.
+
+    Returns:
+        Used memory in MB, or ``None`` when NVML is unavailable, no GPU is
+        present, or any query fails. Callers must treat ``None`` as "not
+        measured" (null) - never coerce it to 0.0.
+    """
+    indices = gpu_indices if gpu_indices else [0]
+    try:
+        import pynvml
+
+        from llenergymeasure.device.gpu_info import nvml_context
+
+        with nvml_context():
+            used_mb = [
+                bytes_to_mb(float(pynvml.nvmlDeviceGetMemoryInfo(handle).used))
+                for handle in (pynvml.nvmlDeviceGetHandleByIndex(idx) for idx in indices)
+            ]
+        return max(used_mb) if used_mb else None
+    except Exception:
+        return None
 
 
 def cleanup_model(model_obj: Any, *, use_gc: bool = True) -> None:

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -313,10 +313,21 @@ class TensorRTEngine:
                 hint="reduce n, use a smaller max_batch_size, or use a smaller model.",
             )
 
-        # Capture peak memory
-        from llenergymeasure.engines._cuda import get_cuda_peak_memory_mb
+        # Capture peak memory - torch first, NVML fallback for out-of-process runs.
+        from llenergymeasure.engines._cuda import (
+            get_cuda_peak_memory_mb,
+            get_nvml_device_memory_mb,
+        )
 
         peak_mb = get_cuda_peak_memory_mb()
+        if peak_mb == 0.0:
+            # TRT-LLM runs its model in a separate executor process, so torch's
+            # per-process allocator here saw nothing (a silent 0.0). Fall back to
+            # NVML device-used memory (whole-device; see get_nvml_device_memory_mb
+            # for the tenancy caveat). None stays 0.0 and is nulled downstream.
+            nvml_peak = get_nvml_device_memory_mb()
+            if nvml_peak is not None:
+                peak_mb = nvml_peak
 
         # Count tokens from RequestOutput objects (same pattern as vLLM)
         from llenergymeasure.engines._observed import count_request_tokens

--- a/src/llenergymeasure/engines/vllm/plugin.py
+++ b/src/llenergymeasure/engines/vllm/plugin.py
@@ -269,14 +269,28 @@ class VLLMEngine:
                 hint="reduce n, use gpu_memory_utilization=0.8, or use a smaller model.",
             )
 
-        # Capture peak memory - torch first, NVML fallback for pre-allocation detection.
-        from llenergymeasure.engines._cuda import get_cuda_peak_memory_mb
+        # Capture peak memory - torch first, NVML fallback for out-of-process
+        # (V1) runs and pre-allocation detection.
+        from llenergymeasure.engines._cuda import (
+            get_cuda_peak_memory_mb,
+            get_nvml_device_memory_mb,
+        )
 
         peak_mb = get_cuda_peak_memory_mb()
 
-        # Heuristic: if peak matches gpu_memory_utilization * total_vram within 5%,
-        # it's likely pre-allocation, not actual usage. Fall back to NVML.
-        if peak_mb > 0:
+        if peak_mb == 0.0:
+            # vLLM V1 runs its model in the EngineCore child process, so torch's
+            # per-process allocator here saw nothing (a silent 0.0). Fall back to
+            # NVML device-used memory (whole-device; see get_nvml_device_memory_mb
+            # for the tenancy caveat). None stays 0.0 and is nulled downstream.
+            nvml_peak = get_nvml_device_memory_mb()
+            if nvml_peak is not None:
+                peak_mb = nvml_peak
+        elif peak_mb > 0:
+            # torch saw an in-process allocation (V0-era), but it may just be
+            # vLLM's pre-allocation. Heuristic: if peak matches
+            # gpu_memory_utilization * total_vram within 5%, it's pre-allocation,
+            # not actual usage - NVML device-used is the closer proxy.
             try:
                 import torch
 
@@ -294,7 +308,7 @@ class VLLMEngine:
                         peak_mb,
                         expected_prealloc,
                     )
-                    nvml_peak = self._nvml_peak_memory_mb()
+                    nvml_peak = get_nvml_device_memory_mb()
                     if nvml_peak is not None:
                         peak_mb = nvml_peak
             except Exception:
@@ -533,24 +547,3 @@ class VLLMEngine:
         if config.task.max_output_tokens is not None:
             kwargs["max_tokens"] = config.task.max_output_tokens
         return BeamSearchParams(**kwargs)
-
-    # -------------------------------------------------------------------------
-    # Private: inference helpers
-    # -------------------------------------------------------------------------
-
-    @staticmethod
-    def _nvml_peak_memory_mb() -> float | None:
-        """Query NVML for current GPU memory used. Returns MB or None on failure."""
-        try:
-            import pynvml
-
-            from llenergymeasure.device.gpu_info import nvml_context
-
-            mem_mb: float | None = None
-            with nvml_context():
-                handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-                info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-                mem_mb = bytes_to_mb(float(info.used))
-            return mem_mb
-        except Exception:
-            return None

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -813,28 +813,42 @@ class MeasurementHarness:
             logger.debug("Config sidecar write failed (non-fatal): %s", exc)
 
     def _capture_model_memory_mb(self, gpu_indices: list[int] | None = None) -> float:
-        """Query torch for GPU max_memory_allocated() after model load.
+        """Capture the post-load model-memory baseline in MB.
 
-        Iterates over gpu_indices (defaults to [0] when None), queries
-        max_memory_allocated(device=idx) per GPU, and returns the max across
-        all ranks. This ensures tensor-parallel experiments report the peak
-        across all participating GPUs.
+        In-process engines (Transformers): torch's per-process allocator sees the
+        loaded weights, so ``torch.cuda.max_memory_allocated(device=idx)`` per
+        rank (max across ``gpu_indices``, defaulting to ``[0]``) is authoritative
+        and captures the tensor-parallel peak.
 
-        Returns 0.0 if torch is unavailable or CUDA is not available.
+        Out-of-process engines (vLLM V1 EngineCore, TRT-LLM executor): the weights
+        are loaded in a child process, so torch here reports a silent 0.0. Fall
+        back to NVML device-used memory (whole-device; see
+        :func:`get_nvml_device_memory_mb` for the tenancy caveat).
+
+        Returns 0.0 only when NEITHER source is available (no torch/CUDA and no
+        NVML, or a CPU run). The domain layer coerces a 0.0 baseline to null so
+        the field is never a silently-wrong zero.
         """
+        torch_mb = 0.0
         if importlib.util.find_spec("torch") is not None:
             try:
                 import torch
 
                 if torch.cuda.is_available():
                     indices = gpu_indices if gpu_indices is not None else [0]
-                    if not indices:
-                        return 0.0
-                    peak = max(torch.cuda.max_memory_allocated(device=idx) for idx in indices)
-                    return bytes_to_mb(peak)
+                    if indices:
+                        peak = max(torch.cuda.max_memory_allocated(device=idx) for idx in indices)
+                        torch_mb = bytes_to_mb(peak)
             except Exception:
-                pass
-        return 0.0
+                torch_mb = 0.0
+        if torch_mb > 0:
+            return torch_mb
+
+        # torch saw nothing: out-of-process engine or no in-process CUDA activity.
+        from llenergymeasure.engines._cuda import get_nvml_device_memory_mb
+
+        nvml_mb = get_nvml_device_memory_mb(gpu_indices)
+        return nvml_mb if nvml_mb is not None else 0.0
 
     def _estimate_flops(
         self,
@@ -1212,13 +1226,21 @@ class MeasurementHarness:
             else None
         )
 
-        # Memory metrics: inference-window-only peak and derived delta.
-        inference_memory_mb = max(0.0, output.peak_memory_mb - model_memory_mb)
+        # Memory metrics: inference-window-only peak and derived delta. Both peak
+        # and model baseline are 0.0 when neither torch nor NVML could measure
+        # them (out-of-process engine with NVML unavailable, or a CPU run); the
+        # delta is only meaningful when both are real, otherwise it stays null
+        # rather than reporting a silently-wrong number.
+        inference_memory_mb: float | None
+        if output.peak_memory_mb > 0 and model_memory_mb > 0:
+            inference_memory_mb = max(0.0, output.peak_memory_mb - model_memory_mb)
+        else:
+            inference_memory_mb = None
         logger.debug(
-            "Memory: model=%.1fMB, peak_inference=%.1fMB, inference_delta=%.1fMB",
+            "Memory: model=%.1fMB, peak_inference=%.1fMB, inference_delta=%s",
             model_memory_mb,
             output.peak_memory_mb,
-            inference_memory_mb,
+            f"{inference_memory_mb:.1f}MB" if inference_memory_mb is not None else "null",
         )
 
         # --- Extended efficiency metrics ---

--- a/tests/unit/domain/test_extended_metrics.py
+++ b/tests/unit/domain/test_extended_metrics.py
@@ -74,7 +74,7 @@ class TestComputeExtendedMetrics:
             kv_cache_stats=None,
         )
         assert isinstance(result, ExtendedEfficiencyMetrics)
-        assert result.memory.peak_memory_mb == 0.0
+        assert result.memory.peak_memory_mb is None
         assert result.gpu_utilisation.sm_utilisation_mean is None
 
 
@@ -88,8 +88,19 @@ class TestComputeMemoryMetrics:
 
     def test_none_memory_stats(self):
         mem = _compute_memory_metrics(100, None)
-        assert mem.peak_memory_mb == 0.0
+        assert mem.peak_memory_mb is None
         assert mem.tokens_per_gb_vram is None
+
+    def test_zero_peak_and_model_coerced_to_null(self):
+        """A 0.0 peak/model reading (out-of-process engine, NVML unavailable) is
+        surfaced as null, never a silent zero."""
+        mem = _compute_memory_metrics(
+            100, {"peak_mb": 0.0, "total_vram_mb": 40960.0, "model_mb": 0.0}
+        )
+        assert mem.peak_memory_mb is None
+        assert mem.model_memory_mb is None
+        assert mem.tokens_per_gb_vram is None
+        assert mem.model_memory_utilisation is None
 
     def test_tokens_per_gb_vram(self):
         mem = _compute_memory_metrics(

--- a/tests/unit/test_oop_engine_memory.py
+++ b/tests/unit/test_oop_engine_memory.py
@@ -1,0 +1,255 @@
+"""Tests for out-of-process engine memory sourcing (NVML fallback).
+
+vLLM V1 runs its model in the EngineCore child process and TRT-LLM in its
+executor process, so torch's per-process allocator in the driver process reads a
+silent 0.0 for peak/model memory. The fix sources those values from NVML
+device-used memory whenever the torch reading is implausible (== 0.0), keeps
+torch for in-process Transformers, and coerces any residual 0.0 to null at the
+domain boundary so the fields are never a silently-wrong zero.
+
+All tests run CPU-only: NVML and torch are mocked.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_config
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MB = 1024 * 1024
+
+
+def _pynvml_mock(used_by_index: dict[int, int]) -> MagicMock:
+    """A pynvml stand-in whose per-index handles report the given used bytes."""
+    mock = MagicMock()
+    mock.nvmlDeviceGetHandleByIndex.side_effect = lambda idx: f"handle-{idx}"
+    mock.nvmlDeviceGetMemoryInfo.side_effect = lambda handle: SimpleNamespace(
+        used=used_by_index[int(str(handle).split("-")[1])]
+    )
+    return mock
+
+
+def _fake_request_output(n_in: int = 3, n_out: int = 2) -> SimpleNamespace:
+    """A minimal RequestOutput accepted by both vLLM and TRT-LLM token counters."""
+    return SimpleNamespace(
+        prompt_token_ids=list(range(n_in)),
+        outputs=[SimpleNamespace(token_ids=list(range(n_out)))],
+        metrics=None,  # vLLM extract_request_metrics -> empty
+        metrics_dict=None,  # TRT-LLM _extract_metrics_dict -> empty
+    )
+
+
+class _FakeLLM:
+    """Stand-in LLM whose generate() returns fake RequestOutputs."""
+
+    def generate(self, prompts, sampling_params):
+        return [_fake_request_output() for _ in prompts]
+
+    def beam_search(self, prompts, params):  # pragma: no cover - not hit on host
+        return [_fake_request_output() for _ in prompts]
+
+
+# ---------------------------------------------------------------------------
+# get_nvml_device_memory_mb - the shared process-agnostic fallback source
+# ---------------------------------------------------------------------------
+
+
+class TestNvmlDeviceMemoryHelper:
+    def test_reads_used_memory_and_converts_to_mb(self):
+        from llenergymeasure.engines._cuda import get_nvml_device_memory_mb
+
+        with patch.dict(sys.modules, {"pynvml": _pynvml_mock({0: 2048 * _MB})}):
+            assert get_nvml_device_memory_mb([0]) == pytest.approx(2048.0)
+
+    def test_defaults_to_index_zero(self):
+        from llenergymeasure.engines._cuda import get_nvml_device_memory_mb
+
+        with patch.dict(sys.modules, {"pynvml": _pynvml_mock({0: 512 * _MB})}):
+            assert get_nvml_device_memory_mb() == pytest.approx(512.0)
+
+    def test_max_across_indices(self):
+        """Matches the torch convention of peaking across tensor-parallel ranks."""
+        from llenergymeasure.engines._cuda import get_nvml_device_memory_mb
+
+        with patch.dict(sys.modules, {"pynvml": _pynvml_mock({0: 1000 * _MB, 1: 3000 * _MB})}):
+            assert get_nvml_device_memory_mb([0, 1]) == pytest.approx(3000.0)
+
+    def test_returns_none_when_pynvml_unavailable(self):
+        from llenergymeasure.engines._cuda import get_nvml_device_memory_mb
+
+        # sys.modules[name] = None makes `import name` raise ImportError.
+        with patch.dict(sys.modules, {"pynvml": None}):
+            assert get_nvml_device_memory_mb([0]) is None
+
+    def test_returns_none_on_query_failure(self):
+        from llenergymeasure.engines._cuda import get_nvml_device_memory_mb
+
+        broken = MagicMock()
+        broken.nvmlDeviceGetHandleByIndex.side_effect = RuntimeError("no such device")
+        with patch.dict(sys.modules, {"pynvml": broken}):
+            assert get_nvml_device_memory_mb([0]) is None
+
+
+# ---------------------------------------------------------------------------
+# Harness model-memory baseline: torch for in-process, NVML for out-of-process
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessModelMemoryCapture:
+    def _harness(self):
+        from llenergymeasure.harness.measurement import MeasurementHarness
+
+        return MeasurementHarness()
+
+    def test_transformers_shaped_torch_value_preserved_no_fallback(self):
+        """In-process engine: torch sees the weights (> 0), so NVML is never consulted."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.max_memory_allocated.return_value = 700 * _MB
+
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch("importlib.util.find_spec", return_value=MagicMock()),
+            patch(
+                "llenergymeasure.engines._cuda.get_nvml_device_memory_mb",
+                side_effect=AssertionError("NVML must not be consulted when torch reads > 0"),
+            ),
+        ):
+            result = self._harness()._capture_model_memory_mb(gpu_indices=[0])
+
+        assert result == pytest.approx(700.0)
+
+    def test_oop_shaped_falls_back_to_nvml_when_torch_zero(self):
+        """Out-of-process engine: torch reads 0.0, so NVML device memory is used."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.max_memory_allocated.return_value = 0  # child-process weights unseen
+
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch("importlib.util.find_spec", return_value=MagicMock()),
+            patch(
+                "llenergymeasure.engines._cuda.get_nvml_device_memory_mb",
+                return_value=8192.0,
+            ),
+        ):
+            result = self._harness()._capture_model_memory_mb(gpu_indices=[0])
+
+        assert result == pytest.approx(8192.0)
+
+    def test_zero_when_neither_source_available(self):
+        """torch reads 0.0 and NVML is unavailable -> 0.0 (nulled at the domain boundary)."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.max_memory_allocated.return_value = 0
+
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch("importlib.util.find_spec", return_value=MagicMock()),
+            patch(
+                "llenergymeasure.engines._cuda.get_nvml_device_memory_mb",
+                return_value=None,
+            ),
+        ):
+            result = self._harness()._capture_model_memory_mb(gpu_indices=[0])
+
+        assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Plugin peak-memory capture: vLLM- and TRT-shaped fallback on 0.0
+# ---------------------------------------------------------------------------
+
+
+class TestVllmPeakMemoryFallback:
+    def _run(self, nvml_return):
+        from llenergymeasure.engines.vllm import VLLMEngine
+
+        config = make_config(engine="vllm", model="test-model")
+        with (
+            patch("llenergymeasure.engines._cuda.get_cuda_peak_memory_mb", return_value=0.0),
+            patch(
+                "llenergymeasure.engines._cuda.get_nvml_device_memory_mb",
+                return_value=nvml_return,
+            ),
+        ):
+            return VLLMEngine().run_inference(config, (_FakeLLM(), object()), ["hi"])
+
+    def test_fallback_fires_when_torch_zero(self):
+        """torch peak 0.0 (V1 out-of-process) -> peak sourced from NVML."""
+        out = self._run(nvml_return=12345.0)
+        assert out.peak_memory_mb == pytest.approx(12345.0)
+
+    def test_stays_zero_when_nvml_unavailable(self):
+        """torch 0.0 and NVML None -> 0.0 (never a fabricated number)."""
+        out = self._run(nvml_return=None)
+        assert out.peak_memory_mb == 0.0
+
+
+class TestTensorRTPeakMemoryFallback:
+    def test_fallback_fires_when_torch_zero(self):
+        from llenergymeasure.engines.tensorrt import TensorRTEngine
+
+        config = make_config(engine="tensorrt", model="test-model")
+        with (
+            patch("llenergymeasure.engines._cuda.get_cuda_peak_memory_mb", return_value=0.0),
+            patch(
+                "llenergymeasure.engines._cuda.get_nvml_device_memory_mb",
+                return_value=6789.0,
+            ),
+        ):
+            out = TensorRTEngine().run_inference(config, (_FakeLLM(), object()), ["hi"])
+
+        assert out.peak_memory_mb == pytest.approx(6789.0)
+
+
+class TestTransformersPeakNoFallback:
+    def test_torch_value_preserved_no_nvml(self):
+        """In-process Transformers: peak is the torch value, NVML never consulted."""
+        pytest.importorskip("torch")
+        from llenergymeasure.engines.transformers import TransformersEngine
+
+        nvml_spy = MagicMock(return_value=99999.0)
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.reset_peak_memory_stats"),
+            patch("torch.cuda.max_memory_allocated", return_value=640 * _MB),
+            patch("torch.manual_seed"),
+            patch("llenergymeasure.engines._cuda.get_nvml_device_memory_mb", nvml_spy),
+            patch.object(TransformersEngine, "_run_batch", return_value=(10, 20, 0.5, 0)),
+        ):
+            config = make_config(engine="transformers", model="test-model")
+            out = TransformersEngine().run_inference(config, (object(), None), ["hi"])
+
+        assert out.peak_memory_mb == pytest.approx(640.0)
+        nvml_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cascade fields un-null when a real peak is present
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeUnNulling:
+    def test_cascade_populated_when_peak_real(self):
+        """A real NVML-sourced peak un-nulls the derived memory metrics that the
+        silent-0.0 bug left null for vLLM/TRT."""
+        from llenergymeasure.domain.extended_metrics import _compute_memory_metrics
+
+        mem = _compute_memory_metrics(
+            2048,
+            {"peak_mb": 2048.0, "total_vram_mb": 40960.0, "model_mb": 8192.0, "kv_cache_mb": 512.0},
+        )
+        assert mem.peak_memory_mb == pytest.approx(2048.0)
+        assert mem.model_memory_mb == pytest.approx(8192.0)
+        assert mem.tokens_per_gb_vram is not None
+        assert mem.model_memory_utilisation == pytest.approx(8192.0 / 40960.0)
+        assert mem.kv_cache_memory_ratio == pytest.approx(512.0 / 2048.0)

--- a/tests/unit/test_peak_memory.py
+++ b/tests/unit/test_peak_memory.py
@@ -183,9 +183,12 @@ def test_memory_efficiency_metrics_has_three_memory_fields():
     assert "inference_memory_mb" in fields, "MemoryEfficiencyMetrics must have inference_memory_mb"
 
 
-def test_inference_memory_mb_default_is_zero():
-    """MemoryEfficiencyMetrics.inference_memory_mb defaults to 0.0."""
+def test_raw_memory_fields_default_to_null():
+    """MemoryEfficiencyMetrics raw memory fields default to null (not measured),
+    never a silent 0.0."""
     from llenergymeasure.domain.metrics import MemoryEfficiencyMetrics
 
     m = MemoryEfficiencyMetrics()
-    assert m.inference_memory_mb == 0.0
+    assert m.inference_memory_mb is None
+    assert m.peak_memory_mb is None
+    assert m.model_memory_mb is None


### PR DESCRIPTION
## Summary

`extended_metrics.memory.{peak_memory_mb,model_memory_mb}` were silently `0.0` (not null) on every vLLM and TensorRT-LLM experiment. vLLM V1 runs its model in the EngineCore child process and TRT-LLM in its executor process, so `torch.cuda.max_memory_allocated()` read in the driver process saw nothing. vLLM's NVML fallback was gated `if peak_mb > 0` on the already-broken torch value (dead code); TRT-LLM had no fallback. The zero cascaded to null `tokens_per_gb_vram` / `model_memory_utilisation` / `kv_cache_memory_ratio`. In-process Transformers was correct and stays torch-sourced.

Verified empirically in the F3+F4 field audit (finding 1) against the v0.11.0 exit sweep: exactly `0.0` on all 6 vllm/tensorrt cells, real values only for transformers.

## Design shape

NVML device-used memory is the fallback source whenever the torch reading is implausible (`== 0.0`), applied at both capture points:

- **Harness model-memory baseline** (`_capture_model_memory_mb`): torch per-rank max first; NVML fallback when torch reads 0.0.
- **Plugin peak-memory** (vLLM + TRT-LLM `run_inference`): torch first; NVML fallback when 0.0. vLLM keeps its existing pre-allocation heuristic (now also routed through the shared helper).
- New shared `engines/_cuda.get_nvml_device_memory_mb(gpu_indices)` centralises the read (max across indices, `None` on failure); it replaces vLLM's private `_nvml_peak_memory_mb`.
- **Transformers** keeps its authoritative torch reading and never consults NVML (in-process).

The three raw memory fields (`peak_memory_mb`, `model_memory_mb`, `inference_memory_mb`) are now `float | None`, and any residual `0.0` is coerced to null at the domain boundary (`_compute_memory_metrics`). Fields are always either a real measurement or null, never a silently-wrong zero.

### Semantic caveats documented

- NVML `used` is a **whole-device** reading: it includes this process's CUDA context and any co-tenants, so the absolute peak/model figures are an **upper bound** on the model's usage. Documented on the helper and the domain fields.
- The derived `inference_memory_mb` = `peak - model` cancels the shared whole-device context term, so the delta stays meaningful even under the whole-device caveat.
- Under `LLEM_DOCKER_GPUS` pinning the container sees only the pinned device(s) (the nvidia runtime restricts NVML visibility too), so NVML index resolution maps to the experiment's own GPUs.

## Files changed

- `engines/_cuda.py` - new `get_nvml_device_memory_mb`; `get_cuda_peak_memory_mb` docstring notes out-of-process blindness.
- `engines/vllm/plugin.py` - fallback fires on 0.0; removed private `_nvml_peak_memory_mb`.
- `engines/tensorrt/plugin.py` - gains the NVML fallback.
- `harness/measurement.py` - model-memory NVML fallback; `inference_memory_mb` null unless both inputs real.
- `domain/metrics.py` - raw memory fields nullable, docstrings updated.
- `domain/extended_metrics.py` - coerce 0.0 to null; guard derived-metric gates against null.

## Test plan

New `tests/unit/test_oop_engine_memory.py` (NVML/torch mocked, CPU-only): NVML helper (MB conversion, max-across-indices, None on failure), harness baseline (transformers torch-preserved / no fallback, oop NVML fallback, both-unavailable -> 0.0), vLLM + TRT peak fallback on 0.0, transformers peak with no NVML consultation, and the cascade fields un-nulling when peak is real. Updated existing assertions in `test_extended_metrics.py` / `test_peak_memory.py` for the new null semantics.

Gates: `make lint`, `make typecheck`, `make test` (3051 passed, 36 skipped) all green.