### PR TITLE
fix(harness): proceed at composite warmup timeout boundary

### DIFF
--- a/changelog.d/+warmup-timeout-boundary.fixed.md
+++ b/changelog.d/+warmup-timeout-boundary.fixed.md
@@ -1,0 +1,1 @@
+A composite server warmup that reaches its timeout now proceeds with the documented `timed_out` disclosure instead of failing the experiment when the warmup traffic schedule ends exactly at the timeout boundary.

--- a/src/llenergymeasure/harness/server_warmup.py
+++ b/src/llenergymeasure/harness/server_warmup.py
@@ -395,7 +395,13 @@ class ServerWarmup:
         """
         sampler = self._sampler_factory()
         counting = _CountingTransport(self._transport)
-        source = self._traffic_factory(context, self._config.timeout_seconds)
+        # Provision the traffic schedule two poll intervals LONGER than the gate
+        # window so a clean full-duration run does not exhaust exactly at the
+        # boundary (the finally block stops it explicitly, so the slack is free on
+        # the happy path).
+        source = self._traffic_factory(
+            context, self._config.timeout_seconds + 2 * self._poll_interval
+        )
         start = self._clock()
         deadline = start + self._config.timeout_seconds
         timed_out = False
@@ -408,9 +414,15 @@ class ServerWarmup:
         traffic_task: asyncio.Task[Any] = asyncio.create_task(source.run(counting))
         try:
             while True:
-                # Watch the traffic each poll: a completion (raise OR early clean
-                # exit) before the gate resolves means the warmup mechanism died.
+                # Watch the traffic each poll. A completion strictly BEFORE the
+                # deadline means the warmup mechanism died early (a raise OR a clean
+                # early exit); a completion AT OR AFTER the deadline is the schedule
+                # ending at the gate boundary, which is a timeout-proceed (a loud
+                # timed_out disclosure), NOT traffic death.
                 if traffic_task.done():
+                    if self._clock() >= deadline:
+                        timed_out = True
+                        break
                     traffic_died = True
                     cause = _traffic_cause(traffic_task)
                     break

--- a/tests/unit/harness/test_server_warmup.py
+++ b/tests/unit/harness/test_server_warmup.py
@@ -177,6 +177,26 @@ class EarlyExitSource:
         return _empty_report(self._n)
 
 
+class ExhaustAfterSource:
+    """Issues ``n`` successful requests then returns cleanly, with NO trailing delay.
+
+    Unlike ``EarlyExitSource`` it never awaits a real timer, so under a fake-clock
+    driver it runs to completion on the poll loop's first yield - letting a test
+    place the clean schedule exhaustion at a controlled point relative to the
+    deadline (at the boundary vs. strictly before it).
+    """
+
+    def __init__(self, n: int = 1) -> None:
+        self._n = n
+        self.issued = 0
+
+    async def run(self, transport: Any, *, drain_timeout: float | None = None) -> IssuerReport:
+        for i in range(self._n):
+            await transport(RequestShape(index=i))
+            self.issued += 1
+        return _empty_report(self.issued)
+
+
 class FakeTransport:
     async def __call__(self, request: Any) -> Any:
         return None
@@ -392,6 +412,65 @@ class TestServerWarmupComposite:
         assert result.converged is False
         # Proceeded (returned) and released everything - never hung.
         assert sampler.stopped and source.cancelled
+
+
+class TestServerWarmupTimeoutBoundary:
+    """Regression: a clean warmup-traffic schedule that ends AT/AFTER the timeout is a
+    timeout-proceed (loud timed_out), NOT traffic death; a schedule that ends strictly
+    BEFORE the timeout is still genuine early exhaustion and fails loudly. Guards the
+    v0.7.0 release-gate defect where a full-duration run failed the experiment cell.
+    """
+
+    def test_clean_exit_at_deadline_proceeds_timed_out(self):
+        # The traffic schedule exhausts cleanly exactly at the gate boundary while the
+        # observables never converge: proceed with the loud timed_out stamp, NO raise.
+        sampler = FakeSampler([])  # never converges
+        source = ExhaustAfterSource(n=1)  # completes on the first poll's yield
+        clk = FakeClock()
+
+        async def advancing_sleep(d: float) -> None:
+            clk.t += max(d, 1.0)  # one poll pushes the clock to the deadline
+            await asyncio.sleep(0)  # yield so the traffic task runs to completion
+
+        sw = _warmup(
+            ServerWarmupConfig(mode="composite", timeout_seconds=1.0),
+            sampler,
+            source,
+            poll_interval=1.0,
+            sleep=advancing_sleep,
+            clock=clk,
+        )
+        asyncio.run(sw(_ctx()))  # must NOT raise
+        result = sw.results[0]
+        assert result.timed_out is True
+        assert result.converged is False
+        assert source.issued == 1  # the warmup traffic actually ran to the boundary
+        assert sampler.stopped  # released, never hung
+
+    def test_clean_exit_before_deadline_still_fails(self):
+        # The same clean schedule exhaustion, but WELL before the deadline: genuine
+        # early death, so WarmupTrafficError still fires (the fix must not mask it).
+        sampler = FakeSampler([])  # never converges
+        source = ExhaustAfterSource(n=3)
+        clk = FakeClock()
+
+        async def advancing_sleep(d: float) -> None:
+            clk.t += max(d, 1.0)
+            await asyncio.sleep(0)
+
+        sw = _warmup(
+            ServerWarmupConfig(mode="composite", timeout_seconds=100.0),
+            sampler,
+            source,
+            poll_interval=1.0,
+            sleep=advancing_sleep,
+            clock=clk,
+        )
+        with pytest.raises(WarmupTrafficError) as exc:
+            asyncio.run(sw(_ctx()))
+        assert exc.value.__cause__ is None  # a clean early exit chains no cause
+        assert "ended" in str(exc.value)
+        assert sw.results == []  # no result recorded for a failed level
 
 
 class TestServerWarmupFixed:


### PR DESCRIPTION
## Summary

- A composite server warmup whose traffic schedule exhausts cleanly at the timeout boundary was misclassified as traffic death (`WarmupTrafficError`), failing the whole experiment cell. The documented and intended behavior at the timeout is to proceed with a loud `timed_out` disclosure; traffic death is reserved for schedules that genuinely end early. Caught live by the v0.7.0 release-gate server study, where it failed both vLLM cells at t=901s against a 900s deadline.
- Fix: a traffic completion at or after the deadline now resolves as timeout-proceed (death only strictly before the deadline; the pre-deadline exception path and the zero-completions guard are unchanged), and the warmup schedule is provisioned two poll intervals longer than the gate window so the boundary case cannot recur in practice. Fixed-mode warmup untouched.

## Test plan

- [x] Two regression tests with two-sided live bite proofs: reverting the classification hunk fails the at-deadline test with the exact live-defect signature; the over-broad mis-fix fails the before-deadline test
- [x] Edge semantics probed: traffic raising at/after the deadline proceeds timed-out; zero completions still raises
- [x] Full unit suite 3599 passed / 37 skipped; warmup module 38/38; make lint + make typecheck green
- [ ] CI passes

## Doc audit

- Shipped docs already describe the intended behavior ("a 900 s failsafe that proceeds"); this fix makes the code match them. Towncrier fragment added.