### PR TITLE
fix(config): sweep retired runner values from examples, CI env, and scripts

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -338,10 +338,10 @@ jobs:
       # (keeps CUDA and NVML indices consistent inside the container). Adjust
       # this value if the free-device layout on the runner changes.
       LLEM_DOCKER_GPUS: device=2
-      # Force docker dispatch for the upstream-image engines (they auto-elevate
+      # Force container dispatch for the upstream-image engines (they auto-elevate
       # anyway, but be explicit for a single-experiment run).
-      LLEM_RUNNER_VLLM: docker
-      LLEM_RUNNER_TENSORRT: docker
+      LLEM_RUNNER_VLLM: container
+      LLEM_RUNNER_TENSORRT: container
     steps:
       - name: Clean workspace (fix root-owned files from Docker)
         run: |

--- a/configs/ci/smoke-tensorrt-pytorch.yaml
+++ b/configs/ci/smoke-tensorrt-pytorch.yaml
@@ -2,7 +2,7 @@
 # inference through the PyTorch backend (tensorrt_llm.LLM class dispatch).
 #
 # Driven by .github/workflows/gpu-ci.yml (engine-smoke matrix). The workflow
-# sets LLEM_RUNNER_TENSORRT=docker and LLEM_IMAGE_TENSORRT=<pinned NGC image>
+# sets LLEM_RUNNER_TENSORRT=container and LLEM_IMAGE_TENSORRT=<pinned NGC image>
 # (resolved from engine_versions/tensorrt/current.yaml), and LLEM_DOCKER_GPUS
 # pins to a free device on the shared box.
 #

--- a/configs/ci/smoke-tensorrt-trt.yaml
+++ b/configs/ci/smoke-tensorrt-trt.yaml
@@ -3,7 +3,7 @@
 # dispatch + trtllm-build engine compile / build-cache path).
 #
 # Driven by .github/workflows/gpu-ci.yml (engine-smoke matrix). The workflow
-# sets LLEM_RUNNER_TENSORRT=docker, LLEM_IMAGE_TENSORRT=<pinned NGC image>
+# sets LLEM_RUNNER_TENSORRT=container, LLEM_IMAGE_TENSORRT=<pinned NGC image>
 # (resolved from engine_versions/tensorrt/current.yaml),
 # LLEM_TRT_BUILD_CACHE_ENABLED=1 (so the on-disk build cache warm on the runner
 # is used), and LLEM_DOCKER_GPUS pins to a free device on the shared box.

--- a/configs/ci/smoke-vllm.yaml
+++ b/configs/ci/smoke-vllm.yaml
@@ -2,7 +2,7 @@
 # inference through the real docker-dispatch plugin path.
 #
 # Driven by .github/workflows/gpu-ci.yml (engine-smoke matrix). The workflow
-# sets LLEM_RUNNER_VLLM=docker and LLEM_IMAGE_VLLM=<pinned upstream image>
+# sets LLEM_RUNNER_VLLM=container and LLEM_IMAGE_VLLM=<pinned upstream image>
 # (resolved from engine_versions/vllm/current.yaml) so dispatch uses the
 # pinned image, and LLEM_DOCKER_GPUS pins to a free device on the shared box.
 #

--- a/configs/example-study-full.yaml
+++ b/configs/example-study-full.yaml
@@ -17,14 +17,14 @@
 
 study_name: full-suite-all-engines
 
-# --- Runners: where each engine runs (local process or Docker container) ---
-# Pin an engine to `local` to run it in-process (the package must be importable
+# --- Runners: where each engine runs (host process or container) ---
+# Pin an engine to `process` to run it in-process (the package must be importable
 # on the host); leave it on auto-detection and a multi-engine study elevates it
-# to Docker for isolation. An explicit pin is always honoured as-is.
+# to a container for isolation. An explicit pin is always honoured as-is.
 runners:
-  transformers: docker
-  vllm: docker
-  tensorrt: docker
+  transformers: container
+  vllm: container
+  tensorrt: container
 
 # --- Execution controls (study-level, non-sweepable) ---
 study_execution:

--- a/configs/tutorials/tutorial-multi-engine.yaml
+++ b/configs/tutorials/tutorial-multi-engine.yaml
@@ -17,9 +17,9 @@
 study_name: tutorial-multi-engine
 
 runners:
-  transformers: docker
-  vllm: docker
-  tensorrt: docker
+  transformers: container
+  vllm: container
+  tensorrt: container
 
 study_execution:
   n_cycles: 1

--- a/src/llenergymeasure/README.md
+++ b/src/llenergymeasure/README.md
@@ -131,7 +131,7 @@ Security utilities:
 
 ### `infra/` (Layer 3)
 - `docker_runner.py` - Docker dispatch (DockerRunner)
-- `runner_resolution.py` - local vs Docker selection
+- `runner_resolution.py` - process vs container runner selection
 - `image_registry.py` - Docker image registry and version tagging
 - `docker_preflight.py` - Docker-level pre-flight checks
 

--- a/tests/fixtures/killpg_vllm_study.yaml
+++ b/tests/fixtures/killpg_vllm_study.yaml
@@ -2,7 +2,7 @@
 # Uses facebook/opt-125m (smallest vLLM-compatible model) for fast loading.
 # High prompt count ensures the experiment won't finish before we kill it.
 # Warmup and baseline disabled to reduce pre-experiment wait time.
-# IMPORTANT: runner forced to local via LLEM_RUNNER_VLLM=local env var in script.
+# IMPORTANT: runner forced to process via LLEM_RUNNER_VLLM=process env var in script.
 
 name: killpg-test
 

--- a/tests/integration/killpg_verify.sh
+++ b/tests/integration/killpg_verify.sh
@@ -25,8 +25,8 @@ MEMORY_RETURN_TIMEOUT=30
 # Delta tolerance in MB: current <= baseline + tolerance counts as "returned"
 MEMORY_TOLERANCE_MB=100
 
-# Force local runner - inside a container, we already have CUDA.
-export LLEM_RUNNER_VLLM=local
+# Force process runner - inside a container, we already have CUDA.
+export LLEM_RUNNER_VLLM=process
 
 # Use llem directly if available (container), else uv run (host)
 if command -v llem &>/dev/null; then

--- a/tests/integration/sigint_verify.sh
+++ b/tests/integration/sigint_verify.sh
@@ -12,8 +12,8 @@ RESULTS_DIR="results"
 # Seconds to wait for manifest to appear before sending SIGINT
 POLL_TIMEOUT=120
 
-# Force local runner - inside a container, we already have CUDA.
-export LLEM_RUNNER_PYTORCH=local
+# Force process runner - inside a container, we already have CUDA.
+export LLEM_RUNNER_TRANSFORMERS=process
 
 # Use llem directly if available (container), else uv run (host)
 if command -v llem &>/dev/null; then

--- a/tests/unit/config/test_example_configs.py
+++ b/tests/unit/config/test_example_configs.py
@@ -35,6 +35,23 @@ STUDY_CONFIGS = [
 ]
 
 
+def test_example_config_runner_values_parse() -> None:
+    """Every ``runners:`` pin in a shipped config passes the canonical parse edge.
+
+    ``load_study`` alone never reaches ``parse_runner_value`` (runner resolution
+    happens at preflight), so a retired runner value in a shipped example parses
+    green here yet errors for every user who actually runs it - which is exactly
+    how the v0.7 ``local``/``docker`` retirement shipped stale example configs.
+    Route each value through the parse edge so stale vocabulary fails loudly.
+    """
+    from llenergymeasure.infra.image_registry import parse_runner_value
+
+    for config_path in STUDY_CONFIGS:
+        raw = yaml.safe_load(config_path.read_text())
+        for value in (raw.get("runners") or {}).values():
+            parse_runner_value(value)  # raises ValueError on retired vocabulary
+
+
 def _field_submodels(annotation: object) -> list[type[BaseModel]]:
     """Return BaseModel subclasses referenced by a field annotation.
 


### PR DESCRIPTION
## Summary

The Wave 0 boundary review found that the v0.7 runner-vocabulary clean break (#880, `local`/`docker` -> `process`/`container`) was applied at every parser/schema edge but never swept through the NON-CODE consumers of those values - which now hard-fail with the migration error. This PR sweeps them:

- **GPU CI env (was breaking the engine-smoke jobs):** `.github/workflows/gpu-ci.yml` job-level `LLEM_RUNNER_VLLM`/`LLEM_RUNNER_TENSORRT` `docker` -> `container` (+ the three `configs/ci/smoke-*.yaml` comments describing them).
- **Flagship example configs (errored at preflight for any user running them):** `configs/example-study-full.yaml` and `configs/tutorials/tutorial-multi-engine.yaml` `runners:` pins `docker` -> `container`, plus the stale comment block still instructing "pin to `local`".
- **Integration scripts:** `tests/integration/killpg_verify.sh` `LLEM_RUNNER_VLLM=local` -> `process`; `tests/integration/sigint_verify.sh` `LLEM_RUNNER_PYTORCH=local` -> `LLEM_RUNNER_TRANSFORMERS=process` (the `PYTORCH` engine token was doubly stale - the var was silently ignored; the fixture's engine is transformers, so the pin is now real and matches the script's stated intent).
- **Prose:** `tests/fixtures/killpg_vllm_study.yaml` comment, `src/llenergymeasure/README.md` module-table line.

**Coverage gap closed:** `tests/unit/config/test_example_configs.py` gains `test_example_config_runner_values_parse` - every `runners:` value in a shipped config is routed through `parse_runner_value` (the canonical parse edge), so a future vocabulary change cannot ship stale examples green again (`load_study` alone never reaches runner resolution, which is how this one slipped).

## Test plan

- New tripwire test passes (and fails on pre-fix configs by construction).
- `uv run pytest tests/unit/config tests/unit/infra -q`: 654 passed, 1 skipped; `make lint` clean.
- This PR's own GPU CI run exercises the fixed env vars end-to-end (engine-smoke matrix consumes `LLEM_RUNNER_*`).

## Doc audit

- Example-config comment blocks and `src/llenergymeasure/README.md` updated in this PR; docs pages were already swept by #880 (verified: how-to/tutorial pages use `container`/`process`).