### PR TITLE
refactor(config): consolidate per-engine facts into ssot descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   own package rule with no shared `groupName`, so a version bump opens a separate
   reviewable PR per engine rather than batching several engines into one diff.
   ([#850])
+- Consolidated per-engine facts (identity package, dtypes, plugin dispatch,
+  parallelism model, default-image version source) behind a single `ssot.ENGINES`
+  descriptor registry; the previously hand-rolled per-engine branch sites now
+  route through it (internal refactor, no behavior change). ([#851])
 
 ### Removed
 
@@ -1210,8 +1214,6 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#843]: https://github.com/henrycgbaker/llenergymeasure/pull/843
 [#844]: https://github.com/henrycgbaker/llenergymeasure/pull/844
 [#845]: https://github.com/henrycgbaker/llenergymeasure/pull/845
-<<<<<<< HEAD
-[#850]: https://github.com/henrycgbaker/llenergymeasure/pull/850
-=======
 [#849]: https://github.com/henrycgbaker/llenergymeasure/pull/849
->>>>>>> origin/main
+[#850]: https://github.com/henrycgbaker/llenergymeasure/pull/850
+[#851]: https://github.com/henrycgbaker/llenergymeasure/pull/851

--- a/docs/reference/engines/configuration.md
+++ b/docs/reference/engines/configuration.md
@@ -378,13 +378,13 @@ cross-engine validators - is in [invalid-combos.md](invalid-combos.md).
   bounds, dormant normalisations) come from each engine's shipped rule corpus.
   Note that the old hand-written `dtype: float32` rejection was dropped with
   the generated configs: vLLM's `dtype` now includes `float32` in its Literal,
-  and the informational `DTYPE_SUPPORT` map (in `ssot.py`) drives
-  pre-flight checks, not Pydantic parsing.
+  and the informational per-engine `dtypes` (on the `ssot.ENGINES` descriptor)
+  drive pre-flight checks, not Pydantic parsing.
 
 ### Engine x dtype support (pre-flight)
 
-From `ssot.DTYPE_SUPPORT` - an informational pre-flight
-map, not a parse-time constraint:
+From the per-engine `dtypes` on the `ssot.ENGINES` descriptor - an informational
+pre-flight map, not a parse-time constraint:
 
 | Engine | `float32` | `float16` | `bfloat16` |
 |--------|-----------|-----------|------------|

--- a/src/llenergymeasure/cli/_display.py
+++ b/src/llenergymeasure/cli/_display.py
@@ -215,7 +215,7 @@ def format_validation_error(e: ValidationError) -> str:
     Includes did-you-mean suggestions for literal_error types.
     Does NOT catch or re-wrap the error - only formats it.
     """
-    from llenergymeasure.config.ssot import DTYPE_SUPPORT
+    from llenergymeasure.config.ssot import ENGINES
 
     errors = e.errors()
     n = len(errors)
@@ -223,8 +223,8 @@ def format_validation_error(e: ValidationError) -> str:
     lines = [header]
 
     # Build a set of valid values for did-you-mean suggestions
-    valid_engines: list[str] = [str(e) for e in DTYPE_SUPPORT]
-    valid_dtypes = list({d for dtypes in DTYPE_SUPPORT.values() for d in dtypes})
+    valid_engines: list[str] = [str(e) for e in ENGINES]
+    valid_dtypes = list({d for descriptor in ENGINES.values() for d in descriptor.dtypes})
 
     for err in errors:
         loc_parts = [str(part) for part in err.get("loc", [])]

--- a/src/llenergymeasure/config/engine_detection.py
+++ b/src/llenergymeasure/config/engine_detection.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-from llenergymeasure.config.ssot import Engine
+from llenergymeasure.config.ssot import ENGINES, Engine
 
 
 def is_engine_available(engine: str) -> bool:
     """Check if an engine is available (installed and importable).
+
+    Imports the engine's ``availability_probe`` package (from the ``ssot.ENGINES``
+    descriptor) via the builtin ``__import__`` - kept over ``importlib`` so an
+    unexpected error during import still surfaces rather than being masked.
 
     Args:
         engine: Engine name ("transformers", "vllm", or "tensorrt").
@@ -15,15 +19,12 @@ def is_engine_available(engine: str) -> bool:
         True if engine is importable, False otherwise.
     """
     try:
-        if engine == Engine.TRANSFORMERS:
-            import torch  # noqa: F401
-        elif engine == Engine.VLLM:
-            import vllm  # noqa: F401
-        elif engine == Engine.TENSORRT:
-            import tensorrt_llm  # noqa: F401
-        else:
-            # Unknown engine
-            return False
+        probe = ENGINES[Engine(engine)].availability_probe
+    except (ValueError, KeyError):
+        # Unknown engine
+        return False
+    try:
+        __import__(probe)
         return True
     except (ImportError, OSError):
         # ImportError: package not installed

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -14,6 +14,7 @@ import from here.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Final, Literal
 
@@ -185,32 +186,106 @@ TIMEOUT_INTERRUPT_POLL: Final = 1
 """Interrupt event wait loop tick."""
 
 # ---------------------------------------------------------------------------
-# Engine capability dicts
+# Per-engine descriptor registry
 # ---------------------------------------------------------------------------
+# ENGINES is the single source of truth for per-engine facts. Every fact an
+# engine carries (identity package, availability probe, plugin location,
+# supported dtypes, parallelism model, default-image version source) lives in
+# one shape here, so a backend is described in exactly one place. Consumers
+# read the descriptor directly, or take a narrow derived view (ENGINE_PACKAGES).
 
-# Precision modes supported by each engine.
-# "float32" = full precision, "float16" = half, "bfloat16" = brain float16.
-# Note: fp16/bf16 require GPU. The cpu engine (future) would be fp32-only.
-# GPU detection and cpu-dtype cross-validation is handled at pre-flight.
-DTYPE_SUPPORT: dict[Engine, list[str]] = {
-    Engine.TRANSFORMERS: ["float32", "float16", "bfloat16"],
-    Engine.VLLM: ["float16", "bfloat16"],  # vLLM does not support fp32 inference
-    Engine.TENSORRT: ["float16", "bfloat16"],  # TRT-LLM does not support fp32 inference
+
+@dataclass(frozen=True)
+class ParallelismModel:
+    """How an engine's config fields map to the set of GPUs to monitor.
+
+    ``multiply_fields`` names the active engine-params attributes whose product
+    (each defaulting to 1 when unset) gives the GPU count - e.g. vLLM multiplies
+    tensor- by pipeline-parallel size. ``all_visible_field``, when set, names an
+    attribute that (when non-None) means the engine shards across every
+    NVML-visible GPU - e.g. transformers ``device_map``. The two are mutually
+    exclusive; an engine with neither always monitors a single GPU.
+    """
+
+    multiply_fields: tuple[str, ...] = ()
+    all_visible_field: str | None = None
+
+
+@dataclass(frozen=True)
+class EngineDescriptor:
+    """Consolidated per-engine facts (see ``ENGINES``)."""
+
+    package: str
+    """Importable package that identifies the engine (version + preflight)."""
+
+    availability_probe: str
+    """Package imported to test whether the engine can run. Transformers probes
+    ``torch`` (its GPU stack), not the always-present ``transformers`` package."""
+
+    plugin_module: str
+    """Module holding the engine's ``EnginePlugin`` implementation."""
+
+    plugin_class: str
+    """Class name of the engine's ``EnginePlugin`` implementation."""
+
+    dtypes: tuple[str, ...]
+    """Precision modes the engine supports ("float32" = full, "float16" = half,
+    "bfloat16" = brain float16). fp16/bf16 require GPU; GPU detection and
+    cpu-dtype cross-validation happen at pre-flight."""
+
+    parallelism: ParallelismModel
+    """How the engine's config maps to the set of GPUs to monitor."""
+
+    image_version_source: Literal["package", "engine"]
+    """Which version tags the engine's default image: the llenergymeasure
+    ``package`` version (first-party GHCR image) or the pinned ``engine`` version
+    (upstream image)."""
+
+
+ENGINES: dict[Engine, EngineDescriptor] = {
+    Engine.TRANSFORMERS: EngineDescriptor(
+        package="transformers",
+        availability_probe="torch",
+        plugin_module="llenergymeasure.engines.transformers",
+        plugin_class="TransformersEngine",
+        dtypes=("float32", "float16", "bfloat16"),
+        parallelism=ParallelismModel(all_visible_field="device_map"),
+        image_version_source="package",
+    ),
+    Engine.VLLM: EngineDescriptor(
+        package="vllm",
+        availability_probe="vllm",
+        plugin_module="llenergymeasure.engines.vllm",
+        plugin_class="VLLMEngine",
+        dtypes=("float16", "bfloat16"),  # vLLM does not support fp32 inference
+        parallelism=ParallelismModel(
+            multiply_fields=("tensor_parallel_size", "pipeline_parallel_size")
+        ),
+        image_version_source="engine",
+    ),
+    Engine.TENSORRT: EngineDescriptor(
+        package="tensorrt_llm",
+        availability_probe="tensorrt_llm",
+        plugin_module="llenergymeasure.engines.tensorrt",
+        plugin_class="TensorRTEngine",
+        dtypes=("float16", "bfloat16"),  # TRT-LLM does not support fp32 inference
+        parallelism=ParallelismModel(multiply_fields=("tensor_parallel_size",)),
+        image_version_source="engine",
+    ),
 }
 
-# Map from engine name to the Python package that provides it.
-# Used by preflight checks and CLI to verify engine availability.
+# Map each engine to the importable package that identifies it - a narrow view
+# derived from ENGINES. Used by preflight checks, health reporting, and the
+# version handshake.
 ENGINE_PACKAGES: dict[Engine, str] = {
-    Engine.TRANSFORMERS: "transformers",
-    Engine.VLLM: "vllm",
-    Engine.TENSORRT: "tensorrt_llm",
+    engine: descriptor.package for engine, descriptor in ENGINES.items()
 }
 
 __all__ = [
     "ALL_ENGINES",
     "CONTAINER_EXCHANGE_DIR",
     "DOCKER_PULL_TIMEOUT",
-    "DTYPE_SUPPORT",
+    "ENGINES",
     "ENGINE_PACKAGES",
     "ENV_BASELINE_SPEC_PATH",
     "ENV_CARBON_INTENSITY",
@@ -251,5 +326,7 @@ __all__ = [
     "TIMEOUT_SIGTERM_GRACE",
     "TIMEOUT_THREAD_JOIN",
     "Engine",
+    "EngineDescriptor",
+    "ParallelismModel",
     "RunnerMode",
 ]

--- a/src/llenergymeasure/device/gpu_info.py
+++ b/src/llenergymeasure/device/gpu_info.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
-from llenergymeasure.config.ssot import Engine
+from llenergymeasure.config.ssot import ENGINES, Engine
 
 logger = logging.getLogger(__name__)
 
@@ -121,39 +121,38 @@ def get_gpu_architecture(device_index: int = 0) -> str:
 def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
     """Determine GPU indices to monitor for an experiment.
 
-    Rules per engine:
-    - **vLLM**: tensor_parallel_size * pipeline_parallel_size GPUs. Both are known
-      from config before the harness runs, so gpu_indices = list(range(total)).
-    - **Transformers**: device_map="auto" (or any non-None device_map) monitors all
-      NVML-visible GPUs. Model sharding is determined at load time inside
-      harness.run(), but gpu_indices must be passed *before* load. Using all
-      visible GPUs is correct and safe.
-    - **TensorRT-LLM**: tensor_parallel_size GPUs. Known from config before harness runs.
-    - **Otherwise**: [0] (single-GPU default, backward compatible).
+    Generic over each engine's ``ParallelismModel`` (from ``ssot.ENGINES``):
+
+    - **multiply_fields** (vLLM ``tensor_parallel_size * pipeline_parallel_size``,
+      TensorRT-LLM ``tensor_parallel_size``): the product of the named config
+      fields (each defaulting to 1) is known before the harness runs, so
+      gpu_indices = list(range(total)).
+    - **all_visible_field** (transformers ``device_map``): a non-None value means
+      the model shards across all NVML-visible GPUs. Sharding is decided at load
+      time inside harness.run(), but gpu_indices must be passed *before* load, so
+      measuring all visible GPUs is correct and safe.
+    - **Neither / no engine section**: [0] (single-GPU default, backward compatible).
 
     Note: num_processes > 1 (data parallelism via Accelerate) is not handled here.
     For local runs this path is not yet implemented; for Docker each subprocess calls
     the harness independently.
     """
-    if config.engine == Engine.VLLM and config.vllm is not None:
-        tp = 1
-        pp = 1
-        engine_params = config.active_engine_params()
-        if engine_params is not None:
-            tp = engine_params.tensor_parallel_size or 1
-            pp = engine_params.pipeline_parallel_size or 1
-        total = tp * pp
+    engine = Engine(config.engine)
+    section = getattr(config, engine.value, None)
+    engine_params = getattr(section, "engine_params", None) if section is not None else None
+    if engine_params is None:
+        return [0]
+
+    parallelism = ENGINES[engine].parallelism
+    if parallelism.multiply_fields:
+        total = 1
+        for field in parallelism.multiply_fields:
+            total *= getattr(engine_params, field, None) or 1
         if total > 1:
             return list(range(total))
-    elif config.engine == Engine.TENSORRT and config.tensorrt is not None:
-        engine_params = config.active_engine_params()
-        tp = (engine_params.tensor_parallel_size or 1) if engine_params is not None else 1
-        if tp > 1:
-            return list(range(tp))
     elif (
-        config.engine == Engine.TRANSFORMERS
-        and config.transformers is not None
-        and getattr(config.active_engine_params(), "device_map", None) is not None
+        parallelism.all_visible_field is not None
+        and getattr(engine_params, parallelism.all_visible_field, None) is not None
     ):
         # Model will shard across all visible GPUs - measure all of them.
         # Best-effort: if pynvml is absent or no NVIDIA GPU, fall through to [0].

--- a/src/llenergymeasure/device/gpu_info.py
+++ b/src/llenergymeasure/device/gpu_info.py
@@ -137,7 +137,10 @@ def _resolve_gpu_indices(config: ExperimentConfig) -> list[int]:
     For local runs this path is not yet implemented; for Docker each subprocess calls
     the harness independently.
     """
-    engine = Engine(config.engine)
+    try:
+        engine = Engine(config.engine)
+    except ValueError:
+        return [0]  # Unrecognised engine - single-GPU default (backward compatible).
     section = getattr(config, engine.value, None)
     engine_params = getattr(section, "engine_params", None) if section is not None else None
     if engine_params is None:

--- a/src/llenergymeasure/engines/__init__.py
+++ b/src/llenergymeasure/engines/__init__.py
@@ -1,6 +1,8 @@
 """Inference engines for llenergymeasure."""
 
-from llenergymeasure.config.ssot import Engine
+import importlib
+
+from llenergymeasure.config.ssot import ENGINES, Engine
 from llenergymeasure.engines.protocol import EnginePlugin
 from llenergymeasure.utils.exceptions import EngineError
 
@@ -9,6 +11,10 @@ __all__ = ["EnginePlugin", "get_engine"]
 
 def get_engine(name: str) -> EnginePlugin:
     """Get an inference engine instance by name.
+
+    Dispatches through the ``ssot.ENGINES`` descriptor registry: the engine's
+    plugin module is imported lazily (only the selected engine's deps load) and
+    its ``EnginePlugin`` class instantiated.
 
     Args:
         name: Engine name ('transformers', 'vllm', 'tensorrt').
@@ -19,16 +25,11 @@ def get_engine(name: str) -> EnginePlugin:
     Raises:
         EngineError: If the engine name is unknown.
     """
-    if name == Engine.TRANSFORMERS:
-        from llenergymeasure.engines.transformers import TransformersEngine
-
-        return TransformersEngine()
-    if name == Engine.VLLM:
-        from llenergymeasure.engines.vllm import VLLMEngine
-
-        return VLLMEngine()
-    if name == Engine.TENSORRT:
-        from llenergymeasure.engines.tensorrt import TensorRTEngine
-
-        return TensorRTEngine()
-    raise EngineError(f"Unknown engine: {name!r}. Available: {', '.join(Engine)}")
+    try:
+        engine = Engine(name)
+    except ValueError:
+        raise EngineError(f"Unknown engine: {name!r}. Available: {', '.join(Engine)}") from None
+    descriptor = ENGINES[engine]
+    module = importlib.import_module(descriptor.plugin_module)
+    plugin_cls: type[EnginePlugin] = getattr(module, descriptor.plugin_class)
+    return plugin_cls()

--- a/src/llenergymeasure/infra/image_registry.py
+++ b/src/llenergymeasure/infra/image_registry.py
@@ -50,6 +50,7 @@ from functools import cache, lru_cache
 
 from llenergymeasure.config.ssot import (
     ALL_ENGINES,
+    ENGINES,
     ENV_IMAGE_PREFIX,
     RUNNER_DOCKER,
     RUNNER_LOCAL,
@@ -66,6 +67,7 @@ __all__ = [
     "DEFAULT_IMAGE_TEMPLATES",
     "get_default_image",
     "image_present_locally",
+    "local_image_for",
     "parse_runner_value",
     "resolve_image",
     "resolve_image_digest",
@@ -91,6 +93,16 @@ DEFAULT_IMAGE_TEMPLATES: dict[str, str] = {
 
 # Local image tag produced by `docker compose build` (no registry prefix).
 LOCAL_IMAGE_TEMPLATE = "llenergymeasure:{engine}"
+
+
+def local_image_for(engine: str) -> str:
+    """Return the local image tag (``llenergymeasure:{engine}``) for *engine*.
+
+    Produced by ``docker compose build`` / ``make docker-build-all``; the single
+    accessor for the tag every resolution path checks (and compares against) when
+    a locally-built image is preferred.
+    """
+    return LOCAL_IMAGE_TEMPLATE.format(engine=engine_str(engine))
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +147,7 @@ def get_default_image(engine: str) -> str:
     # 1. Prefer a locally-built image (fast local iteration). This precedence is
     #    intentional, but a months-stale dev tag can hijack resolution
     #    invisibly, so warn (once) and name the pinned default it bypasses.
-    local_image = LOCAL_IMAGE_TEMPLATE.format(engine=engine)
+    local_image = local_image_for(engine)
     if _image_exists_locally(local_image):
         _warn_local_shadow(engine)
         return local_image
@@ -159,7 +171,7 @@ def _default_image_version(engine: str) -> str:
     Raises:
         ConfigError: The pinned engine version is unavailable at runtime.
     """
-    if engine == Engine.TRANSFORMERS.value:
+    if ENGINES[Engine(engine)].image_version_source == "package":
         from llenergymeasure._version import __version__
 
         return __version__ if __version__ else "latest"
@@ -229,7 +241,7 @@ def _warn_local_shadow(engine: str) -> None:
     deduplicated with ``functools.cache`` keyed on the engine: the same shadow is
     logged only once. ``cache_clear()`` resets the dedup (used by tests).
     """
-    local_image = LOCAL_IMAGE_TEMPLATE.format(engine=engine)
+    local_image = local_image_for(engine)
     pinned_default = _pinned_default_or_none(engine)
     shadowed = (
         f"the version-pinned default {pinned_default}"
@@ -256,7 +268,7 @@ def shadowed_default_image(engine: str, resolved_image: str) -> str | None:
     shadowing fact the resolution warning logs. Best-effort: returns None when
     the pinned default cannot be resolved.
     """
-    if resolved_image != LOCAL_IMAGE_TEMPLATE.format(engine=engine):
+    if resolved_image != local_image_for(engine):
         return None
     return _pinned_default_or_none(engine)
 
@@ -416,7 +428,7 @@ def resolve_image(
 
     # 5. Smart default: delegate to get_default_image() (local build → registry)
     image = get_default_image(engine)
-    local_image = LOCAL_IMAGE_TEMPLATE.format(engine=engine)
+    local_image = local_image_for(engine)
     if image == local_image:
         source = "local_build"
     elif _image_exists_locally(image):

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -20,7 +20,7 @@ from llenergymeasure.config.introspection import (
     get_validation_rules,
 )
 from llenergymeasure.config.models import ExperimentConfig
-from llenergymeasure.config.ssot import DTYPE_SUPPORT
+from llenergymeasure.config.ssot import ENGINES
 from tests.conftest import make_config
 
 # ---------------------------------------------------------------------------
@@ -111,9 +111,9 @@ def test_get_experiment_config_schema_contains_engine_field():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("dt", DTYPE_SUPPORT["transformers"])  # type: ignore[index]  # Engine is str-enum
+@pytest.mark.parametrize("dt", ENGINES["transformers"].dtypes)  # type: ignore[index]  # Engine is str-enum
 def test_all_pytorch_dtype_values_produce_valid_config(dt):
-    """Schema-driven: each SSOT DTYPE_SUPPORT['transformers'] value creates a valid config."""
+    """Schema-driven: each SSOT ENGINES['transformers'].dtypes value creates a valid config."""
     config = make_config(dtype=dt)
     assert config.transformers.engine_params.dtype == dt
 
@@ -268,8 +268,8 @@ def test_capability_matrix_transformers_supports_tensor_parallel():
 
 
 def test_capability_matrix_cells_match_engine_dtype_support():
-    """Each engine's float32 cell must agree with SSOT DTYPE_SUPPORT."""
-    from llenergymeasure.config.ssot import DTYPE_SUPPORT, Engine
+    """Each engine's float32 cell must agree with SSOT ENGINES dtypes."""
+    from llenergymeasure.config.ssot import ENGINES, Engine
 
     caps = get_engine_capabilities()
     for engine, key in (
@@ -277,7 +277,7 @@ def test_capability_matrix_cells_match_engine_dtype_support():
         (Engine.VLLM, "vllm"),
         (Engine.TENSORRT, "tensorrt"),
     ):
-        expected = "float32" in DTYPE_SUPPORT[engine]
+        expected = "float32" in ENGINES[engine].dtypes
         assert caps["float32_precision"][key] is expected
 
 

--- a/tests/unit/config/test_config_schema.py
+++ b/tests/unit/config/test_config_schema.py
@@ -10,7 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from llenergymeasure.config.models import ExperimentConfig, OutputConfig
-from llenergymeasure.config.ssot import DTYPE_SUPPORT
+from llenergymeasure.config.ssot import ENGINES
 from tests.conftest import make_config
 
 # ---------------------------------------------------------------------------
@@ -253,9 +253,9 @@ def test_valid_dtype_bfloat16():
     assert config.transformers.engine_params.dtype == "bfloat16"
 
 
-@pytest.mark.parametrize("dt", DTYPE_SUPPORT["transformers"])  # type: ignore[index]  # Engine is str-enum
+@pytest.mark.parametrize("dt", ENGINES["transformers"].dtypes)  # type: ignore[index]  # Engine is str-enum
 def test_all_pytorch_dtypes_valid(dt):
-    """Schema-driven: all SSOT DTYPE_SUPPORT['transformers'] values are valid."""
+    """Schema-driven: all SSOT ENGINES['transformers'].dtypes values are valid."""
     config = make_config(dtype=dt)
     assert config.transformers.engine_params.dtype == dt
 


### PR DESCRIPTION
## Summary

Slice S6 of the F6 refactor (per-engine branch-site consolidation). Introduces a single per-engine descriptor registry `ssot.ENGINES` holding each engine's facts in one shape, and routes the four hand-rolled per-engine branch/dispatch sites through it. Pure consolidation: no new engine facts, no behavior change, no mode/server axis.

The descriptor (frozen dataclasses, plain data):

```python
@dataclass(frozen=True)
class ParallelismModel:
    multiply_fields: tuple[str, ...] = ()      # e.g. vLLM tensor*pipeline parallel
    all_visible_field: str | None = None       # e.g. transformers device_map

@dataclass(frozen=True)
class EngineDescriptor:
    package: str                               # identity/version package
    availability_probe: str                    # package imported to probe availability
    plugin_module: str                         # EnginePlugin module
    plugin_class: str                          # EnginePlugin class name
    dtypes: tuple[str, ...]                     # supported precisions
    parallelism: ParallelismModel
    image_version_source: Literal["package", "engine"]

ENGINES: dict[Engine, EngineDescriptor] = { ... }   # one entry per engine
```

Each field relocates a fact that already existed hardcoded in one of the branch sites; nothing new was invented.

### The four items

1. **Import-dispatch consolidation (3 sites -> registry).**
   - `engines.get_engine` dispatches via `descriptor.plugin_module` / `plugin_class` (lazy `importlib.import_module` preserves the load-only-the-selected-engine property).
   - `config.is_engine_available` imports `descriptor.availability_probe`. Kept the builtin `__import__(...)` (not `importlib`) so the monkeypatch-based tests still exercise the OSError / unexpected-error paths (the transformers probe stays `torch`, not `transformers` - a contract locked by the tests).
   - `infra._default_image_version` transformers-vs-engine version branch is now driven by `descriptor.image_version_source`.

2. **Parallelism model out of `device/gpu_info.py`.** `_resolve_gpu_indices` is now generic over `descriptor.parallelism` (product of `multiply_fields`, or `all_visible_field` non-None -> all NVML-visible GPUs). No per-engine branches remain.

3. **`local_image_for(engine)` accessor** in `infra/image_registry.py` replaces the four `LOCAL_IMAGE_TEMPLATE.format(engine=...)` call sites.

4. **`DTYPE_SUPPORT` hand-dict folded** into `descriptor.dtypes`; consumers (CLI error text + 2 test files + a reference doc) read from `ENGINES`. `ENGINE_PACKAGES` is retained as a one-line view derived from `ENGINES` (8 consumers, unchanged).

### Grep proof: branch-site literals now route through the registry

`Engine.{TRANSFORMERS,VLLM,TENSORRT}` occurrences across the six touched files:

| file | before | after |
|---|---|---|
| config/ssot.py | 7 | 4 |
| engines/__init__.py | 3 | 0 |
| config/engine_detection.py | 3 | 0 |
| infra/image_registry.py | 4 | 3 |
| device/gpu_info.py | 3 | 0 |
| cli/_display.py | 0 | 0 |
| **TOTAL** | **20** | **7** |

All four dispatch/branch sites drop to **0** per-engine branch literals. The 7 remaining are pure data definitions, not branch logic: the `ENGINES` registry keys (3) + a docstring (1) in ssot.py, and the out-of-scope `DEFAULT_IMAGE_TEMPLATES` keys (3) in image_registry.py.

## Test plan

- `make lint` (ruff check + format + import-linter: 5 contracts kept) - pass
- `make typecheck` (mypy, 312 files) - pass
- `uv run pytest tests/unit/config/ tests/unit/docker/ tests/unit/device/ tests/unit/engines/ -q` - 1087 passed, 31 skipped
- `_resolve_gpu_indices` suite (`tests/unit/test_api.py`) - 17 passed (all vLLM / TensorRT / transformers parallelism cases)
- `get_engine` dispatch + patching (`test_e2e_pipeline.py`, `test_oop_engine_memory.py`, `test_peak_memory.py`) - 33 passed, 3 skipped
- `is_engine_available` monkeypatch tests (`test_engine_detection.py`) and image-registry version/local-tag tests preserved unchanged