### PR TITLE
fix(ci): drop vestigial codegen pin from gpu suite image

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -144,14 +144,16 @@ jobs:
           # Derive the CI image: test deps + an `llem` shim. The project
           # source is NOT baked in (image contract, see header of
           # docker/Dockerfile.transformers) - the test steps bind-mount it.
-          # datamodel-code-generator backs the regen_engine_configs tests
-          # (invoked as a subprocess CLI, no importorskip guard); its pin
-          # must match pyproject [dependency-groups] dev - the generator's
-          # output formatting is version-sensitive. msgspec backs the
-          # importorskip'd type-recovery tests (parity with hosted CI).
+          # msgspec backs the importorskip'd type-recovery tests (parity
+          # with hosted CI). datamodel-code-generator is deliberately NOT
+          # installed: the only test that invokes it
+          # (test_regen_engine_configs.py) is excluded from the container
+          # run below, and a hardcoded pin here would shadow the
+          # Renovate-owned pin in pyproject. If that exclusion is ever
+          # lifted, install the generator by deriving the version from
+          # pyproject - never hardcode it.
           docker run --name llem-ci-setup llenergymeasure-ci:transformers \
-            pip install --no-cache-dir pytest pytest-xdist \
-              "datamodel-code-generator==0.68.1" msgspec
+            pip install --no-cache-dir pytest pytest-xdist msgspec
           # `llem` console-script shim for sigint_verify.sh (which invokes
           # `llem` from PATH): replicate pyproject [project.scripts]
           # llem = "llenergymeasure.cli:app". `exec` keeps the llem PID =


### PR DESCRIPTION
## Summary

Removes the hardcoded `datamodel-code-generator==0.68.1` install from the transformers GPU CI image derivation. The pin was vestigial: the only test that invokes the generator CLI (`test_regen_engine_configs.py`) is `--ignore`d from the very container run that installed it (both added together in #806), so the package was installed and exercised by nothing - while its hardcoded version silently shadowed the Renovate-owned pin in pyproject (about to diverge via the pending 0.69 bump PR).

Ruling applied: dependency versions consumed by CI have exactly one Renovate-owned pin location; downstream occurrences derive from it. Since this occurrence is dead, it is removed rather than derived; the comment documents the derive-not-hardcode requirement if the exclusion is ever lifted.

## Test plan

- gpu-ci.yml is in its own paths filter, so this PR triggers the transformers in-container run - the full unit suite must stay green without the generator installed (it does not import it; the regen test is excluded).
- actionlint via CI.

## Doc audit

No doc update needed: docs/architecture/ci-architecture.md describes the job at topology level, not per-package install detail.