### PR TITLE
refactor(study): session seam + orchestration move to study layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `output_dir` onto the orchestrator's two single-purpose internal parameters
   (`results_dir_override` for a fresh run, resume search base for auto-detect
   resume). The cross-process progress consumer polls with a bounded timeout and a
-  sentinel-aware loop so a silent producer cannot hang the display thread. ([#TBD])
+  sentinel-aware loop so a silent producer cannot hang the display thread. ([#863])
 - Internal restructure (no behavior or results change): the 786-line
   `config/grid.py` is split into a grid-orchestration facade plus
   `config.sweep_expansion` (sweep-block expansion) and `config.cycle_ordering`
@@ -1357,3 +1357,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#857]: https://github.com/henrycgbaker/llenergymeasure/pull/857
 [#860]: https://github.com/henrycgbaker/llenergymeasure/pull/860
 [#862]: https://github.com/henrycgbaker/llenergymeasure/pull/862
+[#863]: https://github.com/henrycgbaker/llenergymeasure/pull/863

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,24 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Changed
 
+- Internal restructure (no behavior or results change): one experiment dispatch
+  is now an `ExperimentSession` (`llenergymeasure.study.session`) - a context
+  manager whose `__enter__` acquires the dispatch's resources, whose `run()`
+  produces the result, and whose `__exit__` releases everything exactly once, on
+  the SIGINT / circuit-break / exception paths alike. Two offline implementations
+  wrap the existing paths (`SubprocessSession`, `DockerSession`); the sweep loop
+  consumes them uniformly, so the manifest, circuit breaker, GPU locks, and SIGINT
+  handling key off the `(session, result)` outcome rather than off "the dispatch
+  function returned once" - the seam a future server mode needs to express
+  one-dispatch-many-results. The orchestration cluster that assembled and drove a
+  study (`_run` and friends) moves from `api/_impl.py` to a study-layer
+  orchestrator (`llenergymeasure.study.orchestration.orchestrate_study`); `api`
+  becomes a thin adapter and the public `run_experiment` / `run_study` signatures
+  and behaviour are unchanged. The adapter now maps the overloaded public
+  `output_dir` onto the orchestrator's two single-purpose internal parameters
+  (`results_dir_override` for a fresh run, resume search base for auto-detect
+  resume). The cross-process progress consumer polls with a bounded timeout and a
+  sentinel-aware loop so a silent producer cannot hang the display thread. ([#TBD])
 - Internal restructure (no behavior or results change): the 786-line
   `config/grid.py` is split into a grid-orchestration facade plus
   `config.sweep_expansion` (sweep-block expansion) and `config.cycle_ordering`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,12 +55,15 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   manager whose `__enter__` acquires the dispatch's resources, whose `run()`
   produces the result, and whose `__exit__` releases everything exactly once, on
   the SIGINT / circuit-break / exception paths alike. Two offline implementations
-  wrap the existing paths (`SubprocessSession`, `DockerSession`); the sweep loop
-  consumes them uniformly, so the manifest, circuit breaker, GPU locks, and SIGINT
-  handling key off the `(session, result)` outcome rather than off "the dispatch
-  function returned once" - the seam a future server mode needs to express
-  one-dispatch-many-results. The orchestration cluster that assembled and drove a
-  study (`_run` and friends) moves from `api/_impl.py` to a study-layer
+  wrap the existing paths (`SubprocessSession`, `DockerSession`). The value of the
+  seam is that the session lifetime (acquire -> produce -> release) is separable
+  from result production, which is what will let a future server session express
+  one lifetime with many result windows (constraint C3); today the sweep loop
+  still drives one session per experiment and consumes its single result, the
+  manifest transitions and circuit breaker follow that one result, GPU locks stay
+  study-scoped, and no N-result consumption is added now. The orchestration
+  cluster that assembled and drove a study (`_run` and friends) moves from
+  `api/_impl.py` to a study-layer
   orchestrator (`llenergymeasure.study.orchestration.orchestrate_study`); `api`
   becomes a thin adapter and the public `run_experiment` / `run_study` signatures
   and behaviour are unchanged. The adapter now maps the overloaded public

--- a/src/llenergymeasure/api/README.md
+++ b/src/llenergymeasure/api/README.md
@@ -81,16 +81,20 @@ All failures are collected and raised together as a single `PreFlightError` so t
 
 ## Dispatch flow
 
+`api/` is a thin adapter; the orchestration itself lives in the study layer
+(`study.orchestration.orchestrate_study`).
+
 ```
 run_experiment(...)
   └─ _to_study_config()       # normalise all input forms to StudyConfig
 run_study(...)
-  └─ _run(study)              # shared dispatcher
-        ├─ run_study_preflight()
-        ├─ resolve_study_runners()
-        ├─ create_study_dir() + ManifestWriter
-        ├─ run_single_experiment()  # single experiment (study layer): harness or DockerRunner directly
-        └─ _run_via_runner()        # multi-experiment: StudyRunner subprocess loop
+  └─ (adapter: map output_dir -> results_dir_override / resume search base)
+     └─ study.orchestration.orchestrate_study(study)   # study-layer dispatcher
+           ├─ run_study_preflight()
+           ├─ resolve_study_runners()
+           ├─ create_study_dir() + ManifestWriter
+           ├─ run_single_experiment()  # single experiment (study layer): harness or DockerRunner directly
+           └─ _run_via_runner()        # multi-experiment: StudyRunner drives one session per experiment
 ```
 
 ## Layer constraints

--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -1,13 +1,18 @@
 """Internal API implementation for llenergymeasure.
 
 This module is internal (underscore prefix). Import via llenergymeasure.__init__ only.
+
+It is a thin adapter over the study-layer orchestrator
+(:func:`llenergymeasure.study.orchestration.orchestrate_study`): it loads and
+validates config, translates the public call forms and the overloaded public
+``output_dir`` argument into the orchestrator's explicit internal parameters, and
+delegates. The public API surface (``load_study`` / ``run_experiment`` /
+``run_study`` signatures and behaviour, and ``api.__all__``) is frozen; the
+orchestration itself lives in the study layer.
 """
 
 from __future__ import annotations
 
-import json
-import logging
-import time
 from pathlib import Path
 from typing import Any, overload
 
@@ -19,19 +24,10 @@ from llenergymeasure.config.models import (
     StudyConfig,
     TaskConfig,
 )
-from llenergymeasure.config.ssot import RUNNER_DOCKER
-from llenergymeasure.domain.bundle_artefacts import (
-    ENVIRONMENT_FILENAME,
-    STUDY_ARTEFACTS_DIR,
-    SYSTEM_OVERRIDES_FILENAME,
-)
-from llenergymeasure.domain.experiment import ExperimentResult, StudyResult, StudySummary
+from llenergymeasure.domain.experiment import ExperimentResult, StudyResult
 from llenergymeasure.domain.progress import ProgressCallback
 from llenergymeasure.infra.runner_resolution import RunnerSpec
-from llenergymeasure.study.single import run_single_experiment
 from llenergymeasure.utils.exceptions import ConfigError
-
-logger = logging.getLogger(__name__)
 
 # Single source of truth for n_prompts default - derived from DatasetConfig field default
 # so run_experiment() kwargs and DatasetConfig always agree.
@@ -157,12 +153,14 @@ def run_experiment(
         ConfigError: Invalid config path, missing model in kwargs form.
         pydantic.ValidationError: Invalid field values (passes through unchanged).
     """
+    from llenergymeasure.study.orchestration import orchestrate_study
+
     study = _to_study_config(
         config, model=model, engine=engine, n_prompts=n_prompts, dataset=dataset, **kwargs
     )
     if output_dir is not None:
         study.output = study.output.model_copy(update={"results_dir": str(output_dir)})
-    study_result = _run(study, skip_preflight=skip_preflight, progress=progress)
+    study_result = orchestrate_study(study, skip_preflight=skip_preflight, progress=progress)
     if not study_result.experiments:
         from llenergymeasure.utils.exceptions import ExperimentError
 
@@ -225,8 +223,8 @@ def run_study(
             showing which fields were overridden by CLI flags vs YAML vs sweep.
         preresolved: Optional ``(runner_specs, system_overrides)`` already
             computed by a prior ``run_study_preflight`` call (e.g. the CLI runs
-            preflight to render the panel). When supplied, ``_run`` reuses it
-            instead of re-running preflight. Must be paired with
+            preflight to render the panel). When supplied, the orchestrator reuses
+            it instead of re-running preflight. Must be paired with
             ``skip_preflight=True`` so the precomputed result is trusted.
 
     Returns:
@@ -239,6 +237,8 @@ def run_study(
         StudyError: Config drift detected (study_design_hash changed).
         pydantic.ValidationError: Invalid field values (passes through unchanged).
     """
+    from llenergymeasure.study.orchestration import orchestrate_study
+
     if isinstance(config, (str, Path)):
         config_path = config_path or Path(config).resolve()
         study = load_study(config_path)
@@ -247,6 +247,16 @@ def run_study(
         study = config
     else:
         raise ConfigError(f"Expected str, Path, or StudyConfig; got {type(config).__name__}")
+
+    # #842 adapter mapping: the public ``output_dir`` is overloaded, so split it
+    # into the orchestrator's two single-purpose internal roles:
+    #   - resume_search_base: base dir scanned for the most recent resumable
+    #     study (auto-detect resume only; ignored when resume_dir is explicit).
+    #   - results_dir_override: results-dir override for a fresh run.
+    # A resume consumes resume_search_base here (to locate the study) and hands
+    # the orchestrator results_dir_override=None; a fresh run does the reverse.
+    resume_search_base = output_dir
+    results_dir_override = output_dir
 
     # Resolve resume state if requested.
     if resume_dir is not None or resume:
@@ -259,8 +269,7 @@ def run_study(
         from llenergymeasure.utils.exceptions import StudyError
 
         if resume_dir is None:
-            _output = output_dir or Path("results")
-            resume_dir = find_resumable_study(_output)
+            resume_dir = find_resumable_study(resume_search_base or Path("results"))
             if resume_dir is None:
                 raise StudyError("No resumable study found. Run a study first or use --resume-dir.")
 
@@ -268,14 +277,14 @@ def run_study(
         validate_config_drift(old_manifest, study)
         prepare_resume_manifest(resume_dir, old_manifest)
 
-    return _run(
+    return orchestrate_study(
         study,
         skip_preflight=skip_preflight,
         progress=progress,
         resume_dir=resume_dir,
-        # Fresh runs (resume_dir is None) use output_dir as the results-dir
-        # override; resume runs already consumed it as the search base above.
-        results_dir_override=output_dir if resume_dir is None else None,
+        # Fresh runs (resume_dir is None) apply results_dir_override; a resume
+        # already consumed output_dir as the search base above, so pass None.
+        results_dir_override=results_dir_override if resume_dir is None else None,
         skip_set=skip_set,
         no_lock=no_lock,
         config_path=config_path,
@@ -334,421 +343,3 @@ def _to_study_config(
             f"Expected str, Path, ExperimentConfig, or None; got {type(config).__name__}"
         )
     return StudyConfig(experiments=[experiment])
-
-
-def _ensure_study_artefacts_dir(study_dir: Path) -> Path:
-    """Create and return the _study-artefacts/ subdirectory."""
-    artefacts_dir = study_dir / STUDY_ARTEFACTS_DIR
-    artefacts_dir.mkdir(exist_ok=True)
-    return artefacts_dir
-
-
-def _write_skipped_configs_log(
-    skipped_configs: list[dict[str, Any]],
-    artefacts_dir: Path,
-    study_design_hash: str = "",
-    study_name: str = "",
-) -> None:
-    """Write detailed skipped-config information to the _study-artefacts directory."""
-    log_path = artefacts_dir / "skipped_configs.log"
-    lines = [
-        f"# study_design_hash: {study_design_hash} | study_name: {study_name}",
-        f"Skipped {len(skipped_configs)} config(s) due to validation errors\n",
-    ]
-    for s in skipped_configs:
-        label = s.get("short_label", "unknown")
-        reason = s.get("reason", "unknown error")
-        lines.append(f"  {label}")
-        lines.append(f"    {reason}")
-        lines.append("")
-    log_path.write_text("\n".join(lines))
-
-
-def _run(
-    study: StudyConfig,
-    skip_preflight: bool = False,
-    progress: ProgressCallback | None = None,
-    resume_dir: Path | None = None,
-    results_dir_override: Path | None = None,
-    skip_set: set[tuple[str, int]] | None = None,
-    no_lock: bool = False,
-    config_path: Path | None = None,
-    cli_overrides: dict[str, Any] | None = None,
-    preresolved: tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]] | None = None,
-) -> StudyResult:
-    """Dispatcher: single experiment runs in-process; multi-experiment uses StudyRunner.
-
-    Always:
-    - Calls run_study_preflight() first (multi-engine guard and Docker pre-flight checks)
-    - Resolves runner specs for all engines in the study
-    - Creates study output directory and ManifestWriter
-    - Returns fully populated StudyResult
-
-    Single-experiment / n_cycles=1:  runs in-process or via DockerRunner directly.
-    Otherwise:                         delegates to StudyRunner.
-    """
-    from llenergymeasure.config.user_config import load_user_config
-    from llenergymeasure.study.manifest import ManifestWriter, create_study_dir
-
-    # Preresolved runner specs bypass preflight; demanding skip_preflight makes the
-    # contract explicit rather than silently ignoring the precomputed result.
-    if preresolved is not None and not skip_preflight:
-        raise ValueError("preresolved requires skip_preflight=True")
-
-    # Load user config first so runner context can be forwarded to preflight,
-    # ensuring preflight uses the same runner resolution as the actual dispatch path.
-    user_config = load_user_config()
-
-    runner_specs, system_overrides = _resolve_runner_specs(
-        study, user_config, preresolved, skip_preflight, progress
-    )
-
-    # Resolve results_dir: resume_dir takes priority, then the fresh-run chain
-    # (CLI -o override > YAML output.results_dir > user config > built-in default).
-    if resume_dir is not None:
-        study_dir = resume_dir
-        # Resume: load the existing manifest written by prepare_resume_manifest()
-        # and wrap it without rebuilding or overwriting the prepared manifest.
-        from llenergymeasure.study.resume import load_resume_state
-
-        loaded_manifest, _ = load_resume_state(study_dir)
-        manifest = ManifestWriter.from_existing(study_dir, loaded_manifest)
-    else:
-        if results_dir_override is not None:
-            results_dir_str = str(results_dir_override)
-        else:
-            results_dir_str = (
-                study.output.results_dir or user_config.output.results_dir or "./results"
-            )
-        study_dir = create_study_dir(study.study_name, Path(results_dir_str))
-        manifest = ManifestWriter(study, study_dir)
-
-    # Create _study-artefacts/ once for config copy, skipped log, and study-level env.
-    artefacts_dir = _ensure_study_artefacts_dir(study_dir)
-
-    _write_study_artefacts(study, artefacts_dir, system_overrides, config_path)
-
-    resolution_logs = _build_resolution_logs(study, cli_overrides)
-
-    wall_start = time.monotonic()
-    is_single = len(study.experiments) == 1 and study.study_execution.n_cycles == 1
-
-    if is_single:
-        result_files, experiment_results, warnings = _run_single_experiment_dispatch(
-            study, manifest, study_dir, runner_specs, progress, resolution_logs
-        )
-    else:
-        result_files, experiment_results, warnings = _run_via_runner(
-            study,
-            manifest,
-            study_dir,
-            runner_specs=runner_specs,
-            progress=progress,
-            skip_set=skip_set,
-            no_lock=no_lock,
-            resolution_logs=resolution_logs,
-        )
-
-    wall_time = time.monotonic() - wall_start
-
-    # Mark the study completed - but never overwrite a terminal abort status the
-    # runner already set (wall-clock timeout or circuit-breaker). Doing so would make
-    # an aborted study look completed and therefore non-resumable, leaving its skipped
-    # experiments to never re-run. The SIGINT path calls mark_interrupted() then
-    # sys.exit(130) before returning here, so 'interrupted' is not normally seen.
-    if manifest.status not in ("timed_out", "circuit_breaker", "interrupted"):
-        manifest.mark_study_completed()
-
-    completed = sum(1 for r in experiment_results if r is not None)
-    failed = len(experiment_results) - completed
-    total_energy = sum(r.total_energy_j for r in experiment_results if r is not None)
-
-    # study.experiments is already cycle-expanded by apply_cycles(), so len() is the true total
-    n_cycles = study.study_execution.n_cycles
-    unique_configs = len(study.experiments) // n_cycles if n_cycles > 0 else len(study.experiments)
-
-    measurement_protocol: dict[str, Any] = {
-        "n_cycles": study.study_execution.n_cycles,
-        "experiment_order": study.study_execution.experiment_order,
-        "experiment_gap_seconds": study.study_execution.experiment_gap_seconds,
-        "cycle_gap_seconds": study.study_execution.cycle_gap_seconds,
-        "shuffle_seed": study.study_execution.shuffle_seed,
-        "experiment_timeout_seconds": study.study_execution.experiment_timeout_seconds,
-    }
-
-    summary = StudySummary(
-        total_experiments=len(study.experiments),
-        completed=completed,
-        failed=failed,
-        total_wall_time_s=wall_time,
-        total_energy_j=total_energy,
-        unique_configurations=unique_configs,
-        warnings=warnings,
-    )
-
-    return StudyResult(
-        experiments=[r for r in experiment_results if r is not None],
-        study_name=study.study_name,
-        study_design_hash=study.study_design_hash,
-        measurement_protocol=measurement_protocol,
-        result_files=result_files,
-        summary=summary,
-        skipped_experiments=study.skipped_configs,
-    )
-
-
-def _resolve_runner_specs(
-    study: StudyConfig,
-    user_config: Any,
-    preresolved: tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]] | None,
-    skip_preflight: bool,
-    progress: ProgressCallback | None,
-) -> tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]]:
-    """Resolve runner specs via preflight, or reuse a caller-provided preresolved result.
-
-    Runs precedence-based multi-engine elevation + Docker preflight (explicit
-    runner pins win; auto-resolved engines elevate to Docker, raising
-    PreFlightError when a local-pinned engine is not importable on the host or an
-    auto-resolved engine needs Docker but it is unavailable), emits preflight
-    progress, and warns when the study mixes local and Docker runners.
-    """
-    from llenergymeasure.study.preflight import run_study_preflight
-
-    if preresolved is not None:
-        runner_specs, system_overrides = preresolved
-    else:
-        if progress:
-            progress.on_step_start("preflight", "Checking", "environment and Docker")
-            t0_pf = time.perf_counter()
-        try:
-            runner_specs, system_overrides = run_study_preflight(
-                study,
-                skip_preflight=skip_preflight,
-                yaml_runners=study.runners,
-                user_config=user_config.runners,
-                yaml_images=study.images,
-                user_config_images=user_config.images or None,
-            )
-        except Exception:
-            if progress:
-                progress.on_step_done("preflight", time.perf_counter() - t0_pf)
-            raise
-        if progress:
-            progress.on_step_done("preflight", time.perf_counter() - t0_pf)
-
-    # Warn on mixed runners (some local, some docker)
-    modes = {spec.mode for spec in runner_specs.values()}
-    if len(modes) > 1:
-        logger.warning(
-            "Mixed runners detected. For consistent measurements, "
-            "consider running all engines in Docker."
-        )
-    return runner_specs, system_overrides
-
-
-def _write_study_artefacts(
-    study: StudyConfig,
-    artefacts_dir: Path,
-    system_overrides: dict[str, dict[str, str]],
-    config_path: Path | None,
-) -> None:
-    """Persist study-level artefacts to ``_study-artefacts/``.
-
-    Writes the original YAML copy (with an identity header), the skipped-config log,
-    the system-overrides record, and the software environment snapshot. Each write is
-    best-effort and logs on failure rather than aborting the run.
-    """
-
-    # Identity fields for all study-level artefacts
-    _study_hash = study.study_design_hash or ""
-    _study_name = study.study_name or ""
-
-    # Copy original YAML config to _study-artefacts/ with identity header.
-    if config_path is not None:
-        dest = artefacts_dir / "study_config.yaml"
-        try:
-            original = Path(config_path).read_text(encoding="utf-8")
-            header = f"# study_design_hash: {_study_hash} | study_name: {_study_name}\n"
-            dest.write_text(header + original, encoding="utf-8")
-            logger.info("Config YAML copied to %s", dest)
-        except FileNotFoundError:
-            logger.warning("Config YAML %s not found, skipping copy", config_path)
-
-    # Persist skipped config details to _study-artefacts/.
-    if study.skipped_configs:
-        _write_skipped_configs_log(study.skipped_configs, artefacts_dir, _study_hash, _study_name)
-
-    # Persist system overrides to _study-artefacts/ (runner auto-elevation, etc.)
-    if system_overrides:
-        overrides_with_identity = {
-            "study_design_hash": _study_hash,
-            "study_name": _study_name,
-            **system_overrides,
-        }
-        overrides_path = artefacts_dir / SYSTEM_OVERRIDES_FILENAME
-        try:
-            overrides_path.write_text(
-                json.dumps(overrides_with_identity, indent=2), encoding="utf-8"
-            )
-            logger.info("System overrides written to %s", overrides_path)
-        except OSError as exc:
-            logger.warning("Failed to write system_overrides.json: %s", exc)
-
-    # Write study-level environment.json (installed_packages + software constants).
-    try:
-        from llenergymeasure.harness.environment import collect_software_environment
-
-        sw_env = collect_software_environment()
-        study_env = {
-            "study_design_hash": _study_hash,
-            "study_name": _study_name,
-            **sw_env,
-        }
-        env_path = artefacts_dir / ENVIRONMENT_FILENAME
-        env_path.write_text(json.dumps(study_env, indent=2), encoding="utf-8")
-        logger.info("Study-level environment written to %s", env_path)
-    except Exception as exc:
-        logger.warning("Failed to write study-level environment.json: %s", exc)
-
-
-def _build_resolution_logs(
-    study: StudyConfig, cli_overrides: dict[str, Any] | None
-) -> dict[str, dict[str, Any]]:
-    """Build per-experiment resolution logs keyed by declared-config hash.
-
-    Computed once here so runners don't need to know about resolution logic.
-    Best-effort: returns whatever was built before any failure.
-    """
-    resolution_logs: dict[str, dict[str, Any]] = {}
-    try:
-        from llenergymeasure.config.introspection import get_swept_field_paths
-        from llenergymeasure.config.resolution import build_resolution_log
-        from llenergymeasure.domain.experiment import compute_declared_config_hash
-
-        swept_fields = get_swept_field_paths(study.experiments)
-        seen_hashes: set[str] = set()
-        for exp in study.experiments:
-            h = compute_declared_config_hash(exp)
-            if h in seen_hashes:
-                continue
-            seen_hashes.add(h)
-            resolution_logs[h] = build_resolution_log(
-                exp.model_dump(),
-                cli_overrides=cli_overrides,
-                swept_fields=swept_fields,
-            )
-    except Exception as exc:
-        logger.debug("Failed to build resolution logs: %s", exc)
-    return resolution_logs
-
-
-def _run_single_experiment_dispatch(
-    study: StudyConfig,
-    manifest: Any,
-    study_dir: Path,
-    runner_specs: Any,
-    progress: ProgressCallback | None,
-    resolution_logs: dict[str, dict[str, Any]],
-) -> tuple[list[str], list[ExperimentResult | None], list[str]]:
-    """Run a single-experiment study in-process, emitting study-table begin/end events.
-
-    For a StudyProgressCallback, emits begin_experiment / end_experiment_(ok|fail) so
-    the study display shows the single experiment's table row.
-    """
-    from llenergymeasure.domain.progress import STEPS_LOCAL, StudyProgressCallback, docker_steps
-
-    study_cb: StudyProgressCallback | None = (
-        progress if isinstance(progress, StudyProgressCallback) else None
-    )
-    if study_cb is not None:
-        from llenergymeasure.utils.formatting import format_experiment_header
-
-        config = study.experiments[0]
-        spec = runner_specs.get(config.engine) if runner_specs else None
-        is_docker = spec and spec.mode == RUNNER_DOCKER
-        if is_docker:
-            host_baseline = (
-                config.measurement.baseline.enabled
-                and config.measurement.baseline.strategy != "fresh"
-            )
-            steps = docker_steps(images_prepared=False, host_baseline=host_baseline)
-        else:
-            steps = list(STEPS_LOCAL)
-        study_cb.begin_experiment(
-            1,
-            format_experiment_header(config),
-            steps,
-            runner_info=spec.to_runner_info() if spec else None,
-        )
-
-    exp_start = time.monotonic()
-    result_files, experiment_results, warnings = run_single_experiment(
-        study,
-        manifest,
-        study_dir,
-        runner_specs=runner_specs,
-        progress=progress,
-        resolution_logs=resolution_logs,
-    )
-    exp_elapsed = time.monotonic() - exp_start
-
-    if study_cb is not None:
-        r = experiment_results[0] if experiment_results else None
-        if r is not None:
-            energy = r.total_energy_j if r.total_energy_j > 0 else None
-            tp = r.avg_tokens_per_second if r.avg_tokens_per_second > 0 else None
-            infer = r.total_inference_time_sec if r.total_inference_time_sec > 0 else None
-            adj_e = r.energy_adjusted_j if r.energy_adjusted_j and r.energy_adjusted_j > 0 else None
-            study_cb.end_experiment_ok(
-                1,
-                exp_elapsed,
-                energy_j=energy,
-                throughput_tok_s=tp,
-                inference_time_sec=infer,
-                adj_energy_j=adj_e,
-                mj_per_tok_adjusted=r.mj_per_tok_adjusted,
-                mj_per_tok_total=r.mj_per_tok_total,
-            )
-        else:
-            study_cb.end_experiment_fail(1, exp_elapsed)
-
-    return result_files, experiment_results, warnings
-
-
-def _run_via_runner(
-    study: StudyConfig,
-    manifest: Any,
-    study_dir: Path,
-    runner_specs: Any = None,
-    progress: ProgressCallback | None = None,
-    skip_set: set[tuple[str, int]] | None = None,
-    no_lock: bool = False,
-    resolution_logs: dict[str, dict[str, Any]] | None = None,
-) -> tuple[list[str], list[ExperimentResult | None], list[str]]:
-    """Delegate to StudyRunner for multi-experiment / multi-cycle runs."""
-    from llenergymeasure.domain.progress import StudyProgressCallback
-    from llenergymeasure.study.runner import StudyRunner
-
-    study_progress = progress if isinstance(progress, StudyProgressCallback) else None
-    runner = StudyRunner(
-        study,
-        manifest,
-        study_dir,
-        runner_specs=runner_specs,
-        progress=study_progress,
-        no_lock=no_lock,
-        skip_set=skip_set,
-        resolution_logs=resolution_logs,
-    )
-    raw_results = runner.run()
-
-    warnings: list[str] = []
-    experiment_results: list[ExperimentResult | None] = []
-    for r in raw_results:
-        if isinstance(r, dict):
-            warnings.append(r.get("message", "Unknown error"))
-            experiment_results.append(None)
-        else:
-            experiment_results.append(r)
-
-    return runner.result_files, experiment_results, warnings

--- a/src/llenergymeasure/config/ssot.py
+++ b/src/llenergymeasure/config/ssot.py
@@ -185,6 +185,11 @@ TIMEOUT_SIGTERM_GRACE: Final = 2
 TIMEOUT_INTERRUPT_POLL: Final = 1
 """Interrupt event wait loop tick."""
 
+TIMEOUT_PROGRESS_QUEUE_POLL: Final = 1
+"""Progress-consumer ``queue.get`` poll tick: bounds each blocking get so the
+display thread stays responsive and a wedged queue cannot hang it indefinitely -
+it loops back and re-checks for the parent's sentinel."""
+
 # ---------------------------------------------------------------------------
 # Per-engine descriptor registry
 # ---------------------------------------------------------------------------
@@ -360,6 +365,7 @@ __all__ = [
     "TIMEOUT_ENV_SNAPSHOT",
     "TIMEOUT_INTERRUPT_POLL",
     "TIMEOUT_NVIDIA_SMI",
+    "TIMEOUT_PROGRESS_QUEUE_POLL",
     "TIMEOUT_SIGTERM_GRACE",
     "TIMEOUT_THREAD_JOIN",
     "BatchSizeModel",

--- a/src/llenergymeasure/study/README.md
+++ b/src/llenergymeasure/study/README.md
@@ -10,7 +10,9 @@ Implements the sweep runner that executes a `StudyConfig` (a list of `Experiment
 
 | Module | Description |
 |--------|-------------|
-| `runner.py` | `StudyRunner` - study-level run loop, dispatch, and result handling |
+| `orchestration.py` | `orchestrate_study()` - study-layer dispatcher: preflight, study dir + manifest, single-vs-sweep branch, `StudyResult` assembly (the `api` layer is a thin adapter over it) |
+| `runner.py` | `StudyRunner` - study-level run loop; drives one `ExperimentSession` per experiment and owns SIGINT, GPU locks, circuit breaker, wall-clock timeout |
+| `session.py` | `ExperimentSession` protocol + offline `SubprocessSession` / `DockerSession` - context-managed engine lifetimes (setup on enter, teardown on exit, always) |
 | `worker.py` | `_run_experiment_worker()` (child entry point), `_collect_result()`, process-group signalling |
 | `_progress.py` | `_QueueProgressCallback` + `_consume_progress_events()` - cross-process progress bridge |
 | `baseline_measure.py` | `_BaselineMixin` - baseline measurement, caching, and drift validation |
@@ -80,6 +82,6 @@ Before each experiment dispatch, `check_gpu_memory_residual()` polls for leftove
 
 ## Related
 
-- See `../api/_impl.py` for `_run()` which instantiates `StudyRunner`
+- See `orchestration.py` for `orchestrate_study()` which instantiates `StudyRunner`; `../api/_impl.py` is the thin public adapter
 - See `../harness/` for the measurement lifecycle each subprocess runs
 - See `../infra/docker_runner.py` for Docker dispatch path

--- a/src/llenergymeasure/study/_progress.py
+++ b/src/llenergymeasure/study/_progress.py
@@ -13,7 +13,10 @@ Pure plumbing: neither half touches ``StudyRunner`` state.
 from __future__ import annotations
 
 import contextlib
+import queue
 from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.config.ssot import TIMEOUT_PROGRESS_QUEUE_POLL
 
 if TYPE_CHECKING:
     from llenergymeasure.domain.progress import StudyProgressCallback
@@ -80,10 +83,21 @@ def _consume_progress_events(
     StudyProgressCallback (typically StudyStepDisplay).
 
     Coarse events (started/completed/failed) are ignored here - study-level
-    begin/end experiment tracking is handled directly by _run_one().
+    begin/end experiment tracking is handled directly by the session dispatch.
+
+    The blocking get is bounded by ``TIMEOUT_PROGRESS_QUEUE_POLL`` and loops on
+    timeout: a dead producer that never flushes its buffer cannot wedge this
+    thread indefinitely on a single ``get``. The parent always enqueues the
+    ``None`` sentinel when the session finishes (even on SIGKILL/timeout), which
+    is what actually ends the loop.
     """
     while True:
-        event = q.get()
+        try:
+            event = q.get(timeout=TIMEOUT_PROGRESS_QUEUE_POLL)
+        except queue.Empty:
+            # No event this tick; re-check for the sentinel rather than blocking
+            # forever on a producer that may have died mid-flush.
+            continue
         if event is None:
             break
 

--- a/src/llenergymeasure/study/orchestration.py
+++ b/src/llenergymeasure/study/orchestration.py
@@ -1,0 +1,461 @@
+"""Study-layer orchestration: the single owner of the run loop's setup + assembly.
+
+``orchestrate_study`` is the study layer's orchestration entry point. It owns
+what used to live in ``api/_impl._run``: resolve runner specs (preflight),
+create the study directory + manifest (or reattach one for resume), write the
+study-level artefacts, build the per-experiment resolution logs, branch between
+the single-experiment in-process path and the multi-experiment ``StudyRunner``,
+and assemble the final ``StudyResult``.
+
+The ``api`` layer is a thin adapter over this module: it translates the public
+call forms into a resolved ``StudyConfig`` and the orchestrator's explicit
+internal parameters, then delegates. Keeping the orchestration here (not in
+``api``) makes the layer boundary honest - the config layer never imports upward
+into ``study`` and the orchestration never re-imports downward from ``api``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from llenergymeasure.config.models import StudyConfig
+from llenergymeasure.config.ssot import RUNNER_DOCKER
+from llenergymeasure.domain.bundle_artefacts import (
+    ENVIRONMENT_FILENAME,
+    STUDY_ARTEFACTS_DIR,
+    SYSTEM_OVERRIDES_FILENAME,
+)
+from llenergymeasure.domain.experiment import ExperimentResult, StudyResult, StudySummary
+from llenergymeasure.domain.progress import ProgressCallback
+from llenergymeasure.infra.runner_resolution import RunnerSpec
+from llenergymeasure.study.single import run_single_experiment
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_study_artefacts_dir(study_dir: Path) -> Path:
+    """Create and return the _study-artefacts/ subdirectory."""
+    artefacts_dir = study_dir / STUDY_ARTEFACTS_DIR
+    artefacts_dir.mkdir(exist_ok=True)
+    return artefacts_dir
+
+
+def _write_skipped_configs_log(
+    skipped_configs: list[dict[str, Any]],
+    artefacts_dir: Path,
+    study_design_hash: str = "",
+    study_name: str = "",
+) -> None:
+    """Write detailed skipped-config information to the _study-artefacts directory."""
+    log_path = artefacts_dir / "skipped_configs.log"
+    lines = [
+        f"# study_design_hash: {study_design_hash} | study_name: {study_name}",
+        f"Skipped {len(skipped_configs)} config(s) due to validation errors\n",
+    ]
+    for s in skipped_configs:
+        label = s.get("short_label", "unknown")
+        reason = s.get("reason", "unknown error")
+        lines.append(f"  {label}")
+        lines.append(f"    {reason}")
+        lines.append("")
+    log_path.write_text("\n".join(lines))
+
+
+def orchestrate_study(
+    study: StudyConfig,
+    skip_preflight: bool = False,
+    progress: ProgressCallback | None = None,
+    resume_dir: Path | None = None,
+    results_dir_override: Path | None = None,
+    skip_set: set[tuple[str, int]] | None = None,
+    no_lock: bool = False,
+    config_path: Path | None = None,
+    cli_overrides: dict[str, Any] | None = None,
+    preresolved: tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]] | None = None,
+) -> StudyResult:
+    """Dispatcher: single experiment runs in-process; multi-experiment uses StudyRunner.
+
+    Always:
+    - Calls run_study_preflight() first (multi-engine guard and Docker pre-flight checks)
+    - Resolves runner specs for all engines in the study
+    - Creates study output directory and ManifestWriter
+    - Returns fully populated StudyResult
+
+    Single-experiment / n_cycles=1:  runs in-process or via DockerRunner directly.
+    Otherwise:                         delegates to StudyRunner.
+
+    The two directory parameters are single-purpose (the ``api`` adapter maps the
+    overloaded public ``output_dir`` onto them):
+    - ``resume_dir``: an explicit study directory to reattach and resume into.
+    - ``results_dir_override``: the results-dir override for a fresh run
+      (precedence head, above YAML ``output.results_dir`` and user config).
+    """
+    from llenergymeasure.config.user_config import load_user_config
+    from llenergymeasure.study.manifest import ManifestWriter, create_study_dir
+
+    # Preresolved runner specs bypass preflight; demanding skip_preflight makes the
+    # contract explicit rather than silently ignoring the precomputed result.
+    if preresolved is not None and not skip_preflight:
+        raise ValueError("preresolved requires skip_preflight=True")
+
+    # Load user config first so runner context can be forwarded to preflight,
+    # ensuring preflight uses the same runner resolution as the actual dispatch path.
+    user_config = load_user_config()
+
+    runner_specs, system_overrides = _resolve_runner_specs(
+        study, user_config, preresolved, skip_preflight, progress
+    )
+
+    # Resolve results_dir: resume_dir takes priority, then the fresh-run chain
+    # (CLI -o override > YAML output.results_dir > user config > built-in default).
+    if resume_dir is not None:
+        study_dir = resume_dir
+        # Resume: load the existing manifest written by prepare_resume_manifest()
+        # and wrap it without rebuilding or overwriting the prepared manifest.
+        from llenergymeasure.study.resume import load_resume_state
+
+        loaded_manifest, _ = load_resume_state(study_dir)
+        manifest = ManifestWriter.from_existing(study_dir, loaded_manifest)
+    else:
+        if results_dir_override is not None:
+            results_dir_str = str(results_dir_override)
+        else:
+            results_dir_str = (
+                study.output.results_dir or user_config.output.results_dir or "./results"
+            )
+        study_dir = create_study_dir(study.study_name, Path(results_dir_str))
+        manifest = ManifestWriter(study, study_dir)
+
+    # Create _study-artefacts/ once for config copy, skipped log, and study-level env.
+    artefacts_dir = _ensure_study_artefacts_dir(study_dir)
+
+    _write_study_artefacts(study, artefacts_dir, system_overrides, config_path)
+
+    resolution_logs = _build_resolution_logs(study, cli_overrides)
+
+    wall_start = time.monotonic()
+    is_single = len(study.experiments) == 1 and study.study_execution.n_cycles == 1
+
+    if is_single:
+        result_files, experiment_results, warnings = _run_single_experiment_dispatch(
+            study, manifest, study_dir, runner_specs, progress, resolution_logs
+        )
+    else:
+        result_files, experiment_results, warnings = _run_via_runner(
+            study,
+            manifest,
+            study_dir,
+            runner_specs=runner_specs,
+            progress=progress,
+            skip_set=skip_set,
+            no_lock=no_lock,
+            resolution_logs=resolution_logs,
+        )
+
+    wall_time = time.monotonic() - wall_start
+
+    # Mark the study completed - but never overwrite a terminal abort status the
+    # runner already set (wall-clock timeout or circuit-breaker). Doing so would make
+    # an aborted study look completed and therefore non-resumable, leaving its skipped
+    # experiments to never re-run. The SIGINT path calls mark_interrupted() then
+    # sys.exit(130) before returning here, so 'interrupted' is not normally seen.
+    if manifest.status not in ("timed_out", "circuit_breaker", "interrupted"):
+        manifest.mark_study_completed()
+
+    completed = sum(1 for r in experiment_results if r is not None)
+    failed = len(experiment_results) - completed
+    total_energy = sum(r.total_energy_j for r in experiment_results if r is not None)
+
+    # study.experiments is already cycle-expanded by apply_cycles(), so len() is the true total
+    n_cycles = study.study_execution.n_cycles
+    unique_configs = len(study.experiments) // n_cycles if n_cycles > 0 else len(study.experiments)
+
+    measurement_protocol: dict[str, Any] = {
+        "n_cycles": study.study_execution.n_cycles,
+        "experiment_order": study.study_execution.experiment_order,
+        "experiment_gap_seconds": study.study_execution.experiment_gap_seconds,
+        "cycle_gap_seconds": study.study_execution.cycle_gap_seconds,
+        "shuffle_seed": study.study_execution.shuffle_seed,
+        "experiment_timeout_seconds": study.study_execution.experiment_timeout_seconds,
+    }
+
+    summary = StudySummary(
+        total_experiments=len(study.experiments),
+        completed=completed,
+        failed=failed,
+        total_wall_time_s=wall_time,
+        total_energy_j=total_energy,
+        unique_configurations=unique_configs,
+        warnings=warnings,
+    )
+
+    return StudyResult(
+        experiments=[r for r in experiment_results if r is not None],
+        study_name=study.study_name,
+        study_design_hash=study.study_design_hash,
+        measurement_protocol=measurement_protocol,
+        result_files=result_files,
+        summary=summary,
+        skipped_experiments=study.skipped_configs,
+    )
+
+
+def _resolve_runner_specs(
+    study: StudyConfig,
+    user_config: Any,
+    preresolved: tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]] | None,
+    skip_preflight: bool,
+    progress: ProgressCallback | None,
+) -> tuple[dict[str, RunnerSpec], dict[str, dict[str, str]]]:
+    """Resolve runner specs via preflight, or reuse a caller-provided preresolved result.
+
+    Runs precedence-based multi-engine elevation + Docker preflight (explicit
+    runner pins win; auto-resolved engines elevate to Docker, raising
+    PreFlightError when a local-pinned engine is not importable on the host or an
+    auto-resolved engine needs Docker but it is unavailable), emits preflight
+    progress, and warns when the study mixes local and Docker runners.
+    """
+    from llenergymeasure.study.preflight import run_study_preflight
+
+    if preresolved is not None:
+        runner_specs, system_overrides = preresolved
+    else:
+        if progress:
+            progress.on_step_start("preflight", "Checking", "environment and Docker")
+            t0_pf = time.perf_counter()
+        try:
+            runner_specs, system_overrides = run_study_preflight(
+                study,
+                skip_preflight=skip_preflight,
+                yaml_runners=study.runners,
+                user_config=user_config.runners,
+                yaml_images=study.images,
+                user_config_images=user_config.images or None,
+            )
+        except Exception:
+            if progress:
+                progress.on_step_done("preflight", time.perf_counter() - t0_pf)
+            raise
+        if progress:
+            progress.on_step_done("preflight", time.perf_counter() - t0_pf)
+
+    # Warn on mixed runners (some local, some docker)
+    modes = {spec.mode for spec in runner_specs.values()}
+    if len(modes) > 1:
+        logger.warning(
+            "Mixed runners detected. For consistent measurements, "
+            "consider running all engines in Docker."
+        )
+    return runner_specs, system_overrides
+
+
+def _write_study_artefacts(
+    study: StudyConfig,
+    artefacts_dir: Path,
+    system_overrides: dict[str, dict[str, str]],
+    config_path: Path | None,
+) -> None:
+    """Persist study-level artefacts to ``_study-artefacts/``.
+
+    Writes the original YAML copy (with an identity header), the skipped-config log,
+    the system-overrides record, and the software environment snapshot. Each write is
+    best-effort and logs on failure rather than aborting the run.
+    """
+
+    # Identity fields for all study-level artefacts
+    _study_hash = study.study_design_hash or ""
+    _study_name = study.study_name or ""
+
+    # Copy original YAML config to _study-artefacts/ with identity header.
+    if config_path is not None:
+        dest = artefacts_dir / "study_config.yaml"
+        try:
+            original = Path(config_path).read_text(encoding="utf-8")
+            header = f"# study_design_hash: {_study_hash} | study_name: {_study_name}\n"
+            dest.write_text(header + original, encoding="utf-8")
+            logger.info("Config YAML copied to %s", dest)
+        except FileNotFoundError:
+            logger.warning("Config YAML %s not found, skipping copy", config_path)
+
+    # Persist skipped config details to _study-artefacts/.
+    if study.skipped_configs:
+        _write_skipped_configs_log(study.skipped_configs, artefacts_dir, _study_hash, _study_name)
+
+    # Persist system overrides to _study-artefacts/ (runner auto-elevation, etc.)
+    if system_overrides:
+        overrides_with_identity = {
+            "study_design_hash": _study_hash,
+            "study_name": _study_name,
+            **system_overrides,
+        }
+        overrides_path = artefacts_dir / SYSTEM_OVERRIDES_FILENAME
+        try:
+            overrides_path.write_text(
+                json.dumps(overrides_with_identity, indent=2), encoding="utf-8"
+            )
+            logger.info("System overrides written to %s", overrides_path)
+        except OSError as exc:
+            logger.warning("Failed to write system_overrides.json: %s", exc)
+
+    # Write study-level environment.json (installed_packages + software constants).
+    try:
+        from llenergymeasure.harness.environment import collect_software_environment
+
+        sw_env = collect_software_environment()
+        study_env = {
+            "study_design_hash": _study_hash,
+            "study_name": _study_name,
+            **sw_env,
+        }
+        env_path = artefacts_dir / ENVIRONMENT_FILENAME
+        env_path.write_text(json.dumps(study_env, indent=2), encoding="utf-8")
+        logger.info("Study-level environment written to %s", env_path)
+    except Exception as exc:
+        logger.warning("Failed to write study-level environment.json: %s", exc)
+
+
+def _build_resolution_logs(
+    study: StudyConfig, cli_overrides: dict[str, Any] | None
+) -> dict[str, dict[str, Any]]:
+    """Build per-experiment resolution logs keyed by declared-config hash.
+
+    Computed once here so runners don't need to know about resolution logic.
+    Best-effort: returns whatever was built before any failure.
+    """
+    resolution_logs: dict[str, dict[str, Any]] = {}
+    try:
+        from llenergymeasure.config.introspection import get_swept_field_paths
+        from llenergymeasure.config.resolution import build_resolution_log
+        from llenergymeasure.domain.experiment import compute_declared_config_hash
+
+        swept_fields = get_swept_field_paths(study.experiments)
+        seen_hashes: set[str] = set()
+        for exp in study.experiments:
+            h = compute_declared_config_hash(exp)
+            if h in seen_hashes:
+                continue
+            seen_hashes.add(h)
+            resolution_logs[h] = build_resolution_log(
+                exp.model_dump(),
+                cli_overrides=cli_overrides,
+                swept_fields=swept_fields,
+            )
+    except Exception as exc:
+        logger.debug("Failed to build resolution logs: %s", exc)
+    return resolution_logs
+
+
+def _run_single_experiment_dispatch(
+    study: StudyConfig,
+    manifest: Any,
+    study_dir: Path,
+    runner_specs: Any,
+    progress: ProgressCallback | None,
+    resolution_logs: dict[str, dict[str, Any]],
+) -> tuple[list[str], list[ExperimentResult | None], list[str]]:
+    """Run a single-experiment study in-process, emitting study-table begin/end events.
+
+    For a StudyProgressCallback, emits begin_experiment / end_experiment_(ok|fail) so
+    the study display shows the single experiment's table row.
+    """
+    from llenergymeasure.domain.progress import STEPS_LOCAL, StudyProgressCallback, docker_steps
+
+    study_cb: StudyProgressCallback | None = (
+        progress if isinstance(progress, StudyProgressCallback) else None
+    )
+    if study_cb is not None:
+        from llenergymeasure.utils.formatting import format_experiment_header
+
+        config = study.experiments[0]
+        spec = runner_specs.get(config.engine) if runner_specs else None
+        is_docker = spec and spec.mode == RUNNER_DOCKER
+        if is_docker:
+            host_baseline = (
+                config.measurement.baseline.enabled
+                and config.measurement.baseline.strategy != "fresh"
+            )
+            steps = docker_steps(images_prepared=False, host_baseline=host_baseline)
+        else:
+            steps = list(STEPS_LOCAL)
+        study_cb.begin_experiment(
+            1,
+            format_experiment_header(config),
+            steps,
+            runner_info=spec.to_runner_info() if spec else None,
+        )
+
+    exp_start = time.monotonic()
+    result_files, experiment_results, warnings = run_single_experiment(
+        study,
+        manifest,
+        study_dir,
+        runner_specs=runner_specs,
+        progress=progress,
+        resolution_logs=resolution_logs,
+    )
+    exp_elapsed = time.monotonic() - exp_start
+
+    if study_cb is not None:
+        r = experiment_results[0] if experiment_results else None
+        if r is not None:
+            energy = r.total_energy_j if r.total_energy_j > 0 else None
+            tp = r.avg_tokens_per_second if r.avg_tokens_per_second > 0 else None
+            infer = r.total_inference_time_sec if r.total_inference_time_sec > 0 else None
+            adj_e = r.energy_adjusted_j if r.energy_adjusted_j and r.energy_adjusted_j > 0 else None
+            study_cb.end_experiment_ok(
+                1,
+                exp_elapsed,
+                energy_j=energy,
+                throughput_tok_s=tp,
+                inference_time_sec=infer,
+                adj_energy_j=adj_e,
+                mj_per_tok_adjusted=r.mj_per_tok_adjusted,
+                mj_per_tok_total=r.mj_per_tok_total,
+            )
+        else:
+            study_cb.end_experiment_fail(1, exp_elapsed)
+
+    return result_files, experiment_results, warnings
+
+
+def _run_via_runner(
+    study: StudyConfig,
+    manifest: Any,
+    study_dir: Path,
+    runner_specs: Any = None,
+    progress: ProgressCallback | None = None,
+    skip_set: set[tuple[str, int]] | None = None,
+    no_lock: bool = False,
+    resolution_logs: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[str], list[ExperimentResult | None], list[str]]:
+    """Delegate to StudyRunner for multi-experiment / multi-cycle runs."""
+    from llenergymeasure.domain.progress import StudyProgressCallback
+    from llenergymeasure.study.runner import StudyRunner
+
+    study_progress = progress if isinstance(progress, StudyProgressCallback) else None
+    runner = StudyRunner(
+        study,
+        manifest,
+        study_dir,
+        runner_specs=runner_specs,
+        progress=study_progress,
+        no_lock=no_lock,
+        skip_set=skip_set,
+        resolution_logs=resolution_logs,
+    )
+    raw_results = runner.run()
+
+    warnings: list[str] = []
+    experiment_results: list[ExperimentResult | None] = []
+    for r in raw_results:
+        if isinstance(r, dict):
+            warnings.append(r.get("message", "Unknown error"))
+            experiment_results.append(None)
+        else:
+            experiment_results.append(r)
+
+    return runner.result_files, experiment_results, warnings

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -26,10 +26,8 @@ import contextlib
 import logging
 import multiprocessing
 import os  # noqa: F401 - patch target: tests patch study.runner.os.{killpg,setpgrp}
-import shutil
 import signal
 import sys
-import tempfile
 import threading
 import time
 import uuid
@@ -41,36 +39,24 @@ from llenergymeasure.config.grid import ExperimentOrder, cycle_boundary_indices
 from llenergymeasure.config.ssot import (
     CONTAINER_EXCHANGE_DIR,
     RUNNER_DOCKER,
-    TEMP_PREFIX_TIMESERIES,
     TIMEOUT_ENV_SNAPSHOT,
     TIMEOUT_INTERRUPT_POLL,
-    TIMEOUT_SIGTERM_GRACE,
-    TIMEOUT_THREAD_JOIN,
     engine_str,
 )
 from llenergymeasure.domain.bundle_artefacts import (
     CONFIG_SIDECAR_FILENAME,
     EQUIVALENCE_GROUPS_FILENAME,
 )
-from llenergymeasure.domain.progress import STEPS_LOCAL, docker_steps
+
+# Re-imported into this module's namespace so existing
+# ``from llenergymeasure.study.runner import X`` sites (tests, study.single)
+# keep resolving here even though the dispatch mechanics now live in
+# study.session / study._progress.
 from llenergymeasure.study._progress import _consume_progress_events
 from llenergymeasure.study.baseline_measure import _BaselineMixin
 from llenergymeasure.study.gaps import run_gap
 from llenergymeasure.study.image_prep import _ImageMixin
-
-# Re-imported into this module's namespace so that (a) existing
-# ``from llenergymeasure.study.runner import X`` sites keep working and
-# (b) ``patch("llenergymeasure.study.runner.<name>")`` intercepts the
-# bare-name call sites inside ``_run_one`` / ``run``.
-from llenergymeasure.study.worker import (
-    _UNSET,
-    COLLECT_RESULT_PROCESS_CRASH,
-    COLLECT_RESULT_TIMEOUT,
-    _collect_result,
-    _derive_exit_reason,
-    _kill_process_group,
-    _run_experiment_worker,
-)
+from llenergymeasure.study.worker import _kill_process_group, _run_experiment_worker
 from llenergymeasure.utils.io import load_json
 
 if TYPE_CHECKING:
@@ -83,6 +69,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "StudyRunner",
+    "_consume_progress_events",
     "_kill_process_group",
     "_run_experiment_worker",
     "_save_and_record",
@@ -759,12 +746,12 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
     def _run_one(self, config: ExperimentConfig, mp_ctx: Any, index: int) -> Any:
         """Dispatch one experiment via Docker or subprocess, collect result or failure dict.
 
-        Checks runner_specs for this experiment's engine first. If a Docker spec is
-        found, delegates to _run_one_docker(). Otherwise falls through to the existing
-        subprocess dispatch path.
-
-        If interrupt_event is set after join, attempts graceful SIGTERM → 2s grace →
-        SIGKILL before collecting whatever result is available.
+        Assigns this experiment's cycle number, then drives the appropriate
+        ``ExperimentSession`` (``DockerSession`` when the engine's runner spec is
+        Docker, else ``SubprocessSession``). The session's context-manager
+        lifecycle owns setup and teardown; ``run()`` produces the single result
+        (offline = one result per session). The grace SIGTERM -> SIGKILL
+        escalation on interrupt lives in ``SubprocessSession.run()``.
         """
         from llenergymeasure.domain.experiment import compute_declared_config_hash
 
@@ -780,152 +767,16 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
                 config, spec, config_hash=config_hash, cycle=cycle, index=index
             )
 
-        timeout = self.study.study_execution.experiment_timeout_seconds
+        from llenergymeasure.study.session import SubprocessSession
 
-        # Signal study display: new experiment starting (subprocess = local steps)
-        if self._progress:
-            from llenergymeasure.utils.formatting import format_experiment_header
-
-            local_spec = self._runner_specs.get(config.engine) if self._runner_specs else None
-            self._progress.begin_experiment(
-                index,
-                format_experiment_header(config),
-                list(STEPS_LOCAL),
-                runner_info=local_spec.to_runner_info() if local_spec else None,
-            )
-
-        exp_start = time.monotonic()
-
-        # Create a temp dir for harness artefacts. The harness receives it as
-        # output_dir (a runtime param, not from config) and writes config.json
-        # there always, plus timeseries.parquet when save_timeseries is on. The
-        # staging dir is created regardless of save_timeseries so the config.json
-        # sidecar - sole home of provenance, authoritative home of identity -
-        # always materialises;
-        # it is cleaned up after _handle_result copies the artefacts into the
-        # study directory.
-        save_ts = self.study.output.save_timeseries
-        ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
-
-        # Resolve cached snapshot in parent - serialised to subprocess via Pipe
-        snapshot = self._get_env_snapshot()
-
-        # Resolve cached baseline in parent - avoids 30s re-measurement per subprocess
-        baseline = self._get_baseline(config) if config.measurement.baseline.enabled else None
-
-        parent_conn, child_conn = mp_ctx.Pipe(duplex=False)
-        progress_queue = mp_ctx.Queue()
-
-        p = mp_ctx.Process(
-            target=_run_experiment_worker,
-            args=(config, child_conn, progress_queue, snapshot),
-            kwargs={
-                "output_dir": str(ts_tmpdir),
-                "save_timeseries": save_ts,
-                "baseline": baseline,
-                "study_dir": str(self.study_dir),
-                "study_run_id": self.study_run_id,
-                "cycle": cycle,
-                "config_hash": config_hash,
-            },
-            daemon=False,  # daemon=False: clean CUDA teardown if parent exits unexpectedly
-        )
-
-        consumer = threading.Thread(
-            target=_consume_progress_events,
-            args=(progress_queue, self._progress),
-            daemon=True,
-        )
-        consumer.start()
-
-        self.manifest.mark_running(config_hash, cycle)
-        self._active_process = p
-
-        # Pre-dispatch GPU memory residual check (MEAS-01, MEAS-02)
-        from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
-
-        check_gpu_memory_residual()
-
-        p.start()
-        child_conn.close()
-
-        # Drain pipe BEFORE join to prevent buffer deadlock (H5).
-        # If pickled ExperimentResult > 64 KB, child blocks on conn.send()
-        # while parent blocks in p.join() - classic deadlock.
-        pipe_payload = _UNSET
-        if parent_conn.poll(timeout=timeout):
-            try:
-                pipe_payload = parent_conn.recv()
-            except Exception:
-                pipe_payload = _UNSET
-
-        # Non-blocking join after pipe is drained (grace for teardown)
-        p.join(timeout=TIMEOUT_THREAD_JOIN)
-
-        # SIGINT was received during join: SIGTERM was already sent by handler.
-        # Grace period for clean CUDA teardown, then SIGKILL.
-        if self._interrupt_event.is_set() and p.is_alive():
-            p.join(timeout=TIMEOUT_SIGTERM_GRACE)
-            if p.is_alive():
-                _kill_process_group(p.pid, signal.SIGKILL)
-                p.join()
-
-        self._active_process = None
-
-        # Sentinel stops consumer thread - covers SIGKILL path too
-        progress_queue.put(None)
-        consumer.join()
-
-        result = _collect_result(p, parent_conn, config, timeout, pipe_payload=pipe_payload)
-        parent_conn.close()
-
-        # Parent writes the sentinel record for SIGKILL / timeout - the
-        # worker's context manager can't flush when its ``__exit__`` never
-        # ran. ``write_sentinel`` is itself best-effort and swallows OSError.
-        if isinstance(result, dict) and result.get("type") in {
-            COLLECT_RESULT_PROCESS_CRASH,
-            COLLECT_RESULT_TIMEOUT,
-        }:
-            from llenergymeasure.study.runtime_observations import write_sentinel
-
-            exit_reason = (
-                "timeout"
-                if result.get("type") == COLLECT_RESULT_TIMEOUT
-                else _derive_exit_reason(p.exitcode)
-            )
-            write_sentinel(
-                config,
-                study_dir=self.study_dir,
-                study_run_id=self.study_run_id,
-                cycle=cycle,
-                config_hash=config_hash,
-                exit_reason=exit_reason,
-                exit_code=p.exitcode,
-            )
-
-        exp_elapsed = time.monotonic() - exp_start
-        local_spec = self._runner_specs.get(config.engine) if self._runner_specs else None
-        self._handle_result(
-            result,
-            config,
-            config_hash,
-            cycle,
-            index,
-            exp_elapsed,
-            ts_source_dir=ts_tmpdir,
-            environment_snapshot=self._get_env_snapshot() if not isinstance(result, dict) else None,
-            runner_provenance=_provenance_from_spec(local_spec),
-            runner_environment=(
-                _runner_environment(local_spec) if not isinstance(result, dict) else None
-            ),
-        )
-
-        # Clean up the temp dir created for timeseries parquet output.
-        # _save_and_record already copied the parquet into the study dir.
-        if ts_tmpdir is not None:
-            shutil.rmtree(ts_tmpdir, ignore_errors=True)
-
-        return result
+        # Subprocess dispatch: a SubprocessSession owns the freshly spawned
+        # worker's lifetime - env prep + spawn on __enter__, teardown on __exit__
+        # (always, including the SIGINT/exception paths). The sweep loop keys off
+        # the single result the session produces (offline = one result/session).
+        with SubprocessSession(
+            self, config, mp_ctx, config_hash=config_hash, cycle=cycle, index=index
+        ) as session:
+            return session.run()
 
     def _handle_result(
         self,
@@ -1041,119 +892,13 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         Returns:
             ExperimentResult on success, or a failure dict on error.
         """
-        from llenergymeasure.infra.docker_errors import docker_exc_to_failure
-        from llenergymeasure.infra.docker_runner import DockerRunner
-        from llenergymeasure.infra.image_registry import get_default_image
-        from llenergymeasure.study.container_lifecycle import (
-            generate_container_labels,
-            generate_container_name,
-            persist_failure_artefacts,
-        )
-        from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
-        from llenergymeasure.utils.exceptions import DockerError
+        from llenergymeasure.study.session import DockerSession
 
-        # Image is pre-resolved during preflight (resolve_image precedence chain).
-        # Fall back to get_default_image() only for direct DockerRunner usage
-        # outside the study path.
-        image = spec.image if spec.image is not None else get_default_image(config.engine)
-
-        study_id = self.study.study_design_hash or "unknown"
-        container_name = generate_container_name(study_id, index)
-        labels = generate_container_labels(study_id)
-
-        # begin_experiment MUST run before _get_baseline so baseline step events
-        # fire against a registered experiment index.
-        if self._progress:
-            from llenergymeasure.utils.formatting import format_experiment_header
-
-            host_baseline = (
-                config.measurement.baseline.enabled
-                and config.measurement.baseline.strategy != "fresh"
-            )
-            steps = docker_steps(
-                images_prepared=self._images_prepared,
-                host_baseline=host_baseline,
-            )
-            self._progress.begin_experiment(
-                index,
-                format_experiment_header(config),
-                steps,
-                runner_info=spec.to_runner_info(),
-            )
-            # Host-side preflight doesn't run in Docker path - checked inside container
-            self._progress.on_step_skip("preflight", "checked inside container")
-
-        extra_mounts = list(spec.extra_mounts) if spec.extra_mounts else []
-        cache_key = self._baseline_cache_key(config)
-        baseline = self._get_baseline(config) if config.measurement.baseline.enabled else None
-        if baseline is not None:
-            # Experiment container reads /run/llem/baseline_cache.json; the host
-            # picks the right per-cache-key file at dispatch time. Docker parses
-            # relative bind-mount sources as named volumes, so resolve first.
-            baseline_cache_path = self._get_baseline_cache_path(cache_key)
-            extra_mounts.append(
-                (
-                    str(baseline_cache_path.resolve()),
-                    f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json",
-                )
-            )
-
-        docker_runner = DockerRunner(
-            image=image,
-            timeout=self.study.study_execution.experiment_timeout_seconds,
-            silence_timeout=self.study.study_execution.stdout_silence_timeout_seconds,
-            source=spec.source,
-            extra_mounts=extra_mounts,
-            container_name=container_name,
-            labels=labels,
-            gpu_indices=self.study.study_execution.gpu_indices,
-        )
-
-        # Pre-dispatch GPU memory residual check (same as local path)
-        check_gpu_memory_residual()
-
-        self.manifest.mark_running(config_hash, cycle)
-
-        exp_start = time.monotonic()
-
-        result: Any
-        docker_ts_dir: Path | None = None
-        try:
-            # Pass study progress as step callback - DockerRunner calls on_step_*
-            # skip_image_check=True when images were verified at study level.
-            result, docker_ts_dir = docker_runner.run(
-                config,
-                progress=self._progress,
-                save_timeseries=self.study.output.save_timeseries,
-                skip_image_check=self._images_prepared,
-            )
-        except DockerError as exc:
-            # Translate to a non-fatal failure dict (silence / timeout / structured
-            # payload classification handled in the shared helper) and persist the
-            # container.log + error JSON so the failure is debuggable.
-            result = docker_exc_to_failure(exc, config_hash)
-            persist_failure_artefacts(exc, self.study_dir, config_hash, cycle, result)
-
-        exp_elapsed = time.monotonic() - exp_start
-        self._handle_result(
-            result,
-            config,
-            config_hash,
-            cycle,
-            index,
-            exp_elapsed,
-            ts_source_dir=docker_ts_dir,
-            environment_snapshot=self._get_env_snapshot() if not isinstance(result, dict) else None,
-            runner_provenance=_provenance_from_spec(spec),
-            runner_environment=(
-                _runner_environment(spec, resolved_image=image)
-                if not isinstance(result, dict)
-                else None
-            ),
-        )
-
-        # Clean up the temp dir after _save_and_record has copied the parquet.
-        if docker_ts_dir is not None:
-            shutil.rmtree(docker_ts_dir, ignore_errors=True)
-
-        return result
+        # Docker dispatch: a DockerSession owns the container lifetime - image +
+        # mount + facade prep on __enter__, teardown on __exit__. The DockerError
+        # -> non-fatal failure-dict translation lives in the session's run(), so
+        # the sweep loop keys off the single result uniformly with the local path.
+        with DockerSession(
+            self, config, spec, config_hash=config_hash, cycle=cycle, index=index
+        ) as session:
+            return session.run()

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -4,6 +4,9 @@
 container lifecycle, circuit breaker, wall-clock timeout, and result handling.
 The separable concerns live in sibling modules and are mixed in or imported:
 
+- ``study.session``: context-managed per-experiment dispatch lifetimes
+  (``ExperimentSession`` + the offline subprocess/docker implementations the
+  run loop drives, one per experiment).
 - ``study.worker``: subprocess-worker surface (child entry point, result
   collection, process-group signalling).
 - ``study._progress``: cross-process progress plumbing.

--- a/src/llenergymeasure/study/session.py
+++ b/src/llenergymeasure/study/session.py
@@ -12,17 +12,20 @@ The two offline (batch) implementations here wrap today's dispatch paths:
 - :class:`DockerSession` - one blocking ``DockerRunner.run`` container.
 
 Offline sessions produce EXACTLY ONE result per session (one engine lifetime =
-one measured window). The protocol shape - a lifetime that a work method drives -
-is deliberately open to a future server session (v0.8.0) that produces N results
-(one per request window) over the same lifetime, without any offline-batch
-assumption baked into the seam. That is the one-dispatch:N-results capability the
-sweep loop is re-keyed to admit (constraint C3); this slice adds no window-spec
-vocabulary and no server session.
+one measured window). The point of the seam is that the session LIFETIME
+(acquire -> produce -> release) is separable from result production: that is what
+admits a future server session (v0.8.0) whose single lifetime produces N results,
+one per request window (constraint C3). This slice adds no window-spec
+vocabulary, no N-result consumption, and no server session - the offline call
+sites still consume one result per session, by design.
 
-The sweep loop in :class:`~llenergymeasure.study.runner.StudyRunner` consumes
-sessions uniformly through ``_run_one`` / ``_run_one_docker``: the manifest,
-circuit breaker, GPU locks, and SIGINT handling all key off the ``(session,
-result)`` outcome rather than off "the dispatch function returned once".
+Today the sweep loop in :class:`~llenergymeasure.study.runner.StudyRunner` drives
+one session per experiment through ``_run_one`` / ``_run_one_docker`` and consumes
+the single result it produces; the manifest transitions and the circuit breaker
+follow that one result. GPU locks stay deliberately study-scoped (a lock outlives
+any one session), and the SIGINT handler acts on the session's active process. A
+v0.8.0 server session plugs in by adding a call site that consumes many results
+over one lifetime - not by re-keying today's loop.
 """
 
 from __future__ import annotations
@@ -125,6 +128,40 @@ class _OfflineSession:
 
     def _cleanup(self) -> None:  # pragma: no cover - overridden
         """Release the session's resources. Called exactly once by __exit__."""
+
+    def _report(
+        self,
+        result: Any,
+        *,
+        exp_elapsed: float,
+        ts_source_dir: Path | None,
+        spec: RunnerSpec | None,
+        resolved_image: str | None = None,
+    ) -> None:
+        """Hand the produced result to the runner's result/manifest handler.
+
+        Shared by both offline sessions: the runner-provenance and environment
+        blocks are populated only for a real result (a failure dict carries no
+        provenance), and the runner-side builders are imported lazily here - the
+        single result-reporting call site both sessions funnel through.
+        """
+        from llenergymeasure.study.runner import _provenance_from_spec, _runner_environment
+
+        is_result = not isinstance(result, dict)
+        self._runner._handle_result(
+            result,
+            self.config,
+            self.config_hash,
+            self.cycle,
+            self.index,
+            exp_elapsed,
+            ts_source_dir=ts_source_dir,
+            environment_snapshot=self._runner._get_env_snapshot() if is_result else None,
+            runner_provenance=_provenance_from_spec(spec),
+            runner_environment=(
+                _runner_environment(spec, resolved_image=resolved_image) if is_result else None
+            ),
+        )
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> bool | None:
         if self._torn_down:
@@ -271,9 +308,8 @@ class SubprocessSession(_OfflineSession):
                 _kill_process_group(p.pid, signal.SIGKILL)
                 p.join()
 
-        runner._active_process = None
-
-        # Sentinel stops consumer thread - covers SIGKILL path too
+        # Sentinel stops consumer thread - covers SIGKILL path too.
+        # (The active-process handle is cleared once, in _cleanup on __exit__.)
         self._stop_consumer()
 
         result = _collect_result(p, parent_conn, config, timeout, pipe_payload=pipe_payload)
@@ -303,21 +339,11 @@ class SubprocessSession(_OfflineSession):
             )
 
         exp_elapsed = time.monotonic() - self._exp_start
-        runner._handle_result(
+        self._report(
             result,
-            config,
-            self.config_hash,
-            self.cycle,
-            self.index,
-            exp_elapsed,
+            exp_elapsed=exp_elapsed,
             ts_source_dir=self._ts_tmpdir,
-            environment_snapshot=(
-                runner._get_env_snapshot() if not isinstance(result, dict) else None
-            ),
-            runner_provenance=_provenance_from_spec(self._local_spec),
-            runner_environment=(
-                _runner_environment(self._local_spec) if not isinstance(result, dict) else None
-            ),
+            spec=self._local_spec,
         )
         return result
 
@@ -493,23 +519,12 @@ class DockerSession(_OfflineSession):
             persist_failure_artefacts(exc, runner.study_dir, self.config_hash, self.cycle, result)
 
         exp_elapsed = time.monotonic() - self._exp_start
-        runner._handle_result(
+        self._report(
             result,
-            config,
-            self.config_hash,
-            self.cycle,
-            self.index,
-            exp_elapsed,
+            exp_elapsed=exp_elapsed,
             ts_source_dir=self._docker_ts_dir,
-            environment_snapshot=(
-                runner._get_env_snapshot() if not isinstance(result, dict) else None
-            ),
-            runner_provenance=_provenance_from_spec(self.spec),
-            runner_environment=(
-                _runner_environment(self.spec, resolved_image=self._image)
-                if not isinstance(result, dict)
-                else None
-            ),
+            spec=self.spec,
+            resolved_image=self._image,
         )
         return result
 
@@ -517,17 +532,3 @@ class DockerSession(_OfflineSession):
         # Clean up the temp dir after _handle_result has copied the parquet.
         if self._docker_ts_dir is not None:
             shutil.rmtree(self._docker_ts_dir, ignore_errors=True)
-
-
-def _provenance_from_spec(spec: RunnerSpec | None) -> Any:
-    """Delegate to the runner-module builder (single home for provenance mapping)."""
-    from llenergymeasure.study.runner import _provenance_from_spec as _impl
-
-    return _impl(spec)
-
-
-def _runner_environment(spec: RunnerSpec | None, *, resolved_image: str | None = None) -> Any:
-    """Delegate to the runner-module builder (single home for the runner block)."""
-    from llenergymeasure.study.runner import _runner_environment as _impl
-
-    return _impl(spec, resolved_image=resolved_image)

--- a/src/llenergymeasure/study/session.py
+++ b/src/llenergymeasure/study/session.py
@@ -1,0 +1,533 @@
+"""Experiment session seam - context-managed engine lifetimes for the sweep loop.
+
+An :class:`ExperimentSession` is one measurement session: a context manager
+whose ``__enter__`` acquires the session's resources (spawn a worker subprocess,
+prepare a container), whose ``run()`` produces the session's result payload, and
+whose ``__exit__`` releases everything - ALWAYS, including on the SIGINT,
+circuit-break, and exception paths.
+
+The two offline (batch) implementations here wrap today's dispatch paths:
+
+- :class:`SubprocessSession` - one freshly spawned worker subprocess.
+- :class:`DockerSession` - one blocking ``DockerRunner.run`` container.
+
+Offline sessions produce EXACTLY ONE result per session (one engine lifetime =
+one measured window). The protocol shape - a lifetime that a work method drives -
+is deliberately open to a future server session (v0.8.0) that produces N results
+(one per request window) over the same lifetime, without any offline-batch
+assumption baked into the seam. That is the one-dispatch:N-results capability the
+sweep loop is re-keyed to admit (constraint C3); this slice adds no window-spec
+vocabulary and no server session.
+
+The sweep loop in :class:`~llenergymeasure.study.runner.StudyRunner` consumes
+sessions uniformly through ``_run_one`` / ``_run_one_docker``: the manifest,
+circuit breaker, GPU locks, and SIGINT handling all key off the ``(session,
+result)`` outcome rather than off "the dispatch function returned once".
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import shutil
+import signal
+import tempfile
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from llenergymeasure.config.ssot import (
+    CONTAINER_EXCHANGE_DIR,
+    TEMP_PREFIX_TIMESERIES,
+    TIMEOUT_SIGTERM_GRACE,
+    TIMEOUT_THREAD_JOIN,
+)
+from llenergymeasure.domain.progress import STEPS_LOCAL, docker_steps
+from llenergymeasure.study._progress import _consume_progress_events
+
+# Re-imported into this module's namespace so the worker-surface helpers resolve
+# at this session's USE site: tests patch e.g.
+# ``llenergymeasure.study.session._collect_result`` (patch-at-use-site).
+from llenergymeasure.study.worker import (
+    _UNSET,
+    COLLECT_RESULT_PROCESS_CRASH,
+    COLLECT_RESULT_TIMEOUT,
+    _collect_result,
+    _derive_exit_reason,
+    _kill_process_group,
+    _run_experiment_worker,
+)
+
+if TYPE_CHECKING:
+    import threading
+
+    from llenergymeasure.config.models import ExperimentConfig
+    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.study.runner import StudyRunner
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ExperimentSession(Protocol):
+    """A context-managed engine lifetime that a work method drives to results.
+
+    Lifecycle:
+    - ``__enter__`` acquires the session's resources (env prep + subprocess
+      spawn, or container preparation) and returns the session.
+    - ``run()`` performs the session's measured work and returns its result
+      payload. Offline sessions return exactly one result (an
+      :class:`~llenergymeasure.domain.experiment.ExperimentResult` on success,
+      or a failure dict); a future server session returns one per request
+      window over the same lifetime.
+    - ``__exit__`` releases every resource the session acquired, on the normal,
+      SIGINT, circuit-break, and exception paths alike, exactly once.
+    """
+
+    def __enter__(self) -> ExperimentSession: ...
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool | None: ...
+
+    def run(self) -> Any: ...
+
+
+class _OfflineSession:
+    """Shared scaffolding for the two offline (one-result) session implementations.
+
+    Holds the driving ``StudyRunner`` (the source of the shared study-level
+    caches and services: env snapshot, baseline, manifest, progress, result
+    handling) plus the per-dispatch identity. ``__exit__`` funnels through
+    ``_cleanup()`` under a one-shot guard so teardown runs exactly once whether
+    the body returned normally or raised.
+    """
+
+    def __init__(
+        self,
+        runner: StudyRunner,
+        config: ExperimentConfig,
+        *,
+        config_hash: str,
+        cycle: int,
+        index: int,
+    ) -> None:
+        self._runner = runner
+        self.config = config
+        self.config_hash = config_hash
+        self.cycle = cycle
+        self.index = index
+        self._torn_down = False
+
+    def __enter__(self) -> _OfflineSession:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def run(self) -> Any:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def _cleanup(self) -> None:  # pragma: no cover - overridden
+        """Release the session's resources. Called exactly once by __exit__."""
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool | None:
+        if self._torn_down:
+            return None
+        self._torn_down = True
+        self._cleanup()
+        return None
+
+
+class SubprocessSession(_OfflineSession):
+    """Offline session: one experiment in a freshly spawned worker subprocess.
+
+    ``__enter__`` stages the timeseries dir, resolves the cached env snapshot +
+    baseline, wires the parent<-child Pipe and the progress-event Queue, spawns
+    the worker (``daemon=False`` for clean CUDA teardown), starts the progress
+    consumer, marks the experiment running, and starts the process after the
+    pre-dispatch GPU-memory residual check. ``run()`` drains the pipe before
+    joining (H5 deadlock fix), honours the SIGINT grace -> SIGKILL escalation,
+    collects the result, writes the parent-side sentinel for crash/timeout, and
+    hands the result to the runner. ``__exit__`` stops the consumer, closes the
+    read end, clears the active-process handle, and removes the staging dir.
+    """
+
+    def __init__(
+        self,
+        runner: StudyRunner,
+        config: ExperimentConfig,
+        mp_ctx: Any,
+        *,
+        config_hash: str,
+        cycle: int,
+        index: int,
+    ) -> None:
+        super().__init__(runner, config, config_hash=config_hash, cycle=cycle, index=index)
+        self._mp_ctx = mp_ctx
+        self.timeout = runner.study.study_execution.experiment_timeout_seconds
+        self._local_spec = runner._runner_specs.get(config.engine) if runner._runner_specs else None
+        # Populated in __enter__.
+        self._ts_tmpdir: Path | None = None
+        self._parent_conn: Any = None
+        self._progress_queue: Any = None
+        self._consumer: threading.Thread | None = None
+        self._process: Any = None
+        self._exp_start: float = 0.0
+        self._consumer_stopped = False
+
+    def __enter__(self) -> SubprocessSession:
+        import threading
+
+        runner = self._runner
+        config = self.config
+
+        # Signal study display: new experiment starting (subprocess = local steps)
+        if runner._progress:
+            from llenergymeasure.utils.formatting import format_experiment_header
+
+            runner._progress.begin_experiment(
+                self.index,
+                format_experiment_header(config),
+                list(STEPS_LOCAL),
+                runner_info=self._local_spec.to_runner_info() if self._local_spec else None,
+            )
+
+        self._exp_start = time.monotonic()
+
+        # Create a temp dir for harness artefacts. The harness receives it as
+        # output_dir (a runtime param, not from config) and writes config.json
+        # there always, plus timeseries.parquet when save_timeseries is on. The
+        # staging dir is created regardless of save_timeseries so the config.json
+        # sidecar - sole home of provenance, authoritative home of identity -
+        # always materialises; __exit__ removes it after _handle_result copies
+        # the artefacts into the study directory.
+        save_ts = runner.study.output.save_timeseries
+        self._ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
+
+        # Resolve cached snapshot in parent - serialised to subprocess via Pipe
+        snapshot = runner._get_env_snapshot()
+
+        # Resolve cached baseline in parent - avoids 30s re-measurement per subprocess
+        baseline = runner._get_baseline(config) if config.measurement.baseline.enabled else None
+
+        self._parent_conn, child_conn = self._mp_ctx.Pipe(duplex=False)
+        self._progress_queue = self._mp_ctx.Queue()
+
+        self._process = self._mp_ctx.Process(
+            target=_run_experiment_worker,
+            args=(config, child_conn, self._progress_queue, snapshot),
+            kwargs={
+                "output_dir": str(self._ts_tmpdir),
+                "save_timeseries": save_ts,
+                "baseline": baseline,
+                "study_dir": str(runner.study_dir),
+                "study_run_id": runner.study_run_id,
+                "cycle": self.cycle,
+                "config_hash": self.config_hash,
+            },
+            daemon=False,  # daemon=False: clean CUDA teardown if parent exits unexpectedly
+        )
+
+        self._consumer = threading.Thread(
+            target=_consume_progress_events,
+            args=(self._progress_queue, runner._progress),
+            daemon=True,
+        )
+        self._consumer.start()
+
+        runner.manifest.mark_running(self.config_hash, self.cycle)
+        runner._active_process = self._process
+
+        # Pre-dispatch GPU memory residual check (MEAS-01, MEAS-02)
+        from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
+
+        check_gpu_memory_residual()
+
+        self._process.start()
+        child_conn.close()
+        return self
+
+    def run(self) -> Any:
+        runner = self._runner
+        config = self.config
+        p = self._process
+        parent_conn = self._parent_conn
+        timeout = self.timeout
+
+        # Drain pipe BEFORE join to prevent buffer deadlock (H5).
+        # If pickled ExperimentResult > 64 KB, child blocks on conn.send()
+        # while parent blocks in p.join() - classic deadlock.
+        pipe_payload = _UNSET
+        if parent_conn.poll(timeout=timeout):
+            try:
+                pipe_payload = parent_conn.recv()
+            except Exception:
+                pipe_payload = _UNSET
+
+        # Non-blocking join after pipe is drained (grace for teardown)
+        p.join(timeout=TIMEOUT_THREAD_JOIN)
+
+        # SIGINT was received during join: SIGTERM was already sent by handler.
+        # Grace period for clean CUDA teardown, then SIGKILL.
+        if runner._interrupt_event.is_set() and p.is_alive():
+            p.join(timeout=TIMEOUT_SIGTERM_GRACE)
+            if p.is_alive():
+                _kill_process_group(p.pid, signal.SIGKILL)
+                p.join()
+
+        runner._active_process = None
+
+        # Sentinel stops consumer thread - covers SIGKILL path too
+        self._stop_consumer()
+
+        result = _collect_result(p, parent_conn, config, timeout, pipe_payload=pipe_payload)
+
+        # Parent writes the sentinel record for SIGKILL / timeout - the
+        # worker's context manager can't flush when its ``__exit__`` never
+        # ran. ``write_sentinel`` is itself best-effort and swallows OSError.
+        if isinstance(result, dict) and result.get("type") in {
+            COLLECT_RESULT_PROCESS_CRASH,
+            COLLECT_RESULT_TIMEOUT,
+        }:
+            from llenergymeasure.study.runtime_observations import write_sentinel
+
+            exit_reason = (
+                "timeout"
+                if result.get("type") == COLLECT_RESULT_TIMEOUT
+                else _derive_exit_reason(p.exitcode)
+            )
+            write_sentinel(
+                config,
+                study_dir=runner.study_dir,
+                study_run_id=runner.study_run_id,
+                cycle=self.cycle,
+                config_hash=self.config_hash,
+                exit_reason=exit_reason,
+                exit_code=p.exitcode,
+            )
+
+        exp_elapsed = time.monotonic() - self._exp_start
+        runner._handle_result(
+            result,
+            config,
+            self.config_hash,
+            self.cycle,
+            self.index,
+            exp_elapsed,
+            ts_source_dir=self._ts_tmpdir,
+            environment_snapshot=(
+                runner._get_env_snapshot() if not isinstance(result, dict) else None
+            ),
+            runner_provenance=_provenance_from_spec(self._local_spec),
+            runner_environment=(
+                _runner_environment(self._local_spec) if not isinstance(result, dict) else None
+            ),
+        )
+        return result
+
+    def _stop_consumer(self) -> None:
+        """Enqueue the consumer sentinel and join it, exactly once."""
+        if self._consumer_stopped:
+            return
+        self._consumer_stopped = True
+        if self._progress_queue is not None:
+            self._progress_queue.put(None)
+        if self._consumer is not None:
+            self._consumer.join()
+
+    def _cleanup(self) -> None:
+        runner = self._runner
+        # Clear the active-process handle so a late SIGINT can't act on a
+        # process this session already finished with.
+        runner._active_process = None
+        # Exception path: the process may still be alive (run() never reached
+        # its join/kill sequence). Reap it so a spawn leak can't outlive the run.
+        if self._process is not None:
+            with contextlib.suppress(Exception):
+                if self._process.is_alive():
+                    _kill_process_group(self._process.pid, signal.SIGKILL)
+                    self._process.join()
+        # Stop the progress consumer (no-op if run() already did).
+        self._stop_consumer()
+        # Close the read end of the Pipe (C4 FD-leak fix): exactly once, here.
+        if self._parent_conn is not None:
+            with contextlib.suppress(Exception):
+                self._parent_conn.close()
+        # Remove the timeseries staging dir after _handle_result copied the parquet.
+        if self._ts_tmpdir is not None:
+            shutil.rmtree(self._ts_tmpdir, ignore_errors=True)
+
+
+class DockerSession(_OfflineSession):
+    """Offline session: one experiment in a blocking ``DockerRunner.run`` container.
+
+    ``__enter__`` resolves the image, container name/labels, emits the study
+    begin-experiment events (before baseline resolution so baseline step events
+    fire against a registered index), assembles the bind mounts (including the
+    per-cache-key baseline cache), builds the ``DockerRunner`` facade, runs the
+    pre-dispatch GPU-memory residual check, and marks the experiment running.
+    ``run()`` performs the blocking container dispatch - translating a
+    ``DockerError`` into a non-fatal failure dict and persisting the failure
+    artefacts - and hands the result to the runner. ``__exit__`` removes the
+    container's timeseries staging dir.
+
+    The container lifecycle is DockerRunner's; this session does not change any
+    ``DockerRunner`` call signature (S13 reworks its internals behind a frozen
+    facade).
+    """
+
+    def __init__(
+        self,
+        runner: StudyRunner,
+        config: ExperimentConfig,
+        spec: RunnerSpec,
+        *,
+        config_hash: str,
+        cycle: int,
+        index: int,
+    ) -> None:
+        super().__init__(runner, config, config_hash=config_hash, cycle=cycle, index=index)
+        self.spec = spec
+        # Populated in __enter__.
+        self._image: str | None = None
+        self._docker_runner: Any = None
+        self._exp_start: float = 0.0
+        self._docker_ts_dir: Path | None = None
+
+    def __enter__(self) -> DockerSession:
+        from llenergymeasure.infra.docker_runner import DockerRunner
+        from llenergymeasure.infra.image_registry import get_default_image
+        from llenergymeasure.study.container_lifecycle import (
+            generate_container_labels,
+            generate_container_name,
+        )
+        from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
+
+        runner = self._runner
+        config = self.config
+        spec = self.spec
+
+        # Image is pre-resolved during preflight (resolve_image precedence chain).
+        # Fall back to get_default_image() only for direct DockerRunner usage
+        # outside the study path.
+        self._image = spec.image if spec.image is not None else get_default_image(config.engine)
+
+        study_id = runner.study.study_design_hash or "unknown"
+        container_name = generate_container_name(study_id, self.index)
+        labels = generate_container_labels(study_id)
+
+        # begin_experiment MUST run before _get_baseline so baseline step events
+        # fire against a registered experiment index.
+        if runner._progress:
+            from llenergymeasure.utils.formatting import format_experiment_header
+
+            host_baseline = (
+                config.measurement.baseline.enabled
+                and config.measurement.baseline.strategy != "fresh"
+            )
+            steps = docker_steps(
+                images_prepared=runner._images_prepared,
+                host_baseline=host_baseline,
+            )
+            runner._progress.begin_experiment(
+                self.index,
+                format_experiment_header(config),
+                steps,
+                runner_info=spec.to_runner_info(),
+            )
+            # Host-side preflight doesn't run in Docker path - checked inside container
+            runner._progress.on_step_skip("preflight", "checked inside container")
+
+        extra_mounts = list(spec.extra_mounts) if spec.extra_mounts else []
+        cache_key = runner._baseline_cache_key(config)
+        baseline = runner._get_baseline(config) if config.measurement.baseline.enabled else None
+        if baseline is not None:
+            # Experiment container reads /run/llem/baseline_cache.json; the host
+            # picks the right per-cache-key file at dispatch time. Docker parses
+            # relative bind-mount sources as named volumes, so resolve first.
+            baseline_cache_path = runner._get_baseline_cache_path(cache_key)
+            extra_mounts.append(
+                (
+                    str(baseline_cache_path.resolve()),
+                    f"{CONTAINER_EXCHANGE_DIR}/baseline_cache.json",
+                )
+            )
+
+        self._docker_runner = DockerRunner(
+            image=self._image,
+            timeout=runner.study.study_execution.experiment_timeout_seconds,
+            silence_timeout=runner.study.study_execution.stdout_silence_timeout_seconds,
+            source=spec.source,
+            extra_mounts=extra_mounts,
+            container_name=container_name,
+            labels=labels,
+            gpu_indices=runner.study.study_execution.gpu_indices,
+        )
+
+        # Pre-dispatch GPU memory residual check (same as local path)
+        check_gpu_memory_residual()
+
+        runner.manifest.mark_running(self.config_hash, self.cycle)
+        self._exp_start = time.monotonic()
+        return self
+
+    def run(self) -> Any:
+        from llenergymeasure.infra.docker_errors import docker_exc_to_failure
+        from llenergymeasure.study.container_lifecycle import persist_failure_artefacts
+        from llenergymeasure.utils.exceptions import DockerError
+
+        runner = self._runner
+        config = self.config
+
+        result: Any
+        try:
+            # Pass study progress as step callback - DockerRunner calls on_step_*
+            # skip_image_check=True when images were verified at study level.
+            result, self._docker_ts_dir = self._docker_runner.run(
+                config,
+                progress=runner._progress,
+                save_timeseries=runner.study.output.save_timeseries,
+                skip_image_check=runner._images_prepared,
+            )
+        except DockerError as exc:
+            # Translate to a non-fatal failure dict (silence / timeout / structured
+            # payload classification handled in the shared helper) and persist the
+            # container.log + error JSON so the failure is debuggable.
+            result = docker_exc_to_failure(exc, self.config_hash)
+            persist_failure_artefacts(exc, runner.study_dir, self.config_hash, self.cycle, result)
+
+        exp_elapsed = time.monotonic() - self._exp_start
+        runner._handle_result(
+            result,
+            config,
+            self.config_hash,
+            self.cycle,
+            self.index,
+            exp_elapsed,
+            ts_source_dir=self._docker_ts_dir,
+            environment_snapshot=(
+                runner._get_env_snapshot() if not isinstance(result, dict) else None
+            ),
+            runner_provenance=_provenance_from_spec(self.spec),
+            runner_environment=(
+                _runner_environment(self.spec, resolved_image=self._image)
+                if not isinstance(result, dict)
+                else None
+            ),
+        )
+        return result
+
+    def _cleanup(self) -> None:
+        # Clean up the temp dir after _handle_result has copied the parquet.
+        if self._docker_ts_dir is not None:
+            shutil.rmtree(self._docker_ts_dir, ignore_errors=True)
+
+
+def _provenance_from_spec(spec: RunnerSpec | None) -> Any:
+    """Delegate to the runner-module builder (single home for provenance mapping)."""
+    from llenergymeasure.study.runner import _provenance_from_spec as _impl
+
+    return _impl(spec)
+
+
+def _runner_environment(spec: RunnerSpec | None, *, resolved_image: str | None = None) -> Any:
+    """Delegate to the runner-module builder (single home for the runner block)."""
+    from llenergymeasure.study.runner import _runner_environment as _impl
+
+    return _impl(spec, resolved_image=resolved_image)

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -6,9 +6,9 @@ StudyRunner. This module is that path. It lives in the study layer so the
 result-saving helper (``_save_and_record``) is an intra-package call rather than
 an api-layer reach into a study-layer private symbol.
 
-The api layer (``api/_impl._run``) keeps the single-experiment dispatch decision
-and the study-level progress begin/end block; it delegates the actual execution
-body to ``run_single_experiment`` here.
+The study-layer orchestrator (``study.orchestration.orchestrate_study``) keeps the
+single-experiment dispatch decision and the study-level progress begin/end block;
+it delegates the actual execution body to ``run_single_experiment`` here.
 """
 
 from __future__ import annotations

--- a/tests/unit/study/conftest.py
+++ b/tests/unit/study/conftest.py
@@ -1,1 +1,54 @@
-"""Shared fixtures for study/ tests."""
+"""Shared fixtures and helpers for study/ tests."""
+
+from __future__ import annotations
+
+import queue
+from unittest.mock import MagicMock
+
+
+def _make_mock_process(
+    *,
+    is_alive_after_join: bool = False,
+    exitcode: int = 0,
+    pid: int = 12345,
+) -> MagicMock:
+    """Factory for a mock Process with controllable lifecycle."""
+    proc = MagicMock()
+    proc.pid = pid
+    proc.exitcode = exitcode
+
+    def fake_join(timeout=None):
+        # After join, is_alive reflects whether timed out
+        pass
+
+    proc.join.side_effect = fake_join
+    proc.is_alive.return_value = is_alive_after_join
+    return proc
+
+
+def _make_mock_context(
+    process: MagicMock,
+    pipe_data: object = None,
+    *,
+    pipe_has_data: bool = True,
+) -> MagicMock:
+    """Build a mock multiprocessing context that returns a controlled process.
+
+    pipe_data: the object that parent_conn.recv() will return.
+    pipe_has_data: if False, parent_conn.poll() returns False (empty pipe).
+    """
+    ctx = MagicMock()
+    ctx.Process.return_value = process
+
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    parent_conn.poll.return_value = pipe_has_data
+    if pipe_data is not None:
+        parent_conn.recv.return_value = pipe_data
+
+    ctx.Pipe.return_value = (parent_conn, child_conn)
+
+    # Queue: use a real in-process queue so the consumer thread works
+    ctx.Queue.return_value = queue.SimpleQueue()
+
+    return ctx

--- a/tests/unit/study/test_session.py
+++ b/tests/unit/study/test_session.py
@@ -30,6 +30,7 @@ from llenergymeasure.study.session import (
     SubprocessSession,
 )
 from tests.conftest import TEST_CONFIG_HASH
+from tests.unit.study.conftest import _make_mock_context, _make_mock_process
 
 # =============================================================================
 # Fixtures / helpers
@@ -63,27 +64,6 @@ def _make_runner(tmp_path: Path, *, runner_specs: dict | None = None) -> StudyRu
     return runner
 
 
-def _make_process(*, is_alive: bool = False, exitcode: int = 0, pid: int = 4242) -> MagicMock:
-    proc = MagicMock()
-    proc.pid = pid
-    proc.exitcode = exitcode
-    proc.is_alive.return_value = is_alive
-    return proc
-
-
-def _make_ctx(process: MagicMock, *, pipe_data: Any = None) -> MagicMock:
-    ctx = MagicMock()
-    ctx.Process.return_value = process
-    parent_conn = MagicMock()
-    child_conn = MagicMock()
-    parent_conn.poll.return_value = pipe_data is not None
-    if pipe_data is not None:
-        parent_conn.recv.return_value = pipe_data
-    ctx.Pipe.return_value = (parent_conn, child_conn)
-    ctx.Queue.return_value = queue.SimpleQueue()
-    return ctx
-
-
 # =============================================================================
 # Protocol conformance
 # =============================================================================
@@ -93,7 +73,7 @@ def test_sessions_satisfy_experiment_session_protocol(tmp_path: Path) -> None:
     """Both offline sessions structurally satisfy the runtime-checkable protocol."""
     runner = _make_runner(tmp_path)
     config = runner.study.experiments[0]
-    ctx = _make_ctx(_make_process())
+    ctx = _make_mock_context(_make_mock_process())
 
     sub = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
     assert isinstance(sub, ExperimentSession)
@@ -115,8 +95,8 @@ def test_subprocess_session_cleanup_runs_once_normal_path(tmp_path: Path) -> Non
     the staging dir - exactly once, and a redundant __exit__ is a no-op."""
     runner = _make_runner(tmp_path)
     config = runner.study.experiments[0]
-    proc = _make_process(is_alive=False, exitcode=0)
-    ctx = _make_ctx(proc, pipe_data={"status": "ok"})
+    proc = _make_mock_process(is_alive_after_join=False, exitcode=0)
+    ctx = _make_mock_context(proc, pipe_data={"status": "ok"})
     parent_conn = ctx.Pipe.return_value[0]
 
     with (
@@ -146,8 +126,8 @@ def test_subprocess_session_cleanup_runs_once_on_exception(tmp_path: Path) -> No
     config = runner.study.experiments[0]
     # is_alive=True: the body raised before run()'s own join/kill sequence, so
     # __exit__ must reap the still-running worker.
-    proc = _make_process(is_alive=True, pid=5150)
-    ctx = _make_ctx(proc)
+    proc = _make_mock_process(is_alive_after_join=True, pid=5150)
+    ctx = _make_mock_context(proc, pipe_has_data=False)
     parent_conn = ctx.Pipe.return_value[0]
 
     with (
@@ -177,8 +157,8 @@ def test_subprocess_session_active_process_set_during_enter(tmp_path: Path) -> N
     """__enter__ registers the worker as the runner's active process (SIGINT target)."""
     runner = _make_runner(tmp_path)
     config = runner.study.experiments[0]
-    proc = _make_process()
-    ctx = _make_ctx(proc, pipe_data={"status": "ok"})
+    proc = _make_mock_process()
+    ctx = _make_mock_context(proc, pipe_data={"status": "ok"})
 
     with patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"):
         session = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)

--- a/tests/unit/study/test_session.py
+++ b/tests/unit/study/test_session.py
@@ -1,0 +1,298 @@
+"""Tests for the study.session seam - context-managed experiment sessions.
+
+Focus: the lifecycle guarantees the sweep loop now leans on:
+- ``ExperimentSession`` protocol conformance for both offline implementations;
+- ``__exit__`` releases resources exactly once, on the normal path and on the
+  interrupt/exception path alike (the SIGINT/circuit-break re-keying);
+- the progress-consumer timeout loop tolerates a silent producer and still
+  exits on the parent's sentinel.
+
+The dispatch mechanics themselves (pipe drain ordering, kill escalation, docker
+translation) are exercised end-to-end through ``StudyRunner.run`` in
+tests/unit/study/test_study_runner.py; here we isolate the session lifecycle.
+"""
+
+from __future__ import annotations
+
+import queue
+import signal
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llenergymeasure.config.models import ExecutionConfig, ExperimentConfig, StudyConfig
+from llenergymeasure.study.runner import StudyRunner
+from llenergymeasure.study.session import (
+    DockerSession,
+    ExperimentSession,
+    SubprocessSession,
+)
+from tests.conftest import TEST_CONFIG_HASH
+
+# =============================================================================
+# Fixtures / helpers
+# =============================================================================
+
+
+def _make_config() -> ExperimentConfig:
+    """A minimal ExperimentConfig with baseline disabled (keeps sessions hermetic)."""
+    return ExperimentConfig(
+        task={"model": "test/model"},
+        engine="transformers",
+        measurement={"baseline": {"enabled": False}},
+    )
+
+
+def _make_study(config: ExperimentConfig) -> StudyConfig:
+    return StudyConfig(
+        experiments=[config],
+        study_name="session-test",
+        study_execution=ExecutionConfig(n_cycles=1, experiment_order="sequential"),
+        study_design_hash=TEST_CONFIG_HASH,
+    )
+
+
+def _make_runner(tmp_path: Path, *, runner_specs: dict | None = None) -> StudyRunner:
+    config = _make_config()
+    study = _make_study(config)
+    runner = StudyRunner(study, MagicMock(), tmp_path, runner_specs=runner_specs)
+    # Env snapshot collection is a real background future; stub it out.
+    runner._get_env_snapshot = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+    return runner
+
+
+def _make_process(*, is_alive: bool = False, exitcode: int = 0, pid: int = 4242) -> MagicMock:
+    proc = MagicMock()
+    proc.pid = pid
+    proc.exitcode = exitcode
+    proc.is_alive.return_value = is_alive
+    return proc
+
+
+def _make_ctx(process: MagicMock, *, pipe_data: Any = None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.Process.return_value = process
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    parent_conn.poll.return_value = pipe_data is not None
+    if pipe_data is not None:
+        parent_conn.recv.return_value = pipe_data
+    ctx.Pipe.return_value = (parent_conn, child_conn)
+    ctx.Queue.return_value = queue.SimpleQueue()
+    return ctx
+
+
+# =============================================================================
+# Protocol conformance
+# =============================================================================
+
+
+def test_sessions_satisfy_experiment_session_protocol(tmp_path: Path) -> None:
+    """Both offline sessions structurally satisfy the runtime-checkable protocol."""
+    runner = _make_runner(tmp_path)
+    config = runner.study.experiments[0]
+    ctx = _make_ctx(_make_process())
+
+    sub = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
+    assert isinstance(sub, ExperimentSession)
+
+    from llenergymeasure.infra.runner_resolution import RunnerSpec
+
+    spec = RunnerSpec(mode="docker", image="img:v1", source="yaml")
+    doc = DockerSession(runner, config, spec, config_hash="h", cycle=1, index=1)
+    assert isinstance(doc, ExperimentSession)
+
+
+# =============================================================================
+# SubprocessSession: cleanup exactly once
+# =============================================================================
+
+
+def test_subprocess_session_cleanup_runs_once_normal_path(tmp_path: Path) -> None:
+    """Normal path: __exit__ closes the pipe, clears the active handle, and removes
+    the staging dir - exactly once, and a redundant __exit__ is a no-op."""
+    runner = _make_runner(tmp_path)
+    config = runner.study.experiments[0]
+    proc = _make_process(is_alive=False, exitcode=0)
+    ctx = _make_ctx(proc, pipe_data={"status": "ok"})
+    parent_conn = ctx.Pipe.return_value[0]
+
+    with (
+        patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"),
+        patch.object(runner, "_handle_result"),
+    ):
+        session = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
+        with session:
+            result = session.run()
+
+    assert result == {"status": "ok"}
+    ts_dir = session._ts_tmpdir
+    assert ts_dir is not None and not ts_dir.exists(), "staging dir was not removed on exit"
+    assert runner._active_process is None
+    parent_conn.close.assert_called_once()
+
+    # A second __exit__ (idempotent guard) must not re-run teardown.
+    session.__exit__(None, None, None)
+    parent_conn.close.assert_called_once()
+
+
+def test_subprocess_session_cleanup_runs_once_on_exception(tmp_path: Path) -> None:
+    """Interrupt/exception path: an error inside the ``with`` body still triggers a
+    single teardown - the live worker is reaped, the pipe closed, the staging dir
+    removed - which is the SIGINT/circuit-break cleanup guarantee the loop leans on."""
+    runner = _make_runner(tmp_path)
+    config = runner.study.experiments[0]
+    # is_alive=True: the body raised before run()'s own join/kill sequence, so
+    # __exit__ must reap the still-running worker.
+    proc = _make_process(is_alive=True, pid=5150)
+    ctx = _make_ctx(proc)
+    parent_conn = ctx.Pipe.return_value[0]
+
+    with (
+        patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"),
+        patch("llenergymeasure.study.session._kill_process_group") as mock_kill,
+    ):
+        session = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
+        ts_dir_before = None
+        with pytest.raises(RuntimeError, match="boom"), session:
+            ts_dir_before = session._ts_tmpdir
+            raise RuntimeError("boom")
+
+    # Teardown ran exactly once despite the exception.
+    assert ts_dir_before is not None and not ts_dir_before.exists()
+    assert runner._active_process is None
+    parent_conn.close.assert_called_once()
+    mock_kill.assert_called_once_with(proc.pid, signal.SIGKILL)
+    proc.join.assert_called()
+
+    # Idempotent: a second __exit__ does not kill or close again.
+    session.__exit__(None, None, None)
+    parent_conn.close.assert_called_once()
+    mock_kill.assert_called_once()
+
+
+def test_subprocess_session_active_process_set_during_enter(tmp_path: Path) -> None:
+    """__enter__ registers the worker as the runner's active process (SIGINT target)."""
+    runner = _make_runner(tmp_path)
+    config = runner.study.experiments[0]
+    proc = _make_process()
+    ctx = _make_ctx(proc, pipe_data={"status": "ok"})
+
+    with patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"):
+        session = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
+        session.__enter__()
+        try:
+            assert runner._active_process is proc
+        finally:
+            session.__exit__(None, None, None)
+    assert runner._active_process is None
+
+
+# =============================================================================
+# DockerSession: cleanup exactly once
+# =============================================================================
+
+
+def test_docker_session_cleanup_removes_staging_dir_once(tmp_path: Path) -> None:
+    """DockerSession.__exit__ removes the container staging dir exactly once."""
+    from llenergymeasure.infra.runner_resolution import RunnerSpec
+
+    spec = RunnerSpec(mode="docker", image="img:v1", source="yaml")
+    runner = _make_runner(tmp_path, runner_specs={"transformers": spec})
+    runner._images_prepared = True
+    config = runner.study.experiments[0]
+
+    docker_ts_dir = tmp_path / "docker-ts"
+    docker_ts_dir.mkdir()
+    fake_result = MagicMock()
+    fake_result.total_energy_j = 1.0
+
+    class _FakeDockerRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def run(self, *args: Any, **kwargs: Any) -> tuple[Any, Path]:
+            return fake_result, docker_ts_dir
+
+    with (
+        patch("llenergymeasure.infra.docker_runner.DockerRunner", _FakeDockerRunner),
+        patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"),
+        patch.object(runner, "_handle_result"),
+    ):
+        session = DockerSession(runner, config, spec, config_hash="h", cycle=1, index=1)
+        with session:
+            session.run()
+
+    assert not docker_ts_dir.exists(), "docker staging dir was not removed on exit"
+    # Idempotent second exit does not raise even though the dir is already gone.
+    session.__exit__(None, None, None)
+
+
+# =============================================================================
+# Progress-consumer timeout loop (decision 4)
+# =============================================================================
+
+
+class _ScriptedQueue:
+    """A queue whose get() replays a script; the ``_EMPTY`` marker raises queue.Empty."""
+
+    EMPTY = object()
+
+    def __init__(self, script: list[Any]) -> None:
+        self._script = list(script)
+
+    def get(self, timeout: float | None = None) -> Any:
+        item = self._script.pop(0)
+        if item is self.EMPTY:
+            raise queue.Empty
+        return item
+
+
+def test_progress_consumer_tolerates_empty_then_exits_on_sentinel() -> None:
+    """The consumer survives ``queue.Empty`` timeouts (silent producer) and exits
+    on the parent's None sentinel, forwarding the real events it did receive."""
+    from llenergymeasure.study._progress import _consume_progress_events
+
+    progress = MagicMock()
+    q = _ScriptedQueue(
+        [
+            {"event": "step_done", "step": "baseline", "elapsed_sec": 1.5},
+            _ScriptedQueue.EMPTY,  # producer silent this tick - must not hang/crash
+            _ScriptedQueue.EMPTY,
+            None,  # parent sentinel ends the loop
+        ]
+    )
+
+    # Returns (does not hang) despite the intervening Empty ticks.
+    _consume_progress_events(q, study_progress=progress)
+
+    progress.on_step_done.assert_called_once_with("baseline", 1.5)
+
+
+def test_progress_consumer_thread_stays_responsive_on_silent_producer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A daemon consumer against a live-but-silent queue keeps polling (does not die
+    on Empty) and exits promptly once the sentinel arrives."""
+    import threading
+    import time
+
+    from llenergymeasure.study._progress import _consume_progress_events
+
+    monkeypatch.setattr("llenergymeasure.study._progress.TIMEOUT_PROGRESS_QUEUE_POLL", 0.01)
+
+    q: queue.Queue = queue.Queue()
+    progress = MagicMock()
+    q.put({"event": "step_done", "step": "s", "elapsed_sec": 0.1})
+
+    t = threading.Thread(target=_consume_progress_events, args=(q, progress), daemon=True)
+    t.start()
+    time.sleep(0.1)  # several poll ticks elapse with an empty queue
+    assert t.is_alive(), "consumer must keep polling on an empty queue, not exit"
+
+    q.put(None)  # sentinel
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "consumer must exit on the sentinel"
+    progress.on_step_done.assert_called_once_with("s", 0.1)

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -31,6 +31,7 @@ from llenergymeasure.study.runner import (
     _run_experiment_worker,
 )
 from tests.conftest import TEST_CONFIG_HASH
+from tests.unit.study.conftest import _make_mock_context, _make_mock_process
 
 # =============================================================================
 # Fixtures
@@ -52,54 +53,6 @@ def study_config(basic_config: ExperimentConfig) -> StudyConfig:
         study_execution=ExecutionConfig(n_cycles=1, experiment_order="sequential"),
         study_design_hash=TEST_CONFIG_HASH,
     )
-
-
-def _make_mock_process(
-    *,
-    is_alive_after_join: bool = False,
-    exitcode: int = 0,
-    pid: int = 12345,
-) -> MagicMock:
-    """Factory for a mock Process with controllable lifecycle."""
-    proc = MagicMock()
-    proc.pid = pid
-    proc.exitcode = exitcode
-
-    def fake_join(timeout=None):
-        # After join, is_alive reflects whether timed out
-        pass
-
-    proc.join.side_effect = fake_join
-    proc.is_alive.return_value = is_alive_after_join
-    return proc
-
-
-def _make_mock_context(
-    process: MagicMock,
-    pipe_data: object = None,
-    *,
-    pipe_has_data: bool = True,
-) -> MagicMock:
-    """Build a mock multiprocessing context that returns a controlled process.
-
-    pipe_data: the object that parent_conn.recv() will return.
-    pipe_has_data: if False, parent_conn.poll() returns False (empty pipe).
-    """
-    ctx = MagicMock()
-    ctx.Process.return_value = process
-
-    parent_conn = MagicMock()
-    child_conn = MagicMock()
-    parent_conn.poll.return_value = pipe_has_data
-    if pipe_data is not None:
-        parent_conn.recv.return_value = pipe_data
-
-    ctx.Pipe.return_value = (parent_conn, child_conn)
-
-    # Queue: use a real in-process queue so the consumer thread works
-    ctx.Queue.return_value = queue.SimpleQueue()
-
-    return ctx
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -1353,7 +1353,7 @@ def test_parent_conn_closed_after_collect_result(study_config: StudyConfig) -> N
 
     with (
         patch("multiprocessing.get_context", return_value=ctx),
-        patch("llenergymeasure.study.runner._collect_result", side_effect=patched_collect),
+        patch("llenergymeasure.study.session._collect_result", side_effect=patched_collect),
     ):
         runner = StudyRunner(study_config, manifest, Path("/tmp/test-fd-leak"))
         runner.run()

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -76,9 +76,9 @@ def test_internal_name_raises_attribute_error():
 
 def test_run_experiment_returns_experiment_result(monkeypatch):
     """run_experiment returns exactly ExperimentResult, not a union or None."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: make_study_result())
+    monkeypatch.setattr(api_module, "orchestrate_study", lambda study, **kw: make_study_result())
 
     config = ExperimentConfig(task={"model": "gpt2"})
     result = run_experiment(config)
@@ -96,7 +96,7 @@ def test_run_experiment_returns_experiment_result(monkeypatch):
 
 def test_run_experiment_yaml_path_form(tmp_path, monkeypatch):
     """run_experiment resolves correctly from a YAML path."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
 
     captured_study = {}
 
@@ -104,7 +104,7 @@ def test_run_experiment_yaml_path_form(tmp_path, monkeypatch):
         captured_study["value"] = study
         return make_study_result()
 
-    monkeypatch.setattr(api_module, "_run", mock_run)
+    monkeypatch.setattr(api_module, "orchestrate_study", mock_run)
 
     config_path = tmp_path / "test_config.yaml"
     config_path.write_text("task:\n  model: gpt2\n")
@@ -123,7 +123,7 @@ def test_run_experiment_yaml_path_form(tmp_path, monkeypatch):
 
 def test_run_experiment_kwargs_form(monkeypatch):
     """run_experiment kwargs form passes model and dataset to ExperimentConfig."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
 
     captured_study = {}
 
@@ -131,7 +131,7 @@ def test_run_experiment_kwargs_form(monkeypatch):
         captured_study["value"] = study
         return make_study_result()
 
-    monkeypatch.setattr(api_module, "_run", mock_run)
+    monkeypatch.setattr(api_module, "orchestrate_study", mock_run)
 
     result = run_experiment(model="gpt2", n_prompts=50)
 
@@ -160,9 +160,9 @@ def test_run_experiment_no_config_no_model_raises():
 
 def test_run_experiment_no_disk_writes(tmp_path, monkeypatch):
     """run_experiment produces no disk writes when output_dir is not specified."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: make_study_result())
+    monkeypatch.setattr(api_module, "orchestrate_study", lambda study, **kw: make_study_result())
 
     # Change working directory to tmp_path to catch any accidental writes
     config = ExperimentConfig(task={"model": "gpt2"})
@@ -215,9 +215,9 @@ def test_version_in_all():
 
 def test_run_experiment_path_object_form(tmp_path, monkeypatch):
     """run_experiment accepts a Path object as well as a str path."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: make_study_result())
+    monkeypatch.setattr(api_module, "orchestrate_study", lambda study, **kw: make_study_result())
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text("task:\n  model: gpt2\n")
@@ -233,7 +233,7 @@ def test_run_experiment_path_object_form(tmp_path, monkeypatch):
 
 def test_run_experiment_kwargs_engine(monkeypatch):
     """run_experiment kwargs form passes engine to ExperimentConfig."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
 
     captured_study = {}
 
@@ -241,7 +241,7 @@ def test_run_experiment_kwargs_engine(monkeypatch):
         captured_study["value"] = study
         return make_study_result()
 
-    monkeypatch.setattr(api_module, "_run", mock_run)
+    monkeypatch.setattr(api_module, "orchestrate_study", mock_run)
 
     run_experiment(model="gpt2", engine="transformers")
 
@@ -319,9 +319,9 @@ def _patch_harness(monkeypatch, result: ExperimentResult) -> None:
 
 def test_run_calls_preflight_once_per_config(monkeypatch, tmp_path):
     """_run() calls run_preflight once for the single in-process experiment."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
 
     preflight_calls: list = []
@@ -351,7 +351,7 @@ def test_run_calls_preflight_once_per_config(monkeypatch, tmp_path):
     config1 = ExperimentConfig(task={"model": "gpt2"})
     study = StudyConfig(experiments=[config1])
 
-    api_module._run(study)
+    api_module.orchestrate_study(study)
 
     assert len(preflight_calls) == 1, f"Expected 1 preflight call, got {len(preflight_calls)}"
     assert preflight_calls[0].task.model == "gpt2"
@@ -366,7 +366,7 @@ def test_run_preserves_runner_abort_status(monkeypatch, tmp_path, abort_status):
     mark_study_completed() unconditionally, clobbering that status and leaving the
     aborted study looking completed (and therefore non-resumable).
     """
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
 
     captured: dict = {}
@@ -396,16 +396,16 @@ def test_run_preserves_runner_abort_status(monkeypatch, tmp_path, abort_status):
             ExperimentConfig(task={"model": "distilgpt2"}),
         ]
     )
-    api_module._run(study)
+    api_module.orchestrate_study(study)
 
     assert captured["manifest"].status == abort_status
 
 
 def test_run_skips_preflight_when_preresolved_supplied(monkeypatch, tmp_path):
     """_run() does NOT re-run study preflight when preresolved is provided."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
     from llenergymeasure.infra.runner_resolution import RunnerSpec
 
@@ -441,7 +441,7 @@ def test_run_skips_preflight_when_preresolved_supplied(monkeypatch, tmp_path):
         {"transformers": RunnerSpec(mode="local", image=None, source="test")},
         {},
     )
-    api_module._run(study, skip_preflight=True, preresolved=preresolved)
+    api_module.orchestrate_study(study, skip_preflight=True, preresolved=preresolved)
 
     assert study_preflight_calls == [], (
         "run_study_preflight must not be called inside _run when preresolved is supplied"
@@ -516,7 +516,7 @@ def test_run_study_fresh_without_output_dir_uses_yaml_results_dir(monkeypatch, t
 
 def test_run_study_resume_uses_output_dir_as_search_base(monkeypatch, tmp_path):
     """Resume: output_dir stays the resumable-study search base, not a results override."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.resume as resume_module
 
     search_bases: list = []
@@ -537,7 +537,7 @@ def test_run_study_resume_uses_output_dir_as_search_base(monkeypatch, tmp_path):
         captured.update(kw)
         return make_study_result()
 
-    monkeypatch.setattr(api_module, "_run", _capture_run)
+    monkeypatch.setattr(api_module, "orchestrate_study", _capture_run)
 
     study = StudyConfig(experiments=[make_config()])
     search_base = tmp_path / "search-here"
@@ -550,7 +550,7 @@ def test_run_study_resume_uses_output_dir_as_search_base(monkeypatch, tmp_path):
 
 def test_run_preresolved_without_skip_preflight_raises():
     """Passing preresolved with skip_preflight=False is rejected, not silently honoured."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
     from llenergymeasure.infra.runner_resolution import RunnerSpec
 
     config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
@@ -562,14 +562,14 @@ def test_run_preresolved_without_skip_preflight_raises():
     )
 
     with pytest.raises(ValueError, match="preresolved requires skip_preflight=True"):
-        api_module._run(study, skip_preflight=False, preresolved=preresolved)
+        api_module.orchestrate_study(study, skip_preflight=False, preresolved=preresolved)
 
 
 def test_run_calls_get_engine_with_correct_name(monkeypatch, tmp_path):
     """_run() calls get_engine with the experiment's engine name."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
 
     mock_result = make_result()
@@ -600,7 +600,7 @@ def test_run_calls_get_engine_with_correct_name(monkeypatch, tmp_path):
     config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
     study = StudyConfig(experiments=[config])
 
-    api_module._run(study)
+    api_module.orchestrate_study(study)
 
     assert len(engine_calls) == 1
     assert engine_calls[0] == "transformers"
@@ -608,9 +608,9 @@ def test_run_calls_get_engine_with_correct_name(monkeypatch, tmp_path):
 
 def test_run_returns_study_result(monkeypatch, tmp_path):
     """_run() returns a StudyResult containing the experiment results."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
 
     mock_result = make_result(experiment_id="wired-001")
@@ -635,7 +635,7 @@ def test_run_returns_study_result(monkeypatch, tmp_path):
     config = ExperimentConfig(task={"model": "gpt2"})
     study = StudyConfig(experiments=[config], study_name="my-study")
 
-    study_result = api_module._run(study)
+    study_result = api_module.orchestrate_study(study)
 
     assert isinstance(study_result, StudyResult)
     assert study_result.study_name == "my-study"
@@ -645,9 +645,9 @@ def test_run_returns_study_result(monkeypatch, tmp_path):
 
 def test_run_propagates_preflight_error(monkeypatch, tmp_path):
     """_run() propagates PreFlightError without catching it."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
 
     def failing_preflight(config):
@@ -670,15 +670,15 @@ def test_run_propagates_preflight_error(monkeypatch, tmp_path):
     study = StudyConfig(experiments=[config])
 
     with pytest.raises(PreFlightError):
-        api_module._run(study)
+        api_module.orchestrate_study(study)
 
 
 def test_run_propagates_engine_error(monkeypatch, tmp_path):
     """_run() propagates EngineError without catching it."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness as harness_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
 
     def _failing_harness_run(self, engine, config, **kw):
@@ -700,7 +700,7 @@ def test_run_propagates_engine_error(monkeypatch, tmp_path):
     study = StudyConfig(experiments=[config])
 
     with pytest.raises(EngineError, match="GPU out of memory"):
-        api_module._run(study)
+        api_module.orchestrate_study(study)
 
 
 def test_run_experiment_end_to_end_mocked(monkeypatch, tmp_path):
@@ -810,9 +810,9 @@ def test_run_study_accepts_path(tmp_path, monkeypatch):
 
 def test_run_dispatches_single_in_process(monkeypatch, tmp_path):
     """Single experiment + n_cycles=1 bypasses StudyRunner (in-process path)."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
     from llenergymeasure.study.runner import StudyRunner
 
@@ -847,7 +847,7 @@ def test_run_dispatches_single_in_process(monkeypatch, tmp_path):
         experiments=[ExperimentConfig(task={"model": "gpt2"})],
         study_execution={"n_cycles": 1, "experiment_order": "sequential"},
     )
-    api_module._run(study)
+    api_module.orchestrate_study(study)
 
     # Single experiment + n_cycles=1 should NOT create StudyRunner
     assert runner_created == [], "StudyRunner was created for single in-process path"
@@ -872,8 +872,8 @@ def test_run_study_returns_study_result_type():
 
 def test_run_resolves_runners_and_passes_to_study_runner(monkeypatch, tmp_path):
     """_run() resolves runners via resolve_study_runners and passes runner_specs to StudyRunner."""
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
     from llenergymeasure.infra.runner_resolution import RunnerSpec
 
@@ -936,7 +936,7 @@ def test_run_resolves_runners_and_passes_to_study_runner(monkeypatch, tmp_path):
         ]
     )
 
-    api_module._run(study)
+    api_module.orchestrate_study(study)
 
     assert len(captured_runner_specs) == 1, "_run_via_runner not called or called multiple times"
     assert captured_runner_specs[0] == resolved_specs
@@ -946,9 +946,9 @@ def test_run_mixed_runner_warning_logged(monkeypatch, tmp_path, caplog):
     """_run() logs a warning when runner_specs has mixed local/docker modes."""
     import logging
 
-    import llenergymeasure.api._impl as api_module
     import llenergymeasure.engines as engines_module
     import llenergymeasure.harness.preflight as pf_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
     from llenergymeasure.infra.runner_resolution import RunnerSpec
 
@@ -981,8 +981,8 @@ def test_run_mixed_runner_warning_logged(monkeypatch, tmp_path, caplog):
 
     study = StudyConfig(experiments=[ExperimentConfig(task={"model": "gpt2"})])
 
-    with caplog.at_level(logging.WARNING, logger="llenergymeasure.api._impl"):
-        api_module._run(study)
+    with caplog.at_level(logging.WARNING, logger="llenergymeasure.study.orchestration"):
+        api_module.orchestrate_study(study)
 
     warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
     assert any("mixed" in m.lower() for m in warning_messages), (
@@ -1003,7 +1003,7 @@ def test_study_summary_total_experiments_no_double_multiply(monkeypatch, tmp_pat
     total_experiments must be 6, not 18 (the pre-fix bug: 6 * 3).
     unique_configurations must be 2 (6 / 3).
     """
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
 
     # Build 6 mock results (2 configs x 3 cycles, already cycle-expanded)
@@ -1051,7 +1051,7 @@ def test_study_summary_total_experiments_no_double_multiply(monkeypatch, tmp_pat
     # Verify our study fixture has exactly 6 experiments
     assert len(study.experiments) == 6
 
-    study_result = api_module._run(study)
+    study_result = api_module.orchestrate_study(study)
 
     assert study_result.summary.total_experiments == 6, (
         f"Expected 6 (cycle-expanded count), got {study_result.summary.total_experiments} "
@@ -1267,7 +1267,7 @@ class TestResolveGpuIndicesTensorrt:
 
 def test_run_experiment_raises_experiment_error_on_empty_results(monkeypatch):
     """run_experiment raises ExperimentError (not IndexError) when _run returns empty experiments."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
     from llenergymeasure.utils.exceptions import ExperimentError
 
     empty_study_result = StudyResult(
@@ -1283,7 +1283,7 @@ def test_run_experiment_raises_experiment_error_on_empty_results(monkeypatch):
         ),
     )
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: empty_study_result)
+    monkeypatch.setattr(api_module, "orchestrate_study", lambda study, **kw: empty_study_result)
 
     config = ExperimentConfig(task={"model": "gpt2"})
     with pytest.raises(ExperimentError) as exc_info:
@@ -1294,7 +1294,7 @@ def test_run_experiment_raises_experiment_error_on_empty_results(monkeypatch):
 
 def test_run_experiment_raises_experiment_error_no_warnings(monkeypatch):
     """run_experiment raises ExperimentError with fallback message when warnings list is empty."""
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
     from llenergymeasure.utils.exceptions import ExperimentError
 
     empty_study_result = StudyResult(
@@ -1309,7 +1309,7 @@ def test_run_experiment_raises_experiment_error_no_warnings(monkeypatch):
         ),
     )
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: empty_study_result)
+    monkeypatch.setattr(api_module, "orchestrate_study", lambda study, **kw: empty_study_result)
 
     config = ExperimentConfig(task={"model": "gpt2"})
     with pytest.raises(ExperimentError, match="Experiment produced no results"):
@@ -1323,7 +1323,7 @@ def test_run_study_partial_failure_returns_partial_results(monkeypatch):
     The study should NOT raise - it returns a StudyResult with the successful
     experiments and a summary showing the failure count.
     """
-    import llenergymeasure.api._impl as api_module
+    import llenergymeasure.study.orchestration as api_module
 
     successful_result = make_result(experiment_id="partial-ok")
 
@@ -1340,7 +1340,7 @@ def test_run_study_partial_failure_returns_partial_results(monkeypatch):
         ),
     )
 
-    monkeypatch.setattr(api_module, "_run", lambda study, **kw: partial_study_result)
+    monkeypatch.setattr(api_module, "orchestrate_study", lambda study, **kw: partial_study_result)
 
     study = StudyConfig(
         experiments=[


### PR DESCRIPTION
## Summary

S11 of the F6 refactor: introduce the dispatch-shape **session seam** (maintainer
ruling: a session object, not an iterator), relocate the orchestration cluster to
the study layer, and clear the two smaller debts the brief names. No behavior,
results, CLI, or public-API change - this restructures who owns the loop, not what
the loop does.

**Session seam (`study/session.py`).** One experiment dispatch is now an
`ExperimentSession`: a context manager whose `__enter__` acquires the dispatch's
resources, whose `run()` produces the result payload, and whose `__exit__` releases
everything exactly once. Two offline implementations wrap today's paths -
`SubprocessSession` (freshly spawned worker) and `DockerSession` (blocking
`DockerRunner.run`). The value of the seam is that the session **lifetime**
(acquire -> produce -> release) is separable from **result production**: an offline
session produces exactly one result, and that separability is what will let a
v0.8.0 server session express one lifetime with many result windows (constraint
C3). This slice adds no window-spec vocabulary, no N-result consumption, and no
server session.

**How the dispatch landed.** `StudyRunner._run_one` / `_run_one_docker` keep their
signatures (the extensive dispatch-mechanics test surface and `test_baseline_strategy`
call them directly) but their bodies now construct and drive a session via the
context-manager protocol; the mechanics moved verbatim into the session. Today the
sweep loop drives one session per experiment and consumes the single result it
produces; the manifest transitions and the circuit breaker follow that one result.

- **SIGINT / cleanup.** The old `_run_one` had no `finally`, so a raise between
  spawn and cleanup leaked the worker, pipe, consumer thread, and temp dir. Teardown
  now lives in `SubprocessSession.__exit__` under a one-shot `_torn_down` guard:
  active-process handle cleared, a still-alive worker reaped (SIGKILL + join), the
  progress consumer stopped, the read end of the pipe closed (exactly once - the C4
  FD-leak invariant the tests assert), and the staging dir removed. The interrupt
  grace `SIGTERM -> 2s -> SIGKILL` escalation stays in `run()` exactly as before; the
  study-level SIGINT handler still reads `runner._active_process`, which the session
  sets on enter and clears on exit. The existing SIGINT/interrupt/timeout/killpg
  StudyRunner tests pass unchanged.
- **Circuit breaker.** Unchanged - `_apply_circuit_breaker` still runs in the loop off
  each result; all existing circuit-breaker / fail-fast / probe / wall-clock-timeout
  tests pass unchanged.
- **GPU locks / manifest / resume.** GPU locks stay deliberately **study-scoped** in
  `run()`'s install/restore handlers (a lock outlives any one session; per the
  behavior freeze on lock naming/scope). Manifest keys and resume behavior untouched.

**Orchestration relocation (`study/orchestration.py`).** The `_run` cluster
(`orchestrate_study` = old `_run`, plus `_resolve_runner_specs`,
`_write_study_artefacts`, `_build_resolution_logs`, single-vs-sweep branch,
`_run_via_runner`, study-dir + manifest setup) moves to a study-layer orchestrator.
`api/_impl.py` is now a thin adapter: load/validate config, translate the call
forms, delegate. The public `run_experiment` / `run_study` signatures, behavior, and
`api.__all__` are frozen.

**output_dir dual-semantics (#842).** The adapter maps the overloaded public
`output_dir` onto the orchestrator's two single-purpose internal parameters -
`results_dir_override` (fresh run) and the resume search base (auto-detect resume) -
with the mapping documented at the boundary. The public signature and CLI are
unchanged.

**Progress-queue timeout.** `study/_progress.py`'s consumer polls with
`q.get(timeout=TIMEOUT_PROGRESS_QUEUE_POLL)` and a sentinel-aware loop, so a silent
producer cannot wedge the display thread on a single blocking `get`; the parent's
`None` sentinel still ends the loop.

## Review fixes (4-angle simplify pass, third commit)

1. **Claim honesty.** Corrected the `session.py` docstring + CHANGELOG entry: they
   previously overclaimed that "the manifest, circuit breaker, GPU locks, and SIGINT
   all key off the (session, result) outcome". Reality (now documented): the offline
   loop consumes one scalar result per session by design, GPU locks are study-scoped
   and never session-keyed, and C3 is satisfied by the separable **lifetime**, not by
   any re-keyed loop. No N-result consumption is built now.
2. **Shared report tail.** Factored `_OfflineSession._report(...)` for the identical
   `_handle_result` call both sessions' `run()` ended with (removes signature-drift
   risk).
3. **Dead double-clear.** Dropped the `_active_process = None` at the end of
   `SubprocessSession.run()`; `_cleanup()` on `__exit__` is the single clear.
4. **Pass-through wrappers.** Deleted the `_provenance_from_spec` / `_runner_environment`
   delegating wrappers in `session.py`; `_report` lazy-imports the runner builders at
   the one call site.
5. **Lagging docstring.** Added the `study.session` bullet to the `runner.py`
   sibling-modules list.
6. **Test-fixture reuse.** Hoisted `_make_mock_process` / `_make_mock_context` into
   `tests/unit/study/conftest.py`; both `test_study_runner.py` and `test_session.py`
   use them (local copies deleted).

## Deviations

- `_run_one` / `_run_one_docker` are kept as the session *drivers* rather than the
  loop building sessions inline. Those methods (and their exact signatures) are a
  hard test contract - `test_baseline_strategy` calls `_run_one_docker` directly and
  the SIGINT tests patch `_run_one` - so keeping them as one-line session drivers
  preserves the regression floor while the lifecycle genuinely lives in the session.
- Test repointing (sanctioned by the brief): `test_api.py` `_run` / `_run_via_runner`
  references point at `study.orchestration`; the mixed-runner warning test's logger
  name follows; the FD-leak test's `_collect_result` patch points at its new use site
  (`study.session`). No behavioral assertions changed.

## Rebase

Rebased onto latest `origin/main` after #860 (grid split) and #862 (progress
registry + step-display split) merged underneath. Neither touches this slice's files
beyond CHANGELOG; the only conflicts were CHANGELOG hunks, union-resolved (all three
entries kept; link-reference block in numeric order incl. #860/#862/#863). The full
suite was re-run post-rebase and stays green, confirming the grid/progress splits do
not break this slice's imports.

## Test plan

- `make lint` - clean; import-linter: 5 contracts kept, 0 broken (new `study/`
  modules respect the layer boundary).
- `make typecheck` - clean (331 source files).
- `uv run pytest tests/unit/ tests/integration/ -q` - **3191 passed, 37 skipped**
  (GPU/docker/slow-marked), 10 deselected (post-rebase).
- New `tests/unit/study/test_session.py` (7 tests) explicitly covers the brief's
  named cases:
  - SIGINT/interrupt path through a session: teardown runs **exactly once** on both
    the normal and exception paths (pipe closed once, staging dir removed, a live
    worker reaped, active handle cleared; a redundant `__exit__` is a no-op).
  - `ExperimentSession` protocol conformance for both offline sessions.
  - `DockerSession` staging-dir cleanup exactly once.
  - the progress timeout loop: the consumer tolerates `queue.Empty` ticks (silent
    producer) and still exits on the sentinel, both synchronously and on a live
    daemon thread.
- Circuit-breaker and resume behavior verified unchanged via the existing
  `test_study_runner.py` circuit-breaker/timeout suites and the `test_api.py` /
  `test_resume.py` resume suites (all pass unchanged).
