### PR TITLE
refactor(config): retire underivable capability-matrix rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `LANDMARKS` tuples it read remain in the version-pinned schema introspectors
   and are still resolved host-side by the transformers producer unit test.
   ([#850])
+- Trimmed the engine capability matrix and dropped the Runtime Limitations table
+  to what the mined engine schema can actually back. Eight capability rows whose
+  cells were hand-authored prose (data parallel, native quantization, float32 /
+  float16 / bfloat16 precision, beam search, speculative decoding, static KV
+  cache) and all seven `get_runtime_limitations()` rows (hardware/package
+  caveats such as "FP8 requires Hopper") are de-claimed; the five
+  field-presence-derivable rows (tensor parallel, bitsandbytes 4-bit / 8-bit,
+  prefix caching, torch.compile) remain, and `docs/reference/engines/invalid-combos.md`
+  is regenerated accordingly. Docs-only: no runtime, CLI, or dispatch path reads
+  these functions, so no validation or measurement behavior changes. ([#866])
 
 ### Fixed
 
@@ -1402,3 +1412,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#862]: https://github.com/henrycgbaker/llenergymeasure/pull/862
 [#863]: https://github.com/henrycgbaker/llenergymeasure/pull/863
 [#864]: https://github.com/henrycgbaker/llenergymeasure/pull/864
+[#866]: https://github.com/henrycgbaker/llenergymeasure/pull/866

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -251,8 +251,8 @@ no error, process does not return.
 
 ## Invalid Parameter Combinations
 
-Rejected config combinations, runtime limitations, and the engine capability
-matrix are catalogued in the generated
+Rejected config combinations and the engine capability matrix are catalogued in
+the generated
 [Invalid Parameter Combinations](/reference/engines/invalid-combos) reference,
 which is regenerated from the config schema on every engine update.
 

--- a/docs/reference/engines/invalid-combos.md
+++ b/docs/reference/engines/invalid-combos.md
@@ -143,42 +143,18 @@ names the paths the engine drives back to their default.
 | vllm | `distributed_executor_backend=external_launcher and data_parallel_rank is set` | Enforced by rule vllm_parallelconfig_dormant_data_parallel_rank_set_true. | data_parallel_rank |
 | vllm | `seed=-1` | Enforced by rule vllm_samplingparams_dormant_seed_eq_neg1. | seed |
 
-## Runtime Limitations
-
-These combinations pass config validation but may fail at runtime
-due to hardware, model, or package requirements.
-
-| Engine | Parameter | Limitation | Resolution |
-|---------|-----------|------------|------------|
-| transformers | `transformers.engine_params.attn_implementation=flash_attention_2` | flash-attn requires Ampere+ GPU (SM80+); fails on older architectures | Use attn_implementation='sdpa' on pre-Ampere GPUs |
-| transformers | `transformers.engine_params.attn_implementation=flash_attention_3` | FA3 requires the flash_attn_3 package (built from flash-attn hopper/ directory) and Ampere+ GPU (SM80+). The Docker PyTorch image includes it pre-built | Install flash_attn_3 from source, or use the Docker runner |
-| vllm | `vllm.engine_params.kv_cache_dtype=fp8` | FP8 KV cache requires Hopper (H100) or newer GPU | Use kv_cache_dtype='auto' for automatic selection |
-| vllm | `vllm.engine_params.attention.backend=flashinfer` | FlashInfer requires JIT compilation on first use | Leave attention.backend unset (auto) or use 'flash_attn' |
-| vllm | `vllm.engine_params.quantization=awq/gptq` | Requires a pre-quantized model checkpoint | Use a quantized model (e.g., TheBloke/*-AWQ) or omit |
-| tensorrt | `tensorrt.engine_params.quant_config.quant_algo=FP8` | FP8 requires SM >= 8.9 (Ada Lovelace or Hopper). A100 (SM80) raises ConfigurationError - no silent emulation or fallback | Use INT8, W4A16_AWQ, W4A16_GPTQ, or W8A16 on A100 |
-| tensorrt | `tensorrt.engine_params.quant_config.quant_algo=INT8` | INT8 quantisation requires a calibrated checkpoint; uncalibrated weights degrade accuracy | Use a pre-quantised checkpoint or a weight-only algo (W4A16_AWQ, W4A16_GPTQ, W8A16) |
-
 ## Engine Capability Matrix
 
 | Feature | Transformers | vLLM | TensorRT |
 |---------|---------|------|----------|
 | Tensor Parallel | Yes | Yes | Yes |
-| Data Parallel | No | No | No |
 | BitsAndBytes (4-bit) | Yes | No | No |
 | BitsAndBytes (8-bit) | Yes | No | No |
-| Native Quantization | No | AWQ/GPTQ/FP8 | INT8/W4A16_AWQ/W4A16_GPTQ/FP8 |
-| float32 precision | Yes | No | No |
-| float16 precision | Yes | Yes | Yes |
-| bfloat16 precision | Yes | Yes | Yes |
 | Prefix Caching | No | Yes | No |
 | torch.compile | Yes | No | No |
-| Beam Search | Yes | Yes | No |
-| Speculative Decoding | Yes | Yes | No |
-| Static KV Cache | Yes | No | No |
 
 **Notes:**
 - vLLM supports 4-bit via AWQ/GPTQ quantized models, not bitsandbytes
-- TensorRT-LLM is optimised for FP16/BF16/INT8, not FP32
 
 ## Recommended Configurations by Use Case
 

--- a/scripts/generate_invalid_combos_doc.py
+++ b/scripts/generate_invalid_combos_doc.py
@@ -18,7 +18,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from llenergymeasure.config.introspection import (
     get_capability_matrix_markdown,
     get_dormant_rules,
-    get_runtime_limitations,
     get_validation_rules,
 )
 from scripts._docgen_common import write_doc
@@ -76,25 +75,6 @@ def generate_markdown() -> str:
         lines.append(
             f"| {dormant['engine']} | `{dormant['combination']}` | "
             f"{dormant['effect']} | {dormant['normalised_fields']} |"
-        )
-
-    lines.extend(
-        [
-            "",
-            "## Runtime Limitations",
-            "",
-            "These combinations pass config validation but may fail at runtime",
-            "due to hardware, model, or package requirements.",
-            "",
-            "| Engine | Parameter | Limitation | Resolution |",
-            "|---------|-----------|------------|------------|",
-        ]
-    )
-
-    for limitation in get_runtime_limitations():
-        lines.append(
-            f"| {limitation['engine']} | `{limitation['parameter']}` | "
-            f"{limitation['limitation']} | {limitation['resolution']} |"
         )
 
     lines.extend(

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -325,11 +325,17 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
 
     This is the SSOT for the capability matrix shown in documentation.
     Capabilities are inferred by checking which fields exist in each
-    engine config and their allowed values.
+    engine config.
+
+    Only capabilities whose values are genuinely derivable from the mined
+    engine schema are reported here. Rows whose truth was hand-authored prose
+    (product-scope decisions, hardware facts, or per-engine literals the schema
+    cannot answer) were retired rather than kept as claims the data cannot back;
+    do not re-add hardcoded rows.
 
     Returns:
         Dict mapping capability names to per-engine support status.
-        Values are True/False for simple support, or str for notes.
+        Values are True/False for support.
     """
     from llenergymeasure.config.harness import TransformersHarness
 
@@ -342,25 +348,12 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
     # engine field.
     transformers_harness_fields = set(TransformersHarness.model_fields.keys())
 
-    # vLLM/TRT quantization are Any-typed in the generated projection (discovery
-    # debt: the mined schema ships no enum), so support is derived from field
-    # presence rather than readable Literal options.
-    vllm_has_quant = "quantization" in vllm_fields
-    trt_has_quant = "quant_config" in tensorrt_fields
-
     return {
         "tensor_parallel": {
             # Transformers exposes HF-native tensor parallelism via tp_plan/tp_size
             "transformers": "tp_plan" in transformers_fields,
             "vllm": "tensor_parallel_size" in vllm_fields,
             "tensorrt": "tensor_parallel_size" in tensorrt_fields,
-        },
-        "data_parallel": {
-            # Transformers data parallelism via Accelerate is not supported in this version
-            "transformers": False,
-            # vLLM/TensorRT manage parallelism internally
-            "vllm": False,
-            "tensorrt": False,
         },
         "bitsandbytes_4bit": {
             "transformers": "load_in_4bit" in transformers_fields,
@@ -372,28 +365,6 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
             "vllm": False,
             "tensorrt": False,
         },
-        "native_quantization": {
-            "transformers": False,  # Transformers relies on bitsandbytes, not native
-            "vllm": "AWQ/GPTQ/FP8" if vllm_has_quant else False,
-            "tensorrt": "INT8/W4A16_AWQ/W4A16_GPTQ/FP8" if trt_has_quant else False,
-        },
-        "float32_precision": {
-            "transformers": True,
-            # vLLM rejects float32: dtype is Literal["float16", "bfloat16", "auto"]
-            "vllm": False,
-            # TensorRT-LLM is optimised for lower precision
-            "tensorrt": False,
-        },
-        "float16_precision": {
-            "transformers": True,
-            "vllm": True,
-            "tensorrt": True,
-        },
-        "bfloat16_precision": {
-            "transformers": True,
-            "vllm": True,
-            "tensorrt": True,
-        },
         "prefix_caching": {
             "transformers": False,
             "vllm": "enable_prefix_caching" in vllm_fields,
@@ -401,21 +372,6 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
         },
         "torch_compile": {
             "transformers": "torch_compile" in transformers_harness_fields,
-            "vllm": False,
-            "tensorrt": False,
-        },
-        "beam_search": {
-            "transformers": "num_beams" in transformers_fields,
-            "vllm": True,
-            "tensorrt": False,
-        },
-        "speculative_decoding": {
-            "transformers": "prompt_lookup_num_tokens" in transformers_fields,
-            "vllm": "speculative_config" in vllm_fields,
-            "tensorrt": False,
-        },
-        "static_kv_cache": {
-            "transformers": "cache_implementation" in transformers_fields,
             "vllm": False,
             "tensorrt": False,
         },
@@ -436,18 +392,10 @@ def get_capability_matrix_markdown() -> str:
     # Define display names
     display_names = {
         "tensor_parallel": "Tensor Parallel",
-        "data_parallel": "Data Parallel",
         "bitsandbytes_4bit": "BitsAndBytes (4-bit)",
         "bitsandbytes_8bit": "BitsAndBytes (8-bit)",
-        "native_quantization": "Native Quantization",
-        "float32_precision": "float32 precision",
-        "float16_precision": "float16 precision",
-        "bfloat16_precision": "bfloat16 precision",
         "prefix_caching": "Prefix Caching",
         "torch_compile": "torch.compile",
-        "beam_search": "Beam Search",
-        "speculative_decoding": "Speculative Decoding",
-        "static_kv_cache": "Static KV Cache",
     }
 
     lines = [
@@ -477,7 +425,6 @@ def get_capability_matrix_markdown() -> str:
     lines.append("")
     lines.append("**Notes:**")
     lines.append("- vLLM supports 4-bit via AWQ/GPTQ quantized models, not bitsandbytes")
-    lines.append("- TensorRT-LLM is optimised for FP16/BF16/INT8, not FP32")
 
     return "\n".join(lines)
 
@@ -692,58 +639,3 @@ def get_dormant_rules() -> list[dict[str, str]]:
             }
         )
     return rows
-
-
-def get_runtime_limitations() -> list[dict[str, str]]:
-    """Get known runtime limitations for documentation.
-
-    These combinations pass config validation but may fail at runtime
-    due to hardware, model, or package requirements.
-
-    Returns:
-        List of dicts with keys: engine, parameter, limitation, resolution.
-    """
-    return [
-        {
-            "engine": "transformers",
-            "parameter": "transformers.engine_params.attn_implementation=flash_attention_2",
-            "limitation": "flash-attn requires Ampere+ GPU (SM80+); fails on older architectures",
-            "resolution": "Use attn_implementation='sdpa' on pre-Ampere GPUs",
-        },
-        {
-            "engine": "transformers",
-            "parameter": "transformers.engine_params.attn_implementation=flash_attention_3",
-            "limitation": "FA3 requires the flash_attn_3 package (built from flash-attn hopper/ directory) and Ampere+ GPU (SM80+). The Docker PyTorch image includes it pre-built",
-            "resolution": "Install flash_attn_3 from source, or use the Docker runner",
-        },
-        {
-            "engine": "vllm",
-            "parameter": "vllm.engine_params.kv_cache_dtype=fp8",
-            "limitation": "FP8 KV cache requires Hopper (H100) or newer GPU",
-            "resolution": "Use kv_cache_dtype='auto' for automatic selection",
-        },
-        {
-            "engine": "vllm",
-            "parameter": "vllm.engine_params.attention.backend=flashinfer",
-            "limitation": "FlashInfer requires JIT compilation on first use",
-            "resolution": "Leave attention.backend unset (auto) or use 'flash_attn'",
-        },
-        {
-            "engine": "vllm",
-            "parameter": "vllm.engine_params.quantization=awq/gptq",
-            "limitation": "Requires a pre-quantized model checkpoint",
-            "resolution": "Use a quantized model (e.g., TheBloke/*-AWQ) or omit",
-        },
-        {
-            "engine": "tensorrt",
-            "parameter": "tensorrt.engine_params.quant_config.quant_algo=FP8",
-            "limitation": "FP8 requires SM >= 8.9 (Ada Lovelace or Hopper). A100 (SM80) raises ConfigurationError - no silent emulation or fallback",
-            "resolution": "Use INT8, W4A16_AWQ, W4A16_GPTQ, or W8A16 on A100",
-        },
-        {
-            "engine": "tensorrt",
-            "parameter": "tensorrt.engine_params.quant_config.quant_algo=INT8",
-            "limitation": "INT8 quantisation requires a calibrated checkpoint; uncalibrated weights degrade accuracy",
-            "resolution": "Use a pre-quantised checkpoint or a weight-only algo (W4A16_AWQ, W4A16_GPTQ, W8A16)",
-        },
-    ]

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -15,7 +15,6 @@ from llenergymeasure.config.introspection import (
     get_engine_params,
     get_experiment_config_schema,
     get_field_role,
-    get_runtime_limitations,
     get_swept_field_paths,
     get_validation_rules,
 )
@@ -251,14 +250,8 @@ def test_get_swept_field_paths_multi_engine_none_subconfigs():
 
 
 # ---------------------------------------------------------------------------
-# get_engine_capabilities (capability matrix must match real engine schema)
+# get_engine_capabilities (capability matrix reports only the derivable subset)
 # ---------------------------------------------------------------------------
-
-
-def test_capability_matrix_vllm_rejects_float32():
-    """vLLM dtype is Literal[float16, bfloat16, auto]; float32 must be unsupported."""
-    caps = get_engine_capabilities()
-    assert caps["float32_precision"]["vllm"] is False
 
 
 def test_capability_matrix_transformers_supports_tensor_parallel():
@@ -267,41 +260,16 @@ def test_capability_matrix_transformers_supports_tensor_parallel():
     assert caps["tensor_parallel"]["transformers"] is True
 
 
-def test_capability_matrix_cells_match_engine_dtype_support():
-    """Each engine's float32 cell must agree with SSOT ENGINES dtypes."""
-    from llenergymeasure.config.ssot import ENGINES, Engine
-
+def test_capability_matrix_reports_only_derivable_rows():
+    """Retired hand-authored rows (precision, data_parallel, ...) are no longer claimed."""
     caps = get_engine_capabilities()
-    for engine, key in (
-        (Engine.TRANSFORMERS, "transformers"),
-        (Engine.VLLM, "vllm"),
-        (Engine.TENSORRT, "tensorrt"),
-    ):
-        expected = "float32" in ENGINES[engine].dtypes
-        assert caps["float32_precision"][key] is expected
-
-
-# ---------------------------------------------------------------------------
-# get_runtime_limitations (parameter paths must reference real config fields)
-# ---------------------------------------------------------------------------
-
-
-def test_runtime_limitations_use_real_field_paths():
-    """No stale/renamed paths: attention.engine, quantization_method, load_format are gone."""
-    params = [limit["parameter"] for limit in get_runtime_limitations()]
-    joined = "\n".join(params)
-    assert "attention.engine" not in joined
-    assert "quantization_method" not in joined
-    assert "load_format" not in joined
-    assert "tensorrt.quantization.method" not in joined
-
-
-def test_runtime_limitations_reference_corrected_vllm_paths():
-    """Corrected vLLM paths use the nested engine_params prefix."""
-    params = [limit["parameter"] for limit in get_runtime_limitations()]
-    assert any("vllm.engine_params.attention.backend=" in p for p in params)
-    assert any("vllm.engine_params.quantization=" in p for p in params)
-    assert any("vllm.engine_params.kv_cache_dtype=" in p for p in params)
+    assert set(caps) == {
+        "tensor_parallel",
+        "bitsandbytes_4bit",
+        "bitsandbytes_8bit",
+        "prefix_caching",
+        "torch_compile",
+    }
 
 
 def test_streaming_constraints_removed():
@@ -309,3 +277,10 @@ def test_streaming_constraints_removed():
     import llenergymeasure.config.introspection as introspection
 
     assert not hasattr(introspection, "get_streaming_constraints")
+
+
+def test_runtime_limitations_removed():
+    """get_runtime_limitations was retired: its rows were 100% hand-authored prose."""
+    import llenergymeasure.config.introspection as introspection
+
+    assert not hasattr(introspection, "get_runtime_limitations")


### PR DESCRIPTION
## Summary

Slice S18 of the F6 refactor: **partial retirement** of the capability matrix
(ratified ruling R3). De-claim the rows whose truth was hand-authored prose that
the mined engine schema cannot back, keep the field-presence-derivable subset,
and regenerate the invalid-combos doc on the honest subset.

This is a **docs-only** surface. Confirmed exhaustively: no runtime, CLI,
`llem run`/`llem study`, or dispatch path reads `get_engine_capabilities`,
`get_capability_matrix_markdown`, or `get_runtime_limitations`. Config
validation and measurement behavior are unchanged.

## Capability matrix: rows retired vs kept (8 retire / 5 keep)

Grounded in the a5 scoping rec (`phase0-a5-extras-scoping.md`, ITEM 3), which
enumerates the derivable subset, plus the ratified R3 count (8/13 capability,
7/7 limitation). a5 names the derivable rows as those that do field-presence
introspection against the mined schema, and the underivable rows as pure
hand-authored prose / product-scope decisions.

**KEPT (5, field-presence-derivable):**

| Row | Why derivable (a5) |
|---|---|
| `tensor_parallel` | all 3 cells introspect the mined schema (`tp_plan`, `tensor_parallel_size`) |
| `bitsandbytes_4bit` | transformers cell = `load_in_4bit` field presence (a5 named-derivable) |
| `bitsandbytes_8bit` | transformers cell = `load_in_8bit` field presence (a5 named-derivable) |
| `prefix_caching` | vLLM cell = `enable_prefix_caching` field presence (a5 named-derivable) |
| `torch_compile` | transformers cell = `torch_compile` on TransformersHarness (a5 named-derivable) |

**RETIRED (8, underivable / hand-authored):**

| Row | a5 justification |
|---|---|
| `data_parallel` | "all False, a product-scope decision: llem hasn't wired Accelerate DP" |
| `float32_precision` | "hardcoded per engine" (named underivable) |
| `float16_precision` | "hardcoded per engine" (all-True hand literal) |
| `bfloat16_precision` | "hardcoded per engine" (all-True hand literal) |
| `beam_search` | "beam_search for vLLM (hardcoded True, not field-checked)" |
| `native_quantization` | Any-typed in the projection; cells render hand-authored enum prose strings ("AWQ/GPTQ/FP8"), not derivable |
| `speculative_decoding` | a5 flags "(partially)"; tensorrt cell hardcoded, not clean-derivable |
| `static_kv_cache` | not in a5's named-derivable set; only 1/3 cells introspected |

The 8/5 split is uniquely forced by combining (a) a5's explicit naming and
(b) the ratified count: a5 names exactly 5 unqualified-derivable rows
(= the KEEP set) and 5 named-underivable rows; the 3 remaining rows
(`native_quantization`, `static_kv_cache`, `speculative_decoding`) are unnamed
or qualified, and the count (keep 5 / retire 8) sends all 3 to retirement. a5's
own headline ("~5 of 13 derivable") corroborates keep = 5.

**Two rows flagged for reviewer attention** (retired per the ratified count +
a5 naming, but debatable on pure introspection merits): `static_kv_cache` is
structurally identical to the kept `prefix_caching`/`torch_compile` (all three
are 1/3-introspected), and `speculative_decoding` is 2/3-introspected (more than
the kept 1/3 rows). a5 named the kept rows and not these; the count leaves no
keep slot for them. If the maintainer prefers a different boundary, the split is
the only place to adjust.

## Runtime limitations: all 7 retired (7/7)

`get_runtime_limitations()` deleted entirely. Per a5 it is "100% hardcoded
prose" (hardware/package caveats: flash-attn needs Ampere+, FP8 KV cache needs
Hopper, FP8 quant needs SM>=8.9, etc.), served inside an auto-generated doc that
claims it "cannot drift from what actually fires at runtime" - a claim these
rows violate. Removing them makes the page honest.

## Warmup 0.0 sentinel: de-claimed, no code touched (trace)

The "warmup 0.0 sentinel" is the engine-protocol return-value signal:
`EnginePlugin.run_warmup_prompt(...) -> 0.0` means "opt out of CV-convergence
warmup" (vLLM/TRT-LLM do single-token kernel warmup; transformers returns a real
latency > 0.0 to drive CV convergence). It is consumed in
`harness/lifecycle.py:283-320`: `first_latency > 0.0` runs
`warmup_until_converged`; `first_latency == 0.0` builds a converged
`WarmupResult` (kernel-warmup branch). The kernel-warmup-vs-disabled ambiguity is
disambiguated by `config.measurement.warmup.enabled` (a user setting
`warmup.enabled=False` forces `first_latency = 0.0`, same branch,
`iterations_completed=0`).

An earlier audit proposed promoting this bare sentinel to a new
`warmup_uses_convergence` capability. R3 rules **de-claim, not new capability
row**: that capability is NOT built (confirmed 0 hits for the symbol anywhere in
the tree). No code in the sentinel path is touched by this slice, so behavior for
warmup 0.0 (engine-returned or user-disabled) is byte-identical. There was never
a capability/limitation row to remove for it - the de-claim is the formal
decision to leave it as a bare sentinel.

## Consumers touched

- `src/llenergymeasure/config/introspection.py` - `get_engine_capabilities` (8 rows dropped + unused `vllm_has_quant`/`trt_has_quant` helpers removed), `get_capability_matrix_markdown` (display-name map trimmed to 5; orphaned FP32 note dropped), `get_runtime_limitations` deleted.
- `scripts/generate_invalid_combos_doc.py` - dropped the `get_runtime_limitations` import and the "## Runtime Limitations" section block.
- `docs/reference/engines/invalid-combos.md` - regenerated via `python scripts/generate_invalid_combos_doc.py`.
- `docs/how-to/troubleshoot.md` - prose no longer references the removed "runtime limitations" section.
- `tests/unit/config/test_config_introspection.py` - removed the 4 tests bound to retired rows (`test_capability_matrix_vllm_rejects_float32`, `test_capability_matrix_cells_match_engine_dtype_support`, both `test_runtime_limitations_*`); added `test_capability_matrix_reports_only_derivable_rows` (pins the kept set = 5) and `test_runtime_limitations_removed` (mirrors the existing `test_streaming_constraints_removed` guard).

## User-visible deltas

- `docs/reference/engines/invalid-combos.md` loses its "Runtime Limitations"
  table and 8 capability-matrix rows. This is the intended de-claim: fewer
  unfounded rows in a page that promised it could not drift. **No new blocking
  errors, no removed validation.** The Config Validation Errors and Dormant
  Parameters sections (both genuinely corpus-derived) are unchanged.
- The hardware/package caveats (flash-attn Ampere+, FP8 Hopper, etc.) are no
  longer surfaced anywhere. If the maintainer wants to preserve that information
  value, relocating it to a plain hand-owned doc page (explicitly not claiming
  "cannot drift") is a natural follow-up; S18 scope is retirement only, so it is
  not done here.

## Verification

- `make lint` (ruff + import-linter 5/5 contracts) clean.
- `make typecheck` (mypy, 339 files) clean.
- `make test` (host suite, `not gpu and not docker and not slow`): **3250 passed, 37 skipped**.
- `make docs-check` passes against the committed regenerated doc.
- Diff stat: 5 files, +27 / -204 (net -177 lines).
