### PR TITLE
fix(results): make sidecar files host-readable and surface rescue failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,20 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- The `config.json` and `environment.json` sidecars now materialise in the experiment
+  directory under docker dispatch. Atomic writes (`result.json`, both sidecars, the study
+  manifest, and equivalence groups) are now created world-readable (0644) instead of the
+  0600 that `tempfile.mkstemp` produces regardless of umask. Previously a root container
+  wrote these two sidecars 0600, and the non-root host then hit `PermissionError` reading
+  them during the rescue step - swallowed at debug level - so both sidecars were silently
+  dropped from every docker-dispatched bundle (`result.json` and `timeseries.parquet`
+  survived because they were already written 0644). Sidecar-rescue failures now log a
+  warning naming the path and reason rather than vanishing.
+- `llem run` warnings now reach the terminal. The package installs a `NullHandler` at
+  import time, which the logging setup mistook for an already-configured handler and so
+  never attached the real stream handler - suppressing every `WARNING`-level message
+  (including the sidecar-rescue backstops above) on the normal run path. The setup now
+  ignores the placeholder and attaches the stream handler.
 - Declared-config and study-design hashes are now computed on a json-mode
   `model_dump`, so a field typed float but defaulted to an int literal (e.g. vllm
   `cpu_offload_gb = 0`) hashes identically whether or not the config has been

--- a/src/llenergymeasure/cli/__init__.py
+++ b/src/llenergymeasure/cli/__init__.py
@@ -57,8 +57,14 @@ def _setup_logging(verbose: int = 0) -> None:
     root_logger = logging.getLogger("llenergymeasure")
     root_logger.setLevel(level)
 
-    # Avoid adding duplicate handlers on repeated calls
-    if not root_logger.handlers:
+    # The package installs a NullHandler at import time (standard library
+    # hygiene). That placeholder alone must NOT count as "already configured",
+    # or the real stream handler is never attached and WARNING-level messages
+    # (e.g. a silently-dropped sidecar during docker rescue) never reach the
+    # user. Add the stream handler unless a real (non-null) one already exists,
+    # which also keeps repeated calls from stacking duplicate handlers.
+    has_stream_handler = any(not isinstance(h, logging.NullHandler) for h in root_logger.handlers)
+    if not has_stream_handler:
         handler = logging.StreamHandler()
         handler.setLevel(level)
         fmt = logging.Formatter(

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -103,6 +103,14 @@ def _atomic_write(content: str, path: Path) -> None:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())
+        # tempfile.mkstemp() creates the file mode 0600 regardless of umask.
+        # Every caller writes a results artefact (result.json, config/environment
+        # sidecars, manifest.json, equivalence groups), all of which must be
+        # world-readable so a non-root host can read a sidecar written by a root
+        # container during docker-dispatch rescue - matching the 0644 that
+        # result.json and timeseries.parquet already get. Without this, the host
+        # rescue hits PermissionError and the sidecar is silently dropped.
+        os.chmod(tmp_path, 0o644)
         os.replace(tmp_path, path)
     except Exception:
         with contextlib.suppress(OSError):

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -211,8 +211,16 @@ def _save_and_record(
                     json.dumps(load_json(rescued_env), indent=2, default=str),
                     result_path.parent / ENVIRONMENT_FILENAME,
                 )
-            except Exception as exc:  # pragma: no cover - best-effort
-                logger.debug("environment.json sidecar rescue failed: %s", exc)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to rescue in-container environment.json for %s (cycle %d) "
+                    "from %s: %s - environment.json will record the dispatching host, "
+                    "not the container the experiment ran in.",
+                    config_hash,
+                    cycle,
+                    rescued_env,
+                    exc,
+                )
             finally:
                 rescued_env.unlink(missing_ok=True)
         elif runner_provenance is not None and runner_provenance.mode == RUNNER_DOCKER:
@@ -248,8 +256,16 @@ def _save_and_record(
                         json.dumps(_payload, indent=2, default=str),
                         result_path.parent / CONFIG_SIDECAR_FILENAME,
                     )
-                except Exception as exc:  # pragma: no cover - best-effort
-                    logger.debug("config.json sidecar move failed: %s", exc)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to move config.json sidecar for %s (cycle %d) from %s: %s - "
+                        "provenance and authoritative engine/model identity will be missing "
+                        "from this result.",
+                        config_hash,
+                        cycle,
+                        config_sidecar_src,
+                        exc,
+                    )
                 finally:
                     config_sidecar_src.unlink(missing_ok=True)
 

--- a/tests/unit/cli/test_logging_setup.py
+++ b/tests/unit/cli/test_logging_setup.py
@@ -1,0 +1,79 @@
+"""Tests for _setup_logging handler attachment.
+
+Regression: the package installs a NullHandler at import time. The setup used
+to treat any existing handler (including that placeholder) as "already
+configured" and never attach the real stream handler, so WARNING-level messages
+never reached the user.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from llenergymeasure.cli import _setup_logging
+
+
+@pytest.fixture
+def restore_llem_logger() -> Iterator[None]:
+    """Snapshot and restore the ``llenergymeasure`` logger's handlers/level."""
+    log = logging.getLogger("llenergymeasure")
+    saved_handlers = list(log.handlers)
+    saved_level = log.level
+    try:
+        yield
+    finally:
+        log.handlers = saved_handlers
+        log.setLevel(saved_level)
+
+
+def test_setup_logging_attaches_stream_handler_over_nullhandler(
+    restore_llem_logger: None,
+) -> None:
+    """A pre-existing NullHandler must not suppress the real stream handler."""
+    log = logging.getLogger("llenergymeasure")
+    # Reproduce the import-time state: only a NullHandler present.
+    log.handlers = [logging.NullHandler()]
+
+    _setup_logging(0)
+
+    stream_handlers = [
+        h
+        for h in log.handlers
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.NullHandler)
+    ]
+    assert stream_handlers, "a real StreamHandler must be attached despite the NullHandler"
+    assert log.level == logging.WARNING
+
+
+def test_setup_logging_default_surfaces_warnings(
+    restore_llem_logger: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """With the NullHandler present, a child-logger WARNING still reaches stderr."""
+    log = logging.getLogger("llenergymeasure")
+    log.handlers = [logging.NullHandler()]
+
+    _setup_logging(0)
+
+    logging.getLogger("llenergymeasure.study.runner").warning("SENTINEL-WARNING")
+
+    captured = capsys.readouterr()
+    assert "SENTINEL-WARNING" in captured.err
+
+
+def test_setup_logging_no_duplicate_stream_handlers(restore_llem_logger: None) -> None:
+    """Repeated calls must not stack duplicate stream handlers."""
+    log = logging.getLogger("llenergymeasure")
+    log.handlers = [logging.NullHandler()]
+
+    _setup_logging(0)
+    _setup_logging(0)
+
+    stream_handlers = [
+        h
+        for h in log.handlers
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.NullHandler)
+    ]
+    assert len(stream_handlers) == 1, "repeated setup must not add duplicate handlers"

--- a/tests/unit/results/test_persistence_atomic.py
+++ b/tests/unit/results/test_persistence_atomic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -65,6 +66,23 @@ def test_atomic_write_overwrites_existing_file(tmp_path: Path) -> None:
     _atomic_write("new content", target)
 
     assert target.read_text() == "new content"
+
+
+def test_atomic_write_produces_world_readable_file(tmp_path: Path) -> None:
+    """_atomic_write() writes mode 0644, not the 0600 mkstemp defaults to.
+
+    Regression: docker dispatch runs the container as root, so a 0600 sidecar
+    is unreadable by the non-root host during the rescue step and gets silently
+    dropped. Results artefacts must be world-readable like result.json.
+    """
+    target = tmp_path / "output.json"
+    _atomic_write("content", target)
+
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o644, f"expected 0644, got {oct(mode)}"
+
+    # No temp file should linger with the restrictive default either.
+    assert list(tmp_path.glob("*.tmp")) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -492,6 +492,114 @@ def test_local_run_uses_host_snapshot_without_warning(tmp_path: Path, caplog) ->
     ), "local dispatch must not emit the docker rescue warning"
 
 
+def test_config_sidecar_rescue_permission_error_warns(tmp_path: Path, monkeypatch, caplog) -> None:
+    """A config.json sidecar the host cannot read (0600, root-owned) warns loudly.
+
+    Regression: under docker dispatch the container runs as root and wrote the
+    sidecar 0600, so the non-root host's load_json raised PermissionError. That
+    error was swallowed at debug level and the sidecar silently vanished. The
+    unreadable file is simulated by monkeypatching load_json to raise
+    PermissionError (a non-root test cannot create a root-owned 0600 file).
+    """
+    import logging
+
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+
+    # Sidecar is present in the staging dir but "unreadable" (rescued 0600 root).
+    config_sidecar_src = tmp_path / "config.json"
+    config_sidecar_src.write_text("{}", encoding="utf-8")
+
+    def _raise_permission(_path):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("llenergymeasure.study.runner.load_json", _raise_permission)
+
+    result = _make_result(with_timeseries=False)
+    manifest = MagicMock()
+    result_files: list[str] = []
+
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.runner"):
+        _save_and_record(
+            result,
+            study_dir,
+            manifest,
+            "aabb1122",
+            1,
+            result_files,
+            model_name="gpt2",
+            engine="transformers",
+            ts_source_dir=tmp_path,
+        )
+
+    warnings = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+    assert any(
+        "Failed to move config.json sidecar" in m and "Permission denied" in m for m in warnings
+    ), f"unreadable config.json must warn loudly with the reason; got {warnings}"
+    # The path must be named in the warning for the user to act on it.
+    assert any(str(config_sidecar_src) in m for m in warnings), (
+        "the rescue-failure warning must name the offending path"
+    )
+    # result.json still lands (a sidecar failure must never lose the measurement).
+    assert len(result_files) == 1
+    assert Path(result_files[0]).exists()
+    # The unreadable staging file is still cleaned up (finally block).
+    assert not config_sidecar_src.exists()
+
+
+def test_environment_sidecar_rescue_permission_error_warns(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    """An environment.json sidecar the host cannot read warns loudly.
+
+    Same root cause as the config.json path: a 0600 root-owned rescued sidecar
+    raised PermissionError that was swallowed at debug. Simulated by patching
+    load_json to raise.
+    """
+    import logging
+
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+
+    # A rescued environment.json is present but "unreadable".
+    (tmp_path / "environment.json").write_text("{}", encoding="utf-8")
+
+    def _raise_permission(_path):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("llenergymeasure.study.runner.load_json", _raise_permission)
+
+    result = _make_result(with_timeseries=False)
+    manifest = MagicMock()
+    result_files: list[str] = []
+
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.runner"):
+        _save_and_record(
+            result,
+            study_dir,
+            manifest,
+            "aabb1122",
+            1,
+            result_files,
+            model_name="gpt2",
+            engine="transformers",
+            ts_source_dir=tmp_path,
+            environment_snapshot=_make_host_snapshot(),
+            runner_provenance=RunnerProvenance(
+                mode="docker", image="img:1.0", source="yaml", image_source="registry"
+            ),
+        )
+
+    warnings = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+    assert any(
+        "Failed to rescue in-container environment.json" in m and "Permission denied" in m
+        for m in warnings
+    ), f"unreadable environment.json must warn loudly with the reason; got {warnings}"
+    # result.json still lands; the unreadable staging file is cleaned up.
+    assert len(result_files) == 1
+    assert not (tmp_path / "environment.json").exists()
+
+
 def test_provenance_from_spec_none_defaults_to_local() -> None:
     """No spec (pure in-process local) records mode=local, source=local, no image."""
     provenance = _provenance_from_spec(None)


### PR DESCRIPTION
## Summary

Under docker dispatch the container runs as root and writes the `config.json` and
`environment.json` sidecars via `_atomic_write`, which uses `tempfile.mkstemp` (mode 0600
regardless of umask). The non-root host then hits `PermissionError` reading them during the
rescue step in `_save_and_record`; the error was swallowed at debug level, so both sidecars
silently vanished from every docker-dispatched bundle (`result.json` and `timeseries.parquet`
survived only because they are written 0644). Diagnosed in the F3+F4 exit-validation audit.

Three complementary fixes:

1. **`_atomic_write` writes 0644.** `os.chmod(tmp_path, 0o644)` before `os.replace`, so all
   results artefacts (result.json, both sidecars, manifest.json, equivalence groups) are
   world-readable and a non-root host can read a root-written sidecar during rescue. All call
   sites are results artefacts with no secrets, so 0644 is content-appropriate.
2. **Rescue failures are loud.** The two swallowed `except Exception` catches in
   `_save_and_record` (config.json move, environment.json rescue) now `logger.warning` with the
   offending path and the underlying reason instead of a debug line.
3. **`llem run` warnings actually surface.** The package installs a `NullHandler` at import
   time; `_setup_logging`'s `if not root_logger.handlers:` guard treated that placeholder as
   "already configured" and never attached the real stream handler, suppressing every
   `WARNING`-level message on the normal run path. The guard now ignores the `NullHandler`.

## Test plan

- New: `_atomic_write` produces 0644 (`test_atomic_write_produces_world_readable_file`).
- New: a 0600-equivalent rescued sidecar (monkeypatched `load_json` -> `PermissionError`) triggers
  the loud warning path with path + reason, for both config.json and environment.json, while
  `result.json` still lands and the staging file is cleaned up.
- New: `_setup_logging` attaches a stream handler despite the `NullHandler`, surfaces a child
  WARNING to stderr, and does not stack duplicate handlers.
- Gates: `make lint`, `make typecheck` (clean), `make test` (3057 passed, 36 skipped).