### PR TITLE
feat(ci): guard against half-absorbed engine version bumps

### DIFF
--- a/.github/workflows/engine-rules-check.yml
+++ b/.github/workflows/engine-rules-check.yml
@@ -77,6 +77,7 @@ jobs:
               - 'engine_versions/*/*/outputs/schema.discovered.json'
               - 'scripts/engine_producers/**'
               - 'scripts/rules_coverage.py'
+              - 'scripts/ci/check_absorbed_bump.py'
               - 'pyproject.toml'
               - 'uv.lock'
               - '.github/workflows/engine-rules-check.yml'
@@ -264,6 +265,43 @@ jobs:
             exit 1
           fi
 
+  absorbed-bump-check:
+    # Gating: a PR that advances an engine pin
+    # (engine_versions/<engine>/current.yaml) must also ship the regenerated
+    # knowledge `make absorb` produces - the versioned snapshot outputs AND the
+    # packaged src copies (config.py / rules.yaml / schema.discovered.json). A
+    # bare pin bump (the Renovate regex-manager shape: it edits current_version
+    # and nothing else) would otherwise merge a config typed against the old
+    # engine surface. Runs only when engine-filter saw an engine-knowledge
+    # change; on non-engine PRs it skips and the fan-in counts it satisfied.
+    needs: engine-filter
+    if: >-
+      always()
+      && (
+        github.event_name == 'workflow_dispatch'
+        || needs.engine-filter.outputs.engine == 'true'
+      )
+    runs-on: ubuntu-latest
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          # Full history so the merge-base against the PR base resolves: the
+          # check diffs BASE_SHA...HEAD to read exactly this PR's changed files.
+          fetch-depth: 0
+      - name: Verify version bumps ship absorbed knowledge
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA}" ]; then
+            echo "No pull_request base (workflow_dispatch run); no diff to check."
+            exit 0
+          fi
+          git fetch --no-tags origin "${BASE_SHA}"
+          git diff --name-only "${BASE_SHA}...HEAD" \
+            | python3 scripts/ci/check_absorbed_bump.py
+
   engine-rules-gate:
     # Branch protection requires this single context instead of the per-engine
     # matrix names. When a matrix job is skipped at job level, GitHub reports
@@ -272,7 +310,7 @@ jobs:
     # the merge waits forever on "Expected". This job is matrix-free and runs
     # on every PR, so it always reports; it fails iff a gating job failed
     # (skipped gating jobs on non-engine PRs pass).
-    needs: [config-codegen, seed-image-check]
+    needs: [config-codegen, seed-image-check, absorbed-bump-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -280,10 +318,12 @@ jobs:
         env:
           CODEGEN: ${{ needs.config-codegen.result }}
           SEED: ${{ needs.seed-image-check.result }}
+          ABSORB: ${{ needs.absorbed-bump-check.result }}
         run: |
           echo "config-codegen: ${CODEGEN}"
           echo "seed-image-check: ${SEED}"
-          for result in "${CODEGEN}" "${SEED}"; do
+          echo "absorbed-bump-check: ${ABSORB}"
+          for result in "${CODEGEN}" "${SEED}" "${ABSORB}"; do
             case "${result}" in
               success|skipped) ;;
               *) exit 1 ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   schema.discovered.json) - so a pin bump can never merge with a config typed
   against the old engine surface. The guard is a pure path check
   (`scripts/ci/check_absorbed_bump.py`) wired into `engine-rules-check.yml`.
+  ([#849])
 
 ## [v0.6.0] - 2026-07-18
 
@@ -1186,3 +1187,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#843]: https://github.com/henrycgbaker/llenergymeasure/pull/843
 [#844]: https://github.com/henrycgbaker/llenergymeasure/pull/844
 [#845]: https://github.com/henrycgbaker/llenergymeasure/pull/845
+[#849]: https://github.com/henrycgbaker/llenergymeasure/pull/849

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+### Added
+
+- CI now fails a bare engine version-pin bump. A PR that advances
+  `engine_versions/<engine>/current.yaml` must also ship the regenerated
+  knowledge `make absorb` produces - the versioned snapshot outputs under
+  `engine_versions/<engine>/<version>/outputs/` and the packaged
+  `src/llenergymeasure/engines/<engine>/` copies (config.py / rules.yaml /
+  schema.discovered.json) - so a pin bump can never merge with a config typed
+  against the old engine surface. The guard is a pure path check
+  (`scripts/ci/check_absorbed_bump.py`) wired into `engine-rules-check.yml`.
+
 ## [v0.6.0] - 2026-07-18
 
 ### Added

--- a/docs/explanation/architecture/ci-architecture.md
+++ b/docs/explanation/architecture/ci-architecture.md
@@ -49,13 +49,16 @@ flowchart TB
         rc_trt[tensorrt]
     end
     sic[seed-image-check - gating]
+    abc[absorbed-bump-check - gating]
     gate[engine-rules-gate - fan-in, always runs]
 
     ef --> config-codegen
     ef --> rules-coverage
     ef --> sic
+    ef --> abc
     config-codegen --> gate
     sic --> gate
+    abc --> gate
 ```
 
 `engine-filter` runs on every PR and decides whether the work jobs do anything
@@ -94,11 +97,22 @@ requires; `rules-coverage` feeds nothing downstream because it is advisory.
   GHCR seed for the current pin already exists, so a bump PR that forgot to seed
   fails at PR time rather than at merge-time promotion.
 
+- **`absorbed-bump-check`** (gating): fails a PR that advances an engine pin
+  (`engine_versions/<engine>/current.yaml`) without shipping the regenerated
+  knowledge `make absorb` produces - the versioned snapshot outputs
+  (`engine_versions/<engine>/<version>/outputs/`) AND the packaged src copies
+  (`src/llenergymeasure/engines/<engine>/` config.py / rules.yaml /
+  schema.discovered.json). A bare pin bump (the Renovate regex-manager shape,
+  which edits `current_version` and nothing else) would otherwise merge a
+  config typed against the old engine surface. The check
+  (`scripts/ci/check_absorbed_bump.py`) is a pure path comparison over the PR's
+  changed files and needs no engine source or install.
+
 - **`engine-rules-gate`** (fan-in, always runs, matrix-free): depends on
-  `config-codegen` and `seed-image-check` and fails iff a gating job failed
-  (skipped gating jobs count as satisfied). This is the only context from this
-  workflow branch protection requires - see below for why the matrix job names
-  cannot be required directly.
+  `config-codegen`, `seed-image-check`, and `absorbed-bump-check` and fails iff
+  a gating job failed (skipped gating jobs count as satisfied). This is the only
+  context from this workflow branch protection requires - see below for why the
+  matrix job names cannot be required directly.
 
 `transformers` is absent from `rules-coverage` on purpose: its config
 validation uses imperative post-init idioms that the validator-site model does
@@ -289,10 +303,10 @@ its `engine-filter`, `engine-rules-gate`, and - on `transformers` engines -
 
 | PR shape | `engine-filter.engine` | Work jobs that run |
 |---|---|---|
-| **Workflow-only edit** (`engine-rules-check.yml` changed) | `true` (self-test) | Both matrices, seed check, gate |
-| **Pin bump** (`engine_versions/<engine>/current.yaml`) | `true` | Both matrices, seed check, gate |
-| **Config or snapshot change** (`engines/<engine>/config.py`, or an `outputs/` snapshot) | `true` | Both matrices, seed check, gate |
-| **Rules edit** (`engines/<engine>/rules.yaml`) or loader change | `true` | Both matrices, seed check, gate |
+| **Workflow-only edit** (`engine-rules-check.yml` changed) | `true` (self-test) | Both matrices, seed check, absorbed-bump-check, gate |
+| **Pin bump** (`engine_versions/<engine>/current.yaml`) | `true` | Both matrices, seed check, absorbed-bump-check, gate |
+| **Config or snapshot change** (`engines/<engine>/config.py`, or an `outputs/` snapshot) | `true` | Both matrices, seed check, absorbed-bump-check, gate |
+| **Rules edit** (`engines/<engine>/rules.yaml`) or loader change | `true` | Both matrices, seed check, absorbed-bump-check, gate |
 | **Pure ci.yml / docs change** | `false` | Work jobs **skip**; `engine-filter` and `engine-rules-gate` still report (green) |
 
 The load-bearing observation is that the last shape does not omit the workflow:

--- a/scripts/ci/check_absorbed_bump.py
+++ b/scripts/ci/check_absorbed_bump.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Guard against a bare engine version-pin bump merging without absorption.
+
+Advancing an engine pin (``engine_versions/<engine>/current.yaml``) is only the
+first line of a bump. The pipeline (``make absorb ENGINE=<engine> SRC=...``)
+also regenerates the knowledge products the new pin implies:
+
+- the versioned snapshot under ``engine_versions/<engine>/<version>/outputs/``
+  (the mined ``schema.discovered.json`` + ``curated.yaml``), and
+- the packaged engine copies under ``src/llenergymeasure/engines/<engine>/``
+  (the generated ``config.py``, the ``rules.yaml`` corpus, and the promoted
+  ``schema.discovered.json``).
+
+A PR that moves only the pin has skipped ``make absorb``: it would ship a typed
+config validated against the OLD engine surface while claiming the new version.
+Renovate's regex manager emits exactly this shape (it edits ``current_version``
+in place and nothing else), so a bare bump must fail at PR time.
+
+This is a pure path check. It reads the PR's changed-file paths (one per line)
+from stdin or ``--changed-files PATH`` and, for each engine whose
+``current.yaml`` moved, asserts both the versioned snapshot outputs AND the
+packaged src copies also changed. It exits non-zero listing every engine whose
+bump is incomplete, naming the absorb command to run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path, PurePosixPath
+
+ENGINES: tuple[str, ...] = ("transformers", "vllm", "tensorrt")
+
+# Packaged engine files a real absorb regenerates under
+# src/llenergymeasure/engines/<engine>/. plugin.py and __init__.py are
+# hand-written glue, not absorb outputs, so they do not count as evidence.
+_SRC_ABSORB_FILES: frozenset[str] = frozenset({"config.py", "rules.yaml", "schema.discovered.json"})
+
+
+def _bumped_engines(changed: set[str]) -> list[str]:
+    """Return engines whose ``current.yaml`` pin moved in this changeset."""
+    return [e for e in ENGINES if f"engine_versions/{e}/current.yaml" in changed]
+
+
+def _has_snapshot_outputs(engine: str, changed: set[str]) -> bool:
+    """True when a versioned snapshot output for ``engine`` changed."""
+    prefix = f"engine_versions/{engine}/"
+    return any(f.startswith(prefix) and "/outputs/" in f for f in changed)
+
+
+def _has_src_copies(engine: str, changed: set[str]) -> bool:
+    """True when a packaged src knowledge file for ``engine`` changed."""
+    prefix = f"src/llenergymeasure/engines/{engine}/"
+    return any(f.startswith(prefix) and PurePosixPath(f).name in _SRC_ABSORB_FILES for f in changed)
+
+
+def check_absorbed_bump(changed_files: list[str]) -> list[str]:
+    """Return one error paragraph per engine whose pin bump is unaccompanied.
+
+    An empty list means every bumped engine shipped its regenerated knowledge
+    (or no pin moved at all).
+    """
+    changed = {f.strip() for f in changed_files if f.strip()}
+    errors: list[str] = []
+    for engine in _bumped_engines(changed):
+        missing: list[str] = []
+        if not _has_snapshot_outputs(engine, changed):
+            missing.append(
+                f"engine_versions/{engine}/<version>/outputs/ "
+                "(mined schema.discovered.json + curated.yaml)"
+            )
+        if not _has_src_copies(engine, changed):
+            missing.append(
+                f"src/llenergymeasure/engines/{engine}/ "
+                "(generated config.py / rules.yaml / schema.discovered.json)"
+            )
+        if not missing:
+            continue
+        lines = [f"{engine}: current.yaml bumped the pin but the absorbed knowledge is missing:"]
+        lines.extend(f"  - {item}" for item in missing)
+        lines.append(f"  Run: make absorb ENGINE={engine} SRC=<{engine} source at the new pin>")
+        lines.append("  then commit the regenerated snapshot outputs and src/ copies.")
+        errors.append("\n".join(lines))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    parser.add_argument(
+        "--changed-files",
+        default="-",
+        help="Path to a newline-delimited list of changed files, or '-' for stdin (default).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.changed_files == "-":
+        changed_files = sys.stdin.read().splitlines()
+    else:
+        changed_files = Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+
+    errors = check_absorbed_bump(changed_files)
+    if not errors:
+        print("Engine pin bumps ship their absorbed knowledge (or no pin moved).")
+        return 0
+
+    print("::error::Bare engine version-pin bump detected (absorption skipped).", file=sys.stderr)
+    for block in errors:
+        print(block, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_absorbed_bump.py
+++ b/tests/unit/scripts/test_check_absorbed_bump.py
@@ -1,0 +1,118 @@
+"""Tests for :mod:`scripts.ci.check_absorbed_bump` - the half-absorbed-bump guard.
+
+The guard is a pure path check: given the PR's changed-file list, it flags any
+engine whose ``current.yaml`` pin moved without the accompanying regenerated
+snapshot outputs AND packaged src copies. These tests pin the pass/fail
+boundary (bare bump fails, full absorb passes, per-leg omissions fail) and the
+multi-engine / non-bump cases.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[3] / "scripts" / "ci"))
+
+import check_absorbed_bump as cab
+
+
+def _full_absorb(engine: str) -> list[str]:
+    """Changed-file list for a complete absorb of ``engine`` (mirrors PR #792)."""
+    return [
+        f"engine_versions/{engine}/current.yaml",
+        f"engine_versions/{engine}/v9_9_9/outputs/schema.discovered.json",
+        f"engine_versions/{engine}/v9_9_9/outputs/curated.yaml",
+        f"src/llenergymeasure/engines/{engine}/config.py",
+        f"src/llenergymeasure/engines/{engine}/rules.yaml",
+        f"src/llenergymeasure/engines/{engine}/schema.discovered.json",
+    ]
+
+
+def test_full_absorb_passes() -> None:
+    assert cab.check_absorbed_bump(_full_absorb("tensorrt")) == []
+
+
+def test_no_pin_change_passes() -> None:
+    """An unrelated PR that never touches a pin is not the guard's concern."""
+    changed = [
+        "src/llenergymeasure/cli/run.py",
+        "docs/reference/cli.md",
+        "src/llenergymeasure/engines/vllm/plugin.py",
+    ]
+    assert cab.check_absorbed_bump(changed) == []
+
+
+def test_bare_pin_bump_fails() -> None:
+    """The Renovate shape: only current.yaml moves. Both legs are missing."""
+    errors = cab.check_absorbed_bump(["engine_versions/vllm/current.yaml"])
+    assert len(errors) == 1
+    msg = errors[0]
+    assert msg.startswith("vllm:")
+    assert "engine_versions/vllm/<version>/outputs/" in msg
+    assert "src/llenergymeasure/engines/vllm/" in msg
+    assert "make absorb ENGINE=vllm" in msg
+
+
+def test_missing_src_copies_fails() -> None:
+    """Snapshot regenerated but the packaged src copies were not promoted."""
+    changed = [
+        "engine_versions/transformers/current.yaml",
+        "engine_versions/transformers/v9_9_9/outputs/schema.discovered.json",
+    ]
+    errors = cab.check_absorbed_bump(changed)
+    assert len(errors) == 1
+    assert "src/llenergymeasure/engines/transformers/" in errors[0]
+    assert "engine_versions/transformers/<version>/outputs/" not in errors[0]
+
+
+def test_missing_snapshot_outputs_fails() -> None:
+    """src copies changed but no versioned snapshot output was committed."""
+    changed = [
+        "engine_versions/tensorrt/current.yaml",
+        "src/llenergymeasure/engines/tensorrt/config.py",
+    ]
+    errors = cab.check_absorbed_bump(changed)
+    assert len(errors) == 1
+    assert "engine_versions/tensorrt/<version>/outputs/" in errors[0]
+    assert "src/llenergymeasure/engines/tensorrt/" not in errors[0]
+
+
+def test_plugin_only_does_not_count_as_src_evidence() -> None:
+    """plugin.py is hand-written glue, not an absorb output - it is not evidence."""
+    changed = [
+        "engine_versions/vllm/current.yaml",
+        "engine_versions/vllm/v9_9_9/outputs/curated.yaml",
+        "src/llenergymeasure/engines/vllm/plugin.py",
+    ]
+    errors = cab.check_absorbed_bump(changed)
+    assert len(errors) == 1
+    assert "src/llenergymeasure/engines/vllm/" in errors[0]
+
+
+def test_multiple_engines_reported_independently() -> None:
+    """A full absorb of one engine plus a bare bump of another: only the bare one fails."""
+    changed = [*_full_absorb("vllm"), "engine_versions/tensorrt/current.yaml"]
+    errors = cab.check_absorbed_bump(changed)
+    assert len(errors) == 1
+    assert errors[0].startswith("tensorrt:")
+
+
+def test_blank_lines_ignored() -> None:
+    """Trailing blank lines from a piped `git diff` are stripped, not misparsed."""
+    changed = ["", "engine_versions/vllm/current.yaml", "  ", ""]
+    errors = cab.check_absorbed_bump(changed)
+    assert len(errors) == 1
+    assert errors[0].startswith("vllm:")
+
+
+def test_main_file_input_bare_bump(tmp_path: Path) -> None:
+    diff = tmp_path / "changed.txt"
+    diff.write_text("engine_versions/vllm/current.yaml\n", encoding="utf-8")
+    assert cab.main(["--changed-files", str(diff)]) == 1
+
+
+def test_main_file_input_full_absorb(tmp_path: Path) -> None:
+    diff = tmp_path / "changed.txt"
+    diff.write_text("\n".join(_full_absorb("tensorrt")) + "\n", encoding="utf-8")
+    assert cab.main(["--changed-files", str(diff)]) == 0


### PR DESCRIPTION
## Summary

Part of F6 slice S2 (engine-knowledge maintenance economies, ruling R5). This
PR adds the half-absorbed-bump CI guard.

A version-pin bump is only the first step of the absorb pipeline
(`make absorb ENGINE=<engine> SRC=...`), which also regenerates the knowledge
the new pin implies:

- the versioned snapshot under `engine_versions/<engine>/<version>/outputs/`
  (mined `schema.discovered.json` + `curated.yaml`), and
- the packaged copies under `src/llenergymeasure/engines/<engine>/`
  (generated `config.py`, the `rules.yaml` corpus, the promoted
  `schema.discovered.json`).

A PR that moves only `current.yaml` has skipped absorb and would ship a config
typed against the OLD engine surface. Renovate's regex manager emits exactly
this shape (it edits `current_version` in place and nothing else). Evidence:
the one full-pipeline bump #792 touched both legs (v1_2_1/outputs/ + src config
+ rules); a bare bump touches neither.

### What changed

- New `scripts/ci/check_absorbed_bump.py`: a pure changed-file path check. For
  each engine whose `current.yaml` moved, it asserts both the versioned
  snapshot outputs AND the packaged src copies also changed, and fails with a
  message naming the `make absorb` command to run.
- New gating `absorbed-bump-check` job in `engine-rules-check.yml`, folded into
  the `engine-rules-gate` fan-in (so the existing required context enforces it;
  no new branch-protection context needed). It runs only when `engine-filter`
  sees an engine-knowledge change; skips (counts satisfied) otherwise. The job
  is stdlib-only python3, no `uv sync`, no engine source.
- `scripts/ci/check_absorbed_bump.py` added to the `engine-filter` path list
  (self-test) and documented in `docs/.../ci-architecture.md` (topology,
  job list, per-PR-shape table).

### Item (a) of S2 (docs CI byte-check) is a NO-OP - not included

The economics scan claimed the four engine-knowledge doc generators
(`generate_schema_doc.py`, `generate_config_docs.py`, `generate_curation_doc.py`,
`generate_invalid_combos_doc.py`) have zero CI drift gate. They already do: the
`docs-freshness` job in `ci.yml` runs `make docs-check`, whose `docs-all`
dependency runs all four generators and then `git diff --exit-code`s every one
of their outputs (`study-config.md`, `schema-*.md`, `curation-*.md`,
`invalid-combos.md`). All four are already gated, so no doc-gate change is made.

## Test plan

- `make lint` (ruff + format + import-linter): clean.
- `make typecheck` (mypy on src/tests/engine_producers): clean, 313 files.
- New unit suite `tests/unit/scripts/test_check_absorbed_bump.py` (10 tests):
  full-absorb passes; bare bump fails both legs; each single-leg omission fails;
  plugin.py alone is not src evidence; multi-engine reported independently;
  blank-line tolerance; file-input `main()`. All pass.
- Manual stdin runs of the CI invocation path (bare bump exit 1, full absorb
  exit 0, unrelated PR exit 0) verified.
- `actionlint` on the changed workflow: clean.
