### PR TITLE
feat(config): derive static-kv-cache and spec-decoding capability rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@ Minor version bumps (`0.x.0`) mark milestone completions. Breaking changes can o
   `LLEM_DOCKER_SHM_SIZE`. Point it at shared storage or a large scratch disk when
   the default home lives on a small volume; the in-container target and `HF_HOME`
   are unchanged. ([#861])
+- Re-added the Speculative Decoding and Static KV Cache rows to the engine
+  capability matrix, this time derived from the mined engine surface instead of
+  hand-authored prose (both were among the rows retired in [#866]). Each cell is
+  a field-presence probe over the generated engine config: Speculative Decoding
+  is True where an engine exposes a speculative field (`prompt_lookup_num_tokens`
+  on transformers, `speculative_config` on vLLM) and False otherwise (tensorrt);
+  Static KV Cache is True where `cache_implementation` exists (transformers) and
+  False otherwise (vLLM, tensorrt). The cells now self-update on every engine bump
+  absorb and carry no hand-maintained booleans. Docs-only: no runtime, CLI, or
+  dispatch path reads these functions. ([#875])
 
 ### Changed
 
@@ -1494,3 +1504,4 @@ Origin: first measurement scaffolding (multi-GPU aggregation, FLOPs, Optimum-ben
 [#869]: https://github.com/henrycgbaker/llenergymeasure/pull/869
 [#871]: https://github.com/henrycgbaker/llenergymeasure/pull/871
 [#872]: https://github.com/henrycgbaker/llenergymeasure/pull/872
+[#875]: https://github.com/henrycgbaker/llenergymeasure/pull/875

--- a/docs/reference/engines/invalid-combos.md
+++ b/docs/reference/engines/invalid-combos.md
@@ -152,6 +152,8 @@ names the paths the engine drives back to their default.
 | BitsAndBytes (8-bit) | Yes | No | No |
 | Prefix Caching | No | Yes | No |
 | torch.compile | Yes | No | No |
+| Speculative Decoding | Yes | Yes | No |
+| Static KV Cache | Yes | No | No |
 
 **Notes:**
 - vLLM supports 4-bit via AWQ/GPTQ quantized models, not bitsandbytes

--- a/src/llenergymeasure/config/introspection.py
+++ b/src/llenergymeasure/config/introspection.py
@@ -375,6 +375,23 @@ def get_engine_capabilities() -> dict[str, dict[str, bool | str]]:
             "vllm": False,
             "tensorrt": False,
         },
+        "speculative_decoding": {
+            # Transformers exposes prompt-lookup (n-gram) speculative decoding via
+            # prompt_lookup_num_tokens; vLLM via its speculative_config sub-model.
+            # tensorrt's curated surface exposes no speculative field, so the same
+            # probe derives to False (and self-updates if a bump curates one in).
+            "transformers": "prompt_lookup_num_tokens" in transformers_fields,
+            "vllm": "speculative_config" in vllm_fields,
+            "tensorrt": "speculative_config" in tensorrt_fields,
+        },
+        "static_kv_cache": {
+            # Static KV cache is selected through the transformers cache_implementation
+            # field (cache_implementation="static"); vLLM (paged) and tensorrt expose
+            # no such selector, so the same probe derives to False for both.
+            "transformers": "cache_implementation" in transformers_fields,
+            "vllm": "cache_implementation" in vllm_fields,
+            "tensorrt": "cache_implementation" in tensorrt_fields,
+        },
     }
 
 
@@ -396,6 +413,8 @@ def get_capability_matrix_markdown() -> str:
         "bitsandbytes_8bit": "BitsAndBytes (8-bit)",
         "prefix_caching": "Prefix Caching",
         "torch_compile": "torch.compile",
+        "speculative_decoding": "Speculative Decoding",
+        "static_kv_cache": "Static KV Cache",
     }
 
     lines = [

--- a/tests/unit/config/test_config_introspection.py
+++ b/tests/unit/config/test_config_introspection.py
@@ -261,7 +261,7 @@ def test_capability_matrix_transformers_supports_tensor_parallel():
 
 
 def test_capability_matrix_reports_only_derivable_rows():
-    """Retired hand-authored rows (precision, data_parallel, ...) are no longer claimed."""
+    """Every row is field-presence-derivable; hand-authored prose rows stay retired."""
     caps = get_engine_capabilities()
     assert set(caps) == {
         "tensor_parallel",
@@ -269,7 +269,45 @@ def test_capability_matrix_reports_only_derivable_rows():
         "bitsandbytes_8bit",
         "prefix_caching",
         "torch_compile",
+        "speculative_decoding",
+        "static_kv_cache",
     }
+
+
+def test_speculative_decoding_cells_track_engine_field_presence():
+    """Each speculative_decoding cell is backed by the field it probes, not a claim."""
+    from llenergymeasure.config.introspection import _engine_params_field_names
+
+    caps = get_engine_capabilities()
+    spec = caps["speculative_decoding"]
+
+    # True cells must be backed by a concrete field in that engine's surface.
+    assert "prompt_lookup_num_tokens" in _engine_params_field_names("transformers")
+    assert spec["transformers"] is True
+    assert "speculative_config" in _engine_params_field_names("vllm")
+    assert spec["vllm"] is True
+
+    # tensorrt's curated surface exposes no speculative field, so the cell is False.
+    assert "speculative_config" not in _engine_params_field_names("tensorrt")
+    assert spec["tensorrt"] is False
+
+
+def test_static_kv_cache_cells_track_engine_field_presence():
+    """static_kv_cache is True only where cache_implementation exists in the surface."""
+    from llenergymeasure.config.introspection import _engine_params_field_names
+
+    caps = get_engine_capabilities()
+    kv = caps["static_kv_cache"]
+
+    # transformers exposes cache_implementation (cache_implementation="static").
+    assert "cache_implementation" in _engine_params_field_names("transformers")
+    assert kv["transformers"] is True
+
+    # vLLM (paged) and tensorrt expose no cache_implementation field, so both False.
+    assert "cache_implementation" not in _engine_params_field_names("vllm")
+    assert kv["vllm"] is False
+    assert "cache_implementation" not in _engine_params_field_names("tensorrt")
+    assert kv["tensorrt"] is False
 
 
 def test_streaming_constraints_removed():


### PR DESCRIPTION
## Summary

Re-adds the two capability-matrix rows that PR #866 flagged as honestly
re-addable (Speculative Decoding, Static KV Cache). Both are now DERIVED from
field presence in each engine's generated config surface via the existing
`_engine_params_field_names` helper, i.e. the same mechanism the surviving
derived rows already use. Every cell is a `"<field>" in <engine>_fields` probe,
so there are no hand-maintained booleans and the cells self-update on every
engine bump absorb. No new machinery.

Per-cell derivation with field evidence:

- **Speculative Decoding** (result: Yes / Yes / No)
  - transformers: `"prompt_lookup_num_tokens" in transformers_fields` -> True.
    Field at `config/generated/transformers.py:29` (prompt-lookup / n-gram
    assisted decoding).
  - vLLM: `"speculative_config" in vllm_fields` -> True. Field at
    `config/generated/vllm.py:174` (nested `SpeculativeConfig` sub-model).
  - tensorrt: `"speculative_config" in tensorrt_fields` -> False. Not in the
    curated generated config (`config/generated/tensorrt.py`); it exists only in
    `engines/tensorrt/schema.discovered.json`, so the cell derives to False and
    self-updates if a future absorb curates the field into the generated config.

- **Static KV Cache** (result: Yes / No / No)
  - transformers: `"cache_implementation" in transformers_fields` -> True. Field
    at `config/generated/transformers.py:24` (`cache_implementation="static"`).
  - vLLM: `"cache_implementation" in vllm_fields` -> False. vLLM is paged and
    exposes no such selector.
  - tensorrt: `"cache_implementation" in tensorrt_fields` -> False. No such
    field. `kv_cache_config` is the paged KV-cache config object, not a
    static-cache selector, so it is deliberately NOT used as the predicate
    (probing it would falsely assert the capability).

The resulting matrix values are identical to the claims PR #866 retired
(Speculative Decoding = Yes/Yes/No, Static KV Cache = Yes/No/No), but they are
now backed by concrete fields rather than hand-authored prose.

No cell was dropped as ambiguous: every True cell is backed by a named field
that concretely encodes the capability, and every False cell is a field-absence
probe over the same surface.

`docs/reference/engines/invalid-combos.md` is regenerated accordingly, and the
CHANGELOG gains an entry under `## [Unreleased]` `### Added`. Docs-only: no
runtime, CLI, or dispatch path reads these introspection functions.

## Test plan

- New `test_speculative_decoding_cells_track_engine_field_presence` and
  `test_static_kv_cache_cells_track_engine_field_presence`: each asserts every
  True cell is backed by the named field's presence in the engine surface and
  every False cell by its absence.
- Updated `test_capability_matrix_reports_only_derivable_rows` to include the two
  re-added keys (the retired hand-authored rows stay retired).
- `pytest tests/unit/config/test_config_introspection.py`: 28 passed.
- Full host suite `pytest -m "not gpu and not docker and not slow"`: 3256 passed,
  37 skipped.
- `make lint` (import-linter 5/5, zero new ignores), `make typecheck` (no issues
  in 343 files), `make docs-check` green, `git status` clean after docs regen.
