### PR TITLE
fix(config): compute config hashes on json-mode dump for round-trip stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- Declared-config and study-design hashes are now computed on a json-mode
+  `model_dump`, so a field typed float but defaulted to an int literal (e.g. vllm
+  `cpu_offload_gb = 0`) hashes identically whether or not the config has been
+  through a JSON round-trip. Previously the host hashed the in-memory int (`0`)
+  while the container re-validated the config the host wrote and hashed the
+  coerced float (`0.0`), producing different hashes; the host then named the
+  result file with a hash the container never wrote and reported "Container
+  exited 0 but no result file found" for a successful run. Configs that pinned
+  such fields explicitly (e.g. `cpu_offload_gb: 0.0`) no longer need to.
 - `environment.json` now records the environment the experiment actually ran in for
   docker-dispatched experiments, instead of the dispatching host's environment. The
   container entrypoint collects the environment snapshot inside the container, threads it

--- a/src/llenergymeasure/config/grid.py
+++ b/src/llenergymeasure/config/grid.py
@@ -286,8 +286,12 @@ def compute_study_design_hash(experiments: list[ExperimentConfig]) -> str:
 
     Deterministic: uses json.dumps with sort_keys=True. Identical experiment lists
     produce the same hash across calls and interpreter restarts.
+
+    Dumps in ``mode="json"`` so a field typed float but defaulted to an int
+    literal serialises identically whether or not the config has been through a
+    JSON round-trip (see :func:`compute_declared_config_hash`).
     """
-    canonical = json.dumps([exp.model_dump() for exp in experiments], sort_keys=True)
+    canonical = json.dumps([exp.model_dump(mode="json") for exp in experiments], sort_keys=True)
     return hashlib.sha256(canonical.encode()).hexdigest()[:16]
 
 

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -35,8 +35,14 @@ def compute_declared_config_hash(config: ExperimentConfig) -> str:
     Layer 3 fields (datacenter_pue, grid_carbon_intensity) are not in
     ExperimentConfig (they live in user config only), so model_dump()
     naturally excludes them. No special exclusion logic needed.
+
+    Dumps in ``mode="json"`` so numeric coercions match the serialized form:
+    a field typed float but defaulted to an int literal (e.g. vllm
+    ``cpu_offload_gb = 0``) stays int in a python-mode dump but becomes ``0.0``
+    after a JSON round-trip. The host and the container must agree on this hash
+    (it names the result file), so both hash the JSON-stable form.
     """
-    canonical = json.dumps(config.model_dump(), sort_keys=True)
+    canonical = json.dumps(config.model_dump(mode="json"), sort_keys=True)
     return _hash_canonical(canonical)
 
 

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -288,6 +288,30 @@ def test_config_hash_different_configs():
     assert h1 != h2
 
 
+def test_config_hash_stable_across_json_round_trip():
+    """Hash is identical before and after a JSON round-trip of the config.
+
+    Regression for the host/container hash split: vllm ``cpu_offload_gb`` is
+    typed float but defaults to the int literal ``0``. Pydantic does not
+    validate defaults, so it stays int ``0`` in memory but becomes ``0.0`` after
+    a JSON round-trip (the container re-validates the config the host wrote via
+    ``model_dump_json``). A python-mode dump hashed those two forms differently,
+    so the container named its result file with a different hash than the host
+    looked for. Hashing the json-mode dump makes both sides agree.
+    """
+    cfg = ExperimentConfig.model_validate(
+        {"engine": "vllm", "task": {"model": "gpt2"}, "vllm": {"engine_params": {}}}
+    )
+    # cpu_offload_gb is int 0 in memory (defaults are not validated)...
+    assert cfg.vllm is not None
+    assert isinstance(cfg.vllm.engine_params.cpu_offload_gb, int)
+    # ...and 0.0 after the exact host-write -> container-read round-trip.
+    round_tripped = ExperimentConfig.model_validate_json(cfg.model_dump_json())
+    assert isinstance(round_tripped.vllm.engine_params.cpu_offload_gb, float)
+
+    assert compute_declared_config_hash(cfg) == compute_declared_config_hash(round_tripped)
+
+
 # ---------------------------------------------------------------------------
 # Task 2.25: MultiGPUMetrics model
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Declared-config and study-design hashes were computed on a python-mode `model_dump()`, which is not JSON-round-trip stable. A field typed `float` but defaulted to an int literal (e.g. vllm `cpu_offload_gb: Annotated[float | None, Field(ge=0.0)] = 0`) stays int `0` in memory (pydantic does not validate defaults) but becomes `0.0` after a JSON round-trip.

Under docker dispatch this split the host and container:

- Host computes `compute_declared_config_hash` on the in-memory config -> hashes int `0`.
- Host writes the config to the exchange dir via `model_dump_json()` -> serialises `0.0`.
- Container re-validates that JSON (`ExperimentConfig.model_validate`) -> `cpu_offload_gb` is now float `0.0` -> its `compute_declared_config_hash` hashes `0.0`.
- The two hashes differ. The host looks for `{host_hash}_result.json` but the container wrote `{container_hash}_result.json`, so a successful run is reported as "Container exited 0 but no result file found".

Prior sweep configs worked around this by pinning `cpu_offload_gb: 0.0` explicitly. This fixes the root cause: both `compute_declared_config_hash` (`domain/experiment.py`) and `compute_study_design_hash` (`config/grid.py`) now dump with `mode="json"`, so numeric coercions match the serialized form and both sides agree.

## Blast-radius audit

Hash VALUES change only for configs that contain an int-defaulted float field (the vllm `cpu_offload_gb` case). Configs without such a field are byte-identical.

Consumers checked - all tolerate a value change (pre-1.0, no cross-version hash contract):

- Result / config / error file names (`{config_hash}_*.json`): host and container now agree - this is the fix, not a regression.
- Resume skip-set (`(config_hash, cycle)` recompute vs manifest): pre-1.0; only affects a study resumed across the upgrade, which re-runs cells whose stored hash predates the change. Acceptable.
- `study_design_hash` (persisted in manifest / used for drift display): same class, fixed for consistency.
- `resolved_config_hash` / `observed_config_hash` (dedup gap analysis): a SEPARATE canonicalization path (`domain/hashing.py` `_normalise` + `canonical_serialise`, driven by `build_resolved_view`/`build_observed_view`). Not touched here. It has a latent int-vs-float normalization gap of the same class, but changing it risks desyncing the resolved-vs-observed comparison, and it is out of scope for this defect. Flagged for a follow-up.

Test fixtures: no test pins a computed declared-config-hash literal. The one pinned computed literal is `study_design_hash == "d46af75d621fc28a"` (transformers study, `test_config_loader.py`); its config has no int-defaulted float field, so the value is unchanged and the test still passes. Other `*_hash == "..."` assertions are placeholder strings assigned directly to models, not computed via the hash functions.

## Test plan

- New regression test `test_config_hash_stable_across_json_round_trip`: a vllm config's declared hash is identical before and after `model_validate_json(model_dump_json(...))`, asserting the in-memory int `0` -> round-tripped float `0.0` transition it guards against.
- `make lint` (ruff + import-linter): pass.
- `make typecheck` (mypy, 310 files): pass.
- `make test`: 3052 passed, 36 skipped.
