### PR TITLE
fix(cli): honor -o output dir for fresh runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+### Fixed
+
+- `llem run -o/--output-dir` is now honored for fresh (non-resume) studies. The flag
+  was documented as "Output directory for results" but was silently a no-op on a fresh
+  run: `run_study` only consumed `output_dir` as the auto-detect-resume search base and
+  never threaded it into the results-dir resolution, so results always landed in the YAML
+  `output.results_dir` (default `./results`). Fresh runs now resolve the base with
+  precedence `-o` override > YAML `output.results_dir` > user config > `./results`, and the
+  preflight/dry-run panel's "Study results path" reflects the same precedence so the
+  preview matches where results actually land. Resume semantics are unchanged (`-o` stays
+  the search base for `--resume`). The results path is placement metadata, excluded from
+  the declared-config, study-design, and dedup hashes, so pointing a study at a different
+  output directory never changes dedup grouping. ([#842])
+
 ## [v0.13.0] - 2026-07-18
 
 ### Added
@@ -1205,3 +1219,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#838]: https://github.com/henrycgbaker/llenergymeasure/pull/838
 [#839]: https://github.com/henrycgbaker/llenergymeasure/pull/839
 [#840]: https://github.com/henrycgbaker/llenergymeasure/pull/840
+[#842]: https://github.com/henrycgbaker/llenergymeasure/pull/842

--- a/docs/reference/library/run_study.md
+++ b/docs/reference/library/run_study.md
@@ -106,7 +106,7 @@ print(f"Total energy: {study_result.summary.total_energy_j:.1f} J")
 | `progress` | `ProgressCallback \| None` | `None` | Progress callback. Receives per-experiment begin/end events and per-step events from worker processes. |
 | `resume_dir` | `Path \| None` | `None` | Explicit study directory to resume. Overrides `resume`. |
 | `resume` | `bool` | `False` | Auto-detect the most recent resumable study in `output_dir` and resume from the last checkpoint. |
-| `output_dir` | `Path \| None` | `None` | Base directory used by auto-detect resume only. Ignored when `resume_dir` is given. |
+| `output_dir` | `Path \| None` | `None` | Dual role by run mode. Fresh run: results-dir override (precedence `output_dir` > YAML `output.results_dir` > user config > `./results`). Auto-detect resume: base directory searched for the most recent resumable study. Ignored when `resume_dir` is given. |
 | `skip_set` | `set[tuple[str, int]] \| None` | `None` | Set of `(config_hash, cycle)` pairs to skip. Populated automatically when resuming; callers rarely need to set this. |
 | `no_lock` | `bool` | `False` | Skip GPU advisory lock acquisition. Equivalent to the `--no-lock` CLI flag. |
 | `config_path` | `Path \| None` | `None` | Original YAML path for artefact copying when `config` is a `StudyConfig` object. Preserved in `_study-artefacts/` for reproducibility. |

--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -208,7 +208,10 @@ def run_study(
         resume_dir: Explicit study directory to resume. Overrides ``resume``.
         resume: When True and resume_dir is None, auto-detect the most recent
             resumable study in ``output_dir`` (default ``results/``).
-        output_dir: Base output directory used by auto-detect resume. Ignored when
+        output_dir: Dual role by run mode. For a fresh run it is the results-dir
+            override (precedence: ``output_dir`` > YAML ``output.results_dir`` >
+            user config > ``./results``). For an auto-detect resume it is the base
+            directory searched for the most recent resumable study. Ignored when
             ``resume_dir`` is given explicitly.
         skip_set: Set of (config_hash, cycle) pairs to skip (already completed in a
             previous run). Populated automatically when resuming; callers rarely
@@ -270,6 +273,9 @@ def run_study(
         skip_preflight=skip_preflight,
         progress=progress,
         resume_dir=resume_dir,
+        # Fresh runs (resume_dir is None) use output_dir as the results-dir
+        # override; resume runs already consumed it as the search base above.
+        results_dir_override=output_dir if resume_dir is None else None,
         skip_set=skip_set,
         no_lock=no_lock,
         config_path=config_path,
@@ -363,6 +369,7 @@ def _run(
     skip_preflight: bool = False,
     progress: ProgressCallback | None = None,
     resume_dir: Path | None = None,
+    results_dir_override: Path | None = None,
     skip_set: set[tuple[str, int]] | None = None,
     no_lock: bool = False,
     config_path: Path | None = None,
@@ -396,7 +403,8 @@ def _run(
         study, user_config, preresolved, skip_preflight, progress
     )
 
-    # Resolve results_dir: resume_dir takes priority, then YAML > user config > built-in default
+    # Resolve results_dir: resume_dir takes priority, then the fresh-run chain
+    # (CLI -o override > YAML output.results_dir > user config > built-in default).
     if resume_dir is not None:
         study_dir = resume_dir
         # Resume: load the existing manifest written by prepare_resume_manifest()
@@ -406,7 +414,12 @@ def _run(
         loaded_manifest, _ = load_resume_state(study_dir)
         manifest = ManifestWriter.from_existing(study_dir, loaded_manifest)
     else:
-        results_dir_str = study.output.results_dir or user_config.output.results_dir or "./results"
+        if results_dir_override is not None:
+            results_dir_str = str(results_dir_override)
+        else:
+            results_dir_str = (
+                study.output.results_dir or user_config.output.results_dir or "./results"
+            )
         study_dir = create_study_dir(study.study_name, Path(results_dir_str))
         manifest = ManifestWriter(study, study_dir)
 

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -574,7 +574,13 @@ def _run_study_impl(
     except Exception:
         runner_specs = None  # graceful: Docker unavailable, show YAML runners
 
-    study_dir_preview = Path("results") / study_dir_name(study_config.study_name)
+    # Mirror the fresh-run results-dir precedence used by _run() so the preflight
+    # panel and dry-run preview show where results will actually land:
+    # CLI -o override > YAML output.results_dir > user config > default.
+    _preview_base = (
+        output or study_config.output.results_dir or user_config.output.results_dir or "results"
+    )
+    study_dir_preview = Path(_preview_base) / study_dir_name(study_config.study_name)
 
     # --- Dry-run branch ---
     if dry_run:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -448,6 +448,106 @@ def test_run_skips_preflight_when_preresolved_supplied(monkeypatch, tmp_path):
     )
 
 
+# =============================================================================
+# run_study output_dir routing: -o overrides the results dir for fresh runs
+# =============================================================================
+
+
+def _capture_results_base(monkeypatch, tmp_path) -> dict:
+    """Patch _run's dependencies so a study 'runs' in-process, capturing the
+    results-dir base passed to create_study_dir.
+
+    Returns a dict populated with ``base`` (the Path handed to create_study_dir).
+    """
+    import llenergymeasure.engines as engines_module
+    import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.preflight as study_pf_module
+
+    captured: dict = {}
+    mock_result = make_result()
+    mock_engine = _MockBackend(mock_result)
+
+    monkeypatch.setattr(pf_module, "run_preflight", lambda config: None)
+    monkeypatch.setattr(study_pf_module, "run_study_preflight", _mock_preflight_return)
+    monkeypatch.setattr(engines_module, "get_engine", lambda name: mock_engine)
+    monkeypatch.setattr(
+        "llenergymeasure.infra.runner_resolution.is_docker_available", lambda: False
+    )
+    _patch_harness(monkeypatch, mock_result)
+
+    def _capture_create(name, output_dir):
+        captured["base"] = output_dir
+        return tmp_path
+
+    monkeypatch.setattr("llenergymeasure.study.manifest.create_study_dir", _capture_create)
+    monkeypatch.setattr(
+        "llenergymeasure.results.persistence.save_result",
+        lambda result, output_dir, **kw: tmp_path / "result.json",
+    )
+    return captured
+
+
+def test_run_study_fresh_honors_output_dir(monkeypatch, tmp_path):
+    """Fresh run: output_dir (CLI -o) overrides the results-dir base."""
+    captured = _capture_results_base(monkeypatch, tmp_path)
+
+    study = StudyConfig(experiments=[make_config()])
+    custom = tmp_path / "custom-out"
+    run_study(study, skip_preflight=True, output_dir=custom)
+
+    assert captured["base"] == custom
+
+
+def test_run_study_fresh_without_output_dir_uses_yaml_results_dir(monkeypatch, tmp_path):
+    """Fresh run without output_dir falls back to YAML output.results_dir."""
+    from llenergymeasure.config.models import OutputConfig
+
+    captured = _capture_results_base(monkeypatch, tmp_path)
+
+    yaml_dir = tmp_path / "yaml-results"
+    study = StudyConfig(
+        experiments=[make_config()],
+        output=OutputConfig(results_dir=str(yaml_dir)),
+    )
+    run_study(study, skip_preflight=True)
+
+    assert captured["base"] == yaml_dir
+
+
+def test_run_study_resume_uses_output_dir_as_search_base(monkeypatch, tmp_path):
+    """Resume: output_dir stays the resumable-study search base, not a results override."""
+    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.resume as resume_module
+
+    search_bases: list = []
+    fake_resume_dir = tmp_path / "study_2026"
+
+    def _fake_find(base):
+        search_bases.append(base)
+        return fake_resume_dir
+
+    monkeypatch.setattr(resume_module, "find_resumable_study", _fake_find)
+    monkeypatch.setattr(resume_module, "load_resume_state", lambda d: ({}, set()))
+    monkeypatch.setattr(resume_module, "validate_config_drift", lambda old, study: None)
+    monkeypatch.setattr(resume_module, "prepare_resume_manifest", lambda d, old: None)
+
+    captured: dict = {}
+
+    def _capture_run(study, **kw):
+        captured.update(kw)
+        return make_study_result()
+
+    monkeypatch.setattr(api_module, "_run", _capture_run)
+
+    study = StudyConfig(experiments=[make_config()])
+    search_base = tmp_path / "search-here"
+    run_study(study, resume=True, output_dir=search_base)
+
+    assert search_bases == [search_base]
+    assert captured["resume_dir"] == fake_resume_dir
+    assert captured["results_dir_override"] is None
+
+
 def test_run_preresolved_without_skip_preflight_raises():
     """Passing preresolved with skip_preflight=False is rejected, not silently honoured."""
     import llenergymeasure.api._impl as api_module


### PR DESCRIPTION
## Summary

`llem run -o/--output-dir` was silently a no-op on fresh (non-resume) studies. The flag is
documented as "Output directory for results", but `run_study` only consumed `output_dir` as
the auto-detect-resume search base and never threaded it into the results-dir resolution, so
fresh-run results always landed in the YAML `output.results_dir` (default `./results`),
regardless of `-o`.

The fix makes `-o` the results-dir override for fresh runs, with precedence
`-o` > YAML `output.results_dir` > user config > `./results`:

- `_run()` gains a `results_dir_override` parameter, applied only on the fresh-run branch
  (the resume branch is untouched and still binds to the resolved `resume_dir`).
- `run_study()` passes `output_dir` through as `results_dir_override` only when
  `resume_dir is None` (a fresh run); on resume, `output_dir` keeps its existing meaning as
  the search base and no override is applied.
- The CLI preflight/dry-run panel's "Study results path" preview now mirrors the same
  precedence, so the preview matches where results actually land (previously it was hardcoded
  to `results/` and ignored both `-o` and the YAML value).

### Seam choice

The override is threaded explicitly through `_run(results_dir_override=...)` rather than
mutating the loaded `StudyConfig`. The results path resolution already lived in one place
(the `_run` fresh-run branch); an explicit parameter keeps the caller's config object
untouched and applies the override at the exact seam that picks the directory. Resume
semantics are preserved because the override is gated on `resume_dir is None`.

### Hash safety

The results path is placement/presentation metadata, not part of any config identity. Verified
it is excluded from every hash:

- `compute_study_design_hash` and `compute_declared_config_hash` hash `ExperimentConfig`
  objects; `output`/`results_dir` live on `StudyConfig` only, so they are structurally absent.
- The resolved/observed dedup hash (`ConfigHashView` in `domain/hashing.py`) has a fixed
  field schema (engine, task, engine/sampling params, passthrough, harness, measurement) with
  no output field.

Pointing a study at a different output directory therefore never changes dedup grouping,
matching the placement-field-exclusion pattern established in #838.

## Test plan

- `make lint` (ruff check + format + import-linter): pass.
- `make typecheck` (mypy, 312 files): pass.
- `tests/unit/test_api.py`: 52 passed, including three new tests:
  - fresh run honors `-o` (override reaches `create_study_dir` as the base),
  - fresh run without `-o` falls back to YAML `output.results_dir`,
  - resume run still uses `output_dir` as the search base and passes
    `results_dir_override=None` to `_run`.
- `tests/unit/cli/test_cli_run.py`, `tests/unit/cli/test_preflight_display.py`,
  `tests/unit/study/test_resume.py`: 73 passed.
- CLI smoke (host-runner-free, `--dry-run`; a real fresh run needs GPU/Docker): with a tiny
  study config, `-o /tmp/cli-smoke-o --dry-run` rendered `Study results path:
  /tmp/cli-smoke-o/...`, and the same config without `-o` rendered its YAML
  `yaml-smoke-dir/...`, confirming the precedence flows end-to-end through the CLI preview.

## Doc audit

- `docs/reference/library/run_study.md`: updated the `output_dir` parameter row, which
  previously said "used by auto-detect resume only", to describe its dual role (fresh-run
  results-dir override vs resume search base).
- `docs/reference/cli.md` (`--output`/`-o` "Output directory for results"),
  `docs/tutorials/first-measurement.md` (`llem run study.yaml --output /data/experiments`),
  and `docs/explanation/methodology/energy-measurement.md` (CLI `--output`) already described
  the intended behavior; they are now accurate rather than aspirational, so no change needed.
- CHANGELOG: entry added under `## [Unreleased]` / `### Fixed`.
