### PR TITLE
feat(ci): publish to PyPI via OIDC trusted publishing on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,14 +200,18 @@ jobs:
           cache-suffix: pkg-3.12
           python-version: "3.12"
       - run: uv build --wheel
-      - name: Install and validate
+      - name: Install wheel and smoke-test CLI
+        # Real smoke on the clean venv: the public API imports, and the `llem`
+        # console entry point resolves and runs its read-only commands to a
+        # zero exit. `set -e` (the default GitHub Actions shell flag) fails the
+        # step on any non-zero exit. CPU-only and fast: `llem config` degrades
+        # to "No GPU detected" on a device-less runner and always exits 0.
         run: |
           python -m venv /tmp/pkg-check
           /tmp/pkg-check/bin/pip install dist/*.whl --quiet
-          /tmp/pkg-check/bin/python -c "
-          from llenergymeasure import run_experiment, ExperimentConfig, ExperimentResult
-          print('Package install OK')
-          "
+          /tmp/pkg-check/bin/python -c "from llenergymeasure import run_experiment, ExperimentConfig, ExperimentResult; print('Public API import OK')"
+          /tmp/pkg-check/bin/llem --help
+          /tmp/pkg-check/bin/llem config
       - name: Version sync check
         run: |
           PYPROJECT_VER=$(python3 -c "import tomllib; f=open('pyproject.toml','rb'); print(tomllib.load(f)['project']['version'])")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,11 +111,40 @@ jobs:
           python-version: "3.12"
       - name: Build package
         run: uv build
+      - name: Upload built distributions
+        # Publish the exact bytes the release job built: publish-pypi downloads
+        # this artifact rather than rebuilding, so PyPI and the GitHub Release
+        # carry identical sdist/wheel files.
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: dist/*
+
+  publish-pypi:
+    needs: release
+    if: inputs.confirm == true || github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    # OIDC trusted publishing: the runner mints a short-lived identity token
+    # PyPI verifies against its pending/configured publisher. No API token or
+    # secret is stored anywhere. id-token: write is the only permission needed;
+    # the job does not check out the repo or touch its contents.
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   docker:
     needs: release

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -91,8 +91,19 @@ re-exported from `__init__.py`.
 6. **CI publishes to PyPI**
 
    The `release.yml` workflow (`.github/workflows/release.yml`) triggers on
-   `push: tags: ["v*"]`. It runs lint, tests, and then publishes the package to
-   PyPI using `uv build` + `uv publish`. No manual upload is required.
+   `push: tags: ["v*"]`. It runs lint, type-check, tests, and version
+   validation, then the `release` job builds the sdist and wheel with
+   `uv build` and the `publish-pypi` job uploads them to PyPI. Publishing uses
+   [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/): the
+   runner mints a short-lived identity token that PyPI verifies against a
+   configured trusted publisher, so no API token or secret is stored in the
+   repository. No manual upload is required.
+
+   Trusted publishing requires a one-time setup on pypi.org: the project's
+   trusted publisher must name this repository, the `release.yml` workflow, and
+   the `pypi` environment. Until that publisher is configured, the
+   `publish-pypi` job fails at the publish step (the build and GitHub Release
+   still succeed).
 
 ---
 

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -36,6 +36,10 @@ libraries. Install with:
 pip install llenergymeasure
 ```
 
+Distributions are published to PyPI automatically on each tagged release via
+OIDC trusted publishing (no manual upload). See
+[Release process](/contributing/release-process) for the mechanism.
+
 ### Engine code runs in Docker
 
 Each engine (Transformers, vLLM, TensorRT-LLM) runs inside its own image,


### PR DESCRIPTION
## Summary

Makes PyPI publishing real for the tag-triggered release pipeline using OIDC trusted publishing (no API tokens or secrets). Before this change `release.yml` built `dist/*` and attached it to the GitHub Release only; there was no PyPI publish step, even though the release docs claimed one existed.

**Publishing will fail at the publish step until the maintainer configures the pending trusted publisher on pypi.org** (see coordinates below). The build and the GitHub Release still succeed regardless, so a partial-setup tag is not fatal to the rest of the pipeline.

## Changes

- **`.github/workflows/release.yml`**
  - The existing `release` job now uploads the built sdist/wheel as a `dist` workflow artifact (`if-no-files-found: error`).
  - New `publish-pypi` job: `needs: release`, `environment: pypi`, `permissions: id-token: write` only. It downloads the `dist` artifact (does not rebuild, so PyPI and the GitHub Release carry identical bytes) and publishes with `pypa/gh-action-pypi-publish@release/v1`. Guarded by the same `confirm` condition as `release`/`docker`, so a dry-run `workflow_dispatch` skips it.
- **`.github/workflows/ci.yml`** - `package-validation` upgraded from an import-only check to a real CPU-only smoke: install the wheel into a clean venv, import the public API, then run `llem --help` and `llem config` to a zero exit (`set -e` fails the step on any non-zero exit). No Docker, no GPU; `llem config` degrades to "No GPU detected" and always exits 0.
- **`docs/contributing/release-process.md`** - step 6 rewritten to describe the actual mechanism (build with `uv build`, publish via OIDC trusted publishing) instead of the previously-claimed and never-implemented `uv publish`; adds a note that the trusted publisher must be configured first.
- **`docs/how-to/install.md`** - short durable note that distributions are published to PyPI automatically from tagged releases via trusted publishing, cross-linking the release process.

## Test plan

- `make lint` passes (ruff check, ruff format check, import-linter: 5 kept / 0 broken).
- Both workflow files parse as YAML.
- Verified locally against the built wheel in a clean venv: public API import OK, `llem --help` exit 0, `llem config` exit 0.
- No `actionlint` run locally (it only runs in CI); YAML eyeballed against repo conventions - kebab-case job id `publish-pypi`, imperative step names (`Upload built distributions`, `Download built distributions`, `Publish to PyPI`, `Install wheel and smoke-test CLI`).
- First real publish only happens at the next pushed tag; cannot be exercised on this PR.

## Doc audit

- `docs/contributing/release-process.md`: the "CI publishes to PyPI using `uv build` + `uv publish`" claim was false (no publish step existed). Corrected to the trusted-publishing mechanism this PR adds.
- `docs/how-to/install.md`: `pip install llenergymeasure` becomes true at the next tagged release; added a version-agnostic note on the publishing mechanism rather than a stale "coming soon" caveat.
- Out of the named scope but worth flagging: `docs/get-started/install.md` carries the same `pip install llenergymeasure` line and no publish-mechanism note. Left unchanged to keep this PR scoped; consider mirroring the note there in a follow-up.

## Maintainer action required (pypi.org pending publisher)

Configure a PyPI trusted publisher (add a "pending publisher" if the project does not yet exist) with exactly:

| Field | Value |
|---|---|
| PyPI Project Name | `llenergymeasure` |
| Owner | `henrycgbaker` |
| Repository name | `llenergymeasure` |
| Workflow name | `release.yml` |
| Environment name | `pypi` |

(The git remote is `github.com/henrycgbaker/llenergymeasure`, so the OIDC `repository` claim will be `henrycgbaker/llenergymeasure` - matching the coordinates above.)