### PR TITLE
refactor(tests): tidy stale test docs and cover gpu-selector conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,17 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ### Fixed
 
+- Test and docstring tidy with one new orchestration regression. Stale harness
+  test docstrings/comments now name the current `build_result` seam (was the
+  pre-split `_build_result`), and the `PowerThermalSampler` test mock drops its
+  dead context-manager wiring since `MeasurementBracket` drives the sampler via
+  `start()`/`stop()`. The GPU-selector conflict warning choke point
+  (`_resolve_runner_specs`) gains coverage: it fires once per dispatch when a
+  Docker runner is present and never for an all-local study. The
+  `WarmupConfig.thermal_floor_seconds=60` docstring no longer misattributes the
+  default to an MLPerf Power thermal mandate; it is a conservative idle-settling
+  default, and MLPerf Power's 60s measurement-window rule is cited where it
+  applies (`harness/windowing.py`). Value and validation unchanged. ([#871])
 - The dispatch-metadata hermeticity stub now covers the whole unit suite rather
   than only `tests/unit/docker/`: the baseline-container and engine docker-path
   tests no longer fail with `PackageNotFoundError` when the suite runs
@@ -1432,3 +1443,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#866]: https://github.com/henrycgbaker/llenergymeasure/pull/866
 [#867]: https://github.com/henrycgbaker/llenergymeasure/pull/867
 [#868]: https://github.com/henrycgbaker/llenergymeasure/pull/868
+[#871]: https://github.com/henrycgbaker/llenergymeasure/pull/871

--- a/src/llenergymeasure/config/models.py
+++ b/src/llenergymeasure/config/models.py
@@ -126,7 +126,10 @@ class WarmupConfig(BaseModel):
     window_size. Either mode is followed by a thermal floor wait.
 
     # Confidence: n_prompts=5 HIGH (DeepSpeed 5-10, Zeus 10, AIEnergyScore 10)
-    # Confidence: thermal_floor_seconds=60 HIGH (MLPerf Power mandates 60s minimum)
+    # thermal_floor_seconds=60: a conservative idle-settling default (chosen, not
+    # externally mandated). MLPerf Power's 60s figure is a measurement-window
+    # minimum for sampling adequacy, not a thermal-settling mandate; that
+    # measurement-window floor is referenced in harness/windowing.py.
     """
 
     model_config = {"extra": "forbid"}

--- a/tests/unit/harness/test_harness.py
+++ b/tests/unit/harness/test_harness.py
@@ -259,9 +259,8 @@ def _make_mock_pts(*, samples: list | None = None):
     mock_pts_instance = MagicMock()
     mock_pts_instance.get_thermal_throttle_info.return_value = ThermalThrottleInfo()
     mock_pts_instance.get_samples.return_value = samples if samples is not None else []
-    # Context manager protocol
-    mock_pts_instance.__enter__ = MagicMock(return_value=mock_pts_instance)
-    mock_pts_instance.__exit__ = MagicMock(return_value=False)
+    # MeasurementBracket drives the sampler via start()/stop() (auto-mocked), not
+    # the context-manager protocol, so no __enter__/__exit__ wiring is needed.
     mock_pts_cls.return_value = mock_pts_instance
     return mock_pts_cls
 
@@ -450,7 +449,7 @@ def test_harness_start_tracking_called_after_thermal_floor_wait(minimal_config):
     We verify ordering by recording call order via side_effect on both
     thermal_floor_wait and select_energy_sampler (which is called just before
     start_tracking). select_energy_sampler returns None so no actual energy
-    measurement object is needed (avoids MagicMock comparison issues in _build_result).
+    measurement object is needed (avoids MagicMock comparison issues in build_result).
     """
     call_order: list[str] = []
 
@@ -460,7 +459,7 @@ def test_harness_start_tracking_called_after_thermal_floor_wait(minimal_config):
 
     def fake_select_energy_sampler(engine_name, *, gpu_indices=None):  # type: ignore[no-untyped-def]
         call_order.append("select_energy_sampler")
-        return None  # No tracker; avoids MagicMock total_j > 0 comparison in _build_result
+        return None  # No tracker; avoids MagicMock total_j > 0 comparison in build_result
 
     engine = FakeBackend()
     harness = MeasurementHarness()
@@ -1053,7 +1052,7 @@ def test_harness_energy_none_still_produces_valid_result(minimal_config):
 
 
 def test_build_result_populates_mj_per_tok(minimal_config):
-    """_build_result() sets mj_per_tok_total when total_tokens > 0."""
+    """build_result() sets mj_per_tok_total when total_tokens > 0."""
     engine = FakeBackend()
     harness = MeasurementHarness()
 

--- a/tests/unit/study/test_orchestration.py
+++ b/tests/unit/study/test_orchestration.py
@@ -1,0 +1,80 @@
+"""Tests for study orchestration seams.
+
+Covers the GPU-selector conflict warning choke point in
+``_resolve_runner_specs``: precedence resolution (env>config) is silent, so the
+orchestrator holds the single loud surface. The warning must fire exactly once
+per dispatch when a Docker container will actually launch, and never for an
+all-local study (GPU scoping only affects containers).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from llenergymeasure.config.models import ExperimentConfig, StudyConfig
+from llenergymeasure.config.runner_spec import RunnerSpec
+from llenergymeasure.config.ssot import RUNNER_DOCKER, RUNNER_LOCAL
+from llenergymeasure.study.orchestration import _resolve_runner_specs
+
+_WARN_TARGET = "llenergymeasure.utils.env_config.warn_on_gpu_selector_conflict"
+
+
+def _study(gpu_indices: list[int] | None) -> StudyConfig:
+    """A minimal study whose only relevant field is study_execution.gpu_indices."""
+    return StudyConfig(
+        experiments=[ExperimentConfig(task={"model": "m1"}, engine="vllm")],
+        study_execution={"gpu_indices": gpu_indices},
+    )
+
+
+def _resolve(study: StudyConfig, runner_specs: dict[str, RunnerSpec]):
+    """Drive the choke point with a preresolved plan (skips preflight entirely)."""
+    return _resolve_runner_specs(
+        study,
+        user_config=None,
+        preresolved=(runner_specs, {}),
+        skip_preflight=True,
+        progress=None,
+    )
+
+
+def test_gpu_selector_warn_fires_once_when_docker_present(monkeypatch):
+    """One Docker runner + both selectors set -> warn called exactly once, with the config indices."""
+    monkeypatch.setenv("LLEM_DOCKER_GPUS", "0")
+    study = _study([0])
+    specs = {"vllm": RunnerSpec(mode=RUNNER_DOCKER, image="img", source="yaml")}
+
+    with patch(_WARN_TARGET) as mock_warn:
+        _resolve(study, specs)
+
+    mock_warn.assert_called_once_with([0])
+
+
+def test_gpu_selector_warn_never_when_all_local(monkeypatch):
+    """All-local study never triggers the warning, even with both selectors set."""
+    monkeypatch.setenv("LLEM_DOCKER_GPUS", "0")
+    study = _study([0])
+    specs = {
+        "vllm": RunnerSpec(mode=RUNNER_LOCAL, image=None, source="default"),
+        "transformers": RunnerSpec(mode=RUNNER_LOCAL, image=None, source="default"),
+    }
+
+    with patch(_WARN_TARGET) as mock_warn:
+        _resolve(study, specs)
+
+    mock_warn.assert_not_called()
+
+
+def test_gpu_selector_warn_not_duplicated_across_docker_runners(monkeypatch):
+    """Multiple Docker runners still warn once (choke point is per-dispatch, not per-runner)."""
+    monkeypatch.setenv("LLEM_DOCKER_GPUS", "0")
+    study = _study([0])
+    specs = {
+        "vllm": RunnerSpec(mode=RUNNER_DOCKER, image="img-a", source="yaml"),
+        "transformers": RunnerSpec(mode=RUNNER_DOCKER, image="img-b", source="yaml"),
+    }
+
+    with patch(_WARN_TARGET) as mock_warn:
+        _resolve(study, specs)
+
+    mock_warn.assert_called_once_with([0])

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1208,7 +1208,7 @@ class TestResolveGpuIndices:
 # ---------------------------------------------------------------------------
 # The per_gpu_j data flow is already wired:
 #   NVMLSampler.stop_tracking() -> EnergyMeasurement.per_gpu_j
-#   MeasurementHarness._build_result() -> ExperimentResult.energy_per_device_j + multi_gpu
+#   build_result() (harness.result_assembly) -> ExperimentResult.energy_per_device_j + multi_gpu
 # With _resolve_gpu_indices returning correct indices for TRT-LLM,
 # multi-GPU energy is automatically summed across all TP ranks.
 # No methodology_notes string needed - data is self-documenting:


### PR DESCRIPTION
## Summary

Wave 5 test-tidy and correctness slice. Fixes stale references to symbols
renamed in the harness result-assembly / measurement split, tidies the
`PowerThermalSampler` test mock to the current `MeasurementBracket` seam, adds
regression coverage for the GPU-selector conflict warning choke point, and
corrects a misattributed justification in a config docstring. No production
behavior changes.

### Test and docstring tidy
- Harness test docstrings/comments in `test_harness.py` now name the current
  `build_result` seam (was the pre-split `_build_result` method).
- `test_api.py` energy-flow comment now names `build_result()`
  (`harness.result_assembly`) instead of `MeasurementHarness._build_result()`.
- `_make_mock_pts` drops its dead context-manager wiring: `MeasurementBracket`
  drives `PowerThermalSampler` via `start()`/`stop()` (auto-mocked), not the
  `__enter__`/`__exit__` protocol.

### New coverage
- New `tests/unit/study/test_orchestration.py` covers `_resolve_runner_specs`:
  the GPU-selector conflict warning fires exactly once per dispatch when a
  Docker runner is present, never for an all-local study, and is not duplicated
  across multiple Docker runners. Patched at the use site.

### Docstring correctness
- `WarmupConfig.thermal_floor_seconds=60` docstring no longer misattributes the
  default to an MLPerf Power thermal mandate. It is a conservative idle-settling
  default; MLPerf Power's 60s rule governs measurement-window duration and is
  referenced in `harness/windowing.py`. Value and validation unchanged.

## Coordination note

Several banked ledger items were skipped because they require editing files
owned by the in-flight PR #869 (`refactor/provenance-unification`): session
`__enter__`/`__exit__` hardening (`study/session.py`) and the
`RunnerSpec.extra_mounts` field removal (cascades to `study/session.py` and
`study/single.py`). These are deferred to a follow-up once #869 lands.

## Test plan
- `make test` (full host suite): 3253 passed, 37 skipped.
- `make lint`: clean.
- `make typecheck`: clean (342 source files).