### PR TITLE
fix(tests): stub dispatch metadata suite-wide for no-dist runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- The dispatch-metadata hermeticity stub now covers the whole unit suite rather
+  than only `tests/unit/docker/`: the baseline-container and engine docker-path
+  tests no longer fail with `PackageNotFoundError` when the suite runs
+  in-container from a source tree on `PYTHONPATH` with no install. The autouse
+  `stub_runtime_requirements` fixture moved up to `tests/unit/conftest.py`; the
+  real-metadata assertions keep their skip-when-absent behaviour. ([#867])
 - The GPU CI in-container suite job no longer livelocks under co-tenant host
   load: OpenMP/MKL thread pools are capped and set to passive wait, the suite
   container gets a CPU quota, a hung test now dumps all thread stacks after 30
@@ -1424,4 +1430,5 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#863]: https://github.com/henrycgbaker/llenergymeasure/pull/863
 [#864]: https://github.com/henrycgbaker/llenergymeasure/pull/864
 [#866]: https://github.com/henrycgbaker/llenergymeasure/pull/866
+[#867]: https://github.com/henrycgbaker/llenergymeasure/pull/867
 [#868]: https://github.com/henrycgbaker/llenergymeasure/pull/868

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,59 @@
+"""Shared fixtures for the unit-test suite."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from unittest.mock import patch
+
+import pytest
+
+# Canned runtime-dependency specs used to keep dispatch-command construction
+# hermetic. Command-construction and container-lifecycle tests only need a
+# non-empty spec list so _materialise_dispatch_assets can write a real
+# requirements file; they never assert on the specs themselves.
+_STUB_RUNTIME_REQUIREMENTS = ("filelock>=3.12", "numpy>=1.24", "pyarrow>=15", "pydantic>=2")
+
+
+@pytest.fixture(autouse=True)
+def stub_runtime_requirements(request):
+    """Keep dispatch-command construction independent of an installed distribution.
+
+    ``append_package_dispatch`` -> ``_materialise_dispatch_assets`` ->
+    ``_runtime_requirements`` reads ``importlib.metadata.requires`` for the
+    llenergymeasure distribution. That metadata exists only when the package is
+    pip-installed; it is absent when the suite runs from a source tree on
+    ``PYTHONPATH`` with no install (the GPU-CI container mounts the repo and sets
+    ``PYTHONPATH`` deliberately, without installing). Without a stub every test
+    that builds a docker command raises ``PackageNotFoundError`` - the docker
+    runner (``tests/unit/docker``), the baseline-container dispatch
+    (``tests/unit/study``), and the engine docker paths (``tests/unit/engines``)
+    all reach it, so the stub is autouse across the whole unit suite.
+
+    These are unit tests of command construction and container lifecycle, so the
+    metadata lookup is stubbed with a canned spec list. Tests that assert on the
+    real distribution metadata mark themselves ``needs_dist_metadata``; they are
+    left unstubbed and skipped when the distribution is not installed.
+
+    The stub is a ``patch.object`` attribute swap, so it takes effect without
+    touching the ``functools.cache``-wrapped resolvers. The process-lifetime
+    ``_materialise_dispatch_assets`` cache is deliberately left intact (it is
+    warmed once and reused, the behaviour the prefix-aware mkdtemp router is
+    built to tolerate); the ``needs_dist_metadata`` tests clear it themselves via
+    their ``_fresh`` helper when they need a live re-materialisation.
+    """
+    from llenergymeasure.infra.docker import command
+
+    if "needs_dist_metadata" in request.keywords:
+        try:
+            importlib.metadata.distribution(command._DISPATCH_DIST_NAME)
+        except importlib.metadata.PackageNotFoundError:
+            pytest.skip(
+                "llenergymeasure distribution metadata is not installed "
+                "(source tree on PYTHONPATH, no install); real-metadata "
+                "assertions are not applicable"
+            )
+        yield
+        return
+
+    with patch.object(command, "_runtime_requirements", return_value=_STUB_RUNTIME_REQUIREMENTS):
+        yield

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -2,16 +2,7 @@
 
 from __future__ import annotations
 
-import importlib.metadata
-from unittest.mock import MagicMock, patch
-
-import pytest
-
-# Canned runtime-dependency specs used to keep dispatch-command construction
-# hermetic. The command-construction and container-lifecycle tests only need a
-# non-empty spec list so _materialise_dispatch_assets can write a real
-# requirements file; they never assert on the specs themselves.
-_STUB_RUNTIME_REQUIREMENTS = ("filelock>=3.12", "numpy>=1.24", "pyarrow>=15", "pydantic>=2")
+from unittest.mock import MagicMock
 
 
 def make_subprocess_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -25,45 +16,3 @@ def make_subprocess_result(returncode: int = 0, stdout: str = "", stderr: str = 
     proc.stdout = stdout
     proc.stderr = stderr
     return proc
-
-
-@pytest.fixture(autouse=True)
-def stub_runtime_requirements(request):
-    """Keep dispatch-command construction independent of an installed distribution.
-
-    ``append_package_dispatch`` -> ``_materialise_dispatch_assets`` ->
-    ``_runtime_requirements`` reads ``importlib.metadata.requires`` for the
-    llenergymeasure distribution. That metadata exists only when the package is
-    pip-installed; it is absent when the suite runs from a source tree on
-    ``PYTHONPATH`` with no install (the GPU-CI container mounts the repo and sets
-    ``PYTHONPATH`` deliberately, without installing). Without a stub every test
-    that builds a docker command raises ``PackageNotFoundError``.
-
-    These are unit tests of command construction and container lifecycle, so the
-    metadata lookup is stubbed with a canned spec list. Tests that assert on the
-    real distribution metadata mark themselves ``needs_dist_metadata``; they are
-    left unstubbed and skipped when the distribution is not installed.
-
-    The stub is a ``patch.object`` attribute swap, so it takes effect without
-    touching the ``functools.cache``-wrapped resolvers. The process-lifetime
-    ``_materialise_dispatch_assets`` cache is deliberately left intact (it is
-    warmed once and reused, the behaviour the prefix-aware mkdtemp router is
-    built to tolerate); the ``needs_dist_metadata`` tests clear it themselves via
-    their ``_fresh`` helper when they need a live re-materialisation.
-    """
-    from llenergymeasure.infra.docker import command
-
-    if "needs_dist_metadata" in request.keywords:
-        try:
-            importlib.metadata.distribution(command._DISPATCH_DIST_NAME)
-        except importlib.metadata.PackageNotFoundError:
-            pytest.skip(
-                "llenergymeasure distribution metadata is not installed "
-                "(source tree on PYTHONPATH, no install); real-metadata "
-                "assertions are not applicable"
-            )
-        yield
-        return
-
-    with patch.object(command, "_runtime_requirements", return_value=_STUB_RUNTIME_REQUIREMENTS):
-        yield


### PR DESCRIPTION
## Summary

The dispatch-metadata hermeticity stub introduced in #861 lived in
`tests/unit/docker/conftest.py`, so it was directory-scoped and only reached
`tests/unit/docker/` tests. The GPU CI hardening in #864 completed the full
in-container suite for the first time since #830 and exposed the last stratum of
the `PackageNotFoundError` latency: 23 tests OUTSIDE `docker/` also real-execute
`build_docker_cmd` -> `append_package_dispatch` ->
`importlib.metadata.requires("llenergymeasure")` and fail when the suite runs
in-container from a source tree on `PYTHONPATH` with no install:

- `tests/unit/study/test_baseline_container.py` (TestBuildBaselineDockerCmd,
  TestRunBaselineContainerFailure)
- `tests/unit/engines/test_vllm_engine.py` (TestShmSizeInDockerRunner)

This hoists the autouse `stub_runtime_requirements` fixture (its current shape:
no cache clears, `patch.object` swap, `needs_dist_metadata` opt-out with
skip-when-absent) from `tests/unit/docker/conftest.py` up to a new
`tests/unit/conftest.py`, so it covers the whole unit suite. Only the fixture
moves; `tests/unit/docker/conftest.py` keeps `make_subprocess_result`. The two
`needs_dist_metadata`-marked tests are unchanged and keep working (the marker
logic travels with the fixture). Product-fallback and install-in-image
alternatives were considered and re-rejected upstream.

## Before / after evidence (no-dist venv: deps present, package uninstalled, `PYTHONPATH=src`)

Before (on `origin/main`):

```
$ PYTHONPATH=src python -m pytest tests/unit/study/test_baseline_container.py tests/unit/engines/test_vllm_engine.py -o "addopts=" -q
23 failed, 75 passed
# every failure: importlib.metadata.PackageNotFoundError: No package metadata was found for llenergymeasure
```

After (this branch):

```
$ PYTHONPATH=src python -m pytest tests/unit/study/test_baseline_container.py tests/unit/engines/test_vllm_engine.py -o "addopts=" -q
98 passed

$ PYTHONPATH=src python -m pytest tests/unit/docker/ -o "addopts=" -q -rs
260 passed, 2 skipped   # the two needs_dist_metadata tests skip in no-dist, as designed
```

Installed env (uv, distribution present): the two marked tests run for real
(`TestDispatchAssetMaterialisation`: 7 passed, 0 skipped).

## Full gates

- `make test`: 3252 passed, 37 skipped
- `make lint`: import-linter 5 contracts kept, 0 broken; ruff clean
- `make typecheck`: no issues in 340 source files

## Doc audit

- CHANGELOG: one Fixed entry added with link ref (test-only fix, matching the
  established precedent for test-only PRs).
- No public API, CLI, config, or product-doc surface changes (test-only).
