### PR TITLE
refactor(infra): split docker_runner into a docker package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   cross-version fields, with the host/container version-skew warning) and the
   bundle-read (strict, via `BundleReader`). One parser, two tolerance settings,
   no duplicated stripping/validation logic across the layer boundary. ([#854])
+- The host HuggingFace cache directory the docker runner bind-mounts into
+  experiment containers is now configurable via the `LLEM_DOCKER_HF_CACHE` env
+  var (default `$HOME/.cache/huggingface`, the historical location), mirroring
+  `LLEM_DOCKER_SHM_SIZE`. Point it at shared storage or a large scratch disk when
+  the default home lives on a small volume; the in-container target and `HF_HOME`
+  are unchanged. ([#861])
 
 ### Changed
 
@@ -76,6 +82,23 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `config.sweep_expansion` (sweep-block expansion) and `config.cycle_ordering`
   (execution-sequence ordering); the public `llenergymeasure.config.grid`
   import surface is unchanged. ([#860])
+- Internal restructure (no behavior or results change): the 1291-line
+  `infra/docker_runner.py` god-module is decomposed into an `infra/docker/`
+  package along its concern seams - `command` (env forwarding, mounts, GPU/shm
+  flags, image ref, and the package-dispatch bootstrap), `lifecycle` (image
+  ensure, container launch, block-until-exit wait, and the stdout-silence +
+  wall-clock watchdog), `exchange` (exchange-dir lifecycle, result read, artefact
+  rescue), and `diagnostics` (container failure classification). `DockerRunner`
+  stays the facade at `infra.docker_runner` with its constructor and public
+  method signatures unchanged. The block-until-exit path is expressed as a
+  separable `launch()` (detach-capable) plus `wait_to_completion()`, with the
+  watchdog isolated inside the wait path only, leaving a clean seam for a future
+  server measurement mode (no server dispatch is built here). The ~90-line Python
+  dependency-import probe previously embedded as a bash heredoc in
+  `container_entrypoint.sh` is extracted to a real package-data module
+  (`infra/_container/probe_imports.py`) that lint/mypy cover and unit tests import
+  directly; the shell script invokes it from the mounted package source and fails
+  loudly with a clear message if it is absent. ([#861])
 - Internal restructure (no behavior or results change): the measured-window
   mechanics are extracted into a mode-agnostic `MeasurementBracket`
   (`llenergymeasure.harness.bracket`) and per-model-load state is split from
@@ -1359,5 +1382,6 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#856]: https://github.com/henrycgbaker/llenergymeasure/pull/856
 [#857]: https://github.com/henrycgbaker/llenergymeasure/pull/857
 [#860]: https://github.com/henrycgbaker/llenergymeasure/pull/860
+[#861]: https://github.com/henrycgbaker/llenergymeasure/pull/861
 [#862]: https://github.com/henrycgbaker/llenergymeasure/pull/862
 [#863]: https://github.com/henrycgbaker/llenergymeasure/pull/863

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -602,6 +602,14 @@ running the vLLM container manually, add `--shm-size 8g` to your `docker run` co
 
 ---
 
+### Model cache location
+
+`llem` bind-mounts the host HuggingFace cache into each engine container so model weights persist
+across runs instead of re-downloading. Override the host directory with the `LLEM_DOCKER_HF_CACHE`
+env var (default `$HOME/.cache/huggingface`) to point at shared storage or a larger disk.
+
+---
+
 ### Pre-flight check failures
 
 `llem` runs pre-flight checks before launching any Docker container. The checks and their

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ markers = [
     "gpu: marks tests as requiring GPU hardware (deselect with '-m \"not gpu\"')",
     "docker: marks tests as requiring Docker with NVIDIA runtime",
     "slow: marks tests as slow (>30s); excluded from Tier 1 fast runs",
+    "needs_dist_metadata: test asserts on installed distribution metadata; skipped when the package is run from a source tree with no install",
 ]
 filterwarnings = [
     "ignore:.*rm_rf.*:pytest.PytestWarning",

--- a/src/llenergymeasure/domain/result_payload.py
+++ b/src/llenergymeasure/domain/result_payload.py
@@ -2,7 +2,7 @@
 
 Lives in the domain layer (Layer 0) so BOTH read paths can share one parser
 without a layering violation: the infra exchange-read path
-(``infra.docker_runner._read_result``) is below ``results`` and could not import
+(``infra.docker.exchange.read_result``) is below ``results`` and could not import
 a parser that lived there, and the bundle-read path
 (``results.bundle.BundleReader`` / ``results.persistence.load_result``) is above
 infra. Domain is below both, so it is the only home a shared parser can have.

--- a/src/llenergymeasure/infra/README.md
+++ b/src/llenergymeasure/infra/README.md
@@ -10,7 +10,12 @@ Manages the full container lifecycle for Docker-isolated experiment execution. A
 
 | Module | Description |
 |--------|-------------|
-| `docker_runner.py` | `DockerRunner` - dispatches a single experiment to an ephemeral container |
+| `docker_runner.py` | `DockerRunner` facade - dispatches a single experiment to an ephemeral container; composes the `docker/` package |
+| `docker/command.py` | Pure `docker run` command builders (env, mounts, GPU/shm flags, image ref, package-dispatch bootstrap) |
+| `docker/lifecycle.py` | Container process execution: image ensure, `launch()`, block-until-exit `wait_to_completion()`, and the stdout-silence watchdog |
+| `docker/exchange.py` | Exchange-dir lifecycle, result read, and the artefact rescue sweep |
+| `docker/diagnostics.py` | Container failure classification (log tail, error payload, error mapping) |
+| `_container/` | Container-side dispatch assets: `container_entrypoint.sh` + the `probe_imports.py` dependency probe it invokes |
 | `container_entrypoint.py` | Container-side entry point (invoked inside Docker) |
 | `runner_resolution.py` | `resolve_runner()`, `resolve_study_runners()` - local vs Docker selection |
 | `docker_preflight.py` | `run_docker_preflight()` - GPU visibility, CUDA/driver compat checks |

--- a/src/llenergymeasure/infra/_container/__init__.py
+++ b/src/llenergymeasure/infra/_container/__init__.py
@@ -1,0 +1,9 @@
+"""Container-side dispatch assets (bind-mounted into the engine container).
+
+Holds the entrypoint shell script and the runtime-dependency import probe
+(:mod:`probe_imports`) the entrypoint invokes. These run INSIDE the dispatch
+container against the bind-mounted package source; the probe is a real module
+(lint/mypy covered, unit-tested) rather than an inline shell heredoc.
+"""
+
+from __future__ import annotations

--- a/src/llenergymeasure/infra/_container/container_entrypoint.sh
+++ b/src/llenergymeasure/infra/_container/container_entrypoint.sh
@@ -8,9 +8,10 @@
 #
 # Responsibilities:
 #   1. Compare the runtime dependency list at /llem-requirements.txt against
-#      what's importable in the container; pip-install only the missing
-#      ones to a host-mounted persistent cache (/llem-runtime-deps/pyN.M),
-#      keyed by container Python minor.
+#      what's importable in the container (via the probe_imports.py module in
+#      the bind-mounted package source); pip-install only the missing ones to a
+#      host-mounted persistent cache (/llem-runtime-deps/pyN.M), keyed by
+#      container Python minor.
 #   2. Set PYTHONPATH so /llem-src (bind-mounted framework source) and the
 #      runtime-deps cache are discoverable.
 #   3. Exec the framework's in-container entrypoint module. For TensorRT-LLM,
@@ -58,114 +59,23 @@ export PYTHONPATH="/llem-src:${DEPS_TARGET}:${PYTHONPATH:-}"
 STAMP="${DEPS_TARGET}/.llem_requirements_hash_${LLEM_ENGINE:-default}"
 REQUIREMENTS_HASH=$(sha256sum /llem-requirements.txt | head -c 16)
 
+# The import probe lives in the bind-mounted package source. It is a real
+# module (lint/mypy covered, unit-tested) run as a plain script file - NOT as a
+# package module - so it never imports the llenergymeasure package and stays
+# runnable in a bare engine image. Its interpreter sees both the image
+# site-packages and our cache mount, since we already added the cache to
+# PYTHONPATH above.
+PROBE_SCRIPT="/llem-src/llenergymeasure/infra/_container/probe_imports.py"
+
 if [ ! -f "$STAMP" ] || [ "$(cat "$STAMP" 2>/dev/null)" != "$REQUIREMENTS_HASH" ]; then
-    # Diff the runtime requirements list against what actually imports in
-    # this interpreter. A dist-info presence check is not sufficient: metadata
-    # can be present while the package fails to import - a compiled extension
-    # built for the wrong ABI, or an otherwise broken install - so each present
-    # requirement is verified by importing its resolved module(s), and primed
-    # if the import raises. Absent metadata short-circuits as missing with no
-    # import attempt. importlib.metadata sees both the image site-packages and
-    # our cache mount, since we already added the cache to PYTHONPATH above.
-    MISSING=$(python3 - <<'PYEOF'
-import functools
-import importlib
-import importlib.metadata
-import sys
-from pathlib import Path
-
-# The requirements list is bind-mounted here inside the container. An optional
-# argv override (defaulting to the mount path) lets the probe run against a
-# synthetic requirements file without changing container behaviour.
-REQUIREMENTS_FILE = sys.argv[1] if len(sys.argv) > 1 else "/llem-requirements.txt"
-
-# Distributions whose top-level import name differs from the distribution name.
-# Keys are canonical (lowercase, dashes) distribution names; values are the
-# module to import. Authoritative: consulted before top_level.txt so noisy or
-# absent top-level metadata cannot mis-resolve these known cases.
-IMPORT_NAME_OVERRIDES = {
-    "nvidia-ml-py": "pynvml",
-    "pyyaml": "yaml",
-    "python-dotenv": "dotenv",
-}
-
-
-def bare_name(spec: str) -> str:
-    # Strip version bounds / extras to get the bare distribution name for the
-    # metadata lookup. The full spec is kept for pip install.
-    name = spec
-    for sep in (">=", "<=", "==", "!=", "~=", "<", ">", "["):
-        if sep in name:
-            name = name.split(sep)[0]
-    return name.strip()
-
-
-def canonical(name: str) -> str:
-    return name.strip().lower().replace("_", "-")
-
-
-@functools.cache
-def reverse_packages() -> dict[str, list[str]]:
-    # Invert importlib.metadata.packages_distributions() (import name -> dist
-    # names) into dist name -> import names, so a distribution's top-level
-    # module(s) can be recovered even when its top_level.txt is absent.
-    mapping: dict[str, list[str]] = {}
-    try:
-        items = importlib.metadata.packages_distributions().items()
-    except Exception:
-        return mapping
-    for import_name, dists in items:
-        for dist_name in dists:
-            mapping.setdefault(canonical(dist_name), []).append(import_name)
-    return mapping
-
-
-def import_names(dist_name, dist) -> list[str]:
-    # Resolve the top-level import name(s) for an installed distribution.
-    key = canonical(dist_name)
-    if key in IMPORT_NAME_OVERRIDES:
-        return [IMPORT_NAME_OVERRIDES[key]]
-    try:
-        top_level = dist.read_text("top_level.txt")
-    except Exception:
-        top_level = None
-    if top_level:
-        names = [ln.strip() for ln in top_level.splitlines() if ln.strip()]
-        if names:
-            return names
-    resolved = reverse_packages().get(key)
-    if resolved:
-        return resolved
-    # Fall back to the normalised distribution name (dashes to underscores).
-    return [dist_name.replace("-", "_")]
-
-
-missing = []
-for line in Path(REQUIREMENTS_FILE).read_text().splitlines():
-    spec = line.strip()
-    if not spec or spec.startswith("#"):
-        continue
-    name = bare_name(spec)
-    if not name:
-        continue
-    try:
-        dist = importlib.metadata.distribution(name)
-    except importlib.metadata.PackageNotFoundError:
-        # Absent metadata: definitely missing, no import attempt needed.
-        missing.append(spec)
-        continue
-    try:
-        for import_name in import_names(name, dist):
-            importlib.import_module(import_name)
-    except Exception:
-        # Present metadata but the module does not import (wrong-ABI extension,
-        # broken install): prime it so the container's pip reinstalls an
-        # ABI-correct copy into the deps cache.
-        missing.append(spec)
-
-print(" ".join(missing))
-PYEOF
-    )
+    if [ ! -f "$PROBE_SCRIPT" ]; then
+        echo "[llem-entry] FATAL: dependency import probe not found at ${PROBE_SCRIPT}." >&2
+        echo "[llem-entry] The llenergymeasure package source is not mounted correctly" >&2
+        echo "[llem-entry] (expected /llem-src/llenergymeasure); reinstall the package or" >&2
+        echo "[llem-entry] check the /llem-src bind-mount." >&2
+        exit 1
+    fi
+    MISSING=$(python3 "$PROBE_SCRIPT" /llem-requirements.txt)
 
     if [ -n "${MISSING}" ]; then
         echo "[llem-entry] Priming missing runtime deps for py${PY_MINOR}: ${MISSING}" >&2

--- a/src/llenergymeasure/infra/_container/probe_imports.py
+++ b/src/llenergymeasure/infra/_container/probe_imports.py
@@ -1,0 +1,141 @@
+"""Runtime-dependency import probe for the container entrypoint.
+
+Runs INSIDE the dispatch container (invoked by ``container_entrypoint.sh``
+against the bind-mounted package source at ``/llem-src``). It diffs the runtime
+requirements list at ``/llem-requirements.txt`` against what actually imports in
+the container's interpreter and prints the space-separated specs that are
+missing, so the entrypoint can pip-install only those into the persistent deps
+cache.
+
+A dist-info presence check is not sufficient: metadata can be present while the
+package fails to import (a compiled extension built for the wrong ABI, or an
+otherwise broken install). So each present requirement is verified by importing
+its resolved module(s), and flagged missing if the import raises. Absent metadata
+short-circuits as missing with no import attempt.
+
+Stdlib-only and self-contained: it is executed as a plain script file
+(``python3 probe_imports.py /llem-requirements.txt``), NOT as a package module,
+so it never imports the ``llenergymeasure`` package and stays runnable in a bare
+engine image. It is a real module (not an inline heredoc) so lint/mypy cover it
+and its unit tests import it directly.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import importlib.metadata
+import sys
+from pathlib import Path
+
+# Distributions whose top-level import name differs from the distribution name.
+# Keys are canonical (lowercase, dashes) distribution names; values are the
+# module to import. Authoritative: consulted before top_level.txt so noisy or
+# absent top-level metadata cannot mis-resolve these known cases.
+IMPORT_NAME_OVERRIDES = {
+    "nvidia-ml-py": "pynvml",
+    "pyyaml": "yaml",
+    "python-dotenv": "dotenv",
+}
+
+
+def bare_name(spec: str) -> str:
+    """Strip version bounds / extras to the bare distribution name.
+
+    The full spec is kept for the pip install; this bare form is the metadata
+    lookup key.
+    """
+    name = spec
+    for sep in (">=", "<=", "==", "!=", "~=", "<", ">", "["):
+        if sep in name:
+            name = name.split(sep)[0]
+    return name.strip()
+
+
+def canonical(name: str) -> str:
+    """Return the canonical (lowercase, dashes) form of a distribution name."""
+    return name.strip().lower().replace("_", "-")
+
+
+@functools.cache
+def reverse_packages() -> dict[str, list[str]]:
+    """Invert ``packages_distributions()`` into dist name -> import name(s).
+
+    ``importlib.metadata.packages_distributions()`` maps import name -> dist
+    names; inverting it lets a distribution's top-level module(s) be recovered
+    even when its ``top_level.txt`` is absent.
+    """
+    mapping: dict[str, list[str]] = {}
+    try:
+        items = importlib.metadata.packages_distributions().items()
+    except Exception:
+        return mapping
+    for import_name, dists in items:
+        for dist_name in dists:
+            mapping.setdefault(canonical(dist_name), []).append(import_name)
+    return mapping
+
+
+def import_names(dist_name: str, dist: importlib.metadata.Distribution) -> list[str]:
+    """Resolve the top-level import name(s) for an installed distribution."""
+    key = canonical(dist_name)
+    if key in IMPORT_NAME_OVERRIDES:
+        return [IMPORT_NAME_OVERRIDES[key]]
+    try:
+        top_level = dist.read_text("top_level.txt")
+    except Exception:
+        top_level = None
+    if top_level:
+        names = [ln.strip() for ln in top_level.splitlines() if ln.strip()]
+        if names:
+            return names
+    resolved = reverse_packages().get(key)
+    if resolved:
+        return resolved
+    # Fall back to the normalised distribution name (dashes to underscores).
+    return [dist_name.replace("-", "_")]
+
+
+def find_missing(requirements_file: str | Path) -> list[str]:
+    """Return the requirement specs whose module(s) are absent or fail to import."""
+    missing: list[str] = []
+    for line in Path(requirements_file).read_text().splitlines():
+        spec = line.strip()
+        if not spec or spec.startswith("#"):
+            continue
+        name = bare_name(spec)
+        if not name:
+            continue
+        try:
+            dist = importlib.metadata.distribution(name)
+        except importlib.metadata.PackageNotFoundError:
+            # Absent metadata: definitely missing, no import attempt needed.
+            missing.append(spec)
+            continue
+        try:
+            for import_name in import_names(name, dist):
+                importlib.import_module(import_name)
+        except Exception:
+            # Present metadata but the module does not import (wrong-ABI
+            # extension, broken install): prime it so the container's pip
+            # reinstalls an ABI-correct copy into the deps cache.
+            missing.append(spec)
+    return missing
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the space-separated missing specs for the given requirements file.
+
+    The requirements list is bind-mounted at ``/llem-requirements.txt`` inside
+    the container; an optional argv override (defaulting to the mount path) lets
+    the probe run against a synthetic requirements file without changing
+    container behaviour.
+    """
+    args = list(sys.argv if argv is None else argv)
+    requirements_file = args[1] if len(args) > 1 else "/llem-requirements.txt"
+    print(" ".join(find_missing(requirements_file)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llenergymeasure/infra/docker/__init__.py
+++ b/src/llenergymeasure/infra/docker/__init__.py
@@ -1,0 +1,15 @@
+"""Docker dispatch internals, decomposed by concern.
+
+The public surface is the :class:`~llenergymeasure.infra.docker_runner.DockerRunner`
+facade (kept at ``llenergymeasure.infra.docker_runner`` so consumers import it
+unchanged). This package holds the concerns that facade composes:
+
+- :mod:`command` - pure ``docker run`` command building (env forwarding, mounts,
+  GPU/shm flags, image ref, package-dispatch bootstrap). Unit-testable without docker.
+- :mod:`lifecycle` - container process execution: image ensure, launch (detach-capable),
+  block-until-exit wait, and the stdout-silence watchdog isolated inside the wait path.
+- :mod:`exchange` - exchange-dir lifecycle, result read, and the artefact rescue sweep.
+- :mod:`diagnostics` - container failure classification (error payload, log tail).
+"""
+
+from __future__ import annotations

--- a/src/llenergymeasure/infra/docker/command.py
+++ b/src/llenergymeasure/infra/docker/command.py
@@ -1,0 +1,527 @@
+"""Pure ``docker run`` command builders for container dispatch.
+
+Everything here is a pure builder: it assembles the argv (env forwarding,
+mounts, GPU/shm flags, image ref, and the package-dispatch bootstrap) without
+running docker, so it is unit-testable without a daemon. The one side effect is
+materialising the dispatch assets (entrypoint script + requirements list) to a
+host tempdir for bind-mounting, and ensuring the host deps cache exists - both
+process-cached and idempotent.
+
+Consumed by ``DockerRunner._build_docker_cmd`` (the experiment dispatch) and by
+``study.baseline_container`` (the baseline dispatch), which share
+:func:`append_package_dispatch` and :func:`append_nccl_env` so the two setups
+cannot drift.
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import importlib.metadata
+import importlib.resources
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+import platformdirs
+
+from llenergymeasure.config.ssot import (
+    CONTAINER_EXCHANGE_DIR,
+    ENV_BASELINE_SPEC_PATH,
+    ENV_CONFIG_PATH,
+    ENV_DEPS_CACHE_DIR,
+    ENV_ENGINE,
+    ENV_ENTRY_MODULE,
+    ENV_HOST_GID,
+    ENV_HOST_UID,
+    ENV_OUTPUT_DIR,
+    ENV_SAVE_TIMESERIES,
+    Engine,
+)
+from llenergymeasure.utils.env_config import (
+    ENV_TRT_BUILD_CACHE_PATH,
+    docker_gpus_arg,
+    docker_hf_cache_dir,
+    docker_shm_size,
+    trt_build_cache_host_dir,
+)
+from llenergymeasure.utils.exceptions import DockerPreFlightError
+
+__all__ = ["append_nccl_env", "append_package_dispatch", "build_docker_cmd"]
+
+# Reserved exchange env keys the docker command builders set deliberately
+# (via -e or --env-file). The blanket "forward every host LLEM_* var" loop
+# must skip these: docker applies -e last-wins over --env-file, so a stray
+# host LLEM_CONFIG_PATH / LLEM_OUTPUT_DIR / ... would silently clobber the
+# intended dispatch value. Built from the actual ENV_* constants so it can't
+# drift from what the builders set.
+_RESERVED_EXCHANGE_ENV: frozenset[str] = frozenset(
+    {
+        ENV_CONFIG_PATH,
+        ENV_OUTPUT_DIR,
+        ENV_SAVE_TIMESERIES,
+        ENV_ENGINE,
+        ENV_ENTRY_MODULE,
+        ENV_HOST_UID,
+        ENV_HOST_GID,
+        ENV_BASELINE_SPEC_PATH,
+    }
+)
+
+# Container-side mount target for the TRT-LLM engine build cache. The host
+# ~/.cache/trt-llm is bind-mounted here; TRT-LLM's own default cache root
+# (/tmp/.cache/tensorrt_llm/llmapi/) is NOT this path and lives on the
+# ephemeral container filesystem, so without pinning the cache to the mount
+# it would silently die with each container. We default
+# LLEM_TRT_BUILD_CACHE_PATH to this mount so the cache works out of the box;
+# a host-set value still wins (forwarded later, docker -e is last-wins).
+_TRT_BUILD_CACHE_CONTAINER_PATH: Final = "/root/.cache/trt-llm"
+
+# Container-side mount target for the HuggingFace cache. The host source is
+# configurable via LLEM_DOCKER_HF_CACHE (see docker_hf_cache_dir); the in-
+# container target and HF_HOME are fixed.
+_HF_CACHE_CONTAINER_PATH: Final = "/root/.cache/huggingface"
+
+# The in-container entrypoint script is shipped as package data (rather than
+# resolved from a repo-root scripts/ dir) so container dispatch works from an
+# installed wheel, not only a source checkout. It is read via
+# importlib.resources and materialised to a host tempdir before bind-mounting
+# (see _materialise_dispatch_assets); docker bind-mounts need a real host path.
+_ENTRY_SCRIPT_PACKAGE: Final = "llenergymeasure.infra"
+_ENTRY_SCRIPT_RESOURCE: Final = "_container/container_entrypoint.sh"
+# Distribution name whose metadata declares the runtime deps the container
+# primes. Read from importlib.metadata so it resolves identically from a
+# checkout and a site-packages install (the old path read the repo-root
+# pyproject.toml, which does not exist for a pip-installed user).
+_DISPATCH_DIST_NAME: Final = "llenergymeasure"
+# Temp-dir prefix for the materialised dispatch assets (entrypoint script +
+# requirements list). One dir per process, cleaned up at interpreter exit.
+_TEMP_PREFIX_DISPATCH: Final = "llem-dispatch-"
+
+
+@functools.cache
+def _resolve_package_dir() -> Path:
+    """Return the ``llenergymeasure`` package directory itself.
+
+    Used to bind-mount the host package source into upstream engine images
+    that don't ship llenergymeasure (vllm, tensorrt) and into our own
+    transformers image. Resolved from ``__file__`` rather than via
+    ``import llenergymeasure`` to keep the infra layer free of upper-layer
+    imports (import-linter contract).
+
+    Layout::
+
+        <site-packages-or-src>/
+            llenergymeasure/       <-- returned (the package dir)
+                infra/
+                    docker/
+                        command.py   <-- __file__
+
+    Three ``.parent`` hops walk command.py -> docker/ -> infra/ -> llenergymeasure/.
+    Encapsulation here localises path knowledge so a future relayout only needs
+    to touch this helper. Cached because ``__file__`` is fixed for the life of
+    the process.
+
+    INVARIANT - why the package dir and not its parent: the mount this feeds
+    (``/llem-src/llenergymeasure``) must expose the ``llenergymeasure`` package
+    and NOTHING else - never the package's on-disk siblings. For a pip/wheel
+    install the parent IS the venv's ``site-packages``. Mounting the parent (the
+    historical ``parent.parent.parent`` walk) put every host third-party package
+    at ``/llem-src``, and ``container_entrypoint.sh`` prepends ``/llem-src`` to
+    ``PYTHONPATH``, so ``PYTHONPATH`` entries always precede the container's own
+    site-packages on ``sys.path`` - every host copy then shadowed the image's
+    native one. Observed: a py3.12 host ``pydantic_core`` C extension shadowing
+    the image's py3.11 build (transformers), and a fresh ``huggingface-hub``
+    shadowing the pinned engine stack (tensorrt). Mounting the package dir alone
+    makes ``/llem-src`` contain only ``llenergymeasure``, so nothing can shadow a
+    container-native dependency. A source checkout is safe either way (its parent
+    is ``src/``, holding only the package); resolving the package dir makes the
+    two install shapes one uniform, always-safe path.
+    """
+    return Path(__file__).resolve().parent.parent.parent
+
+
+@functools.cache
+def _runtime_requirements() -> tuple[str, ...]:
+    """Return llenergymeasure's always-on runtime dependency specs.
+
+    Read from the installed distribution metadata (``importlib.metadata``)
+    rather than a repo-root ``pyproject.toml``, so it resolves identically from
+    a source checkout and a site-packages install. Optional-extra requirements
+    (those carrying an ``extra == ...`` environment marker) are excluded: the
+    container primes only the always-on runtime deps, exactly as the old
+    ``[project.dependencies]`` diff did. Sorted so the materialised file is
+    deterministic (the container hashes it for the deps-probe fast-path stamp).
+    Non-extra environment markers (none exist on current core deps) are
+    discarded rather than forwarded to pip; revisit if a marker-carrying core
+    dependency is ever added.
+    """
+    core: list[str] = []
+    for spec in importlib.metadata.requires(_DISPATCH_DIST_NAME) or []:
+        requirement, _, marker = spec.partition(";")
+        if "extra" in marker:
+            continue
+        requirement = requirement.strip()
+        if requirement:
+            core.append(requirement)
+    return tuple(sorted(core))
+
+
+@functools.cache
+def _materialise_dispatch_assets() -> tuple[Path, Path]:
+    """Materialise the dispatch assets to a host tempdir; return their paths.
+
+    Returns ``(entry_script, requirements_file)`` as real on-disk paths suitable
+    for a docker bind-mount. Both are sourced from the installed package (the
+    script via ``importlib.resources``, the requirements via
+    ``importlib.metadata``) so they resolve from an installed wheel, not only a
+    source checkout - the defect this fixes was resolving them relative to
+    ``__file__``, which landed outside the package for a site-packages install
+    and let docker auto-create empty bind-mount dirs that broke the entrypoint
+    exec.
+
+    Materialised once per process (cached): the content is process-invariant and
+    the mounts are read-only, so a sweep dispatching the same assets hundreds of
+    times pays the extraction cost once. The tempdir is removed at interpreter
+    exit. Raises :class:`DockerPreFlightError` (before any ``docker run``) if an
+    asset cannot be produced, rather than letting docker silently mount an empty
+    directory.
+    """
+    try:
+        script_bytes = (
+            importlib.resources.files(_ENTRY_SCRIPT_PACKAGE)
+            .joinpath(_ENTRY_SCRIPT_RESOURCE)
+            .read_bytes()
+        )
+    except (FileNotFoundError, ModuleNotFoundError, OSError) as exc:
+        raise DockerPreFlightError(
+            "Cannot read the container entrypoint script from the installed "
+            "llenergymeasure package "
+            f"({_ENTRY_SCRIPT_RESOURCE}). The package data is "
+            "incomplete: reinstall llenergymeasure (e.g. "
+            "'pip install --force-reinstall llenergymeasure'), or in a source "
+            "checkout confirm the file exists under src/llenergymeasure/infra/."
+        ) from exc
+
+    requirements = _runtime_requirements()
+    if not requirements:
+        raise DockerPreFlightError(
+            "Cannot derive llenergymeasure's runtime dependencies from the "
+            "installed distribution metadata. Reinstall llenergymeasure so its "
+            "metadata is present (e.g. 'pip install llenergymeasure')."
+        )
+
+    asset_dir = Path(tempfile.mkdtemp(prefix=_TEMP_PREFIX_DISPATCH))
+    atexit.register(shutil.rmtree, asset_dir, ignore_errors=True)
+
+    entry_script = asset_dir / "container_entrypoint.sh"
+    entry_script.write_bytes(script_bytes)
+    entry_script.chmod(0o755)
+
+    requirements_file = asset_dir / "requirements.txt"
+    requirements_file.write_text("\n".join(requirements) + "\n", encoding="utf-8")
+
+    return entry_script, requirements_file
+
+
+@functools.cache
+def _ensure_deps_cache_dir() -> Path:
+    """Resolve the host-side runtime-deps cache directory, creating it if absent.
+
+    The in-container entrypoint script primes any missing runtime deps here on
+    first dispatch and short-circuits subsequent dispatches via a
+    requirements-hash stamp. The cache is keyed by container
+    Python minor (script writes to ``$DEPS_CACHE_ROOT/py{N}.{M}/``), so a
+    single host directory serves multiple engine images even when their
+    Python minors differ.
+
+    Uses ``platformdirs`` for XDG-conformant path resolution; users can
+    override via ``ENV_DEPS_CACHE_DIR`` if they want to share the cache
+    across machines (e.g. on shared cluster storage). Cached because the
+    result is invariant within a process and the mkdir is the only
+    side-effect.
+    """
+    override = os.environ.get(ENV_DEPS_CACHE_DIR)
+    if override:
+        cache_dir = Path(override).expanduser().resolve()
+    else:
+        cache_dir = Path(platformdirs.user_cache_dir("llem")) / "deps"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def append_package_dispatch(
+    cmd: list[str],
+    *,
+    engine: str,
+    entry_module: str | None = None,
+) -> None:
+    """Append the bind-mounts + env + entrypoint that make the package importable.
+
+    Upstream engine images (vllm, tensorrt) and even our transformers image do
+    NOT have ``llenergymeasure`` installed; the framework runs from the host
+    package source bind-mounted at ``/llem-src/llenergymeasure``. This appends
+    the four mounts the in-container entrypoint script needs (package dir, the
+    runtime requirements list, the script itself, and the host deps cache), the
+    env it reads, and points ``--entrypoint`` at the script. The script prepends
+    ``/llem-src`` to ``PYTHONPATH`` and primes any missing runtime deps, then
+    exec's the module named by ``LLEM_ENTRY_MODULE``.
+
+    INVARIANT - ``/llem-src`` must expose the ``llenergymeasure`` package and
+    NOTHING else. The package dir is mounted at the nested target
+    ``/llem-src/llenergymeasure`` (not the package's PARENT at ``/llem-src``)
+    precisely so that no on-disk sibling of the package leaks in. For a
+    pip/wheel install the parent is the venv's ``site-packages``; because the
+    script prepends ``/llem-src`` to ``PYTHONPATH`` and ``PYTHONPATH`` precedes
+    the container's own site-packages on ``sys.path``, mounting the parent let
+    every host third-party package shadow the image's native copy (e.g. a host
+    ``pydantic_core`` C extension built for a different Python minor, or a fresh
+    ``huggingface-hub`` over a pinned engine stack). See ``_resolve_package_dir``.
+
+    The entrypoint script and the requirements list are shipped as package data
+    and materialised to a host tempdir (see ``_materialise_dispatch_assets``) so
+    dispatch works from an installed wheel, not only a source checkout. The
+    package dir at ``/llem-src/llenergymeasure`` resolves from ``__file__``
+    (see ``_resolve_package_dir``): one uniform path for editable and wheel
+    installs, no editable-detection, no llem dist-info in-container (the editable
+    flow has always run without it, proving container-side code never needs it).
+
+    Shared by the experiment dispatch (``DockerRunner._build_docker_cmd``) and
+    the baseline dispatch (``study.baseline_container.build_baseline_docker_cmd``)
+    so the two package-import setups cannot drift.
+
+    Args:
+        cmd: Docker command list to mutate in place (mounts/env appended before
+            the image name, which the caller adds afterwards).
+        engine: Engine value; sets ``LLEM_ENGINE`` so the script routes tensorrt
+            through ``nvidia_entrypoint.sh`` for the libnvinfer ``LD_LIBRARY_PATH``.
+        entry_module: Override for the module the script exec's. ``None`` leaves
+            the script default (``llenergymeasure.entrypoints.container``).
+
+    Raises:
+        DockerPreFlightError: A dispatch asset (entrypoint script or requirements
+            list) could not be materialised from the installed package. Raised
+            before ``docker run`` so a missing source never becomes a silent
+            docker-auto-created empty-dir mount.
+    """
+    pkg_dir = _resolve_package_dir()
+    entry_script, requirements_file = _materialise_dispatch_assets()
+    deps_cache = _ensure_deps_cache_dir()
+    cmd.extend(
+        [
+            "-v",
+            f"{pkg_dir}:/llem-src/llenergymeasure:ro",
+            "-v",
+            f"{requirements_file}:/llem-requirements.txt:ro",
+            "-v",
+            f"{entry_script}:/llem-entry.sh:ro",
+            "-v",
+            f"{deps_cache}:/llem-runtime-deps",
+            "-e",
+            "PYTHONDONTWRITEBYTECODE=1",
+            "-e",
+            f"{ENV_ENGINE}={engine}",
+            "-e",
+            f"{ENV_HOST_UID}={os.getuid()}",
+            "-e",
+            f"{ENV_HOST_GID}={os.getgid()}",
+        ]
+    )
+    if entry_module is not None:
+        cmd.extend(["-e", f"{ENV_ENTRY_MODULE}={entry_module}"])
+    cmd.extend(["--entrypoint", "/llem-entry.sh"])
+
+
+def append_nccl_env(cmd: list[str]) -> None:
+    """Forward host ``NCCL_*`` env vars into the container.
+
+    NCCL tuning/workaround settings must reach the engine process, which runs
+    inside the container rather than on the host. The canonical case is
+    ``NCCL_P2P_DISABLE=1`` on PCIe multi-GPU hosts whose topology lacks
+    functional GPU peer-to-peer (P2P): without it, every tensor-parallel run
+    hangs at the first NCCL collective.
+
+    Uses explicit ``-e KEY=VALUE`` (matching the ``LLEM_*`` forwarding idiom in
+    ``build_docker_cmd``) and iterates keys in sorted order so the built command
+    is deterministic (tests assert on argv). Shared by the experiment dispatch
+    (``DockerRunner._build_docker_cmd``) and the baseline dispatch
+    (``study.baseline_container.build_baseline_docker_cmd``) so the two
+    env-forwarding setups cannot drift.
+
+    Args:
+        cmd: Docker command list to mutate in place (env appended before the
+            image name, which the caller adds afterwards).
+    """
+    for env_key in sorted(k for k in os.environ if k.startswith("NCCL_")):
+        env_val = os.environ[env_key]
+        if env_val:
+            cmd.extend(["-e", f"{env_key}={env_val}"])
+
+
+def _mount_if_absent(
+    cmd: list[str],
+    host: str | Path,
+    container: str,
+    extra_mounts: list[tuple[str, str]],
+    *,
+    extra_env: str | None = None,
+) -> None:
+    """Append ``-v host:container`` unless the user already mounts ``container``.
+
+    Optionally appends ``-e <extra_env>`` after the mount (e.g. HF_HOME).
+    """
+    if any(cp == container for _, cp in extra_mounts):
+        return
+    cmd.extend(["-v", f"{host}:{container}"])
+    if extra_env is not None:
+        cmd.extend(["-e", extra_env])
+
+
+def build_docker_cmd(
+    *,
+    image: str,
+    config: Any,
+    config_hash: str,
+    exchange_dir: str,
+    env_path: Path | None,
+    extra_mounts: list[tuple[str, str]],
+    container_name: str | None,
+    labels: dict[str, str],
+    gpu_indices: list[int] | None,
+) -> list[str]:
+    """Build the ``docker run`` command list.
+
+    All three engines (transformers, vllm, tensorrt) follow the same
+    dispatch shape: the image carries only the engine substrate, the host
+    package source is bind-mounted at ``/llem-src/llenergymeasure``, the
+    runtime requirements list is bind-mounted as a single-file mount at
+    ``/llem-requirements.txt``, the in-container entrypoint script is
+    bind-mounted at ``/llem-entry.sh``, and a host-side deps cache is
+    bind-mounted at ``/llem-runtime-deps``. ``--entrypoint`` always points
+    at ``/llem-entry.sh``; that script
+    (a) diffs the requirements list against installed dists and
+    pip-installs any missing ones to the cache (fast-path skips this when a
+    requirements-hash stamp matches), (b) sets
+    ``PYTHONPATH`` to include the cache and ``/llem-src``, and (c) exec's
+    the framework entrypoint module - routing through
+    ``/opt/nvidia/nvidia_entrypoint.sh`` when ``LLEM_ENGINE=tensorrt``
+    (sets up LD_LIBRARY_PATH for libnvinfer).
+
+    Multi-GPU tensorrt runs are NOT wrapped in mpirun: TensorRT-LLM's LLM
+    API self-manages tensor parallelism (setting ``tensor_parallel_size``
+    makes the LLM class spawn its own worker processes via its MPI/RPC
+    orchestrator), so a single python3 process is correct.
+
+    Args:
+        image:        Docker image to run.
+        config:       ExperimentConfig for the current experiment. Used to
+                      detect TRT-LLM engine and read ``tensorrt.tensor_parallel_size``.
+        config_hash:  Hash prefix for config/result file names.
+        exchange_dir: Host path of the temporary exchange directory.
+        env_path:     Path to a temp env-file (written by ``_env_file``), or None.
+                      When set, ``--env-file <path>`` is added to the command.
+                      Secrets (e.g. HF_TOKEN) are never passed as ``-e KEY=VALUE``
+                      arguments to avoid exposure in ``/proc/<pid>/cmdline``.
+        extra_mounts: User-supplied ``(host, container)`` mount pairs.
+        container_name: Optional ``--name`` for lifecycle management.
+        labels:       Optional ``--label`` key/values for the reaper.
+        gpu_indices:  Optional host GPU indices to scope the container to.
+
+    Returns:
+        List of strings suitable for ``subprocess.run``.
+    """
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "--gpus",
+        docker_gpus_arg(gpu_indices),
+        "-v",
+        f"{exchange_dir}:{CONTAINER_EXCHANGE_DIR}",
+        "-e",
+        f"{ENV_CONFIG_PATH}={CONTAINER_EXCHANGE_DIR}/{config_hash}_config.json",
+        "--shm-size",
+        docker_shm_size(),
+    ]
+
+    # Propagate secrets via --env-file (never as -e KEY=VALUE CLI args)
+    if env_path is not None:
+        cmd.extend(["--env-file", str(env_path)])
+
+    # TRT-LLM engine cache: persist compiled engines across ephemeral
+    # containers. Also default LLEM_TRT_BUILD_CACHE_PATH to the mount target
+    # via extra_env so the cache lands on the mount out of the box (TRT-LLM's
+    # own default root is unmounted); a host-set value overrides this because
+    # the blanket LLEM_* forwarding loop below re-emits it last (docker -e is
+    # last-wins).
+    if config.engine == Engine.TENSORRT:
+        _mount_if_absent(
+            cmd,
+            str(trt_build_cache_host_dir()),
+            _TRT_BUILD_CACHE_CONTAINER_PATH,
+            extra_mounts,
+            extra_env=f"{ENV_TRT_BUILD_CACHE_PATH}={_TRT_BUILD_CACHE_CONTAINER_PATH}",
+        )
+
+    # Auto-mount the host HuggingFace cache so model weights persist across
+    # ephemeral containers; otherwise each run re-downloads the full model.
+    # The host source is configurable via LLEM_DOCKER_HF_CACHE.
+    _mount_if_absent(
+        cmd,
+        docker_hf_cache_dir(),
+        _HF_CACHE_CONTAINER_PATH,
+        extra_mounts,
+        extra_env=f"HF_HOME={_HF_CACHE_CONTAINER_PATH}",
+    )
+
+    # Auto-mount the host flashinfer JIT cache so TRT-LLM warm runs reuse
+    # already-compiled per-arch attention kernels (cold compile is minutes).
+    if config.engine == Engine.TENSORRT:
+        _mount_if_absent(
+            cmd, Path.home() / ".cache" / "flashinfer", "/root/.cache/flashinfer", extra_mounts
+        )
+
+    # Forward LLEM_* env vars into the container so framework defaults set
+    # on the host (e.g. LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP) reach the
+    # experiment process, which actually runs inside the container. Reserved
+    # exchange keys are excluded: we set those deliberately above (or via
+    # the package-dispatch helper), and docker's -e is last-wins over the
+    # --env-file, so a stray host copy would silently clobber the intended
+    # value.
+    for env_key, env_val in os.environ.items():
+        if env_key.startswith("LLEM_") and env_val and env_key not in _RESERVED_EXCHANGE_ENV:
+            cmd.extend(["-e", f"{env_key}={env_val}"])
+
+    # Forward host NCCL_* env vars so multi-GPU tuning/workaround settings
+    # (e.g. NCCL_P2P_DISABLE=1 on PCIe hosts without functional GPU P2P)
+    # reach the engine process, which runs inside the container.
+    append_nccl_env(cmd)
+
+    # Extra volume mounts (engine cache, model cache, etc.)
+    for host_path, container_path in extra_mounts:
+        cmd.extend(["-v", f"{host_path}:{container_path}"])
+
+    # All engines: bind-mount the host package source + bootstrap (so the
+    # package is importable in images that don't ship it) and point
+    # --entrypoint at the script. Shared with the baseline dispatch via
+    # append_package_dispatch so the two cannot drift. The experiment path
+    # uses the script's default entry module
+    # (``llenergymeasure.entrypoints.container``), so entry_module stays None.
+    # ``Engine`` is a (str, Enum) so ``f"{config.engine}"`` resolves to the
+    # raw value via its ``__str__`` override.
+    append_package_dispatch(cmd, engine=f"{config.engine}")
+
+    # Container name and labels for lifecycle management (cleanup, reaper).
+    # These must appear before the image name in the docker run command.
+    if container_name:
+        cmd.extend(["--name", container_name])
+    for key, value in labels.items():
+        cmd.extend(["--label", f"{key}={value}"])
+
+    cmd.append(image)
+
+    # No post-image args - the entrypoint script invokes the framework
+    # module itself; config is passed via env vars (LLEM_CONFIG_PATH etc.).
+    return cmd

--- a/src/llenergymeasure/infra/docker/command.py
+++ b/src/llenergymeasure/infra/docker/command.py
@@ -214,7 +214,10 @@ def _materialise_dispatch_assets() -> tuple[Path, Path]:
         )
 
     asset_dir = Path(tempfile.mkdtemp(prefix=_TEMP_PREFIX_DISPATCH))
-    atexit.register(shutil.rmtree, asset_dir, ignore_errors=True)
+    # Late-bind shutil.rmtree so a test patch of it active at registration time
+    # cannot be captured into the process atexit chain; the real function is
+    # resolved at shutdown, after any patch has been reverted.
+    atexit.register(lambda: shutil.rmtree(asset_dir, ignore_errors=True))
 
     entry_script = asset_dir / "container_entrypoint.sh"
     entry_script.write_bytes(script_bytes)

--- a/src/llenergymeasure/infra/docker/diagnostics.py
+++ b/src/llenergymeasure/infra/docker/diagnostics.py
@@ -1,0 +1,68 @@
+"""Container failure classification: log tail, error payload, error mapping.
+
+When a container exits non-zero, this module persists the stderr tail to a
+``container.log`` in the exchange dir (so it survives for post-mortem), then
+builds the right :class:`DockerError`: it prefers the structured error JSON the
+container entrypoint writes over docker's own stderr (which can carry misleading
+daemon messages), falling back to keyword-based translation of docker stderr.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from llenergymeasure.infra.docker_errors import (
+    DockerContainerError,
+    capture_stderr_snippet,
+    translate_docker_error,
+)
+from llenergymeasure.utils.exceptions import DockerError
+from llenergymeasure.utils.io import load_json
+
+logger = logging.getLogger(__name__)
+
+
+def classify_container_failure(
+    *,
+    returncode: int,
+    stderr_text: str,
+    image: str,
+    exchange_dir: Path,
+    config_hash: str,
+) -> DockerError:
+    """Persist the log tail and return the classified failure error.
+
+    Writes ``container.log`` in the exchange dir, then returns a
+    :class:`DockerError` with ``exchange_dir`` attached for debug discovery. The
+    exchange dir is NOT cleaned up by the caller after a failure - it is
+    preserved for post-mortem, so ``container.log`` and the error JSON survive.
+    """
+    logger.debug("Container failed (exit %d). Debug artifacts at %s", returncode, exchange_dir)
+
+    # Persist container stderr to a log file in the exchange dir so it survives
+    # for post-mortem debugging.
+    container_log_path = exchange_dir / "container.log"
+    try:
+        container_log_path.write_text(stderr_text or "(no stderr captured)", encoding="utf-8")
+        logger.debug("Container log written to %s", container_log_path)
+    except Exception as write_exc:
+        logger.warning("Failed to write container.log: %s", write_exc)
+
+    # Prefer structured error JSON written by the container entrypoint over
+    # Docker's stderr, which can contain misleading daemon messages.
+    error_json_path = exchange_dir / f"{config_hash}_error.json"
+    error: DockerError
+    if error_json_path.exists():
+        payload = load_json(error_json_path)
+        error = DockerContainerError(
+            message=f"{payload.get('type', 'UnknownError')}: {payload.get('message', '')}",
+            fix_suggestion="Check the error traceback in the error JSON for details.",
+            stderr_snippet=capture_stderr_snippet(stderr_text) if stderr_text else None,
+        )
+        error.error_payload = payload
+    else:
+        error = translate_docker_error(returncode, stderr_text, image)
+
+    error.exchange_dir = str(exchange_dir)
+    return error

--- a/src/llenergymeasure/infra/docker/exchange.py
+++ b/src/llenergymeasure/infra/docker/exchange.py
@@ -1,0 +1,113 @@
+"""Exchange-directory lifecycle: create, read the result, rescue, clean up.
+
+The exchange dir is a host tempdir bind-mounted into the container at
+``/run/llem``. The harness writes its result JSON and artefact sidecars there;
+this module owns creating it, reading the result back (via the shared domain
+payload parser), rescuing the artefacts before teardown, and removing it.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from llenergymeasure._version import __version__
+from llenergymeasure.config.ssot import TEMP_PREFIX_EXCHANGE, TEMP_PREFIX_TIMESERIES
+from llenergymeasure.domain.bundle_artefacts import (
+    CONFIG_SIDECAR_FILENAME,
+    ENVIRONMENT_FILENAME,
+    TIMESERIES_FILENAME,
+)
+from llenergymeasure.infra.docker_errors import DockerContainerError
+from llenergymeasure.utils.io import load_json
+
+logger = logging.getLogger(__name__)
+
+
+def create_exchange_dir() -> Path:
+    """Create and return a fresh exchange directory (host tempdir)."""
+    return Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_EXCHANGE))
+
+
+def read_result(exchange_dir: Path, config_hash: str) -> Any:
+    """Read and parse the result JSON written by the container.
+
+    Args:
+        exchange_dir: Host path of the temporary exchange directory.
+        config_hash:  Hash prefix for the result file name.
+
+    Returns:
+        ExperimentResult if the file contains a valid result, or a dict
+        error payload if the container wrote an error JSON.
+
+    Raises:
+        DockerContainerError: If the result file does not exist.
+    """
+    # Lazy import to avoid pulling the heavy domain result models at module
+    # load time (the parser imports ExperimentResult transitively).
+    from llenergymeasure.domain.result_payload import parse_experiment_result_payload
+
+    result_path = exchange_dir / f"{config_hash}_result.json"
+    if not result_path.exists():
+        raise DockerContainerError(
+            message=f"Container exited 0 but no result file found at {result_path}",
+            fix_suggestion="Check container logs for errors during experiment execution.",
+        )
+
+    raw = load_json(result_path)
+
+    # Container may write an error payload even on exit 0 (defensive check).
+    # Error payloads have "type" and "traceback" keys (mirror StudyRunner worker
+    # format). This detection stays here: it is exchange-specific IPC, not a
+    # property of a persisted result.
+    if isinstance(raw, dict) and "type" in raw and "traceback" in raw:
+        return raw
+
+    # Cross-version IPC: strip fields unknown to the host schema (container may
+    # run an older/newer version) and warn on a host/container version skew.
+    # Both behaviours live in the shared parser now, keyed by tolerant=True and
+    # the host version as expected_version.
+    return parse_experiment_result_payload(raw, tolerant=True, expected_version=__version__)
+
+
+def rescue_artefacts(exchange_dir: Path) -> Path | None:
+    """Move the harness artefacts out of the exchange dir before cleanup.
+
+    The harness inside the container wrote its artefacts to /run/llem
+    (= exchange_dir on host): config.json always (the sole home of provenance
+    and the authoritative home of identity), environment.json (the accurate
+    in-container environment snapshot - the host's own snapshot describes the
+    dispatching host, not this container), and timeseries.parquet when enabled.
+    Move any that are present to a fresh temp dir so the caller can copy them
+    into the study directory before the exchange dir is destroyed. config.json
+    must survive too - otherwise a successful docker run lands a result.json
+    with no provenance.
+
+    Returns the rescue temp dir, or ``None`` if no artefacts were present.
+    """
+    artefact_tmpdir: Path | None = None
+    for name in (CONFIG_SIDECAR_FILENAME, ENVIRONMENT_FILENAME, TIMESERIES_FILENAME):
+        src = exchange_dir / name
+        if src.exists():
+            if artefact_tmpdir is None:
+                artefact_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
+            shutil.move(str(src), str(artefact_tmpdir / name))
+    return artefact_tmpdir
+
+
+def cleanup_exchange_dir(exchange_dir: Path) -> None:
+    """Remove the temporary exchange directory.
+
+    Logs a warning on failure but never raises - cleanup must not mask
+    real errors from the caller.
+
+    Args:
+        exchange_dir: Path to remove.
+    """
+    try:
+        shutil.rmtree(exchange_dir)
+    except Exception as exc:
+        logger.warning("Could not remove exchange dir %s: %s", exchange_dir, exc)

--- a/src/llenergymeasure/infra/docker/exchange.py
+++ b/src/llenergymeasure/infra/docker/exchange.py
@@ -32,6 +32,19 @@ def create_exchange_dir() -> Path:
     return Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_EXCHANGE))
 
 
+def write_config(exchange_dir: Path, config: Any, config_hash: str) -> Path:
+    """Serialise the experiment config into the exchange dir; return its path.
+
+    The container reads this at ``/run/llem/{config_hash}_config.json``. Output
+    dir and save_timeseries travel via env vars (not the config), so the written
+    JSON is the clean declared config - the same bytes ``config_hash`` was
+    computed from.
+    """
+    config_path = exchange_dir / f"{config_hash}_config.json"
+    config_path.write_text(config.model_dump_json(), encoding="utf-8")
+    return config_path
+
+
 def read_result(exchange_dir: Path, config_hash: str) -> Any:
     """Read and parse the result JSON written by the container.
 

--- a/src/llenergymeasure/infra/docker/lifecycle.py
+++ b/src/llenergymeasure/infra/docker/lifecycle.py
@@ -1,0 +1,457 @@
+"""Container process lifecycle: image ensure, launch, wait, and the watchdog.
+
+This module owns everything that runs a docker subprocess. The block-until-exit
+mode is expressed as two separable steps so a future server measurement mode
+(v0.8.0) can reuse the launch without inheriting the watchdog:
+
+- :func:`launch` starts the container process (``subprocess.Popen``) and returns
+  it. It is detach-capable: a server lifecycle would call this, then add its own
+  health-poll and explicit stop.
+- :func:`wait_to_completion` streams stdout, forwards progress events, and owns
+  the stdout-silence + wall-clock WATCHDOG. The watchdog lives ONLY here, in the
+  wait path - an idle-between-requests server that reused it would look "stuck",
+  so a server lifecycle must not call this.
+
+:func:`run_blocking` is the classic no-progress path (``subprocess.run`` blocking
+until exit); :func:`ensure_image` is the image-availability pull guard. Neither
+builds server dispatch - only the launch/wait seam is left clean.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.config.ssot import (
+    DOCKER_PULL_TIMEOUT,
+    TIMEOUT_DOCKER_INSPECT,
+    TIMEOUT_THREAD_JOIN,
+)
+from llenergymeasure.domain.progress import resolve_container_step
+from llenergymeasure.infra.docker_errors import (
+    DockerContainerError,
+    DockerStdoutSilenceError,
+    DockerTimeoutError,
+)
+
+if TYPE_CHECKING:
+    from llenergymeasure.domain.progress import ProgressCallback
+
+logger = logging.getLogger(__name__)
+
+# Watchdog poll cadence: small enough to surface timeouts promptly, large
+# enough to keep idle CPU near zero. 0.5s gives users at most a half-second
+# tail beyond their configured ceiling and matches the progress-display
+# heartbeat sampling cadence.
+_WATCHDOG_POLL_INTERVAL = 0.5
+
+# Sentinel for "budget disabled" in the deadline comparison.
+_NO_DEADLINE = float("inf")
+
+# Keywords in container stderr that indicate meaningful activity. When no JSON
+# progress events arrive (old images), surface these as on_step_update to show
+# the container is alive and working.
+_ACTIVITY_KEYWORDS = (
+    "loading",
+    "downloading",
+    "measuring",
+    "warmup",
+    "warming",
+    "inference",
+    "saving",
+    "running",
+    "model",
+    "tokenizer",
+)
+
+
+def ensure_image(image: str, progress: ProgressCallback | None = None) -> None:
+    """Check if the Docker image exists locally; pull with visible output if not.
+
+    Always emits an ``image_check`` step so the user sees the cache lookup.
+    If the image is not cached, emits a separate ``pull`` step.
+    Substeps report image metadata (ID, size, age) for provenance visibility.
+    """
+    from llenergymeasure.utils.formatting import short_name
+
+    short_image = short_name(image)
+
+    if progress:
+        progress.on_step_start("image_check", "Inspecting", short_image)
+    t0 = time.perf_counter()
+
+    check = subprocess.run(
+        ["docker", "image", "inspect", image],
+        capture_output=True,
+        timeout=TIMEOUT_DOCKER_INSPECT,
+    )
+    if check.returncode == 0:
+        if progress:
+            progress.on_step_update("image_check", f"{short_image} (cached)")
+            progress.on_step_done("image_check", time.perf_counter() - t0)
+            progress.on_step_skip("pull", "cached")
+        return
+
+    if progress:
+        progress.on_step_done("image_check", time.perf_counter() - t0)
+
+    # Image not cached - pull it
+    if progress:
+        progress.on_step_start("pull", "Pulling", image)
+    t0_pull = time.perf_counter()
+
+    print(f"Pulling image: {image}", file=sys.stderr)
+    try:
+        pull = subprocess.run(
+            ["docker", "pull", image],
+            stdout=sys.stderr,
+            stderr=sys.stderr,
+            timeout=DOCKER_PULL_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        if progress:
+            progress.on_step_done("pull", time.perf_counter() - t0_pull)
+        from llenergymeasure.infra.docker_errors import DockerImagePullError
+
+        raise DockerImagePullError(
+            message=f"Image pull timed out after {DOCKER_PULL_TIMEOUT}s: {image}",
+            fix_suggestion=f"Pull manually: docker pull {image}",
+        ) from exc
+    if pull.returncode != 0:
+        if progress:
+            progress.on_step_done("pull", time.perf_counter() - t0_pull)
+        from llenergymeasure.infra.docker_errors import DockerImagePullError
+
+        raise DockerImagePullError(
+            message=f"Image not found or could not be pulled: {image}",
+            fix_suggestion=f"docker pull {image}",
+        )
+
+    if progress:
+        progress.on_step_done("pull", time.perf_counter() - t0_pull)
+
+
+def run_blocking(cmd: list[str], timeout: float | None) -> tuple[int, str]:
+    """Run the container blocking until exit (classic, no-progress path).
+
+    Backward-compatible ``subprocess.run`` capture. Returns
+    ``(returncode, stderr_text)``. Raises :class:`DockerTimeoutError` when the
+    wall-clock ``timeout`` is exceeded.
+    """
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DockerTimeoutError(
+            message=f"Container timed out after {timeout}s.",
+            fix_suggestion="Increase timeout or reduce experiment size.",
+        ) from exc
+    return proc.returncode, proc.stderr
+
+
+def launch(cmd: list[str]) -> subprocess.Popen[str]:
+    """Start the container process and return the ``Popen`` handle.
+
+    Detach-capable seam: this only starts the process (stdout/stderr piped). A
+    server measurement mode reuses this and adds its own health-poll + stop; it
+    does NOT call :func:`wait_to_completion` (which owns the watchdog).
+    """
+    try:
+        return subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        raise DockerContainerError(
+            message=f"Failed to start docker process: {exc}",
+            fix_suggestion="Is Docker installed and running?",
+        ) from exc
+
+
+def wait_to_completion(
+    proc: subprocess.Popen[str],
+    *,
+    timeout: float | None,
+    silence_timeout: float | None,
+    progress: ProgressCallback | None = None,
+    mask_secrets_fn: Callable[[str], str] | None = None,
+    container_start_time: float | None = None,
+) -> tuple[int, str]:
+    """Block until ``proc`` exits, streaming stdout and running the watchdog.
+
+    Container inner events (step_start, step_update, step_done) are forwarded as
+    top-level progress steps so the CLI can display each measurement phase
+    individually (Docker BuildKit-style granularity).
+
+    The stdout-silence + wall-clock WATCHDOG is contained here, in the wait path
+    only: it kills the container and raises the matching error if either budget
+    is exhausted. The ``container_start`` step (started by the caller) is ended
+    when the first inner event arrives, capturing the container boot time.
+
+    Returns ``(returncode, stderr_text)``.
+    """
+    stderr_lines: list[str] = []
+
+    # Thread-safe flag shared with stderr thread to track if JSON events arrived
+    container_start_done_event = threading.Event()
+
+    def _read_stderr(pipe: Any) -> None:
+        """Read stderr in a background thread to prevent blocking.
+
+        For old images that don't emit JSON progress events, surfaces
+        interesting log lines as step updates on container_start.
+        """
+        for line in pipe:
+            stderr_lines.append(line)
+            stripped = line.strip()
+            logger.debug("container stderr: %s", stripped)
+            # Surface activity from old images as step updates
+            if (
+                progress is not None
+                and not container_start_done_event.is_set()
+                and stripped
+                and any(kw in stripped.lower() for kw in _ACTIVITY_KEYWORDS)
+            ):
+                # Truncate long log lines and strip log prefix (e.g. "INFO:root:")
+                display_text = stripped
+                if ":" in display_text and display_text.split(":")[0].isupper():
+                    display_text = display_text.split(":", 2)[-1].strip()
+                progress.on_step_update("container_start", display_text[:50])
+        pipe.close()
+
+    # Read stderr in background thread to avoid deadlock
+    stderr_thread = threading.Thread(target=_read_stderr, args=(proc.stderr,), daemon=True)
+    stderr_thread.start()
+
+    # Pump stdout into a queue from a daemon thread so the main loop
+    # can wake up periodically to check both timeout budgets even
+    # when the container is producing nothing. The blocking
+    # ``for line in proc.stdout`` shape this replaces would hang
+    # indefinitely on a stuck CUDA / NCCL / compile step - the
+    # wall-clock proc.wait() never gets a chance to fire because we
+    # never exit the for-loop. See issue #366.
+    stdout_q: queue.Queue[str | None] = queue.Queue()
+
+    def _pump_stdout(pipe: Any) -> None:
+        try:
+            for line in pipe:
+                stdout_q.put(line)
+        finally:
+            stdout_q.put(None)  # sentinel: pipe closed (EOF or process exit)
+
+    assert proc.stdout is not None
+    stdout_thread = threading.Thread(target=_pump_stdout, args=(proc.stdout,), daemon=True)
+    stdout_thread.start()
+
+    container_start_done = False
+    watchdog_start = time.monotonic()
+    last_activity = watchdog_start
+
+    try:
+        while True:
+            wall_remaining, silence_remaining = _check_watchdog_deadlines(
+                proc, timeout, silence_timeout, watchdog_start, last_activity
+            )
+
+            # Cap the queue wait at the poll interval so a Ctrl-C
+            # interrupt is observed within ~0.5s even with both
+            # budgets large.
+            wait_for = min(wall_remaining, silence_remaining, _WATCHDOG_POLL_INTERVAL)
+            try:
+                line = stdout_q.get(timeout=wait_for)
+            except queue.Empty:
+                continue
+            if line is None:
+                break  # stdout pipe closed
+            last_activity = time.monotonic()
+
+            container_start_done = _handle_stdout_line(
+                line,
+                progress,
+                container_start_done,
+                container_start_time,
+                container_start_done_event,
+                mask_secrets_fn,
+            )
+    finally:
+        with suppress(Exception):
+            proc.stdout.close()
+        stdout_thread.join(timeout=TIMEOUT_THREAD_JOIN)
+
+    # If no inner events arrived, end container_start now (old images)
+    if not container_start_done and container_start_time is not None and progress is not None:
+        progress.on_step_done("container_start", time.perf_counter() - container_start_time)
+
+    # Wait for process exit. The watchdog above ensures we only get
+    # here when stdout has closed; proc.wait() blocks only until the
+    # process actually reaps, which is bounded.
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        proc.kill()
+        proc.wait()
+        raise DockerTimeoutError(
+            message=f"Container timed out after {timeout}s.",
+            fix_suggestion="Increase timeout or reduce experiment size.",
+        ) from exc
+
+    stderr_thread.join(timeout=TIMEOUT_THREAD_JOIN)
+    stderr_text = "".join(stderr_lines)
+
+    return proc.returncode, stderr_text
+
+
+def _check_watchdog_deadlines(
+    proc: subprocess.Popen[str],
+    timeout: float | None,
+    silence_timeout: float | None,
+    watchdog_start: float,
+    last_activity: float,
+) -> tuple[float, float]:
+    """Compute the remaining wall-clock and stdout-silence budgets.
+
+    Kills the container and raises the matching watchdog error if either budget
+    is exhausted. Returns ``(wall_remaining, silence_remaining)`` so the caller
+    can cap its queue wait.
+    """
+    now = time.monotonic()
+    wall_remaining = timeout - (now - watchdog_start) if timeout is not None else _NO_DEADLINE
+    silence_remaining = (
+        silence_timeout - (now - last_activity) if silence_timeout is not None else _NO_DEADLINE
+    )
+
+    if wall_remaining <= 0:
+        _kill_container_for_watchdog(proc)
+        raise DockerTimeoutError(
+            message=f"Container timed out after {timeout}s (wall-clock).",
+            fix_suggestion=(
+                "Increase study_execution.experiment_timeout_seconds or reduce experiment size."
+            ),
+        )
+    if silence_remaining <= 0:
+        _kill_container_for_watchdog(proc)
+        raise DockerStdoutSilenceError(
+            message=(
+                f"Container produced no stdout for {silence_timeout}s (likely stuck process)."
+            ),
+            fix_suggestion=(
+                "Increase study_execution.stdout_silence_timeout_seconds "
+                "if your workload legitimately goes silent for longer "
+                "(e.g. fresh TRT-LLM engine builds), or investigate the "
+                "stuck step. Check container logs in the exchange dir."
+            ),
+        )
+    return wall_remaining, silence_remaining
+
+
+def _handle_stdout_line(
+    line: str,
+    progress: ProgressCallback | None,
+    container_start_done: bool,
+    container_start_time: float | None,
+    container_start_done_event: threading.Event,
+    mask_secrets_fn: Callable[[str], str] | None,
+) -> bool:
+    """Process one container stdout line.
+
+    JSON progress events are forwarded to ``progress``; plain output is logged
+    (secrets masked). Returns the updated ``container_start_done`` flag - set True
+    on the first inner event so the ``container_start`` step is ended exactly once.
+    """
+    stripped = line.strip()
+    if stripped.startswith('{"event":') and progress is not None:
+        try:
+            event = json.loads(stripped)
+            event_type = event.get("event")
+            step = event.get("step", "")
+
+            # End "container_start" on first inner event
+            if not container_start_done and container_start_time is not None:
+                container_start_done = True
+                container_start_done_event.set()
+                progress.on_step_done(
+                    "container_start",
+                    time.perf_counter() - container_start_time,
+                )
+
+            # Resolve container-boundary step id (e.g. the container's
+            # "preflight" renders as "container_preflight" host-side). The
+            # mapping lives in the progress registry.
+            step = resolve_container_step(step)
+
+            _dispatch_progress_event(progress, event_type, step, event)
+        except (json.JSONDecodeError, KeyError):
+            logger.debug("Unparseable progress line: %s", stripped)
+    else:
+        if stripped:
+            masked = mask_secrets_fn(stripped) if mask_secrets_fn else stripped
+            logger.debug("container stdout: %s", masked)
+    return container_start_done
+
+
+def _dispatch_progress_event(
+    progress: ProgressCallback, event_type: str, step: str, event: dict[str, Any]
+) -> None:
+    """Forward a single decoded container progress event to the host callback."""
+    if event_type == "step_start":
+        progress.on_step_start(
+            step,
+            event.get("description", ""),
+            event.get("detail", ""),
+        )
+    elif event_type == "step_update":
+        progress.on_step_update(step, event.get("detail", ""))
+    elif event_type == "step_done":
+        progress.on_step_done(step, event.get("elapsed_sec", 0.0))
+    elif event_type == "step_skip":
+        progress.on_step_skip(step, event.get("reason", ""))
+    elif event_type == "substep":
+        progress.on_substep(
+            step,
+            event.get("text", ""),
+            event.get("elapsed_sec", 0.0),
+        )
+    elif event_type == "substep_start":
+        progress.on_substep_start(step, event.get("text", ""))
+    elif event_type == "substep_done":
+        progress.on_substep_done(
+            step,
+            event.get("text"),
+            event.get("elapsed_sec"),
+        )
+
+
+def _kill_container_for_watchdog(proc: subprocess.Popen[str]) -> None:
+    """Terminate then SIGKILL a hung container; swallow any wait failures.
+
+    Used by the unified watchdog when a timeout fires. Mirrors the
+    existing wall-clock kill path: best-effort terminate, then kill,
+    then a final wait so the process group is fully reaped. Any
+    exception from the cleanup path is logged at debug level - the
+    watchdog's responsibility is to *raise the right error*, not to
+    handle a cooperatively-shutting-down container.
+    """
+    for stage, action in (
+        ("terminate", proc.terminate),
+        ("wait-after-terminate", lambda: proc.wait(timeout=2.0)),
+        ("kill", proc.kill),
+        ("wait-after-kill", lambda: proc.wait(timeout=2.0)),
+    ):
+        try:
+            action()
+        except Exception as exc:
+            logger.debug("Watchdog cleanup %s failed: %s", stage, exc)

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -42,10 +42,9 @@ from llenergymeasure.config.ssot import (
     TEMP_PREFIX_ENV_FILE,
 )
 from llenergymeasure.infra.docker import command, diagnostics, exchange, lifecycle
-from llenergymeasure.infra.docker.command import append_nccl_env, append_package_dispatch
 from llenergymeasure.utils.exceptions import DockerError
 
-__all__ = ["DockerRunner", "append_nccl_env", "append_package_dispatch"]
+__all__ = ["DockerRunner"]
 
 logger = logging.getLogger(__name__)
 
@@ -220,12 +219,9 @@ class DockerRunner:
             # --- Write config JSON ---
             # Compute config_hash from the clean config (no output path mutation).
             # Output dir and save_timeseries are passed via env vars, not config.
+            # The exchange dir owns the write (it owns that dir's lifecycle).
             config_hash = compute_declared_config_hash(config)
-            config_path = exchange_dir / f"{config_hash}_config.json"
-            config_path.write_text(
-                config.model_dump_json(),
-                encoding="utf-8",
-            )
+            exchange.write_config(exchange_dir, config, config_hash)
 
             # Pass output params via env vars so the container entrypoint can
             # forward them to the harness as runtime params.

--- a/src/llenergymeasure/infra/docker_runner.py
+++ b/src/llenergymeasure/infra/docker_runner.py
@@ -5,139 +5,49 @@ The DockerRunner manages the full container lifecycle:
 1. Create a temporary exchange directory (``tempfile.mkdtemp(prefix='llem-')``)
 2. Serialise ExperimentConfig to JSON in the exchange dir
 3. Start ``docker run --rm --gpus all`` with the exchange dir mounted as /run/llem
-4. Block until the container exits (subprocess.run)
+4. Block until the container exits
 5. Read the result JSON written by the container entrypoint
 6. Clean up the exchange dir on success; preserve it on failure for debugging
 
-This module is consumed by StudyRunner as the dispatch mechanism when
-``runner=docker`` is resolved by runner_resolution.resolve_runner().
+This module is the facade: the concerns are decomposed into the
+``llenergymeasure.infra.docker`` package (``command`` builds the argv,
+``lifecycle`` runs the container process and owns the watchdog, ``exchange``
+owns the exchange-dir lifecycle + result read + rescue, ``diagnostics``
+classifies failures). ``DockerRunner`` composes them; its constructor and public
+method signatures are unchanged.
+
+It is consumed by StudyRunner as the dispatch mechanism when ``runner=docker``
+is resolved by runner_resolution.resolve_runner().
 """
 
 from __future__ import annotations
 
-import atexit
-import functools
-import importlib.metadata
-import importlib.resources
-import json
 import logging
 import os
-import queue
-import shutil
-import subprocess
-import sys
 import tempfile
-import threading
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final
-
-import platformdirs
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from llenergymeasure.domain.progress import ProgressCallback
 
-from llenergymeasure._version import __version__
 from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
-    DOCKER_PULL_TIMEOUT,
-    ENV_BASELINE_SPEC_PATH,
-    ENV_CONFIG_PATH,
-    ENV_DEPS_CACHE_DIR,
-    ENV_ENGINE,
-    ENV_ENTRY_MODULE,
     ENV_HF_TOKEN,
-    ENV_HOST_GID,
-    ENV_HOST_UID,
     ENV_OUTPUT_DIR,
     ENV_SAVE_TIMESERIES,
     TEMP_PREFIX_ENV_FILE,
-    TEMP_PREFIX_EXCHANGE,
-    TEMP_PREFIX_TIMESERIES,
-    TIMEOUT_DOCKER_INSPECT,
-    TIMEOUT_THREAD_JOIN,
-    Engine,
 )
-from llenergymeasure.domain.bundle_artefacts import (
-    CONFIG_SIDECAR_FILENAME,
-    ENVIRONMENT_FILENAME,
-    TIMESERIES_FILENAME,
-)
-from llenergymeasure.domain.progress import resolve_container_step
-from llenergymeasure.infra.docker_errors import (
-    DockerContainerError,
-    DockerStdoutSilenceError,
-    DockerTimeoutError,
-    capture_stderr_snippet,
-    translate_docker_error,
-)
-from llenergymeasure.utils.env_config import (
-    ENV_TRT_BUILD_CACHE_PATH,
-    docker_gpus_arg,
-    docker_shm_size,
-    trt_build_cache_host_dir,
-)
-from llenergymeasure.utils.exceptions import DockerError, DockerPreFlightError
-from llenergymeasure.utils.io import load_json
+from llenergymeasure.infra.docker import command, diagnostics, exchange, lifecycle
+from llenergymeasure.infra.docker.command import append_nccl_env, append_package_dispatch
+from llenergymeasure.utils.exceptions import DockerError
 
 __all__ = ["DockerRunner", "append_nccl_env", "append_package_dispatch"]
 
 logger = logging.getLogger(__name__)
-
-# Reserved exchange env keys the docker command builders set deliberately
-# (via -e or --env-file). The blanket "forward every host LLEM_* var" loop
-# must skip these: docker applies -e last-wins over --env-file, so a stray
-# host LLEM_CONFIG_PATH / LLEM_OUTPUT_DIR / ... would silently clobber the
-# intended dispatch value. Built from the actual ENV_* constants so it can't
-# drift from what the builders set.
-_RESERVED_EXCHANGE_ENV: frozenset[str] = frozenset(
-    {
-        ENV_CONFIG_PATH,
-        ENV_OUTPUT_DIR,
-        ENV_SAVE_TIMESERIES,
-        ENV_ENGINE,
-        ENV_ENTRY_MODULE,
-        ENV_HOST_UID,
-        ENV_HOST_GID,
-        ENV_BASELINE_SPEC_PATH,
-    }
-)
-
-# Container-side mount target for the TRT-LLM engine build cache. The host
-# ~/.cache/trt-llm is bind-mounted here; TRT-LLM's own default cache root
-# (/tmp/.cache/tensorrt_llm/llmapi/) is NOT this path and lives on the
-# ephemeral container filesystem, so without pinning the cache to the mount
-# it would silently die with each container. We default
-# LLEM_TRT_BUILD_CACHE_PATH to this mount so the cache works out of the box;
-# a host-set value still wins (forwarded later, docker -e is last-wins).
-_TRT_BUILD_CACHE_CONTAINER_PATH: Final = "/root/.cache/trt-llm"
-
-# Watchdog poll cadence: small enough to surface timeouts promptly, large
-# enough to keep idle CPU near zero. 0.5s gives users at most a half-second
-# tail beyond their configured ceiling and matches the progress-display
-# heartbeat sampling cadence.
-_WATCHDOG_POLL_INTERVAL = 0.5
-
-# Sentinel for "budget disabled" in the deadline comparison.
-_NO_DEADLINE = float("inf")
-
-# The in-container entrypoint script is shipped as package data (rather than
-# resolved from a repo-root scripts/ dir) so container dispatch works from an
-# installed wheel, not only a source checkout. It is read via
-# importlib.resources and materialised to a host tempdir before bind-mounting
-# (see _materialise_dispatch_assets); docker bind-mounts need a real host path.
-_ENTRY_SCRIPT_PACKAGE: Final = "llenergymeasure.infra"
-_ENTRY_SCRIPT_RESOURCE: Final = "_container/container_entrypoint.sh"
-# Distribution name whose metadata declares the runtime deps the container
-# primes. Read from importlib.metadata so it resolves identically from a
-# checkout and a site-packages install (the old path read the repo-root
-# pyproject.toml, which does not exist for a pip-installed user).
-_DISPATCH_DIST_NAME: Final = "llenergymeasure"
-# Temp-dir prefix for the materialised dispatch assets (entrypoint script +
-# requirements list). One dir per process, cleaned up at interpreter exit.
-_TEMP_PREFIX_DISPATCH: Final = "llem-dispatch-"
 
 
 @contextmanager
@@ -176,264 +86,6 @@ def _mask_secrets(text: str, secrets: dict[str, str]) -> str:
         if v and len(v) > 4:
             text = text.replace(v, "***")
     return text
-
-
-@functools.cache
-def _resolve_package_dir() -> Path:
-    """Return the ``llenergymeasure`` package directory itself.
-
-    Used to bind-mount the host package source into upstream engine images
-    that don't ship llenergymeasure (vllm, tensorrt) and into our own
-    transformers image. Resolved from ``__file__`` rather than via
-    ``import llenergymeasure`` to keep the infra layer free of upper-layer
-    imports (import-linter contract).
-
-    Layout::
-
-        <site-packages-or-src>/
-            llenergymeasure/       <-- returned (the package dir)
-                infra/
-                    docker_runner.py   <-- __file__
-
-    Two ``.parent`` hops walk docker_runner.py -> infra/ -> llenergymeasure/.
-    Encapsulation here localises path knowledge so a future relayout only needs
-    to touch this helper. Cached because ``__file__`` is fixed for the life of
-    the process.
-
-    INVARIANT - why the package dir and not its parent: the mount this feeds
-    (``/llem-src/llenergymeasure``) must expose the ``llenergymeasure`` package
-    and NOTHING else - never the package's on-disk siblings. For a pip/wheel
-    install the parent IS the venv's ``site-packages``. Mounting the parent (the
-    historical ``parent.parent.parent`` walk) put every host third-party package
-    at ``/llem-src``, and ``container_entrypoint.sh`` prepends ``/llem-src`` to
-    ``PYTHONPATH``, so ``PYTHONPATH`` entries always precede the container's own
-    site-packages on ``sys.path`` - every host copy then shadowed the image's
-    native one. Observed: a py3.12 host ``pydantic_core`` C extension shadowing
-    the image's py3.11 build (transformers), and a fresh ``huggingface-hub``
-    shadowing the pinned engine stack (tensorrt). Mounting the package dir alone
-    makes ``/llem-src`` contain only ``llenergymeasure``, so nothing can shadow a
-    container-native dependency. A source checkout is safe either way (its parent
-    is ``src/``, holding only the package); resolving the package dir makes the
-    two install shapes one uniform, always-safe path.
-    """
-    return Path(__file__).resolve().parent.parent
-
-
-@functools.cache
-def _runtime_requirements() -> tuple[str, ...]:
-    """Return llenergymeasure's always-on runtime dependency specs.
-
-    Read from the installed distribution metadata (``importlib.metadata``)
-    rather than a repo-root ``pyproject.toml``, so it resolves identically from
-    a source checkout and a site-packages install. Optional-extra requirements
-    (those carrying an ``extra == ...`` environment marker) are excluded: the
-    container primes only the always-on runtime deps, exactly as the old
-    ``[project.dependencies]`` diff did. Sorted so the materialised file is
-    deterministic (the container hashes it for the deps-probe fast-path stamp).
-    Non-extra environment markers (none exist on current core deps) are
-    discarded rather than forwarded to pip; revisit if a marker-carrying core
-    dependency is ever added.
-    """
-    core: list[str] = []
-    for spec in importlib.metadata.requires(_DISPATCH_DIST_NAME) or []:
-        requirement, _, marker = spec.partition(";")
-        if "extra" in marker:
-            continue
-        requirement = requirement.strip()
-        if requirement:
-            core.append(requirement)
-    return tuple(sorted(core))
-
-
-@functools.cache
-def _materialise_dispatch_assets() -> tuple[Path, Path]:
-    """Materialise the dispatch assets to a host tempdir; return their paths.
-
-    Returns ``(entry_script, requirements_file)`` as real on-disk paths suitable
-    for a docker bind-mount. Both are sourced from the installed package (the
-    script via ``importlib.resources``, the requirements via
-    ``importlib.metadata``) so they resolve from an installed wheel, not only a
-    source checkout - the defect this fixes was resolving them relative to
-    ``__file__``, which landed outside the package for a site-packages install
-    and let docker auto-create empty bind-mount dirs that broke the entrypoint
-    exec.
-
-    Materialised once per process (cached): the content is process-invariant and
-    the mounts are read-only, so a sweep dispatching the same assets hundreds of
-    times pays the extraction cost once. The tempdir is removed at interpreter
-    exit. Raises :class:`DockerPreFlightError` (before any ``docker run``) if an
-    asset cannot be produced, rather than letting docker silently mount an empty
-    directory.
-    """
-    try:
-        script_bytes = (
-            importlib.resources.files(_ENTRY_SCRIPT_PACKAGE)
-            .joinpath(_ENTRY_SCRIPT_RESOURCE)
-            .read_bytes()
-        )
-    except (FileNotFoundError, ModuleNotFoundError, OSError) as exc:
-        raise DockerPreFlightError(
-            "Cannot read the container entrypoint script from the installed "
-            "llenergymeasure package "
-            f"({_ENTRY_SCRIPT_RESOURCE}). The package data is "
-            "incomplete: reinstall llenergymeasure (e.g. "
-            "'pip install --force-reinstall llenergymeasure'), or in a source "
-            "checkout confirm the file exists under src/llenergymeasure/infra/."
-        ) from exc
-
-    requirements = _runtime_requirements()
-    if not requirements:
-        raise DockerPreFlightError(
-            "Cannot derive llenergymeasure's runtime dependencies from the "
-            "installed distribution metadata. Reinstall llenergymeasure so its "
-            "metadata is present (e.g. 'pip install llenergymeasure')."
-        )
-
-    asset_dir = Path(tempfile.mkdtemp(prefix=_TEMP_PREFIX_DISPATCH))
-    atexit.register(shutil.rmtree, asset_dir, ignore_errors=True)
-
-    entry_script = asset_dir / "container_entrypoint.sh"
-    entry_script.write_bytes(script_bytes)
-    entry_script.chmod(0o755)
-
-    requirements_file = asset_dir / "requirements.txt"
-    requirements_file.write_text("\n".join(requirements) + "\n", encoding="utf-8")
-
-    return entry_script, requirements_file
-
-
-@functools.cache
-def _ensure_deps_cache_dir() -> Path:
-    """Resolve the host-side runtime-deps cache directory, creating it if absent.
-
-    The in-container entrypoint script primes any missing runtime deps here on
-    first dispatch and short-circuits subsequent dispatches via a
-    requirements-hash stamp. The cache is keyed by container
-    Python minor (script writes to ``$DEPS_CACHE_ROOT/py{N}.{M}/``), so a
-    single host directory serves multiple engine images even when their
-    Python minors differ.
-
-    Uses ``platformdirs`` for XDG-conformant path resolution; users can
-    override via ``ENV_DEPS_CACHE_DIR`` if they want to share the cache
-    across machines (e.g. on shared cluster storage). Cached because the
-    result is invariant within a process and the mkdir is the only
-    side-effect.
-    """
-    override = os.environ.get(ENV_DEPS_CACHE_DIR)
-    if override:
-        cache_dir = Path(override).expanduser().resolve()
-    else:
-        cache_dir = Path(platformdirs.user_cache_dir("llem")) / "deps"
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    return cache_dir
-
-
-def append_package_dispatch(
-    cmd: list[str],
-    *,
-    engine: str,
-    entry_module: str | None = None,
-) -> None:
-    """Append the bind-mounts + env + entrypoint that make the package importable.
-
-    Upstream engine images (vllm, tensorrt) and even our transformers image do
-    NOT have ``llenergymeasure`` installed; the framework runs from the host
-    package source bind-mounted at ``/llem-src/llenergymeasure``. This appends
-    the four mounts the in-container entrypoint script needs (package dir, the
-    runtime requirements list, the script itself, and the host deps cache), the
-    env it reads, and points ``--entrypoint`` at the script. The script prepends
-    ``/llem-src`` to ``PYTHONPATH`` and primes any missing runtime deps, then
-    exec's the module named by ``LLEM_ENTRY_MODULE``.
-
-    INVARIANT - ``/llem-src`` must expose the ``llenergymeasure`` package and
-    NOTHING else. The package dir is mounted at the nested target
-    ``/llem-src/llenergymeasure`` (not the package's PARENT at ``/llem-src``)
-    precisely so that no on-disk sibling of the package leaks in. For a
-    pip/wheel install the parent is the venv's ``site-packages``; because the
-    script prepends ``/llem-src`` to ``PYTHONPATH`` and ``PYTHONPATH`` precedes
-    the container's own site-packages on ``sys.path``, mounting the parent let
-    every host third-party package shadow the image's native copy (e.g. a host
-    ``pydantic_core`` C extension built for a different Python minor, or a fresh
-    ``huggingface-hub`` over a pinned engine stack). See ``_resolve_package_dir``.
-
-    The entrypoint script and the requirements list are shipped as package data
-    and materialised to a host tempdir (see ``_materialise_dispatch_assets``) so
-    dispatch works from an installed wheel, not only a source checkout. The
-    package dir at ``/llem-src/llenergymeasure`` resolves from ``__file__``
-    (see ``_resolve_package_dir``): one uniform path for editable and wheel
-    installs, no editable-detection, no llem dist-info in-container (the editable
-    flow has always run without it, proving container-side code never needs it).
-
-    Shared by the experiment dispatch (``DockerRunner._build_docker_cmd``) and
-    the baseline dispatch (``study.baseline_container.build_baseline_docker_cmd``)
-    so the two package-import setups cannot drift.
-
-    Args:
-        cmd: Docker command list to mutate in place (mounts/env appended before
-            the image name, which the caller adds afterwards).
-        engine: Engine value; sets ``LLEM_ENGINE`` so the script routes tensorrt
-            through ``nvidia_entrypoint.sh`` for the libnvinfer ``LD_LIBRARY_PATH``.
-        entry_module: Override for the module the script exec's. ``None`` leaves
-            the script default (``llenergymeasure.entrypoints.container``).
-
-    Raises:
-        DockerPreFlightError: A dispatch asset (entrypoint script or requirements
-            list) could not be materialised from the installed package. Raised
-            before ``docker run`` so a missing source never becomes a silent
-            docker-auto-created empty-dir mount.
-    """
-    pkg_dir = _resolve_package_dir()
-    entry_script, requirements_file = _materialise_dispatch_assets()
-    deps_cache = _ensure_deps_cache_dir()
-    cmd.extend(
-        [
-            "-v",
-            f"{pkg_dir}:/llem-src/llenergymeasure:ro",
-            "-v",
-            f"{requirements_file}:/llem-requirements.txt:ro",
-            "-v",
-            f"{entry_script}:/llem-entry.sh:ro",
-            "-v",
-            f"{deps_cache}:/llem-runtime-deps",
-            "-e",
-            "PYTHONDONTWRITEBYTECODE=1",
-            "-e",
-            f"{ENV_ENGINE}={engine}",
-            "-e",
-            f"{ENV_HOST_UID}={os.getuid()}",
-            "-e",
-            f"{ENV_HOST_GID}={os.getgid()}",
-        ]
-    )
-    if entry_module is not None:
-        cmd.extend(["-e", f"{ENV_ENTRY_MODULE}={entry_module}"])
-    cmd.extend(["--entrypoint", "/llem-entry.sh"])
-
-
-def append_nccl_env(cmd: list[str]) -> None:
-    """Forward host ``NCCL_*`` env vars into the container.
-
-    NCCL tuning/workaround settings must reach the engine process, which runs
-    inside the container rather than on the host. The canonical case is
-    ``NCCL_P2P_DISABLE=1`` on PCIe multi-GPU hosts whose topology lacks
-    functional GPU peer-to-peer (P2P): without it, every tensor-parallel run
-    hangs at the first NCCL collective.
-
-    Uses explicit ``-e KEY=VALUE`` (matching the ``LLEM_*`` forwarding idiom in
-    ``DockerRunner._build_docker_cmd``) and iterates keys in sorted order so the
-    built command is deterministic (tests assert on argv). Shared by the
-    experiment dispatch (``DockerRunner._build_docker_cmd``) and the baseline
-    dispatch (``study.baseline_container.build_baseline_docker_cmd``) so the two
-    env-forwarding setups cannot drift.
-
-    Args:
-        cmd: Docker command list to mutate in place (env appended before the
-            image name, which the caller adds afterwards).
-    """
-    for env_key in sorted(k for k in os.environ if k.startswith("NCCL_")):
-        env_val = os.environ[env_key]
-        if env_val:
-            cmd.extend(["-e", f"{env_key}={env_val}"])
 
 
 class DockerRunner:
@@ -550,7 +202,7 @@ class DockerRunner:
         # Lazy import to avoid heavy domain imports at module load time
         from llenergymeasure.domain.experiment import compute_declared_config_hash
 
-        exchange_dir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_EXCHANGE))
+        exchange_dir = exchange.create_exchange_dir()
 
         # Collect secrets for env-file (never pass as CLI args)
         secrets: dict[str, str] = {}
@@ -563,7 +215,7 @@ class DockerRunner:
         try:
             # --- Ensure image is available (pull with visible output if needed) ---
             if not skip_image_check:
-                self._ensure_image(progress=_p)
+                lifecycle.ensure_image(self.image, progress=_p)
 
             # --- Write config JSON ---
             # Compute config_hash from the clean config (no output path mutation).
@@ -596,7 +248,7 @@ class DockerRunner:
                 )
                 logger.debug("Running docker command: %s", _mask_secrets(str(cmd), secrets))
 
-                # Use Popen streaming when progress callback is provided.
+                # Use streaming launch + wait when a progress callback is provided.
                 # Container inner events (baseline, model, warmup, measure, save)
                 # are forwarded as top-level steps for granular progress display.
                 if _p:
@@ -607,89 +259,34 @@ class DockerRunner:
                         container_start_time=t0_container,
                     )
                 else:
-                    # Classic mode: blocking subprocess.run (backward compatible)
-                    try:
-                        proc = subprocess.run(
-                            cmd,
-                            capture_output=True,
-                            text=True,
-                            timeout=self.timeout,
-                        )
-                    except subprocess.TimeoutExpired as exc:
-                        logger.debug(
-                            "Docker container timed out after %ss. Debug artifacts at %s",
-                            self.timeout,
-                            exchange_dir,
-                        )
-                        raise DockerTimeoutError(
-                            message=f"Container timed out after {self.timeout}s.",
-                            fix_suggestion="Increase timeout or reduce experiment size.",
-                        ) from exc
-                    returncode = proc.returncode
-                    stderr_text = proc.stderr
+                    # Classic mode: blocking run until exit (backward compatible)
+                    returncode, stderr_text = lifecycle.run_blocking(cmd, self.timeout)
 
             # --- Handle non-zero exit ---
             if returncode != 0:
-                logger.debug(
-                    "Container failed (exit %d). Debug artifacts at %s",
-                    returncode,
-                    exchange_dir,
+                error: DockerError = diagnostics.classify_container_failure(
+                    returncode=returncode,
+                    stderr_text=stderr_text,
+                    image=self.image,
+                    exchange_dir=exchange_dir,
+                    config_hash=config_hash,
                 )
-                # Persist container stderr to a log file in the exchange dir
-                # so it survives for post-mortem debugging.
-                container_log_path = exchange_dir / "container.log"
-                try:
-                    container_log_path.write_text(
-                        stderr_text or "(no stderr captured)", encoding="utf-8"
-                    )
-                    logger.debug("Container log written to %s", container_log_path)
-                except Exception as write_exc:
-                    logger.warning("Failed to write container.log: %s", write_exc)
-
-                # Prefer structured error JSON written by the container entrypoint
-                # over Docker's stderr, which can contain misleading daemon messages.
-                error_json_path = exchange_dir / f"{config_hash}_error.json"
-                error: DockerError
-                if error_json_path.exists():
-                    payload = load_json(error_json_path)
-                    error = DockerContainerError(
-                        message=f"{payload.get('type', 'UnknownError')}: {payload.get('message', '')}",
-                        fix_suggestion="Check the error traceback in the error JSON for details.",
-                        stderr_snippet=capture_stderr_snippet(stderr_text) if stderr_text else None,
-                    )
-                    error.error_payload = payload
-                else:
-                    error = translate_docker_error(returncode, stderr_text, self.image)
-
-                error.exchange_dir = str(exchange_dir)
                 # Do NOT clean up - preserve for debugging
                 exchange_dir = None  # type: ignore[assignment]
                 raise error
 
             # --- Read result ---
-            result = self._read_result(exchange_dir, config_hash)
+            result = exchange.read_result(exchange_dir, config_hash)
 
             # --- Rescue artefacts before cleanup ---
-            # The harness inside the container wrote its artefacts to /run/llem
-            # (= exchange_dir on host): config.json always (the sole home of
-            # provenance and the authoritative home of identity), environment.json
-            # (the accurate in-container environment snapshot - the host's own
-            # snapshot describes the dispatching host, not this container), and
-            # timeseries.parquet when enabled. Move them to a temp dir so the
-            # caller can copy them into the study directory before the exchange
-            # dir is destroyed below. config.json must survive too - otherwise a
-            # successful docker run lands a result.json with no provenance.
+            # config.json / environment.json / timeseries.parquet must survive the
+            # exchange-dir teardown so the caller can land them in the study dir.
             artefact_tmpdir: Path | None = None
             if not isinstance(result, dict):
-                for _name in (CONFIG_SIDECAR_FILENAME, ENVIRONMENT_FILENAME, TIMESERIES_FILENAME):
-                    _src = exchange_dir / _name
-                    if _src.exists():
-                        if artefact_tmpdir is None:
-                            artefact_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
-                        shutil.move(str(_src), str(artefact_tmpdir / _name))
+                artefact_tmpdir = exchange.rescue_artefacts(exchange_dir)
 
             # --- Success: clean up ---
-            self._cleanup_exchange_dir(exchange_dir)
+            exchange.cleanup_exchange_dir(exchange_dir)
             exchange_dir = None  # type: ignore[assignment]
 
             # Error payload dicts ({type, message, traceback}) are returned as-is.
@@ -705,392 +302,8 @@ class DockerRunner:
                 logger.debug("Preserving exchange dir for debugging: %s", exchange_dir)
 
     # ------------------------------------------------------------------
-    # Private helpers
+    # Private helpers (thin delegation to the docker/ concern modules)
     # ------------------------------------------------------------------
-
-    def _ensure_image(self, progress: ProgressCallback | None = None) -> None:
-        """Check if the Docker image exists locally; pull with visible output if not.
-
-        Always emits an ``image_check`` step so the user sees the cache lookup.
-        If the image is not cached, emits a separate ``pull`` step.
-        Substeps report image metadata (ID, size, age) for provenance visibility.
-        """
-        short_image = self.short_image
-
-        if progress:
-            progress.on_step_start("image_check", "Inspecting", short_image)
-        t0 = time.perf_counter()
-
-        check = subprocess.run(
-            ["docker", "image", "inspect", self.image],
-            capture_output=True,
-            timeout=TIMEOUT_DOCKER_INSPECT,
-        )
-        if check.returncode == 0:
-            if progress:
-                progress.on_step_update("image_check", f"{short_image} (cached)")
-                progress.on_step_done("image_check", time.perf_counter() - t0)
-                progress.on_step_skip("pull", "cached")
-            return
-
-        if progress:
-            progress.on_step_done("image_check", time.perf_counter() - t0)
-
-        # Image not cached - pull it
-        if progress:
-            progress.on_step_start("pull", "Pulling", self.image)
-        t0_pull = time.perf_counter()
-
-        print(f"Pulling image: {self.image}", file=sys.stderr)
-        try:
-            pull = subprocess.run(
-                ["docker", "pull", self.image],
-                stdout=sys.stderr,
-                stderr=sys.stderr,
-                timeout=DOCKER_PULL_TIMEOUT,
-            )
-        except subprocess.TimeoutExpired as exc:
-            if progress:
-                progress.on_step_done("pull", time.perf_counter() - t0_pull)
-            from llenergymeasure.infra.docker_errors import DockerImagePullError
-
-            raise DockerImagePullError(
-                message=f"Image pull timed out after {DOCKER_PULL_TIMEOUT}s: {self.image}",
-                fix_suggestion=f"Pull manually: docker pull {self.image}",
-            ) from exc
-        if pull.returncode != 0:
-            if progress:
-                progress.on_step_done("pull", time.perf_counter() - t0_pull)
-            from llenergymeasure.infra.docker_errors import DockerImagePullError
-
-            raise DockerImagePullError(
-                message=f"Image not found or could not be pulled: {self.image}",
-                fix_suggestion=f"docker pull {self.image}",
-            )
-
-        if progress:
-            progress.on_step_done("pull", time.perf_counter() - t0_pull)
-
-    def _run_container_streaming(
-        self,
-        cmd: list[str],
-        progress: ProgressCallback | None = None,
-        _mask_secrets_fn: Callable[[str], str] | None = None,
-        container_start_time: float | None = None,
-    ) -> tuple[int, str]:
-        """Run container with Popen, streaming stdout for progress events.
-
-        Container inner events (step_start, step_update, step_done) are
-        forwarded as top-level progress steps so the CLI can display each
-        measurement phase individually (Docker BuildKit-style granularity).
-
-        The ``container_start`` step (started by the caller) is ended when
-        the first inner event arrives, capturing the container boot time.
-
-        Args:
-            cmd: Docker command list.
-            progress: Optional ProgressCallback.
-            _mask_secrets_fn: Optional callable to mask secrets in log output.
-            container_start_time: perf_counter timestamp of container_start step.
-
-        Returns:
-            Tuple of (returncode, stderr_text).
-        """
-        stderr_lines: list[str] = []
-        # Keywords in container stderr that indicate meaningful activity.
-        # When no JSON progress events arrive (old images), surface these
-        # as on_step_update to show the container is alive and working.
-        _ACTIVITY_KEYWORDS = (
-            "loading",
-            "downloading",
-            "measuring",
-            "warmup",
-            "warming",
-            "inference",
-            "saving",
-            "running",
-            "model",
-            "tokenizer",
-        )
-
-        def _read_stderr(pipe: Any) -> None:
-            """Read stderr in a background thread to prevent blocking.
-
-            For old images that don't emit JSON progress events, surfaces
-            interesting log lines as step updates on container_start.
-            """
-            for line in pipe:
-                stderr_lines.append(line)
-                stripped = line.strip()
-                logger.debug("container stderr: %s", stripped)
-                # Surface activity from old images as step updates
-                if (
-                    progress is not None
-                    and not container_start_done_event.is_set()
-                    and stripped
-                    and any(kw in stripped.lower() for kw in _ACTIVITY_KEYWORDS)
-                ):
-                    # Truncate long log lines and strip log prefix (e.g. "INFO:root:")
-                    display_text = stripped
-                    if ":" in display_text and display_text.split(":")[0].isupper():
-                        display_text = display_text.split(":", 2)[-1].strip()
-                    progress.on_step_update("container_start", display_text[:50])
-            pipe.close()
-
-        # Thread-safe flag shared with stderr thread to track if JSON events arrived
-        container_start_done_event = threading.Event()
-
-        try:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-        except OSError as exc:
-            raise DockerContainerError(
-                message=f"Failed to start docker process: {exc}",
-                fix_suggestion="Is Docker installed and running?",
-            ) from exc
-
-        # Read stderr in background thread to avoid deadlock
-        stderr_thread = threading.Thread(target=_read_stderr, args=(proc.stderr,), daemon=True)
-        stderr_thread.start()
-
-        # Pump stdout into a queue from a daemon thread so the main loop
-        # can wake up periodically to check both timeout budgets even
-        # when the container is producing nothing. The blocking
-        # ``for line in proc.stdout`` shape this replaces would hang
-        # indefinitely on a stuck CUDA / NCCL / compile step - the
-        # wall-clock proc.wait() never gets a chance to fire because we
-        # never exit the for-loop. See issue #366.
-        stdout_q: queue.Queue[str | None] = queue.Queue()
-
-        def _pump_stdout(pipe: Any) -> None:
-            try:
-                for line in pipe:
-                    stdout_q.put(line)
-            finally:
-                stdout_q.put(None)  # sentinel: pipe closed (EOF or process exit)
-
-        assert proc.stdout is not None
-        stdout_thread = threading.Thread(target=_pump_stdout, args=(proc.stdout,), daemon=True)
-        stdout_thread.start()
-
-        container_start_done = False
-        watchdog_start = time.monotonic()
-        last_activity = watchdog_start
-
-        try:
-            while True:
-                wall_remaining, silence_remaining = self._check_watchdog_deadlines(
-                    proc, watchdog_start, last_activity
-                )
-
-                # Cap the queue wait at the poll interval so a Ctrl-C
-                # interrupt is observed within ~0.5s even with both
-                # budgets large.
-                wait_for = min(wall_remaining, silence_remaining, _WATCHDOG_POLL_INTERVAL)
-                try:
-                    line = stdout_q.get(timeout=wait_for)
-                except queue.Empty:
-                    continue
-                if line is None:
-                    break  # stdout pipe closed
-                last_activity = time.monotonic()
-
-                container_start_done = self._handle_stdout_line(
-                    line,
-                    progress,
-                    container_start_done,
-                    container_start_time,
-                    container_start_done_event,
-                    _mask_secrets_fn,
-                )
-        finally:
-            with suppress(Exception):
-                proc.stdout.close()
-            stdout_thread.join(timeout=TIMEOUT_THREAD_JOIN)
-
-        # If no inner events arrived, end container_start now (old images)
-        if not container_start_done and container_start_time is not None and progress is not None:
-            progress.on_step_done("container_start", time.perf_counter() - container_start_time)
-
-        # Wait for process exit. The watchdog above ensures we only get
-        # here when stdout has closed; proc.wait() blocks only until the
-        # process actually reaps, which is bounded.
-        try:
-            proc.wait(timeout=self.timeout)
-        except subprocess.TimeoutExpired as exc:
-            proc.kill()
-            proc.wait()
-            raise DockerTimeoutError(
-                message=f"Container timed out after {self.timeout}s.",
-                fix_suggestion="Increase timeout or reduce experiment size.",
-            ) from exc
-
-        stderr_thread.join(timeout=TIMEOUT_THREAD_JOIN)
-        stderr_text = "".join(stderr_lines)
-
-        return proc.returncode, stderr_text
-
-    def _check_watchdog_deadlines(
-        self,
-        proc: subprocess.Popen[str],
-        watchdog_start: float,
-        last_activity: float,
-    ) -> tuple[float, float]:
-        """Compute the remaining wall-clock and stdout-silence budgets.
-
-        Kills the container and raises the matching watchdog error if either budget
-        is exhausted. Returns ``(wall_remaining, silence_remaining)`` so the caller
-        can cap its queue wait.
-        """
-        now = time.monotonic()
-        wall_remaining = (
-            self.timeout - (now - watchdog_start) if self.timeout is not None else _NO_DEADLINE
-        )
-        silence_remaining = (
-            self.silence_timeout - (now - last_activity)
-            if self.silence_timeout is not None
-            else _NO_DEADLINE
-        )
-
-        if wall_remaining <= 0:
-            self._kill_container_for_watchdog(proc)
-            raise DockerTimeoutError(
-                message=f"Container timed out after {self.timeout}s (wall-clock).",
-                fix_suggestion=(
-                    "Increase study_execution.experiment_timeout_seconds or reduce experiment size."
-                ),
-            )
-        if silence_remaining <= 0:
-            self._kill_container_for_watchdog(proc)
-            raise DockerStdoutSilenceError(
-                message=(
-                    f"Container produced no stdout for "
-                    f"{self.silence_timeout}s (likely stuck process)."
-                ),
-                fix_suggestion=(
-                    "Increase study_execution.stdout_silence_timeout_seconds "
-                    "if your workload legitimately goes silent for longer "
-                    "(e.g. fresh TRT-LLM engine builds), or investigate the "
-                    "stuck step. Check container logs in the exchange dir."
-                ),
-            )
-        return wall_remaining, silence_remaining
-
-    def _handle_stdout_line(
-        self,
-        line: str,
-        progress: ProgressCallback | None,
-        container_start_done: bool,
-        container_start_time: float | None,
-        container_start_done_event: threading.Event,
-        mask_secrets_fn: Callable[[str], str] | None,
-    ) -> bool:
-        """Process one container stdout line.
-
-        JSON progress events are forwarded to ``progress``; plain output is logged
-        (secrets masked). Returns the updated ``container_start_done`` flag - set True
-        on the first inner event so the ``container_start`` step is ended exactly once.
-        """
-        stripped = line.strip()
-        if stripped.startswith('{"event":') and progress is not None:
-            try:
-                event = json.loads(stripped)
-                event_type = event.get("event")
-                step = event.get("step", "")
-
-                # End "container_start" on first inner event
-                if not container_start_done and container_start_time is not None:
-                    container_start_done = True
-                    container_start_done_event.set()
-                    progress.on_step_done(
-                        "container_start",
-                        time.perf_counter() - container_start_time,
-                    )
-
-                # Resolve container-boundary step id (e.g. the container's
-                # "preflight" renders as "container_preflight" host-side). The
-                # mapping lives in the progress registry.
-                step = resolve_container_step(step)
-
-                self._dispatch_progress_event(progress, event_type, step, event)
-            except (json.JSONDecodeError, KeyError):
-                logger.debug("Unparseable progress line: %s", stripped)
-        else:
-            if stripped:
-                masked = mask_secrets_fn(stripped) if mask_secrets_fn else stripped
-                logger.debug("container stdout: %s", masked)
-        return container_start_done
-
-    @staticmethod
-    def _dispatch_progress_event(
-        progress: ProgressCallback, event_type: str, step: str, event: dict[str, Any]
-    ) -> None:
-        """Forward a single decoded container progress event to the host callback."""
-        if event_type == "step_start":
-            progress.on_step_start(
-                step,
-                event.get("description", ""),
-                event.get("detail", ""),
-            )
-        elif event_type == "step_update":
-            progress.on_step_update(step, event.get("detail", ""))
-        elif event_type == "step_done":
-            progress.on_step_done(step, event.get("elapsed_sec", 0.0))
-        elif event_type == "step_skip":
-            progress.on_step_skip(step, event.get("reason", ""))
-        elif event_type == "substep":
-            progress.on_substep(
-                step,
-                event.get("text", ""),
-                event.get("elapsed_sec", 0.0),
-            )
-        elif event_type == "substep_start":
-            progress.on_substep_start(step, event.get("text", ""))
-        elif event_type == "substep_done":
-            progress.on_substep_done(
-                step,
-                event.get("text"),
-                event.get("elapsed_sec"),
-            )
-
-    @staticmethod
-    def _kill_container_for_watchdog(proc: subprocess.Popen[str]) -> None:
-        """Terminate then SIGKILL a hung container; swallow any wait failures.
-
-        Used by the unified watchdog when a timeout fires. Mirrors the
-        existing wall-clock kill path: best-effort terminate, then kill,
-        then a final wait so the process group is fully reaped. Any
-        exception from the cleanup path is logged at debug level - the
-        watchdog's responsibility is to *raise the right error*, not to
-        handle a cooperatively-shutting-down container.
-        """
-        for stage, action in (
-            ("terminate", proc.terminate),
-            ("wait-after-terminate", lambda: proc.wait(timeout=2.0)),
-            ("kill", proc.kill),
-            ("wait-after-kill", lambda: proc.wait(timeout=2.0)),
-        ):
-            try:
-                action()
-            except Exception as exc:
-                logger.debug("Watchdog cleanup %s failed: %s", stage, exc)
-
-    def _mount_if_absent(
-        self, cmd: list[str], host: str | Path, container: str, *, extra_env: str | None = None
-    ) -> None:
-        """Append ``-v host:container`` unless the user already mounts ``container``.
-
-        Optionally appends ``-e <extra_env>`` after the mount (e.g. HF_HOME).
-        """
-        if any(cp == container for _, cp in self.extra_mounts):
-            return
-        cmd.extend(["-v", f"{host}:{container}"])
-        if extra_env is not None:
-            cmd.extend(["-e", extra_env])
 
     def _build_docker_cmd(
         self,
@@ -1099,184 +312,38 @@ class DockerRunner:
         exchange_dir: str,
         env_path: Path | None = None,
     ) -> list[str]:
-        """Build the ``docker run`` command list.
-
-        All three engines (transformers, vllm, tensorrt) follow the same
-        dispatch shape: the image carries only the engine substrate, the host
-        package source is bind-mounted at ``/llem-src/llenergymeasure``, the
-        runtime requirements list is bind-mounted as a single-file mount at
-        ``/llem-requirements.txt``, the in-container entrypoint script is
-        bind-mounted at ``/llem-entry.sh``, and a host-side deps cache is
-        bind-mounted at ``/llem-runtime-deps``. ``--entrypoint`` always points
-        at ``/llem-entry.sh``; that script
-        (a) diffs the requirements list against installed dists and
-        pip-installs any missing ones to the cache (fast-path skips this when a
-        requirements-hash stamp matches), (b) sets
-        ``PYTHONPATH`` to include the cache and ``/llem-src``, and (c) exec's
-        the framework entrypoint module - routing through
-        ``/opt/nvidia/nvidia_entrypoint.sh`` when ``LLEM_ENGINE=tensorrt``
-        (sets up LD_LIBRARY_PATH for libnvinfer).
-
-        Multi-GPU tensorrt runs are NOT wrapped in mpirun: TensorRT-LLM's LLM
-        API self-manages tensor parallelism (setting ``tensor_parallel_size``
-        makes the LLM class spawn its own worker processes via its MPI/RPC
-        orchestrator), so a single python3 process is correct.
-
-        Args:
-            config:       ExperimentConfig for the current experiment. Used to
-                          detect TRT-LLM engine and read ``tensorrt.tensor_parallel_size``.
-            config_hash:  Hash prefix for config/result file names.
-            exchange_dir: Host path of the temporary exchange directory.
-            env_path:     Path to a temp env-file (written by ``_env_file``), or None.
-                          When set, ``--env-file <path>`` is added to the command.
-                          Secrets (e.g. HF_TOKEN) are never passed as ``-e KEY=VALUE``
-                          arguments to avoid exposure in ``/proc/<pid>/cmdline``.
-
-        Returns:
-            List of strings suitable for ``subprocess.run``.
-        """
-        cmd = [
-            "docker",
-            "run",
-            "--rm",
-            "--gpus",
-            docker_gpus_arg(self.gpu_indices),
-            "-v",
-            f"{exchange_dir}:{CONTAINER_EXCHANGE_DIR}",
-            "-e",
-            f"{ENV_CONFIG_PATH}={CONTAINER_EXCHANGE_DIR}/{config_hash}_config.json",
-            "--shm-size",
-            docker_shm_size(),
-        ]
-
-        # Propagate secrets via --env-file (never as -e KEY=VALUE CLI args)
-        if env_path is not None:
-            cmd.extend(["--env-file", str(env_path)])
-
-        # TRT-LLM engine cache: persist compiled engines across ephemeral
-        # containers. Also default LLEM_TRT_BUILD_CACHE_PATH to the mount target
-        # via extra_env so the cache lands on the mount out of the box (TRT-LLM's
-        # own default root is unmounted); a host-set value overrides this because
-        # the blanket LLEM_* forwarding loop below re-emits it last (docker -e is
-        # last-wins).
-        if config.engine == Engine.TENSORRT:
-            self._mount_if_absent(
-                cmd,
-                str(trt_build_cache_host_dir()),
-                _TRT_BUILD_CACHE_CONTAINER_PATH,
-                extra_env=f"{ENV_TRT_BUILD_CACHE_PATH}={_TRT_BUILD_CACHE_CONTAINER_PATH}",
-            )
-
-        # Auto-mount the host HuggingFace cache so model weights persist across
-        # ephemeral containers; otherwise each run re-downloads the full model.
-        hf_cache_container = "/root/.cache/huggingface"
-        self._mount_if_absent(
-            cmd,
-            Path.home() / ".cache" / "huggingface",
-            hf_cache_container,
-            extra_env=f"HF_HOME={hf_cache_container}",
+        """Build the ``docker run`` command list (delegates to ``docker.command``)."""
+        return command.build_docker_cmd(
+            image=self.image,
+            config=config,
+            config_hash=config_hash,
+            exchange_dir=exchange_dir,
+            env_path=env_path,
+            extra_mounts=self.extra_mounts,
+            container_name=self._container_name,
+            labels=self._labels,
+            gpu_indices=self.gpu_indices,
         )
 
-        # Auto-mount the host flashinfer JIT cache so TRT-LLM warm runs reuse
-        # already-compiled per-arch attention kernels (cold compile is minutes).
-        if config.engine == Engine.TENSORRT:
-            self._mount_if_absent(
-                cmd, Path.home() / ".cache" / "flashinfer", "/root/.cache/flashinfer"
-            )
+    def _run_container_streaming(
+        self,
+        cmd: list[str],
+        progress: ProgressCallback | None = None,
+        _mask_secrets_fn: Callable[[str], str] | None = None,
+        container_start_time: float | None = None,
+    ) -> tuple[int, str]:
+        """Launch the container then wait for exit, streaming progress.
 
-        # Forward LLEM_* env vars into the container so framework defaults set
-        # on the host (e.g. LLEM_TRANSFORMERS_DEFAULT_DEVICE_MAP) reach the
-        # experiment process, which actually runs inside the container. Reserved
-        # exchange keys are excluded: we set those deliberately above (or via
-        # the package-dispatch helper), and docker's -e is last-wins over the
-        # --env-file, so a stray host copy would silently clobber the intended
-        # value.
-        for env_key, env_val in os.environ.items():
-            if env_key.startswith("LLEM_") and env_val and env_key not in _RESERVED_EXCHANGE_ENV:
-                cmd.extend(["-e", f"{env_key}={env_val}"])
-
-        # Forward host NCCL_* env vars so multi-GPU tuning/workaround settings
-        # (e.g. NCCL_P2P_DISABLE=1 on PCIe hosts without functional GPU P2P)
-        # reach the engine process, which runs inside the container.
-        append_nccl_env(cmd)
-
-        # Extra volume mounts (engine cache, model cache, etc.)
-        for host_path, container_path in self.extra_mounts:
-            cmd.extend(["-v", f"{host_path}:{container_path}"])
-
-        # All engines: bind-mount the host package source + bootstrap (so the
-        # package is importable in images that don't ship it) and point
-        # --entrypoint at the script. Shared with the baseline dispatch via
-        # append_package_dispatch so the two cannot drift. The experiment path
-        # uses the script's default entry module
-        # (``llenergymeasure.entrypoints.container``), so entry_module stays None.
-        # ``Engine`` is a (str, Enum) so ``f"{config.engine}"`` resolves to the
-        # raw value via its ``__str__`` override.
-        append_package_dispatch(cmd, engine=f"{config.engine}")
-
-        # Container name and labels for lifecycle management (cleanup, reaper).
-        # These must appear before the image name in the docker run command.
-        if self._container_name:
-            cmd.extend(["--name", self._container_name])
-        for key, value in self._labels.items():
-            cmd.extend(["--label", f"{key}={value}"])
-
-        cmd.append(self.image)
-
-        # No post-image args - the entrypoint script invokes the framework
-        # module itself; config is passed via env vars (LLEM_CONFIG_PATH etc.).
-        return cmd
-
-    def _read_result(self, exchange_dir: Path, config_hash: str) -> Any:
-        """Read and parse the result JSON written by the container.
-
-        Args:
-            exchange_dir: Host path of the temporary exchange directory.
-            config_hash:  Hash prefix for the result file name.
-
-        Returns:
-            ExperimentResult if the file contains a valid result, or a dict
-            error payload if the container wrote an error JSON.
-
-        Raises:
-            DockerContainerError: If the result file does not exist.
+        The launch (:func:`docker.lifecycle.launch`) is separable from the wait
+        (:func:`docker.lifecycle.wait_to_completion`, which owns the watchdog);
+        this method composes them into the block-until-exit mode.
         """
-        # Lazy import to avoid pulling the heavy domain result models at module
-        # load time (the parser imports ExperimentResult transitively).
-        from llenergymeasure.domain.result_payload import parse_experiment_result_payload
-
-        result_path = exchange_dir / f"{config_hash}_result.json"
-        if not result_path.exists():
-            raise DockerContainerError(
-                message=f"Container exited 0 but no result file found at {result_path}",
-                fix_suggestion="Check container logs for errors during experiment execution.",
-            )
-
-        raw = load_json(result_path)
-
-        # Container may write an error payload even on exit 0 (defensive check).
-        # Error payloads have "type" and "traceback" keys (mirror StudyRunner worker
-        # format). This detection stays here: it is exchange-specific IPC, not a
-        # property of a persisted result.
-        if isinstance(raw, dict) and "type" in raw and "traceback" in raw:
-            return raw
-
-        # Cross-version IPC: strip fields unknown to the host schema (container may
-        # run an older/newer version) and warn on a host/container version skew.
-        # Both behaviours live in the shared parser now, keyed by tolerant=True and
-        # the host version as expected_version.
-        return parse_experiment_result_payload(raw, tolerant=True, expected_version=__version__)
-
-    def _cleanup_exchange_dir(self, exchange_dir: Path) -> None:
-        """Remove the temporary exchange directory.
-
-        Logs a warning on failure but never raises - cleanup must not mask
-        real errors from the caller.
-
-        Args:
-            exchange_dir: Path to remove.
-        """
-        try:
-            shutil.rmtree(exchange_dir)
-        except Exception as exc:
-            logger.warning("Could not remove exchange dir %s: %s", exchange_dir, exc)
+        proc = lifecycle.launch(cmd)
+        return lifecycle.wait_to_completion(
+            proc,
+            timeout=self.timeout,
+            silence_timeout=self.silence_timeout,
+            progress=progress,
+            mask_secrets_fn=_mask_secrets_fn,
+            container_start_time=container_start_time,
+        )

--- a/src/llenergymeasure/study/baseline_container.py
+++ b/src/llenergymeasure/study/baseline_container.py
@@ -34,7 +34,7 @@ from llenergymeasure.config.ssot import (
     TEMP_PREFIX_EXCHANGE,
 )
 from llenergymeasure.harness.baseline import BaselineCache
-from llenergymeasure.infra.docker_runner import append_nccl_env, append_package_dispatch
+from llenergymeasure.infra.docker.command import append_nccl_env, append_package_dispatch
 from llenergymeasure.utils.env_config import docker_gpus_arg
 from llenergymeasure.utils.io import load_json
 
@@ -72,7 +72,7 @@ def build_baseline_docker_cmd(
 ) -> list[str]:
     """Build the ``docker run`` command list for a baseline-only container.
 
-    Reuses ``infra.docker_runner.append_package_dispatch`` (the same mechanism
+    Reuses ``infra.docker.command.append_package_dispatch`` (the same mechanism
     the experiment path uses) to bind-mount the host package source and route
     through ``/llem-entry.sh``. Upstream engine images do not ship the
     ``llenergymeasure`` package, so without this the baseline entry module would

--- a/src/llenergymeasure/utils/env_config.py
+++ b/src/llenergymeasure/utils/env_config.py
@@ -258,6 +258,33 @@ def docker_shm_size() -> str:
     return os.environ.get(ENV_DOCKER_SHM_SIZE, "").strip() or _DEFAULT_DOCKER_SHM_SIZE
 
 
+ENV_DOCKER_HF_CACHE: Final = "LLEM_DOCKER_HF_CACHE"
+"""Host HuggingFace cache directory bind-mounted into llem experiment containers.
+
+The runner auto-mounts this host directory at the container's
+``/root/.cache/huggingface`` (and sets ``HF_HOME`` to it) so downloaded model
+weights persist across ephemeral containers instead of being re-downloaded every
+run. Unset / empty means ``$HOME/.cache/huggingface`` - the historical location.
+Point it elsewhere (e.g. shared cluster storage or a large scratch disk) when the
+default home lives on a small volume. The in-container target and ``HF_HOME`` are
+fixed; only the host source is configurable.
+"""
+
+
+def docker_hf_cache_dir() -> Path:
+    """Return the host HuggingFace cache directory the docker runner bind-mounts.
+
+    Pure passthrough with the historical fallback: unset / empty ->
+    ``$HOME/.cache/huggingface``. ``~`` in an explicit value is expanded. Mirrors
+    the :func:`docker_shm_size` pattern; the container target and ``HF_HOME`` stay
+    fixed at ``/root/.cache/huggingface``.
+    """
+    raw = os.environ.get(ENV_DOCKER_HF_CACHE, "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".cache" / "huggingface"
+
+
 ENV_TRT_BUILD_CACHE_ENABLED: Final = "LLEM_TRT_BUILD_CACHE_ENABLED"
 """Toggle for TRT-LLM on-disk engine build cache.
 

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import importlib.metadata
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Canned runtime-dependency specs used to keep dispatch-command construction
+# hermetic. The command-construction and container-lifecycle tests only need a
+# non-empty spec list so _materialise_dispatch_assets can write a real
+# requirements file; they never assert on the specs themselves.
+_STUB_RUNTIME_REQUIREMENTS = ("filelock>=3.12", "numpy>=1.24", "pyarrow>=15", "pydantic>=2")
 
 
 def make_subprocess_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -16,3 +25,49 @@ def make_subprocess_result(returncode: int = 0, stdout: str = "", stderr: str = 
     proc.stdout = stdout
     proc.stderr = stderr
     return proc
+
+
+@pytest.fixture(autouse=True)
+def stub_runtime_requirements(request):
+    """Keep dispatch-command construction independent of an installed distribution.
+
+    ``append_package_dispatch`` -> ``_materialise_dispatch_assets`` ->
+    ``_runtime_requirements`` reads ``importlib.metadata.requires`` for the
+    llenergymeasure distribution. That metadata exists only when the package is
+    pip-installed; it is absent when the suite runs from a source tree on
+    ``PYTHONPATH`` with no install (the GPU-CI container mounts the repo and sets
+    ``PYTHONPATH`` deliberately, without installing). Without a stub every test
+    that builds a docker command raises ``PackageNotFoundError``.
+
+    These are unit tests of command construction and container lifecycle, so the
+    metadata lookup is stubbed with a canned spec list. Tests that assert on the
+    real distribution metadata mark themselves ``needs_dist_metadata``; they are
+    left unstubbed and skipped when the distribution is not installed.
+
+    The two ``functools.cache``-wrapped resolvers are cleared around every test
+    so the stub (or the real lookup) is what actually runs, regardless of which
+    value an earlier test warmed the cache with.
+    """
+    from llenergymeasure.infra.docker import command
+
+    command._runtime_requirements.cache_clear()
+    command._materialise_dispatch_assets.cache_clear()
+
+    if "needs_dist_metadata" in request.keywords:
+        try:
+            importlib.metadata.distribution(command._DISPATCH_DIST_NAME)
+        except importlib.metadata.PackageNotFoundError:
+            pytest.skip(
+                "llenergymeasure distribution metadata is not installed "
+                "(source tree on PYTHONPATH, no install); real-metadata "
+                "assertions are not applicable"
+            )
+        yield
+    else:
+        with patch.object(
+            command, "_runtime_requirements", return_value=_STUB_RUNTIME_REQUIREMENTS
+        ):
+            yield
+
+    command._runtime_requirements.cache_clear()
+    command._materialise_dispatch_assets.cache_clear()

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -44,14 +44,14 @@ def stub_runtime_requirements(request):
     real distribution metadata mark themselves ``needs_dist_metadata``; they are
     left unstubbed and skipped when the distribution is not installed.
 
-    The two ``functools.cache``-wrapped resolvers are cleared around every test
-    so the stub (or the real lookup) is what actually runs, regardless of which
-    value an earlier test warmed the cache with.
+    The stub is a ``patch.object`` attribute swap, so it takes effect without
+    touching the ``functools.cache``-wrapped resolvers. The process-lifetime
+    ``_materialise_dispatch_assets`` cache is deliberately left intact (it is
+    warmed once and reused, the behaviour the prefix-aware mkdtemp router is
+    built to tolerate); the ``needs_dist_metadata`` tests clear it themselves via
+    their ``_fresh`` helper when they need a live re-materialisation.
     """
     from llenergymeasure.infra.docker import command
-
-    command._runtime_requirements.cache_clear()
-    command._materialise_dispatch_assets.cache_clear()
 
     if "needs_dist_metadata" in request.keywords:
         try:
@@ -63,11 +63,7 @@ def stub_runtime_requirements(request):
                 "assertions are not applicable"
             )
         yield
-    else:
-        with patch.object(
-            command, "_runtime_requirements", return_value=_STUB_RUNTIME_REQUIREMENTS
-        ):
-            yield
+        return
 
-    command._runtime_requirements.cache_clear()
-    command._materialise_dispatch_assets.cache_clear()
+    with patch.object(command, "_runtime_requirements", return_value=_STUB_RUNTIME_REQUIREMENTS):
+        yield

--- a/tests/unit/docker/test_container_entrypoint.py
+++ b/tests/unit/docker/test_container_entrypoint.py
@@ -484,30 +484,8 @@ class TestMainGuard:
 
 
 # ---------------------------------------------------------------------------
-# Dependency-priming probe (bash entrypoint heredoc)
+# Dependency-priming probe (infra/_container/probe_imports.py)
 # ---------------------------------------------------------------------------
-
-
-def _extract_probe_source() -> str:
-    """Return the Python probe embedded in the container entrypoint heredoc.
-
-    The bash entrypoint runs the dep-priming probe as an inline
-    ``python3 - <<'PYEOF' ... PYEOF`` heredoc. Nothing else shells the script,
-    so the probe is exercised here by extracting that block verbatim and
-    running it the way the container does (``python3 <file> [reqs_path]``).
-    Resolved from the repo tree this test lives in (not the installed package)
-    so it validates the script under test.
-    """
-    repo_root = Path(__file__).resolve().parents[3]
-    script_path = (
-        repo_root / "src" / "llenergymeasure" / "infra" / "_container" / "container_entrypoint.sh"
-    )
-    script = script_path.read_text(encoding="utf-8")
-    _, open_marker, rest = script.partition("<<'PYEOF'\n")
-    assert open_marker, "probe heredoc opening marker not found in entrypoint script"
-    probe_src, close_marker, _ = rest.partition("\nPYEOF")
-    assert close_marker, "probe heredoc closing marker not found in entrypoint script"
-    return probe_src
 
 
 def _make_dist(
@@ -535,22 +513,58 @@ def _make_dist(
 
 
 def _run_probe(tmp_path: Path, site: Path, requirements: str) -> list[str]:
-    """Run the extracted probe against a fake site-packages; return missing specs."""
-    probe_py = tmp_path / "probe.py"
-    probe_py.write_text(_extract_probe_source(), encoding="utf-8")
+    """Run the real probe module against a fake site-packages; return missing specs.
+
+    Runs the shipped ``infra/_container/probe_imports.py`` as a plain script file
+    (exactly as the container entrypoint does) with a synthetic site-packages on
+    ``PYTHONPATH``. A fresh subprocess per case avoids in-process
+    ``importlib.metadata`` / ``sys.modules`` contamination from the real
+    environment (some fake dist names, e.g. pyyaml, collide with installed ones).
+    """
+    from llenergymeasure.infra._container import probe_imports
+
     reqs = tmp_path / "requirements.txt"
     reqs.write_text(requirements, encoding="utf-8")
 
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join([str(site), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
     proc = subprocess.run(
-        [sys.executable, str(probe_py), str(reqs)],
+        [sys.executable, probe_imports.__file__, str(reqs)],
         env=env,
         capture_output=True,
         text=True,
     )
     assert proc.returncode == 0, f"probe crashed: {proc.stderr}"
     return proc.stdout.split()
+
+
+class TestProbeImportsUnit:
+    """Direct-import unit coverage of the pure probe helpers.
+
+    The probe is a real module (not an inline heredoc), so its stateless helpers
+    are imported and exercised in-process.
+    """
+
+    def test_bare_name_strips_bounds_and_extras(self):
+        from llenergymeasure.infra._container import probe_imports
+
+        assert probe_imports.bare_name("pyarrow>=14.0") == "pyarrow"
+        assert probe_imports.bare_name("pydantic==2.5.0") == "pydantic"
+        assert probe_imports.bare_name("uvicorn[standard]>=0.30") == "uvicorn"
+        assert probe_imports.bare_name("numpy") == "numpy"
+
+    def test_canonical_normalises_case_and_separators(self):
+        from llenergymeasure.infra._container import probe_imports
+
+        assert probe_imports.canonical("PyYAML") == "pyyaml"
+        assert probe_imports.canonical("nvidia_ml_py") == "nvidia-ml-py"
+
+    def test_known_override_table(self):
+        from llenergymeasure.infra._container import probe_imports
+
+        assert probe_imports.IMPORT_NAME_OVERRIDES["pyyaml"] == "yaml"
+        assert probe_imports.IMPORT_NAME_OVERRIDES["nvidia-ml-py"] == "pynvml"
+        assert probe_imports.IMPORT_NAME_OVERRIDES["python-dotenv"] == "dotenv"
 
 
 class TestDepProbeImportCheck:

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -2096,6 +2096,7 @@ class TestDispatchAssetMaterialisation:
         )
         assert entry_script.read_bytes() == packaged
 
+    @pytest.mark.needs_dist_metadata
     def test_runtime_requirements_include_core_exclude_extras(self):
         """Core runtime deps are present; optional-extra deps (zeus/codecarbon) are not."""
         from llenergymeasure.infra.docker.command import _runtime_requirements
@@ -2113,6 +2114,7 @@ class TestDispatchAssetMaterialisation:
         # No environment markers leak into the materialised specs.
         assert all(";" not in s for s in specs)
 
+    @pytest.mark.needs_dist_metadata
     def test_requirements_file_content_matches_metadata(self):
         """The materialised requirements.txt lines equal _runtime_requirements()."""
         from llenergymeasure.infra.docker.command import (

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -113,14 +113,14 @@ class TestSuccessPath:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree") as mock_rmtree,
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree") as mock_rmtree,
         ):
             # Write a valid result JSON before runner reads it
             config_hash = _docker_config_hash(config)
@@ -156,14 +156,14 @@ class TestSuccessPath:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
         ):
             # Write result under the clean hash - both host and container agree
             result_path = exchange_dir / f"{direct_hash}_result.json"
@@ -189,11 +189,11 @@ class TestContainerFailure:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 return_value=make_subprocess_result(
                     1, stderr="Error: No such image: ghcr.io/example:latest"
                 ),
@@ -211,14 +211,14 @@ class TestContainerFailure:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 return_value=make_subprocess_result(1, stderr="Error: No such image"),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree") as mock_rmtree,
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree") as mock_rmtree,
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -251,11 +251,11 @@ class TestOOMError:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=lambda *a, **k: next(calls),
             ),
         ):
@@ -292,11 +292,11 @@ class TestTimeout:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=fake_run,
             ),
         ):
@@ -319,11 +319,11 @@ class TestPermissionError:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
                     make_subprocess_result(
                         1,
@@ -351,11 +351,11 @@ class TestMissingResultFile:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 return_value=make_subprocess_result(0),
             ),
         ):
@@ -384,14 +384,14 @@ class TestErrorPayloadFromContainer:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 return_value=make_subprocess_result(0),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
         ):
             config_hash = _docker_config_hash(config)
             result_path = exchange_dir / f"{config_hash}_result.json"
@@ -429,10 +429,10 @@ class TestDockerCommandStructure:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
-            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+            patch("llenergymeasure.infra.docker.lifecycle.subprocess.run", side_effect=fake_run),
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -489,10 +489,10 @@ class TestHFTokenPropagation:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
-            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+            patch("llenergymeasure.infra.docker.lifecycle.subprocess.run", side_effect=fake_run),
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -523,10 +523,10 @@ class TestHFTokenPropagation:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
-            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+            patch("llenergymeasure.infra.docker.lifecycle.subprocess.run", side_effect=fake_run),
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -552,14 +552,14 @@ class TestRunnerMetadata:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
         ):
             config_hash = _docker_config_hash(config)
             result_path = exchange_dir / f"{config_hash}_result.json"
@@ -589,18 +589,18 @@ class TestCleanupWarning:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.shutil.rmtree",
+                "llenergymeasure.infra.docker.exchange.shutil.rmtree",
                 side_effect=PermissionError("permission denied"),
             ),
-            caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker_runner"),
+            caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker.exchange"),
         ):
             config_hash = _docker_config_hash(config)
             result_path = exchange_dir / f"{config_hash}_result.json"
@@ -640,10 +640,10 @@ class TestHFTokenSecure:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
-            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+            patch("llenergymeasure.infra.docker.lifecycle.subprocess.run", side_effect=fake_run),
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -690,10 +690,10 @@ class TestHFTokenSecure:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
-            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+            patch("llenergymeasure.infra.docker.lifecycle.subprocess.run", side_effect=fake_run),
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -773,10 +773,10 @@ class TestEngineDispatchEnvVars:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
-            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+            patch("llenergymeasure.infra.docker.lifecycle.subprocess.run", side_effect=fake_run),
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -942,7 +942,7 @@ class TestExtraMounts:
         runner = DockerRunner(image=IMAGE)
 
         with patch(
-            "llenergymeasure.infra.docker_runner.Path.home",
+            "llenergymeasure.infra.docker.command.Path.home",
             return_value=Path("/home/testuser"),
         ):
             cmd = self._build_cmd(config, tmp_path, runner)
@@ -961,7 +961,7 @@ class TestExtraMounts:
         )
 
         with patch(
-            "llenergymeasure.infra.docker_runner.Path.home",
+            "llenergymeasure.infra.docker.command.Path.home",
             return_value=Path("/home/testuser"),
         ):
             cmd = self._build_cmd(config, tmp_path, runner)
@@ -1075,11 +1075,11 @@ class TestContainerLogPersistence:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
                     make_subprocess_result(137, stderr=stderr_content)
                 ),
@@ -1101,11 +1101,11 @@ class TestContainerLogPersistence:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
                     make_subprocess_result(1, stderr="some error text")
                 ),
@@ -1146,15 +1146,15 @@ class TestTimeseriesParquetRescue:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.shutil.rmtree",
+                "llenergymeasure.infra.docker.exchange.shutil.rmtree",
             ) as mock_rmtree,
         ):
             config_hash = _docker_config_hash(config)
@@ -1186,14 +1186,14 @@ class TestTimeseriesParquetRescue:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
         ):
             config_hash = _docker_config_hash(config)
             result_path = exchange_dir / f"{config_hash}_result.json"
@@ -1215,14 +1215,14 @@ class TestTimeseriesParquetRescue:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
         ):
             config_hash = _docker_config_hash(config)
             result_path = exchange_dir / f"{config_hash}_result.json"
@@ -1262,11 +1262,11 @@ class TestErrorJsonOnNonZeroExit:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
                     make_subprocess_result(1, stderr="some docker stderr noise")
                 ),
@@ -1302,11 +1302,11 @@ class TestErrorJsonOnNonZeroExit:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(
                     make_subprocess_result(1, stderr="Error: container failed with unknown reason")
                 ),
@@ -1335,14 +1335,14 @@ class TestVersionMismatchWarning:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
             caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker_runner"),
         ):
             config_hash = _docker_config_hash(config)
@@ -1366,14 +1366,14 @@ class TestVersionMismatchWarning:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
             caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker_runner"),
         ):
             config_hash = _docker_config_hash(config)
@@ -1399,14 +1399,14 @@ class TestVersionMismatchWarning:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
             caplog.at_level(logging.WARNING, logger="llenergymeasure.infra.docker_runner"),
         ):
             config_hash = _docker_config_hash(config)
@@ -1522,7 +1522,7 @@ class TestMountPivot:
 
     def test_resolve_package_dir_is_llenergymeasure(self):
         """The helper points at the ``llenergymeasure`` package directory itself."""
-        from llenergymeasure.infra.docker_runner import _resolve_package_dir
+        from llenergymeasure.infra.docker.command import _resolve_package_dir
 
         pkg_dir = _resolve_package_dir()
         assert pkg_dir.name == "llenergymeasure"
@@ -1530,7 +1530,7 @@ class TestMountPivot:
 
     def test_mount_host_path_matches_resolver(self, tmp_path):
         """The host side of the bind-mount equals ``_resolve_package_dir()``."""
-        from llenergymeasure.infra.docker_runner import _resolve_package_dir
+        from llenergymeasure.infra.docker.command import _resolve_package_dir
 
         cmd = self._build("transformers", tmp_path)
         expected_mount = f"{_resolve_package_dir()}:/llem-src/llenergymeasure:ro"
@@ -1553,7 +1553,7 @@ class TestMountPivot:
         the package dir, and assert the docker args mount only the package dir
         and never expose the foreign sibling.
         """
-        from llenergymeasure.infra import docker_runner
+        from llenergymeasure.infra.docker import command
 
         site_packages = tmp_path / "site-packages"
         pkg_dir = site_packages / "llenergymeasure"
@@ -1571,7 +1571,7 @@ class TestMountPivot:
 
         # Point the resolver at the package dir. Replacing the module attribute
         # sidesteps the functools.cache on the real resolver entirely.
-        monkeypatch.setattr(docker_runner, "_resolve_package_dir", lambda: pkg_dir)
+        monkeypatch.setattr(command, "_resolve_package_dir", lambda: pkg_dir)
 
         cmd = DockerRunner(image=IMAGE)._build_docker_cmd(make_config(), "abc123", "/tmp/llem-test")
 
@@ -1675,10 +1675,10 @@ class TestDockerGpusOverride:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 return_value=str(exchange_dir),
             ),
-            patch("llenergymeasure.infra.docker_runner.subprocess.run", side_effect=fake_run),
+            patch("llenergymeasure.infra.docker.lifecycle.subprocess.run", side_effect=fake_run),
         ):
             runner = DockerRunner(image=IMAGE)
             with pytest.raises(DockerImagePullError):
@@ -1839,14 +1839,14 @@ class TestConfigSidecarRescue:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree") as mock_rmtree,
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree") as mock_rmtree,
         ):
             config_hash = _docker_config_hash(config)
             (exchange_dir / f"{config_hash}_result.json").write_text(
@@ -1880,14 +1880,14 @@ class TestConfigSidecarRescue:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
         ):
             config_hash = _docker_config_hash(config)
             (exchange_dir / f"{config_hash}_result.json").write_text(
@@ -1922,14 +1922,14 @@ class TestConfigSidecarRescue:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree") as mock_rmtree,
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree") as mock_rmtree,
         ):
             config_hash = _docker_config_hash(config)
             (exchange_dir / f"{config_hash}_result.json").write_text(
@@ -1978,14 +1978,14 @@ class TestConfigSidecarRescue:
 
         with (
             patch(
-                "llenergymeasure.infra.docker_runner.tempfile.mkdtemp",
+                "llenergymeasure.infra.docker.exchange.tempfile.mkdtemp",
                 side_effect=_mkdtemp_router(exchange_dir, rescue_dir),
             ),
             patch(
-                "llenergymeasure.infra.docker_runner.subprocess.run",
+                "llenergymeasure.infra.docker.lifecycle.subprocess.run",
                 side_effect=_subprocess_run_with_image_cached(make_subprocess_result(0)),
             ),
-            patch("llenergymeasure.infra.docker_runner.shutil.rmtree"),
+            patch("llenergymeasure.infra.docker.exchange.shutil.rmtree"),
         ):
             config_hash = _docker_config_hash(config)
             (exchange_dir / f"{config_hash}_result.json").write_text(
@@ -2044,7 +2044,7 @@ class TestDispatchAssetMaterialisation:
     @staticmethod
     def _fresh():
         """Clear the process-lifetime caches so each test materialises anew."""
-        from llenergymeasure.infra.docker_runner import (
+        from llenergymeasure.infra.docker.command import (
             _materialise_dispatch_assets,
             _runtime_requirements,
         )
@@ -2054,7 +2054,7 @@ class TestDispatchAssetMaterialisation:
 
     def test_assets_materialised_to_existing_real_files(self):
         """Both dispatch assets resolve to real, non-empty files on disk."""
-        from llenergymeasure.infra.docker_runner import _materialise_dispatch_assets
+        from llenergymeasure.infra.docker.command import _materialise_dispatch_assets
 
         self._fresh()
         entry_script, requirements_file = _materialise_dispatch_assets()
@@ -2071,7 +2071,7 @@ class TestDispatchAssetMaterialisation:
         """The materialised script carries the execute bit (docker execs it)."""
         import os
 
-        from llenergymeasure.infra.docker_runner import _materialise_dispatch_assets
+        from llenergymeasure.infra.docker.command import _materialise_dispatch_assets
 
         self._fresh()
         entry_script, _ = _materialise_dispatch_assets()
@@ -2081,7 +2081,7 @@ class TestDispatchAssetMaterialisation:
         """The materialised script bytes equal the shipped package-data resource."""
         import importlib.resources
 
-        from llenergymeasure.infra.docker_runner import (
+        from llenergymeasure.infra.docker.command import (
             _ENTRY_SCRIPT_PACKAGE,
             _ENTRY_SCRIPT_RESOURCE,
             _materialise_dispatch_assets,
@@ -2098,7 +2098,7 @@ class TestDispatchAssetMaterialisation:
 
     def test_runtime_requirements_include_core_exclude_extras(self):
         """Core runtime deps are present; optional-extra deps (zeus/codecarbon) are not."""
-        from llenergymeasure.infra.docker_runner import _runtime_requirements
+        from llenergymeasure.infra.docker.command import _runtime_requirements
 
         self._fresh()
         specs = _runtime_requirements()
@@ -2115,7 +2115,7 @@ class TestDispatchAssetMaterialisation:
 
     def test_requirements_file_content_matches_metadata(self):
         """The materialised requirements.txt lines equal _runtime_requirements()."""
-        from llenergymeasure.infra.docker_runner import (
+        from llenergymeasure.infra.docker.command import (
             _materialise_dispatch_assets,
             _runtime_requirements,
         )
@@ -2142,12 +2142,12 @@ class TestDispatchAssetMaterialisation:
 
     def test_preflight_error_when_requirements_empty(self):
         """Underivable runtime deps raise DockerPreFlightError before docker run."""
-        from llenergymeasure.infra import docker_runner
+        from llenergymeasure.infra.docker import command
         from llenergymeasure.infra.docker_runner import append_package_dispatch
 
         self._fresh()
         try:
-            with patch.object(docker_runner, "_runtime_requirements", return_value=()):
+            with patch.object(command, "_runtime_requirements", return_value=()):
                 cmd: list[str] = []
                 with pytest.raises(DockerPreFlightError, match="runtime dependencies"):
                     append_package_dispatch(cmd, engine="vllm")

--- a/tests/unit/docker/test_docker_runner.py
+++ b/tests/unit/docker/test_docker_runner.py
@@ -2129,7 +2129,7 @@ class TestDispatchAssetMaterialisation:
         """A missing/unreadable script resource raises DockerPreFlightError before docker run."""
         import importlib.resources
 
-        from llenergymeasure.infra.docker_runner import append_package_dispatch
+        from llenergymeasure.infra.docker.command import append_package_dispatch
 
         self._fresh()
         try:
@@ -2143,7 +2143,7 @@ class TestDispatchAssetMaterialisation:
     def test_preflight_error_when_requirements_empty(self):
         """Underivable runtime deps raise DockerPreFlightError before docker run."""
         from llenergymeasure.infra.docker import command
-        from llenergymeasure.infra.docker_runner import append_package_dispatch
+        from llenergymeasure.infra.docker.command import append_package_dispatch
 
         self._fresh()
         try:

--- a/tests/unit/utils/test_env_config.py
+++ b/tests/unit/utils/test_env_config.py
@@ -9,15 +9,18 @@ pinning). See study/gpu_locks.py.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import pytest
 
 from llenergymeasure.utils.env_config import (
     ENV_DOCKER_GPUS,
+    ENV_DOCKER_HF_CACHE,
     ENV_DOCKER_SHM_SIZE,
     docker_gpus,
     docker_gpus_arg,
     docker_gpus_cache_token,
+    docker_hf_cache_dir,
     docker_shm_size,
     pinned_gpu_lock_ids,
     warn_on_gpu_selector_conflict,
@@ -278,3 +281,25 @@ class TestDockerShmSize:
         """A set value is forwarded verbatim."""
         monkeypatch.setenv(ENV_DOCKER_SHM_SIZE, "16g")
         assert docker_shm_size() == "16g"
+
+
+class TestDockerHfCacheDir:
+    def test_default_is_home_hf_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset LLEM_DOCKER_HF_CACHE -> the historical $HOME/.cache/huggingface."""
+        monkeypatch.delenv(ENV_DOCKER_HF_CACHE, raising=False)
+        assert docker_hf_cache_dir() == Path.home() / ".cache" / "huggingface"
+
+    def test_empty_is_home_hf_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty value falls back to the default."""
+        monkeypatch.setenv(ENV_DOCKER_HF_CACHE, "")
+        assert docker_hf_cache_dir() == Path.home() / ".cache" / "huggingface"
+
+    def test_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A set value is used verbatim as the host mount source."""
+        monkeypatch.setenv(ENV_DOCKER_HF_CACHE, "/mnt/scratch/hf")
+        assert docker_hf_cache_dir() == Path("/mnt/scratch/hf")
+
+    def test_override_expands_user(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A leading ~ in an explicit value is expanded."""
+        monkeypatch.setenv(ENV_DOCKER_HF_CACHE, "~/hf-cache")
+        assert docker_hf_cache_dir() == Path.home() / "hf-cache"


### PR DESCRIPTION
## Summary

Decomposes the 1291-line `infra/docker_runner.py` god-module into an `infra/docker/` package along concern seams. `DockerRunner` stays the facade at `llenergymeasure.infra.docker_runner` with its constructor and public method signatures unchanged, so consumers (StudyRunner, `study.single`, `study.baseline_container`, S11) import it exactly as before.

### Module map (line counts)

| Module | Lines | Concern |
|---|---|---|
| `docker_runner.py` (facade) | 349 | `DockerRunner` + `run()` orchestration, `_env_file` / `_mask_secrets`, re-exports `append_nccl_env` / `append_package_dispatch` |
| `docker/command.py` | 527 | Pure `docker run` builders: env forwarding, mounts, GPU/shm flags, image ref, package-dispatch bootstrap, dispatch-asset materialisation |
| `docker/lifecycle.py` | 455 | Container process execution: `ensure_image`, `launch`, `wait_to_completion`, `run_blocking`, and the watchdog |
| `docker/exchange.py` | 113 | Exchange-dir create / result read / artefact rescue / cleanup |
| `docker/diagnostics.py` | 68 | Container failure classification (log tail, error payload, error mapping) |

(was 1291 lines in one module)

### The launch/wait seam

The block-until-exit path is expressed as two separable steps in `lifecycle.py`:

- `launch(cmd) -> Popen` starts the container process only (detach-capable). A future server measurement mode (v0.8.0) reuses this and adds its own health-poll + explicit stop.
- `wait_to_completion(proc, ...)` streams stdout, forwards progress events, and **owns the stdout-silence + wall-clock watchdog**. The watchdog lives ONLY here, in the wait path - an idle-between-requests server that reused it would look "stuck", so a server lifecycle must not call it.

`DockerRunner._run_container_streaming` composes `launch` + `wait_to_completion` into the block-until-exit mode (kept as a method so the watchdog regression tests call it unchanged). No server dispatch / health-poll / stop is built here - only the seam is left clean (a1 #14/#15).

### Heredoc extraction

The ~90-line Python dependency-import probe previously embedded as a bash heredoc in `container_entrypoint.sh` is now a real package-data module, `infra/_container/probe_imports.py` (`_container` becomes a package). It is lint/mypy-covered and its unit tests import it directly. The shell script invokes it from the bind-mounted package source (`/llem-src/llenergymeasure/infra/_container/probe_imports.py`, needs no new mount) and fails loudly with a clear message if it is absent (the missing-`.py` risk from the brief).

### Cache-mount de-hardcode

The host HuggingFace cache mount is now configurable via `LLEM_DOCKER_HF_CACHE` (default `$HOME/.cache/huggingface`), mirroring the `LLEM_DOCKER_SHM_SIZE` pattern in `utils/env_config.py`. One-line docs addition in the docker how-to.

### Behavior freeze

Same env/mounts/flags, watchdog thresholds and messages, error classification, rescue semantics, and dep-isolation (#844/#845). Syscall monkeypatch targets moved patch-at-use-site into the concern modules (`subprocess.run` -> `docker.lifecycle`, `tempfile.mkdtemp` / `shutil.rmtree` -> `docker.exchange`, `Path.home` -> `docker.command`); the container-probe tests now exercise the real module (subprocess of the shipped file) plus new direct-import unit coverage of the pure helpers.

## Test plan

- `make lint` (ruff + import-linter: 5 contracts kept, 0 broken)
- `make typecheck` (mypy: 330 source files, no issues)
- `uv run pytest tests/unit/ -q` -> 3165 passed, 37 skipped
- `uv run pytest tests/integration/ -q` -> 24 passed, 10 GPU-gated deselected
- Docker unit suite (the regression floor incl. the deflaked rescue + watchdog classes): 303 passed