### PR TITLE
refactor(harness): extract MeasurementBracket and split lifetime state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 - Internal restructure (no behavior or results change): the measured-window
   mechanics are extracted into a mode-agnostic `MeasurementBracket`
   (`llenergymeasure.harness.bracket`) and per-model-load state is split from
-  per-window state, groundwork for a future server measurement mode.
+  per-window state, groundwork for a future server measurement mode. ([#856])
 - **Breaking (results bundle):** the three independent per-artefact
   `schema_version` counters are replaced by a single `bundle_version` ("1.0")
   stamped into `result.json`, `config.json`, and `environment.json`. The bundle
@@ -1298,3 +1298,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#853]: https://github.com/henrycgbaker/llenergymeasure/pull/853
 [#854]: https://github.com/henrycgbaker/llenergymeasure/pull/854
 [#855]: https://github.com/henrycgbaker/llenergymeasure/pull/855
+[#856]: https://github.com/henrycgbaker/llenergymeasure/pull/856

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Changed
 
+- Internal restructure (no behavior or results change): the measured-window
+  mechanics are extracted into a mode-agnostic `MeasurementBracket`
+  (`llenergymeasure.harness.bracket`) and per-model-load state is split from
+  per-window state, groundwork for a future server measurement mode.
 - **Breaking (results bundle):** the three independent per-artefact
   `schema_version` counters are replaced by a single `bundle_version` ("1.0")
   stamped into `result.json`, `config.json`, and `environment.json`. The bundle

--- a/src/llenergymeasure/domain/progress.py
+++ b/src/llenergymeasure/domain/progress.py
@@ -123,6 +123,18 @@ class ProgressCallback(Protocol):
         ...
 
 
+def emit_substep(
+    progress: ProgressCallback | None, step: str, text: str, elapsed_sec: float = 0.0
+) -> None:
+    """Emit a substep event to the progress callback when one is registered.
+
+    Shared by the harness and the measurement bracket so the "no callback -> no-op"
+    guard lives in exactly one place.
+    """
+    if progress is not None:
+        progress.on_substep(step, text, elapsed_sec)
+
+
 @runtime_checkable
 class StudyProgressCallback(ProgressCallback, Protocol):
     """Extended callback for study-level experiment tracking + per-step progress.

--- a/src/llenergymeasure/harness/README.md
+++ b/src/llenergymeasure/harness/README.md
@@ -11,6 +11,7 @@ Measurement lifecycle orchestration for any inference engine. Layer 3 in the six
 | Module | Description |
 |--------|-------------|
 | `measurement.py` | `MeasurementHarness` class, measurement lifecycle implementation |
+| `bracket.py` | `MeasurementBracket` - mode-agnostic measured-window boundary (energy tracker, CUDA syncs, thermal sampler, timestamps); split exit keeps the energy window deliberately wider than the thermal one |
 | `__init__.py` | Re-exports the public surface from `measurement.py` |
 | `warmup.py` | `warmup_until_converged()` - CV-based adaptive warmup; `thermal_floor_wait()` |
 | `baseline.py` | `measure_baseline_power()` - idle GPU power baseline with session cache |

--- a/src/llenergymeasure/harness/__init__.py
+++ b/src/llenergymeasure/harness/__init__.py
@@ -4,17 +4,28 @@ The harness extracts the ~600 lines of identical measurement infrastructure
 duplicated across transformers.py and vllm.py into a single location.
 Engines become thin plugins implementing the 4-method EnginePlugin protocol.
 
-The implementation lives in ``llenergymeasure.harness.measurement``. This package
-init re-exports the public surface plus the module-level helpers that tests patch.
-Note: patching a name on this package does NOT affect ``measurement.py``'s globals -
-tests that patch module globals must target ``llenergymeasure.harness.measurement``.
+The implementation lives in ``llenergymeasure.harness.measurement``; the
+measured-window mechanics live in ``llenergymeasure.harness.bracket``. This
+package init re-exports the public surface plus the module-level helpers that
+tests patch. Note: patching a name on this package does NOT affect the
+implementation modules' globals - tests that patch module globals must target
+the module that owns the name (``measurement`` or ``bracket``).
 """
 
 from __future__ import annotations
 
+from llenergymeasure.harness.bracket import PowerThermalSampler
+
+# Private helpers are re-exported with redundant aliases so legacy
+# ``from llenergymeasure.harness import _cuda_sync`` keeps working. They are
+# intentionally absent from ``__all__`` (private surface). Tests that PATCH these
+# as module globals must target the owning module
+# (``measurement`` for the capture/persistence helpers, ``bracket`` for _cuda_sync).
+from llenergymeasure.harness.bracket import (
+    _cuda_sync as _cuda_sync,
+)
 from llenergymeasure.harness.measurement import (
     MeasurementHarness,
-    PowerThermalSampler,
     collect_environment_snapshot,
     collect_environment_snapshot_async,
     collect_measurement_warnings,
@@ -23,19 +34,11 @@ from llenergymeasure.harness.measurement import (
     measure_baseline_power,
     write_timeseries_parquet,
 )
-
-# Private helpers are re-exported with redundant aliases so legacy
-# ``from llenergymeasure.harness import _cuda_sync`` keeps working. They are
-# intentionally absent from ``__all__`` (private surface). Tests that PATCH these
-# as module globals must target ``llenergymeasure.harness.measurement.<name>``.
 from llenergymeasure.harness.measurement import (
     _capture_observed_params_into_output as _capture_observed_params_into_output,
 )
 from llenergymeasure.harness.measurement import (
     _check_persistence_mode as _check_persistence_mode,
-)
-from llenergymeasure.harness.measurement import (
-    _cuda_sync as _cuda_sync,
 )
 
 __all__ = [

--- a/src/llenergymeasure/harness/bracket.py
+++ b/src/llenergymeasure/harness/bracket.py
@@ -1,0 +1,201 @@
+"""MeasurementBracket - the mode-agnostic measured-window mechanics.
+
+The bracket owns the measured window's boundary: energy-sampler selection,
+energy-tracker start/stop, the pre/post CUDA syncs, the PowerThermalSampler
+lifetime, and the wall-clock + perf-counter timestamps. It is deliberately
+independent of WHAT runs inside it - no engine, no prompts, no InferenceOutput in
+its signature - so server mode (v0.8.0) can reuse it around a load-gen-timed run
+unchanged.
+
+Window-width subtlety (behavior-frozen): the energy tracker is stopped in
+``finish()``, strictly after ``__exit__`` has stopped the thermal sampler. The
+offline caller interleaves its observed-params capture between context exit and
+``finish()`` so capture lands INSIDE the energy window but OUTSIDE the thermal
+timeseries - the energy reading is deliberately slightly wider than the thermal
+window. See ``tests/unit/harness/test_window_ordering.py``.
+
+The window primitives (``select_energy_sampler``,
+``select_energy_sampler_with_diagnostics``, ``_cuda_sync``,
+``PowerThermalSampler``) are resolved through ``llenergymeasure.harness.
+measurement`` - the harness's canonical monkeypatch surface - rather than
+imported directly, so that module stays the single place tests patch them and the
+durable ordering test reads identically across this extraction. The perf clock
+(``time``) is a plain module import here, patchable at ``bracket.time``.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from llenergymeasure.config.models import MeasurementConfig
+    from llenergymeasure.device.power_thermal import PowerThermalSample
+    from llenergymeasure.domain.progress import ProgressCallback
+
+STEP_ENERGY_SELECT = "energy_select"
+STEP_MEASURE = "measure"
+
+
+@dataclass
+class MeasuredWindowCore:
+    """Mode-agnostic product of one measured window.
+
+    Holds only what the window mechanics produce - energy, thermal, timeseries,
+    and the wall-clock span. Mode-specific extras (the InferenceOutput, FLOPs)
+    are composed on top by the caller.
+    """
+
+    thermal_info: Any
+    timeseries_samples: list[PowerThermalSample]
+    energy_measurement: Any
+    # Per-sampler probe reasons, populated only when auto-selection found no
+    # available sampler; the caller folds them into structured measurement_warnings.
+    energy_sampler_reasons: list[str]
+    start_time: datetime
+    end_time: datetime
+
+
+class MeasurementBracket:
+    """Context manager owning the measured-window boundary mechanics.
+
+    Usage (offline)::
+
+        bracket = MeasurementBracket(
+            config.measurement, gpu_indices, progress, measure_detail="inference (N prompts)"
+        )
+        with bracket:
+            output = engine.run_inference(config, model, prompts)
+        # capture runs here: after the thermal sampler stops, before the tracker
+        core = bracket.finish()
+
+    ``__enter__`` selects the energy sampler, starts the tracker, runs the pre
+    CUDA sync, and starts the thermal sampler. ``__exit__`` stops the thermal
+    sampler and runs the post CUDA sync. ``finish()`` stops the energy tracker
+    and returns the :class:`MeasuredWindowCore`.
+    """
+
+    def __init__(
+        self,
+        measurement_config: MeasurementConfig,
+        gpu_indices: list[int] | None,
+        progress: ProgressCallback | None,
+        *,
+        measure_detail: str = "",
+    ) -> None:
+        self._measurement_config = measurement_config
+        self._gpu_indices = gpu_indices
+        self._progress = progress
+        self._measure_detail = measure_detail
+
+        self._energy_sampler: Any = None
+        self._energy_tracker: Any = None
+        self._energy_sampler_reasons: list[str] = []
+        self._thermal_sampler: Any = None
+        self._thermal_info: Any = None
+        self._timeseries_samples: list[Any] = []
+        self._t_inference_start: float = 0.0
+        self._t_inference_end: float = 0.0
+        self._start_time: datetime | None = None
+
+    def _substep(self, step: str, text: str) -> None:
+        """Emit a substep event when a progress callback is registered."""
+        if self._progress is not None:
+            self._progress.on_substep(step, text)
+
+    def __enter__(self) -> MeasurementBracket:
+        from llenergymeasure.harness import measurement as _m
+
+        _p = self._progress
+
+        # 7. Select energy sampler.
+        if _p:
+            _p.on_step_start(STEP_ENERGY_SELECT, "Selecting", "energy sampler")
+            t0_energy = time.perf_counter()
+        self._energy_sampler = _m.select_energy_sampler(
+            self._measurement_config.energy_sampler, gpu_indices=self._gpu_indices
+        )
+        # Capture the per-sampler probe reasons when auto-selection came up empty,
+        # so they reach structured measurement_warnings (not only the log). Kept
+        # off the patchable select_energy_sampler seam (harness tests patch it);
+        # the diagnostics re-probe only runs on the rare no-sampler path.
+        self._energy_sampler_reasons = []
+        if self._energy_sampler is None and self._measurement_config.energy_sampler is not None:
+            _, self._energy_sampler_reasons = _m.select_energy_sampler_with_diagnostics(
+                self._measurement_config.energy_sampler, gpu_indices=self._gpu_indices
+            )
+        sampler_name = type(self._energy_sampler).__name__ if self._energy_sampler else "none"
+        self._substep(STEP_ENERGY_SELECT, f"selected: {sampler_name}")
+        if _p:
+            _p.on_step_update(STEP_ENERGY_SELECT, f"energy sampler ({sampler_name})")
+            _p.on_step_done(STEP_ENERGY_SELECT, time.perf_counter() - t0_energy)
+
+        # 8. Start energy tracking (after warmup + thermal floor).
+        self._energy_tracker = None
+        if self._energy_sampler is not None:
+            self._energy_tracker = self._energy_sampler.start_tracking()
+
+        # 9. CUDA sync before inference (Zeus best practice).
+        _m._cuda_sync()
+        self._substep(STEP_MEASURE, "CUDA sync (pre)")
+
+        if _p:
+            _p.on_step_start(STEP_MEASURE, "Measuring", self._measure_detail)
+        self._substep(STEP_MEASURE, "energy tracker started")
+
+        self._t_inference_start = time.perf_counter()
+        self._start_time = datetime.now()
+
+        # Start the thermal sampler around inference (timeseries + throttle).
+        self._thermal_sampler = _m.PowerThermalSampler(gpu_indices=self._gpu_indices)
+        self._thermal_sampler.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        # Returns None (falsy) so an exception raised inside the window is never
+        # suppressed - the caller's cleanup still runs.
+        from llenergymeasure.harness import measurement as _m
+
+        # Stop the thermal sampler; the energy tracker stays open until finish().
+        self._thermal_sampler.stop()
+        self._t_inference_end = time.perf_counter()
+
+        # 11. CUDA sync after inference, before stopping energy.
+        _m._cuda_sync()
+        self._substep(STEP_MEASURE, "CUDA sync (post)")
+
+        if self._progress:
+            self._progress.on_step_done(STEP_MEASURE, self.inference_duration_sec)
+
+        self._thermal_info = self._thermal_sampler.get_thermal_throttle_info()
+        self._timeseries_samples = self._thermal_sampler.get_samples()
+
+    @property
+    def inference_duration_sec(self) -> float:
+        """Perf-counter delta bracketing the run inside the window."""
+        return self._t_inference_end - self._t_inference_start
+
+    def finish(self) -> MeasuredWindowCore:
+        """Stop the energy tracker and return the finalised window core.
+
+        Called after the caller's post-window work (e.g. observed-params capture)
+        so that work lands inside the energy window but after the thermal window.
+        """
+        energy_measurement = None
+        if self._energy_sampler is not None and self._energy_tracker is not None:
+            energy_measurement = self._energy_sampler.stop_tracking(self._energy_tracker)
+            tracker_duration = energy_measurement.duration_sec if energy_measurement else 0.0
+            self._substep(STEP_MEASURE, f"energy tracker stopped  {tracker_duration:.1f}s")
+        end_time = datetime.now()
+
+        assert self._start_time is not None  # set in __enter__
+        return MeasuredWindowCore(
+            thermal_info=self._thermal_info,
+            timeseries_samples=self._timeseries_samples,
+            energy_measurement=energy_measurement,
+            energy_sampler_reasons=self._energy_sampler_reasons,
+            start_time=self._start_time,
+            end_time=end_time,
+        )

--- a/src/llenergymeasure/harness/bracket.py
+++ b/src/llenergymeasure/harness/bracket.py
@@ -14,29 +14,59 @@ offline caller interleaves its observed-params capture between context exit and
 timeseries - the energy reading is deliberately slightly wider than the thermal
 window. See ``tests/unit/harness/test_window_ordering.py``.
 
-The window primitives (``select_energy_sampler``,
-``select_energy_sampler_with_diagnostics``, ``_cuda_sync``,
-``PowerThermalSampler``) are resolved through ``llenergymeasure.harness.
-measurement`` - the harness's canonical monkeypatch surface - rather than
-imported directly, so that module stays the single place tests patch them and the
-durable ordering test reads identically across this extraction. The perf clock
-(``time``) is a plain module import here, patchable at ``bracket.time``.
+This module owns its window primitives directly (``select_energy_sampler``,
+``select_energy_sampler_with_diagnostics``, ``_cuda_sync``, and a thin
+``PowerThermalSampler`` patch-seam wrapper). They are the bracket's monkeypatch
+surface: harness tests patch them at the use site,
+``llenergymeasure.harness.bracket.<name>``.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import time
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.domain.progress import STEP_ENERGY_SELECT, STEP_MEASURE, emit_substep
+from llenergymeasure.energy import (
+    select_energy_sampler,
+    select_energy_sampler_with_diagnostics,
+)
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import MeasurementConfig
     from llenergymeasure.device.power_thermal import PowerThermalSample
     from llenergymeasure.domain.progress import ProgressCallback
 
-STEP_ENERGY_SELECT = "energy_select"
-STEP_MEASURE = "measure"
+
+def _cuda_sync() -> None:
+    """Synchronise CUDA at a measurement boundary.
+
+    Best-effort - failures are non-fatal and silently ignored.
+    """
+    if importlib.util.find_spec("torch") is not None:
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+        except Exception:
+            pass  # Non-fatal - best effort sync
+
+
+class PowerThermalSampler:  # pragma: no cover
+    """Thin re-export so tests can patch llenergymeasure.harness.bracket.PowerThermalSampler."""
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
+        from llenergymeasure.device.power_thermal import PowerThermalSampler as _PTS
+
+        return _PTS(*args, **kwargs)
+
+    def __enter__(self) -> Any: ...  # type: ignore[empty-body]
+
+    def __exit__(self, *args: Any) -> None: ...  # type: ignore[empty-body]
 
 
 @dataclass
@@ -73,8 +103,9 @@ class MeasurementBracket:
 
     ``__enter__`` selects the energy sampler, starts the tracker, runs the pre
     CUDA sync, and starts the thermal sampler. ``__exit__`` stops the thermal
-    sampler and runs the post CUDA sync. ``finish()`` stops the energy tracker
-    and returns the :class:`MeasuredWindowCore`.
+    sampler and runs the post CUDA sync. ``finish()`` fires the measure-step
+    done event, stops the energy tracker, and returns the
+    :class:`MeasuredWindowCore`.
     """
 
     def __init__(
@@ -100,34 +131,26 @@ class MeasurementBracket:
         self._t_inference_end: float = 0.0
         self._start_time: datetime | None = None
 
-    def _substep(self, step: str, text: str) -> None:
-        """Emit a substep event when a progress callback is registered."""
-        if self._progress is not None:
-            self._progress.on_substep(step, text)
-
     def __enter__(self) -> MeasurementBracket:
-        from llenergymeasure.harness import measurement as _m
-
         _p = self._progress
 
         # 7. Select energy sampler.
         if _p:
             _p.on_step_start(STEP_ENERGY_SELECT, "Selecting", "energy sampler")
             t0_energy = time.perf_counter()
-        self._energy_sampler = _m.select_energy_sampler(
+        self._energy_sampler = select_energy_sampler(
             self._measurement_config.energy_sampler, gpu_indices=self._gpu_indices
         )
         # Capture the per-sampler probe reasons when auto-selection came up empty,
-        # so they reach structured measurement_warnings (not only the log). Kept
-        # off the patchable select_energy_sampler seam (harness tests patch it);
-        # the diagnostics re-probe only runs on the rare no-sampler path.
+        # so they reach structured measurement_warnings (not only the log). The
+        # diagnostics re-probe only runs on the rare no-sampler path.
         self._energy_sampler_reasons = []
         if self._energy_sampler is None and self._measurement_config.energy_sampler is not None:
-            _, self._energy_sampler_reasons = _m.select_energy_sampler_with_diagnostics(
+            _, self._energy_sampler_reasons = select_energy_sampler_with_diagnostics(
                 self._measurement_config.energy_sampler, gpu_indices=self._gpu_indices
             )
         sampler_name = type(self._energy_sampler).__name__ if self._energy_sampler else "none"
-        self._substep(STEP_ENERGY_SELECT, f"selected: {sampler_name}")
+        emit_substep(_p, STEP_ENERGY_SELECT, f"selected: {sampler_name}")
         if _p:
             _p.on_step_update(STEP_ENERGY_SELECT, f"energy sampler ({sampler_name})")
             _p.on_step_done(STEP_ENERGY_SELECT, time.perf_counter() - t0_energy)
@@ -138,39 +161,37 @@ class MeasurementBracket:
             self._energy_tracker = self._energy_sampler.start_tracking()
 
         # 9. CUDA sync before inference (Zeus best practice).
-        _m._cuda_sync()
-        self._substep(STEP_MEASURE, "CUDA sync (pre)")
+        _cuda_sync()
+        emit_substep(_p, STEP_MEASURE, "CUDA sync (pre)")
 
         if _p:
             _p.on_step_start(STEP_MEASURE, "Measuring", self._measure_detail)
-        self._substep(STEP_MEASURE, "energy tracker started")
+        emit_substep(_p, STEP_MEASURE, "energy tracker started")
 
         self._t_inference_start = time.perf_counter()
         self._start_time = datetime.now()
 
         # Start the thermal sampler around inference (timeseries + throttle).
-        self._thermal_sampler = _m.PowerThermalSampler(gpu_indices=self._gpu_indices)
+        self._thermal_sampler = PowerThermalSampler(gpu_indices=self._gpu_indices)
         self._thermal_sampler.start()
         return self
 
     def __exit__(self, *exc: Any) -> None:
         # Returns None (falsy) so an exception raised inside the window is never
         # suppressed - the caller's cleanup still runs.
-        from llenergymeasure.harness import measurement as _m
 
         # Stop the thermal sampler; the energy tracker stays open until finish().
         self._thermal_sampler.stop()
         self._t_inference_end = time.perf_counter()
 
         # 11. CUDA sync after inference, before stopping energy.
-        _m._cuda_sync()
-        self._substep(STEP_MEASURE, "CUDA sync (post)")
-
-        if self._progress:
-            self._progress.on_step_done(STEP_MEASURE, self.inference_duration_sec)
+        _cuda_sync()
+        emit_substep(self._progress, STEP_MEASURE, "CUDA sync (post)")
 
         self._thermal_info = self._thermal_sampler.get_thermal_throttle_info()
         self._timeseries_samples = self._thermal_sampler.get_samples()
+        # The measure-step done event fires in finish(), AFTER the caller's
+        # post-window observed-params capture, matching the pre-refactor order.
 
     @property
     def inference_duration_sec(self) -> float:
@@ -178,16 +199,23 @@ class MeasurementBracket:
         return self._t_inference_end - self._t_inference_start
 
     def finish(self) -> MeasuredWindowCore:
-        """Stop the energy tracker and return the finalised window core.
+        """Fire the measure-step done event, stop the energy tracker, return the core.
 
         Called after the caller's post-window work (e.g. observed-params capture)
-        so that work lands inside the energy window but after the thermal window.
+        so that work lands inside the energy window but after the thermal window,
+        and so the measure-step done event fires after the capture (unchanged from
+        before the bracket extraction).
         """
+        if self._progress:
+            self._progress.on_step_done(STEP_MEASURE, self.inference_duration_sec)
+
         energy_measurement = None
         if self._energy_sampler is not None and self._energy_tracker is not None:
             energy_measurement = self._energy_sampler.stop_tracking(self._energy_tracker)
             tracker_duration = energy_measurement.duration_sec if energy_measurement else 0.0
-            self._substep(STEP_MEASURE, f"energy tracker stopped  {tracker_duration:.1f}s")
+            emit_substep(
+                self._progress, STEP_MEASURE, f"energy tracker stopped  {tracker_duration:.1f}s"
+            )
         end_time = datetime.now()
 
         assert self._start_time is not None  # set in __enter__

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -29,17 +29,9 @@ from llenergymeasure.domain.experiment import (
     compute_declared_config_hash,
     mj_per_token,
 )
-from llenergymeasure.domain.progress import STEP_BASELINE
-
-# Re-exported (redundant aliases) so they stay module attributes of measurement.py:
-# MeasurementBracket resolves them here at call time and tests patch them here.
-# This module is the harness's canonical monkeypatch surface.
-from llenergymeasure.energy import select_energy_sampler as select_energy_sampler
-from llenergymeasure.energy import (
-    select_energy_sampler_with_diagnostics as select_energy_sampler_with_diagnostics,
-)
+from llenergymeasure.domain.progress import STEP_BASELINE, emit_substep
 from llenergymeasure.engines.protocol import EnginePlugin, InferenceOutput
-from llenergymeasure.harness.bracket import MeasurementBracket
+from llenergymeasure.harness.bracket import MeasuredWindowCore, MeasurementBracket
 from llenergymeasure.harness.warmup import thermal_floor_wait, warmup_until_converged
 from llenergymeasure.results.persistence import save_config_sidecar
 from llenergymeasure.utils.formatting import bytes_to_mb
@@ -58,21 +50,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Module-level helpers (extracted from both engines - byte-identical copies)
 # ---------------------------------------------------------------------------
-
-
-def _cuda_sync() -> None:
-    """Synchronise CUDA at measurement boundary.
-
-    Best-effort - failures are non-fatal and silently ignored.
-    """
-    if importlib.util.find_spec("torch") is not None:
-        try:
-            import torch
-
-            if torch.cuda.is_available():
-                torch.cuda.synchronize()
-        except Exception:
-            pass  # Non-fatal - best effort sync
 
 
 def _capture_observed_params_into_output(
@@ -226,27 +203,6 @@ def collect_measurement_warnings(
     )
 
 
-class PowerThermalSampler:  # pragma: no cover
-    """Thin re-export so tests can patch llenergymeasure.harness.PowerThermalSampler."""
-
-    def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
-        from llenergymeasure.device.power_thermal import PowerThermalSampler as _PTS
-
-        return _PTS(*args, **kwargs)
-
-    def __enter__(self) -> Any: ...  # type: ignore[empty-body]
-
-    def __exit__(self, *args: Any) -> None: ...  # type: ignore[empty-body]
-
-
-def _emit_substep(
-    progress: ProgressCallback | None, step: str, text: str, elapsed: float = 0.0
-) -> None:
-    """Emit a substep event to the progress callback when one is registered."""
-    if progress:
-        progress.on_substep(step, text, elapsed)
-
-
 @dataclass
 class _EngineLifetime:
     """Per-model-load state, built once by the load/warmup phases.
@@ -270,22 +226,15 @@ class _EngineLifetime:
 class _MeasuredWindow:
     """Product of one measured inference window.
 
-    Composes the bracket's mode-agnostic :class:`~llenergymeasure.harness.bracket.
-    MeasuredWindowCore` (energy, thermal, timeseries, timestamps) with the
-    offline-specific extras (the InferenceOutput and the FLOPs estimate).
+    Composes the bracket's mode-agnostic
+    :class:`~llenergymeasure.harness.bracket.MeasuredWindowCore` (energy, thermal,
+    timeseries, timestamps, sampler-probe reasons) with the offline-specific
+    extras (the InferenceOutput and the FLOPs estimate).
     """
 
+    core: MeasuredWindowCore
     output: InferenceOutput
-    thermal_info: Any
-    timeseries_samples: list[PowerThermalSample]
-    energy_measurement: Any
-    # Per-sampler probe reasons captured at energy-sampler selection time; only
-    # populated when auto-selection found no available sampler. Carried here so
-    # _persist_and_assemble can fold them into structured measurement_warnings.
-    energy_sampler_reasons: list[str]
     flops_result: Any
-    start_time: datetime
-    end_time: datetime
 
 
 @dataclass(frozen=True)
@@ -474,7 +423,7 @@ class MeasurementHarness:
             baseline = measure_baseline_power(dur, gpu_indices=gpu_indices)
             if baseline is not None:
                 cache_label = " (cached)" if baseline.from_cache else ""
-                _emit_substep(
+                emit_substep(
                     _p,
                     STEP_BASELINE,
                     f"baseline: {baseline.power_w:.1f}W"
@@ -516,7 +465,7 @@ class MeasurementHarness:
 
         # Build model substep callback
         def _on_model_substep(text: str, elapsed: float) -> None:
-            _emit_substep(_p, "model", text, elapsed)
+            emit_substep(_p, "model", text, elapsed)
 
         model = engine.load_model(config, on_substep=_on_model_substep)
 
@@ -532,7 +481,7 @@ class MeasurementHarness:
         # Must happen BEFORE warmup, which allocates KV cache.
         model_memory_mb = self._capture_model_memory_mb(gpu_indices=gpu_indices)
         if model_memory_mb > 0:
-            _emit_substep(_p, "model", f"model memory: {model_memory_mb:.0f}MB")
+            emit_substep(_p, "model", f"model memory: {model_memory_mb:.0f}MB")
 
         return model, snapshot, model_memory_mb, load_time_sec
 
@@ -553,7 +502,7 @@ class MeasurementHarness:
             t0_prompts = time.perf_counter()
         prompts = load_prompts(config)
         logger.debug("Loaded %d prompts via dataset loader", len(prompts))
-        _emit_substep(_p, "prompts", f"tokenised {len(prompts)} prompts")
+        emit_substep(_p, "prompts", f"tokenised {len(prompts)} prompts")
         if _p:
             _p.on_step_done("prompts", time.perf_counter() - t0_prompts)
         return prompts
@@ -622,7 +571,7 @@ class MeasurementHarness:
                 _p.on_step_update("warmup", f"{iters_label} ({converged}{cv_info})")
             _p.on_step_done("warmup", time.perf_counter() - t0_warmup)
         iters = warmup_result.iterations_completed
-        _emit_substep(
+        emit_substep(
             _p,
             "warmup",
             f"{iters} iteration{'s' if iters != 1 else ''}"
@@ -701,18 +650,9 @@ class MeasurementHarness:
                 _p.on_step_update("flops", f"FLOPs: {flops_result.value:.2e}")
             _p.on_step_done("flops", time.perf_counter() - t0_flops)
         if flops_result is not None:
-            _emit_substep(_p, "flops", f"FLOPs: {flops_result.value:.2e}")
+            emit_substep(_p, "flops", f"FLOPs: {flops_result.value:.2e}")
 
-        return _MeasuredWindow(
-            output=output,
-            thermal_info=core.thermal_info,
-            timeseries_samples=core.timeseries_samples,
-            energy_measurement=core.energy_measurement,
-            energy_sampler_reasons=core.energy_sampler_reasons,
-            flops_result=flops_result,
-            start_time=core.start_time,
-            end_time=core.end_time,
-        )
+        return _MeasuredWindow(core=core, output=output, flops_result=flops_result)
 
     def _persist_and_assemble(
         self,
@@ -746,20 +686,21 @@ class MeasurementHarness:
             )
             t0_save = time.perf_counter()
 
+        core = window.core
         write_timeseries = bool(
-            save_timeseries and resolved_output_dir is not None and window.timeseries_samples
+            save_timeseries and resolved_output_dir is not None and core.timeseries_samples
         )
         # Relative name recorded in result JSON; the file lands at this basename.
         timeseries_path: str | None = TIMESERIES_FILENAME if write_timeseries else None
 
         # 15. Collect measurement quality warnings
-        duration_sec = (window.end_time - window.start_time).total_seconds()
+        duration_sec = (core.end_time - core.start_time).total_seconds()
         measurement_warnings = self._collect_warnings(
             duration_sec,
-            window.timeseries_samples,
+            core.timeseries_samples,
             gpu_indices,
-            window.energy_measurement,
-            energy_sampler_reasons=window.energy_sampler_reasons,
+            core.energy_measurement,
+            energy_sampler_reasons=core.energy_sampler_reasons,
         )
 
         # 16. Assemble ExperimentResult
@@ -769,31 +710,31 @@ class MeasurementHarness:
             output=window.output,
             model_memory_mb=lifetime.model_memory_mb,
             snapshot=lifetime.snapshot,
-            start_time=window.start_time,
-            end_time=window.end_time,
+            start_time=core.start_time,
+            end_time=core.end_time,
             duration_sec=duration_sec,
-            thermal_info=window.thermal_info,
-            energy_measurement=window.energy_measurement,
+            thermal_info=core.thermal_info,
+            energy_measurement=core.energy_measurement,
             baseline=lifetime.baseline,
             flops_result=window.flops_result,
             timeseries_path=timeseries_path,
-            timeseries_samples=window.timeseries_samples,
+            timeseries_samples=core.timeseries_samples,
             measurement_warnings=measurement_warnings,
             warmup_result=lifetime.warmup_result,
             prompt_count=len(lifetime.prompts),
             model_load_time_sec=lifetime.model_load_time_sec,
         )
-        _emit_substep(_p, "save", "result assembled")
+        emit_substep(_p, "save", "result assembled")
 
         # 17. Write timeseries Parquet sidecar, tagged with the assembled identity.
         if write_timeseries and resolved_output_dir is not None:
             write_timeseries_parquet(
-                window.timeseries_samples,
+                core.timeseries_samples,
                 resolved_output_dir / TIMESERIES_FILENAME,
                 experiment_id=result.experiment_id,
                 measurement_config_hash=result.measurement_config_hash,
             )
-            _emit_substep(_p, "save", "timeseries parquet written")
+            emit_substep(_p, "save", "timeseries parquet written")
 
         # 18. Write config.json sidecar (observed-params + observed_config_hash)
         # Written to output_dir (temp dir, same as timeseries.parquet) so the
@@ -807,7 +748,7 @@ class MeasurementHarness:
                 methodology=methodology,
                 output_dir=resolved_output_dir,
             )
-            _emit_substep(_p, "save", "config sidecar written")
+            emit_substep(_p, "save", "config sidecar written")
 
         if _p:
             _p.on_step_done("save", time.perf_counter() - t0_save)

--- a/src/llenergymeasure/harness/measurement.py
+++ b/src/llenergymeasure/harness/measurement.py
@@ -30,8 +30,16 @@ from llenergymeasure.domain.experiment import (
     mj_per_token,
 )
 from llenergymeasure.domain.progress import STEP_BASELINE
-from llenergymeasure.energy import select_energy_sampler, select_energy_sampler_with_diagnostics
+
+# Re-exported (redundant aliases) so they stay module attributes of measurement.py:
+# MeasurementBracket resolves them here at call time and tests patch them here.
+# This module is the harness's canonical monkeypatch surface.
+from llenergymeasure.energy import select_energy_sampler as select_energy_sampler
+from llenergymeasure.energy import (
+    select_energy_sampler_with_diagnostics as select_energy_sampler_with_diagnostics,
+)
 from llenergymeasure.engines.protocol import EnginePlugin, InferenceOutput
+from llenergymeasure.harness.bracket import MeasurementBracket
 from llenergymeasure.harness.warmup import thermal_floor_wait, warmup_until_converged
 from llenergymeasure.results.persistence import save_config_sidecar
 from llenergymeasure.utils.formatting import bytes_to_mb
@@ -240,8 +248,32 @@ def _emit_substep(
 
 
 @dataclass
+class _EngineLifetime:
+    """Per-model-load state, built once by the load/warmup phases.
+
+    Everything here is fixed for a given model load and reused across every
+    measured window taken against it. Splitting it from _MeasuredWindow is the
+    server-mode seam (a1 #13: one lifetime, N windows); offline takes exactly one
+    window per lifetime, so no multi-window machinery exists yet.
+    """
+
+    model: Any
+    snapshot: EnvironmentSnapshot | None
+    baseline: BaselineCache | None
+    model_memory_mb: float
+    model_load_time_sec: float
+    prompts: list[str]
+    warmup_result: WarmupResult
+
+
+@dataclass
 class _MeasuredWindow:
-    """Outputs of the measured inference window (steps 7-13 of the run lifecycle)."""
+    """Product of one measured inference window.
+
+    Composes the bracket's mode-agnostic :class:`~llenergymeasure.harness.bracket.
+    MeasuredWindowCore` (energy, thermal, timeseries, timestamps) with the
+    offline-specific extras (the InferenceOutput and the FLOPs estimate).
+    """
 
     output: InferenceOutput
     thermal_info: Any
@@ -322,6 +354,53 @@ class MeasurementHarness:
             EngineError: If model loading or inference fails.
             PreFlightError: If pre-flight checks fail before GPU allocation.
         """
+        # Build the per-model-load lifetime (snapshot, baseline, model, prompts,
+        # warmup); take exactly one measured window against it; then persist.
+        lifetime = self._build_lifetime(
+            engine,
+            config,
+            snapshot=snapshot,
+            gpu_indices=gpu_indices,
+            progress=progress,
+            baseline=baseline,
+        )
+
+        try:
+            # 7-13. Measured inference window (energy, timing, FLOPs)
+            window = self._run_measured_inference(engine, config, lifetime, gpu_indices, progress)
+        finally:
+            # Always release the model from memory, even on inference failure.
+            engine.cleanup(lifetime.model)
+
+        # 14-17. Persist sidecars + assemble the ExperimentResult
+        return self._persist_and_assemble(
+            engine=engine,
+            config=config,
+            lifetime=lifetime,
+            gpu_indices=gpu_indices,
+            window=window,
+            output_dir=output_dir,
+            save_timeseries=save_timeseries,
+            progress=progress,
+        )
+
+    def _build_lifetime(
+        self,
+        engine: EnginePlugin,
+        config: ExperimentConfig,
+        *,
+        snapshot: EnvironmentSnapshot | None,
+        gpu_indices: list[int] | None,
+        progress: ProgressCallback | None,
+        baseline: BaselineCache | None,
+    ) -> _EngineLifetime:
+        """Build the per-model-load lifetime: snapshot, baseline, model, prompts, warmup.
+
+        These phases run once per model load and their products are fixed for
+        every window taken against that load. If warmup fails after the model is
+        live, the model is released here before re-raising (a load or prompt
+        failure leaves nothing to release, matching the pre-refactor path).
+        """
         # 1. Environment snapshot - start background thread (before model loading)
         snapshot_future: Future[EnvironmentSnapshot] | None = None
         if snapshot is None:
@@ -339,34 +418,21 @@ class MeasurementHarness:
         # 4b. Load prompts - BEFORE the measurement window (methodology fix)
         prompts = self._load_prompts(config, progress)
 
+        # 5-6. Warmup convergence + thermal floor wait
         try:
-            # 5-6. Warmup convergence + thermal floor wait
             warmup_result = self._run_warmup(engine, config, model, prompts, progress)
-
-            # 7-13. Measured inference window (energy, timing, FLOPs)
-            window = self._run_measured_inference(
-                engine, config, model, prompts, gpu_indices, progress
-            )
-
-        finally:
-            # Always release model from memory even on exception
+        except BaseException:
             engine.cleanup(model)
+            raise
 
-        # 14-17. Persist sidecars + assemble the ExperimentResult
-        return self._persist_and_assemble(
-            engine=engine,
-            config=config,
+        return _EngineLifetime(
+            model=model,
             snapshot=snapshot,
             baseline=baseline,
-            warmup_result=warmup_result,
             model_memory_mb=model_memory_mb,
             model_load_time_sec=model_load_time_sec,
-            prompt_count=len(prompts),
-            gpu_indices=gpu_indices,
-            window=window,
-            output_dir=output_dir,
-            save_timeseries=save_timeseries,
-            progress=progress,
+            prompts=prompts,
+            warmup_result=warmup_result,
         )
 
     # -------------------------------------------------------------------------
@@ -587,92 +653,45 @@ class MeasurementHarness:
         self,
         engine: EnginePlugin,
         config: ExperimentConfig,
-        model: Any,
-        prompts: list[str],
+        lifetime: _EngineLifetime,
         gpu_indices: list[int] | None,
         progress: ProgressCallback | None,
     ) -> _MeasuredWindow:
-        """Run the measured inference window: select + start energy tracking, sync
-        CUDA, run inference under the thermal sampler, capture observed params, stop
-        tracking, and estimate FLOPs.
+        """Take one measured window via MeasurementBracket, then apply the
+        offline-specific post-window steps: observed-params capture, canonical
+        inference timer, and FLOPs estimation.
 
-        Returns the window outputs needed to assemble the ExperimentResult.
+        The bracket owns the mode-agnostic window mechanics. Observed-params
+        capture is interleaved between the bracket's context exit (thermal sampler
+        stopped) and ``finish()`` (energy tracker stopped), preserving the
+        deliberate energy>thermal window-width gap. See harness/bracket.py and
+        tests/unit/harness/test_window_ordering.py.
         """
         _p = progress
-
-        # 7. Select energy sampler
-        if _p:
-            _p.on_step_start("energy_select", "Selecting", "energy sampler")
-            t0_energy = time.perf_counter()
-        energy_sampler = select_energy_sampler(
-            config.measurement.energy_sampler, gpu_indices=gpu_indices
+        bracket = MeasurementBracket(
+            config.measurement,
+            gpu_indices,
+            progress,
+            measure_detail=f"inference ({config.task.dataset.n_prompts} prompts)",
         )
-        # When auto-selection came up empty, capture the per-sampler probe reasons
-        # so they reach structured measurement_warnings, not only the log. Kept off
-        # the patchable select_energy_sampler seam (harness tests patch it); the
-        # diagnostics re-probe only runs on the no-sampler path, which is rare.
-        energy_sampler_reasons: list[str] = []
-        if energy_sampler is None and config.measurement.energy_sampler is not None:
-            _, energy_sampler_reasons = select_energy_sampler_with_diagnostics(
-                config.measurement.energy_sampler, gpu_indices=gpu_indices
-            )
-        sampler_name = type(energy_sampler).__name__ if energy_sampler else "none"
-        _emit_substep(_p, "energy_select", f"selected: {sampler_name}")
-        if _p:
-            _p.on_step_update("energy_select", f"energy sampler ({sampler_name})")
-            _p.on_step_done("energy_select", time.perf_counter() - t0_energy)
 
-        # 8. Start energy tracking (after warmup + thermal floor)
-        energy_tracker = None
-        if energy_sampler is not None:
-            energy_tracker = energy_sampler.start_tracking()
+        with bracket:
+            output = engine.run_inference(config, lifetime.model, lifetime.prompts)
 
-        # 9. CUDA sync before inference (Zeus best practice)
-        _cuda_sync()
-        _emit_substep(_p, "measure", "CUDA sync (pre)")
-
-        if _p:
-            _p.on_step_start(
-                "measure", "Measuring", f"inference ({config.task.dataset.n_prompts} prompts)"
-            )
-        _emit_substep(_p, "measure", "energy tracker started")
-
-        t_inference_start = time.perf_counter()
-        start_time = datetime.now()
-
-        # Start thermal sampler around inference for timeseries + throttle detection
-        with PowerThermalSampler(gpu_indices=gpu_indices) as thermal_sampler:
-            output = engine.run_inference(config, model, prompts)
-
-        t_inference_end = time.perf_counter()
-
-        # 11. CUDA sync after inference, before stopping energy
-        _cuda_sync()
-        _emit_substep(_p, "measure", "CUDA sync (post)")
-
-        # 11a. Capture observed params post-window (outside NVML sampling).
-        # Must run here - model is still alive; capture overhead (~5-50 ms pure
-        # Python) must not land inside the PowerThermalSampler context above.
-        _capture_observed_params_into_output(engine, config, model, output)
-
-        if _p:
-            _p.on_step_done("measure", t_inference_end - t_inference_start)
-
-        thermal_info = thermal_sampler.get_thermal_throttle_info()
-        timeseries_samples = thermal_sampler.get_samples()
+        # 11a. Capture observed params post-window: after the thermal sampler has
+        # stopped (bracket __exit__) but before the energy tracker stops
+        # (bracket.finish()), so the capture overhead (~5-50 ms pure Python) lands
+        # inside the energy window but outside the thermal timeseries. The model
+        # is still alive.
+        _capture_observed_params_into_output(engine, config, lifetime.model, output)
 
         # Harness sets canonical inference timer - overrides engine's elapsed_time_sec
-        output.inference_time_sec = t_inference_end - t_inference_start
+        output.inference_time_sec = bracket.inference_duration_sec
 
-        # 12. Stop energy tracking
-        energy_measurement = None
-        if energy_sampler is not None and energy_tracker is not None:
-            energy_measurement = energy_sampler.stop_tracking(energy_tracker)
-            tracker_duration = energy_measurement.duration_sec if energy_measurement else 0.0
-            _emit_substep(_p, "measure", f"energy tracker stopped  {tracker_duration:.1f}s")
-        end_time = datetime.now()
+        # 12. Stop energy tracking and finalise the mode-agnostic window core.
+        core = bracket.finish()
 
-        # 13. FLOPs estimation (warmup tokens excluded)
+        # 13. FLOPs estimation (warmup tokens excluded) - offline-specific.
         if _p:
             _p.on_step_start("flops", "Estimating", "FLOPs (PaLM formula)")
             t0_flops = time.perf_counter()
@@ -686,13 +705,13 @@ class MeasurementHarness:
 
         return _MeasuredWindow(
             output=output,
-            thermal_info=thermal_info,
-            timeseries_samples=timeseries_samples,
-            energy_measurement=energy_measurement,
-            energy_sampler_reasons=energy_sampler_reasons,
+            thermal_info=core.thermal_info,
+            timeseries_samples=core.timeseries_samples,
+            energy_measurement=core.energy_measurement,
+            energy_sampler_reasons=core.energy_sampler_reasons,
             flops_result=flops_result,
-            start_time=start_time,
-            end_time=end_time,
+            start_time=core.start_time,
+            end_time=core.end_time,
         )
 
     def _persist_and_assemble(
@@ -700,19 +719,19 @@ class MeasurementHarness:
         *,
         engine: EnginePlugin,
         config: ExperimentConfig,
-        snapshot: EnvironmentSnapshot | None,
-        baseline: BaselineCache | None,
-        warmup_result: WarmupResult,
-        model_memory_mb: float,
-        model_load_time_sec: float | None,
-        prompt_count: int,
+        lifetime: _EngineLifetime,
         gpu_indices: list[int] | None,
         window: _MeasuredWindow,
         output_dir: Path | str | None,
         save_timeseries: bool,
         progress: ProgressCallback | None,
     ) -> ExperimentResult:
-        """Write the timeseries + config sidecars and assemble the ExperimentResult."""
+        """Write the timeseries + config sidecars and assemble the ExperimentResult.
+
+        Reads the per-model-load state (snapshot, baseline, warmup, memory/load
+        timings, prompt count) off ``lifetime`` and the per-window measurement
+        products off ``window``.
+        """
         _p = progress
 
         # 14. Decide the timeseries sidecar path. The Parquet file is written after
@@ -748,21 +767,21 @@ class MeasurementHarness:
             engine_name=engine.name,
             config=config,
             output=window.output,
-            model_memory_mb=model_memory_mb,
-            snapshot=snapshot,
+            model_memory_mb=lifetime.model_memory_mb,
+            snapshot=lifetime.snapshot,
             start_time=window.start_time,
             end_time=window.end_time,
             duration_sec=duration_sec,
             thermal_info=window.thermal_info,
             energy_measurement=window.energy_measurement,
-            baseline=baseline,
+            baseline=lifetime.baseline,
             flops_result=window.flops_result,
             timeseries_path=timeseries_path,
             timeseries_samples=window.timeseries_samples,
             measurement_warnings=measurement_warnings,
-            warmup_result=warmup_result,
-            prompt_count=prompt_count,
-            model_load_time_sec=model_load_time_sec,
+            warmup_result=lifetime.warmup_result,
+            prompt_count=len(lifetime.prompts),
+            model_load_time_sec=lifetime.model_load_time_sec,
         )
         _emit_substep(_p, "save", "result assembled")
 

--- a/tests/unit/harness/conftest.py
+++ b/tests/unit/harness/conftest.py
@@ -2,9 +2,76 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from typing import Any
 from unittest.mock import MagicMock
 
+from llenergymeasure.domain.metrics import WarmupResult
+from llenergymeasure.engines.protocol import InferenceOutput
 from tests.conftest import TEST_POWER_MW
+
+
+@dataclass
+class FakeBackend:
+    """Minimal EnginePlugin for testing MeasurementHarness lifecycle.
+
+    All methods record calls into ``call_log`` (constructor-overridable so a test
+    can thread a shared recorder through it) for order assertions.
+    """
+
+    engine_name: str = "fake"
+    call_log: list[str] = field(default_factory=list)
+    inference_output: InferenceOutput | None = None
+    fail_on_run_inference: bool = False
+
+    @property
+    def name(self) -> str:
+        return self.engine_name
+
+    def load_model(self, config: Any, **kwargs: Any) -> dict:
+        self.call_log.append("load_model")
+        return {"model": "fake_model_object"}
+
+    def warmup(self, config: Any, model: Any, prompts: list[str]) -> WarmupResult:
+        self.call_log.append("warmup")
+        return WarmupResult(
+            converged=True,
+            final_cv=0.0,
+            iterations_completed=1,
+            target_cv=0.01,
+            max_prompts=10,
+        )
+
+    def run_warmup_prompt(self, config: Any, model: Any, prompt: str) -> float:
+        self.call_log.append("run_warmup_prompt")
+        # Return 0.0 = simple kernel warmup (no CV convergence loop needed in tests)
+        return 0.0
+
+    def run_inference(self, config: Any, model: Any, prompts: list[str]) -> InferenceOutput:
+        self.call_log.append("run_inference")
+        if self.fail_on_run_inference:
+            raise RuntimeError("Fake inference failure")
+        if self.inference_output is not None:
+            return self.inference_output
+        return InferenceOutput(
+            elapsed_time_sec=1.0,
+            input_tokens=10,
+            output_tokens=20,
+            peak_memory_mb=512.0,
+            model_memory_mb=256.0,
+            batch_times=[1.0],
+        )
+
+    def cleanup(self, model: Any) -> None:
+        self.call_log.append("cleanup")
+
+
+class FakeBackendWithCapture(FakeBackend):
+    """FakeBackend that also records + returns observed params (post-window capture)."""
+
+    def capture_observed_params(self, config: Any, model: Any, output: Any) -> dict:
+        self.call_log.append("capture_observed_params")
+        return {"engine": {}, "sampling": {}, "library_version": "test"}
 
 
 def make_pynvml_mock(

--- a/tests/unit/harness/conftest.py
+++ b/tests/unit/harness/conftest.py
@@ -23,6 +23,7 @@ class FakeBackend:
     call_log: list[str] = field(default_factory=list)
     inference_output: InferenceOutput | None = None
     fail_on_run_inference: bool = False
+    fail_on_run_warmup: bool = False
 
     @property
     def name(self) -> str:
@@ -44,6 +45,8 @@ class FakeBackend:
 
     def run_warmup_prompt(self, config: Any, model: Any, prompt: str) -> float:
         self.call_log.append("run_warmup_prompt")
+        if self.fail_on_run_warmup:
+            raise RuntimeError("Fake warmup failure")
         # Return 0.0 = simple kernel warmup (no CV convergence loop needed in tests)
         return 0.0
 

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -118,8 +118,22 @@ def test_harness_cleanup_called_on_inference_error(minimal_config):
     with _apply_patches(), pytest.raises(RuntimeError, match="Fake inference failure"):
         harness.run(engine, minimal_config)
 
-    assert "cleanup" in engine.call_log
+    assert engine.call_log.count("cleanup") == 1
     assert "run_inference" in engine.call_log
+
+
+def test_harness_cleanup_called_exactly_once_on_warmup_error(minimal_config):
+    """cleanup() runs exactly once when warmup raises: the model is released by
+    _build_lifetime's own guard, and the window-phase finally must not fire a
+    second release (no double-free)."""
+    engine = FakeBackend(fail_on_run_warmup=True)
+    harness = MeasurementHarness()
+
+    with _apply_patches(), pytest.raises(RuntimeError, match="Fake warmup failure"):
+        harness.run(engine, minimal_config)
+
+    assert engine.call_log.count("cleanup") == 1
+    assert "run_inference" not in engine.call_log
 
 
 def test_harness_returns_experiment_result(minimal_config):

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -670,14 +670,17 @@ def test_inference_time_sec_used_in_result(minimal_config):
     engine = FakeBackend(inference_output=custom_output)
     harness = MeasurementHarness()
 
-    # load_model bracket: 50 -> 52; inference bracket: 100 -> 105.
+    # load_model bracket (measurement.time): 50 -> 52; inference bracket
+    # (bracket.time): 100 -> 105. Both draw from one shared perf_counter iterator.
     perf_counter_values = iter([50.0, 52.0, 100.0, 105.0])
+    mock_time = MagicMock()
+    mock_time.perf_counter.side_effect = lambda: next(perf_counter_values)
 
     with (
         _apply_patches(),
-        patch("llenergymeasure.harness.measurement.time") as mock_time,
+        patch("llenergymeasure.harness.measurement.time", new=mock_time),
+        patch("llenergymeasure.harness.bracket.time", new=mock_time),
     ):
-        mock_time.perf_counter.side_effect = lambda: next(perf_counter_values)
         result = harness.run(engine, minimal_config)
 
     assert result.total_inference_time_sec == pytest.approx(5.0), (

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -6,75 +6,14 @@ No GPU required - all hardware dependencies are mocked.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from llenergymeasure.domain.metrics import WarmupResult
 from llenergymeasure.engines.protocol import InferenceOutput
 from llenergymeasure.harness import MeasurementHarness
-
-# ---------------------------------------------------------------------------
-# FakeBackend - minimal EnginePlugin implementation for tests
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class FakeBackend:
-    """Minimal EnginePlugin for testing MeasurementHarness lifecycle.
-
-    All methods record calls for assertion in tests.
-    """
-
-    engine_name: str = "fake"
-    call_log: list[str] = field(default_factory=list)
-    inference_output: InferenceOutput | None = None
-    fail_on_run_inference: bool = False
-
-    @property
-    def name(self) -> str:
-        return self.engine_name
-
-    def load_model(self, config: Any, **kwargs: Any) -> dict:
-        self.call_log.append("load_model")
-        return {"model": "fake_model_object"}
-
-    def warmup(self, config: Any, model: Any, prompts: list[str]) -> WarmupResult:
-        self.call_log.append("warmup")
-        return WarmupResult(
-            converged=True,
-            final_cv=0.0,
-            iterations_completed=1,
-            target_cv=0.01,
-            max_prompts=10,
-        )
-
-    def run_warmup_prompt(self, config: Any, model: Any, prompt: str) -> float:
-        self.call_log.append("run_warmup_prompt")
-        # Return 0.0 = simple kernel warmup (no CV convergence loop needed in tests)
-        return 0.0
-
-    def run_inference(self, config: Any, model: Any, prompts: list[str]) -> InferenceOutput:
-        self.call_log.append("run_inference")
-        if self.fail_on_run_inference:
-            raise RuntimeError("Fake inference failure")
-        if self.inference_output is not None:
-            return self.inference_output
-        return InferenceOutput(
-            elapsed_time_sec=1.0,
-            input_tokens=10,
-            output_tokens=20,
-            peak_memory_mb=512.0,
-            model_memory_mb=256.0,
-            batch_times=[1.0],
-        )
-
-    def cleanup(self, model: Any) -> None:
-        self.call_log.append("cleanup")
-
+from tests.unit.harness.conftest import FakeBackend, FakeBackendWithCapture
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -121,7 +60,7 @@ def _apply_patches():
             return_value=["test prompt"],
         ),
         patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler",
+            "llenergymeasure.harness.bracket.select_energy_sampler",
             return_value=None,
         ),
         patch(
@@ -132,8 +71,8 @@ def _apply_patches():
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=1e9),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="timeseries.parquet"),
@@ -324,15 +263,15 @@ def test_harness_passes_gpu_indices_to_energy_sampler(minimal_config):
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
         patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler", return_value=None
+            "llenergymeasure.harness.bracket.select_energy_sampler", return_value=None
         ) as mock_seb,
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -360,14 +299,14 @@ def test_harness_passes_gpu_indices_to_thermal_sampler(minimal_config):
         ),
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=None),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=mock_pts_cls),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=mock_pts_cls),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -408,14 +347,14 @@ def test_harness_passes_gpu_indices_to_baseline(minimal_config):
             "llenergymeasure.harness.measurement.measure_baseline_power", return_value=None
         ) as mock_mbp,
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=None),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -444,15 +383,15 @@ def test_harness_defaults_to_no_gpu_indices(minimal_config):
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
         patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler", return_value=None
+            "llenergymeasure.harness.bracket.select_energy_sampler", return_value=None
         ) as mock_seb,
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=mock_pts_cls),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=mock_pts_cls),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -506,7 +445,7 @@ def test_harness_start_tracking_called_after_thermal_floor_wait(minimal_config):
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
         patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler",
+            "llenergymeasure.harness.bracket.select_energy_sampler",
             side_effect=fake_select_energy_sampler,
         ),
         patch(
@@ -517,8 +456,8 @@ def test_harness_start_tracking_called_after_thermal_floor_wait(minimal_config):
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -846,24 +785,13 @@ def test_capture_observed_params_called_post_window(minimal_config, tmp_path: Pa
     the extras keys (observed_engine_params/observed_sampling_params/library_version)
     must be present so _write_config_sidecar can pick them up.
     """
-    captured_calls: list[str] = []
-
-    class FakeBackendWithCapture(FakeBackend):
-        def capture_observed_params(self, config, model, output):
-            captured_calls.append("capture_observed_params")
-            return {
-                "engine": {"dtype": "float32"},
-                "sampling": {"temperature": 0.9},
-                "library_version": "5.0.0",
-            }
-
     engine = FakeBackendWithCapture()
     harness = MeasurementHarness()
 
     with _apply_patches():
         harness.run(engine, minimal_config, output_dir=str(tmp_path))
 
-    assert "capture_observed_params" in captured_calls, (
+    assert "capture_observed_params" in engine.call_log, (
         "engine.capture_observed_params must be called by the harness"
     )
     # config.json sidecar must exist and carry the captured params
@@ -927,7 +855,7 @@ def test_harness_per_gpu_j_wired_to_energy_per_device_j(minimal_config):
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
         patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler",
+            "llenergymeasure.harness.bracket.select_energy_sampler",
             return_value=mock_energy_sampler,
         ),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
@@ -935,8 +863,8 @@ def test_harness_per_gpu_j_wired_to_energy_per_device_j(minimal_config):
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -976,7 +904,7 @@ def test_harness_single_gpu_no_multi_gpu_metrics(minimal_config):
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
         patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler",
+            "llenergymeasure.harness.bracket.select_energy_sampler",
             return_value=mock_energy_sampler,
         ),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
@@ -984,8 +912,8 @@ def test_harness_single_gpu_no_multi_gpu_metrics(minimal_config):
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -1031,16 +959,14 @@ def test_harness_stop_tracking_raises_cleanup_still_called(minimal_config):
         ),
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler", return_value=mock_energy
-        ),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=mock_energy),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -1065,14 +991,14 @@ def test_harness_flops_estimation_raises_returns_zero_flops(minimal_config):
         ),
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=None),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm_from_config",
             side_effect=RuntimeError("model not found"),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -1162,14 +1088,14 @@ def test_harness_flops_none_result_has_none_derived(minimal_config):
         ),
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=None),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm_from_config",
             return_value=None,
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -1211,14 +1137,14 @@ def test_harness_save_timeseries_false_skips_parquet(tmp_path):
         ),
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=None),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="f"),
@@ -1277,7 +1203,7 @@ def test_harness_populates_extended_metrics(minimal_config):
     with (
         _apply_patches(),
         patch(
-            "llenergymeasure.harness.measurement.PowerThermalSampler",
+            "llenergymeasure.harness.bracket.PowerThermalSampler",
             new=_make_mock_pts(samples=samples),
         ),
         patch.object(MeasurementHarness, "_capture_model_memory_mb", return_value=8192.0),
@@ -1328,7 +1254,7 @@ def test_harness_vllm_batch_metrics_none(minimal_config):
     with (
         _apply_patches(),
         patch(
-            "llenergymeasure.harness.measurement.PowerThermalSampler",
+            "llenergymeasure.harness.bracket.PowerThermalSampler",
             new=_make_mock_pts(samples=samples),
         ),
     ):
@@ -1367,15 +1293,15 @@ def test_harness_save_timeseries_true_writes_parquet(tmp_path):
         ),
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=None),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=0),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
         patch(
-            "llenergymeasure.harness.measurement.PowerThermalSampler",
+            "llenergymeasure.harness.bracket.PowerThermalSampler",
             new=_make_mock_pts(samples=[_real_sample()]),
         ),
         patch(

--- a/tests/unit/harness/test_latency_profiling_harness.py
+++ b/tests/unit/harness/test_latency_profiling_harness.py
@@ -15,7 +15,8 @@ from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
 from llenergymeasure.domain.metrics import LatencyMeasurementMode
 from llenergymeasure.engines.protocol import InferenceOutput
 from llenergymeasure.harness import MeasurementHarness
-from tests.unit.harness.test_harness import FakeBackend, _make_mock_pts
+from tests.unit.harness.conftest import FakeBackend
+from tests.unit.harness.test_harness import _make_mock_pts
 
 
 def _config(latency_profiling: bool) -> ExperimentConfig:
@@ -41,14 +42,14 @@ def _apply_patches():
         ),
         patch("llenergymeasure.harness.measurement.measure_baseline_power", return_value=None),
         patch("llenergymeasure.harness.measurement.load_prompts", return_value=["test prompt"]),
-        patch("llenergymeasure.harness.measurement.select_energy_sampler", return_value=None),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", return_value=None),
         patch("llenergymeasure.harness.measurement.thermal_floor_wait", return_value=0.0),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm",
             return_value=MagicMock(value=1e9),
         ),
-        patch("llenergymeasure.harness.measurement._cuda_sync"),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", new=_make_mock_pts()),
+        patch("llenergymeasure.harness.bracket._cuda_sync"),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", new=_make_mock_pts()),
         patch(
             "llenergymeasure.harness.measurement.write_timeseries_parquet",
             return_value=MagicMock(name="timeseries.parquet"),

--- a/tests/unit/harness/test_window_ordering.py
+++ b/tests/unit/harness/test_window_ordering.py
@@ -2,104 +2,67 @@
 
 This locks the FULL boundary order of the measured inference window - the missing
 guard the S8 brief calls out. It threads one shared recorder through a fake
-engine, a fake energy sampler, and a fake thermal sampler, then asserts the
-recorded call sequence rather than any private method name, so it survives the
-later measurement.py decomposition.
+engine (``FakeBackendWithCapture``), a fake energy sampler (a ``FakeEnergySampler``
+subclass), and a fake thermal sampler, then asserts the recorded call sequence
+rather than any private method name, so it survives the later measurement.py
+decomposition.
 
-The harness's window primitives (``select_energy_sampler``, ``_cuda_sync``,
-``PowerThermalSampler``) are patched on ``llenergymeasure.harness.measurement`` -
-the harness's canonical monkeypatch surface. The MeasurementBracket extraction
-keeps resolving those primitives through that module, so this test reads
-identically before and after the extraction.
+The window primitives live on ``llenergymeasure.harness.bracket`` and are patched
+there (patch at the use site). The load-bearing assertion is the window-width
+subtlety: observed-params capture runs INSIDE the energy-tracker window (before
+the tracker stops) but OUTSIDE the thermal sampler (after it stops), so the energy
+reading is deliberately slightly wider than the thermal timeseries. Any reorder
+that moves capture past the tracker stop shifts energy readings at the margin and
+must fail here.
 
-The load-bearing assertion is the window-width subtlety: observed-params capture
-runs INSIDE the energy-tracker window (before the tracker stops) but OUTSIDE the
-thermal sampler (after the thermal sampler stops). The energy reading is
-therefore deliberately slightly wider than the thermal timeseries. Any reorder
-that moves capture past the tracker stop shifts energy readings at the margin
-and must fail here.
+A companion progress-order test locks that the "measure" step-done event fires
+AFTER the observed-params capture (unchanged from before the bracket extraction).
 """
 
 from __future__ import annotations
 
 from concurrent.futures import Future
-from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import patch
 
 from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
 from llenergymeasure.domain.metrics import ThermalThrottleInfo
-from llenergymeasure.energy.nvml import EnergyMeasurement
-from llenergymeasure.engines.protocol import InferenceOutput
 from llenergymeasure.harness import MeasurementHarness
+from tests.fakes import FakeEnergySampler
+from tests.unit.harness.conftest import FakeBackendWithCapture
 
 
-@dataclass
-class _RecordingEngine:
-    """Fake EnginePlugin that records every lifecycle call into a shared log."""
+class _RecordingSampler(FakeEnergySampler):
+    """FakeEnergySampler that records tracker start/stop into a shared log."""
 
-    events: list[str]
-    name: str = "transformers"
-
-    def load_model(self, config: Any, **kwargs: Any) -> dict:
-        self.events.append("model_load")
-        return {"model": "fake"}
-
-    def run_warmup_prompt(self, config: Any, model: Any, prompt: str) -> float:
-        self.events.append("warmup")
-        return 0.0  # kernel-warmup branch: one discarded probe, no CV loop
-
-    def run_inference(self, config: Any, model: Any, prompts: list[str]) -> InferenceOutput:
-        self.events.append("run_inference")
-        return InferenceOutput(
-            elapsed_time_sec=1.0,
-            input_tokens=8,
-            output_tokens=8,
-            peak_memory_mb=0.0,
-            model_memory_mb=0.0,
-        )
-
-    def capture_observed_params(self, config: Any, model: Any, output: Any) -> dict:
-        self.events.append("observed_capture")
-        return {"engine": {}, "sampling": {}, "library_version": "test"}
-
-    def cleanup(self, model: Any) -> None:
-        pass
-
-
-@dataclass
-class _RecordingSampler:
-    """Fake energy sampler recording tracker start/stop into the shared log."""
-
-    events: list[str]
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self._events = events
 
     def start_tracking(self) -> str:
-        self.events.append("tracker_start")
-        return "tracker-handle"
+        self._events.append("tracker_start")
+        return super().start_tracking()
 
-    def stop_tracking(self, tracker: Any) -> EnergyMeasurement:
-        self.events.append("tracker_stop")
-        return EnergyMeasurement(total_j=10.0, duration_sec=1.0, per_gpu_j={0: 10.0})
+    def stop_tracking(self, tracker: Any) -> Any:
+        self._events.append("tracker_stop")
+        return super().stop_tracking(tracker)
 
 
-@dataclass
 class _RecordingThermal:
-    """Fake PowerThermalSampler recording start/stop into the shared log.
+    """Fake PowerThermalSampler recording start/stop into a shared log.
 
-    Records on both the context-manager protocol (current code wraps the run in a
-    ``with``) and direct start/stop calls (the bracket splits the thermal lifetime
-    across its own enter and exit), so the same fake locks the order on either
-    shape.
+    Records on both the context-manager protocol and direct start/stop calls, so
+    the same fake locks the order however the bracket drives the thermal sampler.
     """
 
-    events: list[str]
-    kwargs: dict[str, Any] = field(default_factory=dict)
+    def __init__(self, events: list[str], **kwargs: Any) -> None:
+        self._events = events
 
     def start(self) -> None:
-        self.events.append("thermal_start")
+        self._events.append("thermal_start")
 
     def stop(self) -> None:
-        self.events.append("thermal_stop")
+        self._events.append("thermal_stop")
 
     def __enter__(self) -> _RecordingThermal:
         self.start()
@@ -115,6 +78,24 @@ class _RecordingThermal:
         return []
 
 
+class _StepDoneRecorder:
+    """Progress callback that records only the 'measure' step-done event."""
+
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def on_step_done(self, step: str, elapsed_sec: float) -> None:
+        if step == "measure":
+            self._events.append("step_done:measure")
+
+    def on_step_start(self, *args: Any, **kwargs: Any) -> None: ...
+    def on_step_update(self, *args: Any, **kwargs: Any) -> None: ...
+    def on_step_skip(self, *args: Any, **kwargs: Any) -> None: ...
+    def on_substep(self, *args: Any, **kwargs: Any) -> None: ...
+    def on_substep_start(self, *args: Any, **kwargs: Any) -> None: ...
+    def on_substep_done(self, *args: Any, **kwargs: Any) -> None: ...
+
+
 def _resolved_future(value: Any) -> Future:
     future: Future = Future()
     future.set_result(value)
@@ -126,10 +107,14 @@ def _idx_lt(events: list[str], first: str, second: str) -> bool:
     return events.index(first) < events.index(second)
 
 
-def _run_recorded() -> list[str]:
-    """Run one measurement with recording fakes; return the ordered event log."""
+def _run_recorded(*, record_progress: bool = False) -> list[str]:
+    """Run one measurement with recording fakes; return the ordered event log.
+
+    With ``record_progress`` a :class:`_StepDoneRecorder` is threaded in so the
+    'measure' step-done event lands in the same timeline as the mechanical events.
+    """
     events: list[str] = []
-    engine = _RecordingEngine(events)
+    engine = FakeBackendWithCapture(engine_name="transformers", call_log=events)
     config = ExperimentConfig(
         task={
             "model": "fake/model",
@@ -161,7 +146,9 @@ def _run_recorded() -> list[str]:
         events.append("cuda_sync")
 
     def _thermal(**kwargs: Any) -> _RecordingThermal:
-        return _RecordingThermal(events, kwargs)
+        return _RecordingThermal(events, **kwargs)
+
+    progress = _StepDoneRecorder(events) if record_progress else None
 
     with (
         patch(
@@ -177,12 +164,9 @@ def _run_recorded() -> list[str]:
             "llenergymeasure.harness.measurement.thermal_floor_wait",
             side_effect=_thermal_floor,
         ),
-        patch(
-            "llenergymeasure.harness.measurement.select_energy_sampler",
-            side_effect=_select,
-        ),
-        patch("llenergymeasure.harness.measurement._cuda_sync", side_effect=_cuda_sync),
-        patch("llenergymeasure.harness.measurement.PowerThermalSampler", side_effect=_thermal),
+        patch("llenergymeasure.harness.bracket.select_energy_sampler", side_effect=_select),
+        patch("llenergymeasure.harness.bracket._cuda_sync", side_effect=_cuda_sync),
+        patch("llenergymeasure.harness.bracket.PowerThermalSampler", side_effect=_thermal),
         patch(
             "llenergymeasure.harness.measurement.estimate_flops_palm_from_config",
             return_value=None,
@@ -192,7 +176,7 @@ def _run_recorded() -> list[str]:
             return_value=[],
         ),
     ):
-        harness.run(engine, config, gpu_indices=[0])
+        harness.run(engine, config, gpu_indices=[0], progress=progress)
 
     return events
 
@@ -212,8 +196,8 @@ def test_measured_window_full_order_contract() -> None:
 
     order = [
         idx("baseline"),
-        idx("model_load"),
-        idx("warmup"),
+        idx("load_model"),
+        idx("run_warmup_prompt"),
         idx("thermal_floor"),
         idx("energy_select"),
         idx("tracker_start"),
@@ -222,7 +206,7 @@ def test_measured_window_full_order_contract() -> None:
         idx("run_inference"),
         idx("thermal_stop"),
         post_sync,
-        idx("observed_capture"),
+        idx("capture_observed_params"),
         idx("tracker_stop"),
     ]
     assert order == sorted(order), f"measured-window ordering violated: {events}"
@@ -236,15 +220,15 @@ def test_capture_inside_energy_window_outside_thermal_window() -> None:
     energy reading and shift results at the margin.
     """
     events = _run_recorded()
-    assert _idx_lt(events, "thermal_stop", "observed_capture"), events
-    assert _idx_lt(events, "observed_capture", "tracker_stop"), events
+    assert _idx_lt(events, "thermal_stop", "capture_observed_params"), events
+    assert _idx_lt(events, "capture_observed_params", "tracker_stop"), events
 
 
 def test_engine_work_strictly_outside_tracker_window() -> None:
     """Model load and warmup finish before the energy tracker ever starts."""
     events = _run_recorded()
-    assert _idx_lt(events, "model_load", "tracker_start"), events
-    assert _idx_lt(events, "warmup", "tracker_start"), events
+    assert _idx_lt(events, "load_model", "tracker_start"), events
+    assert _idx_lt(events, "run_warmup_prompt", "tracker_start"), events
 
 
 def test_run_inference_strictly_inside_both_windows() -> None:
@@ -254,3 +238,13 @@ def test_run_inference_strictly_inside_both_windows() -> None:
     assert _idx_lt(events, "run_inference", "thermal_stop"), events
     assert _idx_lt(events, "tracker_start", "run_inference"), events
     assert _idx_lt(events, "run_inference", "tracker_stop"), events
+
+
+def test_measure_step_done_fires_after_capture() -> None:
+    """The 'measure' step-done progress event fires AFTER observed-params capture.
+
+    Pre-refactor the harness fired on_step_done('measure') after the capture; the
+    bracket must preserve that (it fires in finish(), after the caller's capture).
+    """
+    events = _run_recorded(record_progress=True)
+    assert _idx_lt(events, "capture_observed_params", "step_done:measure"), events

--- a/tests/unit/harness/test_window_ordering.py
+++ b/tests/unit/harness/test_window_ordering.py
@@ -1,0 +1,256 @@
+"""Durable NVML measured-window ordering contract.
+
+This locks the FULL boundary order of the measured inference window - the missing
+guard the S8 brief calls out. It threads one shared recorder through a fake
+engine, a fake energy sampler, and a fake thermal sampler, then asserts the
+recorded call sequence rather than any private method name, so it survives the
+later measurement.py decomposition.
+
+The harness's window primitives (``select_energy_sampler``, ``_cuda_sync``,
+``PowerThermalSampler``) are patched on ``llenergymeasure.harness.measurement`` -
+the harness's canonical monkeypatch surface. The MeasurementBracket extraction
+keeps resolving those primitives through that module, so this test reads
+identically before and after the extraction.
+
+The load-bearing assertion is the window-width subtlety: observed-params capture
+runs INSIDE the energy-tracker window (before the tracker stops) but OUTSIDE the
+thermal sampler (after the thermal sampler stops). The energy reading is
+therefore deliberately slightly wider than the thermal timeseries. Any reorder
+that moves capture past the tracker stop shifts energy readings at the margin
+and must fail here.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+from llenergymeasure.config.models import DatasetConfig, ExperimentConfig
+from llenergymeasure.domain.metrics import ThermalThrottleInfo
+from llenergymeasure.energy.nvml import EnergyMeasurement
+from llenergymeasure.engines.protocol import InferenceOutput
+from llenergymeasure.harness import MeasurementHarness
+
+
+@dataclass
+class _RecordingEngine:
+    """Fake EnginePlugin that records every lifecycle call into a shared log."""
+
+    events: list[str]
+    name: str = "transformers"
+
+    def load_model(self, config: Any, **kwargs: Any) -> dict:
+        self.events.append("model_load")
+        return {"model": "fake"}
+
+    def run_warmup_prompt(self, config: Any, model: Any, prompt: str) -> float:
+        self.events.append("warmup")
+        return 0.0  # kernel-warmup branch: one discarded probe, no CV loop
+
+    def run_inference(self, config: Any, model: Any, prompts: list[str]) -> InferenceOutput:
+        self.events.append("run_inference")
+        return InferenceOutput(
+            elapsed_time_sec=1.0,
+            input_tokens=8,
+            output_tokens=8,
+            peak_memory_mb=0.0,
+            model_memory_mb=0.0,
+        )
+
+    def capture_observed_params(self, config: Any, model: Any, output: Any) -> dict:
+        self.events.append("observed_capture")
+        return {"engine": {}, "sampling": {}, "library_version": "test"}
+
+    def cleanup(self, model: Any) -> None:
+        pass
+
+
+@dataclass
+class _RecordingSampler:
+    """Fake energy sampler recording tracker start/stop into the shared log."""
+
+    events: list[str]
+
+    def start_tracking(self) -> str:
+        self.events.append("tracker_start")
+        return "tracker-handle"
+
+    def stop_tracking(self, tracker: Any) -> EnergyMeasurement:
+        self.events.append("tracker_stop")
+        return EnergyMeasurement(total_j=10.0, duration_sec=1.0, per_gpu_j={0: 10.0})
+
+
+@dataclass
+class _RecordingThermal:
+    """Fake PowerThermalSampler recording start/stop into the shared log.
+
+    Records on both the context-manager protocol (current code wraps the run in a
+    ``with``) and direct start/stop calls (the bracket splits the thermal lifetime
+    across its own enter and exit), so the same fake locks the order on either
+    shape.
+    """
+
+    events: list[str]
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def start(self) -> None:
+        self.events.append("thermal_start")
+
+    def stop(self) -> None:
+        self.events.append("thermal_stop")
+
+    def __enter__(self) -> _RecordingThermal:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.stop()
+
+    def get_thermal_throttle_info(self) -> ThermalThrottleInfo:
+        return ThermalThrottleInfo()
+
+    def get_samples(self) -> list[Any]:
+        return []
+
+
+def _resolved_future(value: Any) -> Future:
+    future: Future = Future()
+    future.set_result(value)
+    return future
+
+
+def _idx_lt(events: list[str], first: str, second: str) -> bool:
+    """True when ``first`` is recorded strictly before ``second``."""
+    return events.index(first) < events.index(second)
+
+
+def _run_recorded() -> list[str]:
+    """Run one measurement with recording fakes; return the ordered event log."""
+    events: list[str] = []
+    engine = _RecordingEngine(events)
+    config = ExperimentConfig(
+        task={
+            "model": "fake/model",
+            "dataset": DatasetConfig(n_prompts=1),
+            "max_input_tokens": 32,
+            "max_output_tokens": 32,
+        },
+        engine="transformers",
+        measurement={
+            "baseline": {"enabled": True, "duration_seconds": 5.0},
+            "warmup": {"enabled": True},
+        },
+    )
+    harness = MeasurementHarness()
+
+    def _baseline(*args: Any, **kwargs: Any) -> None:
+        events.append("baseline")
+        return None
+
+    def _thermal_floor(config: Any) -> float:
+        events.append("thermal_floor")
+        return 0.0
+
+    def _select(*args: Any, **kwargs: Any) -> _RecordingSampler:
+        events.append("energy_select")
+        return _RecordingSampler(events)
+
+    def _cuda_sync() -> None:
+        events.append("cuda_sync")
+
+    def _thermal(**kwargs: Any) -> _RecordingThermal:
+        return _RecordingThermal(events, kwargs)
+
+    with (
+        patch(
+            "llenergymeasure.harness.measurement.collect_environment_snapshot_async",
+            return_value=_resolved_future(None),
+        ),
+        patch("llenergymeasure.harness.measurement.load_prompts", return_value=["prompt"]),
+        patch(
+            "llenergymeasure.harness.measurement.measure_baseline_power",
+            side_effect=_baseline,
+        ),
+        patch(
+            "llenergymeasure.harness.measurement.thermal_floor_wait",
+            side_effect=_thermal_floor,
+        ),
+        patch(
+            "llenergymeasure.harness.measurement.select_energy_sampler",
+            side_effect=_select,
+        ),
+        patch("llenergymeasure.harness.measurement._cuda_sync", side_effect=_cuda_sync),
+        patch("llenergymeasure.harness.measurement.PowerThermalSampler", side_effect=_thermal),
+        patch(
+            "llenergymeasure.harness.measurement.estimate_flops_palm_from_config",
+            return_value=None,
+        ),
+        patch(
+            "llenergymeasure.harness.measurement.collect_measurement_warnings",
+            return_value=[],
+        ),
+    ):
+        harness.run(engine, config, gpu_indices=[0])
+
+    return events
+
+
+def test_measured_window_full_order_contract() -> None:
+    """The full pre-window -> window -> boundary order is locked end to end."""
+    events = _run_recorded()
+
+    # Two CUDA syncs bracket the run: pre (before thermal start) and post (after
+    # thermal stop). Split them out before ordering the rest.
+    cuda_positions = [i for i, e in enumerate(events) if e == "cuda_sync"]
+    assert len(cuda_positions) == 2, f"expected two CUDA syncs, got {events}"
+    pre_sync, post_sync = cuda_positions
+
+    def idx(name: str) -> int:
+        return events.index(name)
+
+    order = [
+        idx("baseline"),
+        idx("model_load"),
+        idx("warmup"),
+        idx("thermal_floor"),
+        idx("energy_select"),
+        idx("tracker_start"),
+        pre_sync,
+        idx("thermal_start"),
+        idx("run_inference"),
+        idx("thermal_stop"),
+        post_sync,
+        idx("observed_capture"),
+        idx("tracker_stop"),
+    ]
+    assert order == sorted(order), f"measured-window ordering violated: {events}"
+
+
+def test_capture_inside_energy_window_outside_thermal_window() -> None:
+    """Width subtlety: capture sits after thermal stop but before tracker stop.
+
+    This is the deliberate energy>thermal window-width gap. It must never regress:
+    capture landing after the tracker stop would drop capture overhead out of the
+    energy reading and shift results at the margin.
+    """
+    events = _run_recorded()
+    assert _idx_lt(events, "thermal_stop", "observed_capture"), events
+    assert _idx_lt(events, "observed_capture", "tracker_stop"), events
+
+
+def test_engine_work_strictly_outside_tracker_window() -> None:
+    """Model load and warmup finish before the energy tracker ever starts."""
+    events = _run_recorded()
+    assert _idx_lt(events, "model_load", "tracker_start"), events
+    assert _idx_lt(events, "warmup", "tracker_start"), events
+
+
+def test_run_inference_strictly_inside_both_windows() -> None:
+    """The single inference call is nested inside the thermal and energy windows."""
+    events = _run_recorded()
+    assert _idx_lt(events, "thermal_start", "run_inference"), events
+    assert _idx_lt(events, "run_inference", "thermal_stop"), events
+    assert _idx_lt(events, "tracker_start", "run_inference"), events
+    assert _idx_lt(events, "run_inference", "tracker_stop"), events


### PR DESCRIPTION
## Summary

Slice S8 (F6 Wave 2): the server-admittance heart. Extracts the measured-window
mechanics into a mode-agnostic bracket, splits per-model-load state from
per-window state, and adds a durable NVML-window ordering test. Progress
emission, result values, and windowing are frozen (constraints C2 + C5; a1 audit
items #9, #13).

### Decision 1 - `harness/bracket.py::MeasurementBracket`

New context manager owning the mode-agnostic window mechanics: energy-sampler
selection, tracker start/stop, pre/post CUDA syncs, the PowerThermalSampler
lifetime, and the wall-clock + perf timestamps. Signature is
`MeasurementBracket(config.measurement, gpu_indices, progress, *, measure_detail="")`
- no engine, no prompts, no InferenceOutput (C2). Server mode can reuse it around
a load-gen-timed run unchanged.

The bracket API landed:
- `with bracket:` runs the body inside the window.
- `bracket.inference_duration_sec` - perf-counter delta bracketing the body.
- `bracket.finish() -> MeasuredWindowCore(thermal_info, timeseries_samples,
  energy_measurement, energy_sampler_reasons, start_time, end_time)`.

The split-exit shape from the brief is landed as-is: `__exit__` stops the thermal
sampler + runs the post-sync; `finish()` stops the energy tracker and returns the
core. The offline caller (`_run_measured_inference`) interleaves observed-params
capture, the canonical `inference_time_sec` override, and FLOPs between context
exit and `finish()`; those offline extras stay in measurement.py.

**How the width subtlety is expressed:** structurally, by the split exit. The
thermal sampler stops in `__exit__` while the energy tracker stays open until
`finish()`, so the caller's observed-params capture (run between the two) lands
INSIDE the energy window but OUTSIDE the thermal timeseries. The energy reading
stays deliberately slightly wider than the thermal window - unchanged from
before, and now explicit in the API structure rather than only a comment.

### Decision 2 - lifetime/window state split

New `_EngineLifetime` dataclass (model, snapshot, baseline, model_memory_mb,
model_load_time_sec, prompts, warmup_result) built once by `_build_lifetime`.
`_MeasuredWindow` stays the per-window product, now composing the bracket's
`MeasuredWindowCore` + the offline extras (output, flops_result). `run()` reads:
build lifetime -> one window -> `persist(lifetime, window)`. No flat context bag,
no windows list. This is the server seam (one lifetime, N windows later) without
speculative multi-window machinery. Model cleanup on a post-load
(warmup/inference) failure is preserved.

### Decision 3 - NVML-window ordering test

`tests/unit/harness/test_window_ordering.py` threads one shared recorder through
a recording fake engine + fake energy sampler + fake thermal sampler and asserts
the full order contract on the recorded CALL SEQUENCE (not private method names),
so it survives S9's later decomposition:

```
baseline < model load < warmup < thermal floor < energy_select < tracker_start
  < pre-sync < thermal_start < run_inference < thermal_stop < post-sync
  < observed-capture < tracker_stop
```

plus engine work strictly outside the tracker window, run_inference strictly
inside both windows, and the width subtlety as its own load-bearing assertion
(`thermal_stop < observed-capture < tracker_stop`). Written FIRST against current
code (green), then the bracket was extracted and it passes UNMODIFIED.

### Decision 4 - behavior freeze

Progress step names/labels/substep strings and their emission order are unchanged;
the replay-fixture test (`tests/unit/test_replay_fixtures.py`) passes unmodified;
`windowing.py` is untouched (C5); no config schema change.

### Deviations

- The bracket resolves its window primitives (sampler selection, CUDA sync,
  thermal sampler) through the `measurement` module at call time (redundant-alias
  re-exports), rather than importing them directly. measurement.py is the
  harness's canonical monkeypatch surface (its own docstring says so). This keeps
  every existing harness test AND the durable ordering test patching one place,
  so the ordering test reads identically before and after the extraction - which
  is what lets it be written first against current code and then survive the
  extraction unmodified. The perf clock (`time`) is a plain import in the bracket
  (mypy-clean), patchable at `bracket.time`; the only test changed for this is
  `test_inference_time_sec_used_in_result`, which now patches both
  `measurement.time` and `bracket.time` with a shared perf_counter mock.
- No `.window` property: `finish()` returns the core directly (the brief's
  primary described shape). Kept minimal.

### #855 (S10) integration

Rebased onto post-#855 main. Since selection moved into the bracket, S10's
`energy_sampler_reasons` capture moved from the old selection site into the
bracket: it captures the per-sampler probe reasons on the no-sampler path via
`select_energy_sampler_with_diagnostics`, exposes them on
`MeasuredWindowCore.energy_sampler_reasons`, and `_run_measured_inference` threads
them onto `_MeasuredWindow.energy_sampler_reasons`. The `_MeasuredWindow ->
_persist_and_assemble -> _collect_warnings` handoff from #855 is unchanged, and
S10's measurement_warnings / energy-backend tests pass unmodified. My diff does
not touch any of S10's files (engines/*, harness/preflight, energy/__init__,
harness/measurement_warnings).

## Test plan

- `make lint` (ruff + import-linter): clean, 5 contracts kept.
- `make typecheck` (mypy): clean, 319 files.
- `uv run pytest tests/unit/ -q`: 3156 passed, 37 skipped.
- `uv run pytest tests/integration/ -q`: 24 passed, 10 deselected (GPU-gated).
- The new ordering test passes both before the extraction (against current code)
  and after it, unmodified. The replay-fixture test passes unmodified.
