### PR TITLE
feat(results): expose input and output token counts on result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Added
 
+- `result.json` now exposes `input_tokens` and `output_tokens` alongside `total_tokens`
+  (the actual tokenised counts as observed by the engine, where
+  `total_tokens = input_tokens + output_tokens`). The split was already computed in the
+  harness for the FLOPs-per-token fields but never persisted; exposing it enables auditing
+  declared-vs-actual input lengths. Rides the unreleased schema 5.0 (additive, no version
+  bump).
 - The `timeseries.parquet` sidecar now carries `experiment_id` and
   `measurement_config_hash` as Parquet file-level key-value metadata (not columns), so the
   artefact stays attributable if separated from its result directory. This mirrors the

--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -45,6 +45,8 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 
 | Field | Type | Units | Description |
 |-------|------|-------|-------------|
+| `input_tokens` | `int` | tokens | Actual input (prefill) tokens observed by the engine after tokenisation. `total_tokens = input_tokens + output_tokens`. |
+| `output_tokens` | `int` | tokens | Actual output (decode) tokens observed by the engine. `total_tokens = input_tokens + output_tokens`. |
 | `total_tokens` | `int` | tokens | Total tokens generated during the run. |
 | `total_energy_j` | `float` | joules | Total GPU energy for the run. |
 | `energy_adjusted_j` | `float \| None` | joules | Baseline-subtracted energy attributable to inference. `None` when no baseline was taken. |

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -62,6 +62,8 @@ These are the run totals (post-warmup-exclusion when applicable).
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `input_tokens` | int | Actual input (prefill) tokens observed by the engine after tokenisation (`total_tokens = input_tokens + output_tokens`) |
+| `output_tokens` | int | Actual output (decode) tokens observed by the engine (`total_tokens = input_tokens + output_tokens`) |
 | `total_tokens` | int | Total output tokens generated across all prompts |
 | `total_energy_j` | float | Total GPU energy in joules (raw, no baseline subtraction) |
 | `total_inference_time_sec` | float | Total wall-clock inference time |

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -259,6 +259,8 @@ copies so the file is self-describing when separated from its directory:
   "schema_version": "5.0",
   "engine": "transformers",
   "model_name": "Qwen/Qwen2.5-0.5B",
+  "input_tokens": 6144,
+  "output_tokens": 1536,
   "total_tokens": 7680,
   "total_inference_time_sec": 9.8,
   "avg_tokens_per_second": 783.7,

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -122,6 +122,16 @@ class ExperimentResult(BaseModel):
     )
 
     # Core metrics
+    input_tokens: int = Field(
+        ...,
+        description="Actual input (prefill) tokens as observed by the engine after "
+        "tokenisation. total_tokens = input_tokens + output_tokens.",
+    )
+    output_tokens: int = Field(
+        ...,
+        description="Actual output (decode) tokens as observed by the engine. "
+        "total_tokens = input_tokens + output_tokens.",
+    )
     total_tokens: int = Field(..., description="Total tokens across all processes")
     total_energy_j: float = Field(..., description="Total energy (sum across processes)")
     total_inference_time_sec: float = Field(..., description="Total inference time")

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -1407,6 +1407,8 @@ class MeasurementHarness:
                 method="single_process",
                 num_processes=1,
             ),
+            input_tokens=output.input_tokens,
+            output_tokens=output.output_tokens,
             total_tokens=output.total_tokens,
             total_energy_j=total_energy_j,
             total_inference_time_sec=measured_time_sec,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,8 @@ def make_result(**overrides) -> ExperimentResult:
         "experiment_id": TEST_EXPERIMENT_ID,
         "measurement_config_hash": TEST_MEASUREMENT_HASH,
         "aggregation": AggregationMetadata(num_processes=1),
+        "input_tokens": 800,
+        "output_tokens": 200,
         "total_tokens": 1000,
         "total_energy_j": 10.0,
         "total_inference_time_sec": 5.0,

--- a/tests/fixtures/replay/gpt2_transformers_v5.0.json
+++ b/tests/fixtures/replay/gpt2_transformers_v5.0.json
@@ -4,6 +4,8 @@
   "measurement_config_hash": "9944baab4dabe390",
   "engine": "transformers",
   "model_name": "gpt2",
+  "input_tokens": 1280,
+  "output_tokens": 640,
   "total_tokens": 1920,
   "total_energy_j": 228.03882500813023,
   "total_inference_time_sec": 4.294965875800699,

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -768,6 +768,8 @@ def test_write_config_sidecar_creates_config_json(minimal_config, tmp_path: Path
     result = ExperimentResult(
         experiment_id="test-sidecar-001",
         measurement_config_hash="aabb1122ccdd3344",
+        input_tokens=8,
+        output_tokens=2,
         total_tokens=10,
         total_energy_j=1.0,
         total_inference_time_sec=0.5,

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -30,6 +30,8 @@ def _make_result(
     return ExperimentResult(
         experiment_id="test-save-record-001",
         measurement_config_hash="aabb1122ccdd3344",
+        input_tokens=192,
+        output_tokens=64,
         total_tokens=256,
         total_energy_j=10.0,
         total_inference_time_sec=2.0,

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -32,6 +32,8 @@ def make_result():
         defaults = dict(
             experiment_id="test-001",
             measurement_config_hash="abcdef0123456789",
+            input_tokens=800,
+            output_tokens=200,
             total_tokens=1000,
             total_energy_j=50.0,
             total_inference_time_sec=10.0,

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -54,6 +54,8 @@ def minimal_result() -> ExperimentResult:
     return ExperimentResult(
         experiment_id="persist-test-001",
         measurement_config_hash="abcdef0123456789",
+        input_tokens=384,
+        output_tokens=128,
         total_tokens=512,
         total_energy_j=25.6,
         total_inference_time_sec=5.0,
@@ -71,6 +73,8 @@ def hf_model_result() -> ExperimentResult:
     return ExperimentResult(
         experiment_id="persist-test-hf",
         measurement_config_hash="fedcba9876543210",
+        input_tokens=768,
+        output_tokens=256,
         total_tokens=1024,
         total_energy_j=51.2,
         total_inference_time_sec=10.0,
@@ -88,6 +92,8 @@ def result_with_timeseries() -> ExperimentResult:
     return ExperimentResult(
         experiment_id="persist-test-ts",
         measurement_config_hash="1122334455667788",
+        input_tokens=192,
+        output_tokens=64,
         total_tokens=256,
         total_energy_j=12.8,
         total_inference_time_sec=2.5,
@@ -211,7 +217,11 @@ def test_from_json_loads_correctly(tmp_path: Path, minimal_result: ExperimentRes
     from tests.conftest import EXPERIMENT_SCHEMA_VERSION
 
     assert loaded.schema_version == EXPERIMENT_SCHEMA_VERSION
+    assert loaded.input_tokens == minimal_result.input_tokens
+    assert loaded.output_tokens == minimal_result.output_tokens
     assert loaded.total_tokens == minimal_result.total_tokens
+    # Token split is consistent: total is the sum of the input/output halves.
+    assert loaded.input_tokens + loaded.output_tokens == loaded.total_tokens
     assert loaded.total_energy_j == pytest.approx(minimal_result.total_energy_j)
 
 
@@ -237,6 +247,8 @@ def test_convenience_identity_copies_round_trip(tmp_path: Path) -> None:
         measurement_config_hash="abcdef0123456789",
         engine="vllm",
         model_name=_HF_MODEL,
+        input_tokens=384,
+        output_tokens=128,
         total_tokens=512,
         total_energy_j=25.6,
         total_inference_time_sec=5.0,


### PR DESCRIPTION
## Summary

`ExperimentResult` only exposed `total_tokens`; the input/output split was computed in the harness for the FLOPs-per-token fields (`harness/measurement.py`) but never persisted, blocking declared-vs-actual input-length auditing (audit finding 5, `.product/research/f3f4-field-audit-2026-07-16.md`).

This adds `input_tokens` and `output_tokens` next to `total_tokens` on `ExperimentResult`, populated in `_build_result` from the engine-observed counts already on `EngineOutput` (where `total_tokens == input_tokens + output_tokens` by construction). The addition rides the unreleased schema 5.0 (landed via #812), so it is additive within 5.0 with no version bump.

## Changes

- `domain/experiment.py`: new `input_tokens` / `output_tokens` core-metric fields.
- `harness/measurement.py`: `_build_result` populates both from `output.input_tokens` / `output.output_tokens`.
- Replay fixture, `conftest.make_result`, and all direct result-constructing tests updated with a consistent split.
- `docs/reference/results-schema.md`, `ExperimentResult.md`, and the multi-engine tutorial example updated.
- CHANGELOG `[Unreleased]` Added entry.

## Test plan

- `test_from_json_loads_correctly` now asserts the fields round-trip and that `input + output == total` survives save/load.
- Gates green: `make lint`, `make typecheck`, `make test` (3046 passed, 36 skipped).