### PR TITLE
fix(study): harden session lifecycle and drop dead RunnerSpec mount slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,9 +240,29 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   prefix caching, torch.compile) remain, and `docs/reference/engines/invalid-combos.md`
   is regenerated accordingly. Docs-only: no runtime, CLI, or dispatch path reads
   these functions, so no validation or measurement behavior changes. ([#866])
+- Dropped the unused `extra_mounts` field from `RunnerSpec`. It was never
+  populated by the runner-resolution chain (its own docstring admitted it was
+  populated at dispatch time, not by resolution), so it was wrong-altitude state
+  on a resolved value object. The facade-level `DockerRunner(extra_mounts=...)`
+  parameter - the legitimate mount injection point, used for the baseline-cache
+  bind mount - is unchanged.
 
 ### Fixed
 
+- The subprocess measurement session no longer leaks resources when its
+  `__enter__` fails mid-acquisition. A raise from the pre-dispatch GPU-residual
+  check (after the staging dir, pipe, and progress-consumer thread are acquired
+  but before the worker starts) now releases what was acquired and re-raises;
+  previously the `with` statement skipped `__exit__` on an `__enter__` failure,
+  stranding the consumer thread and leaking the staging tmpdir and pipe FDs.
+  Teardown is hardened to match: the consumer-stop call in `_cleanup` is now
+  exception-guarded like its process-reap and pipe-close siblings, so a raise
+  there can no longer skip the pipe close and staging-dir removal.
+- Doc/comment tidy: the `BundleWriter.write_environment` usage example and two
+  peak-memory test comments now name the current API and formula owner
+  (`write_environment(*, host_snapshot, runner=...)` and `build_offline_metrics`),
+  and a save-and-record test docstring drops the deleted `runner_environment`
+  term for the unified runner provenance block. No behavior change.
 - Test and docstring tidy with one new orchestration regression. Stale harness
   test docstrings/comments now name the current `build_result` seam (was the
   pre-split `_build_result`), and the `PowerThermalSampler` test mock drops its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,9 +255,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   but before the worker starts) now releases what was acquired and re-raises;
   previously the `with` statement skipped `__exit__` on an `__enter__` failure,
   stranding the consumer thread and leaking the staging tmpdir and pipe FDs.
-  Teardown is hardened to match: the consumer-stop call in `_cleanup` is now
-  exception-guarded like its process-reap and pipe-close siblings, so a raise
-  there can no longer skip the pipe close and staging-dir removal. ([#872])
+  Both pipe ends are now tracked on the session, so a failure between opening the
+  pipe and the worker start releases the parent AND child fds deterministically
+  rather than leaving the child end to refcount reclamation. Teardown is hardened
+  to match: the consumer-stop call in `_cleanup` is now exception-guarded like its
+  process-reap and pipe-close siblings, so a raise there can no longer skip the
+  pipe close and staging-dir removal. ([#872])
 - Doc/comment tidy: the `BundleWriter.write_environment` usage example and two
   peak-memory test comments now name the current API and formula owner
   (`write_environment(*, host_snapshot, runner=...)` and `build_offline_metrics`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,7 +245,7 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   populated at dispatch time, not by resolution), so it was wrong-altitude state
   on a resolved value object. The facade-level `DockerRunner(extra_mounts=...)`
   parameter - the legitimate mount injection point, used for the baseline-cache
-  bind mount - is unchanged.
+  bind mount - is unchanged. ([#872])
 
 ### Fixed
 
@@ -257,12 +257,12 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   stranding the consumer thread and leaking the staging tmpdir and pipe FDs.
   Teardown is hardened to match: the consumer-stop call in `_cleanup` is now
   exception-guarded like its process-reap and pipe-close siblings, so a raise
-  there can no longer skip the pipe close and staging-dir removal.
+  there can no longer skip the pipe close and staging-dir removal. ([#872])
 - Doc/comment tidy: the `BundleWriter.write_environment` usage example and two
   peak-memory test comments now name the current API and formula owner
   (`write_environment(*, host_snapshot, runner=...)` and `build_offline_metrics`),
   and a save-and-record test docstring drops the deleted `runner_environment`
-  term for the unified runner provenance block. No behavior change.
+  term for the unified runner provenance block. No behavior change. ([#872])
 - Test and docstring tidy with one new orchestration regression. Stale harness
   test docstrings/comments now name the current `build_result` seam (was the
   pre-split `_build_result`), and the `PowerThermalSampler` test mock drops its
@@ -1485,3 +1485,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#868]: https://github.com/henrycgbaker/llenergymeasure/pull/868
 [#869]: https://github.com/henrycgbaker/llenergymeasure/pull/869
 [#871]: https://github.com/henrycgbaker/llenergymeasure/pull/871
+[#872]: https://github.com/henrycgbaker/llenergymeasure/pull/872

--- a/src/llenergymeasure/config/runner_spec.py
+++ b/src/llenergymeasure/config/runner_spec.py
@@ -15,7 +15,7 @@ next to the taxonomy it describes.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from llenergymeasure.config.ssot import EXPLICIT_RUNNER_SOURCES, RunnerMode
 
@@ -38,15 +38,12 @@ class RunnerSpec:
         image_source: Where the Docker image was resolved from:
                       "env", "yaml", "runner_override", "user_config",
                       "local_build", "registry", or None (local mode / unresolved).
-        extra_mounts: Additional host:container bind-mount pairs. Populated at
-                      dispatch time, not by the resolution chain.
     """
 
     mode: RunnerMode
     image: str | None
     source: str
     image_source: str | None = None
-    extra_mounts: list[tuple[str, str]] = field(default_factory=list)
 
     @property
     def is_explicit(self) -> bool:

--- a/src/llenergymeasure/results/bundle.py
+++ b/src/llenergymeasure/results/bundle.py
@@ -67,7 +67,7 @@ class BundleWriter:
 
         writer = BundleWriter(study_dir, model_name=..., engine=..., config_hash=...)
         result_path = writer.write_result(result, runner_provenance=...)
-        writer.write_environment(host_snapshot=..., runner_environment=..., runner_provenance=...)
+        writer.write_environment(host_snapshot=..., runner=...)
         writer.move_config_sidecar(resolved_config_hash=..., resolution_log=...)
         writer.finalize()
 

--- a/src/llenergymeasure/study/preflight.py
+++ b/src/llenergymeasure/study/preflight.py
@@ -120,7 +120,6 @@ def run_study_preflight(
                 image=image,
                 source=spec.source,
                 image_source=image_source,
-                extra_mounts=spec.extra_mounts,
             )
 
     # Docker pre-flight: run once if any engine resolves to a Docker runner.

--- a/src/llenergymeasure/study/session.py
+++ b/src/llenergymeasure/study/session.py
@@ -203,6 +203,7 @@ class SubprocessSession(_OfflineSession):
         # Populated in __enter__.
         self._ts_tmpdir: Path | None = None
         self._parent_conn: Any = None
+        self._child_conn: Any = None
         self._progress_queue: Any = None
         self._consumer: threading.Thread | None = None
         self._process: Any = None
@@ -250,12 +251,12 @@ class SubprocessSession(_OfflineSession):
             # Resolve cached baseline in parent - avoids 30s re-measurement per subprocess
             baseline = runner._get_baseline(config) if config.measurement.baseline.enabled else None
 
-            self._parent_conn, child_conn = self._mp_ctx.Pipe(duplex=False)
+            self._parent_conn, self._child_conn = self._mp_ctx.Pipe(duplex=False)
             self._progress_queue = self._mp_ctx.Queue()
 
             self._process = self._mp_ctx.Process(
                 target=_run_experiment_worker,
-                args=(config, child_conn, self._progress_queue, snapshot),
+                args=(config, self._child_conn, self._progress_queue, snapshot),
                 kwargs={
                     "output_dir": str(self._ts_tmpdir),
                     "save_timeseries": save_ts,
@@ -284,7 +285,11 @@ class SubprocessSession(_OfflineSession):
             check_gpu_memory_residual()
 
             self._process.start()
-            child_conn.close()
+            # Normal path: drop the parent's copy of the child end immediately so
+            # the pipe delivers EOF when the worker exits. Null it so a later
+            # _cleanup does not double-close.
+            self._child_conn.close()
+            self._child_conn = None
         except BaseException:
             self._torn_down = True
             self._cleanup()
@@ -387,6 +392,12 @@ class SubprocessSession(_OfflineSession):
         if self._parent_conn is not None:
             with contextlib.suppress(Exception):
                 self._parent_conn.close()
+        # Close the child (write) end too: on the __enter__-failure path the
+        # normal-path close never ran, so the parent's copy of the fd would only
+        # be reclaimed by refcounting. The normal path nulls it after closing.
+        if self._child_conn is not None:
+            with contextlib.suppress(Exception):
+                self._child_conn.close()
         # Remove the timeseries staging dir after _handle_result copied the parquet.
         if self._ts_tmpdir is not None:
             shutil.rmtree(self._ts_tmpdir, ignore_errors=True)

--- a/src/llenergymeasure/study/session.py
+++ b/src/llenergymeasure/study/session.py
@@ -3,8 +3,10 @@
 An :class:`ExperimentSession` is one measurement session: a context manager
 whose ``__enter__`` acquires the session's resources (spawn a worker subprocess,
 prepare a container), whose ``run()`` produces the session's result payload, and
-whose ``__exit__`` releases everything - ALWAYS, including on the SIGINT,
-circuit-break, and exception paths.
+whose ``__exit__`` releases everything the session acquired - on the normal,
+SIGINT, circuit-break, and exception paths alike. A failure DURING ``__enter__``
+acquisition (before the ``with`` body is ever entered) releases whatever was
+acquired so far and re-raises, so a partially acquired session never leaks.
 
 The two offline (batch) implementations here wrap today's dispatch paths:
 
@@ -224,59 +226,69 @@ class SubprocessSession(_OfflineSession):
                 runner_info=self._local_spec.to_runner_info() if self._local_spec else None,
             )
 
-        self._exp_start = time.monotonic()
+        # Acquire the session's resources. If any step here raises (e.g. the
+        # pre-dispatch GPU-residual check, which fires before the worker starts),
+        # the `with` statement never calls __exit__, so release whatever was
+        # acquired and re-raise. _cleanup tolerates partial init: every handle
+        # starts None and is None-checked there.
+        try:
+            self._exp_start = time.monotonic()
 
-        # Create a temp dir for harness artefacts. The harness receives it as
-        # output_dir (a runtime param, not from config) and writes config.json
-        # there always, plus timeseries.parquet when save_timeseries is on. The
-        # staging dir is created regardless of save_timeseries so the config.json
-        # sidecar - sole home of provenance, authoritative home of identity -
-        # always materialises; __exit__ removes it after _handle_result copies
-        # the artefacts into the study directory.
-        save_ts = runner.study.output.save_timeseries
-        self._ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
+            # Create a temp dir for harness artefacts. The harness receives it as
+            # output_dir (a runtime param, not from config) and writes config.json
+            # there always, plus timeseries.parquet when save_timeseries is on. The
+            # staging dir is created regardless of save_timeseries so the config.json
+            # sidecar - sole home of provenance, authoritative home of identity -
+            # always materialises; __exit__ removes it after _handle_result copies
+            # the artefacts into the study directory.
+            save_ts = runner.study.output.save_timeseries
+            self._ts_tmpdir = Path(tempfile.mkdtemp(prefix=TEMP_PREFIX_TIMESERIES))
 
-        # Resolve cached snapshot in parent - serialised to subprocess via Pipe
-        snapshot = runner._get_env_snapshot()
+            # Resolve cached snapshot in parent - serialised to subprocess via Pipe
+            snapshot = runner._get_env_snapshot()
 
-        # Resolve cached baseline in parent - avoids 30s re-measurement per subprocess
-        baseline = runner._get_baseline(config) if config.measurement.baseline.enabled else None
+            # Resolve cached baseline in parent - avoids 30s re-measurement per subprocess
+            baseline = runner._get_baseline(config) if config.measurement.baseline.enabled else None
 
-        self._parent_conn, child_conn = self._mp_ctx.Pipe(duplex=False)
-        self._progress_queue = self._mp_ctx.Queue()
+            self._parent_conn, child_conn = self._mp_ctx.Pipe(duplex=False)
+            self._progress_queue = self._mp_ctx.Queue()
 
-        self._process = self._mp_ctx.Process(
-            target=_run_experiment_worker,
-            args=(config, child_conn, self._progress_queue, snapshot),
-            kwargs={
-                "output_dir": str(self._ts_tmpdir),
-                "save_timeseries": save_ts,
-                "baseline": baseline,
-                "study_dir": str(runner.study_dir),
-                "study_run_id": runner.study_run_id,
-                "cycle": self.cycle,
-                "config_hash": self.config_hash,
-            },
-            daemon=False,  # daemon=False: clean CUDA teardown if parent exits unexpectedly
-        )
+            self._process = self._mp_ctx.Process(
+                target=_run_experiment_worker,
+                args=(config, child_conn, self._progress_queue, snapshot),
+                kwargs={
+                    "output_dir": str(self._ts_tmpdir),
+                    "save_timeseries": save_ts,
+                    "baseline": baseline,
+                    "study_dir": str(runner.study_dir),
+                    "study_run_id": runner.study_run_id,
+                    "cycle": self.cycle,
+                    "config_hash": self.config_hash,
+                },
+                daemon=False,  # daemon=False: clean CUDA teardown if parent exits unexpectedly
+            )
 
-        self._consumer = threading.Thread(
-            target=_consume_progress_events,
-            args=(self._progress_queue, runner._progress),
-            daemon=True,
-        )
-        self._consumer.start()
+            self._consumer = threading.Thread(
+                target=_consume_progress_events,
+                args=(self._progress_queue, runner._progress),
+                daemon=True,
+            )
+            self._consumer.start()
 
-        runner.manifest.mark_running(self.config_hash, self.cycle)
-        runner._active_process = self._process
+            runner.manifest.mark_running(self.config_hash, self.cycle)
+            runner._active_process = self._process
 
-        # Pre-dispatch GPU memory residual check (MEAS-01, MEAS-02)
-        from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
+            # Pre-dispatch GPU memory residual check (MEAS-01, MEAS-02)
+            from llenergymeasure.study.gpu_memory import check_gpu_memory_residual
 
-        check_gpu_memory_residual()
+            check_gpu_memory_residual()
 
-        self._process.start()
-        child_conn.close()
+            self._process.start()
+            child_conn.close()
+        except BaseException:
+            self._torn_down = True
+            self._cleanup()
+            raise
         return self
 
     def run(self) -> Any:
@@ -369,7 +381,8 @@ class SubprocessSession(_OfflineSession):
                     _kill_process_group(self._process.pid, signal.SIGKILL)
                     self._process.join()
         # Stop the progress consumer (no-op if run() already did).
-        self._stop_consumer()
+        with contextlib.suppress(Exception):
+            self._stop_consumer()
         # Close the read end of the Pipe (C4 FD-leak fix): exactly once, here.
         if self._parent_conn is not None:
             with contextlib.suppress(Exception):
@@ -459,7 +472,7 @@ class DockerSession(_OfflineSession):
             # Host-side preflight doesn't run in Docker path - checked inside container
             runner._progress.on_step_skip("preflight", "checked inside container")
 
-        extra_mounts = list(spec.extra_mounts) if spec.extra_mounts else []
+        extra_mounts: list[tuple[str, str]] = []
         cache_key = runner._baseline_cache_key(config)
         baseline = runner._get_baseline(config) if config.measurement.baseline.enabled else None
         if baseline is not None:

--- a/src/llenergymeasure/study/single.py
+++ b/src/llenergymeasure/study/single.py
@@ -101,7 +101,6 @@ def run_single_experiment(
             timeout=study.study_execution.experiment_timeout_seconds,
             silence_timeout=study.study_execution.stdout_silence_timeout_seconds,
             source=spec.source,
-            extra_mounts=spec.extra_mounts,
             gpu_indices=gpu_indices,
         )
         docker_ts_dir: Path | None = None

--- a/tests/unit/study/test_save_and_record.py
+++ b/tests/unit/study/test_save_and_record.py
@@ -852,7 +852,7 @@ def test_save_and_record_docker_rescue_failure_keeps_host_runner_block(
     the runner block via the host snapshot) survives and a loud warning fires.
 
     Covers the combination the earlier permission-error test omitted: rescue fails
-    *and* a runner_environment is present. The runner block must not be lost - it was
+    *and* a runner provenance block is present. The runner block must not be lost - it was
     attached to the host snapshot and written by save_environment before the rescue.
     """
     import json

--- a/tests/unit/study/test_session.py
+++ b/tests/unit/study/test_session.py
@@ -180,7 +180,7 @@ def test_subprocess_session_enter_failure_releases_resources(tmp_path: Path) -> 
     config = runner.study.experiments[0]
     proc = _make_mock_process(is_alive_after_join=False)
     ctx = _make_mock_context(proc, pipe_has_data=False)
-    parent_conn = ctx.Pipe.return_value[0]
+    parent_conn, child_conn = ctx.Pipe.return_value
 
     with patch(
         "llenergymeasure.study.gpu_memory.check_gpu_memory_residual",
@@ -192,7 +192,8 @@ def test_subprocess_session_enter_failure_releases_resources(tmp_path: Path) -> 
             pass
 
     # The staging dir was created then removed; the consumer thread was started
-    # then stopped; the pipe read end was closed; the active handle was cleared.
+    # then stopped; both pipe ends were closed (the residual check raised before
+    # the normal-path child close ran); the active handle was cleared.
     ts_dir = session._ts_tmpdir
     assert ts_dir is not None and not ts_dir.exists(), "staging dir leaked on __enter__ failure"
     assert session._consumer is not None and not session._consumer.is_alive(), (
@@ -200,6 +201,7 @@ def test_subprocess_session_enter_failure_releases_resources(tmp_path: Path) -> 
     )
     assert session._consumer_stopped is True
     parent_conn.close.assert_called_once()
+    child_conn.close.assert_called_once()
     assert runner._active_process is None
 
 

--- a/tests/unit/study/test_session.py
+++ b/tests/unit/study/test_session.py
@@ -170,6 +170,72 @@ def test_subprocess_session_active_process_set_during_enter(tmp_path: Path) -> N
     assert runner._active_process is None
 
 
+def test_subprocess_session_enter_failure_releases_resources(tmp_path: Path) -> None:
+    """__enter__ raising at the pre-dispatch GPU-residual check must not strand
+    resources. The check fires after the staging dir, pipe, and consumer thread are
+    acquired but before the worker starts; since a failing __enter__ means the ``with``
+    statement never calls __exit__, __enter__'s own failure path releases what it
+    acquired and re-raises."""
+    runner = _make_runner(tmp_path)
+    config = runner.study.experiments[0]
+    proc = _make_mock_process(is_alive_after_join=False)
+    ctx = _make_mock_context(proc, pipe_has_data=False)
+    parent_conn = ctx.Pipe.return_value[0]
+
+    with patch(
+        "llenergymeasure.study.gpu_memory.check_gpu_memory_residual",
+        side_effect=RuntimeError("residual GPU memory"),
+    ):
+        session = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
+        # The exception propagates out of __enter__ (the `with` body never runs).
+        with pytest.raises(RuntimeError, match="residual GPU memory"), session:
+            pass
+
+    # The staging dir was created then removed; the consumer thread was started
+    # then stopped; the pipe read end was closed; the active handle was cleared.
+    ts_dir = session._ts_tmpdir
+    assert ts_dir is not None and not ts_dir.exists(), "staging dir leaked on __enter__ failure"
+    assert session._consumer is not None and not session._consumer.is_alive(), (
+        "progress consumer thread stranded on __enter__ failure"
+    )
+    assert session._consumer_stopped is True
+    parent_conn.close.assert_called_once()
+    assert runner._active_process is None
+
+
+def test_subprocess_session_cleanup_finishes_when_stop_consumer_raises(tmp_path: Path) -> None:
+    """_cleanup completes its remaining steps when _stop_consumer raises: the pipe is
+    still closed and the staging dir still removed. The consumer-stop call is guarded
+    like its process-reap and pipe-close siblings, so a raise there cannot skip them."""
+    runner = _make_runner(tmp_path)
+    config = runner.study.experiments[0]
+    proc = _make_mock_process(is_alive_after_join=False)
+    ctx = _make_mock_context(proc, pipe_has_data=False)
+    parent_conn = ctx.Pipe.return_value[0]
+
+    with patch("llenergymeasure.study.gpu_memory.check_gpu_memory_residual"):
+        session = SubprocessSession(runner, config, ctx, config_hash="h", cycle=1, index=1)
+        session.__enter__()
+
+    ts_dir = session._ts_tmpdir
+    assert ts_dir is not None and ts_dir.exists()
+    consumer = session._consumer
+
+    # _stop_consumer raises during teardown; the remaining steps must still run.
+    with patch.object(session, "_stop_consumer", side_effect=RuntimeError("consumer boom")):
+        session.__exit__(None, None, None)
+
+    assert not ts_dir.exists(), "staging dir must be removed even when _stop_consumer raises"
+    parent_conn.close.assert_called_once()
+    assert runner._active_process is None
+
+    # _stop_consumer was stubbed out, so its sentinel never reached the real
+    # consumer thread; reap it here so the test leaves no live daemon behind.
+    if consumer is not None:
+        session._progress_queue.put(None)
+        consumer.join(timeout=2.0)
+
+
 # =============================================================================
 # DockerSession: cleanup exactly once
 # =============================================================================

--- a/tests/unit/test_peak_memory.py
+++ b/tests/unit/test_peak_memory.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 
 # ---------------------------------------------------------------------------
-# Formula tests - MeasurementHarness._build_result inference_memory_mb
+# Formula tests - build_offline_metrics (harness/result_assembly.py) inference_memory_mb
 # ---------------------------------------------------------------------------
 
 
@@ -32,7 +32,7 @@ def test_inference_memory_is_peak_minus_model():
         peak_memory_mb=1024.0,
         model_memory_mb=512.0,
     )
-    # Compute using the same formula as MeasurementHarness._build_result
+    # Compute using the same formula as build_offline_metrics (harness/result_assembly.py)
     inference_memory_mb = max(0.0, output.peak_memory_mb - output.model_memory_mb)
     assert inference_memory_mb == 512.0
 

--- a/tests/unit/test_runner_resolution.py
+++ b/tests/unit/test_runner_resolution.py
@@ -395,25 +395,3 @@ class TestResolveStudyRunners:
         # tensorrt: "auto" falls through -> Docker auto-detected
         assert result["tensorrt"].mode == "docker"
         assert result["tensorrt"].source == "auto_detected"
-
-
-# ---------------------------------------------------------------------------
-# RunnerSpec.extra_mounts
-# ---------------------------------------------------------------------------
-
-
-class TestRunnerSpecExtraMounts:
-    def test_extra_mounts_defaults_to_empty_list(self):
-        """RunnerSpec.extra_mounts defaults to empty list when not specified."""
-        spec = RunnerSpec(mode="local", image=None, source="default")
-        assert spec.extra_mounts == []
-
-    def test_extra_mounts_populated(self):
-        """RunnerSpec.extra_mounts stores user-provided mount pairs correctly."""
-        spec = RunnerSpec(
-            mode="docker",
-            image="img",
-            source="yaml",
-            extra_mounts=[("/host/a", "/container/a")],
-        )
-        assert spec.extra_mounts == [("/host/a", "/container/a")]


### PR DESCRIPTION
## Summary

Hardens the offline measurement-session lifecycle against two resource-leak
windows and drops a dead field, plus small doc/comment tidy.

- Fix 1: `SubprocessSession._cleanup` now exception-guards its consumer-stop
  call (`contextlib.suppress(Exception)`), matching the process-reap and
  pipe-close siblings. A raise in `_stop_consumer` can no longer skip the pipe
  close and staging-dir removal.
- Fix 2: `SubprocessSession.__enter__` wraps its acquisition in a
  try/except `BaseException` that flips the teardown guard, runs `_cleanup`, and
  re-raises. A failure before the worker starts (e.g. the pre-dispatch
  GPU-residual check) previously left the `with` statement to skip `__exit__`,
  stranding the consumer thread and leaking the staging tmpdir and pipe FDs.
- Fix 3: the module docstring no longer overclaims `__exit__` releases
  everything "ALWAYS"; it now also describes the `__enter__`-failure path.
- Fix 4: drops the never-populated `RunnerSpec.extra_mounts` field (wrong-altitude
  state on a resolved value object). Updates the two dispatch-path consumers
  (single-experiment and preflight re-construction) and starts the
  `DockerSession` mount list empty. The facade-level `DockerRunner(extra_mounts=...)`
  parameter, the legitimate mount injection point, is untouched.
- Fixes 5-7: stale API references in comments/docstrings now name current owners:
  the peak-memory test comments name `build_offline_metrics`
  (`harness/result_assembly.py`), the `BundleWriter` usage example matches the
  `write_environment(*, host_snapshot, runner=...)` signature, and a
  save-and-record test docstring drops the deleted `runner_environment` term.

Two regression tests are added for fixes 1 and 2.

### Note on the manifest window (fix 2)

The `StudyRunner.run` loop wraps `_run_one` in `try/finally` with no `except`, so
an exception escaping `__enter__` propagates out of `run()` entirely and aborts
the whole study; the manifest entry stays in `running` state and is not marked
failed. That study-abort behavior is pre-existing and unchanged here. The fix is
scoped to resource release only (no manifest "unmark" API is introduced): a
failed GPU-residual check is a hard study-level stop, and this change simply
ensures the aborting session does not leak its thread, tmpdir, and pipe FDs.

## Test plan

- `pytest -m "not gpu and not docker and not slow"`: 3254 passed, 37 skipped, 0 failures.
- New regression tests pass solo and under `-p randomly` seeds 1, 42, 12345
  (order-stable): full `test_session.py` 9 passed each run.
- `make lint`: ruff check + ruff format clean; import-linter 5/5 contracts kept,
  0 new ignores.
- `make typecheck`: mypy clean (343 source files, no issues).
