### PR TITLE
feat(server): ServerSession type with level driver and abort handling

### DIFF
--- a/src/llenergymeasure/domain/progress.py
+++ b/src/llenergymeasure/domain/progress.py
@@ -295,6 +295,11 @@ STEP_MEASURE = "measure"
 STEP_FLOPS = "flops"
 STEP_SAVE = "save"
 
+# Server-mode-only steps (online-serving measurement): launch the engine server
+# and drive it to readiness before the measured windows open.
+STEP_SERVER_LAUNCH = "server_launch"
+STEP_SERVER_READY = "server_ready"
+
 # -------------------------------------------------------------------------
 # Step registry -- the single source of truth for the progress vocabulary.
 #
@@ -310,12 +315,21 @@ STEP_SAVE = "save"
 # run emits. A step declares which surfaces it belongs to and where it sits in
 # each. Future modes (server mode) add their own surface here without touching
 # any consumer.
-SURFACE_LOCAL = "local"  # direct harness run, no container
-SURFACE_DOCKER = "docker"  # container run, baseline measured in-container (fresh)
-SURFACE_DOCKER_HOST_BASELINE = "docker_host_baseline"  # baseline measured on host first
+#: Surface identifiers, aligned with the SM2 runner-mode vocabulary
+#: (process / container, formerly local / docker). Not serialized - internal
+#: step-list keys only - so the rename rides freely (banked from SM2).
+SURFACE_PROCESS = "process"  # direct host harness run, no container
+SURFACE_CONTAINER = "container"  # container run, baseline measured in-container (fresh)
+SURFACE_CONTAINER_HOST_BASELINE = "container_host_baseline"  # baseline measured on host first
+SURFACE_SERVER = "server"  # online-serving measurement (host-driven traffic + sampling)
 
-_ALL_SURFACES = frozenset({SURFACE_LOCAL, SURFACE_DOCKER, SURFACE_DOCKER_HOST_BASELINE})
-_DOCKER_SURFACES = frozenset({SURFACE_DOCKER, SURFACE_DOCKER_HOST_BASELINE})
+#: The offline surfaces (the batch-measurement modes). Setup + offline-only
+#: measurement steps belong here; ``_ALL_SURFACES`` keeps its name and membership
+#: so every existing offline StepSpec is untouched by the rename.
+_ALL_SURFACES = frozenset({SURFACE_PROCESS, SURFACE_CONTAINER, SURFACE_CONTAINER_HOST_BASELINE})
+_DOCKER_SURFACES = frozenset({SURFACE_CONTAINER, SURFACE_CONTAINER_HOST_BASELINE})
+#: The measurement-tail steps every mode shares (offline surfaces + server).
+_MEASUREMENT_SHARED = _ALL_SURFACES | frozenset({SURFACE_SERVER})
 
 
 @dataclass(frozen=True)
@@ -364,16 +378,20 @@ _STEP_SPECS: list[StepSpec] = [
         PHASE_MEASUREMENT,
         65,
         _ALL_SURFACES,
-        order_overrides={SURFACE_DOCKER_HOST_BASELINE: 40},
+        order_overrides={SURFACE_CONTAINER_HOST_BASELINE: 40},
     ),
     StepSpec(STEP_MODEL, "Loading", PHASE_MEASUREMENT, 70, _ALL_SURFACES),
     StepSpec(STEP_PROMPTS, "Loading", PHASE_MEASUREMENT, 80, _ALL_SURFACES),
-    StepSpec(STEP_WARMUP, "Warming up", PHASE_MEASUREMENT, 90, _ALL_SURFACES),
+    # Server-mode setup: launch the engine server and drive it to readiness.
+    StepSpec(STEP_SERVER_LAUNCH, "Launching", PHASE_SETUP, 45, frozenset({SURFACE_SERVER})),
+    StepSpec(STEP_SERVER_READY, "Awaiting", PHASE_SETUP, 55, frozenset({SURFACE_SERVER})),
+    # Warmup / measure / save are shared by offline and server surfaces.
+    StepSpec(STEP_WARMUP, "Warming up", PHASE_MEASUREMENT, 90, _MEASUREMENT_SHARED),
     StepSpec(STEP_THERMAL_FLOOR, "Waiting", PHASE_MEASUREMENT, 100, _ALL_SURFACES),
     StepSpec(STEP_ENERGY_SELECT, "Selecting", PHASE_MEASUREMENT, 110, _ALL_SURFACES),
-    StepSpec(STEP_MEASURE, "Measuring", PHASE_MEASUREMENT, 120, _ALL_SURFACES),
+    StepSpec(STEP_MEASURE, "Measuring", PHASE_MEASUREMENT, 120, _MEASUREMENT_SHARED),
     StepSpec(STEP_FLOPS, "Estimating", PHASE_MEASUREMENT, 130, _ALL_SURFACES),
-    StepSpec(STEP_SAVE, "Saving", PHASE_MEASUREMENT, 140, _ALL_SURFACES),
+    StepSpec(STEP_SAVE, "Saving", PHASE_MEASUREMENT, 140, _MEASUREMENT_SHARED),
 ]
 
 # Derived vocabulary maps. Mutated in place by ``register_step`` so importers
@@ -434,13 +452,22 @@ def docker_steps(*, images_prepared: bool, host_baseline: bool) -> list[str]:
     by the ``docker_host_baseline`` surface's baseline ``order`` override. The
     measurement-phase tail is identical in both.
     """
-    surface = SURFACE_DOCKER_HOST_BASELINE if host_baseline else SURFACE_DOCKER
+    surface = SURFACE_CONTAINER_HOST_BASELINE if host_baseline else SURFACE_CONTAINER
     exclude = _IMAGE_PREP_STEPS if images_prepared else frozenset()
     return steps_for_surface(surface, exclude=exclude)
 
 
-# Local path: no Docker steps, direct harness measurement.
-STEPS_LOCAL: list[str] = steps_for_surface(SURFACE_LOCAL)
+def server_steps() -> list[str]:
+    """Ordered step list for a server-mode (online-serving) experiment.
+
+    Launch -> await readiness -> warm up -> measure windows -> save. Derived from
+    the ``SURFACE_SERVER`` membership like every other surface, so adding a server
+    step is one registry entry (no consumer edits)."""
+    return steps_for_surface(SURFACE_SERVER)
+
+
+# Process path: no container steps, direct host harness measurement.
+STEPS_LOCAL: list[str] = steps_for_surface(SURFACE_PROCESS)
 
 
 # -------------------------------------------------------------------------

--- a/src/llenergymeasure/harness/traffic.py
+++ b/src/llenergymeasure/harness/traffic.py
@@ -402,13 +402,17 @@ class HttpxTransport:
 
     Lazily imports ``httpx`` (the ``server`` extra) and holds an async client
     bound to the engine server's ``base_url``. SM5 ships the seam and the
-    lazy-import guard; the per-engine request encoding and endpoint path are
-    wired by the engine-serving slice, which sets ``base_url`` from the launched
-    server. Call :meth:`aclose` to release the connection pool.
+    lazy-import guard; the server session (SM9) sets ``base_url`` from the
+    launched server and ``path`` to the engine's OpenAI-compatible serving
+    endpoint (e.g. ``/v1/completions``), with each request's ``payload`` the
+    JSON body. Call :meth:`aclose` to release the connection pool.
     """
 
     base_url: str
     timeout: float = 60.0
+    #: Serving endpoint each request is POSTed to. Defaults to root; the server
+    #: session sets it to the engine's OpenAI completions path.
+    path: str = "/"
     _client: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -416,7 +420,7 @@ class HttpxTransport:
         self._client = httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout)
 
     async def __call__(self, request: RequestShape) -> Any:
-        response = await self._client.post("/", json=request.payload)
+        response = await self._client.post(self.path, json=request.payload)
         response.raise_for_status()
         return response.json()
 

--- a/src/llenergymeasure/study/server_session.py
+++ b/src/llenergymeasure/study/server_session.py
@@ -57,7 +57,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from llenergymeasure.harness.server_warmup import (
@@ -158,6 +158,11 @@ class ServerLevelResult:
     when the level failed before it could run (aborted / warmup-failed).
     ``invalid_reason`` names the failure site when the level did not complete
     cleanly (never dropped - recorded invalid-with-reason, contract 3).
+    ``completed_cores`` holds the RAW measured cores of a failed level's
+    cleanly-closed windows (O7.4): full per-window bookkeeping was lost with the
+    abort, so no synthetic ``ServerWindowResult`` is built, but the measured GPU
+    energy is preserved and counted in the session total. SM10 decides their
+    bundle fate (drain-fields-null semantics).
     """
 
     level_index: int
@@ -167,6 +172,7 @@ class ServerLevelResult:
     warmup: ServerWarmupResult | None
     invalid_reason: str | None
     aborted_window_index: int | None = None
+    completed_cores: list[MeasuredWindowCore | None] = field(default_factory=list)
 
     @property
     def valid(self) -> bool:
@@ -399,9 +405,23 @@ async def _drive_levels(
                 aborted = getattr(exc, ABORTED_LEVEL_ATTR, None)
                 if aborted is not None:
                     failures_out.append(_LevelFailure.from_aborted(aborted))
+                else:
+                    # No AbortedLevel: the interrupt landed before any window opened
+                    # (e.g. mid-warmup or mid-ramp). Record a traceable partial so
+                    # the level is not indistinguishable from nothing-attempted.
+                    failures_out.append(
+                        _LevelFailure(
+                            level_index=level_index,
+                            reason="interrupted (warmup)",
+                            aborted_window_index=None,
+                            completed_cores=[],
+                        )
+                    )
                 raise
-            except BaseException as exc:
-                # Any other level failure is recorded and the session continues.
+            except Exception as exc:
+                # Any other level failure is recorded and the session continues
+                # (SystemExit / GeneratorExit are BaseException-not-Exception and
+                # propagate; CancelledError / KeyboardInterrupt are handled above).
                 # An AbortedLevel (window / close / drain failure) carries the
                 # cleanly-closed cores to preserve; a pure ramp-phase failure has
                 # nothing to preserve but still failed the level - record it too.
@@ -636,9 +656,12 @@ class ServerSession:
             )
         for failure in failures:
             warmup = warmup_by_level.get(failure.level_index)
-            # A failed level keeps its cleanly-closed cores (O7.4) but not full
-            # per-window bookkeeping (the traffic report is gone once the issuer
-            # task was cancelled); SM10 owns partial-window persistence.
+            # A failed level keeps its cleanly-closed cores RAW (O7.4): full
+            # per-window bookkeeping was lost with the abort (the traffic report is
+            # gone once the issuer task was cancelled), so no ServerWindowResult is
+            # built, but the measured cores are preserved on the level result and
+            # their energy still counts toward the session total. SM10 owns their
+            # bundle fate (drain-fields-null).
             by_level[failure.level_index] = ServerLevelResult(
                 level_index=failure.level_index,
                 spec=None,
@@ -647,6 +670,7 @@ class ServerSession:
                 warmup=warmup,
                 invalid_reason=failure.reason,
                 aborted_window_index=failure.aborted_window_index,
+                completed_cores=list(failure.completed_cores),
             )
         return [by_level[i] for i in sorted(by_level)]
 
@@ -887,12 +911,42 @@ def _is_server_capable(engine: Any) -> bool:
     )
 
 
+def _core_energy_j(core: MeasuredWindowCore | None) -> float | None:
+    """Raw window energy (J) from a measured core's power series (windowing reuse).
+
+    Mirrors the window manager's full-span energy statistic (clean the samples,
+    trapezoidally integrate the summed-across-GPU power series), so a failed
+    level's preserved-but-unbookkept cores still contribute their measured GPU
+    energy to the session total. Reuses windowing.py's cleaner and the nvml
+    integrator - the same REUSE BINDING the window manager follows - so no
+    integration math is duplicated.
+    """
+    from llenergymeasure.energy.nvml import integrate_power_samples
+    from llenergymeasure.harness.windowing import _clean_samples
+
+    samples = list(getattr(core, "timeseries_samples", []) or []) if core is not None else []
+    if len(samples) < 2:
+        return None
+    cleaned = _clean_samples(samples)
+    if len(cleaned) < 2:
+        return None
+    return sum(integrate_power_samples(cleaned).values())
+
+
 def _sum_window_energy(levels: list[ServerLevelResult]) -> float | None:
     total = 0.0
     seen = False
     for level in levels:
         for window in level.windows:
             energy = window.window.window_energy_j
+            if energy is not None:
+                total += energy
+                seen = True
+        # A failed level's preserved raw cores (no ServerWindowResult) still carry
+        # measured GPU energy: fold it in so the session total does not silently
+        # drop it (contract 3 / O7.4).
+        for core in level.completed_cores:
+            energy = _core_energy_j(core)
             if energy is not None:
                 total += energy
                 seen = True

--- a/src/llenergymeasure/study/server_session.py
+++ b/src/llenergymeasure/study/server_session.py
@@ -1,0 +1,914 @@
+"""Server-mode measurement session - the C1/C3 sibling of the offline sessions.
+
+A :class:`ServerSession` is one online-serving measurement session, the
+one-dispatch:N-results consumer the F6 ``ExperimentSession`` seam was built for
+(constraint C3). Its context-manager lifetime mirrors the offline
+``SubprocessSession`` / ``DockerSession``:
+
+- ``__enter__`` LAUNCHES the engine server (SM6 ``ServerCapable.launch``) and
+  drives it to READY (``await_ready`` with a real probe request whose SHAPE is
+  drawn from the measured traffic distribution, SM8 ``build_probe_request``),
+  then marks the experiment running. A failure DURING acquisition releases the
+  partially-launched server and re-raises, so a failed launch never leaks.
+- ``run()`` drives the SM7 :class:`WindowManager` over the level(s) the session
+  was built for, per level: the SM8 ``ServerWarmup`` hook runs once, the ramp is
+  excluded prospectively, ``windows_per_level`` contiguous measured windows
+  produce one result each, and the traffic drains for latency. It returns a
+  :class:`ServerSessionResult` carrying the N window results (one per window)
+  with each level's warmup outcome stamped in - the "N results over one lifetime"
+  shape (C3). A rate sweep maps to multiple levels (C4); v0.7 feeds one level per
+  dispatch (session grouping of a rate sweep is SM10, not foreclosed here).
+- ``__exit__`` SHUTS the server down (idempotent, leak-free) and runs the
+  drain-finalize, exactly once on the normal, SIGINT, and exception paths alike
+  (the F6 session-hardening invariant).
+
+The measurement loop runs IN-PROCESS on the host (the traffic issuer + the
+host-side NVML energy/thermal sampling); only the engine SERVER runs
+out-of-process (a sibling container or a host subprocess). No serialized config
+crosses a process boundary for the measurement, so the R7W resolved-warmup
+side-channel (an ``ExperimentConfig`` PrivateAttr that JSON would drop) is read
+directly in-process via ``resolved_server_warmup()`` - the SM9/SM12 serialization
+contract holds structurally, and the server itself never consumes the resolved
+warmup (warmup traffic is host-driven).
+
+Contract notes satisfied here (banked from SM7/SM8/R7W delivery):
+
+1. ISSUANCE HORIZON: the level's traffic source issues across the whole level -
+   ``ramp_exclusion + windows_per_level * window_seconds`` - as one continuous
+   run (the manager owns window timing and never resizes the schedule).
+2. TOKEN RECEIPTS: client-side counts flow through the SM7 ``TokenReceiptFn``
+   seam so the energy denominator and the stability gate receive counts. v0.7
+   wires the INTERIM count from what the transport exposes (the server-reported
+   ``usage.completion_tokens``); canonical client-side tokenisation +
+   ``requests.parquet`` are SM11. The limitation is stamped loudly in the result
+   (``token_counting``) and the module constant below.
+3. ABORTED LEVEL: a level failure carries its partial state on the propagating
+   exception as ``llem_aborted_level``; the driver catches it at the DIRECT
+   ``run_level`` await site (an outer Task boundary would substitute a fresh
+   CancelledError and lose it). A ``WarmupTrafficError`` ABORTS the session (the
+   transport is dead, dooming later levels); any other level failure is recorded
+   invalid-with-reason and the session continues to the next level.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from llenergymeasure.harness.server_warmup import (
+    ServerWarmup,
+    ServerWarmupResult,
+    WarmupTrafficError,
+    build_probe_request,
+    describe_server_warmup_protocol,
+)
+from llenergymeasure.harness.traffic import OpenLoopPoissonSource, RequestShape
+from llenergymeasure.harness.window_manager import (
+    ABORTED_LEVEL_ATTR,
+    AbortedLevel,
+    BracketEnergySink,
+    LevelOutcome,
+    LevelPlan,
+    LevelValidation,
+    WarmupContext,
+    WindowManager,
+    WindowRecord,
+    WindowSpec,
+)
+
+if TYPE_CHECKING:
+    from llenergymeasure.config.models import ExperimentConfig, TrafficConfig
+    from llenergymeasure.config.runner_spec import RunnerSpec
+    from llenergymeasure.engines.protocol import ServerCapable
+    from llenergymeasure.harness.bracket import MeasuredWindowCore
+    from llenergymeasure.harness.traffic import RequestRecord, ShapeSource, TrafficSource, Transport
+    from llenergymeasure.infra.server_lifecycle import ServerHandle, ServerPlacement
+    from llenergymeasure.study.runner import StudyRunner
+
+logger = logging.getLogger(__name__)
+
+#: The OpenAI-compatible completions endpoint every v0.7 server engine exposes.
+#: vLLM (``/v1/completions``) and TRT-LLM (``/v1/completions``) agree, and
+#: transformers is E5-gated out of server mode, so a session-layer constant is
+#: the minimal faithful encoding; a future non-OpenAI engine would promote this
+#: to a ``ServerCapable`` member (flagged).
+SERVING_COMPLETIONS_PATH = "/v1/completions"
+
+#: Loud provenance stamp for the INTERIM v0.7 token denominator: client-side
+#: canonical counting + requests.parquet are SM11 (O8). Until then the energy
+#: denominator and stability gate consume the SERVER-REPORTED completion-token
+#: count (auxiliary per O8), which the driver reads off each response.
+TOKEN_COUNTING_SERVER_REPORTED = (
+    "server_reported_usage_interim: the J/token denominator and stability gate "
+    "consume server-reported completion-token counts (usage.completion_tokens), "
+    "an INTERIM stand-in for the SM11 client-side canonical count. Treat J/token "
+    "as provisional until SM11 lands client-side tokenisation + requests.parquet."
+)
+
+#: Interrupt-watcher poll cadence (seconds): how promptly a mid-session SIGINT
+#: (which the study runner's handler records on its interrupt event) is noticed
+#: and cancels the driving task.
+_INTERRUPT_POLL_INTERVAL_S = 0.2
+
+__all__ = [
+    "SERVING_COMPLETIONS_PATH",
+    "TOKEN_COUNTING_SERVER_REPORTED",
+    "ServerLevelResult",
+    "ServerSession",
+    "ServerSessionError",
+    "ServerSessionResult",
+    "ServerWindowResult",
+    "server_reported_token_receipts",
+]
+
+
+# ---------------------------------------------------------------------------
+# Result types (the session's product - the N window results + provenance).
+# SM10 persists these as per-window bundles; here they are the in-memory shape.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ServerWindowResult:
+    """One measured window's result, with the level's warmup provenance stamped in.
+
+    The per-window unit SM10 turns into one bundle. ``warmup`` /
+    ``pre_window_protocol`` are the D6 divergence label (SM12/SM14 render the
+    offline-vs-server pre-window difference); they are identical across a level's
+    windows (one warmup per level) but stamped per window so the persistence layer
+    (which never learns sessions exist) has them locally.
+    """
+
+    level_index: int
+    window: WindowRecord
+    warmup: ServerWarmupResult | None
+    pre_window_protocol: str
+
+
+@dataclass
+class ServerLevelResult:
+    """One rate level's product: its windows + steady-state verdict + warmup outcome.
+
+    ``validation`` is the SM7 window-to-window J/token gate verdict, or ``None``
+    when the level failed before it could run (aborted / warmup-failed).
+    ``invalid_reason`` names the failure site when the level did not complete
+    cleanly (never dropped - recorded invalid-with-reason, contract 3).
+    """
+
+    level_index: int
+    spec: WindowSpec | None
+    windows: list[ServerWindowResult]
+    validation: LevelValidation | None
+    warmup: ServerWarmupResult | None
+    invalid_reason: str | None
+    aborted_window_index: int | None = None
+
+    @property
+    def valid(self) -> bool:
+        return self.invalid_reason is None and self.validation is not None and self.validation.valid
+
+
+@dataclass
+class ServerSessionResult:
+    """One server session's product: the N window results over one server lifetime.
+
+    Not an ``ExperimentResult`` (offline shape) - server metrics derivation is
+    SM12 and per-window persistence is SM10 - so this rides the runner return seam
+    as its own type. ``valid`` is True iff at least one level passed its stability
+    gate. ``token_counting`` carries the loud SM11-interim limitation stamp.
+    """
+
+    engine: str
+    config_hash: str
+    cycle: int
+    index: int
+    serving_mode: str
+    levels: list[ServerLevelResult]
+    token_counting: str
+    total_window_energy_j: float | None
+    elapsed_s: float
+    aborted: bool
+    abort_reason: str | None
+
+    @property
+    def valid(self) -> bool:
+        return any(level.valid for level in self.levels)
+
+    @property
+    def window_count(self) -> int:
+        return sum(len(level.windows) for level in self.levels)
+
+
+# ---------------------------------------------------------------------------
+# Interim token-receipt seam wiring (contract 2). Reads the SERVER-REPORTED
+# completion-token count off the transport's captured response and stamps every
+# token at the request's completion time (E2's completion-timestamp attribution,
+# the request-granular TokenReceiptFn form SM7 documents).
+# ---------------------------------------------------------------------------
+
+
+def server_reported_token_receipts(record: RequestRecord) -> Sequence[float]:
+    """Return a request's output-token receipt timestamps (interim, server-reported).
+
+    All of a request's ``usage.completion_tokens`` tokens are stamped at its
+    ``completed_at`` (request-granular attribution = E2's completion-timestamp
+    rule). Returns ``()`` when the request never completed, raised, or the
+    response carried no usable ``usage.completion_tokens`` - so an unformable
+    denominator degrades to the gate's invalid-with-reason path rather than a lie.
+    """
+    completed_at = record.completed_at
+    result = record.result
+    if completed_at is None or record.error is not None or not isinstance(result, dict):
+        return ()
+    usage = result.get("usage")
+    if not isinstance(usage, dict):
+        return ()
+    n = usage.get("completion_tokens")
+    if not isinstance(n, int) or isinstance(n, bool) or n <= 0:
+        return ()
+    return (completed_at,) * n
+
+
+# ---------------------------------------------------------------------------
+# Request-shape source: OpenAI completions payloads drawn from the config's
+# dataset prompts (SM11 refines the encoding; this is the minimal faithful shape
+# so warmup + measurement + probe all drive the path they measure).
+# ---------------------------------------------------------------------------
+
+
+class _CompletionsShapeSource:
+    """Maps a request index to an OpenAI-completions request shape.
+
+    Cycles through the dataset prompts by index so the measured/warmup traffic and
+    the readiness probe carry representative bodies. ``temperature=0`` keeps the
+    request deterministic; ``max_tokens`` comes from the task's output budget.
+    """
+
+    def __init__(self, prompts: Sequence[str], *, model: str, max_tokens: int) -> None:
+        # A non-empty prompt list is guaranteed by the caller (load_prompts).
+        self._prompts = list(prompts)
+        self._model = model
+        self._max_tokens = max_tokens
+
+    def __call__(self, index: int) -> RequestShape:
+        prompt = self._prompts[index % len(self._prompts)] if self._prompts else "ready?"
+        payload = {
+            "model": self._model,
+            "prompt": prompt,
+            "max_tokens": self._max_tokens,
+            "temperature": 0.0,
+        }
+        return RequestShape(index=index, payload=payload)
+
+
+def _level_traffic_source(
+    base: TrafficConfig,
+    *,
+    rate: float,
+    arrival: str,
+    horizon_seconds: float,
+    shape_source: ShapeSource,
+) -> TrafficSource:
+    """Build an open-loop source whose schedule covers ``horizon_seconds`` (contract 1).
+
+    The schedule must span the WHOLE level (ramp + every measured window) as one
+    continuous run, so the horizon-sized ``window_seconds`` is projected onto a
+    copy of the level's traffic config (carrying its concurrency cap, burstiness,
+    and seed). The window manager owns per-window timing; this only sizes the
+    issuance schedule.
+    """
+    level_config = base.model_copy(
+        update={
+            "rate": rate,
+            "arrival": arrival,
+            "window_seconds": horizon_seconds,
+            "window_requests": None,
+        }
+    )
+    return OpenLoopPoissonSource(level_config, seed=base.seed, shape_source=shape_source)
+
+
+# ---------------------------------------------------------------------------
+# The level driver (contract 3). A standalone coroutine so the abort / continue /
+# session-abort logic is unit-testable with fake managers; ServerSession composes
+# it. Catches AbortedLevel at the DIRECT run_level await site - never through an
+# outer Task boundary that would drop the attribute.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _LevelFailure:
+    """A recorded level failure (never dropped): reason + preserved partial state."""
+
+    level_index: int
+    reason: str
+    aborted_window_index: int | None
+    completed_cores: list[MeasuredWindowCore | None]
+
+    @classmethod
+    def from_aborted(cls, aborted: AbortedLevel) -> _LevelFailure:
+        return cls(
+            level_index=aborted.level_index,
+            reason=aborted.reason,
+            aborted_window_index=aborted.aborted_window_index,
+            completed_cores=list(aborted.completed_cores),
+        )
+
+
+async def _watch_interrupt(
+    interrupt_event: Any,
+    target: asyncio.Task[Any],
+    *,
+    poll_interval: float,
+    sleep: Callable[[float], Awaitable[None]],
+) -> None:
+    """Cancel ``target`` once ``interrupt_event`` is set (the SIGINT bridge).
+
+    The study runner's SIGINT handler records the interrupt on a threading event;
+    this watcher polls it and cancels the driving task so a mid-window / mid-warmup
+    interrupt unwinds cleanly (the window manager aborts the open window and the
+    server is reaped in ``__exit__``). Cancelling the DRIVING task (which awaits
+    ``run_level`` inline) delivers the CancelledError into ``run_level`` itself, so
+    its AbortedLevel attaches to the exception the driver already catches inline.
+    """
+    while not interrupt_event.is_set():
+        await sleep(poll_interval)
+    target.cancel()
+
+
+async def _drive_levels(
+    manager: WindowManager,
+    level_plans: Sequence[LevelPlan],
+    outcomes_out: list[LevelOutcome],
+    failures_out: list[_LevelFailure],
+    *,
+    interrupt_event: Any | None = None,
+    cooldown_seconds: float = 0.0,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    poll_interval: float = _INTERRUPT_POLL_INTERVAL_S,
+) -> str:
+    """Drive the levels, catching per-level aborts inline. Returns a session status.
+
+    Appends each clean :class:`LevelOutcome` to ``outcomes_out`` and each recorded
+    failure to ``failures_out`` AS IT GOES, so an interrupt that re-raises still
+    leaves the partial state visible to the caller. Returns ``"ok"`` when every
+    level was attempted, or ``"warmup_aborted"`` when a ``WarmupTrafficError``
+    aborted the session (a dead transport dooms later levels). Only an interrupt
+    (CancelledError / KeyboardInterrupt) propagates; every other level failure is
+    recorded invalid-with-reason and the session continues (contract 3), so one
+    bad level never crashes the study (mirrors the offline DockerError path).
+    """
+    target = asyncio.current_task()
+    watcher: asyncio.Task[None] | None = None
+    if interrupt_event is not None and target is not None:
+        watcher = asyncio.create_task(
+            _watch_interrupt(interrupt_event, target, poll_interval=poll_interval, sleep=sleep)
+        )
+    try:
+        for level_index, level in enumerate(level_plans):
+            if level_index > 0 and cooldown_seconds > 0.0:
+                await sleep(cooldown_seconds)
+            try:
+                # INLINE await: the AbortedLevel the manager attaches to a failing
+                # level's exception survives, because there is no intervening Task
+                # boundary to substitute a fresh CancelledError (contract 3).
+                outcome = await manager.run_level(level_index, level)
+                outcomes_out.append(outcome)
+            except WarmupTrafficError as exc:
+                # The warmup traffic mechanism is dead: no window opened, and the
+                # measured window's traffic on the same transport would fail too.
+                # Abort the whole session (do not silently skip the level).
+                failures_out.append(
+                    _LevelFailure(
+                        level_index=level_index,
+                        reason=f"warmup failed: {exc}",
+                        aborted_window_index=None,
+                        completed_cores=[],
+                    )
+                )
+                return "warmup_aborted"
+            except (asyncio.CancelledError, KeyboardInterrupt) as exc:
+                # Interrupt (SIGINT via the watcher, or a genuine cancellation):
+                # preserve whatever the manager measured, then propagate so the
+                # session's __exit__ reaps the server.
+                aborted = getattr(exc, ABORTED_LEVEL_ATTR, None)
+                if aborted is not None:
+                    failures_out.append(_LevelFailure.from_aborted(aborted))
+                raise
+            except BaseException as exc:
+                # Any other level failure is recorded and the session continues.
+                # An AbortedLevel (window / close / drain failure) carries the
+                # cleanly-closed cores to preserve; a pure ramp-phase failure has
+                # nothing to preserve but still failed the level - record it too.
+                aborted = getattr(exc, ABORTED_LEVEL_ATTR, None)
+                if aborted is not None:
+                    failures_out.append(_LevelFailure.from_aborted(aborted))
+                else:
+                    failures_out.append(
+                        _LevelFailure(
+                            level_index=level_index,
+                            reason=f"level failed: {exc!r}",
+                            aborted_window_index=None,
+                            completed_cores=[],
+                        )
+                    )
+                continue
+        return "ok"
+    finally:
+        if watcher is not None:
+            watcher.cancel()
+            with contextlib.suppress(BaseException):
+                await watcher
+
+
+# ---------------------------------------------------------------------------
+# ServerSession - the C1/C3 sibling context manager.
+# ---------------------------------------------------------------------------
+
+
+class ServerSession:
+    """Online-serving measurement session: launch -> warm up -> windows -> shutdown.
+
+    Constructed like the offline sessions (runner + config + identity + the
+    resolved runner spec); ``engine`` is injectable for tests, else resolved from
+    the config. The seam-building methods (``_make_shape_source`` /
+    ``_make_transport`` / ``_make_energy_sink`` / ``_make_sampler_factory``) are
+    small and overridable so unit tests exercise ``run()`` with fakes.
+    """
+
+    def __init__(
+        self,
+        runner: StudyRunner,
+        config: ExperimentConfig,
+        spec: RunnerSpec | None,
+        *,
+        config_hash: str,
+        cycle: int,
+        index: int,
+        engine: ServerCapable | None = None,
+    ) -> None:
+        self._runner = runner
+        self.config = config
+        self.spec = spec
+        self.config_hash = config_hash
+        self.cycle = cycle
+        self.index = index
+        self._engine = engine
+        self._torn_down = False
+        self._exp_start = 0.0
+        # Populated in __enter__.
+        self._handle: ServerHandle | None = None
+        self._transport: Transport | None = None
+        self._shape_source: ShapeSource | None = None
+        self._warmup: ServerWarmup | None = None
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def __enter__(self) -> ServerSession:
+        runner = self._runner
+        config = self.config
+        try:
+            self._exp_start = time.monotonic()
+            # begin_experiment first so a launch/readiness failure still balances
+            # with the end_experiment_fail the runner emits on the failure path.
+            self._begin_progress()
+            engine = self._resolve_engine()
+
+            self._shape_source = self._make_shape_source()
+            placement = self._make_placement()
+            self._handle = engine.launch(config, placement)
+
+            probe = build_probe_request(
+                self._shape_source, path=SERVING_COMPLETIONS_PATH, method="POST"
+            )
+            engine.await_ready(self._handle, probe, timeout=self._readiness_timeout())
+
+            self._transport = self._make_transport(self._handle.base_url)
+
+            # The server is up: mark running (a launch/readiness failure above
+            # never reaches here, so a failed launch is recorded as failed, not
+            # left running).
+            runner.manifest.mark_running(self.config_hash, self.cycle)
+        except BaseException:
+            # Acquisition failed before the `with` body: release the partially
+            # launched server and re-raise (a failed launch never leaks).
+            self._torn_down = True
+            self._cleanup()
+            raise
+        return self
+
+    def run(self) -> ServerSessionResult | dict[str, Any]:
+        """Drive the level(s) to N window results; return the session product.
+
+        Returns a :class:`ServerSessionResult` on success (or partial / interrupt),
+        or a failure dict when the session aborts (``WarmupTrafficError`` or no
+        valid window). The dict mirrors the offline failure shape so the sweep
+        loop, circuit breaker, and manifest treat it uniformly.
+        """
+        assert self._transport is not None and self._shape_source is not None
+        interrupt_event = getattr(self._runner, "_interrupt_event", None)
+
+        self._warmup = self._make_warmup(self._shape_source, self._transport)
+        manager = self._make_manager(self._make_energy_sink(), self._warmup)
+        level_plans = self._make_level_plans(self._shape_source, self._transport)
+
+        outcomes: list[LevelOutcome] = []
+        failures: list[_LevelFailure] = []
+        interrupted = False
+        status = "ok"
+        try:
+            status = asyncio.run(
+                _drive_levels(
+                    manager,
+                    level_plans,
+                    outcomes,
+                    failures,
+                    interrupt_event=interrupt_event,
+                    cooldown_seconds=self._cooldown_seconds(),
+                )
+            )
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            if interrupt_event is not None and interrupt_event.is_set():
+                # Interrupted mid-session: the partial state is in outcomes /
+                # failures. Leave the manifest 'running' - the sweep loop's
+                # mark_interrupted downgrades it, as on the offline path.
+                interrupted = True
+            else:
+                raise
+
+        return self._finalise(outcomes, failures, status=status, interrupted=interrupted)
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool | None:
+        if self._torn_down:
+            return None
+        self._torn_down = True
+        self._cleanup()
+        return None
+
+    # -- finalisation --------------------------------------------------------
+
+    def _finalise(
+        self,
+        outcomes: list[LevelOutcome],
+        failures: list[_LevelFailure],
+        *,
+        status: str,
+        interrupted: bool,
+    ) -> ServerSessionResult | dict[str, Any]:
+        """Build the session result (and mark the manifest) from the driver output."""
+        warmup_by_level = self._warmup_results_by_level()
+        levels = self._build_level_results(outcomes, failures, warmup_by_level)
+        total_energy = _sum_window_energy(levels)
+        elapsed = time.monotonic() - self._exp_start
+        aborted = status == "warmup_aborted"
+        abort_reason = failures[-1].reason if aborted and failures else None
+
+        result = ServerSessionResult(
+            engine=_engine_name(self.config),
+            config_hash=self.config_hash,
+            cycle=self.cycle,
+            index=self.index,
+            serving_mode=self.config.serving_mode,
+            levels=levels,
+            token_counting=TOKEN_COUNTING_SERVER_REPORTED,
+            total_window_energy_j=total_energy,
+            elapsed_s=elapsed,
+            aborted=aborted,
+            abort_reason=abort_reason,
+        )
+
+        if interrupted:
+            # Manifest handling is the sweep loop's (mark_interrupted); do not
+            # resolve the entry here.
+            self._end_progress(result, ok=result.valid)
+            return result
+
+        if not result.valid:
+            message = abort_reason or self._invalid_message(levels)
+            error_type = "WarmupTrafficError" if aborted else "ServerSessionInvalid"
+            self._runner.manifest.mark_failed(self.config_hash, self.cycle, error_type, message)
+            self._end_progress(result, ok=False)
+            return {"type": error_type, "message": message}
+
+        # Valid session: mark completed. SM10 wires the per-window bundle files;
+        # the result_file stays empty until then (no bundle persisted at SM9).
+        self._runner.manifest.mark_completed(
+            self.config_hash,
+            self.cycle,
+            "",
+            elapsed_seconds=elapsed,
+            energy_joules=total_energy,
+        )
+        self._end_progress(result, ok=True)
+        return result
+
+    def _build_level_results(
+        self,
+        outcomes: list[LevelOutcome],
+        failures: list[_LevelFailure],
+        warmup_by_level: dict[int, ServerWarmupResult],
+    ) -> list[ServerLevelResult]:
+        by_level: dict[int, ServerLevelResult] = {}
+        for outcome in outcomes:
+            warmup = warmup_by_level.get(outcome.level_index)
+            protocol = self._protocol_label(warmup)
+            windows = [
+                ServerWindowResult(
+                    level_index=outcome.level_index,
+                    window=window,
+                    warmup=warmup,
+                    pre_window_protocol=protocol,
+                )
+                for window in outcome.windows
+            ]
+            by_level[outcome.level_index] = ServerLevelResult(
+                level_index=outcome.level_index,
+                spec=outcome.spec,
+                windows=windows,
+                validation=outcome.validation,
+                warmup=warmup,
+                invalid_reason=None,
+            )
+        for failure in failures:
+            warmup = warmup_by_level.get(failure.level_index)
+            # A failed level keeps its cleanly-closed cores (O7.4) but not full
+            # per-window bookkeeping (the traffic report is gone once the issuer
+            # task was cancelled); SM10 owns partial-window persistence.
+            by_level[failure.level_index] = ServerLevelResult(
+                level_index=failure.level_index,
+                spec=None,
+                windows=[],
+                validation=None,
+                warmup=warmup,
+                invalid_reason=failure.reason,
+                aborted_window_index=failure.aborted_window_index,
+            )
+        return [by_level[i] for i in sorted(by_level)]
+
+    def _warmup_results_by_level(self) -> dict[int, ServerWarmupResult]:
+        if self._warmup is None:
+            return {}
+        return {r.level_index: r for r in self._warmup.results}
+
+    def _protocol_label(self, warmup: ServerWarmupResult | None) -> str:
+        if warmup is not None:
+            return warmup.pre_window_protocol
+        cfg = self.config.resolved_server_warmup()
+        return describe_server_warmup_protocol(cfg) if cfg is not None else "server warmup"
+
+    def _invalid_message(self, levels: list[ServerLevelResult]) -> str:
+        reasons = [level.invalid_reason for level in levels if level.invalid_reason]
+        if reasons:
+            return "; ".join(reasons)
+        gate = [
+            level.validation.reason
+            for level in levels
+            if level.validation is not None and level.validation.reason
+        ]
+        if gate:
+            return "; ".join(gate)
+        return "the server session produced no valid measured window."
+
+    # -- seam construction (overridable for tests) ---------------------------
+
+    def _resolve_engine(self) -> ServerCapable:
+        if self._engine is not None:
+            return self._engine
+        from llenergymeasure.engines import get_engine
+
+        engine = get_engine(_engine_name(self.config))
+        if not _is_server_capable(engine):
+            raise ServerSessionError(
+                f"engine {_engine_name(self.config)!r} does not support server mode "
+                "(it does not implement the ServerCapable launch / await_ready / "
+                "shutdown protocol). Use serving_mode: offline for this engine."
+            )
+        self._engine = engine  # type: ignore[assignment]
+        return engine  # type: ignore[return-value]
+
+    def _make_shape_source(self) -> ShapeSource:
+        from llenergymeasure.datasets.loader import load_prompts
+
+        prompts = load_prompts(self.config)
+        max_tokens = self.config.task.max_output_tokens or 128
+        return _CompletionsShapeSource(prompts, model=self.config.task.model, max_tokens=max_tokens)
+
+    def _make_transport(self, base_url: str) -> Transport:
+        from llenergymeasure.harness.traffic import HttpxTransport
+
+        return HttpxTransport(base_url=base_url, path=SERVING_COMPLETIONS_PATH)
+
+    def _make_energy_sink(self) -> BracketEnergySink:
+        return BracketEnergySink.from_measurement_config(
+            self.config.measurement,
+            self._measurement_gpu_indices(),
+            self._runner._progress if self._runner is not None else None,
+        )
+
+    def _make_sampler_factory(self) -> Callable[[], Any]:
+        from llenergymeasure.device.power_thermal import PowerThermalSampler
+
+        gpu_indices = self._measurement_gpu_indices()
+        return lambda: PowerThermalSampler(gpu_indices=gpu_indices)
+
+    def _make_warmup(self, shape_source: ShapeSource, transport: Transport) -> ServerWarmup:
+        traffic = self._traffic()
+        warmup_config = self.config.resolved_server_warmup()
+        assert warmup_config is not None  # server mode always resolves a warmup
+
+        def traffic_factory(context: WarmupContext, horizon: float) -> TrafficSource:
+            return _level_traffic_source(
+                traffic,
+                rate=context.spec.rate,
+                arrival=context.spec.arrival,
+                horizon_seconds=max(horizon, 1.0),
+                shape_source=shape_source,
+            )
+
+        return ServerWarmup(
+            warmup_config,
+            traffic_factory=traffic_factory,
+            transport=transport,
+            sampler_factory=self._make_sampler_factory(),
+        )
+
+    def _make_manager(self, energy_sink: Any, warmup: ServerWarmup) -> WindowManager:
+        return WindowManager(
+            energy_sink,
+            windows_per_level=self._windows_per_level(),
+            warmup_hook=warmup,
+            drain_timeout=self._drain_timeout(),
+        )
+
+    def _make_level_plans(self, shape_source: ShapeSource, transport: Transport) -> list[LevelPlan]:
+        traffic = self._traffic()
+        spec = WindowSpec.from_traffic_config(traffic)
+        horizon = spec.ramp_exclusion_seconds + self._windows_per_level() * float(
+            spec.duration_seconds or 0.0
+        )
+        source = _level_traffic_source(
+            traffic,
+            rate=spec.rate,
+            arrival=spec.arrival,
+            horizon_seconds=horizon,
+            shape_source=shape_source,
+        )
+        return [
+            LevelPlan(
+                spec=spec,
+                traffic_source=source,
+                transport=transport,
+                token_receipt_fn=server_reported_token_receipts,
+            )
+        ]
+
+    # -- placement / config accessors ---------------------------------------
+
+    def _make_placement(self) -> ServerPlacement:
+        from llenergymeasure.config.ssot import RUNNER_PROCESS
+        from llenergymeasure.infra.server_lifecycle import ServerPlacement
+
+        mode = self.spec.mode if self.spec is not None else RUNNER_PROCESS
+        image = self.spec.image if self.spec is not None else None
+        return ServerPlacement(mode=mode, image=image, gpu_indices=self._placement_gpu_indices())
+
+    def _traffic(self) -> TrafficConfig:
+        assert self.config.server is not None  # server mode requires the section
+        return self.config.server.traffic
+
+    def _windows_per_level(self) -> int:
+        from llenergymeasure.harness.window_manager import DEFAULT_WINDOWS_PER_LEVEL
+
+        return DEFAULT_WINDOWS_PER_LEVEL
+
+    def _cooldown_seconds(self) -> float:
+        return self.config.server.cooldown_seconds if self.config.server is not None else 0.0
+
+    def _drain_timeout(self) -> float | None:
+        return self._runner.study.study_execution.experiment_timeout_seconds
+
+    def _readiness_timeout(self) -> float:
+        return float(self._runner.study.study_execution.experiment_timeout_seconds)
+
+    def _placement_gpu_indices(self) -> list[int] | None:
+        # Physical container scoping (mirrors the offline docker path).
+        return self._runner.study.study_execution.gpu_indices
+
+    def _measurement_gpu_indices(self) -> list[int] | None:
+        # Logical indices the host-side NVML samplers address (mirrors offline).
+        from llenergymeasure.device.gpu_info import _resolve_gpu_indices
+
+        return _resolve_gpu_indices(self.config)
+
+    # -- progress + cleanup --------------------------------------------------
+
+    def _begin_progress(self) -> None:
+        progress = getattr(self._runner, "_progress", None)
+        if progress is None:
+            return
+        from llenergymeasure.domain.progress import server_steps
+        from llenergymeasure.utils.formatting import format_experiment_header
+
+        progress.begin_experiment(
+            self.index,
+            format_experiment_header(self.config),
+            server_steps(),
+            runner_info=self.spec.to_runner_info() if self.spec is not None else None,
+        )
+
+    def _end_progress(self, result: ServerSessionResult, *, ok: bool) -> None:
+        progress = getattr(self._runner, "_progress", None)
+        if progress is None:
+            return
+        elapsed = result.elapsed_s
+        if ok:
+            progress.end_experiment_ok(
+                self.index,
+                elapsed,
+                energy_j=result.total_window_energy_j,
+            )
+        else:
+            progress.end_experiment_fail(
+                self.index, elapsed, error=result.abort_reason or "server session invalid"
+            )
+
+    def _cleanup(self) -> None:
+        """Shut the server down + drain-finalise; runs exactly once from __exit__.
+
+        Idempotent and best-effort (it runs on the normal, SIGINT, and exception
+        paths). The engine's ``shutdown`` is itself idempotent + leak-free (SM6),
+        so a double invocation is a no-op; the transport's connection pool is
+        closed too so a launched-but-never-run session leaks nothing.
+        """
+        handle = self._handle
+        if handle is not None:
+            with contextlib.suppress(Exception):
+                self._shutdown_handle(handle)
+        transport = self._transport
+        if transport is not None:
+            aclose = getattr(transport, "aclose", None)
+            if aclose is not None:
+                with contextlib.suppress(Exception):
+                    _run_sync(aclose())
+
+    def _shutdown_handle(self, handle: ServerHandle) -> None:
+        """Reap the launched server via the engine protocol (falls back to infra)."""
+        if self._engine is not None:
+            self._engine.shutdown(handle)
+            return
+        from llenergymeasure.infra.server_lifecycle import shutdown
+
+        shutdown(handle)
+
+
+class ServerSessionError(Exception):
+    """A server session could not be set up (e.g. a non-server-capable engine)."""
+
+
+# ---------------------------------------------------------------------------
+# Small free helpers
+# ---------------------------------------------------------------------------
+
+
+def _engine_name(config: ExperimentConfig) -> str:
+    from llenergymeasure.config.ssot import engine_str
+
+    return engine_str(config.engine)
+
+
+def _is_server_capable(engine: Any) -> bool:
+    return all(
+        callable(getattr(engine, name, None)) for name in ("launch", "await_ready", "shutdown")
+    )
+
+
+def _sum_window_energy(levels: list[ServerLevelResult]) -> float | None:
+    total = 0.0
+    seen = False
+    for level in levels:
+        for window in level.windows:
+            energy = window.window.window_energy_j
+            if energy is not None:
+                total += energy
+                seen = True
+    return total if seen else None
+
+
+def _run_sync(awaitable: Awaitable[Any]) -> None:
+    """Run a coroutine to completion for best-effort transport teardown.
+
+    Used only on the cleanup path (closing the httpx client). A fresh event loop
+    keeps it independent of any loop ``run()`` already finished with. Best-effort:
+    a missing loop context (already-closed awaitable, etc.) is swallowed.
+    """
+    with contextlib.suppress(RuntimeError):
+        asyncio.run(_as_none(awaitable))
+
+
+async def _as_none(awaitable: Awaitable[Any]) -> None:
+    await awaitable

--- a/src/llenergymeasure/study/server_session.py
+++ b/src/llenergymeasure/study/server_session.py
@@ -707,7 +707,7 @@ class ServerSession:
         return BracketEnergySink.from_measurement_config(
             self.config.measurement,
             self._measurement_gpu_indices(),
-            self._runner._progress if self._runner is not None else None,
+            getattr(self._runner, "_progress", None),
         )
 
     def _make_sampler_factory(self) -> Callable[[], Any]:

--- a/tests/unit/cli/test_step_display.py
+++ b/tests/unit/cli/test_step_display.py
@@ -149,7 +149,7 @@ def test_step_display_renders_registry_added_step_without_renderer_change():
                 label="Ramping",
                 phase="Server",
                 order=200,
-                surfaces=frozenset({progress.SURFACE_LOCAL}),
+                surfaces=frozenset({progress.SURFACE_PROCESS}),
             )
         )
         console, buf = _make_console()

--- a/tests/unit/domain/test_progress.py
+++ b/tests/unit/domain/test_progress.py
@@ -201,16 +201,16 @@ def test_register_step_flows_through_labels_phases_and_ordering():
     saved_labels = dict(progress.STEP_LABELS)
     saved_phases = dict(progress.STEP_PHASES)
     try:
-        # A hypothetical server-mode step: it joins the existing local surface
+        # A hypothetical extra step: it joins the existing process surface
         # (positioned between preflight=10 and container_preflight=60) and its
-        # own brand-new "server" surface - the pattern server mode will use.
+        # own brand-new "future_mode" surface - the register_step extension seam.
         progress.register_step(
             progress.StepSpec(
                 id="server_health",
                 label="Polling",
                 phase="Server",
                 order=45,
-                surfaces=frozenset({progress.SURFACE_LOCAL, "server"}),
+                surfaces=frozenset({progress.SURFACE_PROCESS, "future_mode"}),
             )
         )
 
@@ -219,15 +219,15 @@ def test_register_step_flows_through_labels_phases_and_ordering():
         # Phase mapping flows - a brand-new phase name is carried verbatim.
         assert progress.STEP_PHASES["server_health"] == "Server"
 
-        # Ordering flows: the step lands at its declared position in the local
+        # Ordering flows: the step lands at its declared position in the process
         # surface, between preflight and container_preflight.
-        local = progress.steps_for_surface(progress.SURFACE_LOCAL)
+        local = progress.steps_for_surface(progress.SURFACE_PROCESS)
         assert "server_health" in local
         assert local.index(STEP_PREFLIGHT) < local.index("server_health")
         assert local.index("server_health") < local.index(STEP_CONTAINER_PREFLIGHT)
 
         # Ordering flows in a brand-new surface too: no builder changes needed.
-        assert progress.steps_for_surface("server") == ["server_health"]
+        assert progress.steps_for_surface("future_mode") == ["server_health"]
 
         # A step that opts out of the docker surfaces never appears there.
         assert "server_health" not in docker_steps(images_prepared=False, host_baseline=True)

--- a/tests/unit/study/test_server_session.py
+++ b/tests/unit/study/test_server_session.py
@@ -1,0 +1,685 @@
+"""Tests for the server-mode measurement session (SM9).
+
+Host-only, no GPU, no real server: the engine (ServerCapable), the window
+manager, the energy sink, the traffic source, and the warmup hook are all
+injected fakes, so the full launch -> warm up -> windows -> shutdown lifecycle is
+exercised deterministically.
+
+Charter (server-mode plan section 4 / section 18):
+- one server lifetime produces N window results without re-keying the offline
+  loop (C3);
+- cleanup-exactly-once on the normal, exception, and interrupt paths, with the
+  server reaped on every exit (the F6 session-hardening invariant);
+- the three banked contracts: the issuance horizon covers ramp + N windows; the
+  client-counted tokens flow through the TokenReceiptFn seam (interim,
+  server-reported); an AbortedLevel is caught at the run_level await site and a
+  WarmupTrafficError aborts the session;
+- per-level ServerWarmupResult is stamped into each window result (D6 divergence
+  label);
+- the resolved warmup is read in-process (the serialization-boundary contract).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from llenergymeasure.config.models import ExperimentConfig, ServerWarmupConfig
+from llenergymeasure.config.user_config import UserConfig, UserServerConfig
+from llenergymeasure.harness.server_warmup import ServerWarmupResult, WarmupTrafficError
+from llenergymeasure.harness.traffic import IssuerReport, RequestRecord, RequestShape
+from llenergymeasure.harness.window_manager import (
+    ABORTED_LEVEL_ATTR,
+    ATTRIBUTION_STEADY_STATE_SPAN,
+    AbortedLevel,
+    LevelOutcome,
+    LevelValidation,
+    WindowBookkeeping,
+    WindowBoundaries,
+    WindowRecord,
+    WindowSpec,
+    WindowStartEvent,
+    WindowStopEvent,
+)
+from llenergymeasure.study import server_session as ss
+from llenergymeasure.study.server_session import (
+    ServerSession,
+    ServerSessionError,
+    ServerSessionResult,
+    _CompletionsShapeSource,
+    _drive_levels,
+    _level_traffic_source,
+    server_reported_token_receipts,
+)
+
+# ---------------------------------------------------------------------------
+# Builders / fakes
+# ---------------------------------------------------------------------------
+
+
+def _server_config(**server_overrides: Any) -> ExperimentConfig:
+    """A minimal vLLM server-mode config (transformers+server is rejected)."""
+    server: dict[str, Any] = {"traffic": {"rate": 10, "window_seconds": 60}}
+    server.update(server_overrides)
+    return ExperimentConfig(
+        task={"model": "gpt2"},
+        engine="vllm",
+        serving_mode="server",
+        server=server,
+        measurement={"baseline": {"enabled": False}},
+    )
+
+
+class FakeEngine:
+    """A recording ServerCapable engine (no real process/container)."""
+
+    def __init__(
+        self, *, launch_error: Exception | None = None, ready_error: Exception | None = None
+    ) -> None:
+        self.launch_error = launch_error
+        self.ready_error = ready_error
+        self.launched = 0
+        self.readied = 0
+        self.shutdowns = 0
+        self.handle = SimpleNamespace(base_url="http://127.0.0.1:9", engine="vllm")
+
+    def launch(self, config: Any, placement: Any) -> Any:
+        self.launched += 1
+        if self.launch_error is not None:
+            raise self.launch_error
+        return self.handle
+
+    def await_ready(self, handle: Any, probe: Any, *, timeout: float) -> None:
+        self.readied += 1
+        if self.ready_error is not None:
+            raise self.ready_error
+
+    def shutdown(self, handle: Any) -> None:
+        self.shutdowns += 1
+
+
+class FakeManifest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    def mark_running(self, config_hash: str, cycle: int) -> None:
+        self.calls.append(("running", (config_hash, cycle)))
+
+    def mark_completed(self, config_hash: str, cycle: int, result_file: str, **kw: Any) -> None:
+        self.calls.append(("completed", (config_hash, cycle, result_file, kw)))
+
+    def mark_failed(
+        self, config_hash: str, cycle: int, error_type: str, message: str, **kw: Any
+    ) -> None:
+        self.calls.append(("failed", (config_hash, cycle, error_type, message)))
+
+    @property
+    def statuses(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
+def _fake_runner(
+    *, interrupt_event: Any = None, timeout: float = 30.0, gpu_indices: Any = None
+) -> Any:
+    study = SimpleNamespace(
+        study_execution=SimpleNamespace(experiment_timeout_seconds=timeout, gpu_indices=gpu_indices)
+    )
+    return SimpleNamespace(
+        manifest=FakeManifest(),
+        _progress=None,
+        _interrupt_event=interrupt_event,
+        _runner_specs=None,
+        study=study,
+    )
+
+
+class _FakeShapeSource:
+    def __call__(self, index: int) -> RequestShape:
+        return RequestShape(index=index, payload={"model": "m", "prompt": "hi", "max_tokens": 1})
+
+
+class FakeManager:
+    """A window manager stand-in: run_level returns / raises per a script."""
+
+    def __init__(self, script: list[Any]) -> None:
+        # Each entry is a LevelOutcome (returned) or an Exception (raised).
+        self._script = script
+        self.calls: list[int] = []
+
+    async def run_level(self, level_index: int, level: Any) -> LevelOutcome:
+        self.calls.append(level_index)
+        await asyncio.sleep(0)
+        item = self._script[level_index]
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+class FakeWarmup:
+    """A warmup hook stand-in exposing the ServerWarmup.results surface."""
+
+    def __init__(self, results: list[ServerWarmupResult]) -> None:
+        self.results = results
+
+    async def __call__(self, context: Any) -> None:  # pragma: no cover - fake manager skips it
+        return None
+
+
+def _report(records: list[RequestRecord]) -> IssuerReport:
+    return IssuerReport(
+        records=records,
+        issued_count=len(records),
+        completed_count=sum(1 for r in records if r.completed_at is not None),
+        cap_bound_fraction=0.0,
+        issuance_duration_s=0.0,
+        concurrency_cap=None,
+    )
+
+
+def _window_record(index: int, *, energy: float | None, j_per_token: float | None) -> WindowRecord:
+    spec = WindowSpec(rate=10.0)
+    boundaries = WindowBoundaries(window_start=0.0, span_start=1.0, span_end=2.0)
+    bookkeeping = WindowBookkeeping(
+        boundaries=boundaries,
+        attribution_policy=ATTRIBUTION_STEADY_STATE_SPAN,
+        energy_denominator_tokens=10,
+        latency_records=[],
+        issued_in_span_count=0,
+        completed_in_span_count=0,
+        straddling_count=0,
+    )
+    return WindowRecord(
+        window_index=index,
+        boundaries=boundaries,
+        energy=None,
+        bookkeeping=bookkeeping,
+        window_energy_j=energy,
+        window_j_per_token=j_per_token,
+        intra_window_cov=0.01,
+        start_event=WindowStartEvent(0, index, spec, 1.0),
+        stop_event=WindowStopEvent(0, index, spec, 2.0),
+    )
+
+
+def _level_outcome(
+    level_index: int = 0, *, valid: bool = True, n_windows: int = 3, energy: float = 10.0
+) -> LevelOutcome:
+    windows = [_window_record(i, energy=energy, j_per_token=0.5) for i in range(n_windows)]
+    validation = LevelValidation(
+        valid=valid,
+        reason=None if valid else "window-to-window J/token not steady",
+        cov=0.01,
+        windows_considered=n_windows,
+    )
+    return LevelOutcome(
+        level_index=level_index,
+        spec=WindowSpec(rate=10.0),
+        windows=windows,
+        validation=validation,
+        issuer_report=_report([]),
+    )
+
+
+def _warmup_result(level_index: int = 0) -> ServerWarmupResult:
+    return ServerWarmupResult(
+        level_index=level_index,
+        mode="composite",
+        converged=True,
+        timed_out=False,
+        elapsed_s=1.0,
+        final_observables=None,
+        pre_window_protocol="server convergence-composite warmup (test)",
+    )
+
+
+def _override(session: ServerSession, name: str, fn: Any) -> None:
+    """Attach an untyped test double to a session seam method (mypy/B010-transparent)."""
+    session.__dict__[name] = fn
+
+
+def _make_session(
+    engine: FakeEngine,
+    *,
+    runner: Any = None,
+    config: ExperimentConfig | None = None,
+) -> ServerSession:
+    runner = runner if runner is not None else _fake_runner()
+    config = config if config is not None else _server_config()
+    session = ServerSession(runner, config, None, config_hash="h", cycle=1, index=1, engine=engine)
+    # Stub the heavy real seams so __enter__/run() are host-only. (The seam-override
+    # assignments are intentionally untyped test doubles.)
+    _override(session, "_make_shape_source", lambda: _FakeShapeSource())
+    _override(session, "_make_transport", lambda base_url: SimpleNamespace())
+    _override(session, "_make_energy_sink", lambda: object())
+    return session
+
+
+def _wire_run(
+    session: ServerSession, manager: FakeManager, warmup: FakeWarmup, plans: list[Any] | None = None
+) -> None:
+    _override(session, "_make_warmup", lambda shape, transport: warmup)
+    _override(session, "_make_manager", lambda sink, wu: manager)
+    _override(session, "_make_level_plans", lambda shape, transport: plans or [object()])
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 - token receipts flow from what the transport exposes (interim)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenReceipts:
+    def test_server_reported_tokens_stamped_at_completion(self) -> None:
+        rec = RequestRecord(
+            index=0,
+            issued_at=1.0,
+            request=RequestShape(index=0),
+            completed_at=5.0,
+            result={"usage": {"completion_tokens": 3}},
+        )
+        # Request-granular attribution: n tokens at completed_at (E2 rule).
+        assert server_reported_token_receipts(rec) == (5.0, 5.0, 5.0)
+
+    def test_no_usage_yields_no_receipts(self) -> None:
+        rec = RequestRecord(
+            index=0,
+            issued_at=1.0,
+            request=RequestShape(index=0),
+            completed_at=5.0,
+            result={"choices": [{"text": "pong"}]},
+        )
+        assert server_reported_token_receipts(rec) == ()
+
+    def test_incomplete_or_errored_request_yields_no_receipts(self) -> None:
+        never = RequestRecord(
+            index=0, issued_at=1.0, request=RequestShape(index=0), completed_at=None
+        )
+        assert server_reported_token_receipts(never) == ()
+        errored = RequestRecord(
+            index=1,
+            issued_at=1.0,
+            request=RequestShape(index=1),
+            completed_at=5.0,
+            result={"usage": {"completion_tokens": 2}},
+            error=RuntimeError("boom"),
+        )
+        assert server_reported_token_receipts(errored) == ()
+
+    def test_zero_or_bool_token_count_rejected(self) -> None:
+        for n in (0, -1, True, "3", None):
+            rec = RequestRecord(
+                index=0,
+                issued_at=1.0,
+                request=RequestShape(index=0),
+                completed_at=5.0,
+                result={"usage": {"completion_tokens": n}},
+            )
+            assert server_reported_token_receipts(rec) == ()
+
+
+# ---------------------------------------------------------------------------
+# Request encoding + issuance horizon (contract 1)
+# ---------------------------------------------------------------------------
+
+
+class TestShapeAndHorizon:
+    def test_completions_shape_encodes_openai_body(self) -> None:
+        src = _CompletionsShapeSource(["a", "b"], model="gpt2", max_tokens=7)
+        shape = src(0)
+        assert shape.payload == {
+            "model": "gpt2",
+            "prompt": "a",
+            "max_tokens": 7,
+            "temperature": 0.0,
+        }
+        # Prompts cycle by index.
+        assert src(3).payload["prompt"] == "b"
+
+    def test_level_traffic_source_covers_full_level_horizon(self) -> None:
+        # The issuance schedule must span ramp + windows_per_level * duration as one
+        # continuous run (contract 1): a horizon-sized window_seconds is projected.
+        config = _server_config(traffic={"rate": 20, "window_seconds": 60, "seed": 7})
+        traffic = config.server.traffic
+        horizon = 30.0 + 3 * 60.0  # ramp + 3 windows
+        source = _level_traffic_source(
+            traffic,
+            rate=traffic.rate,
+            arrival=traffic.arrival,
+            horizon_seconds=horizon,
+            shape_source=_FakeShapeSource(),
+        )
+        # The schedule's last offset covers (near) the whole horizon, not one window.
+        assert source.schedule.offsets[-1] > 60.0
+        assert source.schedule.offsets[-1] <= horizon
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 - the level driver: catch AbortedLevel at the run_level await site
+# ---------------------------------------------------------------------------
+
+
+def _drive(manager: Any, plans: list[Any], **kw: Any) -> tuple[str, list[LevelOutcome], list[Any]]:
+    outcomes: list[LevelOutcome] = []
+    failures: list[Any] = []
+    status = asyncio.run(_drive_levels(manager, plans, outcomes, failures, **kw))
+    return status, outcomes, failures
+
+
+class TestDriver:
+    def test_happy_path_collects_every_level(self) -> None:
+        manager = FakeManager([_level_outcome(0), _level_outcome(1)])
+        status, outcomes, failures = _drive(manager, [object(), object()])
+        assert status == "ok"
+        assert [o.level_index for o in outcomes] == [0, 1]
+        assert failures == []
+
+    def test_warmup_traffic_error_aborts_session(self) -> None:
+        # A dead transport dooms later levels: the session aborts, later levels
+        # are NOT run, and the failure is recorded (not silently skipped).
+        manager = FakeManager([WarmupTrafficError("dead"), _level_outcome(1)])
+        status, outcomes, failures = _drive(manager, [object(), object()])
+        assert status == "warmup_aborted"
+        assert outcomes == []
+        assert manager.calls == [0]  # level 1 never attempted
+        assert len(failures) == 1 and "warmup failed" in failures[0].reason
+
+    def test_aborted_level_recorded_then_continues(self) -> None:
+        # A non-warmup level failure carries its partial state on the exception;
+        # the driver catches it at the run_level await site, records it, and
+        # continues to the next level.
+        exc = RuntimeError("mid-window transport failure")
+        setattr(
+            exc,
+            ABORTED_LEVEL_ATTR,
+            AbortedLevel(
+                level_index=0,
+                aborted_window_index=1,
+                reason="aborted: boom",
+                completed_cores=[None],
+            ),
+        )
+        manager = FakeManager([exc, _level_outcome(1)])
+        status, outcomes, failures = _drive(manager, [object(), object()])
+        assert status == "ok"
+        assert manager.calls == [0, 1]  # continued past the failed level
+        assert [o.level_index for o in outcomes] == [1]
+        assert len(failures) == 1
+        assert failures[0].reason == "aborted: boom"
+        assert failures[0].aborted_window_index == 1
+
+    def test_ramp_phase_failure_recorded_and_continues(self) -> None:
+        # A level failure with no AbortedLevel to preserve (e.g. a ramp-phase
+        # error) is still recorded invalid-with-reason and the session continues -
+        # one bad level never crashes the study (contract 3 / offline parity).
+        manager = FakeManager([RuntimeError("ramp-phase blowup"), _level_outcome(1)])
+        status, outcomes, failures = _drive(manager, [object(), object()])
+        assert status == "ok"
+        assert manager.calls == [0, 1]
+        assert [o.level_index for o in outcomes] == [1]
+        assert len(failures) == 1
+        assert "ramp-phase blowup" in failures[0].reason
+        assert failures[0].completed_cores == []
+
+    def test_interrupt_preserves_partial_and_reraises(self) -> None:
+        # SIGINT bridge: the watcher cancels the driving task; the manager attaches
+        # its AbortedLevel to the CancelledError; the driver catches it INLINE
+        # (attribute intact), records the partial, and re-raises so __exit__ reaps.
+        class CancellingManager:
+            def __init__(self) -> None:
+                self.calls: list[int] = []
+
+            async def run_level(self, level_index: int, level: Any) -> LevelOutcome:
+                self.calls.append(level_index)
+                try:
+                    await asyncio.sleep(10)
+                except BaseException as exc:
+                    setattr(
+                        exc,
+                        ABORTED_LEVEL_ATTR,
+                        AbortedLevel(
+                            level_index=level_index,
+                            aborted_window_index=0,
+                            reason="aborted: cancelled",
+                            completed_cores=[None],
+                        ),
+                    )
+                    raise
+                raise AssertionError("sleep should have been cancelled")  # pragma: no cover
+
+        event = threading.Event()
+        event.set()  # interrupt already pending
+        manager = CancellingManager()
+        outcomes: list[LevelOutcome] = []
+        failures: list[Any] = []
+        plans: list[Any] = [object()]
+        with pytest.raises((asyncio.CancelledError, KeyboardInterrupt)):
+            asyncio.run(
+                _drive_levels(
+                    manager,
+                    plans,
+                    outcomes,
+                    failures,
+                    interrupt_event=event,
+                    poll_interval=0.001,
+                )
+            )
+        assert len(failures) == 1
+        assert failures[0].reason == "aborted: cancelled"
+        assert failures[0].completed_cores == [None]
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle - launch / ready / shutdown, cleanup exactly once
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_enter_launches_readies_and_marks_running(self) -> None:
+        engine = FakeEngine()
+        runner = _fake_runner()
+        session = _make_session(engine, runner=runner)
+        with session:
+            assert engine.launched == 1
+            assert engine.readied == 1
+            assert session._handle is not None
+            assert session._handle.base_url == engine.handle.base_url
+            assert runner.manifest.statuses == ["running"]
+        # Exit reaps the server exactly once.
+        assert engine.shutdowns == 1
+
+    def test_enter_failure_on_launch_reaps_and_reraises(self) -> None:
+        engine = FakeEngine(launch_error=RuntimeError("no image"))
+        session = _make_session(engine)
+        with pytest.raises(RuntimeError, match="no image"), session:
+            pass  # pragma: no cover - never entered
+        # Launch failed before a handle existed: nothing to reap, but the failure
+        # path ran cleanup once and never marked running.
+        assert engine.shutdowns == 0
+        assert session._runner.manifest.statuses == []
+
+    def test_enter_failure_on_readiness_reaps_partial_server(self) -> None:
+        engine = FakeEngine(ready_error=RuntimeError("never ready"))
+        session = _make_session(engine)
+        with pytest.raises(RuntimeError, match="never ready"), session:
+            pass  # pragma: no cover - never entered
+        # The server was launched then failed readiness: it MUST be reaped.
+        assert engine.launched == 1
+        assert engine.shutdowns == 1
+
+    def test_exit_is_idempotent(self) -> None:
+        engine = FakeEngine()
+        session = _make_session(engine)
+        session.__enter__()
+        session.__exit__(None, None, None)
+        session.__exit__(None, None, None)  # second exit is a no-op
+        assert engine.shutdowns == 1
+
+    def test_cleanup_runs_on_exception_in_body(self) -> None:
+        engine = FakeEngine()
+        session = _make_session(engine)
+        with pytest.raises(RuntimeError, match="body boom"), session:
+            raise RuntimeError("body boom")
+        assert engine.shutdowns == 1
+
+    def test_non_server_capable_engine_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import llenergymeasure.engines as engines_mod
+
+        # get_engine returns a plain object that is NOT ServerCapable.
+        monkeypatch.setattr(engines_mod, "get_engine", lambda name: SimpleNamespace())
+        session = ServerSession(
+            _fake_runner(), _server_config(), None, config_hash="h", cycle=1, index=1
+        )
+        with pytest.raises(ServerSessionError, match="does not support server mode"):
+            session._resolve_engine()
+
+
+# ---------------------------------------------------------------------------
+# run() - N results, warmup provenance, manifest, contracts
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_run_produces_n_results_with_warmup_provenance(self) -> None:
+        engine = FakeEngine()
+        runner = _fake_runner()
+        session = _make_session(engine, runner=runner)
+        warmup = FakeWarmup([_warmup_result(0)])
+        manager = FakeManager([_level_outcome(0, n_windows=3, energy=10.0)])
+        _wire_run(session, manager, warmup)
+
+        with session:
+            result = session.run()
+
+        assert isinstance(result, ServerSessionResult)
+        assert result.valid is True
+        # N results = one per window (C3).
+        assert result.window_count == 3
+        assert result.token_counting == ss.TOKEN_COUNTING_SERVER_REPORTED
+        # Warmup provenance stamped into EVERY window result (point 4 / D6 label).
+        level = result.levels[0]
+        assert all(w.warmup is not None for w in level.windows)
+        assert all(
+            w.pre_window_protocol == "server convergence-composite warmup (test)"
+            for w in level.windows
+        )
+        # Bookkeeping energy summed for the manifest summary.
+        assert result.total_window_energy_j == pytest.approx(30.0)
+        assert "completed" in runner.manifest.statuses
+
+    def test_run_warmup_traffic_error_returns_failure_dict(self) -> None:
+        engine = FakeEngine()
+        runner = _fake_runner()
+        session = _make_session(engine, runner=runner)
+        warmup = FakeWarmup([])
+        manager = FakeManager([WarmupTrafficError("warmup traffic died")])
+        _wire_run(session, manager, warmup)
+
+        with session:
+            result = session.run()
+
+        assert isinstance(result, dict)
+        assert result["type"] == "WarmupTrafficError"
+        assert "warmup failed" in result["message"]
+        assert "failed" in runner.manifest.statuses
+        assert engine.shutdowns == 1  # server still reaped
+
+    def test_run_invalid_level_returns_failure_dict(self) -> None:
+        engine = FakeEngine()
+        runner = _fake_runner()
+        session = _make_session(engine, runner=runner)
+        warmup = FakeWarmup([_warmup_result(0)])
+        manager = FakeManager([_level_outcome(0, valid=False)])
+        _wire_run(session, manager, warmup)
+
+        with session:
+            result = session.run()
+
+        assert isinstance(result, dict)
+        assert result["type"] == "ServerSessionInvalid"
+        assert "failed" in runner.manifest.statuses
+
+    def test_run_interrupt_returns_partial_and_leaves_manifest_running(self) -> None:
+        event = threading.Event()
+
+        class SlowManager:
+            def __init__(self) -> None:
+                self.calls: list[int] = []
+
+            async def run_level(self, level_index: int, level: Any) -> LevelOutcome:
+                self.calls.append(level_index)
+                event.set()  # trip the interrupt as soon as the level starts
+                try:
+                    await asyncio.sleep(10)
+                except BaseException as exc:
+                    setattr(
+                        exc,
+                        ABORTED_LEVEL_ATTR,
+                        AbortedLevel(
+                            level_index=level_index,
+                            aborted_window_index=0,
+                            reason="aborted: cancelled",
+                            completed_cores=[None],
+                        ),
+                    )
+                    raise
+                raise AssertionError  # pragma: no cover
+
+        engine = FakeEngine()
+        runner = _fake_runner(interrupt_event=event)
+        session = _make_session(engine, runner=runner)
+        warmup = FakeWarmup([_warmup_result(0)])
+        _wire_run(session, SlowManager(), warmup)
+
+        with session:
+            result = session.run()
+
+        assert isinstance(result, ServerSessionResult)
+        # Interrupted mid-session: the level failure is recorded, manifest NOT
+        # resolved here (the sweep loop's mark_interrupted downgrades running).
+        assert "completed" not in runner.manifest.statuses
+        assert "failed" not in runner.manifest.statuses
+        assert runner.manifest.statuses == ["running"]
+        assert result.levels[0].invalid_reason == "aborted: cancelled"
+        assert engine.shutdowns == 1  # server reaped on the interrupt path
+
+
+# ---------------------------------------------------------------------------
+# Contract 5 - the resolved warmup is read IN-PROCESS (no serialization boundary)
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedWarmupSeam:
+    def test_run_reads_overlay_resolved_warmup_in_process(self) -> None:
+        # A user-config overlay attaches a resolved warmup as a PrivateAttr; the
+        # session reads it directly (in-process), never through a serialized config.
+        from llenergymeasure.config.precedence import apply_server_warmup_overlay
+
+        config = _server_config()
+        user = UserConfig(server=UserServerConfig(warmup=ServerWarmupConfig(mode="fixed")))
+        apply_server_warmup_overlay(config, user)
+        assert config.resolved_server_warmup().mode == "fixed"
+
+        engine = FakeEngine()
+        session = _make_session(engine, config=config)
+        captured: dict[str, Any] = {}
+
+        # Real _make_warmup reads resolved_server_warmup(); capture the config it uses.
+        real_make_warmup = ServerSession._make_warmup
+
+        def spy_make_warmup(self: ServerSession, shape: Any, transport: Any) -> Any:
+            warmup = real_make_warmup(self, shape, transport)
+            captured["mode"] = warmup._config.mode
+            return warmup
+
+        _override(session, "_make_warmup", spy_make_warmup.__get__(session, ServerSession))
+        _override(session, "_make_manager", lambda sink, wu: FakeManager([_level_outcome(0)]))
+        _override(session, "_make_level_plans", lambda shape, transport: [object()])
+
+        with session:
+            session.run()
+
+        # The session ran the OVERLAY-RESOLVED protocol (fixed), read in-process.
+        assert captured["mode"] == "fixed"

--- a/tests/unit/study/test_server_session.py
+++ b/tests/unit/study/test_server_session.py
@@ -30,6 +30,7 @@ import pytest
 
 from llenergymeasure.config.models import ExperimentConfig, ServerWarmupConfig
 from llenergymeasure.config.user_config import UserConfig, UserServerConfig
+from llenergymeasure.device.power_thermal import PowerThermalSample
 from llenergymeasure.harness.server_warmup import ServerWarmupResult, WarmupTrafficError
 from llenergymeasure.harness.traffic import IssuerReport, RequestRecord, RequestShape
 from llenergymeasure.harness.window_manager import (
@@ -51,6 +52,7 @@ from llenergymeasure.study.server_session import (
     ServerSessionError,
     ServerSessionResult,
     _CompletionsShapeSource,
+    _core_energy_j,
     _drive_levels,
     _level_traffic_source,
     server_reported_token_receipts,
@@ -222,6 +224,31 @@ def _level_outcome(
         validation=validation,
         issuer_report=_report([]),
     )
+
+
+def _flat_core(power_w: float = 100.0, duration: float = 10.0, n: int = 21) -> Any:
+    """A measured-core stand-in with a flat power series (energy = power * duration)."""
+    samples = [
+        PowerThermalSample(timestamp=1000.0 + duration * i / (n - 1), power_w=power_w, gpu_index=0)
+        for i in range(n)
+    ]
+    return SimpleNamespace(timeseries_samples=samples)
+
+
+def _abort_exc(level_index: int, *, window: int, cores: list[Any]) -> RuntimeError:
+    """A run_level-style exception carrying its AbortedLevel partial state."""
+    exc = RuntimeError("mid-window transport failure")
+    setattr(
+        exc,
+        ABORTED_LEVEL_ATTR,
+        AbortedLevel(
+            level_index=level_index,
+            aborted_window_index=window,
+            reason=f"aborted: window {window}",
+            completed_cores=cores,
+        ),
+    )
+    return exc
 
 
 def _warmup_result(level_index: int = 0) -> ServerWarmupResult:
@@ -470,6 +497,32 @@ class TestDriver:
         assert failures[0].reason == "aborted: cancelled"
         assert failures[0].completed_cores == [None]
 
+    def test_interrupt_without_aborted_level_records_warmup_partial(self) -> None:
+        # A mid-warmup / mid-ramp interrupt raises a bare CancelledError (no
+        # AbortedLevel): the driver synthesizes a traceable "interrupted (warmup)"
+        # partial rather than leaving the level indistinguishable from
+        # nothing-attempted, then propagates so __exit__ reaps (MF4).
+        manager = FakeManager([asyncio.CancelledError()])
+        outcomes: list[LevelOutcome] = []
+        failures: list[Any] = []
+        plans: list[Any] = [object()]
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_drive_levels(manager, plans, outcomes, failures))
+        assert len(failures) == 1
+        assert failures[0].reason == "interrupted (warmup)"
+
+    def test_system_exit_propagates_not_recorded(self) -> None:
+        # SystemExit / GeneratorExit are BaseException-not-Exception: they must
+        # propagate, never become "level failed, continue" (MF2).
+        plans: list[Any] = [object()]
+        for exc_cls in (SystemExit, GeneratorExit):
+            manager = FakeManager([exc_cls()])
+            outcomes: list[LevelOutcome] = []
+            failures: list[Any] = []
+            with pytest.raises(exc_cls):
+                asyncio.run(_drive_levels(manager, plans, outcomes, failures))
+            assert failures == []  # not recorded as a level failure
+
 
 # ---------------------------------------------------------------------------
 # Lifecycle - launch / ready / shutdown, cleanup exactly once
@@ -683,3 +736,75 @@ class TestResolvedWarmupSeam:
 
         # The session ran the OVERLAY-RESOLVED protocol (fixed), read in-process.
         assert captured["mode"] == "fixed"
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 / O7.4 - a failed level's cleanly-closed cores are preserved and
+# their measured GPU energy still counts (the verifier's HIGH must-fix)
+# ---------------------------------------------------------------------------
+
+
+class TestPreservedCores:
+    def test_core_energy_j_flat_series(self) -> None:
+        # Flat 100 W over 10 s -> 1000 J (trapezoidal of a flat series is exact).
+        assert _core_energy_j(_flat_core(power_w=100.0, duration=10.0)) == pytest.approx(1000.0)
+
+    def test_core_energy_j_none_and_too_short(self) -> None:
+        assert _core_energy_j(None) is None
+        assert _core_energy_j(SimpleNamespace(timeseries_samples=[])) is None
+        one = SimpleNamespace(timeseries_samples=[PowerThermalSample(1000.0, 100.0, gpu_index=0)])
+        assert _core_energy_j(one) is None
+
+    def test_mid_level_abort_preserves_cores_and_energy(self) -> None:
+        # The verifier's scenario: level 0 aborts on window 3 with 2 clean cores,
+        # level 1 succeeds. Both cores land on the failed level's result and their
+        # energy is counted in the session total (never silently dropped).
+        core0 = _flat_core(power_w=100.0, duration=10.0)  # 1000 J
+        core1 = _flat_core(power_w=50.0, duration=10.0)  # 500 J
+        engine = FakeEngine()
+        runner = _fake_runner()
+        session = _make_session(engine, runner=runner)
+        warmup = FakeWarmup([_warmup_result(0), _warmup_result(1)])
+        manager = FakeManager(
+            [_abort_exc(0, window=3, cores=[core0, core1]), _level_outcome(1, energy=10.0)]
+        )
+        _wire_run(session, manager, warmup, plans=[object(), object()])
+
+        with session:
+            result = session.run()
+
+        assert isinstance(result, ServerSessionResult)
+        assert result.valid is True  # level 1 passed
+        failed_level = result.levels[0]
+        assert failed_level.invalid_reason is not None
+        assert failed_level.aborted_window_index == 3
+        assert failed_level.completed_cores == [core0, core1]
+        # 1000 + 500 (preserved cores) + 3 windows x 10 J (level 1) = 1530 J.
+        assert result.total_window_energy_j == pytest.approx(1000.0 + 500.0 + 30.0)
+
+
+# ---------------------------------------------------------------------------
+# Real _make_level_plans - issuance horizon spans the whole level (contract 1)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLevelPlans:
+    def test_make_level_plans_covers_full_horizon_and_wires_receipts(self) -> None:
+        # Exercise the REAL (unstubbed) _make_level_plans: it builds one LevelPlan
+        # whose traffic source issues across ramp + windows_per_level x duration and
+        # whose token receipts flow through the interim server-reported seam.
+        config = _server_config(traffic={"rate": 20, "window_seconds": 40, "seed": 3})
+        engine = FakeEngine()
+        session = ServerSession(
+            _fake_runner(), config, None, config_hash="h", cycle=1, index=1, engine=engine
+        )
+        plans = session._make_level_plans(_FakeShapeSource(), SimpleNamespace())
+        assert len(plans) == 1
+        plan = plans[0]
+        horizon = 30.0 + 3 * 40.0  # default ramp + windows_per_level x duration
+        # The schedule spans the whole level, not just one 40 s window.
+        assert plan.traffic_source.schedule.offsets[-1] > 40.0
+        assert plan.traffic_source.schedule.offsets[-1] <= horizon
+        assert plan.token_receipt_fn is server_reported_token_receipts
+        assert plan.spec.rate == 20.0
+        assert plan.spec.duration_seconds == 40.0


### PR DESCRIPTION
## Summary

Adds `ServerSession`, the C1/C3 sibling of the offline subprocess/container sessions for online-serving measurement. This is the **session type only**; it is dormant until the call-site wiring PR activates it (no dispatch path touches it yet, so `runner.py` / `orchestration.py` are byte-unchanged).

- **Lifecycle** (`__enter__` -> `run()` -> `__exit__`): launch the engine server (SM6 `ServerCapable`) and drive it to readiness with a real probe drawn from the measured traffic shape (SM8 `build_probe_request`); drive the SM7 window manager per rate level to N window results (one per window); shut the server down and reap it exactly once on the normal, interrupt, and exception paths.
- **Per-level driver** with inline abort handling (`AbortedLevel` caught at the direct `run_level` await site, never through a Task boundary that would drop it): a `WarmupTrafficError` aborts the session (dead transport dooms later levels); any other level failure is recorded invalid-with-reason and the session continues. A failed level's cleanly-closed measured cores are preserved raw and their GPU energy counts toward the session total (O7.4); `SystemExit` / `GeneratorExit` propagate; a mid-warmup interrupt records a traceable partial.
- **Host-side, in-process measurement**: the traffic issuer plus host-side energy/thermal sampling run in-process; only the engine server is out-of-process, so no serialized config crosses a boundary and the user-config-resolved warmup is read directly (the serialization-boundary contract).
- **Interim token counting**: client-counted output tokens flow to the energy denominator and the stability gate through the token-receipt seam; at this stage they are the SERVER-REPORTED completion-token counts, an interim stand-in loudly stamped in the result (`token_counting`) until client-side canonical counting and the request log land in a later slice.
- **Progress rider**: adds a server-mode step surface and aligns the internal (non-serialized) step-list surface identifiers with the process/container runner vocabulary.

## Test plan

Standalone host suite (this branch, no wiring commits): **3589 passed / 37 skipped**; `ruff`, `import-linter` (5 kept / 0 broken), `mypy src/ + tests/` (354 files) all clean; no SSOT doc drift.

New coverage in `tests/unit/study/test_server_session.py`:
- token receipts (server-reported, request-granular, edge cases); OpenAI-completions shape encoding; issuance-horizon sizing (ramp + windows_per_level x duration) on the real `_make_level_plans`;
- the level driver: happy path, `WarmupTrafficError` session-abort, aborted-level record-and-continue, ramp-phase record-and-continue, interrupt preserves partial + re-raises, `SystemExit`/`GeneratorExit` propagate, mid-warmup interrupt synthesizes a partial;
- lifecycle: launch/readiness/shutdown, cleanup-exactly-once on enter-failure / exception / idempotent double-exit, non-server-capable engine rejected;
- `run()`: N results with warmup provenance stamped per window, warmup-abort -> failure dict, invalid-level -> failure dict, interrupt -> partial with manifest left running, preserved-core energy accounting, overlay-resolved warmup read in-process.

## Doc audit

No SSOT-derived doc changes (no config-model or CLI surface change). The changelog fragment describes the user-visible feature, which only activates with the call-site wiring, so it lands with the follow-up wiring PR; this PR is dormant.