### PR TITLE
docs: sweep post-refactor drift and stamp bundle 2.0 anchor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,3 +115,12 @@ LLEM_DOCKER_GPUS=
 # startup. Raise it (e.g. 16g) for very large tensor-parallel runs; lower it on
 # memory-constrained hosts. Any docker-accepted size string works (512m, 8g).
 LLEM_DOCKER_SHM_SIZE=
+
+# ─── Docker HuggingFace cache (llem-launched experiment containers) ──────────
+# Host-side HuggingFace cache directory bind-mounted into experiment containers
+# so model weights persist across ephemeral containers (otherwise every run
+# re-downloads the full model). Empty means ~/.cache/huggingface, the historical
+# location; ~ in an explicit value is expanded. Point it at shared storage or a
+# large scratch disk when home lives on a small volume. The in-container target
+# and HF_HOME stay fixed at /root/.cache/huggingface.
+LLEM_DOCKER_HF_CACHE=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
 
 ## [Unreleased]
 
+> **Format break (unreleased):** results-bundle format 2.0 as of commit `09ec455e`
+> ([#869]) - unified runner provenance block, single `bundle_version` stamp. 1.0
+> bundles remain readable (best-effort). Ships with the v0.7.0 release; v0.6.0 is
+> the rollback anchor.
+
 ### Added
 
 - CI now fails a bare engine version-pin bump. A PR that advances

--- a/docs/contributing/schema-refresh.md
+++ b/docs/contributing/schema-refresh.md
@@ -133,7 +133,7 @@ CPU runners. The check that guards this page's own output is:
 
 | Check | Workflow / job | What it asserts |
 |---|---|---|
-| `regen_engine_configs.py --check` | `engine-rules-check.yml` / `config-codegen` (matrix over all three engines) | `config.py` is byte-identical to what the committed snapshot regenerates. |
+| `regen_engine_configs.py --check` | `engine-rules-check.yml` / `config-codegen` (matrix over all three engines) | `src/llenergymeasure/config/generated/<engine>.py` is byte-identical to what the committed snapshot regenerates. |
 | `check_discovered_schema_versions.py` | `ci.yml` (matrix over all three engines) | The pin matches the schema version, and the promoted src copy exposes the same parameter surface as the versioned snapshot it was promoted from. This is the drift tripwire for the promotion invariant; with `promote-schemas` in place it should never fire. |
 
 A further byte-identity check in `ci.yml` verifies Pydantic alignment - see
@@ -156,7 +156,7 @@ pin bump under `engine_versions/` triggers them even though nothing under
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `config-codegen` fails on a snapshot PR | `config.py` was not regenerated after the schema changed | Run `regen_engine_configs.py --engine <e> --version <v> --write` and commit `config.py` |
+| `config-codegen` fails on a snapshot PR | `src/llenergymeasure/config/generated/<engine>.py` was not regenerated after the schema changed | Run `regen_engine_configs.py --engine <e> --version <v> --write` and commit `src/llenergymeasure/config/generated/<engine>.py` |
 | `schema-version-check` fails | `schema.discovered.json` version does not match the `current.yaml` pin | Re-run `./scripts/refresh_discovered_schemas.sh <engine>` after the bump and commit the refreshed schema |
 | `docs-freshness` Pydantic-alignment step fails | A config field has no discovered counterpart, or a type narrowed/widened | Add the field to the whitelist in `check_pydantic_matches_discovered.py` if intentional, else fix the snapshot or the curation |
 | Schema discovery fails to import engine | Container missing `--gpus all` | Verify the machine has NVIDIA drivers plus the Container Toolkit |

--- a/docs/explanation/architecture/architecture-overview.md
+++ b/docs/explanation/architecture/architecture-overview.md
@@ -29,7 +29,7 @@ flowchart TB
         src[Engine source<br/>at the pinned version]
         schema[(schema.discovered.json)]
         rules[(rules.yaml)]
-        config[config.py<br/>typed Pydantic model]
+        config[config/generated/&lt;engine&gt;.py<br/>typed Pydantic model]
         src -->|make discover-schema| schema
         src -->|make absorb| rules
         schema -->|code generation| config
@@ -37,7 +37,7 @@ flowchart TB
 
     subgraph verify["VERIFY - CI, read-only on hosted CPU"]
         direction TB
-        codegen[config-codegen:<br/>regenerated config.py is<br/>byte-identical to committed]
+        codegen[config-codegen:<br/>regenerated config model is<br/>byte-identical to committed]
         coverage[rules-coverage:<br/>report uncovered validator sites<br/>advisory]
     end
 
@@ -76,7 +76,7 @@ Upstream engines ship frequently. A self-hosted Renovate cron (`renovate.yml`) w
 
 1. Re-discover the schema: `make discover-schema ENGINE=<engine>`.
 2. Re-absorb the rules against the new source: `make absorb ENGINE=<engine> SRC=<engine-source>`.
-3. Commit the regenerated `schema.discovered.json`, `config.py`, and `rules.yaml`.
+3. Commit the regenerated `schema.discovered.json`, `config/generated/<engine>.py`, and `rules.yaml`.
 4. CI verifies the committed bytes are consistent before merge.
 
 This is a deliberate split: production needs the engine source (and sometimes a GPU), so it runs on a maintainer's machine; verification is a fast read-only check that runs on hosted CPU runners. See [CI architecture](/explanation/architecture/ci-architecture) for the verification surface and [schema refresh](/contributing/schema-refresh) for the schema-side operations guide.
@@ -130,7 +130,7 @@ The trade-off is staleness risk: the artifacts must be refreshed when the engine
 | Term | Meaning |
 |------|---------|
 | **Schema discovery** | Introspecting an engine at its pinned version to record its full parameter surface as `schema.discovered.json` |
-| **Config codegen** | Generating the typed Pydantic `config.py` from the discovered schema; CI asserts the regenerated file is byte-identical to the committed one |
+| **Config codegen** | Generating the typed Pydantic `config/generated/<engine>.py` from the discovered schema; CI asserts the regenerated file is byte-identical to the committed one |
 | **Rule** | A single validation constraint in `rules.yaml`: an `id`, a `severity`, a `match` predicate over config fields, a message template, and provenance |
 | **Severity** | Closed enum: `error` (reject the config) or `dormant` (the engine silently normalises a field; used for deduplication) |
 | **Absorb** | The local workflow that reads an engine's source into candidate rules, verifies them against the engine, and promotes the confirmed ones into `rules.yaml` |
@@ -144,11 +144,13 @@ The trade-off is staleness risk: the artifacts must be refreshed when the engine
 ```
   src/llenergymeasure/engines/
   └── <engine>/                      Per-engine sub-package, ships with the wheel
+      ├── plugin.py                  EnginePlugin implementation (inference code)
       ├── schema.discovered.json     Discovered parameter surface (pinned version)
-      ├── config.py                  Typed Pydantic model, generated from the schema
       └── rules.yaml                 Shipped validation rules (single runtime source)
 
   src/llenergymeasure/config/
+  ├── generated/
+  │   └── <engine>.py                Typed Pydantic model, generated from the schema
   └── engine_rules/
       ├── loader.py                  Runtime rule loader + predicate engine
       └── __init__.py

--- a/docs/explanation/architecture/ci-architecture.md
+++ b/docs/explanation/architecture/ci-architecture.md
@@ -100,11 +100,14 @@ requires; `rules-coverage` feeds nothing downstream because it is advisory.
 - **`absorbed-bump-check`** (gating): fails a PR that advances an engine pin
   (`engine_versions/<engine>/current.yaml`) without shipping the regenerated
   knowledge `make absorb` produces - the versioned snapshot outputs
-  (`engine_versions/<engine>/<version>/outputs/`) AND the packaged src copies
-  (`src/llenergymeasure/engines/<engine>/` config.py / rules.yaml /
-  schema.discovered.json). A bare pin bump (the Renovate regex-manager shape,
-  which edits `current_version` and nothing else) would otherwise merge a
-  config typed against the old engine surface. The check
+  (`engine_versions/<engine>/<version>/outputs/`) AND the packaged src copies:
+  the generated config model at
+  `src/llenergymeasure/config/generated/<engine>.py`, plus the `rules.yaml` and
+  `schema.discovered.json` beside the engine under
+  `src/llenergymeasure/engines/<engine>/`. The config model is checked
+  separately from the engine-local data files. A bare pin bump (the Renovate
+  regex-manager shape, which edits `current_version` and nothing else) would
+  otherwise merge a config typed against the old engine surface. The check
   (`scripts/ci/check_absorbed_bump.py`) is a pure path comparison over the PR's
   changed files and needs no engine source or install.
 

--- a/docs/explanation/architecture/engine-extensibility.md
+++ b/docs/explanation/architecture/engine-extensibility.md
@@ -123,9 +123,9 @@ CI never produces these artifacts; it checks the committed bytes are
 consistent, read-only on hosted CPU runners (see
 [CI architecture](/explanation/architecture/ci-architecture)):
 
-- **`config-codegen`** (gating) regenerates `config.py` from the committed
-  schema snapshot and curation file and asserts it is byte-identical to the
-  committed file. A drifted config fails the check.
+- **`config-codegen`** (gating) regenerates `config/generated/<engine>.py` from
+  the committed schema snapshot and curation file and asserts it is
+  byte-identical to the committed file. A drifted config fails the check.
 - **`rules-coverage`** (advisory) reports validator sites in the engine source
   that no shipped rule covers, without blocking the merge.
 
@@ -153,7 +153,7 @@ checklist is:
 **Produced locally, then committed:**
 
 5. `schema.discovered.json` via `make discover-schema`.
-6. `config.py` via the config generator.
+6. `config/generated/sglang.py` via the config generator.
 7. `rules.yaml` via `make absorb`.
 
 **Verified by CI:**

--- a/docs/explanation/architecture/parameter-curation.md
+++ b/docs/explanation/architecture/parameter-curation.md
@@ -15,7 +15,7 @@ flowchart TD
     discovery[programmatic discovery<br/>scripts/engine_producers/]
     curated[curation decisions<br/>engine_versions/&lt;engine&gt;/v&lt;ver&gt;/outputs/curated.yaml]
     codegen[codegen<br/>scripts/engine_producers/regen_engine_configs.py]
-    pydantic[generated Pydantic models<br/>engines/&lt;engine&gt;/config.py]
+    pydantic[generated Pydantic models<br/>config/generated/&lt;engine&gt;.py]
     drift[drift checker<br/>scripts/check_pydantic_matches_discovered.py]
     allowlist[LLEM_NATIVE_FIELDS<br/>intentional-divergence allowlist]
 

--- a/docs/explanation/methodology/energy-measurement.md
+++ b/docs/explanation/methodology/energy-measurement.md
@@ -246,9 +246,8 @@ timestamps, so a window covering 60% of the cleaned inference span is credited w
 the output tokens. A measurement warning records this approximation, and a second warning
 fires when the realised window is too short to be meaningful.
 
-The survey behind this design (MLPerf Power, SPECpower, the VM-warmup steady-state study,
-and the Cao-Rhinehart detector choice) is recorded in the repository at
-`.product/research/steady-state-measurement-methodology.md`.
+This design is grounded in a survey of prior measurement methodology: MLPerf Power,
+SPECpower, the VM-warmup steady-state study, and the Cao-Rhinehart detector choice.
 
 ---
 

--- a/src/llenergymeasure/api/README.md
+++ b/src/llenergymeasure/api/README.md
@@ -10,7 +10,7 @@ Exposes `run_experiment()` and `run_study()` as the primary library interface. A
 
 | Module | Description |
 |--------|-------------|
-| `_impl.py` | `run_experiment()` and `run_study()` implementations; `_run()` dispatcher |
+| `_impl.py` | Thin `run_experiment()` and `run_study()` implementations; normalise input via `_to_study_config()` and delegate to `study.orchestration.orchestrate_study` |
 | `_gpu.py` | `_resolve_gpu_indices()` - per-engine GPU index resolution |
 | `preflight.py` | `run_preflight()` and `run_study_preflight()` - pre-experiment checks |
 | `__init__.py` | Re-exports `run_experiment`, `run_study` |

--- a/src/llenergymeasure/config/README.md
+++ b/src/llenergymeasure/config/README.md
@@ -715,7 +715,7 @@ Each experiment directory ships sidecars for full reproducibility next to `resul
 ```json
 // config.json (excerpt)
 {
-  "schema_version": "2.0",
+  "bundle_version": "2.0",
   "provenance": {
     "task.model": { "effective": "meta-llama/Llama-2-7b-hf", "source": "yaml" },
     "batching.batch_size": { "effective": 8, "source": "cli_flag", "default": 1 }

--- a/src/llenergymeasure/infra/README.md
+++ b/src/llenergymeasure/infra/README.md
@@ -174,4 +174,4 @@ Gracefully degrades when NVML is unavailable.
 ## Related
 
 - See `../study/runner.py` for StudyRunner which uses DockerRunner for Docker dispatch
-- See `../api/_impl.py` for direct DockerRunner usage in single-experiment path
+- See `../study/single.py` and `../study/session.py` (`DockerSession`) for direct DockerRunner usage in the single-experiment path

--- a/src/llenergymeasure/results/README.md
+++ b/src/llenergymeasure/results/README.md
@@ -1,10 +1,27 @@
 # results/ - Results Persistence
 
 Saves and loads a single experiment's results to and from the filesystem.
-There is no repository object, aggregation command, or export layer here; the
-package is one module, `persistence.py`.
+There is no repository object, aggregation command, or export layer here. The
+package is two modules: `bundle.py`, which owns the per-experiment
+results-bundle write and read policy, and `persistence.py`, which holds the
+low-level filesystem primitives it builds on.
+
+## bundle.py
+
+`BundleWriter` is the single owner of the assembly policy that turns a completed
+experiment into an on-disk bundle: the collision-free experiment directory,
+`result.json` (with runner provenance folded in), `environment.json`, the
+`config.json` sidecar move and patch, and the timeseries attach, all driven by
+the `domain.bundle_artefacts.ARTEFACTS` registry. `BundleReader` is its
+read-side counterpart: given a bundle directory it discovers the artefacts via
+the same registry and returns a `LoadedBundle`. Both are stamped with the single
+`bundle_version` (`"2.0"`).
 
 ## persistence.py
+
+Holds the low-level filesystem primitives `BundleWriter` delegates to (atomic
+writes, collision-safe directory naming, the sidecar writers). `load_result` is
+a thin wrapper over `BundleReader.read`.
 
 Public functions:
 
@@ -37,8 +54,9 @@ collision-free before writing.
 sidecar degrades gracefully (warning, not error) rather than failing the load.
 
 Study-level artefacts (the `_study-artefacts/` directory, `manifest.json`,
-`equivalence_groups.json`) are written by the `study/` and `api/` layers, not
-here. Artefact filenames are defined in `domain/bundle_artefacts.py`.
+`equivalence_groups.json`) are written by the `study/` layer (the `ManifestWriter`
+in `study/orchestration.py`), not here. Artefact filenames are defined in
+`domain/bundle_artefacts.py`.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Post-F6 documentation drift sweep. Corrects stale paths and stamps a bundle-format break anchor in the changelog. No code or generated docs change; every edit is to hand-authored docs, package READMEs, or the changelog.

- **S17 config-model relocation.** The generated engine config models moved from `engines/<engine>/config.py` to `config/generated/<engine>.py`. Realigned every stale reference: the architecture-overview file-and-package map ASCII tree (`engines/<engine>/` now shows `plugin.py` + data files; `config/generated/<engine>.py` added under the config layer) and its mermaid nodes / prose / key-concepts table; the parameter-curation mermaid node; the engine-extensibility `config-codegen` description and the SGLang worked-forecast checklist; the ci-architecture absorbed-bump guard sentence (mirrors `check_absorbed_bump.py` and the `engine-rules-check.yml` paths-filter: engine-local `rules.yaml` + `schema.discovered.json`, config model checked separately); and two schema-refresh table rows.
- **S16 bundle unification.** `config/README.md` sidecar example now uses the live `bundle_version` key (was the retired `schema_version`). A `## [Unreleased]` break-anchor callout in `CHANGELOG.md` records results-bundle format 2.0 (commit `09ec455e`, #869), the 1.0 best-effort read path, the v0.7.0 ship target, and the v0.6.0 rollback anchor.
- **S11 orchestration move.** `api/README.md` `_impl.py` row now matches the file's own Dispatch flow section (thin implementations delegating via `_to_study_config()` to `study.orchestration.orchestrate_study`; the claimed `_run()` dispatcher does not exist). `infra/README.md` DockerRunner pointer now targets `study/single.py` and `study/session.py` (`DockerSession`) instead of the retired `api/_impl.py` path.
- **Bundle ownership.** `results/README.md` now introduces `bundle.py` (`BundleWriter`/`BundleReader`, single `bundle_version` "2.0") and drops the stale "one module" and "written by the study/ and api/ layers" claims (`ManifestWriter` lives in `study/orchestration.py`).
- **Local-only path.** `energy-measurement.md` no longer points at an untracked `.product/` review file; the methodological claim now stands alone.

## Test plan

- `make docs-check` (the CI freshness gate): green ("Generated docs are up to date").
- `make docs-all` then `git status --porcelain`: shows only the 11 hand-edited files, zero generated drift.
- Grep for em/en-dashes (U+2013/U+2014) across the diff: zero occurrences.
- Grep committed docs for `engines/<engine>/config.py`, `schema_version` (sidecar), and `.product/`: no stale references remain (see the two intentionally-left notes below).

### Intentionally left (out of ruled scope)

- `CHANGELOG.md:85` (#868 entry) references `engines/<engine>/config.py` as the *old* location while documenting the S17 move itself. Correct historical reference.
- `CHANGELOG.md` `[Unreleased]` #849 entry still describes the absorbed-bump packaged copies as "config.py / rules.yaml / schema.discovered.json". This is the same drift fixed in ci-architecture.md but sits outside this PR's ruled fix list; flagged for a maintainer call.
