### PR TITLE
refactor(config): relocate RunnerSpec to config layer + preflight honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Changed
 
+- Internal restructure (no behavior or results change): the resolved `RunnerSpec`
+  value object moved from `infra.runner_resolution` to the config layer
+  (`llenergymeasure.config.runner_spec`), so the study layer no longer imports
+  infra for a config-derived fact; its `is_explicit` classification now sits next
+  to the precedence taxonomy it reads in `config.ssot`. The resolution machinery
+  (`resolve_runner`, `resolve_study_runners`, `is_docker_available`) stays in
+  infra. The engine-installed host check is now a public
+  `harness.preflight.check_engine_installed` (was a cross-package private import),
+  and the `LLEM_DOCKER_GPUS` vs `study_execution.gpu_indices` conflict warning is
+  emitted from a single choke point in `orchestrate_study` rather than duplicated
+  across the single-experiment and `StudyRunner` dispatch paths.
 - Internal restructure (no behavior or results change): one experiment dispatch
   is now an `ExperimentSession` (`llenergymeasure.study.session`) - a context
   manager whose `__enter__` acquires the dispatch's resources, whose `run()`

--- a/src/llenergymeasure/api/_impl.py
+++ b/src/llenergymeasure/api/_impl.py
@@ -24,9 +24,9 @@ from llenergymeasure.config.models import (
     StudyConfig,
     TaskConfig,
 )
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.domain.experiment import ExperimentResult, StudyResult
 from llenergymeasure.domain.progress import ProgressCallback
-from llenergymeasure.infra.runner_resolution import RunnerSpec
 from llenergymeasure.utils.exceptions import ConfigError
 
 # Single source of truth for n_prompts default - derived from DatasetConfig field default

--- a/src/llenergymeasure/api/health.py
+++ b/src/llenergymeasure/api/health.py
@@ -37,6 +37,7 @@ from llenergymeasure.config.user_config import (
     load_user_config,
 )
 from llenergymeasure.device.gpu_info import gpu_inventory
+from llenergymeasure.harness.preflight import check_engine_installed
 
 # Reuse the canonical host probes rather than re-implementing them (their home is
 # docker_preflight; runner_resolution reuses the toolkit list too).
@@ -210,7 +211,7 @@ def _resolve_image(engine: str) -> tuple[str | None, bool, str | None]:
 
 
 def _engine_line(engine: str, spec: RunnerSpec) -> CheckLine:
-    importable = importlib.util.find_spec(ENGINE_PACKAGES[Engine(engine)]) is not None
+    importable = check_engine_installed(engine)
     if importable:
         version = _probe_engine_version(engine)
         installed = f"importable locally ({version})" if version else "importable locally"

--- a/src/llenergymeasure/api/health.py
+++ b/src/llenergymeasure/api/health.py
@@ -23,6 +23,7 @@ from typing import Any, Literal
 
 from llenergymeasure.api import probe_energy_sampler
 from llenergymeasure.api.doctor import DoctorReport, run_doctor_checks
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.config.ssot import (
     ENGINE_PACKAGES,
     ENV_HF_TOKEN,
@@ -46,7 +47,7 @@ from llenergymeasure.infra.docker_preflight import (
     docker_daemon_reachable,
 )
 from llenergymeasure.infra.image_registry import get_default_image, image_present_locally
-from llenergymeasure.infra.runner_resolution import RunnerSpec, is_docker_available, resolve_runner
+from llenergymeasure.infra.runner_resolution import is_docker_available, resolve_runner
 from llenergymeasure.infra.version_handshake import SchemaStatus
 from llenergymeasure.utils.exceptions import ConfigError
 

--- a/src/llenergymeasure/cli/_display.py
+++ b/src/llenergymeasure/cli/_display.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from pydantic import ValidationError
 
 if TYPE_CHECKING:
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
 from llenergymeasure.config.models import ExperimentConfig
 from llenergymeasure.domain.experiment import ExperimentResult

--- a/src/llenergymeasure/cli/_preflight_display.py
+++ b/src/llenergymeasure/cli/_preflight_display.py
@@ -29,7 +29,7 @@ from llenergymeasure.config.ssot import SOURCE_MULTI_ENGINE_ELEVATION
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import StudyConfig
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
 
 def build_preflight_panel(

--- a/src/llenergymeasure/config/runner_spec.py
+++ b/src/llenergymeasure/config/runner_spec.py
@@ -1,0 +1,66 @@
+"""RunnerSpec - the resolved runner value object.
+
+A ``RunnerSpec`` is a plain resolved fact about *how* an engine should be
+dispatched (local vs Docker, which image, and the precedence source that
+selected it). It lives in the config/domain foundation layer, not in ``infra``,
+because it is config-derived data consumed by the study layer - the resolution
+*machinery* (Docker detection, env-var reading) stays in
+``infra.runner_resolution``, which imports this value object.
+
+The precedence taxonomy the spec references (the ``source`` tags, ``RunnerMode``,
+and ``EXPLICIT_RUNNER_SOURCES``) is the single source of truth in
+``config.ssot``; ``is_explicit`` reads it directly, so the classification lives
+next to the taxonomy it describes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from llenergymeasure.config.ssot import EXPLICIT_RUNNER_SOURCES, RunnerMode
+
+
+@dataclass
+class RunnerSpec:
+    """Resolved runner specification: where and how an engine should be dispatched.
+
+    A spec is a plain resolved value, independent of any single dispatch: it
+    carries no assumption that it is consumed by exactly one ``run()`` call and
+    no dispatch machinery of its own. The same spec may drive one experiment or
+    be reused across many.
+
+    Attributes:
+        mode:         Execution mode - "local" or "docker".
+        image:        Docker image to use. None for local mode or when the
+                      default should be resolved at dispatch time.
+        source:       Which layer of the precedence chain produced this spec:
+                      "env", "yaml", "user_config", "auto_detected", "default".
+        image_source: Where the Docker image was resolved from:
+                      "env", "yaml", "runner_override", "user_config",
+                      "local_build", "registry", or None (local mode / unresolved).
+    """
+
+    mode: RunnerMode
+    image: str | None
+    source: str
+    image_source: str | None = None
+    extra_mounts: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def is_explicit(self) -> bool:
+        """True if this runner was an explicit user pin (env var / YAML / user config).
+
+        Explicit pins win over multi-engine Docker elevation; auto-resolved
+        runners (``auto_detected`` / ``default``) do not. Classification lives
+        here, next to the ``source`` taxonomy it describes.
+        """
+        return self.source in EXPLICIT_RUNNER_SOURCES
+
+    def to_runner_info(self) -> dict[str, str | None]:
+        """Build runner info dict for progress display callbacks."""
+        return {
+            "mode": self.mode,
+            "source": self.source,
+            "image": self.image,
+            "image_source": self.image_source,
+        }

--- a/src/llenergymeasure/config/runner_spec.py
+++ b/src/llenergymeasure/config/runner_spec.py
@@ -38,6 +38,8 @@ class RunnerSpec:
         image_source: Where the Docker image was resolved from:
                       "env", "yaml", "runner_override", "user_config",
                       "local_build", "registry", or None (local mode / unresolved).
+        extra_mounts: Additional host:container bind-mount pairs. Populated at
+                      dispatch time, not by the resolution chain.
     """
 
     mode: RunnerMode

--- a/src/llenergymeasure/domain/environment.py
+++ b/src/llenergymeasure/domain/environment.py
@@ -100,7 +100,7 @@ class RunnerEnvironment(BaseModel):
     never fails a run.
 
     Sibling of ``experiment.RunnerProvenance`` (which persists into result.json):
-    both mirror ``infra.RunnerSpec``'s mode/image/source. They stay separate
+    both mirror the config-layer ``RunnerSpec``'s mode/image/source. They stay separate
     because their extra fields diverge - this one carries ``image_digest`` (the
     environment.json reproducibility anchor), RunnerProvenance carries
     ``image_source`` (result.json image-resolution provenance).

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -60,9 +60,9 @@ def mj_per_token(energy_j: float, total_tokens: float) -> float | None:
 class RunnerProvenance(BaseModel):
     """How an experiment was executed - local process or Docker container.
 
-    Persisted reproducibility metadata mirroring the fields of the infra-layer
-    ``RunnerSpec``. Kept in the domain layer (no infra import) so it can live on
-    ``ExperimentResult`` and serialise into result.json.
+    Persisted reproducibility metadata mirroring the fields of the config-layer
+    ``RunnerSpec``. Kept in the domain layer (which does not import its config
+    sibling) so it can live on ``ExperimentResult`` and serialise into result.json.
 
     Sibling of ``environment.RunnerEnvironment`` (which persists into
     environment.json): both mirror ``RunnerSpec``'s mode/image/source. They stay

--- a/src/llenergymeasure/harness/preflight.py
+++ b/src/llenergymeasure/harness/preflight.py
@@ -36,8 +36,13 @@ def _check_cuda_available() -> bool:
     return bool(torch.cuda.is_available())
 
 
-def _check_engine_installed(engine: str) -> bool:
-    """Return True if the package that provides *engine* is importable."""
+def check_engine_installed(engine: str) -> bool:
+    """Return True if the package that provides *engine* is importable.
+
+    Public because the study-layer multi-engine pre-flight reuses this host
+    importability check (find_spec on the engine package); harness/preflight owns
+    the fact, so callers import the name rather than reaching for a private symbol.
+    """
     try:
         engine_key = Engine(engine)
     except ValueError:
@@ -134,7 +139,7 @@ def run_preflight(config: ExperimentConfig) -> None:
         failures.append("CUDA not available - is a GPU present and CUDA installed?")
 
     # Check 2: Engine installed
-    if not _check_engine_installed(config.engine):
+    if not check_engine_installed(config.engine):
         package = ENGINE_PACKAGES.get(config.engine, config.engine)
         failures.append(
             f"{config.engine} not available on host (missing: {package}). "

--- a/src/llenergymeasure/infra/runner_resolution.py
+++ b/src/llenergymeasure/infra/runner_resolution.py
@@ -22,15 +22,14 @@ import functools
 import logging
 import os
 import shutil
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from llenergymeasure.config.user_config import UserRunnersConfig
 
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.config.ssot import (
     ENV_RUNNER_PREFIX,
-    EXPLICIT_RUNNER_SOURCES,
     RUNNER_DOCKER,
     RUNNER_LOCAL,
     SOURCE_AUTO_DETECTED,
@@ -38,7 +37,6 @@ from llenergymeasure.config.ssot import (
     SOURCE_ENV,
     SOURCE_USER_CONFIG,
     SOURCE_YAML,
-    RunnerMode,
 )
 
 # The NVIDIA Container Toolkit binary list lives in docker_preflight (its canonical
@@ -50,7 +48,6 @@ from llenergymeasure.infra.docker_preflight import NVIDIA_TOOLKIT_BINS
 from llenergymeasure.infra.image_registry import parse_runner_value
 
 __all__ = [
-    "RunnerSpec",
     "is_docker_available",
     "parse_runner_value",
     "resolve_runner",
@@ -101,52 +98,6 @@ def is_docker_available() -> bool:
         return False
 
     return any(shutil.which(tool) is not None for tool in NVIDIA_TOOLKIT_BINS)
-
-
-# ---------------------------------------------------------------------------
-# RunnerSpec dataclass
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class RunnerSpec:
-    """Resolved runner specification for a single experiment execution.
-
-    Attributes:
-        mode:         Execution mode - "local" or "docker".
-        image:        Docker image to use. None for local mode or when the
-                      default should be resolved at dispatch time.
-        source:       Which layer of the precedence chain produced this spec:
-                      "env", "yaml", "user_config", "auto_detected", "default".
-        image_source: Where the Docker image was resolved from:
-                      "env", "yaml", "runner_override", "user_config",
-                      "local_build", "registry", or None (local mode / unresolved).
-    """
-
-    mode: RunnerMode
-    image: str | None
-    source: str
-    image_source: str | None = None
-    extra_mounts: list[tuple[str, str]] = field(default_factory=list)
-
-    @property
-    def is_explicit(self) -> bool:
-        """True if this runner was an explicit user pin (env var / YAML / user config).
-
-        Explicit pins win over multi-engine Docker elevation; auto-resolved
-        runners (``auto_detected`` / ``default``) do not. Classification lives
-        here, next to the ``source`` taxonomy it describes.
-        """
-        return self.source in EXPLICIT_RUNNER_SOURCES
-
-    def to_runner_info(self) -> dict[str, str | None]:
-        """Build runner info dict for progress display callbacks."""
-        return {
-            "mode": self.mode,
-            "source": self.source,
-            "image": self.image,
-            "image_source": self.image_source,
-        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/llenergymeasure/study/baseline_measure.py
+++ b/src/llenergymeasure/study/baseline_measure.py
@@ -29,8 +29,8 @@ from llenergymeasure.utils.env_config import docker_gpus_cache_token
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig, StudyConfig
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.domain.progress import StudyProgressCallback
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
 
 logger = logging.getLogger(__name__)
 

--- a/src/llenergymeasure/study/image_prep.py
+++ b/src/llenergymeasure/study/image_prep.py
@@ -50,8 +50,8 @@ from llenergymeasure.infra.version_handshake import (
 )
 
 if TYPE_CHECKING:
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.domain.progress import StudyProgressCallback
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
 
 logger = logging.getLogger(__name__)
 

--- a/src/llenergymeasure/study/orchestration.py
+++ b/src/llenergymeasure/study/orchestration.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from llenergymeasure.config.models import StudyConfig
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.config.ssot import RUNNER_DOCKER
 from llenergymeasure.domain.bundle_artefacts import (
     ENVIRONMENT_FILENAME,
@@ -31,7 +32,6 @@ from llenergymeasure.domain.bundle_artefacts import (
 )
 from llenergymeasure.domain.experiment import ExperimentResult, StudyResult, StudySummary
 from llenergymeasure.domain.progress import ProgressCallback
-from llenergymeasure.infra.runner_resolution import RunnerSpec
 from llenergymeasure.study.single import run_single_experiment
 
 logger = logging.getLogger(__name__)
@@ -250,6 +250,17 @@ def _resolve_runner_specs(
             "Mixed runners detected. For consistent measurements, "
             "consider running all engines in Docker."
         )
+
+    # Physical GPU selector precedence (env>config): warn once per study dispatch
+    # when both LLEM_DOCKER_GPUS and study_execution.gpu_indices are set and a
+    # Docker container will actually launch. GPU scoping only affects containers,
+    # so a study with no Docker runner never triggers the warning. Single choke
+    # point for both dispatch paths (single-experiment and StudyRunner).
+    if any(spec.mode == RUNNER_DOCKER for spec in runner_specs.values()):
+        from llenergymeasure.utils.env_config import warn_on_gpu_selector_conflict
+
+        warn_on_gpu_selector_conflict(study.study_execution.gpu_indices)
+
     return runner_specs, system_overrides
 
 

--- a/src/llenergymeasure/study/orchestration.py
+++ b/src/llenergymeasure/study/orchestration.py
@@ -217,7 +217,9 @@ def _resolve_runner_specs(
     runner pins win; auto-resolved engines elevate to Docker, raising
     PreFlightError when a local-pinned engine is not importable on the host or an
     auto-resolved engine needs Docker but it is unavailable), emits preflight
-    progress, and warns when the study mixes local and Docker runners.
+    progress, and warns on two resolved-plan conflicts: mixed local/Docker
+    runners, and a GPU selector set both via LLEM_DOCKER_GPUS and
+    study_execution.gpu_indices when a Docker container will launch.
     """
     from llenergymeasure.study.preflight import run_study_preflight
 
@@ -256,7 +258,7 @@ def _resolve_runner_specs(
     # Docker container will actually launch. GPU scoping only affects containers,
     # so a study with no Docker runner never triggers the warning. Single choke
     # point for both dispatch paths (single-experiment and StudyRunner).
-    if any(spec.mode == RUNNER_DOCKER for spec in runner_specs.values()):
+    if RUNNER_DOCKER in modes:
         from llenergymeasure.utils.env_config import warn_on_gpu_selector_conflict
 
         warn_on_gpu_selector_conflict(study.study_execution.gpu_indices)

--- a/src/llenergymeasure/study/preflight.py
+++ b/src/llenergymeasure/study/preflight.py
@@ -20,8 +20,8 @@ from llenergymeasure.config.ssot import (
 from llenergymeasure.utils.exceptions import PreFlightError
 
 if TYPE_CHECKING:
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.config.user_config import UserRunnersConfig
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,8 @@ def run_study_preflight(
             elevation but Docker is unavailable.
         DockerPreFlightError: Docker pre-flight check failed (inherits PreFlightError).
     """
-    from llenergymeasure.infra.runner_resolution import RunnerSpec, resolve_study_runners
+    from llenergymeasure.config.runner_spec import RunnerSpec
+    from llenergymeasure.infra.runner_resolution import resolve_study_runners
 
     engines = {exp.engine for exp in study.experiments}
     is_multi_engine = len(engines) > 1
@@ -153,7 +154,8 @@ def _apply_multi_engine_precedence(
             in the host environment, or Docker is required to elevate an
             auto-resolved engine but is unavailable.
     """
-    from llenergymeasure.infra.runner_resolution import RunnerSpec, is_docker_available
+    from llenergymeasure.config.runner_spec import RunnerSpec
+    from llenergymeasure.infra.runner_resolution import is_docker_available
 
     explicit_local: list[str] = []
     kept_explicit: list[str] = []
@@ -171,13 +173,13 @@ def _apply_multi_engine_precedence(
 
     # Import pre-flight: every engine pinned to local must be importable here.
     # Reuse the single-engine local-preflight availability check (find_spec on
-    # the engine package) rather than duplicating it. Cross-module private
-    # import, following the documented pattern used elsewhere across the package.
+    # the engine package) rather than duplicating it - it is a public helper on
+    # harness/preflight, which owns the fact.
     import_failures: list[str] = []
     if explicit_local:
-        from llenergymeasure.harness.preflight import _check_engine_installed
+        from llenergymeasure.harness.preflight import check_engine_installed
     for engine_name in sorted(explicit_local):
-        if not _check_engine_installed(engine_name):
+        if not check_engine_installed(engine_name):
             package = ENGINE_PACKAGES.get(Engine(engine_name), engine_name)
             import_failures.append(
                 f"{engine_name}: package '{package}' is not importable in the host "

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -92,8 +92,8 @@ def _provenance_from_spec(spec: RunnerSpec | None) -> RunnerProvenance:
     The config-layer ``RunnerSpec`` cannot live on the domain result (config and
     domain are independent sibling layers), so its execution-mode fields are
     mirrored onto the domain-layer ``RunnerProvenance``. When no spec is available
-    (pure in-process local run),
-    records ``mode="local"`` with ``source="local"`` and no image.
+    (pure in-process local run), records ``mode="local"`` with ``source="local"``
+    and no image.
     """
     from llenergymeasure.domain.experiment import RunnerProvenance
 
@@ -452,11 +452,6 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         uses_docker = bool(
             self._runner_specs and any(s.mode == RUNNER_DOCKER for s in self._runner_specs.values())
         )
-
-        # Physical GPU selector precedence (env>config): LLEM_DOCKER_GPUS wins
-        # over study_execution.gpu_indices. The env-vs-config conflict warning
-        # fires once upstream in orchestrate_study (single choke point), so it is
-        # not repeated here.
 
         # Acquire per-GPU advisory locks before image preparation.
         # Lock names use the PHYSICAL device the study occupies, resolved from

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -64,10 +64,10 @@ from llenergymeasure.utils.io import load_json
 
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig, StudyConfig
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.domain.environment import EnvironmentSnapshot, RunnerEnvironment
     from llenergymeasure.domain.experiment import RunnerProvenance
     from llenergymeasure.domain.progress import StudyProgressCallback
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
     from llenergymeasure.study.manifest import ManifestWriter
 
 __all__ = [
@@ -89,9 +89,10 @@ logger = logging.getLogger(__name__)
 def _provenance_from_spec(spec: RunnerSpec | None) -> RunnerProvenance:
     """Build a RunnerProvenance from a resolved RunnerSpec.
 
-    The infra-layer ``RunnerSpec`` cannot live on the domain result (layer
-    violation), so its execution-mode fields are mirrored onto the domain-layer
-    ``RunnerProvenance``. When no spec is available (pure in-process local run),
+    The config-layer ``RunnerSpec`` cannot live on the domain result (config and
+    domain are independent sibling layers), so its execution-mode fields are
+    mirrored onto the domain-layer ``RunnerProvenance``. When no spec is available
+    (pure in-process local run),
     records ``mode="local"`` with ``source="local"`` and no image.
     """
     from llenergymeasure.domain.experiment import RunnerProvenance
@@ -453,14 +454,9 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         )
 
         # Physical GPU selector precedence (env>config): LLEM_DOCKER_GPUS wins
-        # over study_execution.gpu_indices. GPU scoping only affects Docker
-        # containers, so warn about the conflict only when a container will
-        # actually launch (mirrors single.py, which gates this in its Docker
-        # branch) - no container means no warning.
-        if uses_docker:
-            from llenergymeasure.utils.env_config import warn_on_gpu_selector_conflict
-
-            warn_on_gpu_selector_conflict(config_gpu_indices)
+        # over study_execution.gpu_indices. The env-vs-config conflict warning
+        # fires once upstream in orchestrate_study (single choke point), so it is
+        # not repeated here.
 
         # Acquire per-GPU advisory locks before image preparation.
         # Lock names use the PHYSICAL device the study occupies, resolved from

--- a/src/llenergymeasure/study/session.py
+++ b/src/llenergymeasure/study/session.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     import threading
 
     from llenergymeasure.config.models import ExperimentConfig
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.study.runner import StudyRunner
 
 logger = logging.getLogger(__name__)

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -26,7 +26,7 @@ from llenergymeasure.domain.experiment import ExperimentResult
 from llenergymeasure.domain.progress import ProgressCallback
 
 if TYPE_CHECKING:
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.study.manifest import ManifestWriter
 
 
@@ -89,15 +89,14 @@ def run_single_experiment(
         from llenergymeasure.infra.docker_runner import DockerRunner
         from llenergymeasure.infra.image_registry import get_default_image
         from llenergymeasure.study.container_lifecycle import persist_failure_artefacts
-        from llenergymeasure.utils.env_config import warn_on_gpu_selector_conflict
         from llenergymeasure.utils.exceptions import DockerError
 
         image = spec.image if spec.image is not None else get_default_image(config.engine)
         resolved_docker_image = image
 
-        # Physical GPU scoping precedence (env>config); warn once if both set.
+        # Physical GPU scoping precedence (env>config). The env-vs-config conflict
+        # warning fires once upstream in orchestrate_study (single choke point).
         gpu_indices = study.study_execution.gpu_indices
-        warn_on_gpu_selector_conflict(gpu_indices)
 
         docker_runner = DockerRunner(
             image=image,

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -94,8 +94,7 @@ def run_single_experiment(
         image = spec.image if spec.image is not None else get_default_image(config.engine)
         resolved_docker_image = image
 
-        # Physical GPU scoping precedence (env>config). The env-vs-config conflict
-        # warning fires once upstream in orchestrate_study (single choke point).
+        # Physical GPU scoping precedence (env>config).
         gpu_indices = study.study_execution.gpu_indices
 
         docker_runner = DockerRunner(

--- a/tests/integration/test_docker_runner.py
+++ b/tests/integration/test_docker_runner.py
@@ -114,8 +114,8 @@ class TestDockerRunnerIntegration:
 
     def test_runner_provenance_recorded(self, tmp_path):
         """Docker runner provenance is recorded on the saved result."""
+        from llenergymeasure.config.runner_spec import RunnerSpec
         from llenergymeasure.domain.experiment import RunnerProvenance
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
         from llenergymeasure.study.runner import _provenance_from_spec
 
         provenance = _provenance_from_spec(
@@ -188,7 +188,7 @@ class TestDockerRunnerIntegration:
         )
 
         # Patch resolve_study_runners to force Docker dispatch
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
 
         docker_spec = RunnerSpec(mode="docker", image=IMAGE, source="test")
 

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -38,7 +38,7 @@ def _patch_infra(monkeypatch: Any, tmp_path: Path, mock_result: Any) -> None:
     """
     import llenergymeasure.harness.preflight
     import llenergymeasure.study.preflight
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.study.manifest import ManifestWriter
 
     monkeypatch.setattr(

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -19,8 +19,8 @@ from llenergymeasure.api.health import (
     HealthSection,
     build_health_report,
 )
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.config.user_config import UserConfig
-from llenergymeasure.infra.runner_resolution import RunnerSpec
 from llenergymeasure.infra.version_handshake import SchemaStatus
 
 

--- a/tests/unit/docker/test_docker_preflight.py
+++ b/tests/unit/docker/test_docker_preflight.py
@@ -788,7 +788,7 @@ class TestWiring:
 
     def test_docker_preflight_called_when_docker_runner_resolved(self) -> None:
         """run_study_preflight calls run_docker_preflight when any runner is Docker."""
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
         from llenergymeasure.study.preflight import run_study_preflight
 
         study = make_study(["transformers"])
@@ -821,7 +821,7 @@ class TestWiring:
 
     def test_docker_preflight_not_called_when_all_local_runners(self) -> None:
         """run_study_preflight does NOT call run_docker_preflight when all runners are local."""
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
         from llenergymeasure.study.preflight import run_study_preflight
 
         study = make_study(["transformers"])
@@ -846,7 +846,7 @@ class TestWiring:
 
     def test_skip_preflight_param_passed_through(self) -> None:
         """Passing skip_preflight=True results in run_docker_preflight(skip=True)."""
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
         from llenergymeasure.study.preflight import run_study_preflight
 
         study = make_study(["transformers"])
@@ -876,7 +876,7 @@ class TestWiring:
     def test_yaml_skip_preflight_respected(self) -> None:
         """execution.skip_preflight: true in YAML causes skip=True to be passed."""
         from llenergymeasure.config.models import ExecutionConfig, ExperimentConfig, StudyConfig
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
         from llenergymeasure.study.preflight import run_study_preflight
 
         study = StudyConfig(
@@ -910,7 +910,7 @@ class TestWiring:
     def test_cli_flag_overrides_yaml_false(self) -> None:
         """CLI skip_preflight=True overrides YAML execution.skip_preflight=False."""
         from llenergymeasure.config.models import ExecutionConfig, ExperimentConfig, StudyConfig
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
         from llenergymeasure.study.preflight import run_study_preflight
 
         study = StudyConfig(

--- a/tests/unit/study/test_baseline_strategy.py
+++ b/tests/unit/study/test_baseline_strategy.py
@@ -23,9 +23,9 @@ from llenergymeasure.config.models import (
     ExperimentConfig,
     StudyConfig,
 )
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.config.ssot import CONTAINER_EXCHANGE_DIR
 from llenergymeasure.harness.baseline import BaselineCache
-from llenergymeasure.infra.runner_resolution import RunnerSpec
 from llenergymeasure.study.image_prep import _sanitize_image_for_filename
 from llenergymeasure.study.runner import StudyRunner
 from llenergymeasure.utils.exceptions import DockerError

--- a/tests/unit/study/test_image_prep.py
+++ b/tests/unit/study/test_image_prep.py
@@ -20,8 +20,8 @@ import pytest
 from rich.console import Console
 
 from llenergymeasure.cli._step_display import StudyStepDisplay
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.infra.docker_errors import DockerImagePullError
-from llenergymeasure.infra.runner_resolution import RunnerSpec
 from llenergymeasure.study import image_prep
 from llenergymeasure.study.image_prep import (
     _aggregate_image_errors,

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -13,9 +13,9 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.domain.environment import RunnerEnvironment
 from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
-from llenergymeasure.infra.runner_resolution import RunnerSpec
 from llenergymeasure.study.runner import (
     _provenance_from_spec,
     _runner_environment,

--- a/tests/unit/study/test_session.py
+++ b/tests/unit/study/test_session.py
@@ -78,7 +78,7 @@ def test_sessions_satisfy_experiment_session_protocol(tmp_path: Path) -> None:
     sub = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
     assert isinstance(sub, ExperimentSession)
 
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     spec = RunnerSpec(mode="docker", image="img:v1", source="yaml")
     doc = DockerSession(runner, config, spec, config_hash="h", cycle=1, index=1)
@@ -177,7 +177,7 @@ def test_subprocess_session_active_process_set_during_enter(tmp_path: Path) -> N
 
 def test_docker_session_cleanup_removes_staging_dir_once(tmp_path: Path) -> None:
     """DockerSession.__exit__ removes the container staging dir exactly once."""
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     spec = RunnerSpec(mode="docker", image="img:v1", source="yaml")
     runner = _make_runner(tmp_path, runner_specs={"transformers": spec})

--- a/tests/unit/study/test_single.py
+++ b/tests/unit/study/test_single.py
@@ -317,7 +317,7 @@ def test_docker_single_failure_marks_log_file(monkeypatch, tmp_path):
     """
     from unittest.mock import MagicMock
 
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
     from llenergymeasure.study.manifest import ManifestWriter
     from llenergymeasure.utils.exceptions import DockerError
 

--- a/tests/unit/study/test_study_preflight.py
+++ b/tests/unit/study/test_study_preflight.py
@@ -36,7 +36,7 @@ def patch_env(monkeypatch, *, docker: bool, importable: bool = True) -> MagicMoc
     Args:
         docker: value returned by ``is_docker_available``.
         importable: value returned by the reused host-availability check
-            (``harness.preflight._check_engine_installed``).
+            (``harness.preflight.check_engine_installed``).
 
     Returns:
         The ``run_docker_preflight`` MagicMock, so a caller can assert whether it
@@ -50,7 +50,7 @@ def patch_env(monkeypatch, *, docker: bool, importable: bool = True) -> MagicMoc
         "llenergymeasure.infra.docker_preflight.run_docker_preflight", docker_preflight
     )
     monkeypatch.setattr(
-        "llenergymeasure.harness.preflight._check_engine_installed", lambda engine: importable
+        "llenergymeasure.harness.preflight.check_engine_installed", lambda engine: importable
     )
     return docker_preflight
 
@@ -213,7 +213,7 @@ def test_preflight_forwards_runner_context(monkeypatch):
     def mock_resolve_study_runners(engines, yaml_runners=None, user_config=None):
         captured_calls.append({"yaml_runners": yaml_runners, "user_config": user_config})
         # Return local specs so no Docker preflight is triggered
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
 
         return {b: RunnerSpec(mode="local", image=None, source="default") for b in engines}
 
@@ -241,7 +241,7 @@ def test_preflight_defaults_to_auto_detect_without_context(monkeypatch):
 
     def mock_resolve_study_runners(engines, yaml_runners=None, user_config=None):
         captured_calls.append({"yaml_runners": yaml_runners, "user_config": user_config})
-        from llenergymeasure.infra.runner_resolution import RunnerSpec
+        from llenergymeasure.config.runner_spec import RunnerSpec
 
         return {b: RunnerSpec(mode="local", image=None, source="default") for b in engines}
 

--- a/tests/unit/study/test_study_runner.py
+++ b/tests/unit/study/test_study_runner.py
@@ -1006,14 +1006,14 @@ def test_gpu_memory_check_called_before_dispatch(study_config: StudyConfig) -> N
 
 def _make_docker_runner_spec(image: str = "test/image:latest", source: str = "yaml"):
     """Build a RunnerSpec with mode='docker'."""
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     return RunnerSpec(mode="docker", image=image, source=source)
 
 
 def _make_local_runner_spec(source: str = "default"):
     """Build a RunnerSpec with mode='local'."""
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     return RunnerSpec(mode="local", image=None, source=source)
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -297,7 +297,7 @@ class _MockBackend:
 
 def _mock_preflight_return(study, **kw):
     """Mock preflight that returns (runner_specs, system_overrides) tuple."""
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     engines = {exp.engine for exp in study.experiments}
     specs = {b: RunnerSpec(mode="local", image=None, source="test") for b in engines}
@@ -407,7 +407,7 @@ def test_run_skips_preflight_when_preresolved_supplied(monkeypatch, tmp_path):
     import llenergymeasure.harness.preflight as pf_module
     import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     study_preflight_calls: list = []
 
@@ -551,7 +551,7 @@ def test_run_study_resume_uses_output_dir_as_search_base(monkeypatch, tmp_path):
 def test_run_preresolved_without_skip_preflight_raises():
     """Passing preresolved with skip_preflight=False is rejected, not silently honoured."""
     import llenergymeasure.study.orchestration as api_module
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     config = ExperimentConfig(task={"model": "gpt2"}, engine="transformers")
     study = StudyConfig(experiments=[config])
@@ -875,7 +875,7 @@ def test_run_resolves_runners_and_passes_to_study_runner(monkeypatch, tmp_path):
     import llenergymeasure.harness.preflight as pf_module
     import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     mock_result = make_result(experiment_id="runner-wired")
 
@@ -950,7 +950,7 @@ def test_run_mixed_runner_warning_logged(monkeypatch, tmp_path, caplog):
     import llenergymeasure.harness.preflight as pf_module
     import llenergymeasure.study.orchestration as api_module
     import llenergymeasure.study.preflight as study_pf_module
-    from llenergymeasure.infra.runner_resolution import RunnerSpec
+    from llenergymeasure.config.runner_spec import RunnerSpec
 
     mixed_specs = {
         "transformers": RunnerSpec(mode="local", image=None, source="default"),

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -31,7 +31,7 @@ def _patch_all_checks_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     """Monkeypatch all three checks to succeed."""
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -61,7 +61,7 @@ def test_preflight_passes_when_all_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_preflight_collects_all_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: False)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: False
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: False
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight,
@@ -89,7 +89,7 @@ def test_preflight_collects_all_failures(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_preflight_cuda_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: False)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -110,7 +110,7 @@ def test_preflight_cuda_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_preflight_engine_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: False
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: False
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -131,7 +131,7 @@ def test_preflight_engine_not_installed(monkeypatch: pytest.MonkeyPatch) -> None
 def test_preflight_gated_model(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight,
@@ -156,7 +156,7 @@ def test_preflight_gated_model(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_preflight_model_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight,
@@ -195,7 +195,7 @@ def test_preflight_local_model_path(monkeypatch: pytest.MonkeyPatch, tmp_path: P
 def test_preflight_local_model_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
 
     # Do NOT monkeypatch _check_model_accessible - use real implementation
@@ -219,7 +219,7 @@ def test_preflight_persistence_mode_warning_not_blocking(
     # Patch all three checks to pass
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -255,7 +255,7 @@ def test_preflight_error_format(monkeypatch: pytest.MonkeyPatch) -> None:
     """Trigger 2 failures and check the formatted error string."""
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: False)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: False
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: False
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -289,21 +289,21 @@ def test_check_cuda_available_no_torch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_check_engine_installed_transformers(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_check_engine_installed() delegates to find_spec for transformers."""
+    """check_engine_installed() delegates to find_spec for transformers."""
     mock_spec = MagicMock()  # truthy
     monkeypatch.setattr(
         llenergymeasure.harness.preflight.importlib.util,
         "find_spec",
         lambda name: mock_spec if name == "transformers" else None,
     )
-    assert llenergymeasure.harness.preflight._check_engine_installed("transformers") is True
+    assert llenergymeasure.harness.preflight.check_engine_installed("transformers") is True
 
 
 def test_check_engine_installed_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         llenergymeasure.harness.preflight.importlib.util, "find_spec", lambda name: None
     )
-    assert llenergymeasure.harness.preflight._check_engine_installed("vllm") is False
+    assert llenergymeasure.harness.preflight.check_engine_installed("vllm") is False
 
 
 def test_check_model_accessible_local_exists(tmp_path: Path) -> None:
@@ -485,7 +485,7 @@ def test_run_preflight_collects_hardware_errors(monkeypatch: pytest.MonkeyPatch)
     """run_preflight collects check_hardware errors into PreFlightError."""
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -512,7 +512,7 @@ def test_run_preflight_passes_when_hardware_check_empty(monkeypatch: pytest.Monk
     """run_preflight succeeds when check_hardware returns no errors."""
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -537,7 +537,7 @@ def test_run_preflight_handles_engine_import_error(monkeypatch: pytest.MonkeyPat
     """run_preflight does not crash if get_engine raises during check_hardware."""
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -562,7 +562,7 @@ def test_run_preflight_hardware_errors_counted_correctly(
     """check_hardware errors contribute to the total issue count in PreFlightError."""
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -618,7 +618,7 @@ def test_run_preflight_routes_checkpoint_compat_through_hook(
 
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None
@@ -647,7 +647,7 @@ def test_run_preflight_checkpoint_compat_mock_plugin(monkeypatch: pytest.MonkeyP
     """
     monkeypatch.setattr(llenergymeasure.harness.preflight, "_check_cuda_available", lambda: True)
     monkeypatch.setattr(
-        llenergymeasure.harness.preflight, "_check_engine_installed", lambda engine: True
+        llenergymeasure.harness.preflight, "check_engine_installed", lambda engine: True
     )
     monkeypatch.setattr(
         llenergymeasure.harness.preflight, "_check_model_accessible", lambda model_id: None

--- a/tests/unit/test_runner_resolution.py
+++ b/tests/unit/test_runner_resolution.py
@@ -13,10 +13,10 @@ from unittest.mock import patch
 
 import pytest
 
+from llenergymeasure.config.runner_spec import RunnerSpec
 from llenergymeasure.config.ssot import ENV_RUNNER_PREFIX
 from llenergymeasure.config.user_config import UserRunnersConfig
 from llenergymeasure.infra.runner_resolution import (
-    RunnerSpec,
     is_docker_available,
     parse_runner_value,
     resolve_runner,


### PR DESCRIPTION
## Summary

F6 slice S12: relocate the resolved `RunnerSpec` value object out of the infra layer and make two adjacent layer/duplication seams honest. Residency + honesty only; no user-visible behavior change (no new dispatch capabilities, same warnings, same errors, same dispatch decisions).

`RunnerSpec` and its `is_explicit` classification were config-derived facts about *how* an experiment should be dispatched, consumed by the study layer, yet lived in `infra` - forcing study to import infra for a value object. The precedence taxonomy they reference (`SOURCE_*`, `RunnerMode`, `EXPLICIT_RUNNER_SOURCES`) already lived in `config.ssot`, so moving the value object next to it co-locates the classification with the taxonomy it describes.

### Target layer (decided by import-linter, not taste)

Placed in **`config`**. Both `study` (layer 3) and `infra` (layer 7) may import `config` (layer 9) with zero new import-linter exceptions. `domain` was rejected: `RunnerSpec.is_explicit` reads `EXPLICIT_RUNNER_SOURCES` and the `RunnerMode` type from `config.ssot`, and `config | domain` are independent sibling layers in the `main-layers` contract - a `domain -> config` edge would need a new exception. Per the decided tiebreak ("prefer domain only if both satisfy zero-new-exceptions"), config wins. All 5 contracts remain KEPT.

## Module map (what moved where)

- `RunnerSpec` dataclass (+ `is_explicit`, `to_runner_info`): `infra/runner_resolution.py` -> **new `config/runner_spec.py`**. Docstring generalised to drop the "for a single experiment execution" single-dispatch assumption (a1 #16 / C3): a spec is now documented as a plain resolved value independent of any one `run()` call. No fields or capabilities added.
- Resolution machinery unchanged in `infra` (`resolve_runner`, `resolve_study_runners`, `is_docker_available`) - genuinely environment-touching work; it now imports `RunnerSpec` from config.
- All consumers (api, cli, study, tests) re-pointed to `config.runner_spec`. No back-compat re-export left on infra (`RunnerSpec` dropped from its `__all__`).
- Precedence taxonomy: already in `config.ssot`; not moved (would be churn with no layering benefit and touch many ssot consumers).
- Domain docstrings referencing "infra-layer RunnerSpec" corrected to the config-layer residency + sibling-independence rationale.

## Judgment calls

**Item 3 - `_check_engine_installed`:** promoted to public **`harness.preflight.check_engine_installed`** (in place) rather than relocating it. Smaller diff: `study.preflight` already imports from `harness.preflight` (study is above harness), so making the name public makes the existing edge honest with zero new import edges/exceptions - vs relocating (which would touch the same ~20 test patch targets *and* move the function, risking confusion with the sibling `config.engine_detection.is_engine_available`, which uses `__import__` rather than `find_spec` - deliberately distinct, left untouched).

**Item 4 - `warn_on_gpu_selector_conflict`:** consolidated to a single choke point in `orchestrate_study._resolve_runner_specs`, gated on `any(spec.mode == "docker")`, next to the existing sibling "mixed runners" warning. Previously the same warning was emitted from two mutually-exclusive dispatch branches (`study/single.py` docker branch; `study/runner.py._setup_run_handlers` under `if uses_docker`), each with its own docker-gate and rationale comment. `orchestrate_study` is the sole common parent of both paths (`StudyRunner` and `run_single_experiment` have no other callers), so one gated call there is behavior-equivalent for every path. Message text preserved byte-for-byte (single implementation in `utils.env_config`, unchanged).

## Test plan

- `make lint` (ruff + import-linter): green. Import-linter reports 5 contracts kept, 0 broken.
- `make typecheck` (mypy): Success, no issues in 339 source files.
- `make test` (host suite): 3252 passed, 37 skipped. Test patch targets updated to the use/definition sites (RunnerSpec imports re-pointed; `_check_engine_installed` -> `check_engine_installed`).
- GPU CI transformers job is informational.

## Doc audit

CHANGELOG: one entry under `[Unreleased] > Changed`. No other docs reference the moved symbol's old home; domain docstrings updated inline.
