### PR TITLE
refactor(config): collapse config and engine-layer duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   own package rule with no shared `groupName`, so a version bump opens a separate
   reviewable PR per engine rather than batching several engines into one diff.
   ([#850])
+- Config and engine layer tidy: the three copy-paste engine-section validators collapse to a
+  loop, the sweep and scaffold series writers share one order-preserving dedupe helper, the
+  `EnginePlugin.load_model` protocol return type tightens to `tuple[Any, Any]`, and two
+  unreachable TensorRT plugin guards (already enforced at config validation) are removed.
+  ([#852])
 
 ### Removed
 
@@ -1210,8 +1215,6 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#843]: https://github.com/henrycgbaker/llenergymeasure/pull/843
 [#844]: https://github.com/henrycgbaker/llenergymeasure/pull/844
 [#845]: https://github.com/henrycgbaker/llenergymeasure/pull/845
-<<<<<<< HEAD
-[#850]: https://github.com/henrycgbaker/llenergymeasure/pull/850
-=======
 [#849]: https://github.com/henrycgbaker/llenergymeasure/pull/849
->>>>>>> origin/main
+[#850]: https://github.com/henrycgbaker/llenergymeasure/pull/850
+[#852]: https://github.com/henrycgbaker/llenergymeasure/pull/852

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, get_args
 from pydantic import BaseModel, Field, model_validator
 
 from llenergymeasure.config.harness import HarnessConfig
-from llenergymeasure.config.ssot import SAMPLING_PRESETS, Engine, engine_str
+from llenergymeasure.config.ssot import ALL_ENGINES, SAMPLING_PRESETS, Engine, engine_str
 from llenergymeasure.config.warnings import ConfigValidationWarning
 
 logger = logging.getLogger(__name__)
@@ -597,21 +597,12 @@ class ExperimentConfig(BaseModel):
         the researcher copied the wrong config block. Fail explicitly rather than
         silently ignoring the mismatched section.
         """
-        if self.transformers is not None and self.engine != "transformers":
-            raise ValueError(
-                f"transformers: config section provided but engine={self.engine!r}. "
-                "Remove the transformers: section or set engine: transformers."
-            )
-        if self.vllm is not None and self.engine != "vllm":
-            raise ValueError(
-                f"vllm: config section provided but engine={self.engine!r}. "
-                "Remove the vllm: section or set engine: vllm."
-            )
-        if self.tensorrt is not None and self.engine != "tensorrt":
-            raise ValueError(
-                f"tensorrt: config section provided but engine={self.engine!r}. "
-                "Remove the tensorrt: section or set engine: tensorrt."
-            )
+        for engine in ALL_ENGINES:
+            if getattr(self, engine) is not None and self.engine != engine:
+                raise ValueError(
+                    f"{engine}: config section provided but engine={self.engine!r}. "
+                    f"Remove the {engine}: section or set engine: {engine}."
+                )
         return self
 
     @model_validator(mode="after")

--- a/src/llenergymeasure/config/series.py
+++ b/src/llenergymeasure/config/series.py
@@ -61,6 +61,7 @@ from llenergymeasure.config.engine_rules.loader import (
     evaluate_predicate,
     spec_has_field_ref,
 )
+from llenergymeasure.config.sweep_idioms import _dedupe
 
 __all__ = [
     "SERIES_SHAPES",
@@ -340,22 +341,12 @@ def _finish(
     # shipped field is this narrow, so the round-trip tests stay green; widen
     # here if one ever appears.
     if as_int:
-        ints: list[int] = []
-        for p in points:
-            r = round(p)
-            if r not in ints:
-                ints.append(r)
-        return ints
+        return _dedupe(round(p) for p in points)
     # Round to decimal places, not significant digits: these land in a
     # human-facing YAML file as sweep starting points, so clean numbers like
     # 0.25 read better than the significant-digit form used by the run-time
     # grid expander (config.sweep_idioms).
-    floats: list[float] = []
-    for p in points:
-        f = round(p, 6)
-        if f not in floats:
-            floats.append(f)
-    return floats
+    return _dedupe(round(p, 6) for p in points)
 
 
 _POLICIES: dict[str, Callable[..., list[int] | list[float]]] = {

--- a/src/llenergymeasure/config/sweep_idioms.py
+++ b/src/llenergymeasure/config/sweep_idioms.py
@@ -22,7 +22,10 @@ Any mapping that is not one of the three idiom shapes raises ``ValueError``.
 from __future__ import annotations
 
 import math
-from typing import Any
+from collections.abc import Iterable
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
 
 _SIGNIFICANT_DIGITS = 10
 
@@ -155,6 +158,13 @@ def _round_sig(value: float) -> float:
     return float(f"{value:.{_SIGNIFICANT_DIGITS}g}")
 
 
-def _dedupe(values: list[Any]) -> list[Any]:
-    """Collapse duplicates (e.g. after rounding) to unique values, order preserved."""
+def _dedupe(values: Iterable[_T]) -> list[_T]:
+    """Collapse duplicates (e.g. after rounding) to unique values, order preserved.
+
+    The single order-preserving dedupe shared by the runtime grid expander here
+    and the scaffold series writer (:mod:`llenergymeasure.config.series`). Each
+    caller keeps its own rounding policy explicit at its call site (significant
+    digits for the machine-facing runtime grid vs fixed decimals for the
+    human-facing scaffold YAML); only this collapse is common to both.
+    """
     return list(dict.fromkeys(values))

--- a/src/llenergymeasure/engines/protocol.py
+++ b/src/llenergymeasure/engines/protocol.py
@@ -81,8 +81,13 @@ class EnginePlugin(Protocol):
         self,
         config: ExperimentConfig,
         on_substep: Callable[[str, float], None] | None = None,
-    ) -> Any:
-        """Load model into memory. Returns opaque model object passed to warmup/run_inference/cleanup.
+    ) -> tuple[Any, Any]:
+        """Load model into memory.
+
+        Returns an opaque ``(model, aux)`` tuple passed verbatim as the ``model``
+        argument to warmup/run_inference/cleanup; the second element is
+        engine-specific (tokenizer for transformers, sampling params for
+        vLLM/TRT-LLM).
 
         Args:
             config: Experiment configuration.

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -625,33 +625,18 @@ class TensorRTEngine:
         kv_cache_config = dumped.pop("kv_cache_config", None)
         scheduler_config = dumped.pop("scheduler_config", None)
         dumped.pop("backend", None)  # backend selects the class, never a kwarg
-        fast_build = dumped.pop("fast_build", None)  # TRT-build-only; see below
+        fast_build = dumped.pop("fast_build", None)  # TRT-build-only; re-added on trt path
 
         # fast_build, quant_config and the on-disk build cache are TRT-engine-build
-        # concepts absent from the pytorch backend's TorchLlmArgs (extra='forbid'),
-        # so forwarding them there crashes construction. On the pytorch backend we
-        # refuse the ones carrying declared measurement intent LOUDLY rather than
-        # silently measure a different configuration, and skip the build cache (a
-        # build-speed knob with no effect on what is measured).
-        if not is_trt:
-            if isinstance(quant_config, dict) and quant_config:
-                raise ConfigError(
-                    "quant_config requires backend='trt'. The pytorch backend does "
-                    "not apply a TRT-LLM quantization config (it loads a "
-                    "pre-quantised checkpoint instead); refusing to silently "
-                    "measure an unquantised model. Set backend='trt' or remove "
-                    "quant_config."
-                )
-            if fast_build:
-                raise ConfigError(
-                    "fast_build requires backend='trt'. There is no TRT engine "
-                    "build on the pytorch backend. Set backend='trt' or remove "
-                    "fast_build."
-                )
+        # concepts absent from the pytorch backend's TorchLlmArgs (extra='forbid').
+        # They are popped above so they never forward blindly and are re-added only
+        # on the trt path below. Declaring them with a non-trt backend is already
+        # rejected at config validation (engine rules + the backend Literal), so no
+        # pytorch-path guard is needed here.
 
         kwargs.update(dumped)  # scalars valid on both backends (tp/pp/max_*/dtype)
 
-        # TRT-build-only surface (guarded above for the pytorch backend).
+        # TRT-build-only surface (re-added here only on the trt path).
         if is_trt:
             if fast_build is not None:
                 kwargs["fast_build"] = fast_build

--- a/tests/unit/engines/test_tensorrt_engine.py
+++ b/tests/unit/engines/test_tensorrt_engine.py
@@ -263,24 +263,6 @@ class TestBuildLlmKwargs:
                 tensorrt={"engine_params": {"backend": "pytorch", "fast_build": True}},
             )
 
-    def test_build_llm_kwargs_fast_build_true_pytorch_raises(self):
-        """Plugin-grain guard (defense in depth): if fast_build=True + pytorch bypasses
-        the corpus rule, _build_llm_kwargs still raises ConfigError (no TRT engine build)."""
-        import pytest
-
-        from llenergymeasure.utils.exceptions import ConfigError
-
-        config = make_config(
-            **_TRT_DEFAULTS,
-            tensorrt={"engine_params": {"backend": "pytorch"}},
-        )
-        # Force the conflicting value past config validation (pydantic does not
-        # validate on assignment) to reach the plugin's own guard.
-        config.tensorrt.engine_params.fast_build = True
-        engine = TensorRTEngine()
-        with pytest.raises(ConfigError, match="fast_build requires backend='trt'"):
-            engine._build_llm_kwargs(config)
-
     def test_build_llm_kwargs_fast_build_false_pytorch_dropped(self):
         """The default fast_build=False on the pytorch backend is dropped, not forwarded.
 
@@ -378,24 +360,6 @@ class TestBuildLlmKwargs:
                     "engine_params": {"backend": "pytorch", "quant_config": {"quant_algo": "INT8"}}
                 },
             )
-
-    def test_build_llm_kwargs_quant_config_pytorch_raises(self):
-        """Plugin-grain guard (defense in depth): if quant_config + pytorch bypasses the
-        corpus rule, _build_llm_kwargs still raises ConfigError (loud, not silent)."""
-        import pytest
-
-        from llenergymeasure.utils.exceptions import ConfigError
-
-        config = make_config(
-            **_TRT_DEFAULTS,
-            tensorrt={"engine_params": {"backend": "pytorch"}},
-        )
-        # Force the conflicting value past config validation (pydantic does not
-        # validate on assignment) to reach the plugin's own guard.
-        config.tensorrt.engine_params.quant_config = {"quant_algo": "INT8"}
-        engine = TensorRTEngine()
-        with pytest.raises(ConfigError, match="quant_config requires backend='trt'"):
-            engine._build_llm_kwargs(config)
 
     def test_build_llm_kwargs_enable_build_cache_when_env_set(self, monkeypatch):
         """backend='trt' + LLEM_TRT_BUILD_CACHE_ENABLED=1 -> enable_build_cache=True."""


### PR DESCRIPTION
## Summary

Four small config/engine-layer tidies, no behavior change.

1. **Engine-section validators** (`config/models.py`): the three copy-paste
   blocks in `validate_engine_section_match` collapse to the loop-over-`ALL_ENGINES`
   pattern already used in `config/user_config.py`. The per-engine error messages
   are byte-identical.

2. **Numeric-series dedupe** (`config/sweep_idioms.py`, `config/series.py`): the
   two modules shared one duplicated mechanic - order-preserving dedupe - which
   `series._finish` had reimplemented inline twice. Extracted the single
   `_dedupe` helper (widened to `Iterable[_T] -> list[_T]`); both call it.

   The rounding was NOT converged, because it is genuinely divergent on two axes:
   - **Policy**: `sweep_idioms` rounds to significant digits (machine-facing
     runtime grid); `series` rounds to fixed decimals / nearest int (human-facing
     scaffold YAML - clean numbers like `0.25`).
   - **Application**: `sweep_idioms` rounds interior points only and keeps
     endpoints byte-exact (locked by `test_rounding_collapse_dedupes_preserving_order`,
     which asserts an endpoint `1.0000000000001` survives verbatim); `series`
     rounds every point uniformly.

   A single parameterised `round_and_dedupe(values, round_fn)` was rejected: a
   uniform `round_fn` would round `sweep`'s endpoints and break that test, and
   converging the rounding itself would change tested user-facing output. So the
   shared helper is the dedupe, and each caller keeps its rounding policy explicit
   at its own call site.

3. **Dead TensorRT guards** (`engines/tensorrt/plugin.py`): removed the two
   `ConfigError` guards that rejected `fast_build` / `quant_config` on the pytorch
   backend. They are unreachable in the normal flow - the engine rules corpus
   (`tensorrt_backend_fast_build_requires_trt`, `tensorrt_backend_quant_config_requires_trt`,
   both `severity: error`) rejects those combinations at config validation via the
   `_apply_rules` model validator, before the plugin ever runs. The only way to
   reach the guards was to force a conflicting value past pydantic by direct
   assignment (pydantic does not validate on assignment). The two tests that did
   exactly that are deleted; the config-grain rejection tests and the
   `fast_build=False` drop test remain.

4. **Protocol return type** (`engines/protocol.py`): `EnginePlugin.load_model`
   tightens from `-> Any` to `-> tuple[Any, Any]`. All three plugin implementations
   already declared the tuple return `(model, tokenizer)` / `(llm, sampling_params)`,
   so this only aligns the protocol. `run_inference` is left exactly as is.

## Test plan

- `uv run pytest tests/unit/config/ tests/unit/engines/ tests/unit/study/test_sweep_idioms.py -q`
  -> 866 passed, 31 skipped.
- `uv run pytest tests/unit/engines/test_tensorrt_engine.py -q` -> 60 passed.
- `make lint` -> ruff check + format + import-linter all pass (5 contracts kept).
- `make typecheck` -> mypy clean, no issues in 313 source files (the protocol
  tighten produced no caller fallout: the sole call site in `harness/measurement.py`
  feeds `model: Any` params).
