### PR TITLE
feat(results): add results-bundle writer with single bundle_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,35 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   against the old engine surface. The guard is a pure path check
   (`scripts/ci/check_absorbed_bump.py`) wired into `engine-rules-check.yml`.
   ([#849])
+- A new `BundleWriter` (`llenergymeasure.results.bundle`) owns the per-experiment
+  results-bundle write policy in one place: experiment-dir creation, result.json
+  (with runner provenance), environment.json (host snapshot vs the preferred
+  in-container rescue, plus the host-only runner block), the config.json sidecar
+  move + patch, the timeseries attach, and a `finalize()` step that runs the
+  loudness backstops uniformly from the artefact registry. A completed experiment
+  that references a timeseries whose parquet did not land in the bundle now warns
+  at write time (previously only surfaced at read time). ([#853])
+- The results-bundle artefact set is now a declarative registry (`ARTEFACTS` in
+  `llenergymeasure.domain.bundle_artefacts`): each entry records the filename,
+  whether it is required, whether its absence warrants a loud warning, and
+  whether it is JSON or Parquet. This is the extension point for future bundle
+  artefacts - one registry entry plus one writer method, swept automatically by
+  `finalize()`. ([#853])
 
 ### Changed
 
+- **Breaking (results bundle):** the three independent per-artefact
+  `schema_version` counters are replaced by a single `bundle_version` ("1.0")
+  stamped into `result.json`, `config.json`, and `environment.json`. The bundle
+  version now covers the on-disk layout, the artefact set, and each artefact's
+  schema as one contract, with one number to bump per documented break
+  (`timeseries.parquet` stays unversioned as self-describing columnar data). The
+  `ExperimentResult.schema_version` field is renamed to `bundle_version`, and the
+  `CONFIG_SIDECAR_SCHEMA_VERSION` / `ENVIRONMENT_SCHEMA_VERSION` constants are
+  retired in favour of `BUNDLE_VERSION`. This is a deliberate one-time bundle
+  break: results written by earlier versions remain readable best-effort (the
+  retired `schema_version` key is dropped on load rather than rejected), and no
+  converter tooling is provided. ([#853])
 - The Renovate config now documents its one-engine-per-bump-PR policy: each
   engine's regex-managed pin (`engine_versions/<engine>/current.yaml`) keeps its
   own package rule with no shared `groupName`, so a version bump opens a separate
@@ -1218,3 +1244,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#849]: https://github.com/henrycgbaker/llenergymeasure/pull/849
 [#850]: https://github.com/henrycgbaker/llenergymeasure/pull/850
 [#852]: https://github.com/henrycgbaker/llenergymeasure/pull/852
+[#853]: https://github.com/henrycgbaker/llenergymeasure/pull/853

--- a/src/llenergymeasure/domain/bundle_artefacts.py
+++ b/src/llenergymeasure/domain/bundle_artefacts.py
@@ -63,12 +63,17 @@ class ArtefactSpec:
             that make silent data loss visible (config-sidecar provenance,
             a declared-but-missing timeseries).
         kind: ``"json"`` or ``"parquet"`` - the on-disk encoding.
+        missing_note: Human-readable reason the artefact's absence matters,
+            appended to the ``finalize()`` warning. ``None`` for artefacts whose
+            absence needs no explanation. Lives here so the registry is the sole
+            source: adding an artefact needs one entry, nothing hand-synced.
     """
 
     filename: str
     required: bool
     warn_if_missing: bool
     kind: Literal["json", "parquet"]
+    missing_note: str | None = None
 
 
 # The per-experiment bundle artefact set. BundleWriter/BundleReader iterate this
@@ -78,12 +83,24 @@ class ArtefactSpec:
 ARTEFACTS: dict[str, ArtefactSpec] = {
     "result": ArtefactSpec(RESULT_FILENAME, required=True, warn_if_missing=False, kind="json"),
     "config": ArtefactSpec(
-        CONFIG_SIDECAR_FILENAME, required=False, warn_if_missing=True, kind="json"
+        CONFIG_SIDECAR_FILENAME,
+        required=False,
+        warn_if_missing=True,
+        kind="json",
+        missing_note=(
+            "provenance and authoritative engine/model identity are missing from this result"
+        ),
     ),
     "environment": ArtefactSpec(
         ENVIRONMENT_FILENAME, required=False, warn_if_missing=False, kind="json"
     ),
     "timeseries": ArtefactSpec(
-        TIMESERIES_FILENAME, required=False, warn_if_missing=True, kind="parquet"
+        TIMESERIES_FILENAME,
+        required=False,
+        warn_if_missing=True,
+        kind="parquet",
+        missing_note=(
+            "the result references a timeseries but the parquet did not land in the bundle"
+        ),
     ),
 }

--- a/src/llenergymeasure/domain/bundle_artefacts.py
+++ b/src/llenergymeasure/domain/bundle_artefacts.py
@@ -1,4 +1,4 @@
-"""Canonical filenames for the results-bundle artefacts.
+"""Canonical layout of the results-bundle artefacts.
 
 These names are the on-disk contract between every writer (harness, study, api)
 and every reader (results.persistence, report_gaps, resume). They were inlined
@@ -6,11 +6,27 @@ as string literals across five packages; centralising them here keeps the
 bundle layout in one place and lets the layer contract expose them to all
 writers (domain is the lowest layer above utils, so everything may import it).
 
-These are literal filenames only - no behaviour lives here. Changing a value
-changes the on-disk layout, so treat them as a stable format contract.
+Alongside the filenames this module owns two contract-level facts:
+
+- ``BUNDLE_VERSION`` - the single version stamped into every JSON artefact of a
+  per-experiment bundle. It versions the layout, the artefact set, and each
+  artefact's schema as ONE contract (superseding the retired per-artefact
+  ``schema_version`` counters). Bump it once per documented bundle break.
+- ``ARTEFACTS`` - a declarative table describing each per-experiment artefact
+  (whether it is required, whether its absence is worth a loud warning, and
+  whether it is JSON or Parquet). It is the extension point: a new bundle
+  artefact (e.g. a future server-mode per-request series) is added by
+  registering one entry here plus one writer method, not by hand-gluing a fifth
+  file into the writer. It is deliberately a data table, not plugin machinery.
+
+Changing a filename or the version changes the on-disk layout, so treat them as
+a stable format contract.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
 
 # Study-level artefacts directory (per-study, holds the config copy, skipped
 # configs, system overrides, and the study-level environment snapshot).
@@ -26,3 +42,48 @@ TIMESERIES_FILENAME = "timeseries.parquet"
 MANIFEST_FILENAME = "manifest.json"
 EQUIVALENCE_GROUPS_FILENAME = "equivalence_groups.json"
 SYSTEM_OVERRIDES_FILENAME = "system_overrides.json"
+
+# Single version for the whole per-experiment bundle. Stamped into result.json,
+# config.json, and environment.json (Parquet is self-describing and stays
+# unversioned). One number to bump, one CHANGELOG line per break.
+BUNDLE_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class ArtefactSpec:
+    """Declarative description of one per-experiment bundle artefact.
+
+    Attributes:
+        filename: On-disk name inside the experiment directory.
+        required: The bundle is incomplete without it (result.json). Documents
+            the contract for the reader (S5); the writer guarantees required
+            artefacts by raising if it cannot write them.
+        warn_if_missing: Whether the writer's ``finalize()`` sweep emits a loud
+            warning when the artefact is absent. Used for the loudness backstops
+            that make silent data loss visible (config-sidecar provenance,
+            a declared-but-missing timeseries).
+        kind: ``"json"`` or ``"parquet"`` - the on-disk encoding.
+    """
+
+    filename: str
+    required: bool
+    warn_if_missing: bool
+    kind: Literal["json", "parquet"]
+
+
+# The per-experiment bundle artefact set. BundleWriter/BundleReader iterate this
+# registry for existence checks, loudness backstops, and rescue sweeps. Add a
+# new artefact by registering an entry here plus a writer method - the finalize
+# sweep picks it up automatically.
+ARTEFACTS: dict[str, ArtefactSpec] = {
+    "result": ArtefactSpec(RESULT_FILENAME, required=True, warn_if_missing=False, kind="json"),
+    "config": ArtefactSpec(
+        CONFIG_SIDECAR_FILENAME, required=False, warn_if_missing=True, kind="json"
+    ),
+    "environment": ArtefactSpec(
+        ENVIRONMENT_FILENAME, required=False, warn_if_missing=False, kind="json"
+    ),
+    "timeseries": ArtefactSpec(
+        TIMESERIES_FILENAME, required=False, warn_if_missing=True, kind="parquet"
+    ),
+}

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from llenergymeasure.domain.bundle_artefacts import BUNDLE_VERSION
 from llenergymeasure.domain.environment import EnvironmentSnapshot
 from llenergymeasure.domain.metrics import (
     EnergyBreakdown,
@@ -110,7 +111,11 @@ class ExperimentResult(BaseModel):
     """
 
     # Identity
-    schema_version: str = Field(default="5.0", description="Result schema version")
+    bundle_version: str = Field(
+        default=BUNDLE_VERSION,
+        description="Results-bundle version (layout + artefact set + per-artefact schema, "
+        "as one contract). Replaces the retired per-artefact result schema_version.",
+    )
     experiment_id: str = Field(..., description="Unique experiment identifier")
     measurement_config_hash: str = Field(
         ..., description="SHA-256[:16] of ExperimentConfig (environment excluded)"

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -8,7 +8,7 @@ import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from llenergymeasure.domain.bundle_artefacts import BUNDLE_VERSION
 from llenergymeasure.domain.environment import EnvironmentSnapshot
@@ -279,6 +279,22 @@ class ExperimentResult(BaseModel):
     )
 
     model_config = {"frozen": True, "extra": "forbid"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_legacy_schema_version(cls, data: Any) -> Any:
+        """Read a legacy (pre-bundle_version) result.json best-effort.
+
+        Older bundles stamped result.json with a per-artefact ``schema_version``
+        that no longer exists on this model, which forbids extra fields. Drop the
+        retired key before validation (both ``model_validate`` and
+        ``model_validate_json`` run before-validators on the parsed structure) so
+        a legacy result.json falls back to the current default ``bundle_version``
+        rather than being rejected.
+        """
+        if isinstance(data, dict) and "schema_version" in data:
+            data = {k: v for k, v in data.items() if k != "schema_version"}
+        return data
 
     @property
     def duration_sec(self) -> float:

--- a/src/llenergymeasure/results/bundle.py
+++ b/src/llenergymeasure/results/bundle.py
@@ -1,0 +1,311 @@
+"""Per-experiment results-bundle owner (writer side).
+
+``BundleWriter`` is the single home for the assembly policy that decides how a
+completed experiment becomes an on-disk bundle: the collision-free experiment
+directory, result.json (with runner provenance folded in), environment.json
+(host snapshot vs the preferred in-container rescue, plus the host-only runner
+block), the config.json sidecar move + patch, the timeseries attach, and the
+loudness backstops that make a silently-missing artefact visible.
+
+Previously this policy was smeared across ``results.persistence`` (atomic writes
++ dir naming) and ``study.runner._save_and_record`` (~215 lines of assembly). It
+now lives here, driven by the ``domain.bundle_artefacts.ARTEFACTS`` registry, so
+a future artefact type (e.g. a server-mode per-request series) is added with one
+registry entry plus one writer method - ``finalize()`` sweeps it automatically.
+
+The low-level mechanics (collision-free dir + atomic result/timeseries write,
+the host environment write) stay in ``results.persistence`` and are delegated to:
+``persistence.save_result`` is public API, and keeping the primitive there
+preserves the atomic-write + chmod semantics and the existing regression tests.
+BundleWriter owns the policy; persistence owns the primitives.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.config.ssot import RUNNER_DOCKER
+from llenergymeasure.domain.bundle_artefacts import (
+    ARTEFACTS,
+    BUNDLE_VERSION,
+    CONFIG_SIDECAR_FILENAME,
+    ENVIRONMENT_FILENAME,
+)
+from llenergymeasure.results import persistence
+from llenergymeasure.utils.io import load_json
+
+if TYPE_CHECKING:
+    from llenergymeasure.domain.environment import EnvironmentSnapshot, RunnerEnvironment
+    from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
+
+logger = logging.getLogger(__name__)
+
+# Per-artefact intent notes for the finalize loudness backstops. The wording of
+# each backstop moved here from the smeared _save_and_record; the intent (why a
+# missing artefact matters) is preserved.
+_MISSING_NOTES: dict[str, str] = {
+    "config": ("provenance and authoritative engine/model identity are missing from this result"),
+    "timeseries": ("the result references a timeseries but the parquet did not land in the bundle"),
+}
+
+
+class BundleWriter:
+    """Assemble one per-experiment results bundle under ``study_dir``.
+
+    Usage mirrors the natural write order::
+
+        writer = BundleWriter(study_dir, model_name=..., engine=..., config_hash=...)
+        result_path = writer.write_result(result, runner_provenance=...)
+        writer.write_environment(host_snapshot=..., runner_environment=..., runner_provenance=...)
+        writer.move_config_sidecar(resolved_config_hash=..., resolution_log=...)
+        writer.finalize()
+
+    ``write_result`` must run first: it creates the experiment directory that the
+    later steps write into (available afterwards as :pyattr:`bundle_dir`).
+    """
+
+    def __init__(
+        self,
+        study_dir: Path,
+        *,
+        model_name: str,
+        engine: str,
+        config_hash: str,
+        cycle: int = 1,
+        experiment_index: int | None = None,
+        ts_source_dir: Path | None = None,
+    ) -> None:
+        self._study_dir = Path(study_dir)
+        self._model_name = model_name
+        self._engine = engine
+        self._config_hash = config_hash
+        self._cycle = cycle
+        self._experiment_index = experiment_index
+        # Directory the harness/container staged its artefacts in. Under docker
+        # dispatch this is the rescue dir, which also carries the accurate
+        # in-container environment.json and config.json.
+        self._ts_source_dir = ts_source_dir
+        self._dir: Path | None = None
+        self._experiment_id: str | None = None
+        # Registry keys whose finalize backstop is not expected this run (e.g. an
+        # experiment that produced no timeseries).
+        self._skip_backstops: set[str] = set()
+
+    @property
+    def bundle_dir(self) -> Path:
+        """Directory holding the bundle. Only valid after :pymeth:`write_result`."""
+        if self._dir is None:
+            raise RuntimeError("write_result() must be called before accessing bundle_dir")
+        return self._dir
+
+    def write_result(
+        self, result: ExperimentResult, *, runner_provenance: RunnerProvenance | None = None
+    ) -> Path:
+        """Create the experiment dir and write result.json (+ timeseries copy).
+
+        Attaches ``runner_provenance`` to the frozen result before serialising
+        (it rides in result.json, unlike the environment sidecar). Resolves the
+        timeseries parquet from the result's ``timeseries`` field inside
+        ``ts_source_dir`` and hands it to the atomic writer, then removes the
+        stale staged copy. Returns the path to result.json.
+        """
+        if runner_provenance is not None and hasattr(result, "model_copy"):
+            result = result.model_copy(update={"runner_provenance": runner_provenance})
+
+        ts_filename = getattr(result, "timeseries", None)
+        if not ts_filename:
+            # No timeseries declared: its finalize backstop does not apply.
+            self._skip_backstops.add("timeseries")
+        ts_source: Path | None = None
+        if ts_filename and self._ts_source_dir is not None:
+            candidate = self._ts_source_dir / ts_filename
+            if candidate.exists():
+                ts_source = candidate
+
+        result_path = persistence.save_result(
+            result,
+            self._study_dir,
+            model_name=self._model_name,
+            engine=self._engine,
+            timeseries_source=ts_source,
+            experiment_index=self._experiment_index,
+            cycle=self._cycle,
+        )
+        self._dir = result_path.parent
+        self._experiment_id = getattr(result, "experiment_id", None)
+
+        # Remove the stale staged parquet now that it is copied into the bundle.
+        if ts_source is not None:
+            ts_source.unlink(missing_ok=True)
+        return result_path
+
+    def write_environment(
+        self,
+        *,
+        host_snapshot: EnvironmentSnapshot | None,
+        runner_environment: RunnerEnvironment | None = None,
+        runner_provenance: RunnerProvenance | None = None,
+    ) -> None:
+        """Write environment.json with the rescue-preference policy.
+
+        The host snapshot (patched with the host-only runner block) is written
+        first. Under docker dispatch the accurate snapshot is collected INSIDE
+        the container and rescued to ``ts_source_dir``; that file is preferred
+        and overwrites the host-written one, with the runner block re-applied.
+        A docker run that lands without a rescued snapshot warns loudly: the
+        persisted environment.json would then describe the dispatching host, not
+        the container the experiment actually ran in.
+        """
+        if self._dir is None:
+            raise RuntimeError("write_result() must be called before write_environment()")
+
+        # Attach the host-only runner block to the host snapshot so the host
+        # write carries it (local path, and the docker no-rescue fallback).
+        if runner_environment is not None and host_snapshot is not None:
+            host_snapshot = host_snapshot.model_copy(update={"runner": runner_environment})
+
+        if host_snapshot is not None:
+            persistence.save_environment(
+                host_snapshot,
+                self._experiment_id or "",
+                self._config_hash,
+                self._dir,
+            )
+
+        rescued = (
+            self._ts_source_dir / ENVIRONMENT_FILENAME if self._ts_source_dir is not None else None
+        )
+        if rescued is not None and rescued.exists():
+            self._rescue_environment(rescued, runner_environment)
+        elif runner_provenance is not None and runner_provenance.mode == RUNNER_DOCKER:
+            logger.warning(
+                "No in-container environment.json rescued for %s (cycle %d) at %s - "
+                "environment.json records the dispatching host, not the container "
+                "the experiment ran in.",
+                self._config_hash,
+                self._cycle,
+                self._dir,
+            )
+
+    def _rescue_environment(
+        self, rescued: Path, runner_environment: RunnerEnvironment | None
+    ) -> None:
+        """Prefer the rescued in-container environment.json over the host write.
+
+        Loads the rescued snapshot, patches the host-only runner block into it,
+        and atomically overwrites the host-written environment.json. Best-effort:
+        a read/write failure warns loudly and leaves the host-written file (which
+        already carries the runner block) in place. The staged rescue file is
+        always consumed.
+        """
+        assert self._dir is not None
+        try:
+            payload = load_json(rescued)
+            payload = self._patch_runner_block(payload, runner_environment)
+            persistence._atomic_write(
+                json.dumps(payload, indent=2, default=str),
+                self._dir / ENVIRONMENT_FILENAME,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to rescue in-container environment.json for %s (cycle %d) from %s: %s - "
+                "environment.json will record the dispatching host, not the container the "
+                "experiment ran in.",
+                self._config_hash,
+                self._cycle,
+                rescued,
+                exc,
+            )
+        finally:
+            rescued.unlink(missing_ok=True)
+
+    @staticmethod
+    def _patch_runner_block(
+        payload: dict[str, Any], runner_environment: RunnerEnvironment | None
+    ) -> dict[str, Any]:
+        """Patch the host-only runner block into a rescued environment payload.
+
+        The container writes environment.json without runner facts only the host
+        knows (image ref, registry digest, precedence source). This patches them
+        in and stamps ``bundle_version`` if the (older-image) payload omitted it.
+        A no-op when no runner block is available.
+        """
+        if runner_environment is not None:
+            payload["runner"] = runner_environment.model_dump()
+            payload.setdefault("bundle_version", BUNDLE_VERSION)
+        return payload
+
+    def move_config_sidecar(
+        self,
+        *,
+        resolved_config_hash: str | None = None,
+        resolution_log: dict[str, Any] | None = None,
+    ) -> None:
+        """Move the harness-written config.json into the bundle, patched.
+
+        The harness writes config.json to the staging dir; the host moves it and
+        patches in two fields the harness subprocess cannot compute: the
+        ``resolved_config_hash`` (from StudyConfig) and the per-field
+        ``provenance`` log (whose source labels are only known in the parent).
+        Best-effort: a read/write failure warns loudly and the staged file is
+        always consumed. No-op when no staging dir or no config.json is present.
+        """
+        if self._dir is None:
+            raise RuntimeError("write_result() must be called before move_config_sidecar()")
+        if self._ts_source_dir is None:
+            return
+        src = self._ts_source_dir / CONFIG_SIDECAR_FILENAME
+        if not src.exists():
+            return
+        try:
+            payload = load_json(src)
+            if resolved_config_hash is not None:
+                payload["resolved_config_hash"] = resolved_config_hash
+            if resolution_log:
+                payload["provenance"] = resolution_log
+            payload.setdefault("bundle_version", BUNDLE_VERSION)
+            persistence._atomic_write(
+                json.dumps(payload, indent=2, default=str),
+                self._dir / CONFIG_SIDECAR_FILENAME,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to move config.json sidecar for %s (cycle %d) from %s: %s - "
+                "provenance and authoritative engine/model identity will be missing "
+                "from this result.",
+                self._config_hash,
+                self._cycle,
+                src,
+                exc,
+            )
+        finally:
+            src.unlink(missing_ok=True)
+
+    def finalize(self) -> None:
+        """Run the loudness backstops uniformly from the artefact registry.
+
+        Sweeps every registered artefact flagged ``warn_if_missing`` and warns
+        when one that was expected for this run is absent from the bundle. This
+        is the uniform home for the config-sidecar backstop and the
+        declared-but-missing timeseries backstop; a newly-registered artefact is
+        swept here automatically.
+        """
+        if self._dir is None:
+            raise RuntimeError("write_result() must be called before finalize()")
+        for name, spec in ARTEFACTS.items():
+            if not spec.warn_if_missing or name in self._skip_backstops:
+                continue
+            if not (self._dir / spec.filename).exists():
+                note = _MISSING_NOTES.get(name)
+                logger.warning(
+                    "Bundle artefact '%s' (%s) missing from %s (%s, cycle %d)%s",
+                    name,
+                    spec.filename,
+                    self._dir,
+                    self._config_hash,
+                    self._cycle,
+                    f" - {note}" if note else "",
+                )

--- a/src/llenergymeasure/results/bundle.py
+++ b/src/llenergymeasure/results/bundle.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -42,14 +43,6 @@ if TYPE_CHECKING:
     from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
 
 logger = logging.getLogger(__name__)
-
-# Per-artefact intent notes for the finalize loudness backstops. The wording of
-# each backstop moved here from the smeared _save_and_record; the intent (why a
-# missing artefact matters) is preserved.
-_MISSING_NOTES: dict[str, str] = {
-    "config": ("provenance and authoritative engine/model identity are missing from this result"),
-    "timeseries": ("the result references a timeseries but the parquet did not land in the bundle"),
-}
 
 
 class BundleWriter:
@@ -201,26 +194,51 @@ class BundleWriter:
         already carries the runner block) in place. The staged rescue file is
         always consumed.
         """
+        self._stage_json_artefact(
+            rescued,
+            ENVIRONMENT_FILENAME,
+            lambda payload: self._patch_runner_block(payload, runner_environment),
+            failure_note=(
+                "Failed to rescue in-container environment.json - environment.json will "
+                "record the dispatching host, not the container the experiment ran in"
+            ),
+        )
+
+    def _stage_json_artefact(
+        self,
+        src: Path,
+        dest_filename: str,
+        patch: Callable[[dict[str, Any]], dict[str, Any]],
+        *,
+        failure_note: str,
+    ) -> None:
+        """Move a staged JSON artefact into the bundle, applying ``patch``.
+
+        Shared scaffolding for the environment rescue and the config-sidecar move,
+        which differ only in their patch callback and failure message: load the
+        staged file, apply ``patch``, atomically write it into the bundle dir
+        under ``dest_filename``. Best-effort - a read/write failure logs
+        ``failure_note`` with context and never raises; the staged source is
+        always consumed.
+        """
         assert self._dir is not None
         try:
-            payload = load_json(rescued)
-            payload = self._patch_runner_block(payload, runner_environment)
+            payload = patch(load_json(src))
             persistence._atomic_write(
                 json.dumps(payload, indent=2, default=str),
-                self._dir / ENVIRONMENT_FILENAME,
+                self._dir / dest_filename,
             )
         except Exception as exc:
             logger.warning(
-                "Failed to rescue in-container environment.json for %s (cycle %d) from %s: %s - "
-                "environment.json will record the dispatching host, not the container the "
-                "experiment ran in.",
+                "%s (%s, cycle %d, from %s): %s",
+                failure_note,
                 self._config_hash,
                 self._cycle,
-                rescued,
+                src,
                 exc,
             )
         finally:
-            rescued.unlink(missing_ok=True)
+            src.unlink(missing_ok=True)
 
     @staticmethod
     def _patch_runner_block(
@@ -260,29 +278,24 @@ class BundleWriter:
         src = self._ts_source_dir / CONFIG_SIDECAR_FILENAME
         if not src.exists():
             return
-        try:
-            payload = load_json(src)
+
+        def _patch(payload: dict[str, Any]) -> dict[str, Any]:
             if resolved_config_hash is not None:
                 payload["resolved_config_hash"] = resolved_config_hash
             if resolution_log:
                 payload["provenance"] = resolution_log
             payload.setdefault("bundle_version", BUNDLE_VERSION)
-            persistence._atomic_write(
-                json.dumps(payload, indent=2, default=str),
-                self._dir / CONFIG_SIDECAR_FILENAME,
-            )
-        except Exception as exc:
-            logger.warning(
-                "Failed to move config.json sidecar for %s (cycle %d) from %s: %s - "
-                "provenance and authoritative engine/model identity will be missing "
-                "from this result.",
-                self._config_hash,
-                self._cycle,
-                src,
-                exc,
-            )
-        finally:
-            src.unlink(missing_ok=True)
+            return payload
+
+        self._stage_json_artefact(
+            src,
+            CONFIG_SIDECAR_FILENAME,
+            _patch,
+            failure_note=(
+                "Failed to move config.json sidecar - provenance and authoritative "
+                "engine/model identity will be missing from this result"
+            ),
+        )
 
     def finalize(self) -> None:
         """Run the loudness backstops uniformly from the artefact registry.
@@ -299,7 +312,6 @@ class BundleWriter:
             if not spec.warn_if_missing or name in self._skip_backstops:
                 continue
             if not (self._dir / spec.filename).exists():
-                note = _MISSING_NOTES.get(name)
                 logger.warning(
                     "Bundle artefact '%s' (%s) missing from %s (%s, cycle %d)%s",
                     name,
@@ -307,5 +319,5 @@ class BundleWriter:
                     self._dir,
                     self._config_hash,
                     self._cycle,
-                    f" - {note}" if note else "",
+                    f" - {spec.missing_note}" if spec.missing_note else "",
                 )

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -344,14 +344,11 @@ def load_result(path: Path) -> ExperimentResult:
     from llenergymeasure.domain.experiment import ExperimentResult
 
     path = Path(path)
-    raw = json.loads(path.read_text(encoding="utf-8"))
-    # Legacy (pre-bundle_version) bundles stamped result.json with a per-artefact
-    # ``schema_version``. That key no longer exists on the model, which forbids
-    # extra fields, so drop it to keep a legacy result.json readable best-effort.
+    content = path.read_text(encoding="utf-8")
+    # A legacy (pre-bundle_version) result.json remains readable best-effort: the
+    # ExperimentResult before-validator drops the retired ``schema_version`` key.
     # (The full legacy-fallback + read path lands with the bundle reader.)
-    if isinstance(raw, dict):
-        raw.pop("schema_version", None)
-    result = ExperimentResult.model_validate(raw)
+    result = ExperimentResult.model_validate_json(content)
 
     sidecar = path.parent / TIMESERIES_FILENAME
     if result.timeseries is not None and not sidecar.exists():

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from llenergymeasure.domain.bundle_artefacts import (
+    BUNDLE_VERSION,
     CONFIG_SIDECAR_FILENAME,
     ENVIRONMENT_FILENAME,
     RESULT_FILENAME,
@@ -28,18 +29,6 @@ if TYPE_CHECKING:
     from llenergymeasure.domain.experiment import ExperimentResult
 
 logger = logging.getLogger(__name__)
-
-# Schema version for the config.json sidecar. Independent of result.json's own
-# schema_version; "2.0" succeeds the retired _resolution.json sidecar ("1.0"),
-# whose per-field provenance now lives in this file's ``provenance`` section.
-CONFIG_SIDECAR_SCHEMA_VERSION = "2.0"
-
-# Schema version for the environment.json sidecar. Independent of result.json's
-# and config.json's schema versions. "1.0" is the first explicit version:
-# environment.json previously carried no schema_version. It records the runner
-# block (docker vs local, image + registry digest, precedence source) alongside
-# the hardware/runtime snapshot.
-ENVIRONMENT_SCHEMA_VERSION = "1.0"
 
 
 def _experiment_dir_name(
@@ -197,7 +186,7 @@ def save_config_sidecar(
     written.
     """
     payload: dict[str, object] = {
-        "schema_version": CONFIG_SIDECAR_SCHEMA_VERSION,
+        "bundle_version": BUNDLE_VERSION,
         "experiment_id": experiment_id,
         "measurement_config_hash": config_hash,
         "engine": engine,
@@ -250,7 +239,7 @@ def save_environment(
         Path to the written environment.json file.
     """
     env_data: dict[str, object] = {
-        "schema_version": ENVIRONMENT_SCHEMA_VERSION,
+        "bundle_version": BUNDLE_VERSION,
         "experiment_id": experiment_id,
         "measurement_config_hash": measurement_config_hash,
     }
@@ -355,8 +344,14 @@ def load_result(path: Path) -> ExperimentResult:
     from llenergymeasure.domain.experiment import ExperimentResult
 
     path = Path(path)
-    content = path.read_text(encoding="utf-8")
-    result = ExperimentResult.model_validate_json(content)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    # Legacy (pre-bundle_version) bundles stamped result.json with a per-artefact
+    # ``schema_version``. That key no longer exists on the model, which forbids
+    # extra fields, so drop it to keep a legacy result.json readable best-effort.
+    # (The full legacy-fallback + read path lands with the bundle reader.)
+    if isinstance(raw, dict):
+        raw.pop("schema_version", None)
+    result = ExperimentResult.model_validate(raw)
 
     sidecar = path.parent / TIMESERIES_FILENAME
     if result.timeseries is not None and not sidecar.exists():

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -23,7 +23,6 @@ without data corruption.
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
 import multiprocessing
 import os  # noqa: F401 - patch target: tests patch study.runner.os.{killpg,setpgrp}
@@ -51,7 +50,6 @@ from llenergymeasure.config.ssot import (
 )
 from llenergymeasure.domain.bundle_artefacts import (
     CONFIG_SIDECAR_FILENAME,
-    ENVIRONMENT_FILENAME,
     EQUIVALENCE_GROUPS_FILENAME,
 )
 from llenergymeasure.domain.progress import STEPS_LOCAL, docker_steps
@@ -172,185 +170,52 @@ def _save_and_record(
     runner_provenance: RunnerProvenance | None = None,
     runner_environment: RunnerEnvironment | None = None,
 ) -> None:
-    """Save result to disk and update manifest. Appends result path to result_files.
+    """Assemble the results bundle and update the manifest.
 
-    Resolves the timeseries parquet sidecar from the result object and passes it
-    to save_result() so it is copied into the experiment subdirectory. The stale
-    flat file written by MeasurementHarness is removed after the copy.
+    Thin orchestrator over :class:`llenergymeasure.results.bundle.BundleWriter`,
+    which owns the assembly policy (dir creation, result + provenance write,
+    environment rescue-preference + runner-block patch, config-sidecar move +
+    patch, and the registry-driven loudness backstops). This function only wires
+    the inputs together, appends the result path to ``result_files``, and records
+    the summary metrics on the manifest.
 
     Args:
-        model_name: Model name/path for the experiment directory slug
+        model_name / engine: Identity for the experiment directory slug
             (authoritative home: config.json; the result keeps a convenience copy).
-        engine: Inference engine name for the experiment directory slug
-            (authoritative home: config.json; the result keeps a convenience copy).
-        ts_source_dir: Directory where the harness wrote timeseries.parquet. Under
-            docker dispatch this is the rescue dir and also carries the accurate
-            in-container environment.json, which is preferred over environment_snapshot.
-        environment_snapshot: EnvironmentSnapshot for the per-experiment environment.json
-            sidecar. Written first, then overwritten by a rescued in-container
-            environment.json when docker dispatch produced one (see below).
-        resolution_log: Pre-built per-field resolution log for this experiment,
-            folded into the config.json sidecar's ``provenance`` section.
-        runner_provenance: How the experiment was executed (local vs docker). Attached to the
-            frozen result via model_copy before saving so it persists into result.json.
-        runner_environment: The environment.json ``runner`` block (docker vs local, image +
-            registry digest, precedence source). For local runs it is written via
-            save_environment on the host snapshot; for docker runs it is patched into the
-            rescued in-container environment.json (which the container wrote without runner
-            facts the host alone knows).
+        ts_source_dir: Staging dir where the harness/container wrote config.json,
+            timeseries.parquet, and (under docker) the rescued environment.json.
+        environment_snapshot: Host EnvironmentSnapshot for environment.json (a
+            rescued in-container snapshot is preferred over it when present).
+        resolution_log / resolved_config_hash: Patched into the config.json sidecar.
+        runner_provenance: Execution mode; folded into result.json.
+        runner_environment: The environment.json ``runner`` block (image + digest,
+            precedence source).
 
-    On save failure, marks the experiment as completed with empty path.
+    On any save failure, marks the experiment failed on the manifest.
     """
     try:
-        from llenergymeasure.results.persistence import (
-            ENVIRONMENT_SCHEMA_VERSION,
-            save_environment,
-            save_result,
-        )
+        from llenergymeasure.results.bundle import BundleWriter
 
-        # Attach runner provenance to the frozen result before saving (it
-        # serialises into result.json, unlike the environment sidecar).
-        if runner_provenance is not None and hasattr(result, "model_copy"):
-            result = result.model_copy(update={"runner_provenance": runner_provenance})
-
-        # Resolve timeseries sidecar from result fields.
-        # MeasurementHarness writes timeseries.parquet to the output_dir and
-        # sets result.timeseries = "timeseries.parquet". Both must be present for
-        # the copy to proceed.
-        ts_source: Path | None = None
-        ts_filename = getattr(result, "timeseries", None)
-        if ts_filename and ts_source_dir is not None:
-            candidate = ts_source_dir / ts_filename
-            if candidate.exists():
-                ts_source = candidate
-
-        result_path = save_result(
-            result,
+        writer = BundleWriter(
             study_dir,
             model_name=model_name,
             engine=engine,
-            timeseries_source=ts_source,
-            experiment_index=experiment_index,
+            config_hash=config_hash,
             cycle=cycle,
+            experiment_index=experiment_index,
+            ts_source_dir=ts_source_dir,
         )
-
-        # Attach the runner block to the host snapshot so save_environment writes
-        # it (local path). On the docker path this host-written file is overwritten
-        # by the rescued in-container snapshot below, so the runner block is
-        # re-applied to the rescued file after the overwrite.
-        if runner_environment is not None and environment_snapshot is not None:
-            environment_snapshot = environment_snapshot.model_copy(
-                update={"runner": runner_environment}
-            )
-
-        # Write per-experiment environment.json sidecar
-        if environment_snapshot is not None:
-            save_environment(
-                environment_snapshot,
-                result.experiment_id,
-                config_hash,
-                result_path.parent,
-            )
-
-        # Environment sidecar rescue (docker dispatch): the accurate snapshot is
-        # collected INSIDE the container and rescued to ts_source_dir. The host
-        # snapshot written just above describes the dispatching host, not the
-        # container the experiment actually ran in, so prefer the rescued file
-        # when present - it overwrites the host-written environment.json. Local
-        # in-process runs never produce a rescued file, so this is a no-op for them.
-        rescued_env = ts_source_dir / ENVIRONMENT_FILENAME if ts_source_dir is not None else None
-        if rescued_env is not None and rescued_env.exists():
-            try:
-                from llenergymeasure.results.persistence import _atomic_write
-
-                # The container wrote environment.json without runner facts the
-                # host alone knows (image ref, registry digest, precedence source),
-                # so patch the runner block into the rescued snapshot. The rescued
-                # file already carries schema_version from the container's writer;
-                # setdefault stamps it only if an older image omitted it.
-                _rescued_payload = load_json(rescued_env)
-                if runner_environment is not None:
-                    _rescued_payload["runner"] = runner_environment.model_dump()
-                    _rescued_payload.setdefault("schema_version", ENVIRONMENT_SCHEMA_VERSION)
-                _atomic_write(
-                    json.dumps(_rescued_payload, indent=2, default=str),
-                    result_path.parent / ENVIRONMENT_FILENAME,
-                )
-            except Exception as exc:
-                logger.warning(
-                    "Failed to rescue in-container environment.json for %s (cycle %d) "
-                    "from %s: %s - environment.json will record the dispatching host, "
-                    "not the container the experiment ran in.",
-                    config_hash,
-                    cycle,
-                    rescued_env,
-                    exc,
-                )
-            finally:
-                rescued_env.unlink(missing_ok=True)
-        elif runner_provenance is not None and runner_provenance.mode == RUNNER_DOCKER:
-            # Loudness backstop mirroring the config.json one below: a docker run
-            # that lands without a rescued snapshot means environment.json records
-            # the dispatching host, not the container - a reproducibility defect.
-            logger.warning(
-                "No in-container environment.json rescued for %s (cycle %d) at %s - "
-                "environment.json records the dispatching host, not the container "
-                "the experiment ran in.",
-                config_hash,
-                cycle,
-                result_path.parent,
-            )
-
-        # Move config.json sidecar (written by harness to temp dir) to experiment dir.
-        # Patch in two fields the harness subprocess cannot compute: the
-        # resolved_config_hash from StudyConfig, and the per-field provenance
-        # (source + effective + default) from the pre-built resolution log. The
-        # provenance section replaces the retired _resolution.json sidecar.
-        if ts_source_dir is not None:
-            config_sidecar_src = ts_source_dir / CONFIG_SIDECAR_FILENAME
-            if config_sidecar_src.exists():
-                try:
-                    _payload = load_json(config_sidecar_src)
-                    if resolved_config_hash is not None:
-                        _payload["resolved_config_hash"] = resolved_config_hash
-                    if resolution_log:
-                        _payload["provenance"] = resolution_log
-                    from llenergymeasure.results.persistence import _atomic_write
-
-                    _atomic_write(
-                        json.dumps(_payload, indent=2, default=str),
-                        result_path.parent / CONFIG_SIDECAR_FILENAME,
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to move config.json sidecar for %s (cycle %d) from %s: %s - "
-                        "provenance and authoritative engine/model identity will be missing "
-                        "from this result.",
-                        config_hash,
-                        cycle,
-                        config_sidecar_src,
-                        exc,
-                    )
-                finally:
-                    config_sidecar_src.unlink(missing_ok=True)
-
-        # Loudness backstop: config.json is the sole home of provenance and
-        # the authoritative home of identity. A completed experiment that lands
-        # without one is silent data loss - warn (never fail) so the gap is
-        # visible rather than discovered later at analysis time.
-        if not (result_path.parent / CONFIG_SIDECAR_FILENAME).exists():
-            logger.warning(
-                "No config.json materialised for %s (cycle %d) at %s - provenance "
-                "and authoritative engine/model identity are missing from this result.",
-                config_hash,
-                cycle,
-                result_path.parent,
-            )
-
-        # Clean up the stale flat parquet file after it has been copied into the
-        # experiment subdirectory (mirrors cli/run.py line 288).
-        if ts_source is not None:
-            ts_source.unlink(missing_ok=True)
+        result_path = writer.write_result(result, runner_provenance=runner_provenance)
+        writer.write_environment(
+            host_snapshot=environment_snapshot,
+            runner_environment=runner_environment,
+            runner_provenance=runner_provenance,
+        )
+        writer.move_config_sidecar(
+            resolved_config_hash=resolved_config_hash,
+            resolution_log=resolution_log,
+        )
+        writer.finalize()
 
         result_files.append(str(result_path))
         rel_path = str(result_path.relative_to(study_dir))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,32 @@ def make_user_config(**overrides):
     return UserConfig(**defaults)
 
 
+def write_container_environment_sidecar(path: Path) -> dict:
+    """Write a rescued in-container environment.json (distinct CONTAINER values).
+
+    Shared by the docker-rescue tests: distinct hardware/runtime values so a test
+    can prove the container snapshot wins over the dispatching-host snapshot.
+    """
+    import json
+
+    payload = {
+        "experiment_id": "test-save-record-001",
+        "measurement_config_hash": "aabb1122ccdd3344",
+        "hardware": {
+            "gpu": {"name": "NVIDIA A100-SXM4-80GB", "vram_total_mb": 81920.0},
+            "cuda": {"version": "12.4", "driver_version": "535.104"},
+            "cpu": {"platform": "Linux"},
+            "collected_at": "2026-01-02T00:00:00",
+        },
+        "python_version": "3.10.14",
+        "tool_version": "0.11.0",
+        "cuda_version": "12.4",
+        "cuda_version_source": "torch",
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
 @pytest.fixture
 def sample_config() -> ExperimentConfig:
     return make_config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ TEST_POWER_MW = 200_000  # 200 W in milliwatts (pynvml convention)
 TEST_POWER_W = 200.0
 
 # Derived from model defaults - single source of truth for schema assertions
-EXPERIMENT_SCHEMA_VERSION = ExperimentResult.model_fields["schema_version"].default
+EXPERIMENT_BUNDLE_VERSION = ExperimentResult.model_fields["bundle_version"].default
 
 _EPOCH = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 _EPOCH_END = datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)

--- a/tests/fixtures/replay/gpt2_transformers_v1.0.json
+++ b/tests/fixtures/replay/gpt2_transformers_v1.0.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "5.0",
+  "bundle_version": "1.0",
   "experiment_id": "gpt2_20260313_142111",
   "measurement_config_hash": "9944baab4dabe390",
   "engine": "transformers",

--- a/tests/integration/test_gpu_experiment.py
+++ b/tests/integration/test_gpu_experiment.py
@@ -18,7 +18,7 @@ def _save_replay(result, model: str, engine: str) -> None:
     """Save ExperimentResult JSON as a replay fixture for offline unit tests."""
     _REPLAY_DIR.mkdir(parents=True, exist_ok=True)
     slug = model.replace("/", "-").lower()
-    filename = f"{slug}_{engine}_v{result.schema_version}.json"
+    filename = f"{slug}_{engine}_v{result.bundle_version}.json"
     (_REPLAY_DIR / filename).write_text(result.model_dump_json(indent=2), encoding="utf-8")
 
 
@@ -43,9 +43,9 @@ class TestM1ExitCriteria:
 
         # Core result assertions
         assert isinstance(result, ExperimentResult)
-        from tests.conftest import EXPERIMENT_SCHEMA_VERSION
+        from tests.conftest import EXPERIMENT_BUNDLE_VERSION
 
-        assert result.schema_version == EXPERIMENT_SCHEMA_VERSION
+        assert result.bundle_version == EXPERIMENT_BUNDLE_VERSION
         assert result.measurement_config_hash  # non-empty string
         assert len(result.measurement_config_hash) == 16
 

--- a/tests/unit/results/test_bundle.py
+++ b/tests/unit/results/test_bundle.py
@@ -1,0 +1,325 @@
+"""Unit tests for BundleWriter - the per-experiment results-bundle owner.
+
+These exercise the writer policies directly (not through study.runner._save_and_record,
+which the tests in tests/unit/study/test_save_and_record.py cover end-to-end):
+
+- bundle_version stamping across result.json / config.json / environment.json
+- runner-provenance attach on result.json
+- the environment rescue-preference policy + runner-block patch
+- the config-sidecar move + patch
+- the finalize loudness backstops (missing config, declared-but-missing timeseries)
+- the artefact registry as the server-mode extension point (register + sweep)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from llenergymeasure.domain.bundle_artefacts import ARTEFACTS, BUNDLE_VERSION, ArtefactSpec
+from llenergymeasure.domain.environment import (
+    CPUEnvironment,
+    CUDAEnvironment,
+    EnvironmentMetadata,
+    EnvironmentSnapshot,
+    GPUEnvironment,
+    RunnerEnvironment,
+)
+from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
+from llenergymeasure.results.bundle import BundleWriter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(*, with_timeseries: bool = False) -> ExperimentResult:
+    return ExperimentResult(
+        experiment_id="bundle-test-001",
+        measurement_config_hash="aabb1122ccdd3344",
+        input_tokens=192,
+        output_tokens=64,
+        total_tokens=256,
+        total_energy_j=10.0,
+        total_inference_time_sec=2.0,
+        avg_tokens_per_second=128.0,
+        avg_energy_per_token_j=0.039,
+        total_flops=5e10,
+        timeseries="timeseries.parquet" if with_timeseries else None,
+        start_time=datetime(2026, 3, 25, 10, 0, 0),
+        end_time=datetime(2026, 3, 25, 10, 0, 2),
+    )
+
+
+def _make_snapshot() -> EnvironmentSnapshot:
+    hardware = EnvironmentMetadata(
+        gpu=GPUEnvironment(name="HOST-GPU", vram_total_mb=1.0),
+        cuda=CUDAEnvironment(version="unknown", driver_version="unknown"),
+        cpu=CPUEnvironment(platform="Linux"),
+        collected_at=datetime(2026, 1, 1, 0, 0, 0),
+    )
+    return EnvironmentSnapshot(
+        hardware=hardware,
+        python_version="3.12.12",
+        tool_version="0.6.0",
+        cuda_version=None,
+        cuda_version_source=None,
+    )
+
+
+def _write_container_env(path: Path) -> None:
+    """A rescued in-container environment.json with distinct CONTAINER values."""
+    payload = {
+        "experiment_id": "bundle-test-001",
+        "hardware": {
+            "gpu": {"name": "NVIDIA A100-SXM4-80GB", "vram_total_mb": 81920.0},
+            "cuda": {"version": "12.4", "driver_version": "535.104"},
+            "cpu": {"platform": "Linux"},
+            "collected_at": "2026-01-02T00:00:00",
+        },
+        "python_version": "3.10.14",
+        "tool_version": "0.6.0",
+        "cuda_version": "12.4",
+        "cuda_version_source": "torch",
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _writer(study_dir: Path, *, ts_source_dir: Path | None = None) -> BundleWriter:
+    return BundleWriter(
+        study_dir,
+        model_name="gpt2",
+        engine="transformers",
+        config_hash="aabb1122",
+        cycle=1,
+        ts_source_dir=ts_source_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# write_result
+# ---------------------------------------------------------------------------
+
+
+def test_write_result_stamps_bundle_version(tmp_path: Path) -> None:
+    """result.json carries the single bundle_version stamp."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)
+    result_path = writer.write_result(_make_result())
+    payload = json.loads(result_path.read_text())
+    assert payload["bundle_version"] == BUNDLE_VERSION == "1.0"
+
+
+def test_write_result_attaches_runner_provenance(tmp_path: Path) -> None:
+    """runner_provenance is folded into result.json before serialisation."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)
+    result_path = writer.write_result(
+        _make_result(),
+        runner_provenance=RunnerProvenance(mode="docker", image="img:2.0", source="env"),
+    )
+    payload = json.loads(result_path.read_text())
+    assert payload["runner_provenance"]["mode"] == "docker"
+    assert payload["runner_provenance"]["image"] == "img:2.0"
+    assert payload["runner_provenance"]["source"] == "env"
+
+
+def test_bundle_dir_requires_write_result(tmp_path: Path) -> None:
+    """Accessing bundle_dir before write_result raises (write order contract)."""
+    import pytest
+
+    writer = _writer(tmp_path)
+    with pytest.raises(RuntimeError):
+        _ = writer.bundle_dir
+
+
+# ---------------------------------------------------------------------------
+# write_environment - rescue preference + stamps
+# ---------------------------------------------------------------------------
+
+
+def test_write_environment_local_stamps_bundle_version(tmp_path: Path) -> None:
+    """Local dispatch writes the host snapshot with a bundle_version stamp."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir, ts_source_dir=tmp_path)
+    writer.write_result(_make_result())
+    writer.write_environment(
+        host_snapshot=_make_snapshot(),
+        runner_environment=RunnerEnvironment(mode="local", source="default"),
+        runner_provenance=RunnerProvenance(mode="local", source="local"),
+    )
+    payload = json.loads((writer.bundle_dir / "environment.json").read_text())
+    assert payload["bundle_version"] == "1.0"
+    assert payload["python_version"] == "3.12.12"
+    assert payload["runner"] == {
+        "mode": "local",
+        "image": None,
+        "image_digest": None,
+        "source": "default",
+    }
+
+
+def test_write_environment_prefers_rescued_over_host(tmp_path: Path) -> None:
+    """The rescued in-container environment.json wins over the host snapshot."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _write_container_env(staging / "environment.json")
+
+    writer = _writer(study_dir, ts_source_dir=staging)
+    writer.write_result(_make_result())
+    writer.write_environment(
+        host_snapshot=_make_snapshot(),
+        runner_environment=RunnerEnvironment(
+            mode="docker",
+            image="ghcr.io/acme/vllm:1.0",
+            image_digest="ghcr.io/acme/vllm@sha256:abc123",
+            source="yaml",
+        ),
+        runner_provenance=RunnerProvenance(mode="docker", image="ghcr.io/acme/vllm:1.0"),
+    )
+    payload = json.loads((writer.bundle_dir / "environment.json").read_text())
+    # Container hardware/runtime values win over the host snapshot.
+    assert payload["python_version"] == "3.10.14"
+    assert payload["hardware"]["gpu"]["name"] == "NVIDIA A100-SXM4-80GB"
+    # Host-only runner block patched in, and the payload stamped.
+    assert payload["runner"]["image_digest"] == "ghcr.io/acme/vllm@sha256:abc123"
+    assert payload["bundle_version"] == "1.0"
+    # Rescued staging file consumed.
+    assert not (staging / "environment.json").exists()
+
+
+def test_write_environment_docker_without_rescue_warns(tmp_path: Path, caplog) -> None:
+    """A docker run with no rescued snapshot warns (host, not container, recorded)."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir, ts_source_dir=tmp_path)
+    writer.write_result(_make_result())
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
+        writer.write_environment(
+            host_snapshot=_make_snapshot(),
+            runner_environment=RunnerEnvironment(mode="docker", image="img:1.0", source="yaml"),
+            runner_provenance=RunnerProvenance(mode="docker", image="img:1.0"),
+        )
+    assert any("No in-container environment.json rescued" in rec.message for rec in caplog.records)
+
+
+def test_patch_runner_block_adds_block_and_stamps(tmp_path: Path) -> None:
+    """_patch_runner_block injects the runner block and stamps bundle_version."""
+    payload = BundleWriter._patch_runner_block(
+        {"python_version": "3.10.14"},
+        RunnerEnvironment(mode="docker", image="img:1.0", image_digest=None, source="yaml"),
+    )
+    assert payload["runner"]["mode"] == "docker"
+    assert payload["bundle_version"] == "1.0"
+
+
+def test_patch_runner_block_none_is_noop() -> None:
+    """With no runner block the payload is returned unchanged (no stamp forced)."""
+    payload = BundleWriter._patch_runner_block({"python_version": "3.10.14"}, None)
+    assert payload == {"python_version": "3.10.14"}
+
+
+# ---------------------------------------------------------------------------
+# move_config_sidecar - patch + stamp
+# ---------------------------------------------------------------------------
+
+
+def test_move_config_sidecar_patches_and_stamps(tmp_path: Path) -> None:
+    """The moved config.json gains resolved_config_hash, provenance, bundle_version."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "config.json").write_text(
+        json.dumps({"experiment_id": "bundle-test-001", "engine": "transformers"}),
+        encoding="utf-8",
+    )
+
+    writer = _writer(study_dir, ts_source_dir=staging)
+    writer.write_result(_make_result())
+    resolution_log = {"task.model": {"effective": "gpt2", "source": "yaml"}}
+    writer.move_config_sidecar(resolved_config_hash="resolved_h1", resolution_log=resolution_log)
+
+    payload = json.loads((writer.bundle_dir / "config.json").read_text())
+    assert payload["resolved_config_hash"] == "resolved_h1"
+    assert payload["provenance"] == resolution_log
+    assert payload["bundle_version"] == "1.0"
+    # Staged source consumed.
+    assert not (staging / "config.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# finalize - loudness backstops
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_warns_missing_config(tmp_path: Path, caplog) -> None:
+    """finalize warns when config.json (provenance/identity home) is absent."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)  # no ts_source_dir -> no config.json to move
+    writer.write_result(_make_result())
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
+        writer.finalize()
+    assert any("config.json" in rec.message and "config" in rec.message for rec in caplog.records)
+
+
+def test_finalize_warns_declared_but_missing_timeseries(tmp_path: Path, caplog) -> None:
+    """finalize warns when the result declares a timeseries that did not land."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    # Result declares a timeseries but the staged parquet never existed.
+    writer = _writer(study_dir, ts_source_dir=tmp_path)
+    writer.write_result(_make_result(with_timeseries=True))
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
+        writer.finalize()
+    assert any("timeseries.parquet" in rec.message for rec in caplog.records)
+
+
+def test_finalize_no_timeseries_warning_when_none_declared(tmp_path: Path, caplog) -> None:
+    """No timeseries backstop fires when the result never declared one."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir, ts_source_dir=tmp_path)
+    writer.write_result(_make_result(with_timeseries=False))
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
+        writer.finalize()
+    assert not any("timeseries.parquet" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# artefact registry - the server-mode extension point
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_sweeps_newly_registered_artefact(tmp_path: Path, caplog, monkeypatch) -> None:
+    """A future artefact (e.g. a server-mode series) is swept by finalize once
+    registered - one registry entry is enough, no writer plumbing changes.
+
+    Registering the entry plus a writer method that produces the file is all a
+    v0.8.0 server-mode artefact would need; here we prove finalize picks it up.
+    """
+    monkeypatch.setitem(
+        ARTEFACTS,
+        "request_series",
+        ArtefactSpec(
+            "request_series.parquet", required=False, warn_if_missing=True, kind="parquet"
+        ),
+    )
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)
+    writer.write_result(_make_result())
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
+        writer.finalize()
+    assert any(
+        "request_series" in rec.message and "request_series.parquet" in rec.message
+        for rec in caplog.records
+    ), "finalize must sweep any registered warn_if_missing artefact"

--- a/tests/unit/results/test_bundle.py
+++ b/tests/unit/results/test_bundle.py
@@ -27,30 +27,13 @@ from llenergymeasure.domain.environment import (
     GPUEnvironment,
     RunnerEnvironment,
 )
-from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
+from llenergymeasure.domain.experiment import RunnerProvenance
 from llenergymeasure.results.bundle import BundleWriter
+from tests.conftest import make_result, write_container_environment_sidecar
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_result(*, with_timeseries: bool = False) -> ExperimentResult:
-    return ExperimentResult(
-        experiment_id="bundle-test-001",
-        measurement_config_hash="aabb1122ccdd3344",
-        input_tokens=192,
-        output_tokens=64,
-        total_tokens=256,
-        total_energy_j=10.0,
-        total_inference_time_sec=2.0,
-        avg_tokens_per_second=128.0,
-        avg_energy_per_token_j=0.039,
-        total_flops=5e10,
-        timeseries="timeseries.parquet" if with_timeseries else None,
-        start_time=datetime(2026, 3, 25, 10, 0, 0),
-        end_time=datetime(2026, 3, 25, 10, 0, 2),
-    )
 
 
 def _make_snapshot() -> EnvironmentSnapshot:
@@ -67,24 +50,6 @@ def _make_snapshot() -> EnvironmentSnapshot:
         cuda_version=None,
         cuda_version_source=None,
     )
-
-
-def _write_container_env(path: Path) -> None:
-    """A rescued in-container environment.json with distinct CONTAINER values."""
-    payload = {
-        "experiment_id": "bundle-test-001",
-        "hardware": {
-            "gpu": {"name": "NVIDIA A100-SXM4-80GB", "vram_total_mb": 81920.0},
-            "cuda": {"version": "12.4", "driver_version": "535.104"},
-            "cpu": {"platform": "Linux"},
-            "collected_at": "2026-01-02T00:00:00",
-        },
-        "python_version": "3.10.14",
-        "tool_version": "0.6.0",
-        "cuda_version": "12.4",
-        "cuda_version_source": "torch",
-    }
-    path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def _writer(study_dir: Path, *, ts_source_dir: Path | None = None) -> BundleWriter:
@@ -108,7 +73,7 @@ def test_write_result_stamps_bundle_version(tmp_path: Path) -> None:
     study_dir = tmp_path / "study"
     study_dir.mkdir()
     writer = _writer(study_dir)
-    result_path = writer.write_result(_make_result())
+    result_path = writer.write_result(make_result())
     payload = json.loads(result_path.read_text())
     assert payload["bundle_version"] == BUNDLE_VERSION == "1.0"
 
@@ -119,7 +84,7 @@ def test_write_result_attaches_runner_provenance(tmp_path: Path) -> None:
     study_dir.mkdir()
     writer = _writer(study_dir)
     result_path = writer.write_result(
-        _make_result(),
+        make_result(),
         runner_provenance=RunnerProvenance(mode="docker", image="img:2.0", source="env"),
     )
     payload = json.loads(result_path.read_text())
@@ -147,7 +112,7 @@ def test_write_environment_local_stamps_bundle_version(tmp_path: Path) -> None:
     study_dir = tmp_path / "study"
     study_dir.mkdir()
     writer = _writer(study_dir, ts_source_dir=tmp_path)
-    writer.write_result(_make_result())
+    writer.write_result(make_result())
     writer.write_environment(
         host_snapshot=_make_snapshot(),
         runner_environment=RunnerEnvironment(mode="local", source="default"),
@@ -170,10 +135,10 @@ def test_write_environment_prefers_rescued_over_host(tmp_path: Path) -> None:
     study_dir.mkdir()
     staging = tmp_path / "staging"
     staging.mkdir()
-    _write_container_env(staging / "environment.json")
+    write_container_environment_sidecar(staging / "environment.json")
 
     writer = _writer(study_dir, ts_source_dir=staging)
-    writer.write_result(_make_result())
+    writer.write_result(make_result())
     writer.write_environment(
         host_snapshot=_make_snapshot(),
         runner_environment=RunnerEnvironment(
@@ -200,7 +165,7 @@ def test_write_environment_docker_without_rescue_warns(tmp_path: Path, caplog) -
     study_dir = tmp_path / "study"
     study_dir.mkdir()
     writer = _writer(study_dir, ts_source_dir=tmp_path)
-    writer.write_result(_make_result())
+    writer.write_result(make_result())
     with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         writer.write_environment(
             host_snapshot=_make_snapshot(),
@@ -243,7 +208,7 @@ def test_move_config_sidecar_patches_and_stamps(tmp_path: Path) -> None:
     )
 
     writer = _writer(study_dir, ts_source_dir=staging)
-    writer.write_result(_make_result())
+    writer.write_result(make_result())
     resolution_log = {"task.model": {"effective": "gpt2", "source": "yaml"}}
     writer.move_config_sidecar(resolved_config_hash="resolved_h1", resolution_log=resolution_log)
 
@@ -265,7 +230,7 @@ def test_finalize_warns_missing_config(tmp_path: Path, caplog) -> None:
     study_dir = tmp_path / "study"
     study_dir.mkdir()
     writer = _writer(study_dir)  # no ts_source_dir -> no config.json to move
-    writer.write_result(_make_result())
+    writer.write_result(make_result())
     with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         writer.finalize()
     assert any("config.json" in rec.message and "config" in rec.message for rec in caplog.records)
@@ -277,7 +242,7 @@ def test_finalize_warns_declared_but_missing_timeseries(tmp_path: Path, caplog) 
     study_dir.mkdir()
     # Result declares a timeseries but the staged parquet never existed.
     writer = _writer(study_dir, ts_source_dir=tmp_path)
-    writer.write_result(_make_result(with_timeseries=True))
+    writer.write_result(make_result(timeseries="timeseries.parquet"))
     with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         writer.finalize()
     assert any("timeseries.parquet" in rec.message for rec in caplog.records)
@@ -288,7 +253,7 @@ def test_finalize_no_timeseries_warning_when_none_declared(tmp_path: Path, caplo
     study_dir = tmp_path / "study"
     study_dir.mkdir()
     writer = _writer(study_dir, ts_source_dir=tmp_path)
-    writer.write_result(_make_result(with_timeseries=False))
+    writer.write_result(make_result())
     with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         writer.finalize()
     assert not any("timeseries.parquet" in rec.message for rec in caplog.records)
@@ -316,7 +281,7 @@ def test_finalize_sweeps_newly_registered_artefact(tmp_path: Path, caplog, monke
     study_dir = tmp_path / "study"
     study_dir.mkdir()
     writer = _writer(study_dir)
-    writer.write_result(_make_result())
+    writer.write_result(make_result())
     with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         writer.finalize()
     assert any(

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -267,7 +267,7 @@ def test_save_and_record_folds_provenance_into_config(tmp_path: Path) -> None:
     config_sidecar_src.write_text(
         json.dumps(
             {
-                "schema_version": "2.0",
+                "bundle_version": "1.0",
                 "experiment_id": "test-prov-001",
                 "measurement_config_hash": "aabb1122ccdd3344",
                 "engine": "transformers",
@@ -307,8 +307,8 @@ def test_save_and_record_folds_provenance_into_config(tmp_path: Path) -> None:
     assert payload.get("provenance") == resolution_log, (
         "resolution_log must be folded into config.json as its provenance section"
     )
-    # schema_version from the harness sidecar survives the fold.
-    assert payload["schema_version"] == "2.0"
+    # bundle_version from the harness sidecar survives the fold.
+    assert payload["bundle_version"] == "1.0"
     # The retired standalone sidecar must not appear.
     assert not (result_json_path.parent / "_resolution.json").exists()
     assert not config_sidecar_src.exists()
@@ -436,7 +436,7 @@ def test_docker_without_rescued_environment_warns(tmp_path: Path, caplog) -> Non
     manifest = MagicMock()
     result_files: list[str] = []
 
-    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.runner"):
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         _save_and_record(
             result,
             study_dir,
@@ -470,7 +470,7 @@ def test_local_run_uses_host_snapshot_without_warning(tmp_path: Path, caplog) ->
     manifest = MagicMock()
     result_files: list[str] = []
 
-    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.runner"):
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         _save_and_record(
             result,
             study_dir,
@@ -518,13 +518,13 @@ def test_config_sidecar_rescue_permission_error_warns(tmp_path: Path, monkeypatc
     def _raise_permission(_path):
         raise PermissionError(13, "Permission denied")
 
-    monkeypatch.setattr("llenergymeasure.study.runner.load_json", _raise_permission)
+    monkeypatch.setattr("llenergymeasure.results.bundle.load_json", _raise_permission)
 
     result = _make_result(with_timeseries=False)
     manifest = MagicMock()
     result_files: list[str] = []
 
-    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.runner"):
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         _save_and_record(
             result,
             study_dir,
@@ -572,13 +572,13 @@ def test_environment_sidecar_rescue_permission_error_warns(
     def _raise_permission(_path):
         raise PermissionError(13, "Permission denied")
 
-    monkeypatch.setattr("llenergymeasure.study.runner.load_json", _raise_permission)
+    monkeypatch.setattr("llenergymeasure.results.bundle.load_json", _raise_permission)
 
     result = _make_result(with_timeseries=False)
     manifest = MagicMock()
     result_files: list[str] = []
 
-    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.runner"):
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         _save_and_record(
             result,
             study_dir,
@@ -722,7 +722,7 @@ def test_save_and_record_writes_local_runner_block(tmp_path: Path) -> None:
 
     env_dest = Path(result_files[0]).parent / "environment.json"
     payload = json.loads(env_dest.read_text())
-    assert payload["schema_version"] == "1.0"
+    assert payload["bundle_version"] == "1.0"
     assert payload["runner"] == {
         "mode": "local",
         "image": None,
@@ -780,8 +780,8 @@ def test_save_and_record_docker_rescue_patches_runner_block(tmp_path: Path) -> N
         "image_digest": "ghcr.io/acme/vllm@sha256:abc123",
         "source": "yaml",
     }
-    # schema_version stamped in when the (old-style) container payload omitted it.
-    assert payload["schema_version"] == "1.0"
+    # bundle_version stamped in when the (old-style) container payload omitted it.
+    assert payload["bundle_version"] == "1.0"
     # Container hardware/runtime values still win over the host snapshot.
     assert payload["python_version"] == "3.10.14"
     assert payload["hardware"]["gpu"]["name"] == "NVIDIA A100-SXM4-80GB"
@@ -880,13 +880,13 @@ def test_save_and_record_docker_rescue_failure_keeps_host_runner_block(
     def _raise_permission(_path):
         raise PermissionError(13, "Permission denied")
 
-    monkeypatch.setattr("llenergymeasure.study.runner.load_json", _raise_permission)
+    monkeypatch.setattr("llenergymeasure.results.bundle.load_json", _raise_permission)
 
     result = _make_result(with_timeseries=False)
     manifest = MagicMock()
     result_files: list[str] = []
 
-    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.runner"):
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         _save_and_record(
             result,
             study_dir,
@@ -926,4 +926,4 @@ def test_save_and_record_docker_rescue_failure_keeps_host_runner_block(
         "image_digest": "ghcr.io/acme/vllm@sha256:abc123",
         "source": "yaml",
     }
-    assert payload["schema_version"] == "1.0"
+    assert payload["bundle_version"] == "1.0"

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -21,6 +21,7 @@ from llenergymeasure.study.runner import (
     _runner_environment,
     _save_and_record,
 )
+from tests.conftest import write_container_environment_sidecar
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -359,28 +360,6 @@ def _make_host_snapshot():
     )
 
 
-def _write_container_environment_sidecar(path: Path) -> dict:
-    """Write a rescued in-container environment.json (distinct CONTAINER values)."""
-    import json
-
-    payload = {
-        "experiment_id": "test-save-record-001",
-        "measurement_config_hash": "aabb1122ccdd3344",
-        "hardware": {
-            "gpu": {"name": "NVIDIA A100-SXM4-80GB", "vram_total_mb": 81920.0},
-            "cuda": {"version": "12.4", "driver_version": "535.104"},
-            "cpu": {"platform": "Linux"},
-            "collected_at": "2026-01-02T00:00:00",
-        },
-        "python_version": "3.10.14",
-        "tool_version": "0.11.0",
-        "cuda_version": "12.4",
-        "cuda_version_source": "torch",
-    }
-    path.write_text(json.dumps(payload), encoding="utf-8")
-    return payload
-
-
 def test_docker_rescued_environment_overrides_host(tmp_path: Path) -> None:
     """Under docker dispatch, the rescued in-container environment.json is
     preferred over the host snapshot for the persisted environment.json."""
@@ -390,7 +369,7 @@ def test_docker_rescued_environment_overrides_host(tmp_path: Path) -> None:
     study_dir.mkdir()
 
     # Container rescued environment.json lives in the artefact (ts_source) dir.
-    _write_container_environment_sidecar(tmp_path / "environment.json")
+    write_container_environment_sidecar(tmp_path / "environment.json")
 
     result = _make_result(with_timeseries=False)
     manifest = MagicMock()
@@ -743,7 +722,7 @@ def test_save_and_record_docker_rescue_patches_runner_block(tmp_path: Path) -> N
     study_dir = tmp_path / "study"
     study_dir.mkdir()
 
-    _write_container_environment_sidecar(tmp_path / "environment.json")
+    write_container_environment_sidecar(tmp_path / "environment.json")
 
     result = _make_result(with_timeseries=False)
     manifest = MagicMock()

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -50,16 +50,16 @@ def make_result():
 
 
 # ---------------------------------------------------------------------------
-# Task 2.1: schema_version
+# Task 2.1: bundle_version
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_default(make_result):
-    """schema_version defaults to the current single-segment version (e.g. '5.0')."""
+def test_bundle_version_default(make_result):
+    """bundle_version defaults to the current bundle contract version (e.g. '1.0')."""
     result = make_result()
-    from tests.conftest import EXPERIMENT_SCHEMA_VERSION
+    from tests.conftest import EXPERIMENT_BUNDLE_VERSION
 
-    assert result.schema_version == EXPERIMENT_SCHEMA_VERSION
+    assert result.bundle_version == EXPERIMENT_BUNDLE_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +229,7 @@ def test_frozen_model(make_result):
     """Assignment after construction raises ValidationError (frozen=True)."""
     result = make_result()
     with pytest.raises((ValidationError, TypeError)):
-        result.schema_version = "3.0"  # type: ignore[misc]
+        result.bundle_version = "3.0"  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -368,7 +368,7 @@ def test_json_round_trip(make_result):
     json_str = original.model_dump_json()
     restored = ExperimentResult.model_validate_json(json_str)
 
-    assert restored.schema_version == original.schema_version
+    assert restored.bundle_version == original.bundle_version
     assert restored.experiment_id == original.experiment_id
     assert restored.baseline_power_w == original.baseline_power_w
     assert restored.energy_adjusted_j == original.energy_adjusted_j

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from llenergymeasure.domain.bundle_artefacts import BUNDLE_VERSION
 from llenergymeasure.domain.environment import (
     CPUEnvironment,
     CUDAEnvironment,
@@ -29,7 +30,6 @@ from llenergymeasure.domain.environment import (
 )
 from llenergymeasure.domain.experiment import ExperimentResult
 from llenergymeasure.results.persistence import (
-    ENVIRONMENT_SCHEMA_VERSION,
     load_result,
     save_environment,
 )
@@ -170,9 +170,9 @@ def test_save_atomic_write(tmp_path: Path, minimal_result: ExperimentResult) -> 
     content = result_path.read_text(encoding="utf-8")
     parsed = json.loads(content)
     assert parsed["experiment_id"] == "persist-test-001"
-    from tests.conftest import EXPERIMENT_SCHEMA_VERSION
+    from tests.conftest import EXPERIMENT_BUNDLE_VERSION
 
-    assert parsed["schema_version"] == EXPERIMENT_SCHEMA_VERSION
+    assert parsed["bundle_version"] == EXPERIMENT_BUNDLE_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -216,9 +216,9 @@ def test_from_json_loads_correctly(tmp_path: Path, minimal_result: ExperimentRes
 
     assert loaded.experiment_id == minimal_result.experiment_id
     assert loaded.measurement_config_hash == minimal_result.measurement_config_hash
-    from tests.conftest import EXPERIMENT_SCHEMA_VERSION
+    from tests.conftest import EXPERIMENT_BUNDLE_VERSION
 
-    assert loaded.schema_version == EXPERIMENT_SCHEMA_VERSION
+    assert loaded.bundle_version == EXPERIMENT_BUNDLE_VERSION
     assert loaded.input_tokens == minimal_result.input_tokens
     assert loaded.output_tokens == minimal_result.output_tokens
     assert loaded.total_tokens == minimal_result.total_tokens
@@ -235,6 +235,27 @@ def test_from_json_round_trip(tmp_path: Path, minimal_result: ExperimentResult) 
     original_json = minimal_result.model_dump_json(indent=2)
     loaded_json = loaded.model_dump_json(indent=2)
     assert original_json == loaded_json
+
+
+def test_load_result_tolerates_legacy_schema_version(
+    tmp_path: Path, minimal_result: ExperimentResult
+) -> None:
+    """A pre-bundle_version result.json (carrying the retired ``schema_version``
+    key instead of ``bundle_version``) still loads best-effort - the extra key is
+    dropped rather than rejected by the forbid-extra model."""
+    import json
+
+    result_path = save_result(minimal_result, tmp_path)
+    raw = json.loads(result_path.read_text(encoding="utf-8"))
+    # Simulate a legacy bundle: retired per-artefact key, no bundle_version.
+    raw.pop("bundle_version", None)
+    raw["schema_version"] = "5.0"
+    result_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    loaded = load_result(result_path)
+    assert loaded.experiment_id == minimal_result.experiment_id
+    # Falls back to the current default bundle_version (best-effort read).
+    assert loaded.bundle_version == BUNDLE_VERSION
 
 
 def test_convenience_identity_copies_round_trip(tmp_path: Path) -> None:
@@ -443,12 +464,12 @@ def test_load_result_attaches_environment_sidecar(
     assert loaded.environment.hardware.gpu.name == "NVIDIA A100-SXM4-80GB"
 
 
-def test_save_environment_includes_schema_version(
+def test_save_environment_includes_bundle_version(
     tmp_path: Path,
     minimal_result: ExperimentResult,
     env_snapshot: EnvironmentSnapshot,
 ) -> None:
-    """environment.json carries its own schema_version (independent of result.json)."""
+    """environment.json carries the single bundle_version stamp."""
     import json
 
     result_path = save_result(minimal_result, tmp_path)
@@ -459,7 +480,7 @@ def test_save_environment_includes_schema_version(
         result_path.parent,
     )
     payload = json.loads((result_path.parent / "environment.json").read_text())
-    assert payload["schema_version"] == ENVIRONMENT_SCHEMA_VERSION == "1.0"
+    assert payload["bundle_version"] == BUNDLE_VERSION == "1.0"
 
 
 def test_save_environment_writes_docker_runner_block_roundtrip(
@@ -652,14 +673,11 @@ def test_save_config_sidecar_omits_declared_config_when_absent(tmp_path: Path) -
     assert "measurement_window_discard_fraction" not in payload
 
 
-def test_save_config_sidecar_includes_schema_version(tmp_path: Path) -> None:
-    """The config.json sidecar carries its own schema_version (independent of result.json)."""
+def test_save_config_sidecar_includes_bundle_version(tmp_path: Path) -> None:
+    """The config.json sidecar carries the single bundle_version stamp."""
     import json
 
-    from llenergymeasure.results.persistence import (
-        CONFIG_SIDECAR_SCHEMA_VERSION,
-        save_config_sidecar,
-    )
+    from llenergymeasure.results.persistence import save_config_sidecar
 
     path = save_config_sidecar(
         tmp_path,
@@ -672,7 +690,7 @@ def test_save_config_sidecar_includes_schema_version(tmp_path: Path) -> None:
     )
 
     payload = json.loads(path.read_text())
-    assert payload["schema_version"] == CONFIG_SIDECAR_SCHEMA_VERSION == "2.0"
+    assert payload["bundle_version"] == BUNDLE_VERSION == "1.0"
 
 
 def test_save_config_sidecar_carries_methodology_window(tmp_path: Path) -> None:

--- a/tests/unit/test_replay_fixtures.py
+++ b/tests/unit/test_replay_fixtures.py
@@ -23,13 +23,13 @@ class TestReplayFixtures:
         for result in replay_results:
             assert isinstance(result, ExperimentResult)
 
-    def test_schema_version(self, replay_results):
-        """All replay fixtures match the current ExperimentResult schema_version."""
+    def test_bundle_version(self, replay_results):
+        """All replay fixtures match the current ExperimentResult bundle_version."""
         self._require_fixtures(replay_results)
         for result in replay_results:
-            from tests.conftest import EXPERIMENT_SCHEMA_VERSION
+            from tests.conftest import EXPERIMENT_BUNDLE_VERSION
 
-            assert result.schema_version == EXPERIMENT_SCHEMA_VERSION
+            assert result.bundle_version == EXPERIMENT_BUNDLE_VERSION
 
     def test_energy_values_positive(self, replay_results):
         """Real GPU experiments produce positive energy measurements."""


### PR DESCRIPTION
## Summary

Introduces the results-bundle OWNER (writer side) for slice S4 of the F6 milestone, per the ratified S4/S5 mini-brief. The per-experiment bundle write policy - previously smeared across `results/persistence.py` (atomic writes + dir naming) and `study/runner.py::_save_and_record` (~215 lines of assembly) - now lives in one place, driven by a declarative artefact registry.

### Design decisions (from the brief)

- **Decision 1 - single `bundle_version`:** `BUNDLE_VERSION = "1.0"` lives in `domain/bundle_artefacts.py` and versions the layout + artefact set + per-artefact schema as one contract. The three private per-artefact counters are retired: `ExperimentResult.schema_version` is renamed to `bundle_version`, and `CONFIG_SIDECAR_SCHEMA_VERSION` / `ENVIRONMENT_SCHEMA_VERSION` are removed in favour of the constant. result.json, config.json, and environment.json all now carry `bundle_version: "1.0"`; timeseries.parquet stays unversioned. This is the milestone's one allowed schema break (see CHANGELOG).
- **Decision 3 - artefact registry:** `ARTEFACTS: dict[str, ArtefactSpec]` (filename, required, warn_if_missing, kind) is a plain data table, not plugin machinery. It is the server-mode extension point: a future artefact (e.g. a per-request / load-gen series) is added with one registry entry plus one writer method, and `finalize()` sweeps it automatically. A test proves this (`test_finalize_sweeps_newly_registered_artefact`).
- **`BundleWriter` (`results/bundle.py`)** owns: experiment-dir creation, result write with runner-provenance folded in, environment write with the rescue-preference policy (host snapshot vs preferred in-container rescue) plus the runner-block patch as an explicit, unit-testable `_patch_runner_block`, the config-sidecar move + patch (resolved_config_hash + provenance + bundle_version stamp), the timeseries attach, and `finalize()` running the loudness backstops uniformly from the registry - including the new timeseries warn-if-missing gain (closes ledger 4#4 residue).
- **`_save_and_record` shrinks** to inputs -> BundleWriter -> manifest (executable body ~43 lines, down from ~215). No behaviour change except the new timeseries warn-if-missing.
- **`load_result` minimal touch:** drops a retired `schema_version` key before validating, so it reads both old and new bundles without crashing. The full legacy fallback + read path is slice S5 (not built here).

### Deviations from the brief (flagged)

- The brief says BundleWriter should "absorb `_experiment_dir_name` + `_find_collision_free_dir`" and do the result write itself. Instead, **BundleWriter owns the assembly policy and delegates the atomic dir + result + timeseries mechanics to the existing `persistence.save_result` primitive** (referenced via the module so tests may still patch it). Rationale: `save_result` is public API (`llenergymeasure.api.__all__`) and the F6 exit criterion freezes the external surface; keeping it preserves the atomic-write + chmod-0644 semantics and the save_result-patching regression tests unchanged. The two dir-naming helpers stay private to their sole consumer. Net effect is identical - dir creation happens in exactly one place per path (BundleWriter.write_result). BundleWriter owns policy; persistence owns primitives.
- The environment-rescue / config-move logic moved from `study/runner.py` into `results/bundle.py`, so the three deflaked rescue tests had their `load_json` monkeypatch target and caplog logger updated to `llenergymeasure.results.bundle` (patch-at-use-site; behaviour asserted is unchanged).

## Test plan

- `make lint` (ruff check + format + import-linter: 5 contracts KEPT) and `make typecheck` (mypy, 315 files) both green.
- New direct `BundleWriter` unit tests in `tests/unit/results/test_bundle.py` (13 tests): bundle_version stamps on all three JSON artefacts, runner-provenance attach, environment rescue preference, `_patch_runner_block`, config move + patch, finalize backstops (missing config, declared-but-missing timeseries), and the registry-sweep extension-point proof.
- New `load_result` legacy-tolerance test (`test_load_result_tolerates_legacy_schema_version`).
- Regression floor green: `tests/unit/study/`, `tests/unit/docker/` (incl. the #848-deflaked rescue classes), `tests/unit/results/`, `tests/unit/domain/`.
- Full `tests/unit/` suite: 3132 passed, 36 skipped. `tests/integration/test_e2e_pipeline.py`: 16 passed (exercises the study runner -> BundleWriter -> save_result delegation).

## Notes for S5 (reader slice)

- `bundle_version` is the field to key on. Old bundles carry `schema_version` on result.json only (config/environment used `schema_version` too, but `EnvironmentSnapshot` and the config raw-dict readers already ignore extras). `ExperimentResult` has `extra="forbid"`, so any legacy `schema_version` on result.json must be stripped/migrated before validating - `load_result` already does this minimally; S5 should add the documented `UserWarning` and the real `BundleReader` fallback.
- The exchange payload path (`docker_runner._read_result`) is untouched and already strips unknown fields before validating, so container/host version skew during rollout is handled.
- The registry (`ARTEFACTS`) is the discovery seam for `BundleReader` too - iterate it for existence/read rather than hard-coding filenames.
- BundleWriter delegates to `persistence.save_result`/`save_environment`; the shared ExperimentResult payload parser the brief wants in `domain/result_payload.py` is not extracted here.
