### PR TITLE
fix(infra): verify dep importability in container probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,18 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- The container dependency-priming probe now verifies each runtime requirement
+  actually imports in the container interpreter, not just that its distribution
+  metadata is present. Metadata presence does not prove importability: a package
+  can be installed yet fail to import when a compiled extension was built for the
+  wrong ABI or the install is otherwise broken, and the old presence-only check
+  left such a dependency unprimed. The probe now resolves each distribution's
+  top-level import name (a small override table covers the known non-identity
+  cases `nvidia-ml-py` to `pynvml`, `pyyaml` to `yaml`, and `python-dotenv` to
+  `dotenv`, then `top_level.txt` / `packages_distributions`, falling back to the
+  normalised distribution name) and imports it, priming any requirement whose
+  import raises. Absent metadata still short-circuits as missing with no import
+  attempt, and the requirements-hash fast-path stamp is unchanged. ([#845])
 - Experiment failures now surface their real cause. Under `-v`, a Docker container
   failure prints the traceback the container entrypoint captured (the actual
   engine/CUDA error), instead of the uninformative host-side traceback of the
@@ -1220,3 +1232,4 @@ Core measurement functionality establishing the foundation for all subsequent de
 [#839]: https://github.com/henrycgbaker/llenergymeasure/pull/839
 [#840]: https://github.com/henrycgbaker/llenergymeasure/pull/840
 [#842]: https://github.com/henrycgbaker/llenergymeasure/pull/842
+[#845]: https://github.com/henrycgbaker/llenergymeasure/pull/845

--- a/src/llenergymeasure/infra/_container/container_entrypoint.sh
+++ b/src/llenergymeasure/infra/_container/container_entrypoint.sh
@@ -40,12 +40,13 @@ mkdir -p "$DEPS_TARGET"
 export PYTHONPATH="/llem-src:${DEPS_TARGET}:${PYTHONPATH:-}"
 
 # Fast-path stamp: a sweep typically dispatches the same image hundreds of
-# times with an unchanged requirements list. Running the importlib.metadata
-# probe every dispatch is ~200ms of pure overhead that the steady-state
-# path doesn't need. The stamp file records the requirements hash that was
-# last verified against this cache; matching hash means "deps probe was
-# done, nothing changed, skip it." Mismatch (or absent stamp) triggers a
-# full probe and updates the stamp.
+# times with an unchanged requirements list. Running the import-verification
+# probe every dispatch is pure overhead that the steady-state path doesn't
+# need. The stamp file records the requirements hash that was last verified
+# against this cache; matching hash means "deps probe was done, nothing
+# changed, skip it." Mismatch (or absent stamp) triggers a full probe and
+# updates the stamp. The stamp is written only after a fully-verified prime,
+# so a hit is a sound skip.
 #
 # The stamp is keyed by ENGINE as well as python minor: different engines run
 # different images whose site-packages differ, so "verified, nothing missing"
@@ -58,24 +59,89 @@ STAMP="${DEPS_TARGET}/.llem_requirements_hash_${LLEM_ENGINE:-default}"
 REQUIREMENTS_HASH=$(sha256sum /llem-requirements.txt | head -c 16)
 
 if [ ! -f "$STAMP" ] || [ "$(cat "$STAMP" 2>/dev/null)" != "$REQUIREMENTS_HASH" ]; then
-    # Diff the runtime requirements list against installed dists
-    # (importlib.metadata sees both site-packages and our cache mount,
-    # since we already added the cache to PYTHONPATH above).
+    # Diff the runtime requirements list against what actually imports in
+    # this interpreter. A dist-info presence check is not sufficient: metadata
+    # can be present while the package fails to import - a compiled extension
+    # built for the wrong ABI, or an otherwise broken install - so each present
+    # requirement is verified by importing its resolved module(s), and primed
+    # if the import raises. Absent metadata short-circuits as missing with no
+    # import attempt. importlib.metadata sees both the image site-packages and
+    # our cache mount, since we already added the cache to PYTHONPATH above.
     MISSING=$(python3 - <<'PYEOF'
+import functools
+import importlib
 import importlib.metadata
+import sys
 from pathlib import Path
 
-# Strip version bounds to get the bare distribution name for the
-# installation probe. Keep the full spec for pip install.
+# The requirements list is bind-mounted here inside the container. An optional
+# argv override (defaulting to the mount path) lets the probe run against a
+# synthetic requirements file without changing container behaviour.
+REQUIREMENTS_FILE = sys.argv[1] if len(sys.argv) > 1 else "/llem-requirements.txt"
+
+# Distributions whose top-level import name differs from the distribution name.
+# Keys are canonical (lowercase, dashes) distribution names; values are the
+# module to import. Authoritative: consulted before top_level.txt so noisy or
+# absent top-level metadata cannot mis-resolve these known cases.
+IMPORT_NAME_OVERRIDES = {
+    "nvidia-ml-py": "pynvml",
+    "pyyaml": "yaml",
+    "python-dotenv": "dotenv",
+}
+
+
 def bare_name(spec: str) -> str:
+    # Strip version bounds / extras to get the bare distribution name for the
+    # metadata lookup. The full spec is kept for pip install.
     name = spec
     for sep in (">=", "<=", "==", "!=", "~=", "<", ">", "["):
         if sep in name:
             name = name.split(sep)[0]
     return name.strip()
 
+
+def canonical(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+@functools.cache
+def reverse_packages() -> dict[str, list[str]]:
+    # Invert importlib.metadata.packages_distributions() (import name -> dist
+    # names) into dist name -> import names, so a distribution's top-level
+    # module(s) can be recovered even when its top_level.txt is absent.
+    mapping: dict[str, list[str]] = {}
+    try:
+        items = importlib.metadata.packages_distributions().items()
+    except Exception:
+        return mapping
+    for import_name, dists in items:
+        for dist_name in dists:
+            mapping.setdefault(canonical(dist_name), []).append(import_name)
+    return mapping
+
+
+def import_names(dist_name, dist) -> list[str]:
+    # Resolve the top-level import name(s) for an installed distribution.
+    key = canonical(dist_name)
+    if key in IMPORT_NAME_OVERRIDES:
+        return [IMPORT_NAME_OVERRIDES[key]]
+    try:
+        top_level = dist.read_text("top_level.txt")
+    except Exception:
+        top_level = None
+    if top_level:
+        names = [ln.strip() for ln in top_level.splitlines() if ln.strip()]
+        if names:
+            return names
+    resolved = reverse_packages().get(key)
+    if resolved:
+        return resolved
+    # Fall back to the normalised distribution name (dashes to underscores).
+    return [dist_name.replace("-", "_")]
+
+
 missing = []
-for line in Path("/llem-requirements.txt").read_text().splitlines():
+for line in Path(REQUIREMENTS_FILE).read_text().splitlines():
     spec = line.strip()
     if not spec or spec.startswith("#"):
         continue
@@ -83,8 +149,18 @@ for line in Path("/llem-requirements.txt").read_text().splitlines():
     if not name:
         continue
     try:
-        importlib.metadata.distribution(name)
+        dist = importlib.metadata.distribution(name)
     except importlib.metadata.PackageNotFoundError:
+        # Absent metadata: definitely missing, no import attempt needed.
+        missing.append(spec)
+        continue
+    try:
+        for import_name in import_names(name, dist):
+            importlib.import_module(import_name)
+    except Exception:
+        # Present metadata but the module does not import (wrong-ABI extension,
+        # broken install): prime it so the container's pip reinstalls an
+        # ABI-correct copy into the deps cache.
         missing.append(spec)
 
 print(" ".join(missing))

--- a/tests/unit/docker/test_container_entrypoint.py
+++ b/tests/unit/docker/test_container_entrypoint.py
@@ -8,6 +8,9 @@ the source modules (since container_entrypoint uses lazy local imports).
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -478,3 +481,125 @@ class TestMainGuard:
 
         source = inspect.getsource(container)
         assert 'if __name__ == "__main__":' in source
+
+
+# ---------------------------------------------------------------------------
+# Dependency-priming probe (bash entrypoint heredoc)
+# ---------------------------------------------------------------------------
+
+
+def _extract_probe_source() -> str:
+    """Return the Python probe embedded in the container entrypoint heredoc.
+
+    The bash entrypoint runs the dep-priming probe as an inline
+    ``python3 - <<'PYEOF' ... PYEOF`` heredoc. Nothing else shells the script,
+    so the probe is exercised here by extracting that block verbatim and
+    running it the way the container does (``python3 <file> [reqs_path]``).
+    Resolved from the repo tree this test lives in (not the installed package)
+    so it validates the script under test.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = (
+        repo_root / "src" / "llenergymeasure" / "infra" / "_container" / "container_entrypoint.sh"
+    )
+    script = script_path.read_text(encoding="utf-8")
+    _, open_marker, rest = script.partition("<<'PYEOF'\n")
+    assert open_marker, "probe heredoc opening marker not found in entrypoint script"
+    probe_src, close_marker, _ = rest.partition("\nPYEOF")
+    assert close_marker, "probe heredoc closing marker not found in entrypoint script"
+    return probe_src
+
+
+def _make_dist(
+    site: Path,
+    dist_name: str,
+    version: str,
+    *,
+    module: str | None = None,
+    module_body: str = "",
+    top_level: str | None = None,
+) -> None:
+    """Create a minimal installed distribution under a fake site-packages dir."""
+    dist_info = site / f"{dist_name.replace('-', '_')}-{version}.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {dist_name}\nVersion: {version}\n",
+        encoding="utf-8",
+    )
+    if top_level is not None:
+        (dist_info / "top_level.txt").write_text(top_level + "\n", encoding="utf-8")
+    if module is not None:
+        pkg = site / module
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text(module_body, encoding="utf-8")
+
+
+def _run_probe(tmp_path: Path, site: Path, requirements: str) -> list[str]:
+    """Run the extracted probe against a fake site-packages; return missing specs."""
+    probe_py = tmp_path / "probe.py"
+    probe_py.write_text(_extract_probe_source(), encoding="utf-8")
+    reqs = tmp_path / "requirements.txt"
+    reqs.write_text(requirements, encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(site), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+    proc = subprocess.run(
+        [sys.executable, str(probe_py), str(reqs)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"probe crashed: {proc.stderr}"
+    return proc.stdout.split()
+
+
+class TestDepProbeImportCheck:
+    """The entrypoint probe verifies each requirement actually imports.
+
+    Metadata presence alone is insufficient: a package can be installed yet
+    fail to import (e.g. a compiled extension built for the wrong ABI). These
+    tests build a synthetic site-packages and exercise the probe the way the
+    container does.
+    """
+
+    def test_flags_broken_and_absent_deps(self, tmp_path: Path):
+        """Present-but-importable stays; broken-import and absent are primed."""
+        site = tmp_path / "site"
+        site.mkdir()
+        # (a) present + importable
+        _make_dist(site, "good", "1.0", module="good")
+        # (b) present metadata but the module raises on import (wrong-ABI class)
+        _make_dist(
+            site,
+            "broken",
+            "1.0",
+            module="broken",
+            module_body="raise ImportError('extension built for wrong ABI')",
+        )
+        # (c) absent: no dist-info and no module, only listed in requirements
+        missing = _run_probe(tmp_path, site, "good>=1.0\nbroken>=1.0\nabsent>=1.0\n")
+        assert missing == ["broken>=1.0", "absent>=1.0"]
+
+    def test_resolves_import_name_via_top_level_txt(self, tmp_path: Path):
+        """A dist whose import name differs is resolved via top_level.txt.
+
+        The normalised-name fallback ('mydist') would not import, so a pass
+        proves the top_level.txt resolution path is used.
+        """
+        site = tmp_path / "site"
+        site.mkdir()
+        _make_dist(site, "mydist", "2.0", module="myimportname", top_level="myimportname")
+        missing = _run_probe(tmp_path, site, "mydist>=2.0\n")
+        assert missing == []
+
+    def test_applies_known_import_name_override(self, tmp_path: Path):
+        """pyyaml -> yaml is a hardcoded override.
+
+        The dist provides only a 'yaml' module (no 'pyyaml'), so the normalised
+        fallback would fail to import; a pass proves the override is applied.
+        """
+        site = tmp_path / "site"
+        site.mkdir()
+        _make_dist(site, "pyyaml", "6.0", module="yaml")
+        missing = _run_probe(tmp_path, site, "pyyaml>=6.0\n")
+        assert missing == []


### PR DESCRIPTION
## Summary

Rider PR2 of the ratified dispatch-isolation design (`.product/designs/pip-dispatch-dep-isolation-2026-07-18.md`, rider 1): harden the container entrypoint's dependency-priming probe from a metadata-presence check to a real import check.

The probe (an inline `python3` heredoc in `container_entrypoint.sh`) primed missing runtime deps into a per-python-minor cache, gated by a requirements-hash stamp. Its check used `importlib.metadata.distribution(name)` presence only. Presence of dist-info does not prove importability: a compiled extension built for the wrong ABI, or an otherwise broken install, satisfies the metadata check but fails at import time, and the old check left such a dependency unprimed. This is belt-and-braces once the mount narrowing (#844) removes the known host-site-packages shadowing trigger.

**The change (heredoc only):**
- For each present requirement, resolve its top-level import name(s) and `importlib.import_module` each; on any exception, add the spec to the priming list.
- Import-name resolution: an override table for the known non-identity cases in this project's deps (`nvidia-ml-py` to `pynvml`, `pyyaml` to `yaml`, `python-dotenv` to `dotenv`), then the distribution's `top_level.txt`, then an inverted `packages_distributions()` map, falling back to the normalised distribution name (dashes to underscores).
- Absent metadata still short-circuits as missing with no import attempt (fast path preserved).
- Stamp fast-path semantics unchanged (stamp hit skips the probe; stamp written only after a fully-verified prime).
- Heredoc stays self-contained (stdlib only, py3.10+). Output contract with the surrounding bash is unchanged. The requirements path defaults to the container mount but accepts an optional argv override so the probe is testable.
- Comment block above the probe rewritten to state the import-verification rationale (wrong-ABI failure class).

Scope note: touches only `container_entrypoint.sh` (plus its test and CHANGELOG); does not touch `docker_runner.py`, so no conflict with #844 beyond CHANGELOG.

## Test plan

- New `TestDepProbeImportCheck` in `tests/unit/docker/test_container_entrypoint.py` extracts the heredoc probe verbatim from the script and runs it in a subprocess against a synthetic site-packages the way the container does:
  - present + importable dep -> not primed
  - present metadata but module raises `ImportError` (wrong-ABI class) -> primed
  - absent dep -> primed
  - differing import name resolved via `top_level.txt` -> not primed
  - known override (`pyyaml` to `yaml`) -> not primed
- `make lint` (import-linter 5 kept / 0 broken), `ruff check` + `ruff format --check`, `make typecheck` (mypy clean): all pass.
- `shellcheck` and `bash -n` on the entrypoint script: pass.
- 18/18 in the touched test module pass.
- Live check: ran the hardened probe inside the real `transformers:v0.12.0` container (py3.11). Against the full core requirements list it reports nothing missing (all 11 deps resolve and import, including the 3 overrides); with a synthetic absent dep appended it flags exactly that spec. RC 0, no crash. (Full wheel-install repro from the design's verification bar targets the #844 mount fix and is deferred to the post-#844 exit-gate re-run.)

## Doc audit

- CHANGELOG: entry added under `## [Unreleased]` / `### Fixed` with `([#845])` ref and link definition.
- No product-doc surface changes (probe internals are not user-facing).