### PR TITLE
fix(tests): kill randomized-order flake in docker rescue tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+### Fixed
+
+- Docker-runner rescue tests (`TestConfigSidecarRescue`, `TestTimeseriesParquetRescue`)
+  no longer flake under randomized test ordering: the `tempfile.mkdtemp` mock now routes
+  by prefix instead of assuming a fixed call count, so the process-cached dispatch-asset
+  materialisation can no longer steal the rescue tempdir slot.
+
 ## [v0.6.0] - 2026-07-18
 
 ### Added

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +19,8 @@ from llenergymeasure.config.ssot import (
     ENV_HF_TOKEN,
     ENV_OUTPUT_DIR,
     ENV_SAVE_TIMESERIES,
+    TEMP_PREFIX_EXCHANGE,
+    TEMP_PREFIX_TIMESERIES,
     Engine,
 )
 from llenergymeasure.infra.docker_errors import (
@@ -62,6 +65,36 @@ def _subprocess_run_with_image_cached(*run_results: MagicMock):
         [make_subprocess_result(0), *run_results]
     )  # image inspect → 0, then user results
     return lambda *a, **k: next(results)
+
+
+# The real mkdtemp, captured before any test patches it, so the router can
+# materialise the dispatch-asset dir on a real filesystem path.
+_REAL_MKDTEMP = tempfile.mkdtemp
+
+
+def _mkdtemp_router(exchange_dir: Path, rescue_dir: Path):
+    """Return a prefix-aware ``tempfile.mkdtemp`` side_effect for the rescue tests.
+
+    ``DockerRunner.run`` calls ``tempfile.mkdtemp`` with distinct prefixes: the
+    exchange dir (``TEMP_PREFIX_EXCHANGE``), the artefact rescue dir
+    (``TEMP_PREFIX_TIMESERIES``), and - only when the process-lifetime
+    dispatch-asset cache (``_materialise_dispatch_assets``) is cold - the
+    dispatch-asset dir. Routing by prefix rather than call order makes these
+    tests independent of whether an earlier test already warmed that cache; a
+    positional ``iter([exchange, rescue])`` flaked whenever the cold-cache path
+    stole the rescue slot and the rescue call then raised ``StopIteration``.
+    """
+
+    def _route(*, prefix: str = "", **_kw) -> str:
+        if prefix == TEMP_PREFIX_TIMESERIES:
+            return str(rescue_dir)
+        if prefix == TEMP_PREFIX_EXCHANGE:
+            return str(exchange_dir)
+        # Dispatch-asset dir (cold cache): a real tempdir so the entrypoint
+        # script and requirements file can actually be written to it.
+        return _REAL_MKDTEMP(prefix=prefix)
+
+    return _route
 
 
 # ---------------------------------------------------------------------------
@@ -1111,13 +1144,10 @@ class TestTimeseriesParquetRescue:
         rescue_dir = tmp_path / "llem-ts-rescued"
         rescue_dir.mkdir()
 
-        # tempfile.mkdtemp is called twice: once for exchange dir, once for rescue dir
-        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
-
         with (
             patch(
                 "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
-                side_effect=lambda **kw: next(mkdtemp_returns),
+                side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
@@ -1807,14 +1837,10 @@ class TestConfigSidecarRescue:
         rescue_dir = tmp_path / "llem-cfg-rescued"
         rescue_dir.mkdir()
 
-        # mkdtemp: 1st = exchange dir, 2nd = artefact rescue dir (created lazily
-        # when the first artefact - config.json - is found).
-        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
-
         with (
             patch(
                 "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
-                side_effect=lambda **kw: next(mkdtemp_returns),
+                side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
@@ -1852,12 +1878,10 @@ class TestConfigSidecarRescue:
         rescue_dir = tmp_path / "llem-both-rescued"
         rescue_dir.mkdir()
 
-        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
-
         with (
             patch(
                 "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
-                side_effect=lambda **kw: next(mkdtemp_returns),
+                side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
@@ -1896,12 +1920,10 @@ class TestConfigSidecarRescue:
         rescue_dir = tmp_path / "llem-env-rescued"
         rescue_dir.mkdir()
 
-        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
-
         with (
             patch(
                 "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
-                side_effect=lambda **kw: next(mkdtemp_returns),
+                side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",
@@ -1954,12 +1976,10 @@ class TestConfigSidecarRescue:
         study_dir = tmp_path / "study"
         study_dir.mkdir()
 
-        mkdtemp_returns = iter([str(exchange_dir), str(rescue_dir)])
-
         with (
             patch(
                 "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
-                side_effect=lambda **kw: next(mkdtemp_returns),
+                side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
                 "llenergymeasure.infra.docker_runner.subprocess.run",


### PR DESCRIPTION
## Summary

The docker-runner rescue tests flaked under randomized test ordering (`pytest-randomly`).

- **What was flaky:** `TestConfigSidecarRescue` (all 4 tests) and `TestTimeseriesParquetRescue::test_parquet_rescued_to_temp_dir`. Each mocked `tempfile.mkdtemp` with a positional `iter([exchange_dir, rescue_dir])`, assuming exactly two `mkdtemp` calls in a fixed order.
- **Root cause:** `DockerRunner.run` also materialises the dispatch assets via the `functools.cache`d `_materialise_dispatch_assets()`, which calls `tempfile.mkdtemp` a *third* time whenever that process-lifetime cache is cold. When a rescue test ran before any test that warmed the cache (e.g. the class run in isolation, or a random order that put it first), the cold-cache dispatch call consumed the `rescue_dir` slot and the subsequent rescue `mkdtemp` raised `StopIteration`. Whether the cache was warm was pure test-ordering luck, hence the flake.
- **Fix:** Replace the positional iterator with a prefix-aware `_mkdtemp_router(exchange_dir, rescue_dir)` side_effect. It routes `TEMP_PREFIX_EXCHANGE` -> exchange dir, `TEMP_PREFIX_TIMESERIES` -> rescue dir, and delegates any other prefix (the dispatch-asset dir) to the real `mkdtemp`. The tests no longer depend on call count, cache warmth, or execution order. No product code changed; the `functools.cache` is a legitimate optimisation.

Files touched:
- `tests/unit/docker/test_docker_runner.py` - add `_mkdtemp_router` helper + `_REAL_MKDTEMP`; wire it into all 5 rescue-test call sites; drop the now-stale ordering comments.
- `CHANGELOG.md` - one line under `[Unreleased]` / Fixed.

## Test plan

- Reproduced the flake pre-fix: running either class in isolation (cold cache) fails with `StopIteration` at the rescue `mkdtemp`.
- Post-fix, `TestConfigSidecarRescue` passes **30/30** consecutive runs with varying `--randomly-seed` values.
- Full `tests/unit/docker/test_docker_runner.py` passes **10/10** under 10 distinct random seeds (96 tests each).
- `make lint` (ruff check + format --check + import-linter contracts) passes.
- `make typecheck` (mypy, 312 source files) passes.