### PR TITLE
docs: add cloud GPU VM quickstart and MIG/rootless guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+### Added
+
+- Generic-environment documentation. A new how-to page, "Running on a cloud GPU
+  VM", covers AWS/GCP/Azure GPU instances end to end: prerequisites (linking the
+  canonical NVIDIA driver, Docker, and NVIDIA Container Toolkit guides),
+  known-good provider images and network egress needs, `pip install
+  llenergymeasure` through `llem doctor`, a first measurement, and a multi-engine
+  study. It states the supported-environment matrix (supported: bare-metal GPU
+  hosts, any Docker-capable GPU host, cloud GPU VMs; out of scope for now:
+  Slurm/apptainer, Windows native, fractional-GPU power measurement) and adds MIG
+  operational guidance (`LLEM_DOCKER_GPUS=device=MIG-<uuid>` slice pinning with
+  the per-physical-GPU power-telemetry caveat). The Docker setup guide gains a
+  conservative rootless-Docker/Podman note (detected but untested) and a MIG
+  cross-reference. This documents capabilities the dispatch code already had.
+  ([#840])
+
 ### Changed
 
 - Study preparation now pulls missing Docker engine images concurrently (one
@@ -1098,3 +1114,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#834]: https://github.com/henrycgbaker/llenergymeasure/pull/834
 [#835]: https://github.com/henrycgbaker/llenergymeasure/pull/835
 [#836]: https://github.com/henrycgbaker/llenergymeasure/pull/836
+[#840]: https://github.com/henrycgbaker/llenergymeasure/pull/840

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -136,6 +136,9 @@ prefixed `[ok]`/`[warn]`/`[fail]` with a `->` fix hint for anything not ready.
 
 Run your first measurement: [Quick start](/get-started/quick-start).
 
+On a cloud GPU VM (AWS, GCP, Azure)? See [Running on a cloud GPU VM](/how-to/cloud-gpu-vm)
+for a provider-aware quickstart from a fresh instance to a multi-engine study.
+
 ---
 
 ## Advanced install topics

--- a/docs/how-to/cloud-gpu-vm.md
+++ b/docs/how-to/cloud-gpu-vm.md
@@ -1,0 +1,237 @@
+---
+title: Running on a cloud GPU VM
+description: Quickstart for AWS, GCP, and Azure GPU instances - prerequisites, pip install, llem doctor, first measurement, and a multi-engine study.
+---
+
+# Running on a cloud GPU VM
+
+LLenergyMeasure runs unchanged on a cloud GPU VM. There is nothing cloud-specific
+in the tool: it needs an NVIDIA GPU, an NVIDIA driver, Docker, and the NVIDIA
+Container Toolkit, and it reaches the same public image and model registries from
+a cloud instance as it does from a bare-metal host. This page is the fast path for
+getting a fresh AWS, GCP, or Azure GPU instance from zero to a multi-engine study.
+
+If your instance already has a working NVIDIA driver and Docker with GPU
+passthrough (most GPU-oriented cloud images do - see [Provider images](#provider-images)),
+skip straight to [Install LLenergyMeasure](#install-llenergymeasure).
+
+---
+
+## Supported environments
+
+This is the milestone's supported-environment statement. LLenergyMeasure's
+dispatch mechanics are written generically - Docker is resolved from `PATH`, GPU
+selection is a pure passthrough to `docker run --gpus`, and no host-specific
+tuning is baked in as a default - so the same install works across the following:
+
+**Supported:**
+
+- Bare-metal GPU hosts (workstation, on-prem server, datacentre node).
+- Any Docker-capable GPU host (Docker Engine plus NVIDIA Container Toolkit on Linux).
+- Cloud GPU VMs (AWS, GCP, Azure) with a GPU attached.
+
+**Out of scope for now:**
+
+- Slurm / apptainer (no HPC-scheduler or Singularity/Apptainer integration).
+- Windows native (the Docker-based engines are Linux-only).
+- Fractional-GPU power measurement (per-slice power on partitioned GPUs - see
+  [MIG and partitioned GPUs](#mig-and-partitioned-gpus)).
+
+"Supported" means the path is exercised and documented; it does not mean every
+provider image or instance type is individually certified. The requirement is
+always the same four pieces (GPU, driver, Docker, NVIDIA Container Toolkit) plus
+network egress to the registries below.
+
+---
+
+## Prerequisites
+
+You need an NVIDIA driver, Docker Engine, and the NVIDIA Container Toolkit on a
+Linux instance. These are the same prerequisites as any other host - this page
+does not duplicate the install steps, it links the canonical guides:
+
+- **NVIDIA driver** - [NVIDIA driver installation guide](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/).
+  Verify with `nvidia-smi`.
+- **Docker Engine** - [official Docker Engine install guide](https://docs.docker.com/engine/install/).
+- **NVIDIA Container Toolkit** - [NVIDIA Container Toolkit install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
+  This is what makes `docker run --gpus all` work.
+
+For a from-scratch walkthrough of all three (with verification commands at each
+step), see the [Docker Setup Guide](/how-to/docker-setup). Come back here for the
+cloud-specific notes.
+
+### Provider images
+
+Most cloud providers publish GPU-oriented base images that ship the driver,
+Docker, and (often) the NVIDIA Container Toolkit preinstalled. Using one of these
+removes the driver/toolkit install entirely. Known-good starting points:
+
+| Provider | Image family | Typical GPU instance types | Preinstalled |
+|----------|-------------|----------------------------|--------------|
+| AWS | Deep Learning AMI (DLAMI, GPU) | `g5`/`g6` (A10G, L4), `p4d`/`p4de` (A100), `p5` (H100) | Driver, Docker, NVIDIA Container Toolkit |
+| GCP | Deep Learning VM / GPU-optimised image | `g2` (L4), `a2` (A100), `a3` (H100) | Driver (or install script), Docker |
+| Azure | Data Science VM / GPU image + NVIDIA GPU Driver Extension | `NCasT4_v3` (T4), `NVadsA10_v5` (A10), `NC A100 v4`, `ND H100 v5` | Driver (via extension), Docker |
+
+These are pointers, not certifications: confirm the three prerequisites on your
+specific image with `nvidia-smi` and the GPU-in-Docker check below, rather than
+assuming a given AMI or image is complete. On a bare Linux GPU image with nothing
+preinstalled, follow the [Docker Setup Guide](/how-to/docker-setup) end to end.
+
+**Verify GPU passthrough into Docker** (the one check that matters most on a fresh
+instance):
+
+```bash
+docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi
+```
+
+If this prints the GPU table from inside the container, the instance is ready. If
+it fails, see [Docker Setup - Troubleshooting](/how-to/docker-setup#troubleshooting).
+
+### Network egress
+
+A cloud instance behind a restrictive security group or firewall must be able to
+reach the registries LLenergyMeasure pulls from. Allow outbound HTTPS to:
+
+- `pypi.org` and `files.pythonhosted.org` - `pip install llenergymeasure`.
+- `ghcr.io` - the first-party Transformers image.
+- Docker Hub (`registry-1.docker.io`, `auth.docker.io`) - the upstream vLLM image
+  (`vllm/vllm-openai`).
+- `nvcr.io` - the upstream TensorRT-LLM image (NVIDIA NGC).
+- `huggingface.co` and `cdn-lfs.huggingface.co` - model and dataset downloads.
+
+An instance that cannot reach these reports the pull failure at run time. For a
+genuinely air-gapped or egress-blocked instance, pre-fetch images and models on a
+connected host and see the offline notes in
+[Advanced install topics](/how-to/install#getting-engine-images).
+
+---
+
+## Install LLenergyMeasure
+
+The host package is the orchestrator only - it carries no GPU or engine
+libraries, so it installs on any Python 3.10+ environment:
+
+```bash
+pip install llenergymeasure
+```
+
+See [Install](/get-started/install) for the sampler extras (`zeus`, `codecarbon`)
+and [Advanced install topics](/how-to/install) for locked-down or offline installs.
+
+---
+
+## Check the environment with `llem doctor`
+
+Before running anything, confirm the instance is ready:
+
+```bash
+llem doctor
+```
+
+`llem doctor` reports the GPU and driver, per-engine availability (importable
+locally or via Docker, and whether each image is cached), the energy samplers, the
+Docker CLI/daemon and NVIDIA Container Toolkit, and `HF_TOKEN` presence. Every line
+is prefixed `[ok]`/`[warn]`/`[fail]` with a `->` fix hint. On a cloud instance the
+lines to check first are the `GPU / driver` section (the instance's GPU is
+detected) and `Docker` (daemon reachable, toolkit detected).
+
+For gated models (Llama, Mistral, and similar) set your Hugging Face token so
+downloads succeed:
+
+```bash
+export HF_TOKEN=...   # create one at https://huggingface.co/settings/tokens
+```
+
+See [Install - Verify your install](/get-started/install#verify-your-install) for
+the full `llem doctor` output format.
+
+---
+
+## First measurement
+
+Run a single experiment to confirm the full path works end to end. Create a YAML
+file:
+
+```yaml
+# experiment.yaml
+engine: vllm
+task:
+  model: gpt2
+  dataset:
+    source: aienergyscore
+    n_prompts: 50
+runners:
+  vllm: docker
+```
+
+Then run it:
+
+```bash
+llem run experiment.yaml
+```
+
+On first use `llem` pulls the vLLM image (allow a few minutes for the multi-GB
+pull on a fresh instance), launches the container, runs the experiment inside it,
+and writes the result. For an annotated walkthrough, see
+[Your first measurement](/tutorials/first-measurement).
+
+---
+
+## Multi-engine study
+
+Once a single experiment works, a study measures the same model across multiple
+engines in one run. `llem` prepares all the required Docker images once up front
+(pulling any that are missing concurrently), then runs each experiment. Follow the
+[Multi-engine study tutorial](/tutorials/multi-engine-study) for a complete,
+annotated study configuration and how to read the comparison.
+
+The first study on a fresh instance pays the one-time image-pull cost for every
+engine it uses (the vLLM and TensorRT-LLM upstream images are large). Subsequent
+studies reuse the cached images. To pre-fetch during instance setup rather than on
+the first run, see [Docker Setup - Pre-fetch images manually](/how-to/docker-setup#pre-fetch-images-manually).
+
+---
+
+## MIG and partitioned GPUs
+
+A100 and H100 GPUs can be partitioned into Multi-Instance GPU (MIG) slices, and
+some cloud SKUs ship pre-partitioned. LLenergyMeasure runs on a MIG slice - GPU
+selection is a pure passthrough to `docker run --gpus`, which accepts a MIG UUID.
+
+List the MIG instances on the host:
+
+```bash
+nvidia-smi -L
+```
+
+Each MIG instance appears with a `MIG-<uuid>` identifier. Pin `llem` to one slice
+by setting `LLEM_DOCKER_GPUS` to the matching `--gpus` selector (quote it so the
+shell keeps the value intact):
+
+```bash
+export LLEM_DOCKER_GPUS="device=MIG-<uuid>"
+llem run experiment.yaml
+```
+
+`LLEM_DOCKER_GPUS` forwards verbatim to the engine container's `--gpus` flag; the
+same variable pins whole devices on a shared multi-GPU host (see
+[Docker Setup - GPU not visible inside container](/how-to/docker-setup#gpu-not-visible-inside-container)).
+
+> **Power telemetry on MIG is limited.** NVML reports power for the parent
+> physical GPU, not per MIG instance, so energy readings on a MIG slice include
+> all instances sharing the card and cannot be attributed to a single slice.
+> Per-slice (fractional-GPU) power measurement is out of scope. This is a
+> hardware/NVML limitation, not a tool setting; see
+> [Energy measurement - Limitations](/explanation/methodology/energy-measurement#limitations)
+> for the full methodology caveat. Throughput and latency on a MIG slice are
+> measured normally.
+
+---
+
+## See also
+
+- [Docker Setup Guide](/how-to/docker-setup) - full driver, Docker, and toolkit walkthrough.
+- [Install](/get-started/install) and [Advanced install topics](/how-to/install) - install, extras, offline.
+- [Your first measurement](/tutorials/first-measurement) and [Multi-engine study](/tutorials/multi-engine-study).
+- [Running on a single or consumer GPU](/how-to/single-gpu-or-limited-hardware) - low-VRAM knobs.
+- [Troubleshooting](/how-to/troubleshoot) - common failure modes.

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -87,6 +87,19 @@ docker run hello-world
 
 Expected output includes `Hello from Docker!`.
 
+### Rootless Docker and Podman
+
+The tested and supported runtime is rootful Docker Engine (the standard install
+above). `llem` resolves whatever `docker` binary is on `PATH`, so a
+Docker-compatible CLI - rootless Docker, or Podman exposed as `docker` - may work,
+and `llem` records the detected runtime in its environment snapshot. These paths
+are **not tested and GPU passthrough on them is not validated**: rootless Docker
+and Podman each have their own NVIDIA Container Toolkit / CDI setup that differs
+from rootful Docker. If you must use one, verify GPU passthrough with the container
+check in [Step 4](#step-4-verify-gpu-access-in-docker) first, and configure the
+toolkit per your runtime's own documentation. For a supported setup, use rootful
+Docker.
+
 ### BuildKit builder setup (recommended)
 
 Docker image builds use BuildKit under the hood. The default builder has a conservative
@@ -549,6 +562,11 @@ keeps CUDA and NVML indices consistent inside the container (both enumerate from
 tensor-parallel runs, `llem` also forwards every `NCCL_*` host variable into the container;
 see [multi-GPU with TensorRT-LLM](/how-to/run-with-tensorrt-llm#multi-gpu-tensor-parallelism).
 
+`LLEM_DOCKER_GPUS` also accepts a Multi-Instance GPU (MIG) instance UUID
+(`device=MIG-<uuid>`) to pin `llem` to a single MIG slice on a partitioned A100 or
+H100. See [Running on a cloud GPU VM - MIG and partitioned GPUs](/how-to/cloud-gpu-vm#mig-and-partitioned-gpus)
+for the operational steps and the power-telemetry caveat.
+
 ---
 
 ### Shared memory errors with vLLM
@@ -604,3 +622,4 @@ workflow and the `schema-version-check` CI guard.
 - [Getting Started](/tutorials/first-measurement) - run your first vLLM or TensorRT-LLM experiment
 - [Engine Configuration](/reference/engines/configuration) - configure vLLM, TensorRT-LLM, and switch between engines
 - [Fast rebuilds and first-pull cost](/how-to/install#fast-rebuilds-and-first-pull-cost) - how the GHCR layer cache speeds up local Docker builds
+- [Running on a cloud GPU VM](/how-to/cloud-gpu-vm) - AWS/GCP/Azure quickstart, provider images, and MIG guidance

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -90,7 +90,7 @@ llem v0.12.0
 
 ## Docker Setup
 
-For vLLM or TensorRT-LLM engines, Docker with NVIDIA Container Toolkit is required. See the [Docker Setup Guide](/how-to/docker-setup) for a complete walkthrough covering driver installation, toolkit setup, and verification.
+For vLLM or TensorRT-LLM engines, Docker with NVIDIA Container Toolkit is required. See the [Docker Setup Guide](/how-to/docker-setup) for a complete walkthrough covering driver installation, toolkit setup, and verification. On a cloud GPU VM (AWS, GCP, Azure), see [Running on a cloud GPU VM](/how-to/cloud-gpu-vm) for provider-image notes (what is preinstalled) and the network egress the pulls need.
 
 ---
 

--- a/website/sidebarsHowTo.ts
+++ b/website/sidebarsHowTo.ts
@@ -4,6 +4,7 @@ const sidebarsHowTo: SidebarsConfig = {
   howToSidebar: [
     'install',
     'docker-setup',
+    'cloud-gpu-vm',
     'run-with-docker-vllm',
     'run-with-tensorrt-llm',
     'interpret-results',


### PR DESCRIPTION
## Summary

Closes the generic-environment documentation gap the F5/B3 genericity audit
found: the dispatch code already supports cloud GPU VMs and MIG, but the docs
never said so. Adds a cloud-VM quickstart, records the milestone's ratified
supported-environment matrix as a support statement, and documents the two
capabilities that were code-only until now (MIG GPU pinning and passive
rootless/Podman detection), conservatively.

Slice S14 of the ratified v0.13.0 (F5) plan. Docs-only; `src/` untouched.

## Changes

- **New page `docs/how-to/cloud-gpu-vm.md`** ("Running on a cloud GPU VM"):
  - Prerequisites that link the canonical NVIDIA driver, Docker Engine, and
    NVIDIA Container Toolkit install guides rather than duplicating them.
  - Provider-image table (AWS DLAMI, GCP Deep Learning VM, Azure GPU images)
    with typical GPU instance types and what is preinstalled, framed as
    pointers not certifications, plus the network egress the pulls need.
  - The path from `pip install llenergymeasure` -> `llem doctor` -> first
    measurement -> multi-engine study.
  - The ratified supported/out-of-scope environment matrix (supported:
    bare-metal, any Docker-capable GPU host, cloud GPU VMs; out of scope:
    Slurm/apptainer, Windows native, fractional-GPU power measurement).
  - MIG operational guidance (`LLEM_DOCKER_GPUS=device=MIG-<uuid>`) with the
    honest caveat that NVML power readings on a MIG slice are per physical GPU,
    linking the existing methodology limitations rather than restating them.
- **`docs/how-to/docker-setup.md`**: short "Rootless Docker and Podman"
  subsection (detected in the environment snapshot, but not tested and GPU
  passthrough not validated - use rootful Docker for a supported setup); MIG
  cross-reference on the `LLEM_DOCKER_GPUS` section; cloud page in Next Steps.
- **Sidebar**: register `cloud-gpu-vm` in `website/sidebarsHowTo.ts` after
  `docker-setup`.
- **Cross-links**: from `docs/get-started/install.md` and
  `docs/how-to/install.md` to the new cloud page.

## Test plan

- `docusaurus build` succeeds with no broken-link errors (the site sets
  `onBrokenLinks: 'throw'`), so every new internal link and anchor resolves.
- No em/en dashes and no `src/` changes; pre-push lint and format checks pass.

## Doc audit

- All added cross-links point at existing pages/anchors (verified by the
  throwing build): docker-setup sections, both install pages, the tutorials,
  and `energy-measurement#limitations`.
- Reuses existing methodology and Docker-setup content by reference (DRY); no
  duplicated install steps or restated caveats.
- CHANGELOG `[Unreleased]` "Added" entry follows in a separate commit once this
  PR number is known (per the slice plan; expect CHANGELOG union at merge).
