### PR TITLE
refactor(domain): unify runner provenance and dedup the bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,25 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Changed
 
+- **Breaking (results bundle):** `bundle_version` bumps to `"2.0"` for the
+  provenance-unification break. The sibling runner-provenance models
+  (`RunnerProvenance` on `result.json`, `RunnerEnvironment` on
+  `environment.json`) merge into one `RunnerProvenance`
+  (`llenergymeasure.domain.provenance`) carrying the field superset
+  (`mode`, `image`, `source`, `image_source`, `image_digest`); `RunnerEnvironment`
+  is deleted and both artefacts still serialise a runner block. The top-level
+  `ExperimentResult.baseline_power_w` copy is retired - `energy_breakdown.baseline_power_w`
+  is the single home. Four never-populated environment fields (`pcie_gen`,
+  `mig_enabled`, `cudnn_version`, `fan_speed_pct`) are dropped, and the
+  driver-reported CUDA field `CUDAEnvironment.version` is renamed
+  `driver_supported_version` (the NVML driver-supported CUDA version, distinct
+  from `EnvironmentSnapshot.cuda_version`, the runtime version the stack was
+  built against). A new `ExperimentResult.measurement_mode` (`"offline"` today)
+  is the offline/server discriminator. Results written by earlier versions
+  remain readable best-effort with a single warning: the retired top-level keys
+  are dropped on load, the legacy CUDA key is mapped, the dead fields are ignored,
+  and the old separate runner block reads into the unified model; no converter
+  tooling is provided. ([#869])
 - Internal restructure (no behavior or results change): the generated per-engine
   config models moved from `src/llenergymeasure/engines/<engine>/config.py` to the
   config layer at `src/llenergymeasure/config/generated/<engine>.py`, beside their
@@ -1443,4 +1462,5 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#866]: https://github.com/henrycgbaker/llenergymeasure/pull/866
 [#867]: https://github.com/henrycgbaker/llenergymeasure/pull/867
 [#868]: https://github.com/henrycgbaker/llenergymeasure/pull/868
+[#869]: https://github.com/henrycgbaker/llenergymeasure/pull/869
 [#871]: https://github.com/henrycgbaker/llenergymeasure/pull/871

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,9 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   driver-reported CUDA field `CUDAEnvironment.version` is renamed
   `driver_supported_version` (the NVML driver-supported CUDA version, distinct
   from `EnvironmentSnapshot.cuda_version`, the runtime version the stack was
-  built against). A new `ExperimentResult.measurement_mode` (`"offline"` today)
-  is the offline/server discriminator. Results written by earlier versions
+  built against). A new `ExperimentResult.serving_mode` (`"offline"` today)
+  is the offline/server discriminator, mirroring the config-side
+  `ExperimentConfig.serving_mode`. Results written by earlier versions
   remain readable best-effort with a single warning: the retired top-level keys
   are dropped on load, the legacy CUDA key is mapped, the dead fields are ignored,
   and the old separate runner block reads into the unified model; no converter

--- a/docs/how-to/interpret-results.md
+++ b/docs/how-to/interpret-results.md
@@ -123,7 +123,7 @@ The full result is saved as a JSON file in the `results/` directory. Key fields:
 |-------|---------------|
 | `total_energy_j` | Total GPU energy in joules (same as "Total" in terminal output) |
 | `energy_adjusted_j` | Baseline-subtracted energy in joules (same as "Adjusted" in terminal output). `null` when no baseline was measured. |
-| `baseline_power_w` | Idle GPU power in watts (same as "Baseline"). `null` when baseline disabled. |
+| `energy_breakdown.baseline_power_w` | Idle GPU power in watts (same as "Baseline"). `null` when baseline disabled. |
 | `mj_per_tok_total` | Millijoules per token from raw (unadjusted) energy. |
 | `mj_per_tok_adjusted` | Millijoules per token from baseline-adjusted energy. **The right field for cross-experiment comparisons.** |
 | `avg_tokens_per_second` | Output throughput in tokens/second (same as "Throughput"). |

--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -30,10 +30,11 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `bundle_version` | `str` | Results-bundle version (current: `"1.0"`), shared across `result.json`, `config.json`, and `environment.json` as one contract. |
+| `bundle_version` | `str` | Results-bundle version (current: `"2.0"`), shared across `result.json`, `config.json`, and `environment.json` as one contract. |
 | `experiment_id` | `str` | Unique identifier for this experiment run. |
 | `measurement_config_hash` | `str` | 16-char SHA-256 hex of the `ExperimentConfig` (environment fields excluded). Matches the hash in the result directory name on disk. |
 | `llenergymeasure_version` | `str \| None` | Package version that produced this result. |
+| `measurement_mode` | `str` | The measurement mode that produced this result: the offline/server discriminator. `"offline"` for batch measurement (the only mode today); `"server"` arrives with server mode (v0.8.0). A plain string, not a closed vocabulary. |
 | `engine` | `str` | Inference engine used. Convenience copy; authoritative home is the `config.json` sidecar. |
 | `model_name` | `str` | Model name/path measured. Convenience copy; authoritative home is the `config.json` sidecar. |
 
@@ -69,9 +70,8 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `baseline_power_w` | `float \| None` | Idle GPU power in watts measured before the experiment. `None` when baseline measurement is disabled. |
 | `energy_per_device_j` | `list[float] \| None` | Per-GPU energy breakdown. Currently populated by the Zeus sampler only. `None` for NVML and CodeCarbon. |
-| `energy_breakdown` | `EnergyBreakdown \| None` | Detailed breakdown with baseline adjustment intervals. |
+| `energy_breakdown` | `EnergyBreakdown \| None` | Detailed breakdown with baseline adjustment intervals. Carries `baseline_power_w` (idle GPU power in watts), the single home for the baseline reading since bundle 2.0 retired the former top-level `baseline_power_w` copy. |
 
 ### Multi-GPU
 

--- a/docs/reference/library/ExperimentResult.md
+++ b/docs/reference/library/ExperimentResult.md
@@ -34,7 +34,7 @@ produced by `model.model_dump(mode="json")` and shares the same field names and 
 | `experiment_id` | `str` | Unique identifier for this experiment run. |
 | `measurement_config_hash` | `str` | 16-char SHA-256 hex of the `ExperimentConfig` (environment fields excluded). Matches the hash in the result directory name on disk. |
 | `llenergymeasure_version` | `str \| None` | Package version that produced this result. |
-| `measurement_mode` | `str` | The measurement mode that produced this result: the offline/server discriminator. `"offline"` for batch measurement (the only mode today); `"server"` arrives with server mode (v0.8.0). A plain string, not a closed vocabulary. |
+| `serving_mode` | `str` | The serving mode that produced this result: the offline/server discriminator, mirroring the config-side `ExperimentConfig.serving_mode`. `"offline"` for batch measurement (the only mode today); `"server"` arrives with server mode (v0.8.0). A plain string, not a closed vocabulary. |
 | `engine` | `str` | Inference engine used. Convenience copy; authoritative home is the `config.json` sidecar. |
 | `model_name` | `str` | Model name/path measured. Convenience copy; authoritative home is the `config.json` sidecar. |
 

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -45,7 +45,7 @@ The scientific record. One JSON file per experiment cell. Stamped with `bundle_v
 | `experiment_id` | str | Unique experiment identifier (`{model}_{YYYYMMDD_HHMMSS}` for single experiments; study-level cells inherit a richer per-cell identifier) |
 | `measurement_config_hash` | str | SHA-256[:16] of `ExperimentConfig` with environment fields excluded; same hash -> logically identical experiments |
 | `llenergymeasure_version` | str &#124; null | Package version that produced this result |
-| `measurement_mode` | str | The measurement mode that produced this result: the offline/server discriminator. `"offline"` for batch measurement (the only mode today); server mode (v0.8.0) will stamp `"server"`. A plain string, not a closed vocabulary |
+| `serving_mode` | str | The serving mode that produced this result: the offline/server discriminator, mirroring the config-side `ExperimentConfig.serving_mode`. `"offline"` for batch measurement (the only mode today); server mode (v0.8.0) will stamp `"server"`. A plain string, not a closed vocabulary |
 | `engine` | str | Inference engine used. Convenience copy; authoritative home is the `config.json` sidecar |
 | `model_name` | str | Model name/path measured. Convenience copy; authoritative home is the `config.json` sidecar |
 

--- a/docs/reference/results-schema.md
+++ b/docs/reference/results-schema.md
@@ -18,7 +18,7 @@ results/
 └── <study-name>_<UTC-timestamp>/
     ├── manifest.json                            # study-level checkpoint + summary
     ├── 001_c0_<model>-<engine>_<hash>/          # one experiment cell
-    │   ├── result.json                          # measurement metrics (bundle_version 1.0)
+    │   ├── result.json                          # measurement metrics (bundle_version 2.0)
     │   ├── config.json                          # engine/model/methodology + resolved config + provenance
     │   ├── environment.json                     # hardware/runtime snapshot + runner provenance
     │   └── timeseries.parquet                   # GPU power/thermal/memory samples
@@ -33,7 +33,7 @@ results/
 
 ## `result.json` - per-experiment record
 
-The scientific record. One JSON file per experiment cell. Stamped with `bundle_version` `"1.0"` (the single version shared across every artefact in the bundle).
+The scientific record. One JSON file per experiment cell. Stamped with `bundle_version` `"2.0"` (the single version shared across every artefact in the bundle).
 
 `result.json` is measurement output. Configuration inputs and methodology - `engine_version`, `measurement_methodology`, `steady_state_window`, `measurement_window_discard_fraction`, `steady_state_not_detected` - live in the `config.json` sidecar, not here. The one deliberate duplication: `result.json` keeps `model_name` and `engine` as convenience copies so a result file is self-describing when separated from its directory; the authoritative home for both is `config.json`.
 
@@ -41,10 +41,11 @@ The scientific record. One JSON file per experiment cell. Stamped with `bundle_v
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `bundle_version` | str | Results-bundle version (currently `"1.0"`), shared across `result.json`, `config.json`, and `environment.json` as one contract |
+| `bundle_version` | str | Results-bundle version (currently `"2.0"`), shared across `result.json`, `config.json`, and `environment.json` as one contract |
 | `experiment_id` | str | Unique experiment identifier (`{model}_{YYYYMMDD_HHMMSS}` for single experiments; study-level cells inherit a richer per-cell identifier) |
 | `measurement_config_hash` | str | SHA-256[:16] of `ExperimentConfig` with environment fields excluded; same hash -> logically identical experiments |
 | `llenergymeasure_version` | str &#124; null | Package version that produced this result |
+| `measurement_mode` | str | The measurement mode that produced this result: the offline/server discriminator. `"offline"` for batch measurement (the only mode today); server mode (v0.8.0) will stamp `"server"`. A plain string, not a closed vocabulary |
 | `engine` | str | Inference engine used. Convenience copy; authoritative home is the `config.json` sidecar |
 | `model_name` | str | Model name/path measured. Convenience copy; authoritative home is the `config.json` sidecar |
 
@@ -97,8 +98,8 @@ These are the run totals (post-warmup-exclusion when applicable).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `baseline_power_w` | float &#124; null | Idle GPU power in watts, measured before this experiment |
-| `energy_adjusted_j` | float &#124; null | Total energy minus `baseline_power_w x total_inference_time_sec`. The "net inference work" energy figure. |
+| `energy_breakdown.baseline_power_w` | float &#124; null | Idle GPU power in watts, measured before this experiment. The single home for the baseline power reading (the former top-level `baseline_power_w` copy was retired in bundle 2.0) |
+| `energy_adjusted_j` | float &#124; null | Total energy minus `energy_breakdown.baseline_power_w x total_inference_time_sec`. The "net inference work" energy figure. |
 | `energy_per_device_j` | list[float] &#124; null | Per-GPU energy breakdown (length = `num_processes`) |
 
 For the methodology that motivates baseline subtraction, see [Methodology &gt; Baseline power](/explanation/methodology/methodology#baseline-power).
@@ -191,16 +192,19 @@ batch is attributed `batch_time / batch_size` (the `PER_REQUEST_BATCH` mode in
 
 ### Environment sidecar (sibling file)
 
-`environment.json` lives next to `result.json` and records the hardware/runtime environment the experiment ran in (schema `1.0`, independent of `result.json`): GPU, CUDA, driver, CPU, platform, Python and tool versions. Under Docker dispatch it captures the *in-container* environment, not the dispatching host.
+`environment.json` lives next to `result.json` and records the hardware/runtime environment the experiment ran in (stamped with the shared `bundle_version` `2.0`): GPU, CUDA, driver, CPU, platform, Python and tool versions. Under Docker dispatch it captures the *in-container* environment, not the dispatching host.
 
-It also carries a `runner` block - the reproducibility anchor for cross-run comparability:
+Two distinct CUDA facts are recorded and must not be conflated: `hardware.cuda.driver_supported_version` is the maximum CUDA version the installed NVIDIA driver supports (from NVML, matching the `CUDA Version` in the `nvidia-smi` header), while the top-level `cuda_version` (with `cuda_version_source`) is the runtime CUDA version the software stack was actually built against (torch / version.txt / nvcc).
+
+It also carries a `runner` block - the reproducibility anchor for cross-run comparability. It is the same unified `RunnerProvenance` model `result.json` carries as `runner_provenance`, serialised into both artefacts:
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `mode` | str | `"docker"` (containerized) or `"local"` (host process) - a first-order variable for energy/latency comparability. Mirrors `result.json`'s `runner_provenance.mode` |
+| `mode` | str | `"docker"` (containerized) or `"local"` (host process) - a first-order variable for energy/latency comparability |
 | `image` | str &#124; null | Docker image reference that ran (`null` for local) |
-| `image_digest` | str &#124; null | Resolved registry digest (`repo@sha256:...`) pinning the full stack (base image, CUDA, torch, patches). `null` for local runs, and for locally-built images with no registry digest |
 | `source` | str | Which precedence layer selected the runner (`env`, `yaml`, `user_config`, `auto_detected`, `default`, `multi_engine_elevation`, or `local`) |
+| `image_source` | str &#124; null | Where the Docker image was resolved from (`null` for local runs or when unresolved) |
+| `image_digest` | str &#124; null | Resolved registry digest (`repo@sha256:...`) pinning the full stack (base image, CUDA, torch, patches). `null` for local runs, and for locally-built images with no registry digest |
 
 Sidecars written before this block existed load with `runner: null`.
 
@@ -287,9 +291,9 @@ For the Python API equivalent (`StudyResult` object), see [Reference &gt; Librar
 
 ## Bundle versioning
 
-The whole bundle carries one `bundle_version` (currently `"1.0"`), stamped identically into `result.json`, `config.json`, and `environment.json` (`timeseries.parquet` is self-describing columnar data and stays unversioned). It versions the on-disk layout, the artefact set, and each artefact's schema as a single contract, so there is one number to bump and one changelog line per documented break. This replaces the three independent per-artefact `schema_version` counters that earlier releases carried. It follows semantic versioning: minor bumps add fields without breaking existing readers, major bumps signal breaking changes. Pre-1.0 the policy is conservative - new fields land as `Optional` with `default = null` so existing parsers don't break.
+The whole bundle carries one `bundle_version` (currently `"2.0"`), stamped identically into `result.json`, `config.json`, and `environment.json` (`timeseries.parquet` is self-describing columnar data and stays unversioned). It versions the on-disk layout, the artefact set, and each artefact's schema as a single contract, so there is one number to bump and one changelog line per documented break. This replaces the three independent per-artefact `schema_version` counters that earlier releases carried. It follows semantic versioning: minor bumps add fields without breaking existing readers, major bumps signal breaking changes. Pre-1.0 the policy is conservative - new fields land as `Optional` with `default = null` so existing parsers don't break.
 
-Bundles written before `bundle_version` existed remain readable best-effort: the canonical reader (`llenergymeasure.results.bundle.BundleReader`, wrapped by `load_result`) drops the retired `schema_version` key rather than rejecting it and emits a single warning. There is no in-place migration and no converter tooling.
+Older bundles remain readable best-effort: the canonical reader (`llenergymeasure.results.bundle.BundleReader`, wrapped by `load_result`) tolerates a legacy shape rather than rejecting it, emitting a single warning per bundle. A bundle 1.0 (the provenance-unification break) reads with its retired top-level `baseline_power_w` copy and `schema_version` key dropped on load, its pre-rename `hardware.cuda.version` mapped onto `driver_supported_version`, its never-populated hardware fields (`pcie_gen`, `mig_enabled`, `cudnn_version`, `fan_speed_pct`) ignored, and its old separate runner block read into the unified `RunnerProvenance` model. There is no in-place migration and no converter tooling.
 
 ## See also
 

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -267,7 +267,7 @@ copies so the file is self-describing when separated from its directory:
 {
   "experiment_id": "qwen-transformers-bf16-bs16-fa2-2026-05-07T14-32-08",
   "bundle_version": "2.0",
-  "measurement_mode": "offline",
+  "serving_mode": "offline",
   "engine": "transformers",
   "model_name": "Qwen/Qwen2.5-0.5B",
   "input_tokens": 6144,

--- a/docs/tutorials/multi-engine-study.md
+++ b/docs/tutorials/multi-engine-study.md
@@ -247,7 +247,7 @@ After the run completes, the study directory looks roughly like this:
 results/tutorial-multi-engine_2026-05-07T14-32-08/
 ├── manifest.json                       # study-level: timing, config, completion
 ├── 001_c0_qwen-transformers_a1b2c3.../ # one experiment cell
-│   ├── result.json                     # measurement metrics only (bundle_version 1.0)
+│   ├── result.json                     # measurement metrics only (bundle_version 2.0)
 │   ├── config.json                     # engine/model/methodology + resolved config + provenance
 │   └── timeseries.parquet              # GPU power/thermal/memory samples
 ├── 002_c0_qwen-transformers_d4e5f6.../
@@ -259,14 +259,15 @@ experiment list, study timing, completion status per cell, and the
 effective study-level config. This is what you load when you want to
 *reason about the study as a whole* rather than one cell.
 
-A single `result.json` is measurement output (bundle_version 1.0). Configuration
+A single `result.json` is measurement output (bundle_version 2.0). Configuration
 moved to the sidecar; only `engine` and `model_name` remain as convenience
 copies so the file is self-describing when separated from its directory:
 
 ```json
 {
   "experiment_id": "qwen-transformers-bf16-bs16-fa2-2026-05-07T14-32-08",
-  "bundle_version": "1.0",
+  "bundle_version": "2.0",
+  "measurement_mode": "offline",
   "engine": "transformers",
   "model_name": "Qwen/Qwen2.5-0.5B",
   "input_tokens": 6144,
@@ -275,12 +276,11 @@ copies so the file is self-describing when separated from its directory:
   "total_inference_time_sec": 9.8,
   "avg_tokens_per_second": 783.7,
   "total_energy_j": 891.4,
-  "baseline_power_w": 12.3,
   "mj_per_tok_total": 116.1,
   "mj_per_tok_adjusted": 100.4,
   "total_flops": 1.18e+12,
   "flops_per_output_token": 1.54e+8,
-  "energy_breakdown": { "...": "..." }
+  "energy_breakdown": { "baseline_power_w": 12.3, "...": "..." }
 }
 ```
 
@@ -291,7 +291,7 @@ provenance:
 
 ```json
 {
-  "bundle_version": "1.0",
+  "bundle_version": "2.0",
   "engine": "transformers",
   "engine_version": "4.57.1",
   "model_name": "Qwen/Qwen2.5-0.5B",

--- a/src/llenergymeasure/cli/_display.py
+++ b/src/llenergymeasure/cli/_display.py
@@ -37,8 +37,11 @@ def print_result_summary(result: ExperimentResult) -> None:
     # --- Energy ---
     print("Energy")
     print(f"  Total          {_sig3(result.total_energy_j)} J")
-    if result.baseline_power_w is not None:
-        print(f"  Baseline       {_sig3(result.baseline_power_w)} W")
+    baseline_power_w = (
+        result.energy_breakdown.baseline_power_w if result.energy_breakdown is not None else None
+    )
+    if baseline_power_w is not None:
+        print(f"  Baseline       {_sig3(baseline_power_w)} W")
     if result.energy_adjusted_j is not None:
         print(f"  Adjusted       {_sig3(result.energy_adjusted_j)} J")
     # Per-token energy (mJ/tok) - prefer adjusted, fall back to total, no recomputation

--- a/src/llenergymeasure/device/environment.py
+++ b/src/llenergymeasure/device/environment.py
@@ -114,8 +114,8 @@ def _collect_gpu(pynvml: Any, handle: Any) -> GPUEnvironment:
 
 
 def _collect_cuda(pynvml: Any) -> CUDAEnvironment:
-    """Collect CUDA and driver version information."""
-    cuda_version = "unknown"
+    """Collect CUDA driver information reported by NVML."""
+    driver_supported_version = "unknown"
     driver_version = "unknown"
 
     try:
@@ -131,13 +131,13 @@ def _collect_cuda(pynvml: Any) -> CUDAEnvironment:
         cuda_driver_version = pynvml.nvmlSystemGetCudaDriverVersion()
         major = cuda_driver_version // 1000
         minor = (cuda_driver_version % 1000) // 10
-        cuda_version = f"{major}.{minor}"
-        logger.debug("Environment: CUDA version = %s", cuda_version)
+        driver_supported_version = f"{major}.{minor}"
+        logger.debug("Environment: driver-supported CUDA version = %s", driver_supported_version)
     except (pynvml.NVMLError, AttributeError) as e:
-        logger.debug("Environment: failed to get CUDA version: %s", e)
+        logger.debug("Environment: failed to get driver-supported CUDA version: %s", e)
 
     return CUDAEnvironment(
-        version=cuda_version,
+        driver_supported_version=driver_supported_version,
         driver_version=driver_version,
     )
 
@@ -239,7 +239,7 @@ def _unavailable_metadata() -> EnvironmentMetadata:
     """Create metadata with reasonable defaults when NVML unavailable."""
     return EnvironmentMetadata(
         gpu=GPUEnvironment(name="unavailable", vram_total_mb=0.0),
-        cuda=CUDAEnvironment(version="unknown", driver_version="unknown"),
+        cuda=CUDAEnvironment(driver_supported_version="unknown", driver_version="unknown"),
         thermal=ThermalEnvironment(),
         cpu=_collect_cpu(),
         container=_collect_container(),

--- a/src/llenergymeasure/domain/bundle_artefacts.py
+++ b/src/llenergymeasure/domain/bundle_artefacts.py
@@ -46,7 +46,14 @@ SYSTEM_OVERRIDES_FILENAME = "system_overrides.json"
 # Single version for the whole per-experiment bundle. Stamped into result.json,
 # config.json, and environment.json (Parquet is self-describing and stays
 # unversioned). One number to bump, one CHANGELOG line per break.
-BUNDLE_VERSION = "1.0"
+#
+# 2.0 (provenance unification): RunnerProvenance/RunnerEnvironment merged to one
+# model (result.json runner gains image_digest, environment.json runner gains
+# image_source); the top-level result.json baseline_power_w copy dropped (single
+# home: energy_breakdown.baseline_power_w); never-populated environment fields
+# dropped (pcie_gen, mig_enabled, cudnn_version, fan_speed_pct); the CUDA hardware
+# field version renamed to driver_supported_version; measurement_mode added.
+BUNDLE_VERSION = "2.0"
 
 
 @dataclass(frozen=True)

--- a/src/llenergymeasure/domain/bundle_artefacts.py
+++ b/src/llenergymeasure/domain/bundle_artefacts.py
@@ -52,7 +52,7 @@ SYSTEM_OVERRIDES_FILENAME = "system_overrides.json"
 # image_source); the top-level result.json baseline_power_w copy dropped (single
 # home: energy_breakdown.baseline_power_w); never-populated environment fields
 # dropped (pcie_gen, mig_enabled, cudnn_version, fan_speed_pct); the CUDA hardware
-# field version renamed to driver_supported_version; measurement_mode added.
+# field version renamed to driver_supported_version; serving_mode added.
 BUNDLE_VERSION = "2.0"
 
 

--- a/src/llenergymeasure/domain/environment.py
+++ b/src/llenergymeasure/domain/environment.py
@@ -5,9 +5,11 @@ enabling post-hoc analysis of environmental factors affecting measurements.
 """
 
 from datetime import datetime
-from typing import Literal
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from llenergymeasure.domain.provenance import RunnerProvenance
 
 
 class GPUEnvironment(BaseModel):
@@ -19,25 +21,33 @@ class GPUEnvironment(BaseModel):
         default=None,
         description="CUDA compute capability (e.g., '8.0')",
     )
-    pcie_gen: int | None = Field(
-        default=None,
-        description="PCIe generation",
-    )
-    mig_enabled: bool = Field(
-        default=False,
-        description="Whether MIG (Multi-Instance GPU) is enabled",
-    )
 
 
 class CUDAEnvironment(BaseModel):
-    """CUDA runtime information."""
+    """CUDA driver information reported by NVML."""
 
-    version: str = Field(..., description="CUDA version (e.g., '12.4')")
-    driver_version: str = Field(..., description="NVIDIA driver version string")
-    cudnn_version: str | None = Field(
-        default=None,
-        description="cuDNN version string",
+    driver_supported_version: str = Field(
+        ...,
+        description="Maximum CUDA version the installed NVIDIA driver supports, from NVML "
+        "(nvmlSystemGetCudaDriverVersion; this is the 'CUDA Version' nvidia-smi prints in its "
+        "header). A driver-side capability, distinct from the runtime CUDA version the software "
+        "stack was actually built against - that is EnvironmentSnapshot.cuda_version.",
     )
+    driver_version: str = Field(..., description="NVIDIA driver package version string")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _map_legacy_cuda_version(cls, data: Any) -> Any:
+        """Read a legacy (bundle 1.0) CUDA block best-effort.
+
+        Bundle 1.0 stored this driver-supported CUDA version under the ambiguous
+        key ``version``. Map it onto ``driver_supported_version`` so an older
+        environment.json loads rather than failing the now-renamed required field.
+        """
+        if isinstance(data, dict) and "version" in data and "driver_supported_version" not in data:
+            data = dict(data)
+            data["driver_supported_version"] = data.pop("version")
+        return data
 
 
 class ThermalEnvironment(BaseModel):
@@ -54,10 +64,6 @@ class ThermalEnvironment(BaseModel):
     default_power_limit_w: float | None = Field(
         default=None,
         description="Factory default GPU power limit in Watts",
-    )
-    fan_speed_pct: float | None = Field(
-        default=None,
-        description="Fan speed as percentage (0-100)",
     )
 
 
@@ -88,43 +94,6 @@ class ContainerEnvironment(BaseModel):
     )
 
 
-class RunnerEnvironment(BaseModel):
-    """How an experiment was executed - containerized (docker) or on the host (local).
-
-    Records the runner mode (docker vs local), the exact Docker image and its
-    resolved registry digest (the reproducibility anchor pinning the full
-    software stack: base image, CUDA, torch, patches), and the precedence
-    source that selected the runner. The digest is None for local runs, and
-    also None when it cannot be resolved (image built locally with no registry
-    digest, docker unavailable, inspect error) - resolution is best-effort and
-    never fails a run.
-
-    Sibling of ``experiment.RunnerProvenance`` (which persists into result.json):
-    both mirror the config-layer ``RunnerSpec``'s mode/image/source. They stay separate
-    because their extra fields diverge - this one carries ``image_digest`` (the
-    environment.json reproducibility anchor), RunnerProvenance carries
-    ``image_source`` (result.json image-resolution provenance).
-    """
-
-    mode: Literal["docker", "local"] = Field(
-        ..., description="Execution mode - 'docker' (containerized) or 'local' (host process)"
-    )
-    image: str | None = Field(
-        default=None,
-        description="Docker image reference used (None for local runs)",
-    )
-    image_digest: str | None = Field(
-        default=None,
-        description="Resolved image registry digest ('repo@sha256:...'). None for local "
-        "runs or when the digest could not be resolved (e.g. locally-built image).",
-    )
-    source: str = Field(
-        ...,
-        description="RunnerSpec precedence source that selected the runner (e.g. 'env', "
-        "'yaml', 'user_config', 'auto_detected', 'default', 'multi_engine_elevation', 'local')",
-    )
-
-
 class EnvironmentMetadata(BaseModel):
     """Complete environment metadata for an experiment.
 
@@ -133,7 +102,7 @@ class EnvironmentMetadata(BaseModel):
     """
 
     gpu: GPUEnvironment = Field(..., description="GPU hardware information")
-    cuda: CUDAEnvironment = Field(..., description="CUDA runtime information")
+    cuda: CUDAEnvironment = Field(..., description="CUDA driver information")
     thermal: ThermalEnvironment = Field(
         default_factory=ThermalEnvironment,
         description="GPU thermal state at experiment start",
@@ -162,11 +131,16 @@ class EnvironmentSnapshot(BaseModel):
     hardware: EnvironmentMetadata
     python_version: str
     tool_version: str
-    cuda_version: str | None = None
-    cuda_version_source: str | None = None  # "torch" | "version_txt" | "nvcc" | None
-    runner: RunnerEnvironment | None = Field(
+    cuda_version: str | None = Field(
         default=None,
-        description="How the experiment was executed (docker vs local, image + digest, "
-        "precedence source). None for older sidecars written before runner provenance "
-        "was recorded.",
+        description="Runtime CUDA version the software stack was built against, detected via "
+        "the torch/version.txt/nvcc fallback chain (cuda_version_source records which). Distinct "
+        "from the driver-supported CUDA version in hardware.cuda.driver_supported_version.",
+    )
+    cuda_version_source: str | None = None  # "torch" | "version_txt" | "nvcc" | None
+    runner: RunnerProvenance | None = Field(
+        default=None,
+        description="How the experiment was executed (docker vs local, image + digest + source, "
+        "the unified runner-provenance model). None for older sidecars written before runner "
+        "provenance was recorded.",
     )

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -100,13 +100,14 @@ class ExperimentResult(BaseModel):
     llenergymeasure_version: str | None = Field(
         default=None, description="Package version that produced this result"
     )
-    measurement_mode: str = Field(
+    serving_mode: str = Field(
         default="offline",
-        description="Measurement mode that produced this result: the offline/server "
-        'discriminator. "offline" for batch measurement (the only mode today); "server" '
-        "arrives with server mode (v0.8.0). A plain string, not a closed vocabulary, so the "
-        "mode set can grow without a schema break. Stamped by the assembler from the "
-        "measurement source (see harness.result_assembly.SourceMetrics).",
+        description="Serving mode that produced this result: the offline/server "
+        'discriminator, mirroring the config-side ExperimentConfig.serving_mode. "offline" for '
+        'batch measurement (the only mode today); "server" arrives with server mode (v0.8.0). A '
+        "plain string, not a closed vocabulary, so the mode set can grow without a schema break. "
+        "Stamped by the assembler from the measurement source (see "
+        "harness.result_assembly.SourceMetrics).",
     )
 
     # Convenience identity copies. Deliberate small duplication so a result.json

--- a/src/llenergymeasure/domain/experiment.py
+++ b/src/llenergymeasure/domain/experiment.py
@@ -21,6 +21,11 @@ from llenergymeasure.domain.metrics import (
     WarmupResult,
 )
 
+# Re-exported for import stability: RunnerProvenance now lives in its own shared
+# domain module (both experiment and environment carry it, and experiment
+# imports environment, so a shared low-level module avoids an import cycle).
+from llenergymeasure.domain.provenance import RunnerProvenance
+
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig
 
@@ -55,34 +60,6 @@ def mj_per_token(energy_j: float, total_tokens: float) -> float | None:
     is accepted.
     """
     return (energy_j / total_tokens * 1000.0) if total_tokens > 0 else None
-
-
-class RunnerProvenance(BaseModel):
-    """How an experiment was executed - local process or Docker container.
-
-    Persisted reproducibility metadata mirroring the fields of the config-layer
-    ``RunnerSpec``. Kept in the domain layer (which does not import its config
-    sibling) so it can live on ``ExperimentResult`` and serialise into result.json.
-
-    Sibling of ``environment.RunnerEnvironment`` (which persists into
-    environment.json): both mirror ``RunnerSpec``'s mode/image/source. They stay
-    separate because their extra fields diverge - this one carries
-    ``image_source`` (result.json image-resolution provenance), RunnerEnvironment
-    carries ``image_digest`` (the environment.json reproducibility anchor).
-    """
-
-    mode: str = Field(..., description='Execution mode - "local" or "docker"')
-    image: str | None = Field(default=None, description="Docker image used (None for local mode)")
-    source: str | None = Field(
-        default=None,
-        description='Precedence layer that produced the runner ("env", "yaml", '
-        '"user_config", "auto_detected", "default", "local")',
-    )
-    image_source: str | None = Field(
-        default=None, description="Where the Docker image was resolved from (None for local mode)"
-    )
-
-    model_config = {"frozen": True, "extra": "forbid"}
 
 
 class AggregationMetadata(BaseModel):
@@ -122,6 +99,14 @@ class ExperimentResult(BaseModel):
     )
     llenergymeasure_version: str | None = Field(
         default=None, description="Package version that produced this result"
+    )
+    measurement_mode: str = Field(
+        default="offline",
+        description="Measurement mode that produced this result: the offline/server "
+        'discriminator. "offline" for batch measurement (the only mode today); "server" '
+        "arrives with server mode (v0.8.0). A plain string, not a closed vocabulary, so the "
+        "mode set can grow without a schema break. Stamped by the assembler from the "
+        "measurement source (see harness.result_assembly.SourceMetrics).",
     )
 
     # Convenience identity copies. Deliberate small duplication so a result.json
@@ -180,9 +165,6 @@ class ExperimentResult(BaseModel):
     )
 
     # Energy detail
-    baseline_power_w: float | None = Field(
-        default=None, description="Idle GPU power (W) measured before experiment"
-    )
     energy_adjusted_j: float | None = Field(
         default=None, description="Baseline-subtracted energy attributable to inference"
     )
@@ -282,18 +264,22 @@ class ExperimentResult(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _drop_legacy_schema_version(cls, data: Any) -> Any:
-        """Read a legacy (pre-bundle_version) result.json best-effort.
+    def _drop_legacy_keys(cls, data: Any) -> Any:
+        """Read a legacy result.json best-effort by dropping retired top-level keys.
 
-        Older bundles stamped result.json with a per-artefact ``schema_version``
-        that no longer exists on this model, which forbids extra fields. Drop the
-        retired key before validation (both ``model_validate`` and
-        ``model_validate_json`` run before-validators on the parsed structure) so
-        a legacy result.json falls back to the current default ``bundle_version``
-        rather than being rejected.
+        This model forbids extra fields, so keys retired across a bundle break
+        would reject an older result.json outright. Drop them before validation
+        (both ``model_validate`` and ``model_validate_json`` run before-validators
+        on the parsed structure) so a legacy result.json degrades to the current
+        defaults rather than being rejected:
+
+        - ``schema_version`` (pre-``bundle_version`` per-artefact counter).
+        - ``baseline_power_w`` (bundle 1.0 top-level copy; the single home is now
+          ``energy_breakdown.baseline_power_w``).
         """
-        if isinstance(data, dict) and "schema_version" in data:
-            data = {k: v for k, v in data.items() if k != "schema_version"}
+        legacy_keys = {"schema_version", "baseline_power_w"}
+        if isinstance(data, dict) and legacy_keys & data.keys():
+            data = {k: v for k, v in data.items() if k not in legacy_keys}
         return data
 
     @property

--- a/src/llenergymeasure/domain/provenance.py
+++ b/src/llenergymeasure/domain/provenance.py
@@ -1,0 +1,53 @@
+"""Unified runner-provenance domain model.
+
+``RunnerProvenance`` records how one experiment was executed - as a local host
+process or inside a Docker container - together with the image, its resolved
+registry digest, and the precedence source that selected the runner. It mirrors
+the config-layer ``RunnerSpec`` (config and domain are independent sibling
+layers, so the config value object cannot itself live on a domain result).
+
+It lives in its own domain module rather than on ``experiment`` or
+``environment`` because both of those import it and ``experiment`` already
+imports ``environment``; a shared low-level module is the only home that avoids
+an import cycle. The one model is serialised into BOTH per-experiment bundle
+artefacts (dual serialisation): ``result.json`` (via
+``ExperimentResult.runner_provenance``, keeping result.json self-contained) and
+``environment.json`` (via ``EnvironmentSnapshot.runner``). It carries the
+superset of the fields the two sinks used to split across the retired
+``RunnerEnvironment`` sibling: ``image_source`` (the result.json image-resolution
+provenance) and ``image_digest`` (the environment.json reproducibility anchor).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RunnerProvenance(BaseModel):
+    """How an experiment was executed - local process or Docker container.
+
+    Persisted reproducibility metadata mirroring the fields of the config-layer
+    ``RunnerSpec``. Serialised into both result.json and environment.json.
+    """
+
+    mode: str = Field(..., description='Execution mode - "local" or "docker"')
+    image: str | None = Field(default=None, description="Docker image used (None for local mode)")
+    source: str | None = Field(
+        default=None,
+        description='Precedence layer that produced the runner ("env", "yaml", '
+        '"user_config", "auto_detected", "default", "multi_engine_elevation", "local")',
+    )
+    image_source: str | None = Field(
+        default=None,
+        description="Where the Docker image was resolved from (None for local mode or when "
+        "unresolved). The result.json image-resolution provenance.",
+    )
+    image_digest: str | None = Field(
+        default=None,
+        description="Resolved image registry digest ('repo@sha256:...'). None for local runs "
+        "or when the digest could not be resolved (locally-built image, docker unavailable, "
+        "inspect error) - resolution is best-effort and never fails a run. The environment.json "
+        "reproducibility anchor pinning the full software stack.",
+    )
+
+    model_config = {"frozen": True, "extra": "forbid"}

--- a/src/llenergymeasure/harness/result_assembly.py
+++ b/src/llenergymeasure/harness/result_assembly.py
@@ -71,6 +71,10 @@ class SourceMetrics:
     producer that returns one of these - the assembler never changes.
     """
 
+    # Measurement mode discriminator ("offline" today; "server" for the future
+    # LoadGen producer). The assembler stamps it onto ExperimentResult verbatim,
+    # so the mode a result was produced in travels through this one seam.
+    measurement_mode: str
     # Token counts (raw workload).
     input_tokens: int
     output_tokens: int
@@ -435,6 +439,7 @@ def build_offline_metrics(
     )
 
     return SourceMetrics(
+        measurement_mode="offline",
         input_tokens=output.input_tokens,
         output_tokens=output.output_tokens,
         total_tokens=output.total_tokens,
@@ -535,6 +540,7 @@ def assemble_experiment_result(
         experiment_id=experiment_id,
         measurement_config_hash=compute_declared_config_hash(config),
         llenergymeasure_version=__version__,
+        measurement_mode=metrics.measurement_mode,
         # Convenience identity copies; authoritative home is config.json.
         engine=engine_name,
         model_name=config.task.model,
@@ -560,7 +566,6 @@ def assemble_experiment_result(
         timeseries=timeseries_path,
         mj_per_tok_total=_mj_total,
         mj_per_tok_adjusted=_mj_adjusted,
-        baseline_power_w=energy_breakdown.baseline_power_w if energy_breakdown else None,
         energy_adjusted_j=energy_adjusted_j,
         energy_per_device_j=energy_per_device_j,
         multi_gpu=multi_gpu,

--- a/src/llenergymeasure/harness/result_assembly.py
+++ b/src/llenergymeasure/harness/result_assembly.py
@@ -71,10 +71,10 @@ class SourceMetrics:
     producer that returns one of these - the assembler never changes.
     """
 
-    # Measurement mode discriminator ("offline" today; "server" for the future
+    # Serving mode discriminator ("offline" today; "server" for the future
     # LoadGen producer). The assembler stamps it onto ExperimentResult verbatim,
     # so the mode a result was produced in travels through this one seam.
-    measurement_mode: str
+    serving_mode: str
     # Token counts (raw workload).
     input_tokens: int
     output_tokens: int
@@ -439,7 +439,7 @@ def build_offline_metrics(
     )
 
     return SourceMetrics(
-        measurement_mode="offline",
+        serving_mode="offline",
         input_tokens=output.input_tokens,
         output_tokens=output.output_tokens,
         total_tokens=output.total_tokens,
@@ -540,7 +540,7 @@ def assemble_experiment_result(
         experiment_id=experiment_id,
         measurement_config_hash=compute_declared_config_hash(config),
         llenergymeasure_version=__version__,
-        measurement_mode=metrics.measurement_mode,
+        serving_mode=metrics.serving_mode,
         # Convenience identity copies; authoritative home is config.json.
         engine=engine_name,
         model_name=config.task.model,

--- a/src/llenergymeasure/results/bundle.py
+++ b/src/llenergymeasure/results/bundle.py
@@ -53,8 +53,9 @@ from llenergymeasure.results import persistence
 from llenergymeasure.utils.io import load_json
 
 if TYPE_CHECKING:
-    from llenergymeasure.domain.environment import EnvironmentSnapshot, RunnerEnvironment
-    from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
+    from llenergymeasure.domain.environment import EnvironmentSnapshot
+    from llenergymeasure.domain.experiment import ExperimentResult
+    from llenergymeasure.domain.provenance import RunnerProvenance
 
 logger = logging.getLogger(__name__)
 
@@ -153,8 +154,7 @@ class BundleWriter:
         self,
         *,
         host_snapshot: EnvironmentSnapshot | None,
-        runner_environment: RunnerEnvironment | None = None,
-        runner_provenance: RunnerProvenance | None = None,
+        runner: RunnerProvenance | None = None,
     ) -> None:
         """Write environment.json with the rescue-preference policy.
 
@@ -165,14 +165,18 @@ class BundleWriter:
         A docker run that lands without a rescued snapshot warns loudly: the
         persisted environment.json would then describe the dispatching host, not
         the container the experiment actually ran in.
+
+        ``runner`` is the unified runner provenance: it is both the
+        environment.json ``runner`` block (image + digest + source) and the
+        mode discriminator for the missing-rescue docker warning.
         """
         if self._dir is None:
             raise RuntimeError("write_result() must be called before write_environment()")
 
         # Attach the host-only runner block to the host snapshot so the host
         # write carries it (local path, and the docker no-rescue fallback).
-        if runner_environment is not None and host_snapshot is not None:
-            host_snapshot = host_snapshot.model_copy(update={"runner": runner_environment})
+        if runner is not None and host_snapshot is not None:
+            host_snapshot = host_snapshot.model_copy(update={"runner": runner})
 
         if host_snapshot is not None:
             persistence.save_environment(
@@ -186,8 +190,8 @@ class BundleWriter:
             self._ts_source_dir / ENVIRONMENT_FILENAME if self._ts_source_dir is not None else None
         )
         if rescued is not None and rescued.exists():
-            self._rescue_environment(rescued, runner_environment)
-        elif runner_provenance is not None and runner_provenance.mode == RUNNER_DOCKER:
+            self._rescue_environment(rescued, runner)
+        elif runner is not None and runner.mode == RUNNER_DOCKER:
             logger.warning(
                 "No in-container environment.json rescued for %s (cycle %d) at %s - "
                 "environment.json records the dispatching host, not the container "
@@ -197,9 +201,7 @@ class BundleWriter:
                 self._dir,
             )
 
-    def _rescue_environment(
-        self, rescued: Path, runner_environment: RunnerEnvironment | None
-    ) -> None:
+    def _rescue_environment(self, rescued: Path, runner: RunnerProvenance | None) -> None:
         """Prefer the rescued in-container environment.json over the host write.
 
         Loads the rescued snapshot, patches the host-only runner block into it,
@@ -211,7 +213,7 @@ class BundleWriter:
         self._stage_json_artefact(
             rescued,
             ENVIRONMENT_FILENAME,
-            lambda payload: self._patch_runner_block(payload, runner_environment),
+            lambda payload: self._patch_runner_block(payload, runner),
             failure_note=(
                 "Failed to rescue in-container environment.json - environment.json will "
                 "record the dispatching host, not the container the experiment ran in"
@@ -256,7 +258,7 @@ class BundleWriter:
 
     @staticmethod
     def _patch_runner_block(
-        payload: dict[str, Any], runner_environment: RunnerEnvironment | None
+        payload: dict[str, Any], runner: RunnerProvenance | None
     ) -> dict[str, Any]:
         """Patch the host-only runner block into a rescued environment payload.
 
@@ -265,8 +267,8 @@ class BundleWriter:
         in and stamps ``bundle_version`` if the (older-image) payload omitted it.
         A no-op when no runner block is available.
         """
-        if runner_environment is not None:
-            payload["runner"] = runner_environment.model_dump()
+        if runner is not None:
+            payload["runner"] = runner.model_dump()
             payload.setdefault("bundle_version", BUNDLE_VERSION)
         return payload
 
@@ -475,19 +477,25 @@ class BundleReader:
     def _read_result_artefact(path: Path) -> ExperimentResult:
         """Parse result.json strictly, with the legacy best-effort fallback.
 
-        A pre-bundle_version result.json (no ``bundle_version`` key) is still
-        read best-effort with a single ``UserWarning`` - the one documented
-        pre-1.0 bundle break. The shared parser (tolerant=False) validates the
-        payload; the ExperimentResult before-validator drops the retired
-        ``schema_version`` key so the legacy file falls back to the default
-        ``bundle_version`` rather than being rejected.
+        A legacy result.json - one with no ``bundle_version`` key, or a
+        ``bundle_version`` older than the current ``BUNDLE_VERSION`` - is read
+        best-effort with a single ``UserWarning`` covering the whole bundle (the
+        one documented pre-1.0 break policy). The shared parser (tolerant=False)
+        validates the payload; the ExperimentResult before-validator drops keys
+        retired across a bundle break (``schema_version``, the top-level
+        ``baseline_power_w`` copy) so the legacy file falls back to the current
+        defaults rather than being rejected. Legacy environment.json shapes (the
+        old separate runner block, the renamed CUDA field, the dropped hardware
+        fields) are tolerated on the environment read path, silently, so this one
+        warning is not multiplied per artefact.
         """
         from llenergymeasure.domain.result_payload import parse_experiment_result_payload
 
         raw = load_json(path)
-        if isinstance(raw, dict) and "bundle_version" not in raw:
+        if isinstance(raw, dict) and raw.get("bundle_version") != BUNDLE_VERSION:
             warnings.warn(
-                "pre-bundle_version result; readable best-effort",
+                f"legacy results bundle (bundle_version={raw.get('bundle_version')!r}); "
+                "readable best-effort",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/llenergymeasure/study/runner.py
+++ b/src/llenergymeasure/study/runner.py
@@ -65,9 +65,9 @@ from llenergymeasure.utils.io import load_json
 if TYPE_CHECKING:
     from llenergymeasure.config.models import ExperimentConfig, StudyConfig
     from llenergymeasure.config.runner_spec import RunnerSpec
-    from llenergymeasure.domain.environment import EnvironmentSnapshot, RunnerEnvironment
-    from llenergymeasure.domain.experiment import RunnerProvenance
+    from llenergymeasure.domain.environment import EnvironmentSnapshot
     from llenergymeasure.domain.progress import StudyProgressCallback
+    from llenergymeasure.domain.provenance import RunnerProvenance
     from llenergymeasure.study.manifest import ManifestWriter
 
 __all__ = [
@@ -86,48 +86,35 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-def _provenance_from_spec(spec: RunnerSpec | None) -> RunnerProvenance:
-    """Build a RunnerProvenance from a resolved RunnerSpec.
-
-    The config-layer ``RunnerSpec`` cannot live on the domain result (config and
-    domain are independent sibling layers), so its execution-mode fields are
-    mirrored onto the domain-layer ``RunnerProvenance``. When no spec is available
-    (pure in-process local run), records ``mode="local"`` with ``source="local"``
-    and no image.
-    """
-    from llenergymeasure.domain.experiment import RunnerProvenance
-
-    if spec is None:
-        return RunnerProvenance(mode="local", image=None, source="local", image_source=None)
-    return RunnerProvenance(
-        mode=spec.mode,
-        image=spec.image,
-        source=spec.source,
-        image_source=spec.image_source,
-    )
-
-
-def _runner_environment(
+def _provenance_from_spec(
     spec: RunnerSpec | None, *, resolved_image: str | None = None
-) -> RunnerEnvironment:
-    """Build the environment.json ``runner`` block from a resolved RunnerSpec.
+) -> RunnerProvenance:
+    """Build the unified RunnerProvenance from a resolved RunnerSpec.
 
-    Records docker-vs-local, the exact image and its resolved registry digest
-    (the reproducibility anchor), and the precedence source. For docker specs
-    the digest is resolved host-side via ``docker image inspect`` on the image
-    that actually ran (``resolved_image`` when the spec left the image implicit).
-    Digest resolution is best-effort: an unresolved digest records None and is
-    debug-logged, never raising - so environment.json provenance never fails a run.
+    The config-layer ``RunnerSpec`` cannot live on a domain result (config and
+    domain are independent sibling layers), so its execution-mode fields are
+    mirrored onto the domain-layer ``RunnerProvenance``. The one model is
+    serialised into both result.json (self-contained provenance) and the
+    environment.json ``runner`` block, so this single builder populates the full
+    superset - including the registry digest the environment block anchors on.
 
-    Local specs (and no spec at all) record ``mode="local"`` with no image or
-    digest and the spec's source (``"local"`` when no spec was resolved).
+    For docker specs the digest is resolved host-side via ``docker image inspect``
+    on the image that actually ran (``resolved_image`` when the spec left the
+    image implicit). Digest resolution is best-effort: an unresolved digest
+    records None and is debug-logged, never raising - so provenance never fails a
+    run. Local specs (and no spec at all) record ``mode="local"`` with no image,
+    digest, or image_source and the spec's source (``"local"`` when no spec was
+    resolved).
     """
-    from llenergymeasure.domain.environment import RunnerEnvironment
+    from llenergymeasure.domain.provenance import RunnerProvenance
 
     if spec is None or spec.mode != RUNNER_DOCKER:
-        return RunnerEnvironment(
+        return RunnerProvenance(
             mode="local",
+            image=None,
             source=spec.source if spec is not None else "local",
+            image_source=None,
+            image_digest=None,
         )
 
     from llenergymeasure.infra.image_registry import resolve_image_digest
@@ -137,10 +124,16 @@ def _runner_environment(
     if image is not None and digest is None:
         logger.debug(
             "Could not resolve registry digest for runner image %s; "
-            "environment.json runner.image_digest will be null.",
+            "runner provenance image_digest will be null.",
             image,
         )
-    return RunnerEnvironment(mode="docker", image=image, image_digest=digest, source=spec.source)
+    return RunnerProvenance(
+        mode=spec.mode,
+        image=image,
+        source=spec.source,
+        image_source=spec.image_source,
+        image_digest=digest,
+    )
 
 
 def _save_and_record(
@@ -159,7 +152,6 @@ def _save_and_record(
     resolution_log: dict[str, Any] | None = None,
     resolved_config_hash: str | None = None,
     runner_provenance: RunnerProvenance | None = None,
-    runner_environment: RunnerEnvironment | None = None,
 ) -> None:
     """Assemble the results bundle and update the manifest.
 
@@ -178,9 +170,9 @@ def _save_and_record(
         environment_snapshot: Host EnvironmentSnapshot for environment.json (a
             rescued in-container snapshot is preferred over it when present).
         resolution_log / resolved_config_hash: Patched into the config.json sidecar.
-        runner_provenance: Execution mode; folded into result.json.
-        runner_environment: The environment.json ``runner`` block (image + digest,
-            precedence source).
+        runner_provenance: The unified runner provenance (mode, image, source,
+            image_source, image_digest); folded into result.json and written as
+            the environment.json ``runner`` block.
 
     On any save failure, marks the experiment failed on the manifest.
     """
@@ -199,8 +191,7 @@ def _save_and_record(
         result_path = writer.write_result(result, runner_provenance=runner_provenance)
         writer.write_environment(
             host_snapshot=environment_snapshot,
-            runner_environment=runner_environment,
-            runner_provenance=runner_provenance,
+            runner=runner_provenance,
         )
         writer.move_config_sidecar(
             resolved_config_hash=resolved_config_hash,
@@ -783,7 +774,6 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
         ts_source_dir: Path | None = None,
         environment_snapshot: Any | None = None,
         runner_provenance: RunnerProvenance | None = None,
-        runner_environment: RunnerEnvironment | None = None,
     ) -> None:
         """Update manifest and signal study display based on experiment outcome."""
         model_name = config.task.model
@@ -825,7 +815,6 @@ class StudyRunner(_BaselineMixin, _ImageMixin):
                 resolution_log=self._resolution_logs.get(config_hash),
                 resolved_config_hash=self._resolved_hashes.get(config_hash),
                 runner_provenance=runner_provenance,
-                runner_environment=runner_environment,
             )
             if self._progress:
                 host_path = self.result_files[-1] if self.result_files else None

--- a/src/llenergymeasure/study/session.py
+++ b/src/llenergymeasure/study/session.py
@@ -145,7 +145,7 @@ class _OfflineSession:
         provenance), and the runner-side builders are imported lazily here - the
         single result-reporting call site both sessions funnel through.
         """
-        from llenergymeasure.study.runner import _provenance_from_spec, _runner_environment
+        from llenergymeasure.study.runner import _provenance_from_spec
 
         is_result = not isinstance(result, dict)
         self._runner._handle_result(
@@ -157,9 +157,8 @@ class _OfflineSession:
             exp_elapsed,
             ts_source_dir=ts_source_dir,
             environment_snapshot=self._runner._get_env_snapshot() if is_result else None,
-            runner_provenance=_provenance_from_spec(spec),
-            runner_environment=(
-                _runner_environment(spec, resolved_image=resolved_image) if is_result else None
+            runner_provenance=(
+                _provenance_from_spec(spec, resolved_image=resolved_image) if is_result else None
             ),
         )
 

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -51,7 +51,6 @@ def run_single_experiment(
     from llenergymeasure.domain.experiment import compute_declared_config_hash
     from llenergymeasure.study.runner import (
         _provenance_from_spec,
-        _runner_environment,
         _save_and_record,
     )
 
@@ -235,8 +234,7 @@ def run_single_experiment(
         environment_snapshot=snapshot,
         resolution_log=(resolution_logs or {}).get(config_hash),
         resolved_config_hash=resolved_config_hash,
-        runner_provenance=_provenance_from_spec(spec),
-        runner_environment=_runner_environment(spec, resolved_image=resolved_docker_image),
+        runner_provenance=_provenance_from_spec(spec, resolved_image=resolved_docker_image),
     )
 
     # Clean up temp dirs

--- a/tests/fixtures/replay/gpt2_transformers_v2.0.json
+++ b/tests/fixtures/replay/gpt2_transformers_v2.0.json
@@ -1,5 +1,6 @@
 {
-  "bundle_version": "1.0",
+  "bundle_version": "2.0",
+  "measurement_mode": "offline",
   "experiment_id": "gpt2_20260313_142111",
   "measurement_config_hash": "9944baab4dabe390",
   "engine": "transformers",
@@ -15,7 +16,6 @@
   "flops_per_output_token": 746638848.0,
   "flops_per_input_token": 373319424.0,
   "flops_per_second": 111257895065.56113,
-  "baseline_power_w": 35.94775694444444,
   "energy_adjusted_j": 68.95598090375523,
   "energy_per_device_j": null,
   "energy_breakdown": {

--- a/tests/fixtures/replay/gpt2_transformers_v2.0.json
+++ b/tests/fixtures/replay/gpt2_transformers_v2.0.json
@@ -1,6 +1,6 @@
 {
   "bundle_version": "2.0",
-  "measurement_mode": "offline",
+  "serving_mode": "offline",
   "experiment_id": "gpt2_20260313_142111",
   "measurement_config_hash": "9944baab4dabe390",
   "engine": "transformers",

--- a/tests/helpers/runtime_obs.py
+++ b/tests/helpers/runtime_obs.py
@@ -43,7 +43,7 @@ def write_resolution(
     subdir = study_dir / dir_name
     subdir.mkdir(parents=True, exist_ok=True)
     payload = {
-        "bundle_version": "1.0",
+        "bundle_version": "2.0",
         "experiment_id": f"exp-{full_hash[:8]}",
         "measurement_config_hash": full_hash,
         "engine": engine,

--- a/tests/unit/cli/test_cli_display.py
+++ b/tests/unit/cli/test_cli_display.py
@@ -17,6 +17,7 @@ from llenergymeasure.cli._display import (
     print_result_summary,
 )
 from llenergymeasure.cli._vram import DTYPE_BYTES
+from llenergymeasure.domain.metrics import EnergyBreakdown
 from llenergymeasure.utils.exceptions import ConfigError
 
 # =============================================================================
@@ -306,7 +307,7 @@ def test_print_result_summary_minimal(capsys):
 
     result = make_result(
         total_flops=0.0,
-        baseline_power_w=None,
+        energy_breakdown=None,
         energy_adjusted_j=None,
         measurement_warnings=[],
         latency_stats=None,
@@ -323,11 +324,11 @@ def test_print_result_summary_minimal(capsys):
 
 
 def test_print_result_summary_with_baseline(capsys):
-    """Result with baseline_power_w shows 'Baseline' line."""
+    """A result whose energy_breakdown carries baseline power shows the 'Baseline' line."""
     from tests.conftest import make_result
 
     result = make_result(
-        baseline_power_w=50.0,
+        energy_breakdown=EnergyBreakdown(raw_j=100.0, adjusted_j=92.0, baseline_power_w=50.0),
         energy_adjusted_j=8.0,
     )
     print_result_summary(result)

--- a/tests/unit/cli/test_cli_run.py
+++ b/tests/unit/cli/test_cli_run.py
@@ -42,7 +42,7 @@ def _make_mock_result() -> MagicMock:
     result.avg_tokens_per_second = 42.0
     result.duration_sec = 5.0
     result.measurement_warnings = []
-    result.baseline_power_w = None
+    result.energy_breakdown = None
     result.energy_adjusted_j = None
     result.total_flops = 0.0
     result.latency_stats = None

--- a/tests/unit/docker/test_container_entrypoint.py
+++ b/tests/unit/docker/test_container_entrypoint.py
@@ -100,7 +100,7 @@ class TestRunContainerExperiment:
         snap = EnvironmentSnapshot(
             hardware=EnvironmentMetadata(
                 gpu=GPUEnvironment(name="NVIDIA A100-SXM4-80GB", vram_total_mb=81920.0),
-                cuda=CUDAEnvironment(version="12.4", driver_version="535.104"),
+                cuda=CUDAEnvironment(driver_supported_version="12.4", driver_version="535.104"),
                 cpu=CPUEnvironment(platform="Linux"),
                 collected_at=datetime(2026, 1, 2, 0, 0, 0),
             ),

--- a/tests/unit/harness/test_measurement_integration.py
+++ b/tests/unit/harness/test_measurement_integration.py
@@ -751,7 +751,7 @@ def test_harness_build_result_populates_timeseries_field() -> None:
 
 
 def test_harness_build_result_propagates_baseline_fields() -> None:
-    """_build_result() with a baseline populates baseline_power_w and energy_adjusted_j (RES-06)."""
+    """build_result() with a baseline populates the energy breakdown baseline (RES-06)."""
     from llenergymeasure.harness.baseline import BaselineCache
 
     kwargs = _make_build_result_args()
@@ -765,8 +765,9 @@ def test_harness_build_result_propagates_baseline_fields() -> None:
 
     result, _ = build_result(**kwargs)
 
-    assert result.baseline_power_w == pytest.approx(30.0), (
-        "baseline_power_w should be populated from EnergyBreakdown.baseline_power_w"
+    assert result.energy_breakdown is not None
+    assert result.energy_breakdown.baseline_power_w == pytest.approx(30.0), (
+        "baseline power should be populated on the single energy_breakdown home"
     )
     assert result.energy_adjusted_j is not None, (
         "energy_adjusted_j should be populated when baseline is provided"

--- a/tests/unit/infra/test_environment_snapshot.py
+++ b/tests/unit/infra/test_environment_snapshot.py
@@ -34,7 +34,7 @@ def _make_hardware() -> env_module.EnvironmentMetadata:
     """Build a minimal EnvironmentMetadata for testing."""
     return env_module.EnvironmentMetadata(
         gpu=env_module.GPUEnvironment(name="NVIDIA A100-SXM4-80GB", vram_total_mb=81920),
-        cuda=env_module.CUDAEnvironment(version="12.4", driver_version="535.104"),
+        cuda=env_module.CUDAEnvironment(driver_supported_version="12.4", driver_version="535.104"),
         thermal=env_module.ThermalEnvironment(),
         cpu=env_module.CPUEnvironment(platform="Linux"),
         container=env_module.ContainerEnvironment(),

--- a/tests/unit/results/test_bundle.py
+++ b/tests/unit/results/test_bundle.py
@@ -497,7 +497,7 @@ def test_bundle_reader_tolerates_1_0_bundle(tmp_path: Path) -> None:
 
     # result.json: legacy top-level keys dropped, model reads with 2.0 defaults.
     assert loaded.result.experiment_id == "legacy-001"
-    assert loaded.result.measurement_mode == "offline"  # new field defaults
+    assert loaded.result.serving_mode == "offline"  # new field defaults
     assert not hasattr(loaded.result, "baseline_power_w")  # dropped field
     # The single baseline home survives on the breakdown.
     assert loaded.result.energy_breakdown is not None

--- a/tests/unit/results/test_bundle.py
+++ b/tests/unit/results/test_bundle.py
@@ -35,7 +35,6 @@ from llenergymeasure.domain.environment import (
     EnvironmentMetadata,
     EnvironmentSnapshot,
     GPUEnvironment,
-    RunnerEnvironment,
 )
 from llenergymeasure.domain.experiment import RunnerProvenance
 from llenergymeasure.results.bundle import BundleReader, BundleWriter, LoadedBundle
@@ -49,7 +48,7 @@ from tests.conftest import make_result, write_container_environment_sidecar
 def _make_snapshot() -> EnvironmentSnapshot:
     hardware = EnvironmentMetadata(
         gpu=GPUEnvironment(name="HOST-GPU", vram_total_mb=1.0),
-        cuda=CUDAEnvironment(version="unknown", driver_version="unknown"),
+        cuda=CUDAEnvironment(driver_supported_version="unknown", driver_version="unknown"),
         cpu=CPUEnvironment(platform="Linux"),
         collected_at=datetime(2026, 1, 1, 0, 0, 0),
     )
@@ -85,7 +84,7 @@ def test_write_result_stamps_bundle_version(tmp_path: Path) -> None:
     writer = _writer(study_dir)
     result_path = writer.write_result(make_result())
     payload = json.loads(result_path.read_text())
-    assert payload["bundle_version"] == BUNDLE_VERSION == "1.0"
+    assert payload["bundle_version"] == BUNDLE_VERSION == "2.0"
 
 
 def test_write_result_attaches_runner_provenance(tmp_path: Path) -> None:
@@ -125,17 +124,17 @@ def test_write_environment_local_stamps_bundle_version(tmp_path: Path) -> None:
     writer.write_result(make_result())
     writer.write_environment(
         host_snapshot=_make_snapshot(),
-        runner_environment=RunnerEnvironment(mode="local", source="default"),
-        runner_provenance=RunnerProvenance(mode="local", source="local"),
+        runner=RunnerProvenance(mode="local", source="default"),
     )
     payload = json.loads((writer.bundle_dir / "environment.json").read_text())
-    assert payload["bundle_version"] == "1.0"
+    assert payload["bundle_version"] == "2.0"
     assert payload["python_version"] == "3.12.12"
     assert payload["runner"] == {
         "mode": "local",
         "image": None,
-        "image_digest": None,
         "source": "default",
+        "image_source": None,
+        "image_digest": None,
     }
 
 
@@ -151,13 +150,12 @@ def test_write_environment_prefers_rescued_over_host(tmp_path: Path) -> None:
     writer.write_result(make_result())
     writer.write_environment(
         host_snapshot=_make_snapshot(),
-        runner_environment=RunnerEnvironment(
+        runner=RunnerProvenance(
             mode="docker",
             image="ghcr.io/acme/vllm:1.0",
             image_digest="ghcr.io/acme/vllm@sha256:abc123",
             source="yaml",
         ),
-        runner_provenance=RunnerProvenance(mode="docker", image="ghcr.io/acme/vllm:1.0"),
     )
     payload = json.loads((writer.bundle_dir / "environment.json").read_text())
     # Container hardware/runtime values win over the host snapshot.
@@ -165,7 +163,7 @@ def test_write_environment_prefers_rescued_over_host(tmp_path: Path) -> None:
     assert payload["hardware"]["gpu"]["name"] == "NVIDIA A100-SXM4-80GB"
     # Host-only runner block patched in, and the payload stamped.
     assert payload["runner"]["image_digest"] == "ghcr.io/acme/vllm@sha256:abc123"
-    assert payload["bundle_version"] == "1.0"
+    assert payload["bundle_version"] == "2.0"
     # Rescued staging file consumed.
     assert not (staging / "environment.json").exists()
 
@@ -179,8 +177,7 @@ def test_write_environment_docker_without_rescue_warns(tmp_path: Path, caplog) -
     with caplog.at_level(logging.WARNING, logger="llenergymeasure.results.bundle"):
         writer.write_environment(
             host_snapshot=_make_snapshot(),
-            runner_environment=RunnerEnvironment(mode="docker", image="img:1.0", source="yaml"),
-            runner_provenance=RunnerProvenance(mode="docker", image="img:1.0"),
+            runner=RunnerProvenance(mode="docker", image="img:1.0", source="yaml"),
         )
     assert any("No in-container environment.json rescued" in rec.message for rec in caplog.records)
 
@@ -189,10 +186,10 @@ def test_patch_runner_block_adds_block_and_stamps(tmp_path: Path) -> None:
     """_patch_runner_block injects the runner block and stamps bundle_version."""
     payload = BundleWriter._patch_runner_block(
         {"python_version": "3.10.14"},
-        RunnerEnvironment(mode="docker", image="img:1.0", image_digest=None, source="yaml"),
+        RunnerProvenance(mode="docker", image="img:1.0", image_digest=None, source="yaml"),
     )
     assert payload["runner"]["mode"] == "docker"
-    assert payload["bundle_version"] == "1.0"
+    assert payload["bundle_version"] == "2.0"
 
 
 def test_patch_runner_block_none_is_noop() -> None:
@@ -225,7 +222,7 @@ def test_move_config_sidecar_patches_and_stamps(tmp_path: Path) -> None:
     payload = json.loads((writer.bundle_dir / "config.json").read_text())
     assert payload["resolved_config_hash"] == "resolved_h1"
     assert payload["provenance"] == resolution_log
-    assert payload["bundle_version"] == "1.0"
+    assert payload["bundle_version"] == "2.0"
     # Staged source consumed.
     assert not (staging / "config.json").exists()
 
@@ -326,8 +323,7 @@ def _write_full_bundle(tmp_path: Path) -> Path:
     writer.write_result(make_result())
     writer.write_environment(
         host_snapshot=_make_snapshot(),
-        runner_environment=RunnerEnvironment(mode="local", source="default"),
-        runner_provenance=RunnerProvenance(mode="local", source="local"),
+        runner=RunnerProvenance(mode="local", source="default"),
     )
     writer.move_config_sidecar(resolved_config_hash="resolved_h1", resolution_log=None)
     writer.finalize()
@@ -411,10 +407,113 @@ def test_bundle_reader_legacy_fallback_warns(tmp_path: Path) -> None:
     raw["schema_version"] = "5.0"
     result_path.write_text(json.dumps(raw), encoding="utf-8")
 
-    with pytest.warns(UserWarning, match="pre-bundle_version result; readable best-effort"):
+    with pytest.warns(UserWarning, match="legacy results bundle"):
         loaded = BundleReader.read(writer.bundle_dir)
     assert loaded.result.experiment_id == "test-001"
     assert loaded.result.bundle_version == BUNDLE_VERSION
+
+
+def test_bundle_reader_tolerates_1_0_bundle(tmp_path: Path) -> None:
+    """A full bundle 1.0 (pre-unification shape) reads best-effort, ONE warning.
+
+    Exercises every 2.0 break against a synthetic 1.0-shaped bundle written by
+    hand: result.json carries the retired top-level baseline_power_w copy and a
+    schema_version key with a runner_provenance block lacking image_digest;
+    environment.json carries the old separate RunnerEnvironment-shaped runner
+    block (no image_source), the never-populated hardware fields (pcie_gen,
+    mig_enabled, cudnn_version, fan_speed_pct), and the pre-rename cuda.version
+    key. The reader drops/maps the legacy shapes rather than rejecting them, and
+    emits exactly one bundle-level UserWarning.
+    """
+    bundle_dir = tmp_path / "study" / "exp-legacy"
+    bundle_dir.mkdir(parents=True)
+
+    result_payload = {
+        "bundle_version": "1.0",
+        "schema_version": "5.0",  # retired per-artefact counter
+        "experiment_id": "legacy-001",
+        "measurement_config_hash": "deadbeef",
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "total_tokens": 30,
+        "total_energy_j": 5.0,
+        "total_inference_time_sec": 1.0,
+        "avg_tokens_per_second": 30.0,
+        "avg_energy_per_token_j": 0.25,
+        "total_flops": 0.0,
+        "baseline_power_w": 42.0,  # bundle 1.0 top-level copy (dropped in 2.0)
+        "energy_breakdown": {"raw_j": 5.0, "baseline_power_w": 42.0},
+        "start_time": "2026-01-01T00:00:00",
+        "end_time": "2026-01-01T00:00:01",
+        # runner_provenance in its 1.0 shape: no image_digest key.
+        "runner_provenance": {
+            "mode": "docker",
+            "image": "img:1.0",
+            "source": "yaml",
+            "image_source": "registry",
+        },
+    }
+    (bundle_dir / "result.json").write_text(json.dumps(result_payload), encoding="utf-8")
+
+    env_payload = {
+        "bundle_version": "1.0",
+        "hardware": {
+            "gpu": {
+                "name": "NVIDIA A100",
+                "vram_total_mb": 81920.0,
+                "compute_capability": "8.0",
+                "pcie_gen": 4,  # dropped field
+                "mig_enabled": False,  # dropped field
+            },
+            "cuda": {
+                "version": "12.4",  # pre-rename key -> driver_supported_version
+                "driver_version": "550.54",
+                "cudnn_version": "9.1",  # dropped field
+            },
+            "thermal": {"temperature_c": 40.0, "fan_speed_pct": 30.0},  # fan_speed_pct dropped
+            "cpu": {"platform": "Linux"},
+            "container": {"detected": True, "runtime": "docker"},
+            "collected_at": "2026-01-01T00:00:00",
+        },
+        "python_version": "3.10.14",
+        "tool_version": "0.6.0",
+        "cuda_version": "12.1",
+        "cuda_version_source": "torch",
+        # runner in its old RunnerEnvironment shape: no image_source key.
+        "runner": {
+            "mode": "docker",
+            "image": "img:1.0",
+            "image_digest": "img@sha256:abc",
+            "source": "yaml",
+        },
+    }
+    (bundle_dir / "environment.json").write_text(json.dumps(env_payload), encoding="utf-8")
+
+    with pytest.warns(UserWarning, match="legacy results bundle") as record:
+        loaded = BundleReader.read(bundle_dir)
+
+    # Exactly one bundle-level warning (not multiplied across artefacts).
+    assert sum(issubclass(w.category, UserWarning) for w in record) == 1
+
+    # result.json: legacy top-level keys dropped, model reads with 2.0 defaults.
+    assert loaded.result.experiment_id == "legacy-001"
+    assert loaded.result.measurement_mode == "offline"  # new field defaults
+    assert not hasattr(loaded.result, "baseline_power_w")  # dropped field
+    # The single baseline home survives on the breakdown.
+    assert loaded.result.energy_breakdown is not None
+    assert loaded.result.energy_breakdown.baseline_power_w == 42.0
+    # Old runner_provenance shape reads into the unified model (digest defaults None).
+    assert loaded.result.runner_provenance is not None
+    assert loaded.result.runner_provenance.image_source == "registry"
+    assert loaded.result.runner_provenance.image_digest is None
+
+    # environment.json: dead fields ignored, cuda version mapped, runner unified.
+    assert loaded.environment is not None
+    assert loaded.environment.hardware.cuda.driver_supported_version == "12.4"
+    assert loaded.environment.cuda_version == "12.1"
+    assert loaded.environment.runner is not None
+    assert loaded.environment.runner.image_digest == "img@sha256:abc"
+    assert loaded.environment.runner.image_source is None
 
 
 def test_bundle_reader_declared_but_missing_timeseries_warns(tmp_path: Path) -> None:

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -14,11 +14,9 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from llenergymeasure.config.runner_spec import RunnerSpec
-from llenergymeasure.domain.environment import RunnerEnvironment
 from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
 from llenergymeasure.study.runner import (
     _provenance_from_spec,
-    _runner_environment,
     _save_and_record,
 )
 from tests.conftest import write_container_environment_sidecar
@@ -308,7 +306,9 @@ def test_save_and_record_folds_provenance_into_config(tmp_path: Path) -> None:
     assert payload.get("provenance") == resolution_log, (
         "resolution_log must be folded into config.json as its provenance section"
     )
-    # bundle_version from the harness sidecar survives the fold.
+    # bundle_version the harness sidecar already carried survives the fold: the
+    # move patches with setdefault and never clobbers an existing stamp (here a
+    # deliberately older "1.0" proves non-clobbering).
     assert payload["bundle_version"] == "1.0"
     # The retired standalone sidecar must not appear.
     assert not (result_json_path.parent / "_resolution.json").exists()
@@ -316,11 +316,21 @@ def test_save_and_record_folds_provenance_into_config(tmp_path: Path) -> None:
 
 
 def test_provenance_from_spec_docker() -> None:
-    """A docker RunnerSpec maps onto a docker RunnerProvenance."""
+    """A docker RunnerSpec maps onto the unified RunnerProvenance, digest resolved."""
+    from unittest.mock import patch
+
     spec = RunnerSpec(mode="docker", image="img:1.0", source="yaml", image_source="registry")
-    provenance = _provenance_from_spec(spec)
+    with patch(
+        "llenergymeasure.infra.image_registry.resolve_image_digest",
+        return_value="img@sha256:abc",
+    ):
+        provenance = _provenance_from_spec(spec)
     assert provenance == RunnerProvenance(
-        mode="docker", image="img:1.0", source="yaml", image_source="registry"
+        mode="docker",
+        image="img:1.0",
+        source="yaml",
+        image_source="registry",
+        image_digest="img@sha256:abc",
     )
 
 
@@ -347,7 +357,7 @@ def _make_host_snapshot():
 
     hardware = EnvironmentMetadata(
         gpu=GPUEnvironment(name="HOST-GPU", vram_total_mb=1.0),
-        cuda=CUDAEnvironment(version="unknown", driver_version="unknown"),
+        cuda=CUDAEnvironment(driver_supported_version="unknown", driver_version="unknown"),
         cpu=CPUEnvironment(platform="Linux"),
         collected_at=datetime(2026, 1, 1, 0, 0, 0),
     )
@@ -696,17 +706,17 @@ def test_save_and_record_writes_local_runner_block(tmp_path: Path) -> None:
         runner_provenance=RunnerProvenance(
             mode="local", image=None, source="default", image_source=None
         ),
-        runner_environment=RunnerEnvironment(mode="local", source="default"),
     )
 
     env_dest = Path(result_files[0]).parent / "environment.json"
     payload = json.loads(env_dest.read_text())
-    assert payload["bundle_version"] == "1.0"
+    assert payload["bundle_version"] == "2.0"
     assert payload["runner"] == {
         "mode": "local",
         "image": None,
-        "image_digest": None,
         "source": "default",
+        "image_source": None,
+        "image_digest": None,
     }
 
 
@@ -740,13 +750,11 @@ def test_save_and_record_docker_rescue_patches_runner_block(tmp_path: Path) -> N
         ts_source_dir=tmp_path,
         environment_snapshot=_make_host_snapshot(),
         runner_provenance=RunnerProvenance(
-            mode="docker", image="ghcr.io/acme/vllm:1.0", source="yaml", image_source="registry"
-        ),
-        runner_environment=RunnerEnvironment(
             mode="docker",
             image="ghcr.io/acme/vllm:1.0",
-            image_digest="ghcr.io/acme/vllm@sha256:abc123",
             source="yaml",
+            image_source="registry",
+            image_digest="ghcr.io/acme/vllm@sha256:abc123",
         ),
     )
 
@@ -756,11 +764,12 @@ def test_save_and_record_docker_rescue_patches_runner_block(tmp_path: Path) -> N
     assert payload["runner"] == {
         "mode": "docker",
         "image": "ghcr.io/acme/vllm:1.0",
-        "image_digest": "ghcr.io/acme/vllm@sha256:abc123",
         "source": "yaml",
+        "image_source": "registry",
+        "image_digest": "ghcr.io/acme/vllm@sha256:abc123",
     }
     # bundle_version stamped in when the (old-style) container payload omitted it.
-    assert payload["bundle_version"] == "1.0"
+    assert payload["bundle_version"] == "2.0"
     # Container hardware/runtime values still win over the host snapshot.
     assert payload["python_version"] == "3.10.14"
     assert payload["hardware"]["gpu"]["name"] == "NVIDIA A100-SXM4-80GB"
@@ -791,13 +800,11 @@ def test_save_and_record_docker_without_rescue_writes_runner_block(tmp_path: Pat
         ts_source_dir=tmp_path,  # no environment.json rescued
         environment_snapshot=_make_host_snapshot(),
         runner_provenance=RunnerProvenance(
-            mode="docker", image="ghcr.io/acme/vllm:1.0", source="yaml", image_source="registry"
-        ),
-        runner_environment=RunnerEnvironment(
             mode="docker",
             image="ghcr.io/acme/vllm:1.0",
-            image_digest=None,
             source="yaml",
+            image_source="registry",
+            image_digest=None,
         ),
     )
 
@@ -809,32 +816,33 @@ def test_save_and_record_docker_without_rescue_writes_runner_block(tmp_path: Pat
     assert payload["runner"]["image_digest"] is None
 
 
-def test_runner_environment_local_and_none_spec() -> None:
-    """_runner_environment maps local specs (and no spec) onto a local runner block."""
-    local = _runner_environment(RunnerSpec(mode="local", image=None, source="user_config"))
+def test_provenance_from_spec_local_and_none_spec() -> None:
+    """_provenance_from_spec maps local specs (and no spec) onto a local provenance."""
+    local = _provenance_from_spec(RunnerSpec(mode="local", image=None, source="user_config"))
     assert local.mode == "local"
     assert local.image is None
+    assert local.image_source is None
     assert local.image_digest is None
     assert local.source == "user_config"
 
-    no_spec = _runner_environment(None)
+    no_spec = _provenance_from_spec(None)
     assert no_spec.mode == "local"
     assert no_spec.source == "local"
 
 
-def test_runner_environment_docker_digest_failure_is_none() -> None:
+def test_provenance_from_spec_docker_digest_failure_is_none() -> None:
     """A docker spec whose digest cannot be resolved records image_digest=None (never raises)."""
     from unittest.mock import patch
 
     with patch("llenergymeasure.infra.image_registry.resolve_image_digest", return_value=None):
-        env = _runner_environment(
+        prov = _provenance_from_spec(
             RunnerSpec(mode="docker", image=None, source="auto_detected"),
             resolved_image="ghcr.io/acme/vllm:1.0",
         )
-    assert env.mode == "docker"
-    assert env.image == "ghcr.io/acme/vllm:1.0"
-    assert env.image_digest is None
-    assert env.source == "auto_detected"
+    assert prov.mode == "docker"
+    assert prov.image == "ghcr.io/acme/vllm:1.0"
+    assert prov.image_digest is None
+    assert prov.source == "auto_detected"
 
 
 def test_save_and_record_docker_rescue_failure_keeps_host_runner_block(
@@ -878,13 +886,11 @@ def test_save_and_record_docker_rescue_failure_keeps_host_runner_block(
             ts_source_dir=tmp_path,
             environment_snapshot=_make_host_snapshot(),
             runner_provenance=RunnerProvenance(
-                mode="docker", image="ghcr.io/acme/vllm:1.0", source="yaml", image_source="registry"
-            ),
-            runner_environment=RunnerEnvironment(
                 mode="docker",
                 image="ghcr.io/acme/vllm:1.0",
-                image_digest="ghcr.io/acme/vllm@sha256:abc123",
                 source="yaml",
+                image_source="registry",
+                image_digest="ghcr.io/acme/vllm@sha256:abc123",
             ),
         )
 
@@ -902,7 +908,8 @@ def test_save_and_record_docker_rescue_failure_keeps_host_runner_block(
     assert payload["runner"] == {
         "mode": "docker",
         "image": "ghcr.io/acme/vllm:1.0",
-        "image_digest": "ghcr.io/acme/vllm@sha256:abc123",
         "source": "yaml",
+        "image_source": "registry",
+        "image_digest": "ghcr.io/acme/vllm@sha256:abc123",
     }
-    assert payload["bundle_version"] == "1.0"
+    assert payload["bundle_version"] == "2.0"

--- a/tests/unit/study/test_single.py
+++ b/tests/unit/study/test_single.py
@@ -225,7 +225,7 @@ def test_config_sidecar_materialises_without_timeseries(monkeypatch, tmp_path):
         captured_output_dirs.append(output_dir)
         if output_dir is not None:
             (Path(output_dir) / "config.json").write_text(
-                _json.dumps({"bundle_version": "1.0", "engine": "transformers"}),
+                _json.dumps({"bundle_version": "2.0", "engine": "transformers"}),
                 encoding="utf-8",
             )
         return mock_result

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -97,13 +97,13 @@ def test_engine_version_rejected(make_result):
 # ---------------------------------------------------------------------------
 
 
-def test_baseline_power_w_optional(make_result):
-    """baseline_power_w defaults to None, accepts float."""
-    result_none = make_result()
-    assert result_none.baseline_power_w is None
+def test_measurement_mode_defaults_offline(make_result):
+    """measurement_mode defaults to 'offline' and accepts an arbitrary string."""
+    result_default = make_result()
+    assert result_default.measurement_mode == "offline"
 
-    result_set = make_result(baseline_power_w=42.5)
-    assert result_set.baseline_power_w == 42.5
+    result_server = make_result(measurement_mode="server")
+    assert result_server.measurement_mode == "server"
 
 
 def test_energy_adjusted_j_optional(make_result):
@@ -357,7 +357,6 @@ def test_json_round_trip(make_result):
         energy_per_output_token_j=0.05,
     )
     original = make_result(
-        baseline_power_w=42.5,
         energy_adjusted_j=45.2,
         energy_per_device_j=[25.0, 25.0],
         multi_gpu=mgpu,
@@ -370,7 +369,6 @@ def test_json_round_trip(make_result):
 
     assert restored.bundle_version == original.bundle_version
     assert restored.experiment_id == original.experiment_id
-    assert restored.baseline_power_w == original.baseline_power_w
     assert restored.energy_adjusted_j == original.energy_adjusted_j
     assert restored.energy_per_device_j == original.energy_per_device_j
     assert restored.multi_gpu is not None

--- a/tests/unit/test_experiment_result_v2.py
+++ b/tests/unit/test_experiment_result_v2.py
@@ -97,13 +97,13 @@ def test_engine_version_rejected(make_result):
 # ---------------------------------------------------------------------------
 
 
-def test_measurement_mode_defaults_offline(make_result):
-    """measurement_mode defaults to 'offline' and accepts an arbitrary string."""
+def test_serving_mode_defaults_offline(make_result):
+    """serving_mode defaults to 'offline' and accepts an arbitrary string."""
     result_default = make_result()
-    assert result_default.measurement_mode == "offline"
+    assert result_default.serving_mode == "offline"
 
-    result_server = make_result(measurement_mode="server")
-    assert result_server.measurement_mode == "server"
+    result_server = make_result(serving_mode="server")
+    assert result_server.serving_mode == "server"
 
 
 def test_energy_adjusted_j_optional(make_result):

--- a/tests/unit/test_persistence_v2.py
+++ b/tests/unit/test_persistence_v2.py
@@ -26,9 +26,8 @@ from llenergymeasure.domain.environment import (
     EnvironmentMetadata,
     EnvironmentSnapshot,
     GPUEnvironment,
-    RunnerEnvironment,
 )
-from llenergymeasure.domain.experiment import ExperimentResult
+from llenergymeasure.domain.experiment import ExperimentResult, RunnerProvenance
 from llenergymeasure.results.persistence import (
     load_result,
     save_environment,
@@ -299,8 +298,6 @@ def test_runner_provenance_docker_round_trips(
     """A docker runner_provenance survives save/load and serialises into result.json."""
     import json
 
-    from llenergymeasure.domain.experiment import RunnerProvenance
-
     result = minimal_result.model_copy(
         update={
             "runner_provenance": RunnerProvenance(
@@ -331,8 +328,6 @@ def test_runner_provenance_local_round_trips(
     tmp_path: Path, minimal_result: ExperimentResult
 ) -> None:
     """A local runner_provenance survives save/load with no image."""
-    from llenergymeasure.domain.experiment import RunnerProvenance
-
     result = minimal_result.model_copy(
         update={"runner_provenance": RunnerProvenance(mode="local", image=None, source="local")}
     )
@@ -428,7 +423,7 @@ def env_snapshot() -> EnvironmentSnapshot:
     """Minimal EnvironmentSnapshot for sidecar round-trip tests."""
     hardware = EnvironmentMetadata(
         gpu=GPUEnvironment(name="NVIDIA A100-SXM4-80GB", vram_total_mb=81920),
-        cuda=CUDAEnvironment(version="12.4", driver_version="535.104"),
+        cuda=CUDAEnvironment(driver_supported_version="12.4", driver_version="535.104"),
         cpu=CPUEnvironment(platform="Linux"),
         collected_at=datetime(2026, 1, 1, 12, 0, 0),
     )
@@ -480,7 +475,7 @@ def test_save_environment_includes_bundle_version(
         result_path.parent,
     )
     payload = json.loads((result_path.parent / "environment.json").read_text())
-    assert payload["bundle_version"] == BUNDLE_VERSION == "1.0"
+    assert payload["bundle_version"] == BUNDLE_VERSION == "2.0"
 
 
 def test_save_environment_writes_docker_runner_block_roundtrip(
@@ -493,11 +488,12 @@ def test_save_environment_writes_docker_runner_block_roundtrip(
 
     snapshot = env_snapshot.model_copy(
         update={
-            "runner": RunnerEnvironment(
+            "runner": RunnerProvenance(
                 mode="docker",
                 image="ghcr.io/acme/vllm:1.19.0-cuda12",
-                image_digest="ghcr.io/acme/vllm@sha256:deadbeef",
                 source="auto_detected",
+                image_source="registry",
+                image_digest="ghcr.io/acme/vllm@sha256:deadbeef",
             )
         }
     )
@@ -514,8 +510,9 @@ def test_save_environment_writes_docker_runner_block_roundtrip(
     assert payload["runner"] == {
         "mode": "docker",
         "image": "ghcr.io/acme/vllm:1.19.0-cuda12",
-        "image_digest": "ghcr.io/acme/vllm@sha256:deadbeef",
         "source": "auto_detected",
+        "image_source": "registry",
+        "image_digest": "ghcr.io/acme/vllm@sha256:deadbeef",
     }
 
     # ... and load_result reconstructs it onto result.environment.runner.
@@ -535,7 +532,7 @@ def test_save_environment_writes_local_runner_block_roundtrip(
 ) -> None:
     """A local runner block records mode=local with no image or digest."""
     snapshot = env_snapshot.model_copy(
-        update={"runner": RunnerEnvironment(mode="local", source="default")}
+        update={"runner": RunnerProvenance(mode="local", source="default")}
     )
     result_path = save_result(minimal_result, tmp_path)
     save_environment(
@@ -690,7 +687,7 @@ def test_save_config_sidecar_includes_bundle_version(tmp_path: Path) -> None:
     )
 
     payload = json.loads(path.read_text())
-    assert payload["bundle_version"] == BUNDLE_VERSION == "1.0"
+    assert payload["bundle_version"] == BUNDLE_VERSION == "2.0"
 
 
 def test_save_config_sidecar_carries_methodology_window(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Slice S16 of the F6 refactor (Wave 4): provenance unification, following the maintainer-ruled forks R-1..R-6 plus the serving_mode naming ratification. Single logical change, bundle break to 2.0.

- **R-1 unify the model, keep dual serialisation.** The sibling `RunnerProvenance` (result.json) and `RunnerEnvironment` (environment.json) collapse into ONE domain model, `RunnerProvenance`, homed in a new shared `domain/provenance.py` (both `experiment` and `environment` import it, and `experiment` imports `environment`, so a shared low-level module is the only home that avoids an import cycle). It carries the field superset: `mode, image, source, image_source, image_digest`. `RunnerEnvironment` is deleted; `EnvironmentSnapshot.runner` takes the unified model. Both artefacts still carry a runner block (dual serialisation); result.json stays self-contained. The two divergent builders collapse into one `_provenance_from_spec(spec, *, resolved_image=None)` that populates the full superset (digest resolved best-effort for docker); `_save_and_record` / `BundleWriter.write_environment` drop the second runner param. `EnvironmentMetadata` is NOT merged (hardware env is a different concern).

- **R-2 drop dead fields.** `GPUEnvironment.pcie_gen`, `GPUEnvironment.mig_enabled`, `CUDAEnvironment.cudnn_version`, `ThermalEnvironment.fan_speed_pct` had no writer; dropped.

- **R-3 CUDA duplication determination (see below).** The two CUDA facts are genuinely different -> renamed for honesty.

- **R-4 serving-mode slot.** `ExperimentResult.serving_mode: str = "offline"` (plain str, not a Literal), stamped through `SourceMetrics` (the mode seam) by the assembler. Documented as the offline/server discriminator; no other server machinery (C3/C5). (Introduced as `measurement_mode`; renamed to `serving_mode` per the naming ratification below.)

- **R-5 baseline dedup.** `ExperimentResult.baseline_power_w` (the copy) is dropped; `EnergyBreakdown.baseline_power_w` is the single persisted home; `BaselineCache` stays (transient). Consumers re-pointed (below).

- **R-6 bundle break.** `BUNDLE_VERSION` 1.0 -> 2.0. The reader reads a 1.0 bundle best-effort with ONE `UserWarning` per bundle; legacy shapes dropped/mapped, not rejected.

## Naming ratification: measurement_mode -> serving_mode

Per the maintainer naming ruling (rides this same bundle 2.0 break), the discriminator this PR introduced is named `serving_mode`, not `measurement_mode`. The config-side field will be `ExperimentConfig.serving_mode` (top-level, v0.7 server mode), and the result discriminator must match it. `measurement_mode` was rejected because it connotes instrument configuration (samplers / windows / warmup), which this field does not describe. Same semantics and values (`"offline"` default; `"server"` is the future value). The pre-existing latency-capture `measurement_mode` (`latency_stats.measurement_mode`) is a different concept and is untouched.

## R-3 determination + evidence

**The two facts are genuinely different -> RENAME (not dedup).**

- `EnvironmentMetadata.cuda.version` came from NVML `nvmlSystemGetCudaDriverVersion()` (`device/environment.py:_collect_cuda`). Per the NVML/CUDA driver API this is the *maximum CUDA version the installed driver supports* - the same value `nvidia-smi` prints as `CUDA Version` in its header. A driver-side capability.
- `EnvironmentSnapshot.cuda_version` (+ `cuda_version_source`) came from `detect_cuda_version_with_source()`, a `torch.version.cuda` -> `/usr/local/cuda/version.txt` -> `nvcc --version` fallback chain - the *runtime CUDA the software stack was actually built against* (e.g. a `cu121` torch wheel).

These routinely differ in practice (a driver supporting 12.4 running a torch built for 12.1, since CUDA is backward compatible), so they are two facts, not one detected twice. Renamed `CUDAEnvironment.version` -> `driver_supported_version` with a docstring stating the distinction; `EnvironmentSnapshot.cuda_version` kept (it already had source attribution) with its docstring clarified. A before-validator maps the legacy `version` key so old environment.json still loads.

## R-5 consumers re-pointed

Grepped all consumers of the dropped `ExperimentResult.baseline_power_w`:
- `harness/result_assembly.py` (the writer) - the construction line removed.
- `cli/_display.py` - re-pointed to `result.energy_breakdown.baseline_power_w` with `energy_breakdown is None` degradation (prints the Baseline line only when present).
- Tests re-pointed at the new home: `test_cli_display.py` (constructs an `EnergyBreakdown`), `test_cli_run.py` (mock sets `energy_breakdown = None`), `test_measurement_integration.py` (asserts on `energy_breakdown.baseline_power_w`), `test_experiment_result_v2.py` (dropped-field test replaced with a `serving_mode` test; round-trip drops the field).
No aggregation/report/manifest consumer reads the dropped field.

## Reader tolerance test evidence

`tests/unit/results/test_bundle.py::test_bundle_reader_tolerates_1_0_bundle` writes a synthetic full 1.0-shaped bundle by hand and reads it: result.json with the retired top-level `baseline_power_w` + `schema_version` and a runner_provenance block lacking `image_digest`; environment.json with the old separate runner block (no `image_source`), the four dead hardware fields, and the pre-rename `cuda.version`. It asserts exactly ONE bundle-level `UserWarning`, the legacy top-level keys dropped, `serving_mode` defaulting to `offline`, `energy_breakdown.baseline_power_w` preserved, the legacy CUDA key mapped to `driver_supported_version`, and both old runner shapes read into the unified model. The existing legacy-fallback test and the golden replay fixture (migrated 1.0 -> 2.0, values preserved) also cover the path.

## CLI display deltas

One: the Energy section's `Baseline <n> W` line now reads `result.energy_breakdown.baseline_power_w` instead of the removed top-level field. Output is byte-identical for any result carrying an energy breakdown (the normal case); a result with `energy_breakdown = None` degrades identically to before (line omitted). No other display strings changed.

## Out of scope (untouched, per instructions)

`RunnerSpec.extra_mounts`; capability/limitation files (S18); generated engine configs / `config/models.py` engine fields / import-linter (S17).

## Test plan

- `make lint` green, `make typecheck` green (340 files), `make test` green (3253 passed, 37 skipped), both before and after the rename.
- `make docs-check` green (no generated-doc drift).
- Reader-tolerance + replay-fixture + persistence round-trip suites exercised.

## Doc audit

Updated the authoritative bundle-contract docs for the 2.0 break: `docs/reference/results-schema.md` (version, dropped baseline row -> nested home, unified runner block gaining `image_source`, the two CUDA facts, legacy-read policy, `serving_mode` row), `docs/reference/library/ExperimentResult.md` (version, `serving_mode` row, dropped baseline row), and the concrete examples in `docs/tutorials/multi-engine-study.md` and `docs/how-to/interpret-results.md`. Generated docs unaffected. Methodology explainer docs use `baseline_power_w` as a formula variable (still valid) and were left as-is.