### PR TITLE
feat(infra): warn when local image tag shadows pinned default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+### Changed
+
+- Image resolution now warns when a locally-built `llenergymeasure:{engine}` tag
+  wins over the version-pinned default. That precedence is intentional (fast local
+  iteration), but a months-stale dev tag could hijack resolution invisibly: on one
+  host a stale local vLLM tag even failed the schema handshake as a hard mismatch
+  while the user had no idea a local image was being preferred. The warning names
+  the local tag in use, the version-pinned default it bypassed, and the remedy
+  (`docker rmi llenergymeasure:{engine}` to restore the pinned default, or pin an
+  explicit image via `runners.<engine>` / `LLEM_IMAGE_<ENGINE>`); it is emitted
+  once per resolution. `llem doctor` surfaces the same shadowing fact on the
+  affected engine's row. Resolution behaviour is unchanged. ([#843])
+
 ## [v0.13.0] - 2026-07-18
 
 ### Added
@@ -1205,3 +1218,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#838]: https://github.com/henrycgbaker/llenergymeasure/pull/838
 [#839]: https://github.com/henrycgbaker/llenergymeasure/pull/839
 [#840]: https://github.com/henrycgbaker/llenergymeasure/pull/840
+[#843]: https://github.com/henrycgbaker/llenergymeasure/pull/843

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -312,6 +312,14 @@ the first-party GHCR image for transformers (at the package version), and the ca
 upstream image for vLLM / TensorRT-LLM (`vllm/vllm-openai`,
 `nvcr.io/nvidia/tensorrt-llm/release`, at the pinned engine version).
 
+> **Heads-up: a stale local tag silently wins.** Because the local build takes
+> precedence, a months-old `llenergymeasure:{engine}` tag keeps winning level 5 long
+> after the pinned default has moved on, which can surface as a schema-handshake
+> mismatch. When a local tag wins, `llem` logs a warning naming the pinned default it
+> bypassed, and `llem doctor` flags it on the engine's row. To restore the pinned
+> default, remove the local tag with `docker rmi llenergymeasure:{engine}`; to keep a
+> specific image, pin it explicitly at level 1-4 (for example `LLEM_IMAGE_{ENGINE}`).
+
 ### Auto-pull on first use
 
 When `llem` needs a registry image that is not cached locally, it pulls it automatically

--- a/src/llenergymeasure/api/doctor.py
+++ b/src/llenergymeasure/api/doctor.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass
 
 from llenergymeasure._version import __version__
 from llenergymeasure.config.ssot import Engine
-from llenergymeasure.infra.image_registry import get_default_image, image_present_locally
+from llenergymeasure.infra.image_registry import (
+    get_default_image,
+    image_present_locally,
+    shadowed_default_image,
+)
 from llenergymeasure.infra.version_handshake import (
     BundledEngineVersionMismatchError,
     SchemaStatus,
@@ -48,6 +52,9 @@ class EngineDoctorResult:
     status: SchemaStatus
     local_present: bool | None = None
     detail: str = ""
+    # Set when a local bare tag (``llenergymeasure:{engine}``) won resolution:
+    # names the version-pinned default it shadows, else None.
+    shadows_default: str | None = None
 
 
 @dataclass(frozen=True)
@@ -159,6 +166,7 @@ def run_doctor_checks(
                 status=status,
                 local_present=local_present,
                 detail=_detail_for(engine, status),
+                shadows_default=shadowed_default_image(engine, image),
             )
         )
 

--- a/src/llenergymeasure/api/health.py
+++ b/src/llenergymeasure/api/health.py
@@ -374,6 +374,16 @@ def _image_handshake_section(report: DoctorReport | None) -> HealthSection:
         status = _SCHEMA_TO_STATUS.get(row.status, "warn")
         message = f"{row.engine}: {row.status.value} ({row.image})"
         lines.append(CheckLine(status, message, row.detail or None))
+        if row.shadows_default:
+            lines.append(
+                CheckLine(
+                    "warn",
+                    f"{row.engine}: local tag {row.image} shadows pinned default "
+                    f"{row.shadows_default}",
+                    f"docker rmi {row.image} to restore the pinned default, "
+                    f"or pin an explicit image via runners.{row.engine}",
+                )
+            )
 
     if report.skip_check_active:
         lines.append(
@@ -466,6 +476,7 @@ def _image_report_to_dict(report: DoctorReport | None) -> dict[str, Any] | None:
                 "status": row.status.value,
                 "local_present": row.local_present,
                 "detail": row.detail,
+                "shadows_default": row.shadows_default,
             }
             for row in report.results
         ],

--- a/src/llenergymeasure/infra/image_registry.py
+++ b/src/llenergymeasure/infra/image_registry.py
@@ -137,7 +137,7 @@ def get_default_image(engine: str) -> str:
     #    invisibly, so warn (once) and name the pinned default it bypasses.
     local_image = LOCAL_IMAGE_TEMPLATE.format(engine=engine)
     if _image_exists_locally(local_image):
-        _warn_local_shadow(engine, local_image)
+        _warn_local_shadow(engine)
         return local_image
 
     # 2. Per-engine default remote image at the resolved version.
@@ -200,11 +200,17 @@ def _resolve_pinned_default(engine: str) -> str:
     return template.format(version=_default_image_version(engine))
 
 
+@cache
 def _pinned_default_or_none(engine: str) -> str | None:
     """Best-effort name of the version-pinned default a local bare tag bypasses.
 
     Returns None when it cannot be resolved (unknown engine or a broken wheel),
     so naming the bypassed default never fails a run.
+
+    Cached on the engine so the shadow warning and ``shadowed_default_image``
+    (both called per engine within ``run_doctor_checks``) resolve the bypassed
+    default once, sharing a single file read instead of two. ``cache_clear()``
+    resets the memoization (used by tests).
     """
     from llenergymeasure.infra.version_handshake import BundledEngineVersionMismatchError
 
@@ -215,33 +221,28 @@ def _pinned_default_or_none(engine: str) -> str | None:
 
 
 @cache
-def _warn_local_shadow(engine: str, local_image: str) -> None:
+def _warn_local_shadow(engine: str) -> None:
     """Warn (once per process) that a local bare tag shadows the pinned default.
 
     ``get_default_image`` runs repeatedly per engine within a single study prep
-    (preflight, then once per experiment and cycle), so both the warning and the
-    (comparatively expensive) resolution of the bypassed default are deduplicated
-    with ``functools.cache`` keyed on the engine: the same shadow is logged only
-    once. ``cache_clear()`` resets the dedup (used by tests).
+    (preflight, then once per experiment and cycle), so the warning is
+    deduplicated with ``functools.cache`` keyed on the engine: the same shadow is
+    logged only once. ``cache_clear()`` resets the dedup (used by tests).
     """
+    local_image = LOCAL_IMAGE_TEMPLATE.format(engine=engine)
     pinned_default = _pinned_default_or_none(engine)
-    if pinned_default is None:
-        logger.warning(
-            "Using local Docker image %s, which shadows this engine's "
-            "version-pinned default. A stale local tag can silently win image "
-            "resolution. Run `docker rmi %s` to restore the pinned default, or "
-            "pin an explicit image via runners.<engine> or LLEM_IMAGE_<ENGINE>.",
-            local_image,
-            local_image,
-        )
-        return
+    shadowed = (
+        f"the version-pinned default {pinned_default}"
+        if pinned_default is not None
+        else "this engine's version-pinned default"
+    )
     logger.warning(
-        "Using local Docker image %s, which shadows the version-pinned default "
-        "%s. A stale local tag can silently win image resolution. Run "
-        "`docker rmi %s` to restore the pinned default, or pin an explicit image "
-        "via runners.<engine> or LLEM_IMAGE_<ENGINE>.",
+        "Using local Docker image %s, which shadows %s. A stale local tag can "
+        "silently win image resolution. Run `docker rmi %s` to restore the "
+        "pinned default, or pin an explicit image via runners.<engine> or "
+        "LLEM_IMAGE_<ENGINE>.",
         local_image,
-        pinned_default,
+        shadowed,
         local_image,
     )
 

--- a/src/llenergymeasure/infra/image_registry.py
+++ b/src/llenergymeasure/infra/image_registry.py
@@ -46,7 +46,7 @@ import json
 import logging
 import os
 import subprocess
-from functools import lru_cache
+from functools import cache, lru_cache
 
 from llenergymeasure.config.ssot import (
     ALL_ENGINES,
@@ -69,6 +69,7 @@ __all__ = [
     "parse_runner_value",
     "resolve_image",
     "resolve_image_digest",
+    "shadowed_default_image",
     "show_image_resolution",
 ]
 
@@ -131,22 +132,16 @@ def get_default_image(engine: str) -> str:
             tells the user to set ``runners.<engine>`` to an explicit
             ``docker:<image>`` reference.
     """
-    # 1. Prefer a locally-built image (fast local iteration).
+    # 1. Prefer a locally-built image (fast local iteration). This precedence is
+    #    intentional, but a months-stale dev tag can hijack resolution
+    #    invisibly, so warn (once) and name the pinned default it bypasses.
     local_image = LOCAL_IMAGE_TEMPLATE.format(engine=engine)
     if _image_exists_locally(local_image):
-        logger.info("Using local image %s (from docker compose build)", local_image)
+        _warn_local_shadow(engine, local_image)
         return local_image
 
     # 2. Per-engine default remote image at the resolved version.
-    engine_name = engine_str(engine)
-    template = DEFAULT_IMAGE_TEMPLATES.get(engine_name)
-    if template is None:
-        raise ConfigError(
-            f"No default Docker image is defined for engine {engine_name!r}. "
-            f'Set runners.{engine_name} to "docker:<image>:<tag>" in your study '
-            f"YAML to pin an explicit image."
-        )
-    image = template.format(version=_default_image_version(engine_name))
+    image = _resolve_pinned_default(engine_str(engine))
     logger.info("No local image found; using default image %s", image)
     return image
 
@@ -183,6 +178,86 @@ def _default_image_version(engine: str) -> str:
             f"pin an explicit image."
         )
     return version
+
+
+def _resolve_pinned_default(engine: str) -> str:
+    """Resolve *engine*'s version-pinned default remote image.
+
+    Shared by ``get_default_image`` (step 2) and the shadow-warning path so the
+    warning always names the exact image a local bare tag bypassed.
+
+    Raises:
+        ConfigError: the engine has no default template, or its pinned engine
+            version is unavailable at runtime (a partial or broken wheel).
+    """
+    template = DEFAULT_IMAGE_TEMPLATES.get(engine)
+    if template is None:
+        raise ConfigError(
+            f"No default Docker image is defined for engine {engine!r}. "
+            f'Set runners.{engine} to "docker:<image>:<tag>" in your study '
+            f"YAML to pin an explicit image."
+        )
+    return template.format(version=_default_image_version(engine))
+
+
+def _pinned_default_or_none(engine: str) -> str | None:
+    """Best-effort name of the version-pinned default a local bare tag bypasses.
+
+    Returns None when it cannot be resolved (unknown engine or a broken wheel),
+    so naming the bypassed default never fails a run.
+    """
+    from llenergymeasure.infra.version_handshake import BundledEngineVersionMismatchError
+
+    try:
+        return _resolve_pinned_default(engine_str(engine))
+    except (ConfigError, BundledEngineVersionMismatchError):
+        return None
+
+
+@cache
+def _warn_local_shadow(engine: str, local_image: str) -> None:
+    """Warn (once per process) that a local bare tag shadows the pinned default.
+
+    ``get_default_image`` runs repeatedly per engine within a single study prep
+    (preflight, then once per experiment and cycle), so both the warning and the
+    (comparatively expensive) resolution of the bypassed default are deduplicated
+    with ``functools.cache`` keyed on the engine: the same shadow is logged only
+    once. ``cache_clear()`` resets the dedup (used by tests).
+    """
+    pinned_default = _pinned_default_or_none(engine)
+    if pinned_default is None:
+        logger.warning(
+            "Using local Docker image %s, which shadows this engine's "
+            "version-pinned default. A stale local tag can silently win image "
+            "resolution. Run `docker rmi %s` to restore the pinned default, or "
+            "pin an explicit image via runners.<engine> or LLEM_IMAGE_<ENGINE>.",
+            local_image,
+            local_image,
+        )
+        return
+    logger.warning(
+        "Using local Docker image %s, which shadows the version-pinned default "
+        "%s. A stale local tag can silently win image resolution. Run "
+        "`docker rmi %s` to restore the pinned default, or pin an explicit image "
+        "via runners.<engine> or LLEM_IMAGE_<ENGINE>.",
+        local_image,
+        pinned_default,
+        local_image,
+    )
+
+
+def shadowed_default_image(engine: str, resolved_image: str) -> str | None:
+    """Return the version-pinned default *resolved_image* bypasses, or None.
+
+    When *resolved_image* is the local bare tag for *engine* (a locally built
+    image won resolution), return the version-pinned default it shadows;
+    otherwise None. Lets diagnostics (``llem doctor``) surface the same
+    shadowing fact the resolution warning logs. Best-effort: returns None when
+    the pinned default cannot be resolved.
+    """
+    if resolved_image != LOCAL_IMAGE_TEMPLATE.format(engine=engine):
+        return None
+    return _pinned_default_or_none(engine)
 
 
 def image_present_locally(image: str) -> bool:

--- a/tests/unit/api/test_doctor.py
+++ b/tests/unit/api/test_doctor.py
@@ -29,6 +29,40 @@ def test_reports_resolved_image_and_local_presence():
     assert row.local_present is True
 
 
+def test_local_tag_win_surfaces_shadowed_default():
+    """When a local bare tag wins resolution, the row names the pinned default it
+    shadows so ``llem doctor`` surfaces the same fact the resolution warning logs."""
+    from llenergymeasure.infra.version_handshake import read_bundled_engine_version
+
+    with (
+        patch("llenergymeasure.api.doctor.compute_expconf_fingerprint", return_value="f" * 64),
+        patch("llenergymeasure.api.doctor.get_default_image", return_value="llenergymeasure:vllm"),
+        patch("llenergymeasure.api.doctor.image_present_locally", return_value=True),
+        patch("llenergymeasure.api.doctor.inspect_image_stamp", return_value=_EMPTY_STAMP),
+    ):
+        report = run_doctor_checks(engines=("vllm",))
+
+    (row,) = report.results
+    assert row.image == "llenergymeasure:vllm"
+    assert row.shadows_default == f"vllm/vllm-openai:v{read_bundled_engine_version('vllm')}"
+
+
+def test_remote_image_has_no_shadowed_default():
+    with (
+        patch("llenergymeasure.api.doctor.compute_expconf_fingerprint", return_value="f" * 64),
+        patch(
+            "llenergymeasure.api.doctor.get_default_image",
+            return_value="vllm/vllm-openai:v0.19.1",
+        ),
+        patch("llenergymeasure.api.doctor.image_present_locally", return_value=False),
+        patch("llenergymeasure.api.doctor.inspect_image_stamp", return_value=_EMPTY_STAMP),
+    ):
+        report = run_doctor_checks(engines=("vllm",))
+
+    (row,) = report.results
+    assert row.shadows_default is None
+
+
 def test_unresolvable_default_becomes_unreachable_row_with_fix():
     def _raise(engine):
         raise ConfigError(f'Set runners.{engine} to "docker:<image>:<tag>"')

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -286,6 +286,31 @@ def test_handshake_mismatch_is_fail() -> None:
     assert "rebuild" in (fail.fix or "")
 
 
+def test_handshake_local_tag_shadow_renders_warn_line() -> None:
+    report = DoctorReport(
+        host_pkg_version="0.13.0",
+        host_fingerprint="a" * 64,
+        skip_check_active=False,
+        results=[
+            EngineDoctorResult(
+                engine="vllm",
+                image="llenergymeasure:vllm",
+                pkg_version="0.19.1",
+                image_fingerprint="a" * 64,
+                status=SchemaStatus.OK,
+                local_present=True,
+                shadows_default="vllm/vllm-openai:v0.19.1",
+            )
+        ],
+    )
+    section = health._image_handshake_section(report)
+    shadow = next(line for line in section.lines if "shadows pinned default" in line.message)
+    assert shadow.status == "warn"
+    assert "llenergymeasure:vllm" in shadow.message
+    assert "vllm/vllm-openai:v0.19.1" in shadow.message
+    assert "docker rmi llenergymeasure:vllm" in (shadow.fix or "")
+
+
 def test_handshake_unreachable_is_warn() -> None:
     report = _doctor_report(SchemaStatus.UNREACHABLE)
     section = health._image_handshake_section(report)

--- a/tests/unit/docker/test_image_registry.py
+++ b/tests/unit/docker/test_image_registry.py
@@ -152,13 +152,19 @@ class TestLocalImageShadowWarning:
 
     @pytest.fixture(autouse=True)
     def _clear_shadow_dedup(self):
-        """``_warn_local_shadow`` is @lru_cache'd for once-per-process dedup; clear
-        it so a warning from one test does not suppress the next."""
-        from llenergymeasure.infra.image_registry import _warn_local_shadow
+        """``_warn_local_shadow`` (warn-once) and ``_pinned_default_or_none``
+        (shared resolution) are both @cache'd; clear both so a warning from one
+        test does not suppress the next and no stale default leaks across tests."""
+        from llenergymeasure.infra.image_registry import (
+            _pinned_default_or_none,
+            _warn_local_shadow,
+        )
 
         _warn_local_shadow.cache_clear()
+        _pinned_default_or_none.cache_clear()
         yield
         _warn_local_shadow.cache_clear()
+        _pinned_default_or_none.cache_clear()
 
     def test_warns_and_names_local_tag_and_bypassed_default(self, caplog):
         from llenergymeasure.infra.image_registry import get_default_image

--- a/tests/unit/docker/test_image_registry.py
+++ b/tests/unit/docker/test_image_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -139,6 +140,90 @@ class TestGetDefaultImage:
             pytest.raises(ConfigError, match=r'runners\.vllm to "docker:'),
         ):
             get_default_image("vllm")
+
+
+# ---------------------------------------------------------------------------
+# Local-tag shadow warning
+# ---------------------------------------------------------------------------
+
+
+class TestLocalImageShadowWarning:
+    """A local bare tag winning resolution warns once, naming the bypassed default."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_shadow_dedup(self):
+        """``_warn_local_shadow`` is @lru_cache'd for once-per-process dedup; clear
+        it so a warning from one test does not suppress the next."""
+        from llenergymeasure.infra.image_registry import _warn_local_shadow
+
+        _warn_local_shadow.cache_clear()
+        yield
+        _warn_local_shadow.cache_clear()
+
+    def test_warns_and_names_local_tag_and_bypassed_default(self, caplog):
+        from llenergymeasure.infra.image_registry import get_default_image
+        from llenergymeasure.infra.version_handshake import read_bundled_engine_version
+
+        bypassed = f"vllm/vllm-openai:v{read_bundled_engine_version('vllm')}"
+
+        with (
+            patch("llenergymeasure.infra.image_registry._image_exists_locally", return_value=True),
+            caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.image_registry"),
+        ):
+            image = get_default_image("vllm")
+
+        # Resolution result is unchanged: local tag still wins.
+        assert image == "llenergymeasure:vllm"
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        text = warnings[0].getMessage()
+        assert "llenergymeasure:vllm" in text  # (1) the local tag used
+        assert bypassed in text  # (2) the version-pinned default it bypassed
+        assert "docker rmi llenergymeasure:vllm" in text  # (3) the remedy
+
+    def test_no_warning_when_local_tag_absent(self, caplog):
+        from llenergymeasure.infra.image_registry import get_default_image
+        from llenergymeasure.infra.version_handshake import read_bundled_engine_version
+
+        with (
+            patch("llenergymeasure.infra.image_registry._image_exists_locally", return_value=False),
+            caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.image_registry"),
+        ):
+            image = get_default_image("vllm")
+
+        # Resolution result is unchanged: pinned default wins, no shadow.
+        assert image == f"vllm/vllm-openai:v{read_bundled_engine_version('vllm')}"
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_deduplicated_across_repeated_calls(self, caplog):
+        from llenergymeasure.infra.image_registry import get_default_image
+
+        with (
+            patch("llenergymeasure.infra.image_registry._image_exists_locally", return_value=True),
+            caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.image_registry"),
+        ):
+            get_default_image("vllm")
+            get_default_image("vllm")
+            get_default_image("vllm")
+
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
+class TestShadowedDefaultImage:
+    """``shadowed_default_image`` names the bypassed default only for the local tag."""
+
+    def test_returns_bypassed_default_for_local_tag(self):
+        from llenergymeasure.infra.image_registry import shadowed_default_image
+        from llenergymeasure.infra.version_handshake import read_bundled_engine_version
+
+        result = shadowed_default_image("vllm", "llenergymeasure:vllm")
+        assert result == f"vllm/vllm-openai:v{read_bundled_engine_version('vllm')}"
+
+    def test_none_when_resolved_image_is_not_the_local_tag(self):
+        from llenergymeasure.infra.image_registry import shadowed_default_image
+
+        assert shadowed_default_image("vllm", "vllm/vllm-openai:v0.19.1") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`get_default_image()` prefers a locally-built `llenergymeasure:{engine}` bare tag
over the version-pinned default (GHCR for transformers, upstream-pinned for
vLLM / TensorRT-LLM). That precedence is intentional for fast local iteration,
but a months-stale dev tag can hijack resolution invisibly: on one host a stale
local vLLM tag even failed the schema handshake as a hard mismatch while the user
had no idea a local image was being preferred.

This change keeps the precedence unchanged and makes the shadowing visible:

- When the local bare tag wins, `get_default_image()` emits a `logger.warning`
  naming (1) the local tag in use, (2) the version-pinned default it bypassed,
  and (3) the remedy (`docker rmi llenergymeasure:<engine>` to restore the pinned
  default, or pin explicitly via `runners.<engine>` / `LLEM_IMAGE_<ENGINE>`).
- The warning is deduplicated once per engine per process via `functools.cache`
  on a small helper (`_warn_local_shadow`). `get_default_image()` is called
  repeatedly per engine in one study prep (preflight, then per experiment/cycle),
  so this avoids log spam; the resolution of the bypassed default is computed
  inside the cached helper too, so its file I/O also runs once.
- The remote-default resolution is factored into a shared `_resolve_pinned_default`
  so the warning always names the exact image the bare tag bypassed (no drift
  between the warned default and the actually-resolved default).
- `llem doctor` surfaces the same fact: `EngineDoctorResult` gains a
  `shadows_default` field (populated via the new public `shadowed_default_image`),
  and the health renderer adds a `warn` line on the affected engine's row with the
  same remedy. This is the exact surface where the ds01 mismatch would appear.

Resolution behaviour is unchanged in every case.

## Test plan

- `make lint` - clean (ruff check, ruff format --check, import-linter: 5 kept, 0 broken).
- `make typecheck` - clean (mypy, 312 source files).
- New unit tests in `tests/unit/docker/test_image_registry.py`:
  - warning emitted naming the local tag + bypassed default + remedy when the
    local tag exists (mocked `_image_exists_locally`);
  - no warning when the local tag does not exist;
  - resolution result unchanged in both branches;
  - warning deduplicated across repeated calls;
  - `shadowed_default_image` returns the bypassed default only for the local tag.
- New unit tests in `tests/unit/api/test_doctor.py` (row carries `shadows_default`
  when a local tag wins, `None` for a remote image) and
  `tests/unit/api/test_health.py` (renderer emits the shadow warn line).
- Touched modules green: `test_image_registry.py`, `test_doctor.py`,
  `test_health.py` (68 passed). Full host suite green apart from one pre-existing
  failure unrelated to this diff
  (`test_docker_runner.py::TestConfigSidecarRescue::test_config_sidecar_rescued_when_no_timeseries`,
  a `mkdtemp` side-effect generator exhaustion that reproduces identically on
  `origin/main`).

## Doc audit

- `docs/how-to/docker-setup.md` documents the local-tag smart default (level 5);
  added a short "a stale local tag silently wins" heads-up there naming the same
  remedy (`docker rmi`) and the doctor surfacing, aligned with the new warning.
- `CHANGELOG.md`: entry under `## [Unreleased]` `### Changed` with the `([#843])`
  reference and link definition.
- No user-facing API rename; the new `shadowed_default_image` is additive.
