### PR TITLE
chore: release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   exchange dir alongside `timeseries.parquet`, and the local path always stages an output
   dir for the sidecar. If a completed experiment ends without a `config.json`, the runner
   logs a warning rather than dropping the provenance silently. ([#811])
+- Docs: purged stale `effective_config` terminology and pre-consolidation flat-layout
+  references across the methodology, how-to, tutorial, and generated reference pages,
+  aligning them with the `config.json` sidecar and the current bundle layout. ([#820])
 - `result.json` schema bumped `4.0` -> `5.0` (breaking). `result.json` is now measurement
   output: the configuration/methodology fields `engine_version`, `measurement_methodology`,
   `steady_state_window`, `measurement_window_discard_fraction`, and
@@ -821,7 +824,8 @@ Core measurement functionality establishing the foundation for all subsequent de
 - Major directory restructuring separating config, core, and result handling.
 
 
-[Unreleased]: https://github.com/henrycgbaker/llenergymeasure/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/henrycgbaker/llenergymeasure/compare/v0.12.0...HEAD
+[v0.12.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.12.0
 [v0.11.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.11.0
 [v0.10.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.10.0
 [v0.9.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.9.0
@@ -1012,6 +1016,7 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#816]: https://github.com/henrycgbaker/llenergymeasure/pull/816
 [#817]: https://github.com/henrycgbaker/llenergymeasure/pull/817
 [#819]: https://github.com/henrycgbaker/llenergymeasure/pull/819
+[#820]: https://github.com/henrycgbaker/llenergymeasure/pull/820
 [#821]: https://github.com/henrycgbaker/llenergymeasure/pull/821
 [#822]: https://github.com/henrycgbaker/llenergymeasure/pull/822
 [#823]: https://github.com/henrycgbaker/llenergymeasure/pull/823

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 - Docs: purged stale `effective_config` terminology and pre-consolidation flat-layout
   references across the methodology, how-to, tutorial, and generated reference pages,
   aligning them with the `config.json` sidecar and the current bundle layout. ([#820])
+- Docs: refreshed version and project-status references (citation, release process,
+  roadmap, landing page) to the post-v0.11.0 state. ([#824])
 - `result.json` schema bumped `4.0` -> `5.0` (breaking). `result.json` is now measurement
   output: the configuration/methodology fields `engine_version`, `measurement_methodology`,
   `steady_state_window`, `measurement_window_discard_fraction`, and
@@ -1020,3 +1022,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#821]: https://github.com/henrycgbaker/llenergymeasure/pull/821
 [#822]: https://github.com/henrycgbaker/llenergymeasure/pull/822
 [#823]: https://github.com/henrycgbaker/llenergymeasure/pull/823
+[#824]: https://github.com/henrycgbaker/llenergymeasure/pull/824

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+## [v0.12.0] - 2026-07-17
+
 ### Added
 
 - `result.json` now exposes `input_tokens` and `output_tokens` alongside `total_tokens`
@@ -14,18 +16,19 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `total_tokens = input_tokens + output_tokens`). The split was already computed in the
   harness for the FLOPs-per-token fields but never persisted; exposing it enables auditing
   declared-vs-actual input lengths. Rides the unreleased schema 5.0 (additive, no version
-  bump).
+  bump). ([#819])
 - The `timeseries.parquet` sidecar now carries `experiment_id` and
   `measurement_config_hash` as Parquet file-level key-value metadata (not columns), so the
   artefact stays attributable if separated from its result directory. This mirrors the
   identity fields the JSON sidecars already carry and completes the per-experiment bundle
   identity rationalisation. Data columns and schema are unchanged; readers that ignore file
-  metadata are unaffected.
+  metadata are unaffected. ([#813])
 - The per-experiment `config.json` sidecar now carries its own `schema_version`
   (`"2.0"`), independent of `result.json`'s schema version. It succeeds the retired
   `_resolution.json` sidecar (`"1.0"`), whose per-field provenance now lives in this file.
+  ([#811])
 - `equivalence_groups.json` now records `study_name` alongside `study_id`, so the
-  study-level artefact stays attributable if separated from its parent directory.
+  study-level artefact stays attributable if separated from its parent directory. ([#811])
 
 ### Changed
 
@@ -40,7 +43,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `save_timeseries` off: the docker runner rescues `config.json` from the container
   exchange dir alongside `timeseries.parquet`, and the local path always stages an output
   dir for the sidecar. If a completed experiment ends without a `config.json`, the runner
-  logs a warning rather than dropping the provenance silently.
+  logs a warning rather than dropping the provenance silently. ([#811])
 - `result.json` schema bumped `4.0` -> `5.0` (breaking). `result.json` is now measurement
   output: the configuration/methodology fields `engine_version`, `measurement_methodology`,
   `steady_state_window`, `measurement_window_discard_fraction`, and
@@ -55,7 +58,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   results-schema and `run_study` reference docs for the join pattern). The `config.json`
   sidecar is guaranteed to materialise next to every `result.json` on all successful runs -
   including the docker (multi-engine) path and runs with `save_timeseries` off - so the
-  join never dangles.
+  join never dangles. ([#812])
 
 ### Fixed
 
@@ -67,12 +70,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   them during the rescue step - swallowed at debug level - so both sidecars were silently
   dropped from every docker-dispatched bundle (`result.json` and `timeseries.parquet`
   survived because they were already written 0644). Sidecar-rescue failures now log a
-  warning naming the path and reason rather than vanishing.
+  warning naming the path and reason rather than vanishing. ([#823])
 - `llem run` warnings now reach the terminal. The package installs a `NullHandler` at
   import time, which the logging setup mistook for an already-configured handler and so
   never attached the real stream handler - suppressing every `WARNING`-level message
   (including the sidecar-rescue backstops above) on the normal run path. The setup now
-  ignores the placeholder and attaches the stream handler.
+  ignores the placeholder and attaches the stream handler. ([#823])
 - Declared-config and study-design hashes are now computed on a json-mode
   `model_dump`, so a field typed float but defaulted to an int literal (e.g. vllm
   `cpu_offload_gb = 0`) hashes identically whether or not the config has been
@@ -81,7 +84,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   coerced float (`0.0`), producing different hashes; the host then named the
   result file with a hash the container never wrote and reported "Container
   exited 0 but no result file found" for a successful run. Configs that pinned
-  such fields explicitly (e.g. `cpu_offload_gb: 0.0`) no longer need to.
+  such fields explicitly (e.g. `cpu_offload_gb: 0.0`) no longer need to. ([#822])
 - `environment.json` now records the environment the experiment actually ran in for
   docker-dispatched experiments, instead of the dispatching host's environment. The
   container entrypoint collects the environment snapshot inside the container, threads it
@@ -91,7 +94,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   python version, `cuda_version` null, `container.detected` false) was written for every
   docker run, defeating reproducibility metadata on the multi-engine path. Local
   in-process runs are unchanged. A docker run that completes without a rescued snapshot now
-  logs a warning rather than silently recording host values.
+  logs a warning rather than silently recording host values. ([#821])
 
 ## [v0.11.0] - 2026-07-16
 
@@ -1001,7 +1004,14 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#808]: https://github.com/henrycgbaker/llenergymeasure/pull/808
 [#809]: https://github.com/henrycgbaker/llenergymeasure/pull/809
 [#810]: https://github.com/henrycgbaker/llenergymeasure/pull/810
+[#811]: https://github.com/henrycgbaker/llenergymeasure/pull/811
+[#812]: https://github.com/henrycgbaker/llenergymeasure/pull/812
+[#813]: https://github.com/henrycgbaker/llenergymeasure/pull/813
 [#814]: https://github.com/henrycgbaker/llenergymeasure/pull/814
 [#815]: https://github.com/henrycgbaker/llenergymeasure/pull/815
 [#816]: https://github.com/henrycgbaker/llenergymeasure/pull/816
 [#817]: https://github.com/henrycgbaker/llenergymeasure/pull/817
+[#819]: https://github.com/henrycgbaker/llenergymeasure/pull/819
+[#821]: https://github.com/henrycgbaker/llenergymeasure/pull/821
+[#822]: https://github.com/henrycgbaker/llenergymeasure/pull/822
+[#823]: https://github.com/henrycgbaker/llenergymeasure/pull/823

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llenergymeasure"
-version = "0.11.0"
+version = "0.12.0"
 description = "LLenergyMeasure - LLM inference efficiency measurement framework"
 authors = [
     {name = "henrycgbaker", email = "henry.c.g.baker@gmail.com"},

--- a/src/llenergymeasure/_version.py
+++ b/src/llenergymeasure/_version.py
@@ -5,4 +5,4 @@ by modules at every layer to avoid pulling in the full __init__.py
 import chain.
 """
 
-__version__: str = "0.11.0"
+__version__: str = "0.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -565,7 +565,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "llenergymeasure"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },
@@ -2030,10 +2030,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -2079,10 +2079,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -2132,7 +2132,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2193,7 +2193,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Release-prep for v0.12.0 (the F3+F4 results-correctness milestone). Implementation was completed and exit-validated 7/7 on 2026-07-16 (live docker study at e2cf32f2); the tag is being cut now on the maintainer's word after soak.

**Headline:** the results bundle is rationalised and every declared field verified to populate. `config.json` becomes the single home for declared/observed config and per-field provenance (retiring `_resolution.json`); `result.json` slims to measurement-only output with schema 5.0; `timeseries.parquet` carries experiment identity as file metadata; input/output token counts are exposed; `environment.json` records the in-container environment under docker dispatch.

**Fixes in the line:** sidecar files written world-readable with loud rescue-failure warnings, and the NullHandler logging fix that had been suppressing ALL warnings on the normal CLI path (#823); config hashes computed on json-mode dump for host/container round-trip stability (#822); in-container environment snapshot rescue (#821); stale effective_config docs purge (#820).

## Changes

- Version bump 0.11.0 -> 0.12.0 in `pyproject.toml`, `src/llenergymeasure/_version.py` (the SSOT that `__init__.py` re-exports), and `uv.lock`; the three sources match at 0.12.0.
- `CHANGELOG.md`: retitled the `[Unreleased]` section to `[v0.12.0] - 2026-07-17`, kept a fresh empty `[Unreleased]` above it, added the `[v0.12.0]` release-tag link ref, pointed the `[Unreleased]` compare link at `v0.12.0...HEAD`, backfilled PR citations on all section entries (#811-#813, #819-#823 with link definitions), and added the missing #820 docs entry under Changed (docs-entry precedent from 0.11.0).
- `uv.lock` also picks up marker normalisation from the current uv (no dependency version changes).

## Gates

- `make lint` passes (ruff check + format + import-linter, 5 contracts kept).
- Version sources match at 0.12.0; runtime `import __version__` returns 0.12.0.
- No `.py`/`.toml`/`.cfg` file pins the old 0.12.0-predecessor package version.
- Every `[#N]` citation in the changelog has a link definition.

## Before tagging

Squash-merge this PR, then tag the squash commit `v0.12.0` and push the tag; the release pipeline publishes from the tag.