### PR TITLE
fix(cli): clarify -o/--output dual role for fresh vs resume runs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,7 +26,7 @@ Run an LLM efficiency experiment
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--output` | `-o` | str |  | Output directory for results |
+| `--output` | `-o` | str |  | Results directory for a fresh run; with --resume, the base directory searched for the study to resume |
 | `--dry-run` |  | flag | `false` | Validate config and estimate VRAM without running |
 | `--quiet` | `-q` | flag | `false` | Suppress progress bars |
 | `--verbose` | `-v` | int | `0` | Increase verbosity (-v=INFO, -vv=DEBUG) |

--- a/src/llenergymeasure/cli/run.py
+++ b/src/llenergymeasure/cli/run.py
@@ -51,7 +51,11 @@ def run(
     ] = None,
     output: Annotated[
         str | None,
-        typer.Option("--output", "-o", help="Output directory for results"),
+        typer.Option(
+            "--output",
+            "-o",
+            help="Results directory for a fresh run; with --resume, the base directory searched for the study to resume",
+        ),
     ] = None,
     dry_run: Annotated[
         bool,


### PR DESCRIPTION
## Summary

Post-F5 CLI-surface docs sweep. One correctness fix landed; the other planned
fix was already resolved upstream.

- **`-o/--output` help string was half-true.** PR #842 gave `output_dir` dual
  semantics - a results-dir override for a fresh run, and the base directory
  searched for a study to resume when `--resume` is given - but the Typer help
  string still read only "Output directory for results". Updated it to honestly
  cover both meanings, and regenerated `docs/reference/cli.md` from the new
  string (the file is auto-generated by `scripts/generate_cli_reference.py`).

  New help text: `Results directory for a fresh run; with --resume, the base
  directory searched for the study to resume`

- **`llem config` reference: nothing to fix.** The planned second fix targeted a
  stale `llem config` reference at line ~13 of the generated Python API doc
  (`docs/reference/api/llenergymeasure.md`, a build-time gitignored artefact
  sourced from the disclaimer in `scripts/generate_api_docs.py`). PR #834
  already swapped that line from `(llem run, llem config)` to
  `(llem run, llem doctor)` when it removed the command. A full sweep of the
  committed tree finds no remaining `llem config` references except the CHANGELOG
  entry documenting the removal, which is correct historical record and left
  untouched.

## Test plan

- `make lint` - clean (ruff check, ruff format --check, import-linter 5/5 kept)
- `make typecheck` - clean (mypy, 312 source files)
- `make docs-check` - up to date (regenerated SSOT docs match committed copies)
- `uv run llem run --help` - renders the new dual-meaning `-o/--output` line
