### PR TITLE
feat(results): add results-bundle reader over shared payload parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   whether it is JSON or Parquet. This is the extension point for future bundle
   artefacts - one registry entry plus one writer method, swept automatically by
   `finalize()`. ([#853])
+- A `BundleReader` (`llenergymeasure.results.bundle`) is the read-side owner
+  counterpart to `BundleWriter`. `BundleReader.read(bundle_dir)` discovers the
+  artefacts via the same `ARTEFACTS` registry and returns a `LoadedBundle`
+  (result + environment + config payload + the discovered paths); a
+  newly-registered artefact surfaces in `LoadedBundle.paths` automatically. It
+  reads a pre-`bundle_version` bundle best-effort with a single warning (the one
+  documented pre-1.0 break). `read_sidecar(bundle_dir, key)` is the
+  registry-driven single-artefact accessor for consumers that need one JSON
+  sidecar without materialising the whole bundle. ([#854])
+- A shared `parse_experiment_result_payload` parser
+  (`llenergymeasure.domain.result_payload`) now backs both result read paths -
+  the docker exchange-read (`infra.docker_runner._read_result`, tolerant of
+  cross-version fields, with the host/container version-skew warning) and the
+  bundle-read (strict, via `BundleReader`). One parser, two tolerance settings,
+  no duplicated stripping/validation logic across the layer boundary. ([#854])
 
 ### Changed
 
@@ -47,6 +62,14 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   break: results written by earlier versions remain readable best-effort (the
   retired `schema_version` key is dropped on load rather than rejected), and no
   converter tooling is provided. ([#853])
+- `results.persistence.load_result` is now a thin wrapper over
+  `BundleReader.read` (public API and behaviour unchanged: it still returns an
+  `ExperimentResult` with the environment snapshot attached). The read policy
+  moved to the bundle owner. `report-gaps` now reads each per-experiment
+  `config.json` provenance sidecar through `BundleReader.read_sidecar` rather
+  than a bare file read, so the on-disk sidecar location and encoding are owned
+  in one place; behaviour (malformed-sidecar failure counting, manifest and
+  prefix-scan resolution paths) is unchanged. ([#854])
 - The Renovate config now documents its one-engine-per-bump-PR policy: each
   engine's regex-managed pin (`engine_versions/<engine>/current.yaml`) keeps its
   own package rule with no shared `groupName`, so a version bump opens a separate
@@ -1250,3 +1273,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#851]: https://github.com/henrycgbaker/llenergymeasure/pull/851
 [#852]: https://github.com/henrycgbaker/llenergymeasure/pull/852
 [#853]: https://github.com/henrycgbaker/llenergymeasure/pull/853
+[#854]: https://github.com/henrycgbaker/llenergymeasure/pull/854

--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -30,7 +30,7 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schema_version` | `str` | Result schema version (current: `"5.0"`). |
+| `bundle_version` | `str` | Results-bundle version (current: `"1.0"`), shared across `result.json`, `config.json`, and `environment.json` as one contract. |
 | `experiment_id` | `str` | Unique identifier for this experiment run. |
 | `measurement_config_hash` | `str` | 16-char SHA-256 hex of the `ExperimentConfig` (environment fields excluded). Matches the hash in the result directory name on disk. |
 | `llenergymeasure_version` | `str \| None` | Package version that produced this result. |

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -18,7 +18,7 @@ results/
 └── <study-name>_<UTC-timestamp>/
     ├── manifest.json                            # study-level checkpoint + summary
     ├── 001_c0_<model>-<engine>_<hash>/          # one experiment cell
-    │   ├── result.json                          # measurement metrics (schema 5.0)
+    │   ├── result.json                          # measurement metrics (bundle_version 1.0)
     │   ├── config.json                          # engine/model/methodology + resolved config + provenance
     │   ├── environment.json                     # hardware/runtime snapshot + runner provenance
     │   └── timeseries.parquet                   # GPU power/thermal/memory samples
@@ -33,7 +33,7 @@ results/
 
 ## `result.json` - per-experiment record
 
-The scientific record. One JSON file per experiment cell. Schema version `5.0`.
+The scientific record. One JSON file per experiment cell. Stamped with `bundle_version` `"1.0"` (the single version shared across every artefact in the bundle).
 
 `result.json` is measurement output. Configuration inputs and methodology - `engine_version`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected` - live in the `config.json` sidecar, not here. The one deliberate duplication: `result.json` keeps `model_name` and `engine` as convenience copies so a result file is self-describing when separated from its directory; the authoritative home for both is `config.json`.
 
@@ -41,7 +41,7 @@ The scientific record. One JSON file per experiment cell. Schema version `5.0`.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schema_version` | str | Result schema version (currently `"5.0"`) |
+| `bundle_version` | str | Results-bundle version (currently `"1.0"`), shared across `result.json`, `config.json`, and `environment.json` as one contract |
 | `experiment_id` | str | Unique experiment identifier (`{model}_{YYYYMMDD_HHMMSS}` for single experiments; study-level cells inherit a richer per-cell identifier) |
 | `measurement_config_hash` | str | SHA-256[:16] of `ExperimentConfig` with environment fields excluded; same hash -> logically identical experiments |
 | `llenergymeasure_version` | str &#124; null | Package version that produced this result |
@@ -285,11 +285,11 @@ ts = pd.read_parquet(study / "001_c0_qwen-transformers_a1b2c3" / "timeseries.par
 
 For the Python API equivalent (`StudyResult` object), see [Reference &gt; Library API](/reference/api/llenergymeasure).
 
-## Schema versioning
+## Bundle versioning
 
-`result.json.schema_version` follows semantic versioning: minor bumps add fields without breaking existing readers, major bumps signal breaking changes. Pre-1.0 the policy is conservative - new fields land as `Optional` with `default = null` so existing parsers don't break.
+The whole bundle carries one `bundle_version` (currently `"1.0"`), stamped identically into `result.json`, `config.json`, and `environment.json` (`timeseries.parquet` is self-describing columnar data and stays unversioned). It versions the on-disk layout, the artefact set, and each artefact's schema as a single contract, so there is one number to bump and one changelog line per documented break. This replaces the three independent per-artefact `schema_version` counters that earlier releases carried. It follows semantic versioning: minor bumps add fields without breaking existing readers, major bumps signal breaking changes. Pre-1.0 the policy is conservative - new fields land as `Optional` with `default = null` so existing parsers don't break.
 
-Schema `5.0` is a breaking change: it removes `engine_version`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, and `steady_state_not_detected` from `result.json`. Those configuration/methodology fields now live in the `config.json` sidecar. `result.json` keeps `model_name` and `engine` as convenience copies (authoritative home: `config.json`). Old bundles remain readable as their own schema version - there is no in-place migration.
+Bundles written before `bundle_version` existed remain readable best-effort: the canonical reader (`llenergymeasure.results.bundle.BundleReader`, wrapped by `load_result`) drops the retired `schema_version` key rather than rejecting it and emits a single warning. There is no in-place migration and no converter tooling.
 
 ## See also
 

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -247,7 +247,7 @@ After the run completes, the study directory looks roughly like this:
 results/tutorial-multi-engine_2026-05-07T14-32-08/
 ├── manifest.json                       # study-level: timing, config, completion
 ├── 001_c0_qwen-transformers_a1b2c3.../ # one experiment cell
-│   ├── result.json                     # measurement metrics only (schema 5.0)
+│   ├── result.json                     # measurement metrics only (bundle_version 1.0)
 │   ├── config.json                     # engine/model/methodology + resolved config + provenance
 │   └── timeseries.parquet              # GPU power/thermal/memory samples
 ├── 002_c0_qwen-transformers_d4e5f6.../
@@ -259,14 +259,14 @@ experiment list, study timing, completion status per cell, and the
 effective study-level config. This is what you load when you want to
 *reason about the study as a whole* rather than one cell.
 
-A single `result.json` is measurement output (schema 5.0). Configuration
+A single `result.json` is measurement output (bundle_version 1.0). Configuration
 moved to the sidecar; only `engine` and `model_name` remain as convenience
 copies so the file is self-describing when separated from its directory:
 
 ```json
 {
   "experiment_id": "qwen-transformers-bf16-bs16-fa2-2026-05-07T14-32-08",
-  "schema_version": "5.0",
+  "bundle_version": "1.0",
   "engine": "transformers",
   "model_name": "Qwen/Qwen2.5-0.5B",
   "input_tokens": 6144,
@@ -291,7 +291,7 @@ provenance:
 
 ```json
 {
-  "schema_version": "2.0",
+  "bundle_version": "1.0",
   "engine": "transformers",
   "engine_version": "4.57.1",
   "model_name": "Qwen/Qwen2.5-0.5B",

--- a/src/llenergymeasure/api/report_gaps.py
+++ b/src/llenergymeasure/api/report_gaps.py
@@ -42,7 +42,7 @@ from typing import Any, Literal
 import yaml
 
 from llenergymeasure.config.ssot import Engine
-from llenergymeasure.domain.bundle_artefacts import CONFIG_SIDECAR_FILENAME, MANIFEST_FILENAME
+from llenergymeasure.domain.bundle_artefacts import MANIFEST_FILENAME
 from llenergymeasure.study.runtime_observations import RUNTIME_OBSERVATIONS_FILENAME
 from llenergymeasure.utils.io import load_json
 
@@ -402,10 +402,8 @@ def _load_kwargs_via_manifest(
         if config_hash in by_hash:
             # Same config can repeat across cycles; one flat dict suffices.
             continue
-        config_path = study_dir / Path(result_file).parent / CONFIG_SIDECAR_FILENAME
-        if not config_path.exists():
-            continue
-        flat, failed = _read_provenance_sidecar(config_path)
+        bundle_dir = study_dir / Path(result_file).parent
+        flat, failed = _read_provenance_sidecar(bundle_dir)
         if failed:
             failures += 1
             continue
@@ -432,10 +430,7 @@ def _load_kwargs_via_prefix_scan(
             c in "0123456789abcdef" for c in hash_prefix
         ):
             continue
-        config_path = entry / CONFIG_SIDECAR_FILENAME
-        if not config_path.exists():
-            continue
-        flat, failed = _read_provenance_sidecar(config_path)
+        flat, failed = _read_provenance_sidecar(entry)
         if failed:
             failures += 1
             continue
@@ -445,18 +440,30 @@ def _load_kwargs_via_prefix_scan(
 
 
 def _read_provenance_sidecar(
-    path: Path,
+    bundle_dir: Path,
 ) -> tuple[dict[str, Any] | None, bool]:
-    """Parse ``config.json`` at ``path``; return (flat_kwargs or None, failed).
+    """Read the config.json provenance from ``bundle_dir``; return (flat_kwargs, failed).
 
-    Reads the ``provenance`` section (per-field ``{source, effective, default}``
-    entries) and flattens it to ``{dotted_path: effective_value}``.
+    Routes the per-experiment config.json read through the bundle owner
+    (:meth:`llenergymeasure.results.bundle.BundleReader.read_sidecar`, the
+    registry-driven single-artefact accessor) so the sidecar's on-disk location
+    and encoding stay owned in one place rather than re-derived here. Reads the
+    ``provenance`` section (per-field ``{source, effective, default}`` entries)
+    and flattens it to ``{dotted_path: effective_value}``.
+
+    Returns ``(None, False)`` when the sidecar is absent or carries no
+    ``provenance`` section, and ``(None, True)`` when it is present but
+    unparseable (so the caller can count it as a malformed-sidecar failure).
     """
+    from llenergymeasure.results.bundle import BundleReader
+
     try:
-        payload = load_json(path)
+        payload = BundleReader.read_sidecar(bundle_dir, "config")
     except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("Failed to parse config.json at %s: %s", path, exc)
+        logger.warning("Failed to parse config.json in %s: %s", bundle_dir, exc)
         return None, True
+    if payload is None:
+        return None, False
     provenance = payload.get("provenance") or {}
     if not isinstance(provenance, dict):
         return None, False

--- a/src/llenergymeasure/domain/README.md
+++ b/src/llenergymeasure/domain/README.md
@@ -40,10 +40,13 @@ Experiment result models.
 **ExperimentResult** - The user-visible output of a single-process measurement
 run. Holds the final metrics (energy, throughput, FLOPs, latency) directly.
 
-## Schema Version
+## Bundle Version
 
-Results include a `schema_version` field on `ExperimentResult` (see its default in
-`experiment.py`) for forward compatibility.
+`ExperimentResult` carries a `bundle_version` field (see its default in
+`experiment.py`, sourced from `bundle_artefacts.BUNDLE_VERSION`). It is the single
+version for the whole per-experiment bundle - the same value is stamped into
+`config.json` and `environment.json` - and it replaces the retired per-artefact
+`schema_version` counters.
 
 ## Related
 

--- a/src/llenergymeasure/domain/result_payload.py
+++ b/src/llenergymeasure/domain/result_payload.py
@@ -1,0 +1,76 @@
+"""Shared ExperimentResult payload parser.
+
+Lives in the domain layer (Layer 0) so BOTH read paths can share one parser
+without a layering violation: the infra exchange-read path
+(``infra.docker_runner._read_result``) is below ``results`` and could not import
+a parser that lived there, and the bundle-read path
+(``results.bundle.BundleReader`` / ``results.persistence.load_result``) is above
+infra. Domain is below both, so it is the only home a shared parser can have.
+
+The two call shapes differ only in tolerance:
+
+- The docker exchange payload is cross-version IPC: the container may run an
+  older or newer llenergymeasure than the host, so unknown fields are stripped
+  before validation and a version-skew warning is logged when the container
+  version does not match the host (``tolerant=True`` with ``expected_version``
+  set to the host version).
+- A persisted bundle is our own on-disk contract: no stripping, no version
+  handshake (``tolerant=False``, ``expected_version=None``).
+
+Tolerance for the retired per-artefact ``schema_version`` key is handled by the
+``ExperimentResult`` before-validator, so both call shapes read legacy payloads.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from llenergymeasure.domain.experiment import ExperimentResult
+
+logger = logging.getLogger(__name__)
+
+
+def parse_experiment_result_payload(
+    raw: dict[str, Any],
+    *,
+    tolerant: bool,
+    expected_version: str | None = None,
+) -> ExperimentResult:
+    """Parse a raw result payload into an :class:`ExperimentResult`.
+
+    Args:
+        raw: The decoded JSON object for one result. Mutated in place when
+            ``tolerant`` strips unknown fields (callers pass a fresh dict).
+        tolerant: When True, strip fields unknown to the current
+            ``ExperimentResult`` schema before validation (cross-version IPC).
+            When False, validate strictly - our own persisted bundle contract,
+            where an unexpected field signals real drift, not version skew.
+        expected_version: When set, log a version-skew warning if the parsed
+            result's ``llenergymeasure_version`` is None or differs from it (the
+            docker host/container image handshake). None disables the check (the
+            bundle path, which has no cross-version handshake).
+
+    Returns:
+        The validated ExperimentResult.
+    """
+    if tolerant:
+        known = set(ExperimentResult.model_fields)
+        extra = set(raw) - known
+        if extra:
+            for key in extra:
+                raw.pop(key)
+            logger.debug("Stripped unknown fields from result payload: %s", extra)
+
+    result = ExperimentResult.model_validate(raw)
+
+    if expected_version is not None:
+        version = result.llenergymeasure_version
+        if version is None or version != expected_version:
+            logger.warning(
+                "Container result version %s differs from host %s - rebuild Docker images",
+                version,
+                expected_version,
+            )
+
+    return result

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -1239,7 +1239,9 @@ class DockerRunner:
         Raises:
             DockerContainerError: If the result file does not exist.
         """
-        from llenergymeasure.domain.experiment import ExperimentResult
+        # Lazy import to avoid pulling the heavy domain result models at module
+        # load time (the parser imports ExperimentResult transitively).
+        from llenergymeasure.domain.result_payload import parse_experiment_result_payload
 
         result_path = exchange_dir / f"{config_hash}_result.json"
         if not result_path.exists():
@@ -1251,30 +1253,17 @@ class DockerRunner:
         raw = load_json(result_path)
 
         # Container may write an error payload even on exit 0 (defensive check).
-        # Error payloads have "type" and "traceback" keys (mirror StudyRunner worker format).
+        # Error payloads have "type" and "traceback" keys (mirror StudyRunner worker
+        # format). This detection stays here: it is exchange-specific IPC, not a
+        # property of a persisted result.
         if isinstance(raw, dict) and "type" in raw and "traceback" in raw:
             return raw
 
-        # Strip fields unknown to the host schema (container may run an older/newer
-        # version that produces fields the host model doesn't expect).
-        known_fields = set(ExperimentResult.model_fields)
-        extra_keys = set(raw.keys()) - known_fields
-        if extra_keys:
-            for key in extra_keys:
-                raw.pop(key)
-            logger.debug("Stripped unknown fields from container result: %s", extra_keys)
-
-        result = ExperimentResult.model_validate(raw)
-
-        container_version = result.llenergymeasure_version
-        if container_version is None or container_version != __version__:
-            logger.warning(
-                "Container result version %s differs from host %s - rebuild Docker images",
-                container_version,
-                __version__,
-            )
-
-        return result
+        # Cross-version IPC: strip fields unknown to the host schema (container may
+        # run an older/newer version) and warn on a host/container version skew.
+        # Both behaviours live in the shared parser now, keyed by tolerant=True and
+        # the host version as expected_version.
+        return parse_experiment_result_payload(raw, tolerant=True, expected_version=__version__)
 
     def _cleanup_exchange_dir(self, exchange_dir: Path) -> None:
         """Remove the temporary exchange directory.

--- a/src/llenergymeasure/results/bundle.py
+++ b/src/llenergymeasure/results/bundle.py
@@ -1,4 +1,4 @@
-"""Per-experiment results-bundle owner (writer side).
+"""Per-experiment results-bundle owner (writer + reader).
 
 ``BundleWriter`` is the single home for the assembly policy that decides how a
 completed experiment becomes an on-disk bundle: the collision-free experiment
@@ -7,24 +7,37 @@ directory, result.json (with runner provenance folded in), environment.json
 block), the config.json sidecar move + patch, the timeseries attach, and the
 loudness backstops that make a silently-missing artefact visible.
 
+``BundleReader`` is its read-side counterpart: given a bundle directory it
+discovers the artefacts via the same ``ARTEFACTS`` registry, parses result.json
+(the one required artefact), attaches the environment.json snapshot, and returns
+a :class:`LoadedBundle` (result + environment + config payload + the discovered
+paths). ``persistence.load_result`` is a thin wrapper over it, kept for API
+stability. A registry-driven single-artefact accessor (:meth:`BundleReader.read_sidecar`)
+serves consumers that need one JSON sidecar (e.g. ``report-gaps`` reading config
+provenance) without materialising the whole bundle.
+
 Previously this policy was smeared across ``results.persistence`` (atomic writes
 + dir naming) and ``study.runner._save_and_record`` (~215 lines of assembly). It
 now lives here, driven by the ``domain.bundle_artefacts.ARTEFACTS`` registry, so
 a future artefact type (e.g. a server-mode per-request series) is added with one
-registry entry plus one writer method - ``finalize()`` sweeps it automatically.
+registry entry plus one writer method - ``finalize()`` sweeps it automatically
+and ``read()`` surfaces it in ``LoadedBundle.paths``.
 
 The low-level mechanics (collision-free dir + atomic result/timeseries write,
 the host environment write) stay in ``results.persistence`` and are delegated to:
 ``persistence.save_result`` is public API, and keeping the primitive there
 preserves the atomic-write + chmod semantics and the existing regression tests.
-BundleWriter owns the policy; persistence owns the primitives.
+BundleWriter owns the write policy; BundleReader owns the read policy;
+persistence owns the primitives.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import warnings
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +47,7 @@ from llenergymeasure.domain.bundle_artefacts import (
     BUNDLE_VERSION,
     CONFIG_SIDECAR_FILENAME,
     ENVIRONMENT_FILENAME,
+    TIMESERIES_FILENAME,
 )
 from llenergymeasure.results import persistence
 from llenergymeasure.utils.io import load_json
@@ -321,3 +335,179 @@ class BundleWriter:
                     self._cycle,
                     f" - {spec.missing_note}" if spec.missing_note else "",
                 )
+
+
+@dataclass(frozen=True)
+class LoadedBundle:
+    """Everything :class:`BundleReader` recovers from one per-experiment bundle.
+
+    Attributes:
+        bundle_dir: The directory the bundle was read from.
+        result: The parsed ``result.json`` (the one required artefact), with the
+            environment snapshot attached to ``result.environment`` when present.
+        environment: The parsed ``environment.json`` snapshot, or None when the
+            sidecar is absent or unparseable. The same object attached to
+            ``result.environment``; exposed here for direct access.
+        config: The raw ``config.json`` payload dict (provenance, declared
+            config, observed hashes), or None when the sidecar is absent.
+        paths: Registry key -> on-disk path for every artefact present in the
+            bundle. A newly-registered artefact appears here automatically.
+    """
+
+    bundle_dir: Path
+    result: ExperimentResult
+    environment: EnvironmentSnapshot | None
+    config: dict[str, Any] | None
+    paths: dict[str, Path]
+
+
+class BundleReader:
+    """Read a per-experiment results bundle, discovery driven by the registry.
+
+    The counterpart to :class:`BundleWriter`. :meth:`read` iterates the
+    ``ARTEFACTS`` registry to discover which artefacts are present, enforces the
+    ``required`` contract (raising when result.json is missing), parses the JSON
+    artefacts with their typed models, and returns a :class:`LoadedBundle`.
+    :meth:`read_sidecar` is the registry-driven single-artefact accessor for
+    consumers that need one JSON sidecar without materialising the whole bundle.
+    """
+
+    @staticmethod
+    def read(bundle_dir: Path) -> LoadedBundle:
+        """Read the bundle under ``bundle_dir`` into a :class:`LoadedBundle`.
+
+        Discovery is registry-driven: every entry in ``ARTEFACTS`` is checked for
+        presence (populating ``LoadedBundle.paths``) and a missing ``required``
+        artefact raises. result.json is parsed strictly via the shared payload
+        parser; environment.json and config.json are best-effort (a corrupt or
+        absent optional sidecar yields None, never an error). When the result
+        references a timeseries whose parquet did not land, a ``UserWarning`` is
+        emitted (matching the historical ``load_result`` behaviour).
+
+        Args:
+            bundle_dir: The per-experiment bundle directory (the parent of
+                result.json).
+
+        Returns:
+            The assembled :class:`LoadedBundle`.
+
+        Raises:
+            FileNotFoundError: A required artefact (result.json) is missing.
+        """
+        bundle_dir = Path(bundle_dir)
+
+        paths: dict[str, Path] = {}
+        for name, spec in ARTEFACTS.items():
+            candidate = bundle_dir / spec.filename
+            if candidate.exists():
+                paths[name] = candidate
+            elif spec.required:
+                raise FileNotFoundError(
+                    f"Required bundle artefact '{name}' ({spec.filename}) missing from {bundle_dir}"
+                )
+
+        result = BundleReader._read_result_artefact(paths["result"])
+
+        environment = BundleReader._read_environment_artefact(paths.get("environment"))
+        if environment is not None:
+            result = result.model_copy(update={"environment": environment})
+
+        # config.json is best-effort here (a corrupt sidecar must not break the
+        # whole read); read_sidecar's strict variant is for consumers that need
+        # to distinguish absent from corrupt.
+        config: dict[str, Any] | None = None
+        if "config" in paths:
+            try:
+                config = load_json(paths["config"])
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("Could not load config sidecar %s: %s", paths["config"], exc)
+
+        # Declared-but-missing timeseries: the result references a parquet that is
+        # not in the bundle. Preserves the historical load_result degradation.
+        if result.timeseries is not None and "timeseries" not in paths:
+            warnings.warn(
+                f"Timeseries sidecar missing at {bundle_dir / TIMESERIES_FILENAME}. "
+                "result.timeseries field preserved but file is not present.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        return LoadedBundle(
+            bundle_dir=bundle_dir,
+            result=result,
+            environment=environment,
+            config=config,
+            paths=paths,
+        )
+
+    @staticmethod
+    def read_sidecar(bundle_dir: Path, key: str) -> dict[str, Any] | None:
+        """Read one registry JSON artefact's raw payload from a bundle dir.
+
+        The registry-driven single-artefact read for consumers that want one
+        sidecar (e.g. ``report-gaps`` reading the config.json ``provenance``
+        section) without loading result.json or the whole bundle. Returns the
+        decoded payload, or None when the artefact is absent. A present but
+        unparseable file raises so callers can distinguish an absent sidecar
+        from a corrupt one.
+
+        Args:
+            bundle_dir: The per-experiment bundle directory.
+            key: The ``ARTEFACTS`` registry key (e.g. ``"config"``).
+
+        Returns:
+            The decoded JSON payload, or None when the artefact is absent.
+
+        Raises:
+            ValueError: The keyed artefact is not a JSON artefact.
+            OSError / json.JSONDecodeError: The artefact is present but unreadable.
+        """
+        spec = ARTEFACTS[key]
+        if spec.kind != "json":
+            raise ValueError(f"Artefact '{key}' is {spec.kind}, not a JSON sidecar")
+        path = Path(bundle_dir) / spec.filename
+        if not path.exists():
+            return None
+        payload: dict[str, Any] = load_json(path)
+        return payload
+
+    @staticmethod
+    def _read_result_artefact(path: Path) -> ExperimentResult:
+        """Parse result.json strictly, with the legacy best-effort fallback.
+
+        A pre-bundle_version result.json (no ``bundle_version`` key) is still
+        read best-effort with a single ``UserWarning`` - the one documented
+        pre-1.0 bundle break. The shared parser (tolerant=False) validates the
+        payload; the ExperimentResult before-validator drops the retired
+        ``schema_version`` key so the legacy file falls back to the default
+        ``bundle_version`` rather than being rejected.
+        """
+        from llenergymeasure.domain.result_payload import parse_experiment_result_payload
+
+        raw = load_json(path)
+        if isinstance(raw, dict) and "bundle_version" not in raw:
+            warnings.warn(
+                "pre-bundle_version result; readable best-effort",
+                UserWarning,
+                stacklevel=2,
+            )
+        return parse_experiment_result_payload(raw, tolerant=False, expected_version=None)
+
+    @staticmethod
+    def _read_environment_artefact(path: Path | None) -> EnvironmentSnapshot | None:
+        """Load environment.json into an EnvironmentSnapshot (best-effort).
+
+        Returns None when the sidecar is absent or cannot be parsed, so a missing
+        or corrupt sidecar never breaks the read. The sidecar's extra
+        ``experiment_id`` / ``measurement_config_hash`` / ``bundle_version`` keys
+        are ignored by EnvironmentSnapshot validation.
+        """
+        if path is None:
+            return None
+        from llenergymeasure.domain.environment import EnvironmentSnapshot
+
+        try:
+            return EnvironmentSnapshot.model_validate_json(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Could not load environment sidecar %s: %s", path, exc)
+            return None

--- a/src/llenergymeasure/results/persistence.py
+++ b/src/llenergymeasure/results/persistence.py
@@ -12,7 +12,6 @@ import logging
 import os
 import shutil
 import tempfile
-import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -325,14 +324,13 @@ def save_result(
 def load_result(path: Path) -> ExperimentResult:
     """Load ExperimentResult from a result.json path.
 
-    Auto-discovers timeseries.parquet and environment.json sidecars
-    in the same directory. If the result references a timeseries sidecar
-    but the file is missing, loads successfully and emits a UserWarning
-    (graceful degradation).
-
-    When an environment.json sidecar is present, it is parsed and attached
-    to ``result.environment``. This is best-effort: a missing or corrupt
-    sidecar leaves ``result.environment`` as None and never raises.
+    Thin wrapper over :meth:`llenergymeasure.results.bundle.BundleReader.read`,
+    kept as public API for stability. The reader owns the read policy: it
+    auto-discovers the timeseries.parquet and environment.json sidecars in the
+    same directory, parses result.json (dropping the retired ``schema_version``
+    key on legacy bundles), attaches the environment snapshot to
+    ``result.environment`` when present, and emits a UserWarning when the result
+    references a timeseries whose parquet is missing (graceful degradation).
 
     Args:
         path: Path to result.json (as returned by save_result()).
@@ -341,46 +339,6 @@ def load_result(path: Path) -> ExperimentResult:
         ExperimentResult loaded from disk, with ``environment`` populated
         from the environment.json sidecar when one is present.
     """
-    from llenergymeasure.domain.experiment import ExperimentResult
+    from llenergymeasure.results.bundle import BundleReader
 
-    path = Path(path)
-    content = path.read_text(encoding="utf-8")
-    # A legacy (pre-bundle_version) result.json remains readable best-effort: the
-    # ExperimentResult before-validator drops the retired ``schema_version`` key.
-    # (The full legacy-fallback + read path lands with the bundle reader.)
-    result = ExperimentResult.model_validate_json(content)
-
-    sidecar = path.parent / TIMESERIES_FILENAME
-    if result.timeseries is not None and not sidecar.exists():
-        warnings.warn(
-            f"Timeseries sidecar missing at {sidecar}. "
-            "result.timeseries field preserved but file is not present.",
-            UserWarning,
-            stacklevel=2,
-        )
-
-    environment = _load_environment_sidecar(path.parent / ENVIRONMENT_FILENAME)
-    if environment is not None:
-        result = result.model_copy(update={"environment": environment})
-
-    return result
-
-
-def _load_environment_sidecar(path: Path) -> EnvironmentSnapshot | None:
-    """Load an environment.json sidecar into an EnvironmentSnapshot.
-
-    Best-effort: returns None when the sidecar is absent or cannot be parsed,
-    so a missing or corrupt sidecar never breaks load_result. The sidecar's
-    extra ``experiment_id`` / ``measurement_config_hash`` keys are ignored by
-    EnvironmentSnapshot validation.
-    """
-    if not path.exists():
-        return None
-
-    from llenergymeasure.domain.environment import EnvironmentSnapshot
-
-    try:
-        return EnvironmentSnapshot.model_validate_json(path.read_text(encoding="utf-8"))
-    except Exception as exc:
-        logger.warning("Could not load environment sidecar %s: %s", path, exc)
-        return None
+    return BundleReader.read(Path(path).parent).result

--- a/tests/helpers/runtime_obs.py
+++ b/tests/helpers/runtime_obs.py
@@ -43,7 +43,7 @@ def write_resolution(
     subdir = study_dir / dir_name
     subdir.mkdir(parents=True, exist_ok=True)
     payload = {
-        "schema_version": "2.0",
+        "bundle_version": "1.0",
         "experiment_id": f"exp-{full_hash[:8]}",
         "measurement_config_hash": full_hash,
         "engine": engine,

--- a/tests/unit/api/test_report_gaps.py
+++ b/tests/unit/api/test_report_gaps.py
@@ -466,3 +466,35 @@ def test_multiple_study_dirs_aggregate(tmp_path: Path) -> None:
     assert len(gaps) == 1
     assert gaps[0].collision_count == 2
     assert gaps[0].contrast_count == 1
+
+
+def test_corrupt_config_sidecar_counted_as_failure(tmp_path: Path, caplog) -> None:
+    """A present-but-unparseable config.json is a malformed-sidecar failure.
+
+    Guards the routing of the config-sidecar read through the bundle owner
+    (BundleReader.read_sidecar): a corrupt sidecar must still be flagged and
+    logged, and valid sibling sidecars must still produce their gaps.
+    """
+    import logging
+
+    study = tmp_path / "study"
+    study.mkdir()
+
+    h_fire = _fake_hash("fire")
+    h_bad = _fake_hash("bad")
+
+    _write_resolution(study, 1, 1, "transformers", h_fire, {"do_sample": False})
+    bad_dir = _write_resolution(study, 2, 1, "transformers", h_bad, {"do_sample": True})
+    # Corrupt the second experiment's config.json (present but unparseable).
+    (bad_dir / "config.json").write_text("{ not valid json", encoding="utf-8")
+
+    _write_jsonl_record(study, config_hash=h_fire, warnings_emitted=["gap warn"])
+    _write_jsonl_record(study, config_hash=h_bad)
+
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.api.report_gaps"):
+        gaps = find_runtime_gaps([study])
+
+    # The valid sidecar still yields its gap; the corrupt one is skipped + logged.
+    assert len(gaps) == 1
+    assert gaps[0].collision_count == 1
+    assert any("malformed config.json sidecar" in r.message for r in caplog.records)

--- a/tests/unit/domain/test_result_payload.py
+++ b/tests/unit/domain/test_result_payload.py
@@ -1,0 +1,104 @@
+"""Unit tests for the shared ExperimentResult payload parser.
+
+The parser is the one seam both read paths share: the docker exchange-read
+(cross-version IPC, tolerant) and the bundle-read (our own strict contract).
+These tests pin the tolerance parity between the two shapes and the version-skew
+handshake.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from llenergymeasure.domain.result_payload import parse_experiment_result_payload
+from tests.conftest import make_result
+
+_LOGGER = "llenergymeasure.domain.result_payload"
+
+
+def _payload(**overrides) -> dict:
+    """A valid result payload as a raw dict (JSON round-tripped for fidelity)."""
+    raw = json.loads(make_result(**overrides).model_dump_json())
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Tolerance parity: exchange (tolerant) vs bundle (strict)
+# ---------------------------------------------------------------------------
+
+
+def test_both_paths_parse_a_clean_payload_identically() -> None:
+    """A clean payload parses to the same result via tolerant and strict modes."""
+    raw_a = _payload()
+    raw_b = _payload()
+    exchange = parse_experiment_result_payload(raw_a, tolerant=True)
+    bundle = parse_experiment_result_payload(raw_b, tolerant=False)
+    assert exchange.model_dump_json() == bundle.model_dump_json()
+
+
+def test_tolerant_strips_unknown_fields() -> None:
+    """The exchange path drops fields the host schema does not know (version skew)."""
+    raw = _payload()
+    raw["a_field_from_a_newer_container"] = {"nested": 1}
+    result = parse_experiment_result_payload(raw, tolerant=True)
+    assert result.experiment_id == "test-001"
+
+
+def test_strict_rejects_unknown_fields() -> None:
+    """The bundle path is strict: an unknown field is real drift, not skew."""
+    raw = _payload()
+    raw["a_field_from_a_newer_container"] = {"nested": 1}
+    with pytest.raises(ValidationError):
+        parse_experiment_result_payload(raw, tolerant=False)
+
+
+def test_both_paths_tolerate_the_retired_schema_version_key() -> None:
+    """Legacy ``schema_version`` is dropped by the model before-validator on both paths."""
+    raw_a = _payload()
+    raw_a.pop("bundle_version", None)
+    raw_a["schema_version"] = "5.0"
+    raw_b = dict(raw_a)
+    # Even strict mode reads it: the retired key is dropped before validation.
+    assert parse_experiment_result_payload(raw_a, tolerant=False).experiment_id == "test-001"
+    assert parse_experiment_result_payload(raw_b, tolerant=True).experiment_id == "test-001"
+
+
+# ---------------------------------------------------------------------------
+# Version-skew handshake (expected_version)
+# ---------------------------------------------------------------------------
+
+
+def test_version_warning_when_expected_version_differs(caplog) -> None:
+    """A version mismatch against expected_version warns (the docker handshake)."""
+    raw = _payload(llenergymeasure_version="0.1.0")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        parse_experiment_result_payload(raw, tolerant=True, expected_version="9.9.9")
+    assert any("rebuild Docker images" in r.message for r in caplog.records)
+
+
+def test_version_warning_when_result_version_none(caplog) -> None:
+    """A None result version also warns when a version is expected."""
+    raw = _payload()  # llenergymeasure_version defaults to None
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        parse_experiment_result_payload(raw, tolerant=True, expected_version="1.0.0")
+    assert any("rebuild Docker images" in r.message for r in caplog.records)
+
+
+def test_no_version_warning_when_versions_match(caplog) -> None:
+    """No warning when the result version matches expected_version."""
+    raw = _payload(llenergymeasure_version="1.2.3")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        parse_experiment_result_payload(raw, tolerant=True, expected_version="1.2.3")
+    assert not any("rebuild Docker images" in r.message for r in caplog.records)
+
+
+def test_no_version_handshake_on_the_bundle_path(caplog) -> None:
+    """The bundle path passes expected_version=None: no handshake, no warning."""
+    raw = _payload()  # version None
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        parse_experiment_result_payload(raw, tolerant=False, expected_version=None)
+    assert not any("rebuild Docker images" in r.message for r in caplog.records)

--- a/tests/unit/results/test_bundle.py
+++ b/tests/unit/results/test_bundle.py
@@ -1,7 +1,8 @@
-"""Unit tests for BundleWriter - the per-experiment results-bundle owner.
+"""Unit tests for the per-experiment results-bundle owner (writer + reader).
 
-These exercise the writer policies directly (not through study.runner._save_and_record,
-which the tests in tests/unit/study/test_save_and_record.py cover end-to-end):
+The writer tests exercise the BundleWriter policies directly (not through
+study.runner._save_and_record, which tests/unit/study/test_save_and_record.py
+covers end-to-end):
 
 - bundle_version stamping across result.json / config.json / environment.json
 - runner-provenance attach on result.json
@@ -9,6 +10,13 @@ which the tests in tests/unit/study/test_save_and_record.py cover end-to-end):
 - the config-sidecar move + patch
 - the finalize loudness backstops (missing config, declared-but-missing timeseries)
 - the artefact registry as the server-mode extension point (register + sweep)
+
+The reader tests exercise BundleReader:
+
+- happy-path read into a LoadedBundle (result + environment + config + paths)
+- registry-driven discovery, including a newly-registered artefact surfacing
+- the strict required-artefact contract and the legacy best-effort fallback
+- the read_sidecar single-artefact accessor
 """
 
 from __future__ import annotations
@@ -17,6 +25,8 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
+
+import pytest
 
 from llenergymeasure.domain.bundle_artefacts import ARTEFACTS, BUNDLE_VERSION, ArtefactSpec
 from llenergymeasure.domain.environment import (
@@ -28,7 +38,7 @@ from llenergymeasure.domain.environment import (
     RunnerEnvironment,
 )
 from llenergymeasure.domain.experiment import RunnerProvenance
-from llenergymeasure.results.bundle import BundleWriter
+from llenergymeasure.results.bundle import BundleReader, BundleWriter, LoadedBundle
 from tests.conftest import make_result, write_container_environment_sidecar
 
 # ---------------------------------------------------------------------------
@@ -288,3 +298,179 @@ def test_finalize_sweeps_newly_registered_artefact(tmp_path: Path, caplog, monke
         "request_series" in rec.message and "request_series.parquet" in rec.message
         for rec in caplog.records
     ), "finalize must sweep any registered warn_if_missing artefact"
+
+
+# ---------------------------------------------------------------------------
+# BundleReader - read side
+# ---------------------------------------------------------------------------
+
+
+def _write_full_bundle(tmp_path: Path) -> Path:
+    """Write a complete bundle (result + environment + config) and return its dir."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "config.json").write_text(
+        json.dumps(
+            {
+                "experiment_id": "test-001",
+                "engine": "transformers",
+                "provenance": {"task.model": {"effective": "gpt2", "source": "yaml"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    writer = _writer(study_dir, ts_source_dir=staging)
+    writer.write_result(make_result())
+    writer.write_environment(
+        host_snapshot=_make_snapshot(),
+        runner_environment=RunnerEnvironment(mode="local", source="default"),
+        runner_provenance=RunnerProvenance(mode="local", source="local"),
+    )
+    writer.move_config_sidecar(resolved_config_hash="resolved_h1", resolution_log=None)
+    writer.finalize()
+    return writer.bundle_dir
+
+
+def test_bundle_reader_happy_path(tmp_path: Path) -> None:
+    """read() returns a LoadedBundle with result + environment + config + paths."""
+    bundle_dir = _write_full_bundle(tmp_path)
+
+    loaded = BundleReader.read(bundle_dir)
+
+    assert isinstance(loaded, LoadedBundle)
+    assert loaded.bundle_dir == bundle_dir
+    assert loaded.result.experiment_id == "test-001"
+    # Environment parsed and attached to the result (matching load_result).
+    assert loaded.environment is not None
+    assert loaded.result.environment is loaded.environment
+    assert loaded.environment.python_version == "3.12.12"
+    # Config payload surfaced as a raw dict.
+    assert loaded.config is not None
+    assert loaded.config["provenance"]["task.model"]["effective"] == "gpt2"
+    # Registry-keyed paths for every present artefact.
+    assert loaded.paths["result"].name == "result.json"
+    assert loaded.paths["config"].name == "config.json"
+    assert loaded.paths["environment"].name == "environment.json"
+
+
+def test_bundle_reader_registry_driven_discovery(tmp_path: Path, monkeypatch) -> None:
+    """A newly-registered artefact present in the dir surfaces in LoadedBundle.paths.
+
+    Discovery is driven by the ARTEFACTS registry, so a future artefact (e.g. a
+    server-mode per-request series) is picked up by read() with one registry
+    entry - no reader plumbing changes.
+    """
+    monkeypatch.setitem(
+        ARTEFACTS,
+        "request_series",
+        ArtefactSpec(
+            "request_series.parquet", required=False, warn_if_missing=False, kind="parquet"
+        ),
+    )
+    bundle_dir = _write_full_bundle(tmp_path)
+    (bundle_dir / "request_series.parquet").write_bytes(b"PAR1")
+
+    loaded = BundleReader.read(bundle_dir)
+    assert loaded.paths["request_series"].name == "request_series.parquet"
+
+
+def test_bundle_reader_missing_result_raises(tmp_path: Path) -> None:
+    """A bundle dir without the required result.json raises (strict contract)."""
+    empty = tmp_path / "empty-bundle"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError):
+        BundleReader.read(empty)
+
+
+def test_bundle_reader_optional_sidecars_absent(tmp_path: Path) -> None:
+    """A result-only bundle reads with environment and config as None."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)
+    writer.write_result(make_result())
+
+    loaded = BundleReader.read(writer.bundle_dir)
+    assert loaded.environment is None
+    assert loaded.config is None
+    assert "config" not in loaded.paths
+    assert "environment" not in loaded.paths
+
+
+def test_bundle_reader_legacy_fallback_warns(tmp_path: Path) -> None:
+    """A pre-bundle_version result.json reads best-effort with ONE UserWarning."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)
+    result_path = writer.write_result(make_result())
+    # Simulate a legacy bundle: retired per-artefact key, no bundle_version.
+    raw = json.loads(result_path.read_text(encoding="utf-8"))
+    raw.pop("bundle_version", None)
+    raw["schema_version"] = "5.0"
+    result_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.warns(UserWarning, match="pre-bundle_version result; readable best-effort"):
+        loaded = BundleReader.read(writer.bundle_dir)
+    assert loaded.result.experiment_id == "test-001"
+    assert loaded.result.bundle_version == BUNDLE_VERSION
+
+
+def test_bundle_reader_declared_but_missing_timeseries_warns(tmp_path: Path) -> None:
+    """read() warns when the result references a parquet that did not land."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)
+    writer.write_result(make_result(timeseries="timeseries.parquet"))
+
+    with pytest.warns(UserWarning, match="Timeseries sidecar missing"):
+        BundleReader.read(writer.bundle_dir)
+
+
+def test_bundle_reader_corrupt_environment_is_best_effort(tmp_path: Path) -> None:
+    """A corrupt environment.json yields environment=None, never an error."""
+    study_dir = tmp_path / "study"
+    study_dir.mkdir()
+    writer = _writer(study_dir)
+    writer.write_result(make_result())
+    (writer.bundle_dir / "environment.json").write_text("{ not valid json", encoding="utf-8")
+
+    loaded = BundleReader.read(writer.bundle_dir)
+    assert loaded.environment is None
+    assert loaded.result.experiment_id == "test-001"
+
+
+# ---------------------------------------------------------------------------
+# BundleReader.read_sidecar - registry-driven single-artefact accessor
+# ---------------------------------------------------------------------------
+
+
+def test_read_sidecar_returns_config_payload(tmp_path: Path) -> None:
+    """read_sidecar reads the config.json payload without loading result.json."""
+    bundle_dir = _write_full_bundle(tmp_path)
+    payload = BundleReader.read_sidecar(bundle_dir, "config")
+    assert payload is not None
+    assert payload["provenance"]["task.model"]["effective"] == "gpt2"
+
+
+def test_read_sidecar_absent_returns_none(tmp_path: Path) -> None:
+    """An absent sidecar returns None (not an error)."""
+    empty = tmp_path / "bundle"
+    empty.mkdir()
+    assert BundleReader.read_sidecar(empty, "config") is None
+
+
+def test_read_sidecar_corrupt_raises(tmp_path: Path) -> None:
+    """A present-but-unparseable sidecar raises so callers can flag it a failure."""
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "config.json").write_text("{ not valid json", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        BundleReader.read_sidecar(bundle, "config")
+
+
+def test_read_sidecar_rejects_non_json_artefact(tmp_path: Path) -> None:
+    """read_sidecar is JSON-only: a parquet artefact key is a programming error."""
+    with pytest.raises(ValueError, match="not a JSON sidecar"):
+        BundleReader.read_sidecar(tmp_path, "timeseries")

--- a/tests/unit/study/test_single.py
+++ b/tests/unit/study/test_single.py
@@ -225,7 +225,7 @@ def test_config_sidecar_materialises_without_timeseries(monkeypatch, tmp_path):
         captured_output_dirs.append(output_dir)
         if output_dir is not None:
             (Path(output_dir) / "config.json").write_text(
-                _json.dumps({"schema_version": "2.0", "engine": "transformers"}),
+                _json.dumps({"bundle_version": "1.0", "engine": "transformers"}),
                 encoding="utf-8",
             )
         return mock_result


### PR DESCRIPTION
## Summary

Slice S5 of the F6 milestone: completes the per-experiment results-bundle owner with the read side (S4 shipped the writer in #853).

- **Shared parser (`domain/result_payload.py`).** `parse_experiment_result_payload(raw, *, tolerant, expected_version)` is the one seam both read paths share. The docker exchange-read (`infra.docker_runner._read_result`) calls it with `tolerant=True` and the host version, preserving cross-version field stripping and the host/container version-skew warning exactly; the bundle-read calls it strictly. It lives in the domain layer (Layer 0) so infra (Layer 1) and results (Layer 3) can both import it without a layering violation. The exchange path keeps its own error-payload detection; results keeps sidecar attach.
- **`BundleReader` (`results/bundle.py`).** `read(bundle_dir) -> LoadedBundle` (result + environment + config payload + registry-keyed `paths`), discovery driven by the `ARTEFACTS` registry: `required` is enforced (missing result.json raises), `kind` is dispatched (JSON parsed, parquet path-only), and a newly-registered artefact surfaces in `LoadedBundle.paths` automatically. A pre-`bundle_version` bundle reads best-effort with one `UserWarning` (the single documented pre-1.0 break). `read_sidecar(bundle_dir, key)` is the registry-driven single-artefact accessor. `persistence.load_result` becomes a thin wrapper over `read` (public API and behaviour unchanged).
- **Production caller.** Investigation confirmed the S4 handover: `resume` reads only the study-level `manifest.json` (not a per-experiment bundle artefact), and `report-gaps` reads per-experiment `config.json` provenance sidecars (never result.json - its fixtures create config.json-only dirs). So `report-gaps` is routed through `BundleReader.read_sidecar` (config-only, no result.json over-read), becoming the real production caller `load_result` never had. Forcing it through the full `read()` would break every fixture and regress the config-only reads, exactly the "do not force blindly" case the brief flagged.
- **Docs.** `results-schema.md`, `library/ExperimentResult.md`, `domain/README.md`, and `tutorials/multi-engine-study.md` rewritten from the retired `schema_version` "5.0"/"2.0" contract to `bundle_version` "1.0". None are generator-owned (verified). Config-sidecar fixture dead-literals (`test_single.py`, `runtime_obs.py`) refreshed; the two manifest fixtures were left alone because `StudyManifest.schema_version` is a real study-level field, not the bundle version.

## Test plan

- `make lint` - clean.
- `make typecheck` - clean (316 files).
- `uv run pytest tests/unit/ -q` - 3136 passed, 36 skipped.
- `uv run pytest tests/integration/test_e2e_pipeline.py -q` - 16 passed.
- Docker rescue/version tests (`tests/unit/docker/test_docker_runner.py`) - 96 passed (version-skew warning still asserted after the parser move).
- New: `tests/unit/domain/test_result_payload.py` (tolerance parity: tolerant strips vs strict rejects, legacy `schema_version` dropped on both, version-skew handshake). `tests/unit/results/test_bundle.py` (BundleReader happy path, registry-driven discovery incl. a newly-registered artefact in `LoadedBundle.paths`, required-missing raises, legacy fallback warning, corrupt-environment best-effort, `read_sidecar` present/absent/corrupt/non-JSON). `tests/unit/api/test_report_gaps.py` (corrupt config.json still counted as a malformed-sidecar failure through the new routing).