### PR TITLE
refactor(harness): tidy harness and engine seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,17 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `EnginePlugin.load_model` protocol return type tightens to `tuple[Any, Any]`, and two
   unreachable TensorRT plugin guards (already enforced at config validation) are removed.
   ([#852])
+- The TensorRT HF pre-quantised-checkpoint gate (AWQ/GPTQ rejection unless a
+  prebuilt `engine_path` is supplied) is folded into the tensorrt plugin's
+  `check_hardware` hook and no longer a standalone preflight step. Preflight now
+  routes every engine uniformly through `check_hardware`, so there is one
+  compatibility seam instead of an engine-specific branch. Behaviour is unchanged
+  (same error, same actionable message); the `check_hardware` contract now also
+  carries GPU-independent config/checkpoint-compat errors. ([#855])
+- The vLLM `gpu_memory_utilization` pre-allocation heuristic (deciding whether a
+  torch peak reading is really vLLM's up-front reservation) is extracted from
+  `run_inference` to a named, unit-tested `_peak_matches_vllm_prealloc` helper.
+  Internal refactor, no behavior change. ([#855])
 
 ### Removed
 
@@ -99,6 +110,14 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   no longer flake under randomized test ordering: the `tempfile.mkdtemp` mock now routes
   by prefix instead of assuming a fixed call count, so the process-cached dispatch-asset
   materialisation can no longer steal the rescue tempdir slot.
+- `TransformersEngine.load_model` now wraps model/tokenizer construction failures
+  in `EngineError` (naming the model and engine), at parity with the vllm and
+  tensorrt plugins. A missing/gated model, OOM, or bad dtype at load time surfaces
+  as one actionable error rather than a bare transformers traceback. ([#855])
+- When energy auto-selection finds no available sampler, the per-sampler probe
+  reasons ("zeus: package not installed", ...) are now folded into the structured
+  `energy_measurement_unavailable` measurement warning, not only logged. Containers
+  and CI surface why energy was unavailable without log spelunking. ([#855])
 
 ## [v0.6.0] - 2026-07-18
 
@@ -1274,3 +1293,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#852]: https://github.com/henrycgbaker/llenergymeasure/pull/852
 [#853]: https://github.com/henrycgbaker/llenergymeasure/pull/853
 [#854]: https://github.com/henrycgbaker/llenergymeasure/pull/854
+[#855]: https://github.com/henrycgbaker/llenergymeasure/pull/855

--- a/src/llenergymeasure/energy/__init__.py
+++ b/src/llenergymeasure/energy/__init__.py
@@ -74,9 +74,37 @@ def select_energy_sampler(
     Raises:
         ConfigError: When an explicitly requested sampler is not available.
     """
+    sampler, _reasons = select_energy_sampler_with_diagnostics(explicit, gpu_indices=gpu_indices)
+    return sampler
+
+
+def select_energy_sampler_with_diagnostics(
+    explicit: str | None,
+    gpu_indices: list[int] | None = None,
+) -> tuple[EnergySampler | None, list[str]]:
+    """Select a sampler AND return the per-sampler probe reasons.
+
+    Same selection rules as :func:`select_energy_sampler`, but the second tuple
+    element carries the diagnostic why-chain so a caller (the harness) can put the
+    reason a measurement backend failed to come up into structured
+    ``measurement_warnings`` - not only the log. The reasons list is non-empty
+    only on the ``"auto"`` path when NO sampler was available; a disabled sampler
+    (``None``) and a successful selection both return ``[]``.
+
+    Args:
+        explicit: Sampler name, ``"auto"``, or ``None`` to disable energy measurement.
+        gpu_indices: GPU device indices to monitor. Defaults to [0] when None.
+            Forwarded to NVMLSampler and ZeusSampler constructors.
+
+    Returns:
+        ``(sampler_or_none, reasons)``.
+
+    Raises:
+        ConfigError: When an explicitly requested sampler is not available.
+    """
     # Intentional disable - null in YAML maps to Python None
     if explicit is None:
-        return None
+        return None, []
 
     if explicit == "auto":
         return _auto_select(gpu_indices=gpu_indices)
@@ -89,15 +117,16 @@ def select_energy_sampler(
             f"Energy sampler '{explicit}' is not available on this system.\n"
             f"Install with: {guidance}"
         )
-    return sampler
+    return sampler, []
 
 
-def _auto_select(gpu_indices: list[int] | None = None) -> EnergySampler | None:
+def _auto_select(gpu_indices: list[int] | None = None) -> tuple[EnergySampler | None, list[str]]:
     """Auto-select best available sampler: Zeus > NVML > CodeCarbon > None.
 
-    On total failure (no sampler available) this logs a warning naming the reason
-    each probe was skipped or rejected, so a silent energy=0.0 result is never the
-    only trace of a measurement backend that failed to come up.
+    Returns ``(sampler, [])`` on success. On total failure (no sampler available)
+    logs a warning naming the reason each probe was skipped or rejected, and also
+    returns those reasons as the second tuple element so a silent energy=0.0
+    result is never the only trace of a measurement backend that failed to come up.
     """
     # Record why each candidate was skipped or rejected, for the failure warning.
     reasons: list[str] = []
@@ -106,7 +135,7 @@ def _auto_select(gpu_indices: list[int] | None = None) -> EnergySampler | None:
     if importlib.util.find_spec("zeus") is not None:
         sampler = ZeusSampler(gpu_indices=gpu_indices)
         if sampler.is_available():
-            return sampler
+            return sampler, []
         reasons.append("zeus: installed but is_available() returned False")
     else:
         reasons.append("zeus: package not installed")
@@ -114,14 +143,14 @@ def _auto_select(gpu_indices: list[int] | None = None) -> EnergySampler | None:
     # NVML - always available on GPU machines (nvidia-ml-py is a base dep)
     nvml_sampler = NVMLSampler(gpu_indices=gpu_indices)
     if nvml_sampler.is_available():
-        return nvml_sampler
+        return nvml_sampler, []
     reasons.append("nvml: is_available() returned False (no NVIDIA GPU or NVML init failed)")
 
     # CodeCarbon - software fallback (no gpu_indices: CodeCarbon handles its own GPU detection)
     if importlib.util.find_spec("codecarbon") is not None:
         cc_sampler = CodeCarbonSampler()
         if cc_sampler.is_available():
-            return cc_sampler
+            return cc_sampler, []
         reasons.append("codecarbon: installed but is_available() returned False")
     else:
         reasons.append("codecarbon: package not installed")
@@ -133,7 +162,7 @@ def _auto_select(gpu_indices: list[int] | None = None) -> EnergySampler | None:
         "not a measured zero. Probe results: %s",
         "; ".join(reasons),
     )
-    return None
+    return None, reasons
 
 
 def _instantiate(name: str, gpu_indices: list[int] | None = None) -> EnergySampler:
@@ -169,4 +198,5 @@ __all__ = [
     "NVMLSampler",
     "ZeusSampler",
     "select_energy_sampler",
+    "select_energy_sampler_with_diagnostics",
 ]

--- a/src/llenergymeasure/engines/protocol.py
+++ b/src/llenergymeasure/engines/protocol.py
@@ -132,12 +132,18 @@ class EnginePlugin(Protocol):
         ...
 
     def check_hardware(self, config: ExperimentConfig) -> list[str]:
-        """Return host-GPU compatibility errors (empty list when compatible).
+        """Return host/engine compatibility errors (empty list when compatible).
+
+        The single preflight compatibility hook: it carries host-GPU hardware
+        gates AND engine-specific config/checkpoint compatibility (e.g. TRT-LLM
+        rejecting HF pre-quantised AWQ/GPTQ checkpoints).
 
         - Never raises; errors propagate via the returned list.
-        - Returns ``[]`` when no GPU is visible (containers without a visible
-          device must not block at config time).
-        - Pure: no weight loading, no GPU allocation, no engine construction.
+        - GPU-dependent gates return ``[]`` when no GPU is visible (containers
+          without a visible device must not block at config time); GPU-independent
+          config/checkpoint checks may still return errors in that case.
+        - No weight loading, no GPU allocation, no engine construction. May read
+          model metadata (e.g. a checkpoint ``config.json``), not weights.
         """
         ...
 

--- a/src/llenergymeasure/engines/tensorrt/plugin.py
+++ b/src/llenergymeasure/engines/tensorrt/plugin.py
@@ -17,6 +17,7 @@ engine is ready.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import logging
 import time
@@ -27,8 +28,91 @@ from typing import Any
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.engines.protocol import InferenceOutput
 from llenergymeasure.utils.exceptions import ConfigError, EngineError
+from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
+
+# TRT-LLM's LLM API cannot load AutoAWQ / AutoGPTQ community-format HF
+# checkpoints directly on EITHER backend at 1.2.1 (live-verified against
+# Qwen2.5-0.5B-Instruct-AWQ): the trt backend raises NotImplementedError on the
+# config.json quant_method (llm_utils.py only handles fp8/mxfp4 there), and the
+# pytorch backend asserts on the weight layout (linear.py expects the ModelOpt
+# packing, not AutoAWQ's qweight). TRT-LLM's supported pre-quantised path is its
+# own ModelOpt export (hf_quant_config.json) or a pre-built engine via
+# engine_path. Detection keys on the HF-declared quant_method rather than a
+# regex over model ids, so user-renamed forks are still caught - extend by
+# adding the canonical quant_method string, not a pattern.
+_TRT_UNSUPPORTED_HF_QUANT_METHODS: tuple[str, ...] = ("awq", "gptq")
+
+
+def _read_model_quant_method(model_id: str) -> str | None:
+    """Return the HF ``quantization_config.quant_method`` for *model_id*, or None.
+
+    ``quantization_config.quant_method`` is HF's authoritative quantisation
+    declaration - every quantisation library (AutoAWQ, AutoGPTQ, bitsandbytes,
+    compressed-tensors) writes it, so it's the stable signal for "is this
+    checkpoint pre-quantised, and how?".
+
+    Returns None for both "no quantisation declared" AND "couldn't determine"
+    (network error, missing config, malformed JSON, no huggingface_hub
+    installed). Callers must treat None as "not detected, proceed" rather
+    than "definitely unquantised" - failing closed on transient errors would
+    block legitimate runs on every network hiccup.
+    """
+    config_data: dict[str, object] | None = None
+
+    if model_id.startswith(("/", "./", "~")):
+        config_path = Path(model_id).expanduser() / "config.json"
+        try:
+            config_data = load_json(config_path)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("Could not read local config.json for %s: %s", model_id, exc)
+            return None
+    else:
+        if importlib.util.find_spec("huggingface_hub") is None:
+            return None
+        try:
+            from huggingface_hub import hf_hub_download
+
+            local = hf_hub_download(repo_id=model_id, filename="config.json")
+            config_data = load_json(local)
+        except Exception as exc:
+            logger.debug("Could not fetch HF config.json for %s: %s", model_id, exc)
+            return None
+
+    quant_block = config_data.get("quantization_config") if isinstance(config_data, dict) else None
+    if not isinstance(quant_block, dict):
+        return None
+    method = quant_block.get("quant_method")
+    return method.lower() if isinstance(method, str) else None
+
+
+def _check_tensorrt_checkpoint_compat(config: ExperimentConfig) -> str | None:
+    """Reject HF pre-quantised checkpoints on TRT-LLM unless ``engine_path`` is set.
+
+    A checkpoint-compatibility check (GPU-independent): reads the HF-declared
+    quant_method and rejects AWQ/GPTQ community checkpoints, which TRT-LLM's LLM
+    API cannot load unless the user supplied a prebuilt engine via ``engine_path``.
+    """
+    # engine_path is an extra="allow" passthrough inside engine_params (matches
+    # this plugin's read in _build_llm_kwargs).
+    engine_params = config.active_engine_params()
+    if engine_params is not None and getattr(engine_params, "engine_path", None):
+        return None
+
+    method = _read_model_quant_method(config.task.model)
+    if method is None or method not in _TRT_UNSUPPORTED_HF_QUANT_METHODS:
+        return None
+
+    return (
+        f"{config.task.model} is an HF {method.upper()} checkpoint; TRT-LLM's LLM API "
+        f"cannot load it on either backend at 1.2.1 (the trt backend rejects the "
+        f"quant_method, the pytorch backend rejects the weight layout). Use a "
+        f"ModelOpt-quantised checkpoint (with hf_quant_config.json) instead, or "
+        f"pre-build a TRT-LLM engine (`trtllm-build --checkpoint_dir <converted> ...`) "
+        f"and set `tensorrt.engine_params.engine_path` to the build output. See "
+        f"docs/how-to/run-with-tensorrt-llm.md#hf-pre-quantised-checkpoints."
+    )
 
 
 def _validate_engine_directory(engine_path: Path, tp_size: int) -> list[str]:
@@ -490,24 +574,32 @@ class TensorRTEngine:
 
     @staticmethod
     def check_hardware(config: ExperimentConfig) -> list[str]:
-        """Check SM capability + FP8 requirements against the visible GPU.
+        """Return checkpoint-compat + SM/FP8 compatibility errors for TRT-LLM.
 
-        Gates:
-          - SM >= 7.5 (Turing minimum for TRT-LLM)
-          - FP8 weight quant requires SM >= 8.9 (Ada Lovelace / Hopper)
-          - FP8 KV-cache quant requires SM >= 8.9
+        Two classes of check, both surfaced through this one hook so the harness
+        preflight routes every engine uniformly through ``check_hardware``:
 
-        Returns ``[]`` when no GPU is visible.
+        - Checkpoint compatibility (GPU-independent): reject HF pre-quantised
+          AWQ/GPTQ checkpoints, which TRT-LLM's LLM API cannot load unless a
+          prebuilt ``engine_path`` is supplied. Runs regardless of GPU visibility.
+        - Hardware gates (need a visible GPU): SM >= 7.5 (Turing minimum); FP8
+          weight quant and FP8 KV-cache quant each require SM >= 8.9 (Ada
+          Lovelace / Hopper). Skipped when no GPU is visible.
         """
+        errors: list[str] = []
+
+        checkpoint_error = _check_tensorrt_checkpoint_compat(config)
+        if checkpoint_error is not None:
+            errors.append(checkpoint_error)
+
         from llenergymeasure.device.gpu_info import get_compute_capability
 
         sm = get_compute_capability()
         if sm is None:
-            return []
+            return errors
 
         major, minor = sm
         sm_float = major + minor / 10
-        errors: list[str] = []
 
         if sm_float < 7.5:
             errors.append(

--- a/src/llenergymeasure/engines/transformers/plugin.py
+++ b/src/llenergymeasure/engines/transformers/plugin.py
@@ -18,6 +18,7 @@ from typing import Any
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.domain.metrics import LatencyMeasurementMode
 from llenergymeasure.engines.protocol import InferenceOutput
+from llenergymeasure.utils.exceptions import EngineError
 
 logger = logging.getLogger(__name__)
 
@@ -96,20 +97,29 @@ class TransformersEngine:
         kwargs = self._model_load_kwargs(config)
         logger.info("Loading model %r with kwargs: %s", config.task.model, list(kwargs.keys()))
 
-        t0 = time.perf_counter()
-        tokenizer = AutoTokenizer.from_pretrained(
-            config.task.model, trust_remote_code=kwargs.get("trust_remote_code", False)
-        )
-        if tokenizer.pad_token is None:
-            tokenizer.pad_token = tokenizer.eos_token
-        if on_substep is not None:
-            on_substep("tokenizer loaded", time.perf_counter() - t0)
+        # Wrap construction in EngineError for parity with the vllm/tensorrt
+        # plugins: a load failure (missing/gated model, OOM, bad dtype) surfaces
+        # as a single actionable EngineError naming the model and engine, not a
+        # bare transformers traceback.
+        try:
+            t0 = time.perf_counter()
+            tokenizer = AutoTokenizer.from_pretrained(
+                config.task.model, trust_remote_code=kwargs.get("trust_remote_code", False)
+            )
+            if tokenizer.pad_token is None:
+                tokenizer.pad_token = tokenizer.eos_token
+            if on_substep is not None:
+                on_substep("tokenizer loaded", time.perf_counter() - t0)
 
-        t0 = time.perf_counter()
-        model = AutoModelForCausalLM.from_pretrained(config.task.model, **kwargs)
-        model.eval()
-        if on_substep is not None:
-            on_substep("model weights loaded", time.perf_counter() - t0)
+            t0 = time.perf_counter()
+            model = AutoModelForCausalLM.from_pretrained(config.task.model, **kwargs)
+            model.eval()
+            if on_substep is not None:
+                on_substep("model weights loaded", time.perf_counter() - t0)
+        except Exception as e:
+            raise EngineError(
+                f"Transformers model loading failed for {config.task.model!r}: {e}"
+            ) from e
 
         # allow_tf32 + torch.compile are llem-orchestration knobs (HarnessConfig),
         # not engine-native config.

--- a/src/llenergymeasure/engines/vllm/plugin.py
+++ b/src/llenergymeasure/engines/vllm/plugin.py
@@ -91,6 +91,27 @@ def _capture_kv_cache_stats(llm: Any) -> dict[str, Any] | None:
     return stats or None
 
 
+def _peak_matches_vllm_prealloc(
+    peak_mb: float, total_vram_mb: float, gpu_memory_utilization: float
+) -> bool:
+    """Return True when a torch peak reading is really vLLM's up-front reservation.
+
+    vLLM reserves ``gpu_memory_utilization * total_vram`` when the engine is
+    constructed. A torch peak that lands within 5% of that reservation is the
+    pre-allocation, not the inference-window working set, so the caller should
+    prefer the NVML device-used proxy over this value.
+
+    Returns False for a non-positive expected reservation (no VRAM reading or a
+    zero utilisation), which keeps the caller on the torch value - matching the
+    prior inline behaviour where a zero divisor was swallowed and the torch value
+    retained.
+    """
+    expected_prealloc_mb = total_vram_mb * gpu_memory_utilization
+    if expected_prealloc_mb <= 0:
+        return False
+    return abs(peak_mb - expected_prealloc_mb) / expected_prealloc_mb < 0.05
+
+
 def _extract_request_stats(outputs: Any) -> tuple[list[float], list[float], list[float]]:
     """Per-request (e2e_ms, ttft_ms, decode_itl_ms) from vLLM V1 ``RequestStateStats``.
 
@@ -361,9 +382,9 @@ class VLLMEngine:
                 peak_mb = nvml_peak
         elif peak_mb > 0:
             # torch saw an in-process allocation (V0-era), but it may just be
-            # vLLM's pre-allocation. Heuristic: if peak matches
-            # gpu_memory_utilization * total_vram within 5%, it's pre-allocation,
-            # not actual usage - NVML device-used is the closer proxy.
+            # vLLM's pre-allocation. If the peak matches gpu_memory_utilization *
+            # total_vram within 5% it is pre-allocation, not actual usage - NVML
+            # device-used is the closer proxy (see _peak_matches_vllm_prealloc).
             try:
                 import torch
 
@@ -374,12 +395,11 @@ class VLLMEngine:
                 gpu_util = 0.9  # vLLM default
                 if engine_params is not None and engine_params.gpu_memory_utilization is not None:
                     gpu_util = engine_params.gpu_memory_utilization
-                expected_prealloc = total_vram * gpu_util
-                if abs(peak_mb - expected_prealloc) / expected_prealloc < 0.05:
+                if _peak_matches_vllm_prealloc(peak_mb, total_vram, gpu_util):
                     logger.debug(
                         "torch peak (%.1fMB) matches pre-allocation (%.1fMB), trying NVML",
                         peak_mb,
-                        expected_prealloc,
+                        total_vram * gpu_util,
                     )
                     nvml_peak = get_nvml_device_memory_mb()
                     if nvml_peak is not None:

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -30,7 +30,7 @@ from llenergymeasure.domain.experiment import (
     mj_per_token,
 )
 from llenergymeasure.domain.progress import STEP_BASELINE
-from llenergymeasure.energy import select_energy_sampler
+from llenergymeasure.energy import select_energy_sampler, select_energy_sampler_with_diagnostics
 from llenergymeasure.engines.protocol import EnginePlugin, InferenceOutput
 from llenergymeasure.harness.warmup import thermal_floor_wait, warmup_until_converged
 from llenergymeasure.results.persistence import save_config_sidecar
@@ -201,6 +201,7 @@ def collect_measurement_warnings(
     temp_end_c: float | None,
     nvml_sample_count: int,
     energy_measurement_present: bool = True,
+    energy_sampler_reasons: list[str] | None = None,
 ) -> list[str]:  # pragma: no cover
     from llenergymeasure.harness.measurement_warnings import (
         collect_measurement_warnings as _cmw,
@@ -213,6 +214,7 @@ def collect_measurement_warnings(
         temp_end_c=temp_end_c,
         nvml_sample_count=nvml_sample_count,
         energy_measurement_present=energy_measurement_present,
+        energy_sampler_reasons=energy_sampler_reasons,
     )
 
 
@@ -245,6 +247,10 @@ class _MeasuredWindow:
     thermal_info: Any
     timeseries_samples: list[PowerThermalSample]
     energy_measurement: Any
+    # Per-sampler probe reasons captured at energy-sampler selection time; only
+    # populated when auto-selection found no available sampler. Carried here so
+    # _persist_and_assemble can fold them into structured measurement_warnings.
+    energy_sampler_reasons: list[str]
     flops_result: Any
     start_time: datetime
     end_time: datetime
@@ -601,6 +607,15 @@ class MeasurementHarness:
         energy_sampler = select_energy_sampler(
             config.measurement.energy_sampler, gpu_indices=gpu_indices
         )
+        # When auto-selection came up empty, capture the per-sampler probe reasons
+        # so they reach structured measurement_warnings, not only the log. Kept off
+        # the patchable select_energy_sampler seam (harness tests patch it); the
+        # diagnostics re-probe only runs on the no-sampler path, which is rare.
+        energy_sampler_reasons: list[str] = []
+        if energy_sampler is None and config.measurement.energy_sampler is not None:
+            _, energy_sampler_reasons = select_energy_sampler_with_diagnostics(
+                config.measurement.energy_sampler, gpu_indices=gpu_indices
+            )
         sampler_name = type(energy_sampler).__name__ if energy_sampler else "none"
         _emit_substep(_p, "energy_select", f"selected: {sampler_name}")
         if _p:
@@ -674,6 +689,7 @@ class MeasurementHarness:
             thermal_info=thermal_info,
             timeseries_samples=timeseries_samples,
             energy_measurement=energy_measurement,
+            energy_sampler_reasons=energy_sampler_reasons,
             flops_result=flops_result,
             start_time=start_time,
             end_time=end_time,
@@ -720,7 +736,11 @@ class MeasurementHarness:
         # 15. Collect measurement quality warnings
         duration_sec = (window.end_time - window.start_time).total_seconds()
         measurement_warnings = self._collect_warnings(
-            duration_sec, window.timeseries_samples, gpu_indices, window.energy_measurement
+            duration_sec,
+            window.timeseries_samples,
+            gpu_indices,
+            window.energy_measurement,
+            energy_sampler_reasons=window.energy_sampler_reasons,
         )
 
         # 16. Assemble ExperimentResult
@@ -942,6 +962,7 @@ class MeasurementHarness:
         timeseries_samples: list[PowerThermalSample],
         gpu_indices: list[int] | None = None,
         energy_measurement: Any = None,
+        energy_sampler_reasons: list[str] | None = None,
     ) -> list[str]:
         """Collect measurement quality warnings from timeseries samples.
 
@@ -949,6 +970,10 @@ class MeasurementHarness:
         Its presence is a separate signal from ``timeseries_samples`` (which come from
         the thermal-telemetry sampler) - an absent energy measurement must be flagged
         even when thermal telemetry sampled fine.
+
+        ``energy_sampler_reasons`` is the per-sampler probe why-chain captured at
+        selection time; it enriches the energy_measurement_unavailable warning so
+        the reason each backend was skipped/rejected is structured, not log-only.
         """
         temp_start: float | None = None
         temp_end: float | None = None
@@ -968,6 +993,7 @@ class MeasurementHarness:
             temp_end_c=temp_end,
             nvml_sample_count=nvml_count,
             energy_measurement_present=energy_measurement is not None,
+            energy_sampler_reasons=energy_sampler_reasons,
         )
 
     @staticmethod

--- a/src/llenergymeasure/harness/measurement_warnings.py
+++ b/src/llenergymeasure/harness/measurement_warnings.py
@@ -14,6 +14,7 @@ def collect_measurement_warnings(
     temp_end_c: float | None,
     nvml_sample_count: int,
     energy_measurement_present: bool = True,
+    energy_sampler_reasons: list[str] | None = None,
     # thermal_drift_threshold default 10C - confidence LOW, no peer citation, flagged for validation
     thermal_drift_threshold_c: float = 10.0,
 ) -> list[str]:
@@ -42,6 +43,10 @@ def collect_measurement_warnings(
         energy_measurement_present: Whether the authoritative energy backend produced a
             measurement. False means energy was not measured (sampler unavailable or
             disabled); reported energy is absent, not a measured zero.
+        energy_sampler_reasons: Per-sampler probe why-chain from auto-selection (e.g.
+            "zeus: package not installed"). When energy is absent and this is
+            non-empty, the reasons are appended to the energy_measurement_unavailable
+            warning so the diagnosis is structured, not only in the log.
         thermal_drift_threshold_c: Maximum acceptable temperature change in Celsius.
             Default 10C - confidence LOW (engineering judgement, no peer citation,
             flagged for validation).
@@ -85,10 +90,13 @@ def collect_measurement_warnings(
 
     # 5. Authoritative energy measurement absent
     if not energy_measurement_present:
-        warnings.append(
+        message = (
             "energy_measurement_unavailable: no energy sampler produced a measurement; "
             "reported energy is absent, not a measured zero. Set an explicit energy "
             "backend or install a supported sampler (zeus/nvml/codecarbon)."
         )
+        if energy_sampler_reasons:
+            message = f"{message} Sampler probe results: {'; '.join(energy_sampler_reasons)}."
+        warnings.append(message)
 
     return warnings

--- a/src/llenergymeasure/harness/preflight.py
+++ b/src/llenergymeasure/harness/preflight.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.config.ssot import ENGINE_PACKAGES, Engine
 from llenergymeasure.utils.exceptions import PreFlightError
-from llenergymeasure.utils.io import load_json
 
 logger = logging.getLogger(__name__)
 
@@ -81,89 +80,6 @@ def _check_model_accessible(model_id: str) -> str | None:
         # Network error, timeout, etc. - don't block
         logger.debug("Model accessibility check skipped (network error): %s", exc)
         return None
-
-
-# TRT-LLM's LLM API cannot load AutoAWQ / AutoGPTQ community-format HF
-# checkpoints directly on EITHER backend at 1.2.1 (live-verified against
-# Qwen2.5-0.5B-Instruct-AWQ): the trt backend raises NotImplementedError on the
-# config.json quant_method (llm_utils.py only handles fp8/mxfp4 there), and the
-# pytorch backend asserts on the weight layout (linear.py expects the ModelOpt
-# packing, not AutoAWQ's qweight). TRT-LLM's supported pre-quantised path is its
-# own ModelOpt export (hf_quant_config.json) or a pre-built engine via
-# engine_path. Detection keys on the HF-declared quant_method rather than a
-# regex over model ids, so user-renamed forks are still caught - extend by
-# adding the canonical quant_method string, not a pattern.
-_TRT_UNSUPPORTED_HF_QUANT_METHODS: tuple[str, ...] = ("awq", "gptq")
-
-
-def _read_model_quant_method(model_id: str) -> str | None:
-    """Return the HF ``quantization_config.quant_method`` for *model_id*, or None.
-
-    ``quantization_config.quant_method`` is HF's authoritative quantisation
-    declaration - every quantisation library (AutoAWQ, AutoGPTQ, bitsandbytes,
-    compressed-tensors) writes it, so it's the stable signal for "is this
-    checkpoint pre-quantised, and how?".
-
-    Returns None for both "no quantisation declared" AND "couldn't determine"
-    (network error, missing config, malformed JSON, no huggingface_hub
-    installed). Callers must treat None as "not detected, proceed" rather
-    than "definitely unquantised" - failing closed on transient errors would
-    block legitimate runs on every network hiccup.
-    """
-    import json
-
-    config_data: dict[str, object] | None = None
-
-    if model_id.startswith(("/", "./", "~")):
-        config_path = Path(model_id).expanduser() / "config.json"
-        try:
-            config_data = load_json(config_path)
-        except (OSError, json.JSONDecodeError) as exc:
-            logger.debug("Could not read local config.json for %s: %s", model_id, exc)
-            return None
-    else:
-        if importlib.util.find_spec("huggingface_hub") is None:
-            return None
-        try:
-            from huggingface_hub import hf_hub_download
-
-            local = hf_hub_download(repo_id=model_id, filename="config.json")
-            config_data = load_json(local)
-        except Exception as exc:
-            logger.debug("Could not fetch HF config.json for %s: %s", model_id, exc)
-            return None
-
-    quant_block = config_data.get("quantization_config") if isinstance(config_data, dict) else None
-    if not isinstance(quant_block, dict):
-        return None
-    method = quant_block.get("quant_method")
-    return method.lower() if isinstance(method, str) else None
-
-
-def _check_tensorrt_checkpoint_compat(config: ExperimentConfig) -> str | None:
-    """Reject HF pre-quantised checkpoints on TRT-LLM unless ``engine_path`` is set."""
-    if config.engine != Engine.TENSORRT:
-        return None
-
-    # engine_path is an extra="allow" passthrough inside engine_params (matches
-    # the tensorrt plugin's read in _build_llm_kwargs).
-    engine_params = config.active_engine_params()
-    if engine_params is not None and getattr(engine_params, "engine_path", None):
-        return None
-
-    method = _read_model_quant_method(config.task.model)
-    if method is None or method not in _TRT_UNSUPPORTED_HF_QUANT_METHODS:
-        return None
-
-    return (
-        f"{config.task.model} is an HF {method.upper()} checkpoint; TRT-LLM's LLM API "
-        f"cannot load it on either backend at 1.2.1 (the trt backend rejects the "
-        f"quant_method, the pytorch backend rejects the weight layout). Use a "
-        f"ModelOpt-quantised checkpoint (with hf_quant_config.json) instead, or "
-        f"pre-build a TRT-LLM engine (`trtllm-build --checkpoint_dir <converted> ...`) "
-        f"and set `tensorrt.engine_params.engine_path` to the build output. See "
-        f"docs/how-to/run-with-tensorrt-llm.md#hf-pre-quantised-checkpoints."
-    )
 
 
 def _warn_if_persistence_mode_off(gpu_indices: list[int] | None = None) -> None:
@@ -233,8 +149,11 @@ def run_preflight(config: ExperimentConfig) -> None:
     if model_error is not None:
         failures.append(model_error)
 
-    # Check 4: Hardware compatibility (invariants validator runs at
-    # config-load; this catches host-GPU-dependent issues via check_hardware).
+    # Check 4: Hardware + checkpoint compatibility via the engine's check_hardware
+    # hook (invariants validator runs at config-load; this catches host-GPU-dependent
+    # issues plus engine-specific config/checkpoint compatibility, e.g. TRT-LLM
+    # rejecting HF pre-quantised AWQ/GPTQ checkpoints). Every engine routes through
+    # the same hook - no engine-specific branches here.
     try:
         from llenergymeasure.engines.probe_adapter import build_config_probe
 
@@ -242,11 +161,6 @@ def run_preflight(config: ExperimentConfig) -> None:
         failures.extend(engine_errors)
     except Exception:
         pass  # get_engine may fail if engine not installed - already caught by Check 2
-
-    # Check 5: TRT-LLM cannot consume HF pre-quantised checkpoints natively.
-    checkpoint_error = _check_tensorrt_checkpoint_compat(config)
-    if checkpoint_error is not None:
-        failures.append(checkpoint_error)
 
     if failures:
         n = len(failures)

--- a/tests/unit/energy/test_energy_backends_v2.py
+++ b/tests/unit/energy/test_energy_backends_v2.py
@@ -537,3 +537,64 @@ def test_codecarbon_stop_tracking_none_tracker_is_empty() -> None:
     assert isinstance(result, EnergyMeasurement)
     assert result.total_j == 0.0
     assert result.per_gpu_j is None
+
+
+# ---------------------------------------------------------------------------
+# select_energy_sampler_with_diagnostics - reasons handoff for the harness
+# ---------------------------------------------------------------------------
+
+
+def test_select_with_diagnostics_none_returns_no_reasons() -> None:
+    """Intentional disable (None) returns (None, []) - no diagnostics wanted."""
+    from llenergymeasure.energy import select_energy_sampler_with_diagnostics
+
+    sampler, reasons = select_energy_sampler_with_diagnostics(None)
+    assert sampler is None
+    assert reasons == []
+
+
+def test_select_with_diagnostics_auto_none_carries_reasons() -> None:
+    """When auto-selection finds nothing, the per-sampler why-chain is returned.
+
+    This is the structured backup that lets the harness surface the reason
+    energy came up empty in measurement_warnings, not only the log.
+    """
+    from llenergymeasure.energy import select_energy_sampler_with_diagnostics
+
+    with (
+        patch("importlib.util.find_spec", return_value=None),
+        patch("llenergymeasure.energy.NVMLSampler.is_available", return_value=False),
+    ):
+        sampler, reasons = select_energy_sampler_with_diagnostics("auto")
+
+    assert sampler is None
+    assert any("zeus" in r for r in reasons)
+    assert any("nvml" in r for r in reasons)
+    assert any("codecarbon" in r for r in reasons)
+
+
+def test_select_with_diagnostics_auto_success_has_empty_reasons() -> None:
+    """A successful auto-selection returns the sampler and no reasons."""
+    from llenergymeasure.energy import select_energy_sampler_with_diagnostics
+
+    def fake_find_spec(name: str):
+        return None if name == "zeus" else MagicMock()
+
+    with (
+        patch("importlib.util.find_spec", side_effect=fake_find_spec),
+        patch("llenergymeasure.energy.NVMLSampler.is_available", return_value=True),
+    ):
+        sampler, reasons = select_energy_sampler_with_diagnostics("auto")
+
+    assert sampler is not None
+    assert reasons == []
+
+
+def test_select_energy_sampler_wrapper_still_returns_bare_sampler() -> None:
+    """The bare select_energy_sampler wrapper is unchanged (single return value)."""
+    with (
+        patch("importlib.util.find_spec", return_value=None),
+        patch("llenergymeasure.energy.NVMLSampler.is_available", return_value=False),
+    ):
+        result = select_energy_sampler("auto")
+    assert result is None

--- a/tests/unit/engines/test_check_hardware.py
+++ b/tests/unit/engines/test_check_hardware.py
@@ -38,6 +38,12 @@ def test_check_hardware_is_static(engine_cls, monkeypatch):
         "llenergymeasure.device.gpu_info.get_compute_capability",
         lambda gpu_index=0: (8, 0),
     )
+    # Keep hermetic: the tensorrt hook reads the HF quant_method; stub it so no
+    # HF Hub call is attempted for the hub-style "test-model" id.
+    monkeypatch.setattr(
+        "llenergymeasure.engines.tensorrt.plugin._read_model_quant_method",
+        lambda _: None,
+    )
     engine_name = {
         TransformersEngine: "transformers",
         VLLMEngine: "vllm",
@@ -99,6 +105,19 @@ def _patch_sm(monkeypatch, sm: tuple[int, int] | None) -> None:
 
 
 class TestTensorRTCheckHardware:
+    @pytest.fixture(autouse=True)
+    def _hermetic_quant_reader(self, monkeypatch):
+        """Stub the HF quant_method reader so the SM/FP8 tests never hit the Hub.
+
+        check_hardware now routes the checkpoint-compat check too; these tests
+        exercise the hardware gates only, so a None quant_method (not detected)
+        keeps them focused and offline.
+        """
+        monkeypatch.setattr(
+            "llenergymeasure.engines.tensorrt.plugin._read_model_quant_method",
+            lambda _: None,
+        )
+
     def test_sm_none_returns_empty(self, monkeypatch):
         """SM detection returns None (no GPU visible) -> no errors."""
         _patch_sm(monkeypatch, None)
@@ -211,3 +230,154 @@ class TestShortCircuitRegression:
         assert any("SM >= 7.5" in e for e in errors), (
             f"expected SM-floor error from check_hardware; got {errors!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# TensorRT: HF pre-quantised checkpoint gate, now routed THROUGH check_hardware
+# (was the standalone preflight Check 5; folded into the plugin so the harness
+# preflight calls one uniform hook for every engine).
+# ---------------------------------------------------------------------------
+
+
+def _stub_quant_method(monkeypatch, value: str | None) -> None:
+    monkeypatch.setattr(
+        "llenergymeasure.engines.tensorrt.plugin._read_model_quant_method",
+        lambda _: value,
+    )
+
+
+class TestTensorRTCheckpointCompat:
+    """The AWQ/GPTQ checkpoint gate is reachable via TensorRTEngine.check_hardware.
+
+    SM is pinned to None (no visible GPU) so only the GPU-independent
+    checkpoint-compat error can appear - proving the checkpoint check runs even
+    when the hardware gates short-circuit on a missing device.
+    """
+
+    def test_rejects_awq(self, monkeypatch):
+        _patch_sm(monkeypatch, None)
+        _stub_quant_method(monkeypatch, "awq")
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"tensor_parallel_size": 1}},
+        )
+        errors = TensorRTEngine.check_hardware(config)
+        assert len(errors) == 1
+        err = errors[0]
+        assert "AWQ" in err
+        assert "engine_path" in err
+        assert "trtllm-build" in err
+        # Names what was tried at 1.2.1: both backends fail, ModelOpt is the path.
+        assert "1.2.1" in err
+        assert "either backend" in err
+        assert "ModelOpt" in err
+
+    def test_rejects_gptq(self, monkeypatch):
+        _patch_sm(monkeypatch, None)
+        _stub_quant_method(monkeypatch, "gptq")
+        config = make_config(
+            engine="tensorrt",
+            tensorrt={"engine_params": {"tensor_parallel_size": 1}},
+            model="Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
+        )
+        errors = TensorRTEngine.check_hardware(config)
+        assert len(errors) == 1
+        assert "GPTQ" in errors[0]
+
+    def test_passes_non_quantised(self, monkeypatch):
+        _patch_sm(monkeypatch, None)
+        _stub_quant_method(monkeypatch, None)
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"tensor_parallel_size": 1}},
+        )
+        assert TensorRTEngine.check_hardware(config) == []
+
+    def test_skips_when_engine_path_set(self, monkeypatch):
+        """A prebuilt engine_path means the user pre-built the engine; do not block."""
+        _patch_sm(monkeypatch, None)
+        _stub_quant_method(monkeypatch, "awq")
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={
+                "engine_params": {
+                    "tensor_parallel_size": 1,
+                    "engine_path": "/some/built/engine",
+                    "backend": "trt",
+                }
+            },
+        )
+        assert TensorRTEngine.check_hardware(config) == []
+
+    def test_network_failure_does_not_block(self, monkeypatch):
+        """Transient HF Hub failures (reader returns None) must not block."""
+        _patch_sm(monkeypatch, None)
+        _stub_quant_method(monkeypatch, None)
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"tensor_parallel_size": 1}},
+        )
+        assert TensorRTEngine.check_hardware(config) == []
+
+    def test_checkpoint_and_sm_errors_collected_together(self, monkeypatch):
+        """AWQ checkpoint AND a too-low SM both surface from the one hook."""
+        _patch_sm(monkeypatch, (7, 0))  # below the 7.5 floor
+        _stub_quant_method(monkeypatch, "awq")
+        config = make_config(
+            **_TRT_DEFAULTS,
+            tensorrt={"engine_params": {"tensor_parallel_size": 1}},
+        )
+        errors = TensorRTEngine.check_hardware(config)
+        assert any("AWQ" in e for e in errors)
+        assert any("SM >= 7.5" in e for e in errors)
+
+
+class TestOtherEnginesNoCheckpointGate:
+    """transformers / vLLM do not carry the TRT checkpoint gate (structural)."""
+
+    @pytest.mark.parametrize(
+        "engine_cls,engine_name",
+        [(TransformersEngine, "transformers"), (VLLMEngine, "vllm")],
+        ids=["transformers", "vllm"],
+    )
+    def test_awq_model_not_flagged(self, monkeypatch, engine_cls, engine_name):
+        _patch_sm(monkeypatch, (8, 0))
+        # Even if the tensorrt reader would say "awq", non-TRT hooks never call it.
+        _stub_quant_method(monkeypatch, "awq")
+        config = make_config(model="Qwen/Qwen2.5-7B-Instruct-AWQ", engine=engine_name)
+        assert engine_cls.check_hardware(config) == []
+
+
+# ---------------------------------------------------------------------------
+# _read_model_quant_method: local-path parsing (moved from preflight to the
+# tensorrt plugin). No stubbing here - these exercise the real reader.
+# ---------------------------------------------------------------------------
+
+
+def test_read_quant_method_local_path(tmp_path):
+    """Local model directories with an AWQ config.json are detected."""
+    import json
+
+    from llenergymeasure.engines.tensorrt.plugin import _read_model_quant_method
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"quantization_config": {"quant_method": "AWQ"}})
+    )
+    assert _read_model_quant_method(str(tmp_path)) == "awq"
+
+
+def test_read_quant_method_local_path_no_config(tmp_path):
+    """Local directories without config.json return None (skip)."""
+    from llenergymeasure.engines.tensorrt.plugin import _read_model_quant_method
+
+    assert _read_model_quant_method(str(tmp_path)) is None
+
+
+def test_read_quant_method_local_path_no_quant_block(tmp_path):
+    """Local config.json without quantization_config returns None."""
+    import json
+
+    from llenergymeasure.engines.tensorrt.plugin import _read_model_quant_method
+
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen2"}))
+    assert _read_model_quant_method(str(tmp_path)) is None

--- a/tests/unit/engines/test_transformers_load.py
+++ b/tests/unit/engines/test_transformers_load.py
@@ -1,0 +1,93 @@
+"""Model-load failure wrapping for TransformersEngine.load_model().
+
+Parity with the vllm/tensorrt plugins: a from_pretrained() failure (missing or
+gated model, OOM, bad dtype) surfaces as a single actionable EngineError naming
+the model and engine, not a bare transformers traceback.
+
+transformers is not installed on the host, so a fake module is injected into
+sys.modules; torch IS required (load_model builds dtype kwargs before the
+wrapped construction).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from llenergymeasure.engines.transformers import TransformersEngine
+from llenergymeasure.utils.exceptions import EngineError
+from tests.conftest import make_config
+
+pytest.importorskip("torch")
+
+
+def _install_fake_transformers(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tokenizer_raises: bool,
+    model_raises: bool,
+) -> None:
+    """Inject a fake ``transformers`` module whose from_pretrained can raise."""
+    fake = types.ModuleType("transformers")
+
+    class _FakeTokenizer:
+        pad_token = "<pad>"  # not None, so load_model skips the eos assignment
+        eos_token = "<eos>"
+
+    class _AutoTokenizer:
+        @staticmethod
+        def from_pretrained(*_args, **_kwargs):
+            if tokenizer_raises:
+                raise RuntimeError("tokenizer download failed")
+            return _FakeTokenizer()
+
+    class _AutoModelForCausalLM:
+        @staticmethod
+        def from_pretrained(*_args, **_kwargs):
+            if model_raises:
+                raise RuntimeError("CUDA out of memory while loading weights")
+            raise AssertionError("unexpected success in test")
+
+    fake.AutoTokenizer = _AutoTokenizer  # type: ignore[attr-defined]
+    fake.AutoModelForCausalLM = _AutoModelForCausalLM  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "transformers", fake)
+
+
+def test_load_model_wraps_tokenizer_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tokenizer from_pretrained() failure becomes an EngineError."""
+    _install_fake_transformers(monkeypatch, tokenizer_raises=True, model_raises=False)
+    config = make_config(engine="transformers", model="fake/model-xyz")
+
+    with pytest.raises(EngineError) as exc_info:
+        TransformersEngine().load_model(config)
+
+    msg = str(exc_info.value)
+    assert "Transformers model loading failed" in msg
+    assert "fake/model-xyz" in msg  # model name is in the context
+    assert "tokenizer download failed" in msg  # original cause chained in
+
+
+def test_load_model_wraps_model_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model-weights from_pretrained() failure becomes an EngineError."""
+    _install_fake_transformers(monkeypatch, tokenizer_raises=False, model_raises=True)
+    config = make_config(engine="transformers", model="fake/model-abc")
+
+    with pytest.raises(EngineError) as exc_info:
+        TransformersEngine().load_model(config)
+
+    msg = str(exc_info.value)
+    assert "Transformers model loading failed" in msg
+    assert "fake/model-abc" in msg
+
+
+def test_load_model_failure_chains_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The EngineError preserves the original exception via __cause__."""
+    _install_fake_transformers(monkeypatch, tokenizer_raises=True, model_raises=False)
+    config = make_config(engine="transformers", model="fake/model-xyz")
+
+    with pytest.raises(EngineError) as exc_info:
+        TransformersEngine().load_model(config)
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)

--- a/tests/unit/engines/test_vllm_engine.py
+++ b/tests/unit/engines/test_vllm_engine.py
@@ -903,3 +903,45 @@ class TestFlashAttnFieldsWired:
         kwargs = VLLMEngine()._build_llm_kwargs(config)
         assert kwargs["flash_attn_version"] == 2
         assert kwargs["flash_attn_max_num_splits_for_cuda_graph"] == 16
+
+
+# ---------------------------------------------------------------------------
+# _peak_matches_vllm_prealloc: the extracted gpu_memory_utilization heuristic.
+# A torch peak within 5% of gpu_memory_utilization * total_vram is vLLM's
+# up-front reservation, not the inference working set.
+# ---------------------------------------------------------------------------
+
+
+class TestPeakMatchesVllmPrealloc:
+    def test_exact_match_is_prealloc(self):
+        from llenergymeasure.engines.vllm.plugin import _peak_matches_vllm_prealloc
+
+        # expected = 40000 * 0.9 = 36000; peak == expected -> pre-allocation.
+        assert _peak_matches_vllm_prealloc(36000.0, 40000.0, 0.9) is True
+
+    def test_just_inside_5pct_is_prealloc(self):
+        from llenergymeasure.engines.vllm.plugin import _peak_matches_vllm_prealloc
+
+        expected = 40000.0 * 0.9  # 36000
+        # 4.9% below expected -> still counted as pre-allocation.
+        assert _peak_matches_vllm_prealloc(expected * 0.951, 40000.0, 0.9) is True
+
+    def test_at_5pct_boundary_is_not_prealloc(self):
+        from llenergymeasure.engines.vllm.plugin import _peak_matches_vllm_prealloc
+
+        expected = 40000.0 * 0.9
+        # Exactly 5% off: strict `< 0.05` means this is NOT pre-allocation.
+        assert _peak_matches_vllm_prealloc(expected * 0.95, 40000.0, 0.9) is False
+
+    def test_far_below_is_real_usage(self):
+        from llenergymeasure.engines.vllm.plugin import _peak_matches_vllm_prealloc
+
+        # Real inference working set well under the reservation -> not prealloc.
+        assert _peak_matches_vllm_prealloc(12000.0, 40000.0, 0.9) is False
+
+    def test_non_positive_expected_returns_false(self):
+        from llenergymeasure.engines.vllm.plugin import _peak_matches_vllm_prealloc
+
+        # No VRAM reading or zero utilisation -> keep the torch value (no div-by-zero).
+        assert _peak_matches_vllm_prealloc(36000.0, 0.0, 0.9) is False
+        assert _peak_matches_vllm_prealloc(36000.0, 40000.0, 0.0) is False

--- a/tests/unit/harness/test_measurement_warnings.py
+++ b/tests/unit/harness/test_measurement_warnings.py
@@ -157,3 +157,48 @@ def test_returns_list_of_strings():
     result = collect_measurement_warnings(30.0, True, 40.0, 40.0, 0)
     assert isinstance(result, list)
     assert all(isinstance(w, str) for w in result)
+
+
+# ---------------------------------------------------------------------------
+# energy_sampler_reasons: the per-sampler probe why-chain enriches the
+# energy_measurement_unavailable warning (structured backup for the log-only
+# diagnostic).
+# ---------------------------------------------------------------------------
+
+
+def test_energy_reasons_appended_when_absent():
+    """Probe reasons are folded into the unavailable warning when energy is absent."""
+    reasons = ["zeus: package not installed", "nvml: is_available() returned False"]
+    warnings = collect_measurement_warnings(
+        30.0, True, 40.0, 40.0, 50, energy_measurement_present=False, energy_sampler_reasons=reasons
+    )
+    unavailable = [w for w in warnings if "energy_measurement_unavailable" in w]
+    assert len(unavailable) == 1
+    assert "Sampler probe results:" in unavailable[0]
+    assert "zeus: package not installed" in unavailable[0]
+    assert "nvml: is_available() returned False" in unavailable[0]
+
+
+def test_energy_reasons_ignored_when_present():
+    """Reasons never surface when energy WAS measured (no unavailable warning)."""
+    warnings = collect_measurement_warnings(
+        30.0,
+        True,
+        40.0,
+        40.0,
+        50,
+        energy_measurement_present=True,
+        energy_sampler_reasons=["zeus: package not installed"],
+    )
+    assert not any("energy_measurement_unavailable" in w for w in warnings)
+    assert not any("Sampler probe results" in w for w in warnings)
+
+
+def test_energy_absent_without_reasons_stays_generic():
+    """Empty/omitted reasons keep the generic unavailable message (no dangling text)."""
+    warnings = collect_measurement_warnings(
+        30.0, True, 40.0, 40.0, 50, energy_measurement_present=False, energy_sampler_reasons=[]
+    )
+    unavailable = [w for w in warnings if "energy_measurement_unavailable" in w]
+    assert len(unavailable) == 1
+    assert "Sampler probe results" not in unavailable[0]

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -598,145 +598,71 @@ def test_get_compute_capability_returns_tuple_or_none() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test: TRT-LLM HF pre-quantised checkpoint gate
+# Test: TRT-LLM checkpoint-compat now routes through the check_hardware hook
+# (the standalone Check 5 was folded into the tensorrt plugin; the detailed
+# checkpoint-gate unit tests live in tests/unit/engines/test_check_hardware.py).
 # ---------------------------------------------------------------------------
 
 
-def test_trt_checkpoint_compat_skips_non_tensorrt_engine(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Non-tensorrt engines do not trigger the quant-checkpoint gate."""
-    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+def test_run_preflight_routes_checkpoint_compat_through_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_preflight surfaces the TRT checkpoint-compat error via check_hardware.
 
+    Proves the routing: the AWQ/GPTQ gate is no longer a standalone preflight
+    check - it flows through the real tensorrt plugin's check_hardware (Check 4,
+    build_config_probe), the same uniform hook every engine uses. Stubbing the
+    plugin-owned quant reader keeps the test hermetic (no HF Hub call).
+    """
+    import llenergymeasure.engines.tensorrt.plugin as trt_plugin
+
+    monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight,
-        "_read_model_quant_method",
-        lambda _: "awq",
+        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
     )
-    config = make_config(engine="transformers")
-    assert _check_tensorrt_checkpoint_compat(config) is None
-
-
-def test_trt_checkpoint_compat_passes_non_quantised(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Non-quantised models on TRT-LLM pass the gate."""
-    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
-
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight,
-        "_read_model_quant_method",
-        lambda _: None,
+        llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
     )
-    config = make_config(engine="tensorrt", tensorrt={"engine_params": {"tensor_parallel_size": 1}})
-    assert _check_tensorrt_checkpoint_compat(config) is None
+    # Plugin-owned quant reader (moved out of preflight into the tensorrt plugin).
+    monkeypatch.setattr(trt_plugin, "_read_model_quant_method", lambda _: "awq")
 
-
-def test_trt_checkpoint_compat_rejects_awq(monkeypatch: pytest.MonkeyPatch) -> None:
-    """HF AWQ checkpoint on TRT-LLM yields an actionable error."""
-    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
-
-    monkeypatch.setattr(
-        llenergymeasure.harness.preflight,
-        "_read_model_quant_method",
-        lambda _: "awq",
-    )
     config = make_config(
         engine="tensorrt",
         tensorrt={"engine_params": {"tensor_parallel_size": 1}},
         model="Qwen/Qwen2.5-7B-Instruct-AWQ",
     )
-    err = _check_tensorrt_checkpoint_compat(config)
-    assert err is not None
-    assert "AWQ" in err
-    assert "engine_path" in err
-    assert "trtllm-build" in err
-    # Names what was tried at 1.2.1: both backends fail, ModelOpt is the path.
-    assert "1.2.1" in err
-    assert "either backend" in err
-    assert "ModelOpt" in err
+    with pytest.raises(PreFlightError) as exc_info:
+        run_preflight(config)
+
+    msg = str(exc_info.value)
+    assert "AWQ" in msg
+    assert "engine_path" in msg
 
 
-def test_trt_checkpoint_compat_rejects_gptq(monkeypatch: pytest.MonkeyPatch) -> None:
-    """HF GPTQ checkpoint on TRT-LLM yields an actionable error."""
-    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+def test_run_preflight_checkpoint_compat_mock_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A checkpoint-compat error returned by a plugin's check_hardware surfaces.
 
+    Uses a mock plugin to assert the harness collects whatever check_hardware
+    returns - checkpoint-compat is no longer special-cased in preflight.
+    """
+    monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight,
-        "_read_model_quant_method",
-        lambda _: "gptq",
+        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
     )
-    config = make_config(
-        engine="tensorrt",
-        tensorrt={"engine_params": {"tensor_parallel_size": 1}},
-        model="Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
-    )
-    err = _check_tensorrt_checkpoint_compat(config)
-    assert err is not None
-    assert "GPTQ" in err
-
-
-def test_trt_checkpoint_compat_skips_when_engine_path_set(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Explicit engine_path means the user pre-built the engine; do not block."""
-    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
-
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight,
-        "_read_model_quant_method",
-        lambda _: "awq",
+        llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
     )
-    # engine_path is an extra="allow" passthrough inside engine_params (same
-    # location the tensorrt plugin reads it from).
-    config = make_config(
-        engine="tensorrt",
-        tensorrt={
-            "engine_params": {
-                "tensor_parallel_size": 1,
-                "engine_path": "/some/built/engine",
-                "backend": "trt",
-            }
-        },
-    )
-    assert _check_tensorrt_checkpoint_compat(config) is None
 
+    class _FakePlugin:
+        name = "tensorrt"
 
-def test_trt_checkpoint_compat_network_failure_does_not_block(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Transient HF Hub failures must not block dispatch."""
-    from llenergymeasure.harness.preflight import _check_tensorrt_checkpoint_compat
+        def check_hardware(self, config):
+            return ["some-model is an HF AWQ checkpoint; set tensorrt.engine_params.engine_path"]
 
-    monkeypatch.setattr(
-        llenergymeasure.harness.preflight,
-        "_read_model_quant_method",
-        lambda _: None,  # Simulates "couldn't determine"
-    )
-    config = make_config(engine="tensorrt", tensorrt={"engine_params": {"tensor_parallel_size": 1}})
-    assert _check_tensorrt_checkpoint_compat(config) is None
+    monkeypatch.setattr("llenergymeasure.engines.get_engine", lambda name: _FakePlugin())
 
+    config = ExperimentConfig(task={"model": "test-model"}, engine="tensorrt")
+    with pytest.raises(PreFlightError) as exc_info:
+        run_preflight(config)
 
-def test_read_quant_method_local_path(tmp_path: Path) -> None:
-    """Local model directories with an AWQ config.json are detected."""
-    import json
-
-    from llenergymeasure.harness.preflight import _read_model_quant_method
-
-    (tmp_path / "config.json").write_text(
-        json.dumps({"quantization_config": {"quant_method": "AWQ"}})
-    )
-    assert _read_model_quant_method(str(tmp_path)) == "awq"
-
-
-def test_read_quant_method_local_path_no_config(tmp_path: Path) -> None:
-    """Local directories without config.json return None (skip)."""
-    from llenergymeasure.harness.preflight import _read_model_quant_method
-
-    assert _read_model_quant_method(str(tmp_path)) is None
-
-
-def test_read_quant_method_local_path_no_quant_block(tmp_path: Path) -> None:
-    """Local config.json without quantization_config returns None."""
-    import json
-
-    from llenergymeasure.harness.preflight import _read_model_quant_method
-
-    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen2"}))
-    assert _read_model_quant_method(str(tmp_path)) is None
+    assert "AWQ checkpoint" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Slice S10 (F6 Wave 2): four harness/engine seam tidies, each bringing a lone
outlier into line with the shared idiom.

1. **transformers load wrapped in EngineError.** `TransformersEngine.load_model`
   was the only engine load whose `from_pretrained` calls were not wrapped. It
   now wraps tokenizer + model construction in `EngineError`, at parity with the
   vllm/tensorrt plugins, and names the model plus engine in the message (bare
   transformers tracebacks no longer leak through the plugin seam).

2. **TRT checkpoint-compat routed through `check_hardware`.** The AWQ/GPTQ
   pre-quantised-checkpoint gate was a standalone `_check_tensorrt_checkpoint_compat`
   function plus its own preflight step (Check 5). It is folded into the tensorrt
   plugin's `check_hardware` hook (the GPU-independent checkpoint check runs first,
   before the SM/FP8 gates and regardless of GPU visibility). `harness/preflight.py`
   now routes every engine uniformly through `check_hardware` via
   `build_config_probe` (Check 4); the engine-specific Check 5 branch is gone.
   No new protocol methods (C1): the check rides the existing `check_hardware`
   seam. The reader helper `_read_model_quant_method` moved to the plugin too.

3. **Energy sampler selection reasons reach `measurement_warnings`.** When
   auto-selection finds no available energy sampler, the per-sampler why-chain
   ("zeus: package not installed", ...) was log-only. A new
   `select_energy_sampler_with_diagnostics` returns `(sampler, reasons)`; the
   harness captures the reasons on the no-sampler path and folds them into the
   structured `energy_measurement_unavailable` warning so containers/CI surface
   the diagnosis without log spelunking. The bare `select_energy_sampler` seam
   (patched by many harness tests) is unchanged.

4. **vLLM memory heuristic extracted.** The inline
   `gpu_memory_utilization * total_vram` pre-allocation heuristic in
   `run_inference` is extracted to a named, unit-tested
   `_peak_matches_vllm_prealloc(peak_mb, total_vram_mb, gpu_util)` (no behavior
   change; the prior swallowed zero-divisor case maps to a `False` guard).

### Overlap note (S8/S9 in flight on `harness/measurement.py`)

Item 3's harness footprint is minimal and confined to the warnings path: one
field on `_MeasuredWindow` (`energy_sampler_reasons`), the selection-site capture,
and threading it into `_collect_warnings`. The measured-inference bracket and the
`run()`/`_build_result` phase structure are untouched.

## Test plan

- `make lint` (ruff check + format + import-linter): clean.
- `make typecheck` (mypy src + tests + producers): clean, 317 files.
- Full `uv run pytest tests/unit/ -q`: 3152 passed, 37 skipped.
- New/updated tests:
  - `test_transformers_load.py`: tokenizer- and model-load failures wrap to
    `EngineError` with model name + chained cause.
  - `test_check_hardware.py`: AWQ/GPTQ rejected, non-quantised/engine_path/None
    pass, checkpoint + SM errors collected together, transformers/vLLM never
    carry the gate; `_read_model_quant_method` local-path parsing. Hermetic
    (HF quant reader stubbed).
  - `test_preflight.py`: `run_preflight` routes checkpoint-compat through the
    real tensorrt `check_hardware`, and via a mock plugin.
  - `test_measurement_warnings.py`: probe reasons enrich the unavailable
    warning; ignored when energy present; generic when reasons empty.
  - `test_energy_backends_v2.py`: `select_energy_sampler_with_diagnostics`
    reasons handoff; bare wrapper unchanged.
  - `test_vllm_engine.py`: `_peak_matches_vllm_prealloc` boundary tests
    (exact, just-inside 5%, at-5% boundary, far-below, non-positive expected).
