### PR TITLE
docs: refresh version and status references post release

### DIFF
--- a/docs/contributing/citation.md
+++ b/docs/contributing/citation.md
@@ -15,7 +15,7 @@ If you use LLenergyMeasure in research, please cite it as:
   title     = {{LLenergyMeasure}: Measure how implementation choices drive
                 LLM inference efficiency},
   year      = {2026},
-  version   = {0.9.0},
+  version   = {0.11.0},
   url       = {https://github.com/henrycgbaker/llenergymeasure},
   note      = {Pre-1.0 release. See GitHub releases for the current version.
                 Multi-engine, methodology-first measurement framework for
@@ -26,7 +26,7 @@ If you use LLenergyMeasure in research, please cite it as:
 For a plain-text reference:
 
 > Baker, H. C. G. (2026). *LLenergyMeasure: Measure how implementation choices
-> drive LLM inference efficiency* (v0.9.0).
+> drive LLM inference efficiency* (v0.11.0).
 > https://github.com/henrycgbaker/llenergymeasure
 
 ---

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -30,12 +30,13 @@ Two files hold the version and must stay in sync:
 
 | File | Field | Example |
 |------|-------|---------|
-| `pyproject.toml` | `[project] version = "..."` | `version = "0.9.0"` |
-| `src/llenergymeasure/__init__.py` | `__version__ = "..."` | `__version__ = "0.9.0"` |
+| `pyproject.toml` | `[project] version = "..."` | `version = "0.11.0"` |
+| `src/llenergymeasure/_version.py` | `__version__ = "..."` | `__version__ = "0.11.0"` |
 
 A mismatch between these two files is a bug. The build system reads
 `pyproject.toml`; the runtime API (`llem --version`, `llenergymeasure.__version__`)
-reads `__init__.py`.
+reads `__version__`, which is defined in `src/llenergymeasure/_version.py` and
+re-exported from `__init__.py`.
 
 ---
 
@@ -48,15 +49,15 @@ reads `__init__.py`.
    ```toml
    [project]
    name = "llenergymeasure"
-   version = "0.10.0"
+   version = "0.12.0"
    ```
 
-2. **Bump the version in `__init__.py`**
+2. **Bump the version in `_version.py`**
 
-   Update `__version__` in `src/llenergymeasure/__init__.py`:
+   Update `__version__` in `src/llenergymeasure/_version.py`:
 
    ```python
-   __version__ = "0.10.0"
+   __version__ = "0.12.0"
    ```
 
    Both files must show the same version string.
@@ -72,7 +73,7 @@ reads `__init__.py`.
    Commit the three changed files with the message:
 
    ```
-   chore: release 0.10.0
+   chore: release 0.12.0
    ```
 
    This commit goes directly to `main` via the normal PR flow.
@@ -80,8 +81,8 @@ reads `__init__.py`.
 5. **Create and push the git tag**
 
    ```bash
-   git tag v0.10.0
-   git push origin v0.10.0
+   git tag v0.12.0
+   git push origin v0.12.0
    ```
 
    The tag must use the `v` prefix and match the version string exactly.

--- a/docs/contributing/roadmap.md
+++ b/docs/contributing/roadmap.md
@@ -14,13 +14,14 @@ Released milestones:
 | v0.7.0 | Core single-experiment: CLI, config system, Transformers engine, energy measurement, results schema |
 | v0.8.0 | Study/sweep: multi-experiment grid sweeps, manifest writer, deduplication, subprocess isolation |
 | v0.9.0 | Docker + vLLM: containerised engine architecture, vLLM engine, Docker CI, logging overhaul |
+| v0.10.0 | Engine-knowledge-as-data: each engine's config, schema, and validation rules are generated from version-pinned upstream snapshots rather than hand-curated; terminology renames; study-authoring improvements |
+| v0.11.0 | TensorRT-LLM activated as a measured third engine (both the PyTorch and compiled-TRT backends), with in-framework build caching and GPU hardware preflight |
 
-v0.10.0 (in progress) is the engine-knowledge-as-data milestone: each engine's
-config, schema, and validation rules are generated from version-pinned upstream
-snapshots rather than hand-curated, alongside study-authoring improvements.
-TensorRT-LLM activation is the v0.11.0 milestone and still needs live
-end-to-end validation on GPU hardware before tagging. Run `llem --version`
-against your installed package for the authoritative current version.
+The current focus is results-correctness hardening: a single coherent
+per-experiment results bundle and verified field population. An internal
+refactor-and-tidy pass follows, ahead of the stable 1.0.0 release. Run
+`llem --version` against your installed package for the authoritative current
+version.
 
 Pre-1.0 disclaimer: the tool is research-grade for single-machine use. It is
 not yet at the stability and API-stability bar of a 1.0 release.
@@ -29,9 +30,10 @@ not yet at the stability and API-stability bar of a 1.0 release.
 
 ## What is planned
 
-### Milestone 5 - SGLang
+### SGLang engine
 
-Next planned milestone. Key deliverable: SGLang engine backend with
+A planned future engine, targeted after the near-term results-correctness and
+1.0.0 work. Key deliverable: SGLang engine backend with
 RadixAttention energy profiles. RadixAttention's KV-cache reuse mechanism
 creates an unusual energy signature (lower energy on repeated prefix patterns)
 that requires a dedicated measurement treatment.
@@ -40,7 +42,7 @@ Scope includes: SGLang Docker image, engine plugin, config schema and
 validation rules, and methodology documentation for prefix-aware energy
 measurement.
 
-### Beyond Milestone 5
+### Further candidates
 
 Under consideration (not yet scoped):
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -477,7 +477,7 @@ const BIBTEX = `@software{baker2026llenergymeasure,
   title     = {{LLenergyMeasure}: Measure how implementation choices drive
                 LLM inference efficiency},
   year      = {2026},
-  version   = {0.9.0},
+  version   = {0.11.0},
   url       = {https://github.com/henrycgbaker/llenergymeasure},
   note      = {Pre-1.0 release. See GitHub releases for the current version.
                 Multi-engine, methodology-first measurement framework for


### PR DESCRIPTION
## Summary

Post-release freshness pass over tracked docs after v0.11.0 shipped (TensorRT-LLM
activated as a measured third engine). Fixes only the pages that had stale version
or engine-status claims; healthy pages were left untouched.

- `docs/contributing/roadmap.md`: add v0.10.0 and v0.11.0 rows to the released-milestones
  table; replace the "v0.10.0 (in progress)" / "TensorRT-LLM ... still needs live GPU
  validation before tagging" paragraph (both shipped) with the current near-term focus;
  drop the now-incorrect "Milestone 5 - SGLang / Next planned milestone" framing (v0.11.0
  was that milestone; SGLang is a post-1.0 candidate).
- `docs/contributing/citation.md`: bump the suggested citation version 0.9.0 -> 0.11.0
  (bibtex and plain-text).
- `docs/contributing/release-process.md`: bump the version-sources example 0.9.0 -> 0.11.0
  and the worked release example 0.10.0 -> 0.12.0 (the actual next release); correct the
  version-file reference from `__init__.py` to `_version.py`, which is the real SSOT
  (`__init__.py` only re-exports `__version__`, so the old instruction had no line to edit).
- `website/src/pages/index.tsx`: bump the homepage citation version 0.9.0 -> 0.11.0.

README already presented TensorRT-LLM as a working engine and needed no change; CHANGELOG
is healthy ([v0.11.0] dated, [Unreleased] holds the F3/F4 work). Image-tag examples using
`v0.9.0` were left as illustrative snippets (registry-tag concern, not version narration).

## Test plan

- `make docs-check` - pass (generated SSOT docs up to date, no drift).
- `make lint` - pass (ruff check, ruff format --check, import-linter: 5 contracts kept).