### PR TITLE
chore: renumber to canonical version epoch (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,47 +7,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
-### Changed
-
-- Image resolution now warns when a locally-built `llenergymeasure:{engine}` tag
-  wins over the version-pinned default. That precedence is intentional (fast local
-  iteration), but a months-stale dev tag could hijack resolution invisibly: on one
-  host a stale local vLLM tag even failed the schema handshake as a hard mismatch
-  while the user had no idea a local image was being preferred. The warning names
-  the local tag in use, the version-pinned default it bypassed, and the remedy
-  (`docker rmi llenergymeasure:{engine}` to restore the pinned default, or pin an
-  explicit image via `runners.<engine>` / `LLEM_IMAGE_<ENGINE>`); it is emitted
-  once per resolution. `llem doctor` surfaces the same shadowing fact on the
-  affected engine's row. Resolution behaviour is unchanged. ([#843])
-
-### Fixed
-
-- `llem run -o/--output-dir` is now honored for fresh (non-resume) studies. The flag
-  was documented as "Output directory for results" but was silently a no-op on a fresh
-  run: `run_study` only consumed `output_dir` as the auto-detect-resume search base and
-  never threaded it into the results-dir resolution, so results always landed in the YAML
-  `output.results_dir` (default `./results`). Fresh runs now resolve the base with
-  precedence `-o` override > YAML `output.results_dir` > user config > `./results`, and the
-  preflight/dry-run panel's "Study results path" reflects the same precedence so the
-  preview matches where results actually land. Resume semantics are unchanged (`-o` stays
-  the search base for `--resume`). The results path is placement metadata, excluded from
-  the declared-config, study-design, and dedup hashes, so pointing a study at a different
-  output directory never changes dedup grouping. ([#842])
-- Fresh `pip install` + Docker dispatch no longer crashes the transformers and
-  TensorRT-LLM engines inside their containers. The package bind-mount now
-  exposes only the `llenergymeasure` package (mounted at
-  `/llem-src/llenergymeasure`) instead of the package's parent directory. For a
-  wheel install that parent is the venv's entire `site-packages`, and because
-  the container entrypoint prepends `/llem-src` to `PYTHONPATH` (which precedes
-  the container's own site-packages on `sys.path`), every host third-party
-  package used to shadow the image's native copy - a host `pydantic_core` C
-  extension built for a different Python minor broke transformers, and a fresh
-  `huggingface-hub` broke TensorRT-LLM's version guard. Mounting the package
-  directory alone makes `/llem-src` contain nothing but `llenergymeasure`, so
-  host dependencies can no longer shadow container-native ones. One uniform
-  mount serves editable and wheel installs alike. ([#844])
-
-## [v0.13.0] - 2026-07-18
+## [v0.6.0] - 2026-07-18
 
 ### Added
 
@@ -103,6 +63,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Changed
 
+- Image resolution now warns when a locally-built `llenergymeasure:{engine}` tag
+  wins over the version-pinned default. That precedence is intentional (fast local
+  iteration), but a months-stale dev tag could hijack resolution invisibly: on one
+  host a stale local vLLM tag even failed the schema handshake as a hard mismatch
+  while the user had no idea a local image was being preferred. The warning names
+  the local tag in use, the version-pinned default it bypassed, and the remedy
+  (`docker rmi llenergymeasure:{engine}` to restore the pinned default, or pin an
+  explicit image via `runners.<engine>` / `LLEM_IMAGE_<ENGINE>`); it is emitted
+  once per resolution. `llem doctor` surfaces the same shadowing fact on the
+  affected engine's row. Resolution behaviour is unchanged. ([#843])
 - Study preparation now pulls missing Docker engine images concurrently (one
   `docker pull` per thread, capped at 3) instead of serialising them. A
   multi-engine study on a fresh box no longer waits for several multi-GB pulls
@@ -158,6 +128,30 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   normalised distribution name) and imports it, priming any requirement whose
   import raises. Absent metadata still short-circuits as missing with no import
   attempt, and the requirements-hash fast-path stamp is unchanged. ([#845])
+- Fresh `pip install` + Docker dispatch no longer crashes the transformers and
+  TensorRT-LLM engines inside their containers. The package bind-mount now
+  exposes only the `llenergymeasure` package (mounted at
+  `/llem-src/llenergymeasure`) instead of the package's parent directory. For a
+  wheel install that parent is the venv's entire `site-packages`, and because
+  the container entrypoint prepends `/llem-src` to `PYTHONPATH` (which precedes
+  the container's own site-packages on `sys.path`), every host third-party
+  package used to shadow the image's native copy - a host `pydantic_core` C
+  extension built for a different Python minor broke transformers, and a fresh
+  `huggingface-hub` broke TensorRT-LLM's version guard. Mounting the package
+  directory alone makes `/llem-src` contain nothing but `llenergymeasure`, so
+  host dependencies can no longer shadow container-native ones. One uniform
+  mount serves editable and wheel installs alike. ([#844])
+- `llem run -o/--output-dir` is now honored for fresh (non-resume) studies. The flag
+  was documented as "Output directory for results" but was silently a no-op on a fresh
+  run: `run_study` only consumed `output_dir` as the auto-detect-resume search base and
+  never threaded it into the results-dir resolution, so results always landed in the YAML
+  `output.results_dir` (default `./results`). Fresh runs now resolve the base with
+  precedence `-o` override > YAML `output.results_dir` > user config > `./results`, and the
+  preflight/dry-run panel's "Study results path" reflects the same precedence so the
+  preview matches where results actually land. Resume semantics are unchanged (`-o` stays
+  the search base for `--resume`). The results path is placement metadata, excluded from
+  the declared-config, study-design, and dedup hashes, so pointing a study at a different
+  output directory never changes dedup grouping. ([#842])
 - Experiment failures now surface their real cause. Under `-v`, a Docker container
   failure prints the traceback the container entrypoint captured (the actual
   engine/CUDA error), instead of the uninformative host-side traceback of the
@@ -225,7 +219,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   installed wheel. A preflight error is raised before `docker run` if a dispatch asset cannot
   be materialised, replacing the silent empty-directory mount. ([#830])
 
-## [v0.12.0] - 2026-07-17
+## [v0.5.1] - 2026-07-17
 
 ### Added
 
@@ -319,7 +313,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   in-process runs are unchanged. A docker run that completes without a rescued snapshot now
   logs a warning rather than silently recording host values. ([#821])
 
-## [v0.11.0] - 2026-07-16
+## [v0.5.0] - 2026-07-16
 
 ### Added
 
@@ -569,7 +563,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   tests (net -25k lines). The drift check drops the retired miner rows and keeps the live
   schema-producer path. ([#796])
 
-## [v0.10.0] - 2026-07-13
+## [v0.4.1] - 2026-07-13
 
 The engine-knowledge-as-data milestone. Hand-curated per-engine config was replaced by
 typed Pydantic configs code-generated from validation rules mined directly from engine
@@ -842,7 +836,7 @@ this line. Engine pins advanced to vLLM 0.19.1, TensorRT-LLM 1.0.0, and Transfor
   `parameter-discovery.yml`, and predecessors. ([#483], [#485])
 
 
-## [v0.9.0] - 2026-03-20
+## [v0.4.0] - 2026-03-20
 
 Docker infrastructure, vLLM engine, TensorRT-LLM engine, package restructure, test hardening, and CI.
 
@@ -879,7 +873,7 @@ Docker infrastructure, vLLM engine, TensorRT-LLM engine, package restructure, te
 - Dead code, stale type annotations, and unused dependencies. ([#130])
 
 
-## [v0.8.0] - 2026-02-27
+## [v0.3.0] - 2026-02-27
 
 Multi-experiment study sweeps.
 
@@ -893,7 +887,7 @@ Multi-experiment study sweeps.
 - Manifest-based progress tracking with resume support. ([#23])
 
 
-## [v0.7.0] - 2026-02-27
+## [v0.2.0] - 2026-02-27
 
 First end-to-end single-experiment release.
 
@@ -907,114 +901,33 @@ First end-to-end single-experiment release.
 - Results persistence in Parquet format. ([#22])
 
 
----
+## [v0.1.1] - 2025-12-29
 
-## Historical (pre-0.x)
+Post-thesis re-founding. One December development burst rebuilt the frozen thesis
+prototype into an installable, tested package.
 
-> The entries below predate the current 0.x versioning scheme introduced in early 2026.
-> They describe the research prototype and early CLI rewrites that were restructured and
-> re-versioned starting from v0.1.0. Version numbers v1.x and v2.0.0 referenced here are
-> legacy labels from that era; they do not correspond to any published release under the
-> current scheme. The 2026-03-04 history reset remapped these to sequential 0.x tags
-> (v0.1.0-v0.6.0) for consistency with the current versioning scheme.
+- Package renamed `llm-bench` -> `lem`; all imports moved to `llenergymeasure`.
+- Energy-backend plugin registry with automatic CodeCarbon registration; `FlopsEstimator`
+  with a three-strategy fallback chain (calflops, architecture, parameter estimate), each
+  returning a confidence level; results aggregation with temporal-overlap detection and
+  GPU-attribution verification; CSV/JSON export; structured logging replacing `print()`.
+- Typer-based CLI with `experiment`, `aggregate`, `config`, `results`, and `datasets`
+  subcommands; `ExperimentOrchestrator` with protocol-based dependency injection; the
+  earlier `MAIN_*.py` entry points removed.
+- A 416-test suite (unit, integration, and end-to-end) runnable without GPU access via
+  mocked data; `requirements.txt` retired in favour of the Poetry lockfile; methodology
+  documentation added.
+- Production containerisation: a multi-stage Dockerfile on a CUDA 12.4 base, Docker Compose
+  production and dev profiles, a VS Code devcontainer with GPU passthrough, and Makefile
+  targets for common Docker operations.
 
-### v0.6.0 (2025-12-29) - formerly v1.16.0
+## [v0.1.0] - 2025-05-17
 
-Production-ready containerisation with full GPU support and streamlined developer experience.
+Thesis research prototype complete: stable multi-model benchmarking on production
+hardware. The code was frozen at this point for the maintainer's thesis (submitted
+~2025-07).
 
-#### Added
-
-- Multi-stage Dockerfile with `nvidia/cuda:12.4.1-runtime-ubuntu22.04` base image (builder,
-  runtime, and dev stages).
-- Docker Compose profiles separating production and development workflows (`lem-app`, `lem-dev`).
-- VS Code devcontainer configuration with GPU passthrough and Ruff/Pylance extensions.
-- Makefile targets for common Docker operations (`make docker-build`, `make experiment`,
-  `make datasets`).
-
-#### Changed
-
-- CI workflow reliability improved with concurrency groups preventing parallel releases.
-- Dev container runs as root, eliminating permission complexity with virtual environments.
-
-#### Fixed
-
-- Docker CUDA 12.4 base image aligned with host driver requirements.
-- Volume permission errors resolved by running dev containers as root.
-- Deprecated `torch_dtype` parameter replaced with `dtype` in model loading.
-- Removed obsolete `TRANSFORMERS_CACHE` environment variable (superseded by `HF_HOME`).
-- CodeCarbon pandas `FutureWarning` suppressed.
-- `nvidia-smi` GPU utilisation parsing handles `[N/A]` values gracefully.
-
----
-
-### v0.5.0 (2025-12-21) - formerly v1.15.0
-
-Comprehensive test coverage ensuring reliability across all components.
-
-#### Added
-
-- End-to-end CLI tests (8 tests) validating complete benchmark workflows.
-- Integration tests (47 tests) covering non-GPU workflows.
-- Methodology documentation (`docs/methodology.md`) explaining measurement approach.
-
-#### Changed
-
-- Total test count: 416 passing tests (unit + integration + e2e).
-- All tests run without GPU access using mocked/simulated data.
-
-#### Removed
-
-- `requirements.txt` (306 frozen packages) - all dependencies now managed via Poetry lockfile.
-
----
-
-### v0.4.0 (2025-12-21) - formerly v1.13.0
-
-User-friendly command-line interface replacing legacy entry points.
-
-#### Added
-
-- Typer-based CLI (`lem`) with subcommands: `experiment`, `aggregate`, `config validate`,
-  `config show`, `results list`, `results show`, `datasets`.
-- `ExperimentOrchestrator` with protocol-based dependency injection.
-- `ExperimentContext` dataclass for runtime state management.
-- Accelerate launcher with configurable retry logic.
-- 25 CLI tests and 27 orchestration unit tests.
-
-#### Removed
-
-- Legacy `MAIN_*.py` entry points (6 files).
-
----
-
-### v0.3.0 (2025-12-20) - formerly v1.10.0
-
-Major architectural refactor establishing clean module boundaries.
-
-#### Breaking Changes
-
-- Package renamed: `llm-bench` to `lem`. All imports now use `llenergymeasure`.
-
-#### Added
-
-- Energy backend plugin registry with automatic CodeCarbon registration.
-- `FlopsEstimator` with three-strategy fallback chain (calflops, architecture, parameter
-  estimate), each returning a confidence level.
-- Results aggregation with temporal overlap detection and GPU attribution verification.
-- Export functionality for CSV and JSON formats.
-- 296 unit tests covering all new modules.
-
-#### Changed
-
-- Replaced `print()` statements with Loguru structured logging.
-
----
-
-### v0.2.0 (2025-05-17) - formerly v1.0.0
-
-Research phase complete - stable multi-model benchmarking validated on production hardware.
-
-#### Added
+### Added
 
 - Multi-model experiment support with scenario-based configuration.
 - Experiment suite CSV export with consistent naming conventions.
@@ -1025,33 +938,34 @@ Research phase complete - stable multi-model benchmarking validated on productio
 - Plotting functionality for efficiency metrics visualisation.
 - FLOPs caching preventing redundant calculations.
 
----
+## [v0.0.1] - 2025-03-22
 
-### v0.1.0 (2025-03-22) - formerly v0.5.0
+Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-benchmark).
 
-Core measurement functionality establishing the foundation for all subsequent development.
-
-#### Added
+### Added
 
 - Distributed results aggregation across multiple GPUs with per-process JSON files.
 - FLOPs calculation with quantisation awareness and `calflops` integration.
 - Robust process cleanup with signal handlers and distributed barrier synchronisation.
 - Optimum benchmark integration for standardised measurements.
 
-#### Changed
+### Changed
 
 - Distributed execution stability improved: proper NCCL initialisation and teardown.
 - Major directory restructuring separating config, core, and result handling.
 
 
-[Unreleased]: https://github.com/henrycgbaker/llenergymeasure/compare/v0.13.0...HEAD
-[v0.13.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.13.0
-[v0.12.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.12.0
-[v0.11.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.11.0
-[v0.10.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.10.0
-[v0.9.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.9.0
-[v0.8.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.8.0
-[v0.7.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.7.0
+[Unreleased]: https://github.com/henrycgbaker/llenergymeasure/compare/v0.6.0...HEAD
+[v0.6.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.6.0
+[v0.5.1]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.5.1
+[v0.5.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.5.0
+[v0.4.1]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.4.1
+[v0.4.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.4.0
+[v0.3.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.3.0
+[v0.2.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.2.0
+[v0.1.1]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.1.1
+[v0.1.0]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.1.0
+[v0.0.1]: https://github.com/henrycgbaker/llenergymeasure/releases/tag/v0.0.1
 
 [#22]: https://github.com/henrycgbaker/llenergymeasure/pull/22
 [#23]: https://github.com/henrycgbaker/llenergymeasure/pull/23

--- a/docs/contributing/citation.md
+++ b/docs/contributing/citation.md
@@ -15,7 +15,7 @@ If you use LLenergyMeasure in research, please cite it as:
   title     = {{LLenergyMeasure}: Measure how implementation choices drive
                 LLM inference efficiency},
   year      = {2026},
-  version   = {0.11.0},
+  version   = {0.6.0},
   url       = {https://github.com/henrycgbaker/llenergymeasure},
   note      = {Pre-1.0 release. See GitHub releases for the current version.
                 Multi-engine, methodology-first measurement framework for
@@ -26,7 +26,7 @@ If you use LLenergyMeasure in research, please cite it as:
 For a plain-text reference:
 
 > Baker, H. C. G. (2026). *LLenergyMeasure: Measure how implementation choices
-> drive LLM inference efficiency* (v0.11.0).
+> drive LLM inference efficiency* (v0.6.0).
 > https://github.com/henrycgbaker/llenergymeasure
 
 ---

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -30,8 +30,8 @@ Two files hold the version and must stay in sync:
 
 | File | Field | Example |
 |------|-------|---------|
-| `pyproject.toml` | `[project] version = "..."` | `version = "0.11.0"` |
-| `src/llenergymeasure/_version.py` | `__version__ = "..."` | `__version__ = "0.11.0"` |
+| `pyproject.toml` | `[project] version = "..."` | `version = "0.6.0"` |
+| `src/llenergymeasure/_version.py` | `__version__ = "..."` | `__version__ = "0.6.0"` |
 
 A mismatch between these two files is a bug. The build system reads
 `pyproject.toml`; the runtime API (`llem --version`, `llenergymeasure.__version__`)
@@ -49,7 +49,7 @@ re-exported from `__init__.py`.
    ```toml
    [project]
    name = "llenergymeasure"
-   version = "0.12.0"
+   version = "0.6.0"
    ```
 
 2. **Bump the version in `_version.py`**
@@ -57,7 +57,7 @@ re-exported from `__init__.py`.
    Update `__version__` in `src/llenergymeasure/_version.py`:
 
    ```python
-   __version__ = "0.12.0"
+   __version__ = "0.6.0"
    ```
 
    Both files must show the same version string.
@@ -73,7 +73,7 @@ re-exported from `__init__.py`.
    Commit the three changed files with the message:
 
    ```
-   chore: release 0.12.0
+   chore: release 0.6.0
    ```
 
    This commit goes directly to `main` via the normal PR flow.
@@ -81,8 +81,8 @@ re-exported from `__init__.py`.
 5. **Create and push the git tag**
 
    ```bash
-   git tag v0.12.0
-   git push origin v0.12.0
+   git tag v0.6.0
+   git push origin v0.6.0
    ```
 
    The tag must use the `v` prefix and match the version string exactly.

--- a/docs/contributing/roadmap.md
+++ b/docs/contributing/roadmap.md
@@ -11,17 +11,18 @@ Released milestones:
 
 | Version | What shipped |
 |---------|-------------|
-| v0.7.0 | Core single-experiment: CLI, config system, Transformers engine, energy measurement, results schema |
-| v0.8.0 | Study/sweep: multi-experiment grid sweeps, manifest writer, deduplication, subprocess isolation |
-| v0.9.0 | Docker + vLLM: containerised engine architecture, vLLM engine, Docker CI, logging overhaul |
-| v0.10.0 | Engine-knowledge-as-data: each engine's config, schema, and validation rules are generated from version-pinned upstream snapshots rather than hand-curated; terminology renames; study-authoring improvements |
-| v0.11.0 | TensorRT-LLM activated as a measured third engine (both the PyTorch and compiled-TRT backends), with in-framework build caching and GPU hardware preflight |
+| v0.2.0 | Core single-experiment: CLI, config system, Transformers engine, energy measurement, results schema |
+| v0.3.0 | Study/sweep: multi-experiment grid sweeps, manifest writer, deduplication, subprocess isolation |
+| v0.4.0 | Docker + vLLM: containerised engine architecture, vLLM engine, Docker CI, logging overhaul |
+| v0.4.1 | Engine-knowledge-as-data: each engine's config, schema, and validation rules are generated from version-pinned upstream snapshots rather than hand-curated; terminology renames; study-authoring improvements |
+| v0.5.0 | TensorRT-LLM activated as a measured third engine (both the PyTorch and compiled-TRT backends), with in-framework build caching and GPU hardware preflight |
+| v0.5.1 | Results correctness: a single coherent per-experiment results bundle, schema consolidation, and provenance sidecars |
+| v0.6.0 | Public packaging: first PyPI release, pip-install Docker dispatch, a lean CLI surface, and cloud-VM documentation |
 
-The current focus is results-correctness hardening: a single coherent
-per-experiment results bundle and verified field population. An internal
-refactor-and-tidy pass follows, ahead of the stable 1.0.0 release. Run
-`llem --version` against your installed package for the authoritative current
-version.
+The current milestone is public packaging: the first PyPI release, pip-install
+Docker dispatch, and a lean CLI surface. An internal refactor-and-tidy pass
+follows, ahead of the stable 1.0.0 release. Run `llem --version` against your
+installed package for the authoritative current version.
 
 Pre-1.0 disclaimer: the tool is research-grade for single-machine use. It is
 not yet at the stability and API-stability bar of a 1.0 release.
@@ -73,7 +74,7 @@ without a deprecation notice:
   a config path plus session flags (`--output`, `--resume`, `--dry-run`);
   experiment parameters live in the YAML config, not in flags.
 
-Pre-1.0 disclaimer: minor-version bumps (0.10 to 0.11 etc.) may include
+Pre-1.0 disclaimer: minor-version bumps (0.5 to 0.6 etc.) may include
 breaking changes to internal APIs, engine plugin interfaces, and sampler
 backends. Changes that break the stable contracts above will be called out
 explicitly in the changelog.

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -331,7 +331,7 @@ Runners
   vllm              docker
     ↳ llenergymeasure:vllm                              ← local build
   transformers      docker
-    ↳ ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.12.0  ← registry
+    ↳ ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.6.0  ← registry
 ```
 
 ### Study-level image preparation
@@ -353,7 +353,7 @@ make docker-pull
 # Or pull each engine's default image individually. transformers is a
 # first-party GHCR image tagged with the llenergymeasure version; vLLM and
 # TensorRT-LLM are upstream images tagged with the pinned engine version.
-docker pull ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.12.0
+docker pull ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.6.0
 docker pull vllm/vllm-openai:v0.19.1
 docker pull nvcr.io/nvidia/tensorrt-llm/release:1.2.1
 ```
@@ -375,7 +375,7 @@ Output shows local vs registry source for each engine:
 ```
 === Image resolution ===
   tensorrt   -> nvcr.io/nvidia/tensorrt-llm/release:1.2.1  (registry)
-  transformers -> ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.12.0  (registry)
+  transformers -> ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.6.0  (registry)
   vllm       -> vllm/vllm-openai:v0.19.1  (registry)
 ```
 

--- a/docs/how-to/faq.md
+++ b/docs/how-to/faq.md
@@ -116,7 +116,7 @@ Tensor parallel is supported via engine-native fields (`tensorrt.engine_params.t
 
 ### How do I cite `llem` in a paper?
 
-Until a formal release citation is published, cite the GitHub repository: `https://github.com/henrycgbaker/llenergymeasure` plus the version (`llem --version` or pin `llenergymeasure==0.12.0` in your reproducibility appendix). The full effective configuration is in every experiment's `config.json` sidecar (`declared_config` plus provenance) - share that file for full reproducibility.
+Until a formal release citation is published, cite the GitHub repository: `https://github.com/henrycgbaker/llenergymeasure` plus the version (`llem --version` or pin `llenergymeasure==0.6.0` in your reproducibility appendix). The full effective configuration is in every experiment's `config.json` sidecar (`declared_config` plus provenance) - share that file for full reproducibility.
 
 ### What should I include in a paper for measurement reproducibility?
 

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -83,7 +83,7 @@ images locally.
 Expected output:
 
 ```
-llem v0.12.0
+llem v0.6.0
 ```
 
 ---
@@ -185,7 +185,7 @@ vLLM and TensorRT-LLM are pulled from upstream images (`vllm/vllm-openai`,
 `nvcr.io/nvidia/tensorrt-llm/release`) and need no project-side cache.
 
 Example build times on a reference host (AMD EPYC 7742-class, 128 cores, 504 GB
-RAM - Docker 27.0.3 / Buildx v0.32.1 / llenergymeasure 0.12.0):
+RAM - Docker 27.0.3 / Buildx v0.32.1 / llenergymeasure 0.6.0):
 
 | Engine | Image size | Cold build | First GHCR pull | Warm local rebuild |
 |--------|-----------|------------|-----------------|--------------------|

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -143,10 +143,10 @@ bind-mount host source at run time, so they always see the current schema.
 **Fix:** Rebuild the Transformers image from the current source:
 
 ```bash
-docker build -f docker/Dockerfile.transformers -t ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.12.0 .
+docker build -f docker/Dockerfile.transformers -t ghcr.io/henrycgbaker/llenergymeasure/transformers:v0.6.0 .
 ```
 
-Replace `v0.12.0` with your installed version (`llem --version`). See
+Replace `v0.6.0` with your installed version (`llem --version`). See
 [Installation - Getting Engine Images](/how-to/install#getting-engine-images)
 for full instructions.
 
@@ -340,8 +340,8 @@ tag-copy completes in seconds.
 like:
 
 ```
-Docker image 'llenergymeasure:transformers' was built from llenergymeasure 0.12.0
-(schema 9988776655ff) but the host is running 0.12.0 (schema a1b2c3d4e5f6).
+Docker image 'llenergymeasure:transformers' was built from llenergymeasure 0.6.0
+(schema 9988776655ff) but the host is running 0.6.0 (schema a1b2c3d4e5f6).
 The container will reject ExperimentConfig fields added on the host after
 the image was built.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llenergymeasure"
-version = "0.13.0"
+version = "0.6.0"
 description = "LLenergyMeasure - LLM inference efficiency measurement framework"
 authors = [
     {name = "henrycgbaker", email = "henry.c.g.baker@gmail.com"},

--- a/src/llenergymeasure/_version.py
+++ b/src/llenergymeasure/_version.py
@@ -5,4 +5,4 @@ by modules at every layer to avoid pulling in the full __init__.py
 import chain.
 """
 
-__version__: str = "0.13.0"
+__version__: str = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "llenergymeasure"
-version = "0.13.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

Ahead of the first PyPI publish, the project adopts a single canonical version history in place of the two partial numbering eras that had accreted (an early v1.x/v2.x prototype era remapped onto v0.1.0-v0.6.0, plus the later v0.7.0-v0.13.0 iteration ledger). The numbering had run well ahead of honest maturity: the package only became stranger-installable this milestone. Under the canonical scheme a minor bump means "a new thing a user can do" and a patch means "the same things re-founded or done more correctly", with the frozen thesis prototype anchored as the true v0.1.0 origin. The net effect is that today's unreleased state releases as `0.6.0`. This PR carries the version files, a full CHANGELOG rewrite, and a docs sweep; it does not touch `src/` beyond `_version.py`.

## Canonical remap table

| Canonical | Old anchor | Date kept | Capability story |
|---|---|---|---|
| v0.0.1 | old v0.1.0 | 2025-03-22 | Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-benchmark) |
| v0.1.0 | old v0.2.0 | 2025-05-17 | Thesis research prototype complete: stable multi-model benchmarking on production hardware; code frozen for thesis |
| v0.1.1 | old v0.3.0-v0.6.0 | 2025-12-29 | Post-thesis re-founding: rename to llenergymeasure, energy-backend plugin registry, Typer CLI, 416-test suite, containerisation (collapses one December burst) |
| v0.2.0 | old v0.7.0 | 2026-02-27 | Core single-experiment: config system, transformers engine, energy measurement, results schema, CLI |
| v0.3.0 | old v0.8.0 | 2026-02-27 | Multi-experiment studies: sweep grammar, manifest, resume |
| v0.4.0 | old v0.9.0 | 2026-03-20 | Containerised multi-engine: Docker lifecycle, vLLM activated, GHCR publishing |
| v0.4.1 | old v0.10.0 | 2026-07-13 | Engine-knowledge re-founding: mined/codegen configs, renames, doctor, docs site |
| v0.5.0 | old v0.11.0 | 2026-07-16 | Third engine measured: TensorRT-LLM, both backends, build cache, hardware gates |
| v0.5.1 | old v0.12.0 | 2026-07-17 | Results correctness: bundle consolidation, schema 5.0, provenance sidecars |
| v0.6.0 | unreleased 0.13.0 + in-flight fixes | tag day | Public packaging: PyPI debut, pip-install dispatch, lean CLI surface, cloud-VM docs |

The previously-untagged `0.13.0` CHANGELOG section and the in-flight dispatch-isolation fixes (#842, #843, #844, #845) are folded into the `v0.6.0` section, since they are part of that still-untagged release. A fresh empty `[Unreleased]` sits above it.

## What changed

- `pyproject.toml` + `src/llenergymeasure/_version.py`: `0.13.0` -> `0.6.0`; `uv.lock` regenerated (one-line version change).
- `CHANGELOG.md`: full canonical rewrite. Historical sections renumbered per the table with original dates preserved; the "formerly vX.Y.Z" annotations and the pre-0.x preamble erased; link definitions rebuilt (`[Unreleased]` compares `v0.6.0...HEAD`; one release-tag link per canonical version); all PR citation links kept.
- Docs sweep to canonical numbers: roadmap milestone table and "where we are" prose; citation BibTeX and inline reference; example outputs and image tags in the how-to guides (install, FAQ, troubleshoot, docker-setup) and the release-process walkthrough.

## Test plan

- `make lint` (ruff check, ruff format check, import-linter 5/5 contracts) - pass.
- `make typecheck` (mypy, 312 source files) - pass.
- ci.yml version-sync logic: `pyproject.toml` == `_version.py` == `0.6.0` - holds.
- CHANGELOG link-resolution check: every `[#N]` citation resolves to a link def (206 distinct); every `[vX.Y.Z]` section has a matching link def; headers strictly descending canonical order; no duplicate sections.
- Grep sweeps confirm zero remaining old-version strings in `docs/` and no "formerly"/"legacy" strings in the changelog or docs.

## Follow-up (not in this PR)

The tag, GitHub Release, and container-registry renaming is a separate operational ceremony performed after this merge: deleting the old `v0.1.0`-`v0.12.0` tags/Releases and the old GHCR image tags, pushing the canonical historical tags with notes-only Releases, and cutting `v0.6.0` through the release pipeline (which creates `transformers:v0.6.0` and the first PyPI publish). This PR is the in-repo half only.
